### PR TITLE
Bootstrap Part 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,292 @@
 version = 4
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "futures-core"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+
+[[package]]
+name = "futures-task"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-util"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shelterwood"
 version = "0.1.0"
+dependencies = [
+ "fastrand",
+ "shelterwood-test-support",
+ "slab",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "shelterwood-api-reachability"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
+name = "shelterwood-test-support"
+version = "0.1.0"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,13 @@
 [workspace]
 default-members = [
     "crates/shelterwood",
+    "crates/test-support",
+    "tools/api-reachability",
 ]
 members = [
     "crates/shelterwood",
+    "crates/test-support",
+    "tools/api-reachability",
 ]
 resolver = "3"
 
@@ -13,3 +17,10 @@ resolver = "3"
 name = "shelterwood"
 
 [workspace.dependencies]
+fastrand = "2.5.0"
+serde_json = "1.0.151"
+slab = "0.4.12"
+thiserror = "2.0.19"
+tokio = { version = "1.53.1", features = ["rt-multi-thread", "sync", "time"] }
+tokio-util = { version = "0.7.19", features = ["rt"] }
+tracing = "0.1.44"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ nix develop
 just test  # to run tests
 ```
 
+The runtime-path and public-API-reachability checks are temporary guardrails
+for the initial implementation. Once the runtime boundary is clear from the
+surrounding source code, these checks can be removed rather than maintained as
+permanent project infrastructure.
+
 ## License
 
 Licensed under either of

--- a/crates/shelterwood/Cargo.toml
+++ b/crates/shelterwood/Cargo.toml
@@ -2,6 +2,16 @@
 name = "shelterwood"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.97.1"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+fastrand.workspace = true
+slab.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+shelterwood-test-support = { path = "../test-support" }

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -1,20 +1,8 @@
-//! Core library for Shelterwood.
+#![warn(missing_docs)]
 
-/// Returns a greeting for `name`.
-///
-/// ```
-/// assert_eq!(shelterwood::greet("world"), "hello, world");
-/// ```
-pub fn greet(name: &str) -> String {
-    format!("hello, {name}")
-}
+//! Structured supervision and actors for asynchronous Rust systems.
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn greets_by_name() {
-        assert_eq!(greet("shelterwood"), "hello, shelterwood");
-    }
-}
+// M0 deliberately establishes the complete runtime boundary before its first
+// consumer lands in M1.
+#[allow(dead_code)]
+mod runtime;

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -1,0 +1,183 @@
+//! The only boundary between the library and its async runtime.
+
+use std::{any::Any, future::Future, ops::RangeBounds, time::Duration};
+
+use tokio::{
+    sync::{mpsc, oneshot, watch},
+    task, time,
+};
+
+/// A runtime-owned monotonic instant.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct Instant(time::Instant);
+
+impl Instant {
+    pub(crate) fn now() -> Self {
+        Self(time::Instant::now())
+    }
+
+    pub(crate) fn checked_add(self, duration: Duration) -> Option<Self> {
+        self.0.checked_add(duration).map(Self)
+    }
+
+    pub(crate) fn saturating_duration_since(self, earlier: Self) -> Duration {
+        self.0.saturating_duration_since(earlier.0)
+    }
+}
+
+/// A spawned operation whose identity is retained through joining.
+pub(crate) struct JoinHandle<I, T> {
+    id: I,
+    inner: task::JoinHandle<T>,
+}
+
+impl<I, T> JoinHandle<I, T> {
+    pub(crate) fn id(&self) -> &I {
+        &self.id
+    }
+
+    pub(crate) fn abort(&self) {
+        self.inner.abort();
+    }
+}
+
+/// The runtime-level outcome consumed by the exit classifier.
+pub(crate) enum JoinOutcome<I, T> {
+    Ok {
+        id: I,
+        value: T,
+    },
+    Panic {
+        id: I,
+        payload: Box<dyn Any + Send + 'static>,
+    },
+    Cancelled {
+        id: I,
+    },
+}
+
+pub(crate) fn spawn<I, F>(id: I, future: F) -> JoinHandle<I, F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    JoinHandle {
+        id,
+        inner: task::spawn(future),
+    }
+}
+
+pub(crate) fn spawn_blocking<I, F, T>(id: I, operation: F) -> JoinHandle<I, T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    JoinHandle {
+        id,
+        inner: task::spawn_blocking(operation),
+    }
+}
+
+pub(crate) async fn join<I, T>(handle: JoinHandle<I, T>) -> JoinOutcome<I, T> {
+    let JoinHandle { id, inner } = handle;
+    match inner.await {
+        Ok(value) => JoinOutcome::Ok { id, value },
+        Err(error) if error.is_panic() => JoinOutcome::Panic {
+            id,
+            payload: error.into_panic(),
+        },
+        Err(error) => {
+            debug_assert!(error.is_cancelled());
+            JoinOutcome::Cancelled { id }
+        }
+    }
+}
+
+pub(crate) async fn sleep(duration: Duration) {
+    time::sleep(duration).await;
+}
+
+pub(crate) async fn sleep_until(deadline: Instant) {
+    time::sleep_until(deadline.0).await;
+}
+
+pub(crate) enum Timeout<T> {
+    Completed(T),
+    Elapsed,
+}
+
+pub(crate) async fn timeout<F>(duration: Duration, future: F) -> Timeout<F::Output>
+where
+    F: Future,
+{
+    match time::timeout(duration, future).await {
+        Ok(value) => Timeout::Completed(value),
+        Err(_) => Timeout::Elapsed,
+    }
+}
+
+pub(crate) type WatchSender<T> = watch::Sender<T>;
+pub(crate) type WatchReceiver<T> = watch::Receiver<T>;
+
+pub(crate) fn watch_channel<T>(initial: T) -> (WatchSender<T>, WatchReceiver<T>) {
+    watch::channel(initial)
+}
+
+pub(crate) type OneshotSender<T> = oneshot::Sender<T>;
+pub(crate) type OneshotReceiver<T> = oneshot::Receiver<T>;
+
+pub(crate) fn oneshot_channel<T>() -> (OneshotSender<T>, OneshotReceiver<T>) {
+    oneshot::channel()
+}
+
+pub(crate) type MpscSender<T> = mpsc::Sender<T>;
+pub(crate) type MpscReceiver<T> = mpsc::Receiver<T>;
+
+pub(crate) fn bounded_mpsc<T>(capacity: usize) -> (MpscSender<T>, MpscReceiver<T>) {
+    mpsc::channel(capacity)
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct CancellationToken(tokio_util::sync::CancellationToken);
+
+impl CancellationToken {
+    pub(crate) fn new() -> Self {
+        Self(tokio_util::sync::CancellationToken::new())
+    }
+
+    pub(crate) fn child_token(&self) -> Self {
+        Self(self.0.child_token())
+    }
+
+    pub(crate) fn cancel(&self) {
+        self.0.cancel();
+    }
+
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.0.is_cancelled()
+    }
+
+    pub(crate) async fn cancelled(&self) {
+        self.0.cancelled().await;
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct JitterRng(fastrand::Rng);
+
+impl JitterRng {
+    pub(crate) fn from_system_entropy() -> Self {
+        Self(fastrand::Rng::with_seed(fastrand::u64(..)))
+    }
+
+    pub(crate) fn sample<R>(&mut self, range: R) -> u64
+    where
+        R: RangeBounds<u64>,
+    {
+        self.0.u64(range)
+    }
+}
+
+pub(crate) async fn yield_now() {
+    task::yield_now().await;
+}

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "shelterwood-test-support"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.97.1"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+tokio = { workspace = true, features = ["macros", "test-util"] }

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -221,19 +221,24 @@ pub async fn poll_until(
 
 /// Asserts that a predicate remains false for a bounded quiet window.
 pub async fn assert_quiet(duration: Duration, mut predicate: impl FnMut() -> bool) {
+    const POLL_INTERVAL: Duration = Duration::from_millis(1);
+
     let deadline = tokio::time::Instant::now() + duration;
     loop {
         assert!(!predicate(), "quiet-window predicate became true");
-        if tokio::time::Instant::now() >= deadline {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
             return;
         }
-        tokio::task::yield_now().await;
+        tokio::time::sleep(POLL_INTERVAL.min(deadline - now)).await;
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ConsumeCount, LiveFlag, ReleaseGate};
+    use std::time::Duration;
+
+    use super::{ConsumeCount, LiveFlag, ReleaseGate, assert_quiet};
 
     #[test]
     fn guards_report_drop_and_consumption() {
@@ -252,5 +257,15 @@ mod tests {
         let gate = ReleaseGate::default();
         gate.release();
         gate.wait().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn quiet_window_completes_with_paused_time() {
+        let duration = Duration::from_secs(1);
+        let started_at = tokio::time::Instant::now();
+
+        assert_quiet(duration, || false).await;
+
+        assert_eq!(tokio::time::Instant::now() - started_at, duration);
     }
 }

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -1,0 +1,256 @@
+//! Deterministic fixtures shared by Shelterwood's conformance tests.
+
+use std::{
+    sync::{
+        Arc, Condvar, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use tokio::sync::Notify;
+
+/// An observable flag paired with an owned liveness guard.
+#[derive(Clone, Debug)]
+pub struct LiveFlag(Arc<AtomicBool>);
+
+impl LiveFlag {
+    /// Creates a live flag and the guard whose drop clears it.
+    pub fn guarded() -> (Self, LiveGuard) {
+        let value = Arc::new(AtomicBool::new(true));
+        (Self(Arc::clone(&value)), LiveGuard(value))
+    }
+
+    /// Reports whether the paired guard is still live.
+    pub fn is_live(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+/// Clears its paired [`LiveFlag`] when dropped.
+#[derive(Debug)]
+pub struct LiveGuard(Arc<AtomicBool>);
+
+impl Drop for LiveGuard {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Counts consumption and fallback drops of owned one-shot resources.
+#[derive(Clone, Debug, Default)]
+pub struct ConsumeCount(Arc<AtomicUsize>);
+
+impl ConsumeCount {
+    /// Creates a guard that increments this count when consumed or dropped.
+    pub fn guard(&self) -> ConsumeGuard {
+        ConsumeGuard(Some(Arc::clone(&self.0)))
+    }
+
+    /// Returns the number of observed consumptions.
+    pub fn get(&self) -> usize {
+        self.0.load(Ordering::SeqCst)
+    }
+
+    /// Asserts that exactly one consumption occurred.
+    #[track_caller]
+    pub fn assert_once(&self) {
+        assert_eq!(self.get(), 1, "resource must be consumed exactly once");
+    }
+}
+
+/// A consume-once witness whose fallback effect runs on drop.
+#[derive(Debug)]
+pub struct ConsumeGuard(Option<Arc<AtomicUsize>>);
+
+impl ConsumeGuard {
+    /// Consumes the witness and records its effect immediately.
+    pub fn consume(mut self) {
+        self.record();
+    }
+
+    fn record(&mut self) {
+        if let Some(count) = self.0.take() {
+            count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+}
+
+impl Drop for ConsumeGuard {
+    fn drop(&mut self) {
+        self.record();
+    }
+}
+
+/// A one-permit asynchronous gate used to sequence child progress.
+#[derive(Clone, Debug, Default)]
+pub struct ReleaseGate(Arc<Notify>);
+
+impl ReleaseGate {
+    /// Waits until the gate is released.
+    pub async fn wait(&self) {
+        self.0.notified().await;
+    }
+
+    /// Releases one current or future waiter.
+    pub fn release(&self) {
+        self.0.notify_one();
+    }
+}
+
+/// Coordinates acceptance before a fixture begins receiving work.
+#[derive(Clone, Debug, Default)]
+pub struct ParkBeforeReceive {
+    accepted: Arc<Notify>,
+    release: ReleaseGate,
+}
+
+impl ParkBeforeReceive {
+    /// Marks the fixture as having accepted its input.
+    pub fn mark_accepted(&self) {
+        self.accepted.notify_one();
+    }
+
+    /// Waits for the fixture to report acceptance.
+    pub async fn wait_accepted(&self) {
+        self.accepted.notified().await;
+    }
+
+    /// Parks until receiving is explicitly released.
+    pub async fn park(&self) {
+        self.release.wait().await;
+    }
+
+    /// Allows the fixture to begin receiving.
+    pub fn release(&self) {
+        self.release.release();
+    }
+}
+
+#[derive(Debug, Default)]
+struct DestructorState {
+    entered: bool,
+    released: bool,
+}
+
+/// Controls a fixture whose destructor blocks at an exact test window.
+#[derive(Clone, Debug, Default)]
+pub struct DestructorGate(Arc<(Mutex<DestructorState>, Condvar)>);
+
+impl DestructorGate {
+    /// Creates a value that blocks in `Drop` until this gate is released.
+    pub fn blocker(&self) -> DestructorBlocker {
+        DestructorBlocker(Arc::clone(&self.0))
+    }
+
+    /// Blocks the calling test thread until the destructor has started.
+    pub fn wait_entered(&self) {
+        let (state, changed) = &*self.0;
+        let mut state = state.lock().expect("destructor gate mutex poisoned");
+        while !state.entered {
+            state = changed
+                .wait(state)
+                .expect("destructor gate mutex poisoned while waiting");
+        }
+    }
+
+    /// Releases the blocked destructor.
+    pub fn release(&self) {
+        let (state, changed) = &*self.0;
+        let mut state = state.lock().expect("destructor gate mutex poisoned");
+        state.released = true;
+        changed.notify_all();
+    }
+}
+
+/// A value that blocks in `Drop` under a [`DestructorGate`].
+#[derive(Debug)]
+pub struct DestructorBlocker(Arc<(Mutex<DestructorState>, Condvar)>);
+
+impl Drop for DestructorBlocker {
+    fn drop(&mut self) {
+        let (state, changed) = &*self.0;
+        let mut state = state.lock().expect("destructor gate mutex poisoned");
+        state.entered = true;
+        changed.notify_all();
+        while !state.released {
+            state = changed
+                .wait(state)
+                .expect("destructor gate mutex poisoned while blocking");
+        }
+    }
+}
+
+/// A fixture that panics when dropped.
+#[derive(Debug, Default)]
+pub struct PanicOnDrop;
+
+impl Drop for PanicOnDrop {
+    fn drop(&mut self) {
+        panic!("intentional destructor panic");
+    }
+}
+
+/// Pauses Tokio's clock for deterministic timing tests.
+pub fn pause_time() {
+    tokio::time::pause();
+}
+
+/// Advances Tokio's paused clock.
+pub async fn advance_time(duration: Duration) {
+    tokio::time::advance(duration).await;
+}
+
+/// Polls a synchronous observation until it succeeds or the deadline expires.
+pub async fn poll_until(
+    timeout: Duration,
+    interval: Duration,
+    mut predicate: impl FnMut() -> bool,
+) -> bool {
+    tokio::time::timeout(timeout, async {
+        loop {
+            if predicate() {
+                return;
+            }
+            tokio::time::sleep(interval).await;
+        }
+    })
+    .await
+    .is_ok()
+}
+
+/// Asserts that a predicate remains false for a bounded quiet window.
+pub async fn assert_quiet(duration: Duration, mut predicate: impl FnMut() -> bool) {
+    let deadline = tokio::time::Instant::now() + duration;
+    loop {
+        assert!(!predicate(), "quiet-window predicate became true");
+        if tokio::time::Instant::now() >= deadline {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConsumeCount, LiveFlag, ReleaseGate};
+
+    #[test]
+    fn guards_report_drop_and_consumption() {
+        let (flag, guard) = LiveFlag::guarded();
+        assert!(flag.is_live());
+        drop(guard);
+        assert!(!flag.is_live());
+
+        let count = ConsumeCount::default();
+        count.guard().consume();
+        count.assert_once();
+    }
+
+    #[tokio::test]
+    async fn release_gate_stores_one_permit() {
+        let gate = ReleaseGate::default();
+        gate.release();
+        gate.wait().await;
+    }
+}

--- a/flake.lock
+++ b/flake.lock
@@ -51,7 +51,19 @@
     },
     "root": {
       "inputs": {
-        "rust-env": "rust-env"
+        "crane": [
+          "rust-env",
+          "crane"
+        ],
+        "nixpkgs": [
+          "rust-env",
+          "nixpkgs"
+        ],
+        "rust-env": "rust-env",
+        "rust-overlay": [
+          "rust-env",
+          "rust-overlay"
+        ]
       }
     },
     "rust-env": {
@@ -83,11 +95,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785907205,
-        "narHash": "sha256-Ds1vTi53af4wDMAveSR/K0JnywDslLwmgwhVIiwnNmY=",
+        "lastModified": 1785993740,
+        "narHash": "sha256-naSJ+p7zkIT2hHNSJkhxiPZlmVRgE3UdODinMM7rpD8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c5cb13481d718fac906aa9cfd85f9b60e1a546cb",
+        "rev": "3d1b34a12a26be073f7ae67165a6b61229ca6025",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,26 +10,15 @@
 
   outputs =
     {
-      self,
       crane,
-      nixpkgs,
       rust-env,
-      rust-overlay,
+      ...
     }:
-    let
-      base = rust-env.lib.mkRustProject {
-        src = ./.;
-      };
-    in
-    base
-    // {
-      checks = builtins.mapAttrs (
-        system: baseChecks:
+    rust-env.lib.mkRustProject {
+      src = ./.;
+      extraChecks =
+        pkgs:
         let
-          pkgs = import nixpkgs {
-            inherit system;
-            overlays = [ (import rust-overlay) ];
-          };
           nightlyToolchain = pkgs.rust-bin.selectLatestNightlyWith (
             toolchain:
             toolchain.default.override {
@@ -55,8 +44,7 @@
           };
           cargoArtifacts = craneLibNightly.buildDepsOnly commonArgs;
         in
-        baseChecks
-        // {
+        {
           part0-enforcement = craneLibNightly.mkCargoDerivation (
             commonArgs
             // {
@@ -72,7 +60,6 @@
               doInstallCargoArtifacts = false;
             }
           );
-        }
-      ) base.checks;
+        };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,17 +3,76 @@
 
   inputs = {
     rust-env.url = "github:ralexstokes/rust-nix-template";
+    crane.follows = "rust-env/crane";
+    nixpkgs.follows = "rust-env/nixpkgs";
+    rust-overlay.follows = "rust-env/rust-overlay";
   };
 
   outputs =
-    { self, rust-env }:
-    rust-env.lib.mkRustProject {
-      src = ./.;
-      # Escape hatches (see the template repo's README):
-      #   projectName = "my-project";
-      #   extraShellPackages = pkgs: [ pkgs.mdbook ];
-      #   extraChecks = pkgs: { };
-      #   extraCiCommands = "cargo run --locked -p hello --example smoke";
-      #   extraSourceFilter = path: type: false;
+    {
+      self,
+      crane,
+      nixpkgs,
+      rust-env,
+      rust-overlay,
+    }:
+    let
+      base = rust-env.lib.mkRustProject {
+        src = ./.;
+      };
+    in
+    base
+    // {
+      checks = builtins.mapAttrs (
+        system: baseChecks:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ (import rust-overlay) ];
+          };
+          nightlyToolchain = pkgs.rust-bin.selectLatestNightlyWith (
+            toolchain:
+            toolchain.default.override {
+              extensions = [ "rustfmt" ];
+            }
+          );
+          craneLib = crane.mkLib pkgs;
+          craneLibNightly = craneLib.overrideToolchain nightlyToolchain;
+          source = pkgs.lib.cleanSourceWith {
+            src = pkgs.lib.cleanSource ./.;
+            filter =
+              path: type:
+              type == "directory"
+              || craneLib.filterCargoSources path type
+              || pkgs.lib.hasSuffix ".sh" (toString path);
+          };
+          commonArgs = {
+            pname = "shelterwood-part0-enforcement";
+            version = "0.1.0";
+            src = source;
+            strictDeps = true;
+            cargoExtraArgs = "--locked --workspace --all-features";
+          };
+          cargoArtifacts = craneLibNightly.buildDepsOnly commonArgs;
+        in
+        baseChecks
+        // {
+          part0-enforcement = craneLibNightly.mkCargoDerivation (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              nativeBuildInputs = [ pkgs.ripgrep ];
+              buildPhaseCargoCommand = ''
+                RUSTDOCFLAGS="-Z unstable-options --output-format json" \
+                  cargo rustdoc --locked -p shelterwood --all-features --lib
+                cargo run --locked -p shelterwood-api-reachability -- \
+                  target/doc/shelterwood.json
+                ${pkgs.bash}/bin/bash ./tools/check-runtime-paths.sh
+              '';
+              doInstallCargoArtifacts = false;
+            }
+          );
+        }
+      ) base.checks;
     };
 }

--- a/justfile
+++ b/justfile
@@ -24,12 +24,19 @@ test:
 doc-check:
     RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --no-deps --all-features
 
+runtime-api-check:
+    RUSTDOCFLAGS="-Z unstable-options --output-format json" cargo +nightly rustdoc --locked -p shelterwood --all-features --lib
+    cargo run --locked -p shelterwood-api-reachability -- target/doc/shelterwood.json
+
+runtime-path-check:
+    ./tools/check-runtime-paths.sh
+
 nixfmt-check:
     git ls-files -z '*.nix' | xargs -0 nixfmt --check
 
 # Fast local CI mirror — reuses the local cargo cache and incremental builds.
 # The clean Nix lane retains the explicit all-target build for non-test codegen coverage.
-ci: fmt lint test doc-check nixfmt-check
+ci: fmt lint test doc-check runtime-api-check runtime-path-check nixfmt-check
 
 # Full clean Nix CI lane; use before pushing or when touching Nix files.
 ci-nix:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.1"
 components = ["clippy", "rust-analyzer", "rustfmt"]
 profile = "minimal"

--- a/tools/api-reachability/Cargo.toml
+++ b/tools/api-reachability/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "shelterwood-api-reachability"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.97.1"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+serde_json.workspace = true

--- a/tools/api-reachability/src/main.rs
+++ b/tools/api-reachability/src/main.rs
@@ -1,0 +1,208 @@
+use std::{
+    collections::{BTreeSet, HashMap, HashSet, VecDeque},
+    env,
+    error::Error,
+    fs,
+    path::PathBuf,
+};
+
+use serde_json::Value;
+
+const FORBIDDEN_ROOTS: &[&str] = &["tokio", "tokio_util"];
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let path = env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .ok_or("usage: shelterwood-api-reachability <rustdoc-json>")?;
+    let document: Value = serde_json::from_slice(&fs::read(&path)?)?;
+    let leaks = find_leaks(&document)?;
+
+    if leaks.is_empty() {
+        println!("public API runtime reachability: clean");
+        return Ok(());
+    }
+
+    eprintln!("runtime types are reachable from public Shelterwood items:");
+    for leak in leaks {
+        eprintln!("  {leak}");
+    }
+    Err("public API runtime reachability check failed".into())
+}
+
+fn find_leaks(document: &Value) -> Result<BTreeSet<String>, Box<dyn Error>> {
+    let index = object_field(document, "index")?;
+    let paths = object_field(document, "paths")?;
+
+    let local_paths: HashMap<String, String> = paths
+        .iter()
+        .filter(|(_, summary)| summary.get("crate_id").and_then(Value::as_u64) == Some(0))
+        .map(|(id, summary)| (id.clone(), display_path(summary)))
+        .collect();
+    let known_ids: HashSet<String> = index.keys().chain(paths.keys()).cloned().collect();
+
+    let mut leaks = BTreeSet::new();
+    for (root_id, root_path) in &local_paths {
+        let mut queue = VecDeque::from([root_id.clone()]);
+        let mut visited = HashSet::new();
+
+        while let Some(id) = queue.pop_front() {
+            if !visited.insert(id.clone()) {
+                continue;
+            }
+            let Some(item) = index.get(&id) else {
+                continue;
+            };
+            let mut references = Vec::new();
+            collect_references(item, &known_ids, &mut references);
+            for reference in references {
+                let Some(summary) = paths.get(&reference) else {
+                    if index.contains_key(&reference) {
+                        queue.push_back(reference);
+                    }
+                    continue;
+                };
+                if summary.get("crate_id").and_then(Value::as_u64) == Some(0) {
+                    queue.push_back(reference);
+                    continue;
+                }
+                let path = path_segments(summary);
+                if path
+                    .first()
+                    .is_some_and(|root| FORBIDDEN_ROOTS.contains(&root.as_str()))
+                {
+                    leaks.insert(format!("{root_path} -> {}", path.join("::")));
+                }
+            }
+        }
+    }
+
+    Ok(leaks)
+}
+
+fn object_field<'a>(
+    document: &'a Value,
+    name: &str,
+) -> Result<&'a serde_json::Map<String, Value>, Box<dyn Error>> {
+    document
+        .get(name)
+        .and_then(Value::as_object)
+        .ok_or_else(|| format!("rustdoc JSON has no object field `{name}`").into())
+}
+
+fn display_path(summary: &Value) -> String {
+    let path = path_segments(summary);
+    if path.is_empty() {
+        "<unnamed-local-item>".to_owned()
+    } else {
+        path.join("::")
+    }
+}
+
+fn path_segments(summary: &Value) -> Vec<String> {
+    summary
+        .get("path")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_owned)
+        .collect()
+}
+
+fn collect_references(value: &Value, known_ids: &HashSet<String>, output: &mut Vec<String>) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                collect_references(value, known_ids, output);
+            }
+        }
+        Value::Object(fields) => {
+            for (name, value) in fields {
+                if matches!(
+                    name.as_str(),
+                    "id" | "items" | "impls" | "fields" | "variants" | "implementations"
+                ) {
+                    collect_ids(value, known_ids, output);
+                } else {
+                    collect_references(value, known_ids, output);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_ids(value: &Value, known_ids: &HashSet<String>, output: &mut Vec<String>) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                collect_ids(value, known_ids, output);
+            }
+        }
+        Value::Object(fields) => {
+            for value in fields.values() {
+                collect_ids(value, known_ids, output);
+            }
+        }
+        Value::Number(value) => push_known(value.to_string(), known_ids, output),
+        Value::String(value) => push_known(value.clone(), known_ids, output),
+        _ => {}
+    }
+}
+
+fn push_known(value: String, known_ids: &HashSet<String>, output: &mut Vec<String>) {
+    if known_ids.contains(&value) {
+        output.push(value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use serde_json::json;
+
+    use super::find_leaks;
+
+    #[test]
+    fn follows_public_type_ids_without_treating_every_number_as_an_id() {
+        let document = json!({
+            "index": {
+                "0": {
+                    "id": 0,
+                    "span": { "begin": [3, 1] },
+                    "inner": { "module": { "items": [1] } }
+                },
+                "1": {
+                    "id": 1,
+                    "span": { "begin": [3, 2] },
+                    "inner": {
+                        "function": {
+                            "sig": {
+                                "output": {
+                                    "resolved_path": { "id": 2 }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "paths": {
+                "0": { "crate_id": 0, "path": ["shelterwood"] },
+                "1": { "crate_id": 0, "path": ["shelterwood", "leak"] },
+                "2": { "crate_id": 7, "path": ["tokio", "time", "Instant"] },
+                "3": { "crate_id": 7, "path": ["tokio", "sync", "watch"] }
+            }
+        });
+
+        let leaks = find_leaks(&document).expect("fixture must be valid rustdoc-shaped JSON");
+        assert_eq!(
+            leaks,
+            BTreeSet::from([
+                "shelterwood -> tokio::time::Instant".to_owned(),
+                "shelterwood::leak -> tokio::time::Instant".to_owned(),
+            ])
+        );
+    }
+}

--- a/tools/check-runtime-paths.sh
+++ b/tools/check-runtime-paths.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly source_root="crates/shelterwood/src"
+readonly forbidden='\b(tokio|tokio_util|fastrand)::'
+
+set +e
+matches="$({
+  rg --line-number \
+    --glob '*.rs' \
+    --glob '!runtime.rs' \
+    --glob '!runtime/**' \
+    "$forbidden" \
+    "$source_root"
+} 2>&1)"
+status=$?
+set -e
+
+case "$status" in
+  0)
+    echo "runtime or randomness paths found outside the runtime module:" >&2
+    echo "$matches" >&2
+    exit 1
+    ;;
+  1)
+    echo "runtime module path restriction: clean"
+    ;;
+  *)
+    echo "$matches" >&2
+    exit "$status"
+    ;;
+esac


### PR DESCRIPTION
## Summary

- bootstrap the Rust 1.97.1 workspace with the locked 2026-08-06 nightly and nightly Clippy
- add the complete private `runtime` boundary module and shared test-support skeleton
- enforce runtime API isolation through rustdoc JSON reachability and source-path checks
- keep the local specification and implementation-plan documents out of the PR

## Why

Part I implementation needs to begin under the repository, toolchain, and runtime-boundary constraints defined by M0. This change establishes those constraints while the core crate is still intentionally near-empty. API construction and trait shapes will be enforced by the compiler as their real implementations land, without maintaining standalone mock compile probes.

## Impact

The workspace now has a reproducible Nix-backed stable/nightly toolchain, centralized dependencies, shared conformance-test fixtures, and matching fast and clean CI lanes. Runtime-specific paths are confined to the descriptively named private `runtime` module.

## Validation

- `./scripts/dev just ci`
- `./scripts/dev just ci-nix`
- challenged the reachability checker with a temporary public Tokio return type and confirmed that it failed before removing the fixture