### PR TITLE
M7: add incarnation refinements and contramap

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2505,7 +2505,7 @@ the status line in each section is the detailed authority.
 
 | Section | M6 status | Implementation boundary |
 |---|---|---|
-| §15 incarnation refinements | **Accepted / Evidence-gated (M7)** | pinning and next-incarnation wait are accepted; the bounded idempotent-call helper is decided by its M7 re-port |
+| §15 incarnation refinements | **Accepted (M7)** | pinning, next-incarnation wait, and the bounded idempotent-call helper are implemented; the helper's shard-store gate verdict is **build** |
 | §16 keyed conflation | **Accepted (M8)** | keyed latest-wins only; a priority/control lane is evidence-gated to M12 |
 | §17 message mapping | **Accepted (M7) / Evidence-gated** | `contramap` is accepted; `project` waits for the durability consumer |
 | §18 peer monitoring | **Accepted (M8)** | actor, task, and scope memberships through a separate event source |
@@ -2515,14 +2515,24 @@ the status line in each section is the detailed authority.
 | §22 hosting | **Accepted (M11)** | one non-restarting incarnation behind the shared runner |
 | §23 lifetime and timing | **Accepted (M11)** | cross-actor timers, all-of completion, and sibling readiness |
 
+**Evidence-gate ledger.** A verdict changes only when the named artifact is
+ported, and the implementation plus this row change together.
+
+| Gate | Deciding artifact | Verdict |
+|---|---|---|
+| §15 `call_idempotent` | repaired shard-store retry loop re-ported onto the candidate API in M7 | **build** — the synchronous constructor closure carries the operation ledger id without friction; response timeout remains an external reconciliation arm |
+| §17 `project` | provenance-sensitive durability prototype | open; no consumer has yet demonstrated the provenance wall |
+| §16 control/priority lane | M12 trading-engine urgent-control-under-flood port | open |
+
 ## 15. Incarnation refinements
 
-**Status: Accepted / Evidence-gated (M7).** Pinning and the
-next-incarnation awaitable are accepted. The repaired shard-store artifact
-(Appendix C) exercises every retry transition and validates the candidate
-`call_idempotent` shape; M7 decides build-or-omit by re-porting that artifact
-onto the candidate API. No general retry helper and no automatic
-reconciliation are implied.
+**Status: Accepted (M7); `call_idempotent` gate verdict: build.** Pinning and
+the next-incarnation awaitable are implemented. The repaired shard-store
+artifact (Appendix C) was re-ported onto the candidate `call_idempotent` API:
+its synchronous constructor closure carries the durable operation id without
+friction, every retry transition remains observable, and response timeout
+still exits to application reconciliation. No general retry helper and no
+automatic reconciliation are implied.
 
 Core already mints `Incarnation` tokens and carries them in events, errors,
 and snapshots (§3.3) — that was the retrofit-hostile half. This adds the
@@ -2622,12 +2632,15 @@ types verbatim; only the additional B.3 `Superseded` outcome varies.
     an explicit capability proof. Nothing buffers, nothing persists, and
     each individual send remains at-most-once (§1 principle 6); it is not
     durable or at-least-once delivery.
-  - The repaired shard-store loop is the M6 API artifact: one overall
-    `Instant` budget, clamped attempt slices, a provoked restart for
-    `ReplyDropped`, and an accepted request parked past its response slice.
-    Its response-timeout arm consults the durable journal and never resends;
-    a handler-entry counter plus an immediate empty-one-slot mailbox probe
-    proves exactly one acceptance in that arm without adding §20 feature code.
+  - The repaired shard-store loop was the M6 API artifact and its M7 re-port
+    is the adoption verdict: `call_idempotent` now owns the one overall budget,
+    clamped attempt slices, and superseding-incarnation wait. A provoked
+    restart proves `ReplyDropped` retries only on the successor; an accepted
+    request parked past its response slice returns the terminal attempt
+    history to the artifact, whose response-timeout arm consults the durable
+    journal and never resends. A handler-entry counter plus an immediate
+    empty-one-slot mailbox probe proves exactly one acceptance in that arm
+    without adding §20 feature code. **Verdict: build.**
   - Conformance tests (with this feature): a call failing only with
     `ResponseTimedOut` produces exactly one send attempt — the helper
     never resends after acceptance; and a `ReplyDropped` retry lands only
@@ -3953,11 +3966,13 @@ conflation, outlines, metrics) and port in full alongside it.
    mount → readiness → directory cutover → exact-handle retire, with
    idempotent operation ids, compensating cleanup, a durable abort path,
    and post-commit reconciliation. Fault injection covers pre-commit crash
-   and post-commit reply loss. The M6 repair additionally hand-rolls §15's
-   retry table with one overall `Instant` budget and clamped attempt slices:
+   and post-commit reply loss. The M6 repair first hand-rolled §15's retry
+   table; M7 re-ports that loop onto `call_idempotent`, whose policy carries
+   the clamped attempt slice under one overall budget:
    `AcceptanceTimedOut` retries, `ReplyDropped` first observes a strictly
-   superseding live incarnation, and `ResponseTimedOut` reconciles the durable
-   journal without resending. Deterministic gates provoke the restart and park
+   superseding live incarnation, and terminal `ResponseTimedOut` returns to
+   the artifact, which reconciles the durable journal without resending.
+   Deterministic gates provoke the restart and park
    an accepted handler beyond its response slice; a handler-entry counter plus
    an immediate empty-one-slot mailbox probe proves that response timeout
    produced exactly one acceptance. The script proves

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -59,6 +59,10 @@ pub(crate) fn now() -> Instant {
     runtime::now()
 }
 
+pub(crate) fn jitter_sample() -> f64 {
+    runtime::jitter_sample()
+}
+
 pub(crate) struct ActorWork {
     handle: Option<runtime::JoinHandle<(), ()>>,
     abort: runtime::AbortHandle,

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -26,8 +26,10 @@ pub use exit::{
 };
 pub use identity::{Incarnation, Membership};
 pub use mailbox::{
-    ActorRef, CallError, CallErrorKind, CallFuture, Replied, Reply, ReplyError, ReplyReceive,
-    ReplyReceiver, SendError, SendErrorKind, SendFuture, SendTimeout,
+    ActorRef, Attempt, AttemptEnd, CallError, CallErrorKind, CallFuture, IdempotentCallError,
+    IdempotentCallErrorKind, IdempotentCallFuture, NextIncarnation, NextIncarnationError,
+    PinnedRef, Replied, Reply, ReplyError, ReplyReceive, ReplyReceiver, RetryPolicy, SendError,
+    SendErrorKind, SendFuture, SendPayload, SendTimeout,
 };
 pub use observe::{
     ChildSnapshot, ChildState, LIFECYCLE_EVENT_CAPACITY, LifecycleEvent, LifecycleEventKind,
@@ -41,6 +43,7 @@ pub use policy::{
 };
 pub use raw::{
     Blocking, DeadlineElapsed, Guard, RawActor, RawContext, RawDef, RawOnceDef, Rejected,
+    RejectedKind,
 };
 pub use task::{CancellationToken, OneShotTaskRef, TaskContext, TaskDef, TaskOnceDef, TaskRef};
 pub use tree::{

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1814,9 +1814,16 @@ where
                 kind: IdempotentCallErrorKind::BudgetExhausted,
             });
         }
-        let slice = policy.per_attempt.min(remaining);
         let (reply, mut receiver) = Reply::channel();
         let message = make_msg(reply);
+        let remaining = overall_remaining(started, overall_deadline);
+        if remaining.is_zero() {
+            return Err(IdempotentCallError {
+                attempts,
+                kind: IdempotentCallErrorKind::BudgetExhausted,
+            });
+        }
+        let slice = policy.per_attempt.min(remaining);
         let reply = receiver
             .shared
             .take()

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1,5 +1,9 @@
 //! Membership-owned actor mailboxes and request/reply capabilities.
 
+// `SendError<M>` intentionally owns `M`: guaranteed-unaccepted sends must let
+// callers recover arbitrarily sized messages without another allocation.
+#![allow(clippy::result_large_err)]
+
 use std::{
     collections::VecDeque,
     fmt,
@@ -13,7 +17,7 @@ use std::{
 };
 
 use crate::{
-    ChildId, Incarnation, Mailbox, Membership,
+    Backoff, ChildId, Incarnation, Mailbox, Membership, PolicyError,
     driver::{MemberCell, Signal, SignalWatcher},
 };
 
@@ -29,18 +33,58 @@ pub enum SendErrorKind {
     Terminated,
     /// A timed send was withdrawn before acceptance.
     TimedOut,
+    /// An incarnation-pinned ref no longer names the accepting incarnation.
+    Superseded {
+        /// Incarnation the ref was pinned to.
+        pinned: Incarnation,
+        /// Newest currently bound incarnation, when one exists.
+        newest_observed: Option<Incarnation>,
+    },
 }
 
-/// A failed send with its recoverable message and identity evidence.
+/// Payload carried by a failed ingress operation.
+///
+/// Ordinary actor refs always return [`SendPayload::Recovered`]. A
+/// contramapped ref has already consumed its input while applying the mapping
+/// closure and therefore returns [`SendPayload::Projected`].
+#[derive(Eq, PartialEq)]
+pub enum SendPayload<M> {
+    /// The value was not accepted and is recoverable by the caller.
+    Recovered(M),
+    /// The value was consumed by an eager ingress projection.
+    Projected,
+}
+
+impl<M> fmt::Debug for SendPayload<M> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Recovered(_) => formatter.write_str("Recovered(<payload>)"),
+            Self::Projected => formatter.write_str("Projected"),
+        }
+    }
+}
+
+/// A failed send with its payload disposition and identity evidence.
 pub struct SendError<M> {
     /// Target actor id.
     pub actor_id: ChildId,
     /// Incarnation required by the error-kind identity table.
     pub incarnation_observed: Option<Incarnation>,
-    /// Message proven not to have been accepted.
-    pub message: M,
+    /// Disposition of the value submitted at this ingress layer.
+    pub payload: SendPayload<M>,
     /// Failure category.
     pub kind: SendErrorKind,
+}
+
+impl<M> SendError<M> {
+    /// Recovers an unaccepted value from an unmapped ingress layer.
+    #[must_use]
+    pub fn into_message(self) -> Option<M> {
+        match self.payload {
+            SendPayload::Recovered(message) => Some(message),
+            SendPayload::Projected => None,
+        }
+    }
 }
 
 impl<M> fmt::Debug for SendError<M> {
@@ -49,7 +93,7 @@ impl<M> fmt::Debug for SendError<M> {
             .debug_struct("SendError")
             .field("actor_id", &self.actor_id)
             .field("incarnation_observed", &self.incarnation_observed)
-            .field("message", &"<recoverable message>")
+            .field("payload", &self.payload)
             .field("kind", &self.kind)
             .finish()
     }
@@ -70,6 +114,7 @@ impl fmt::Display for SendErrorKind {
             Self::Full => "mailbox is full",
             Self::Terminated => "actor membership is terminal",
             Self::TimedOut => "acceptance deadline elapsed",
+            Self::Superseded { .. } => "pinned actor incarnation was superseded",
         })
     }
 }
@@ -86,6 +131,13 @@ pub enum CallErrorKind {
     ResponseTimedOut,
     /// The accepted request's reply capability was dropped unanswered.
     ReplyDropped,
+    /// An incarnation-pinned ref no longer names the accepting incarnation.
+    Superseded {
+        /// Incarnation the ref was pinned to.
+        pinned: Incarnation,
+        /// Newest currently bound incarnation, when one exists.
+        newest_observed: Option<Incarnation>,
+    },
 }
 
 /// A failed request/reply call with retry-discipline identity evidence.
@@ -122,6 +174,155 @@ impl fmt::Display for CallErrorKind {
             Self::AcceptanceTimedOut => "request acceptance deadline elapsed",
             Self::ResponseTimedOut => "response deadline elapsed after acceptance",
             Self::ReplyDropped => "reply capability was dropped unanswered",
+            Self::Superseded { .. } => "pinned actor incarnation was superseded",
+        })
+    }
+}
+
+fn call_error_kind_from_send(
+    kind: SendErrorKind,
+    pinned: Option<Incarnation>,
+    observed: Option<Incarnation>,
+) -> CallErrorKind {
+    match kind {
+        SendErrorKind::Superseded {
+            pinned,
+            newest_observed,
+        } => CallErrorKind::Superseded {
+            pinned,
+            newest_observed,
+        },
+        SendErrorKind::NotRunning if pinned.is_some() => CallErrorKind::Superseded {
+            pinned: pinned.expect("checked pinned call"),
+            newest_observed: observed,
+        },
+        SendErrorKind::NotRunning
+        | SendErrorKind::Full
+        | SendErrorKind::Terminated
+        | SendErrorKind::TimedOut => CallErrorKind::Terminated,
+    }
+}
+
+/// Failure while awaiting a strictly newer accepting incarnation.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum NextIncarnationError {
+    /// The actor membership terminalized before a newer incarnation ran.
+    Terminated {
+        /// Final incarnation, or `None` when the membership never ran.
+        last: Option<Incarnation>,
+    },
+    /// The deadline elapsed before a newer accepting incarnation ran.
+    TimedOut,
+}
+
+impl fmt::Display for NextIncarnationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Terminated { .. } => "actor membership terminalized",
+            Self::TimedOut => "next-incarnation deadline elapsed",
+        })
+    }
+}
+
+impl std::error::Error for NextIncarnationError {}
+
+/// Validated retry data for [`ActorRef::call_idempotent`].
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct RetryPolicy {
+    per_attempt: Duration,
+    backoff: Backoff,
+}
+
+impl RetryPolicy {
+    /// Constructs a policy with a non-zero per-attempt slice.
+    pub fn new(per_attempt: Duration, backoff: Backoff) -> Result<Self, PolicyError> {
+        if per_attempt.is_zero() {
+            Err(PolicyError::ZeroDuration)
+        } else {
+            Ok(Self {
+                per_attempt,
+                backoff,
+            })
+        }
+    }
+
+    /// Returns the maximum budget for one call attempt.
+    #[must_use]
+    pub const fn per_attempt(self) -> Duration {
+        self.per_attempt
+    }
+
+    /// Returns the delay policy applied after retryable failures.
+    #[must_use]
+    pub const fn backoff(self) -> Backoff {
+        self.backoff
+    }
+}
+
+/// Why one idempotent-call attempt ended.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum AttemptEnd {
+    /// The request was withdrawn before acceptance.
+    AcceptanceTimedOut,
+    /// The accepting incarnation dropped the reply capability.
+    ReplyDropped,
+    /// The request was accepted but its response slice expired.
+    ResponseTimedOut,
+    /// The target membership terminalized before acceptance.
+    Terminated,
+}
+
+/// Identity evidence for one completed idempotent-call attempt.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Attempt {
+    /// Accepting or newest-observed incarnation for this attempt.
+    pub incarnation: Option<Incarnation>,
+    /// Terminal observation for this attempt.
+    pub ended: AttemptEnd,
+}
+
+/// Terminal category for an idempotent call.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum IdempotentCallErrorKind {
+    /// The overall logical-operation budget elapsed.
+    BudgetExhausted,
+    /// An accepted request's response slice elapsed; reconcile, never resend.
+    ResponseTimedOut,
+    /// The actor membership terminalized.
+    Terminated,
+}
+
+/// Terminal idempotent-call failure with complete attempt history.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IdempotentCallError {
+    /// Attempts that actually began, in call order.
+    pub attempts: Vec<Attempt>,
+    /// Terminal category.
+    pub kind: IdempotentCallErrorKind,
+}
+
+impl fmt::Display for IdempotentCallError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "idempotent call failed after {} attempt(s): {}",
+            self.attempts.len(),
+            self.kind
+        )
+    }
+}
+
+impl std::error::Error for IdempotentCallError {}
+
+impl fmt::Display for IdempotentCallErrorKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::BudgetExhausted => "overall deadline elapsed",
+            Self::ResponseTimedOut => "response deadline elapsed after acceptance",
+            Self::Terminated => "actor membership terminalized",
         })
     }
 }
@@ -415,9 +616,10 @@ enum OperationOutcome<M> {
         newest_observed: Option<Incarnation>,
     },
     Accepted(Incarnation),
-    Terminated {
-        message: Option<M>,
-        final_incarnation: Option<Incarnation>,
+    Failed {
+        payload: Option<SendPayload<M>>,
+        observed: Option<Incarnation>,
+        kind: SendErrorKind,
     },
     Withdrawn,
 }
@@ -428,12 +630,14 @@ struct OperationState<M> {
 }
 
 struct SendOperation<M> {
+    pinned: Option<Incarnation>,
     state: Mutex<OperationState<M>>,
 }
 
 impl<M> SendOperation<M> {
-    fn new(message: M) -> Arc<Self> {
+    fn new(message: M, pinned: Option<Incarnation>) -> Arc<Self> {
         Arc::new(Self {
+            pinned,
             state: Mutex::new(OperationState {
                 outcome: OperationOutcome::Waiting {
                     message: Some(message),
@@ -467,22 +671,28 @@ impl<M> SendOperation<M> {
         Some((message, wake))
     }
 
-    fn terminate(&self, final_incarnation: Option<Incarnation>) {
-        let wake = {
+    fn fail(&self, observed: Option<Incarnation>, kind: SendErrorKind) -> Option<Waker> {
+        {
             let mut state = self.state.lock().expect("send operation mutex poisoned");
             let OperationOutcome::Waiting { message, .. } = &mut state.outcome else {
-                return;
+                return None;
             };
-            let message = message.take();
-            state.outcome = OperationOutcome::Terminated {
-                message,
-                final_incarnation,
+            let payload = message.take().map(SendPayload::Recovered);
+            state.outcome = OperationOutcome::Failed {
+                payload,
+                observed,
+                kind,
             };
             state.waker.take()
-        };
-        if let Some(waker) = wake {
-            waker.wake();
         }
+    }
+
+    fn terminate(&self, final_incarnation: Option<Incarnation>) -> Option<Waker> {
+        self.fail(final_incarnation, SendErrorKind::Terminated)
+    }
+
+    fn pinned(&self) -> Option<Incarnation> {
+        self.pinned
     }
 }
 
@@ -582,9 +792,28 @@ impl<M: Send + 'static> MailboxCell<M> {
         match state.status {
             BindingStatus::Terminal(final_incarnation) => {
                 drop(state);
-                operation.terminate(final_incarnation);
+                if let Some(waker) = operation.terminate(final_incarnation) {
+                    waker.wake();
+                }
             }
             BindingStatus::Bound(incarnation) => {
+                if operation
+                    .pinned()
+                    .is_some_and(|pinned| pinned != incarnation)
+                {
+                    let pinned = operation.pinned().expect("checked pinned incarnation");
+                    drop(state);
+                    if let Some(waker) = operation.fail(
+                        Some(incarnation),
+                        SendErrorKind::Superseded {
+                            pinned,
+                            newest_observed: Some(incarnation),
+                        },
+                    ) {
+                        waker.wake();
+                    }
+                    return;
+                }
                 operation.observe(incarnation);
                 let can_accept = match state.kind {
                     Some(MailboxKind::Queue(capacity)) => {
@@ -631,13 +860,47 @@ impl<M: Send + 'static> MailboxCell<M> {
             }
             BindingStatus::Frozen(incarnation) => {
                 operation.observe(incarnation);
-                state.waiters.push_back(Arc::clone(operation));
+                if let Some(pinned) = operation.pinned() {
+                    let kind = if pinned == incarnation {
+                        SendErrorKind::NotRunning
+                    } else {
+                        SendErrorKind::Superseded {
+                            pinned,
+                            newest_observed: Some(incarnation),
+                        }
+                    };
+                    drop(state);
+                    if let Some(waker) = operation.fail(Some(incarnation), kind) {
+                        waker.wake();
+                    }
+                } else {
+                    state.waiters.push_back(Arc::clone(operation));
+                }
             }
-            BindingStatus::Unbound => state.waiters.push_back(Arc::clone(operation)),
+            BindingStatus::Unbound => {
+                if let Some(pinned) = operation.pinned() {
+                    drop(state);
+                    if let Some(waker) = operation.fail(
+                        None,
+                        SendErrorKind::Superseded {
+                            pinned,
+                            newest_observed: None,
+                        },
+                    ) {
+                        waker.wake();
+                    }
+                } else {
+                    state.waiters.push_back(Arc::clone(operation));
+                }
+            }
         }
     }
 
-    fn try_send(&self, message: M) -> Result<Incarnation, SendError<M>> {
+    fn try_send(
+        &self,
+        message: M,
+        pinned: Option<Incarnation>,
+    ) -> Result<Incarnation, SendError<M>> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         match state.status {
             BindingStatus::Terminal(final_incarnation) => {
@@ -645,7 +908,7 @@ impl<M: Send + 'static> MailboxCell<M> {
                 Err(SendError {
                     actor_id: self.actor_id.clone(),
                     incarnation_observed: final_incarnation,
-                    message,
+                    payload: SendPayload::Recovered(message),
                     kind: SendErrorKind::Terminated,
                 })
             }
@@ -654,8 +917,13 @@ impl<M: Send + 'static> MailboxCell<M> {
                 Err(SendError {
                     actor_id: self.actor_id.clone(),
                     incarnation_observed: None,
-                    message,
-                    kind: SendErrorKind::NotRunning,
+                    payload: SendPayload::Recovered(message),
+                    kind: pinned.map_or(SendErrorKind::NotRunning, |pinned| {
+                        SendErrorKind::Superseded {
+                            pinned,
+                            newest_observed: None,
+                        }
+                    }),
                 })
             }
             BindingStatus::Frozen(incarnation) => {
@@ -663,8 +931,29 @@ impl<M: Send + 'static> MailboxCell<M> {
                 Err(SendError {
                     actor_id: self.actor_id.clone(),
                     incarnation_observed: Some(incarnation),
-                    message,
-                    kind: SendErrorKind::NotRunning,
+                    payload: SendPayload::Recovered(message),
+                    kind: match pinned {
+                        Some(pinned) if pinned != incarnation => SendErrorKind::Superseded {
+                            pinned,
+                            newest_observed: Some(incarnation),
+                        },
+                        _ => SendErrorKind::NotRunning,
+                    },
+                })
+            }
+            BindingStatus::Bound(incarnation)
+                if pinned.is_some_and(|pinned| pinned != incarnation) =>
+            {
+                state.sends_rejected = state.sends_rejected.saturating_add(1);
+                let pinned = pinned.expect("checked pinned incarnation");
+                Err(SendError {
+                    actor_id: self.actor_id.clone(),
+                    incarnation_observed: Some(incarnation),
+                    payload: SendPayload::Recovered(message),
+                    kind: SendErrorKind::Superseded {
+                        pinned,
+                        newest_observed: Some(incarnation),
+                    },
                 })
             }
             BindingStatus::Bound(incarnation) => match state.kind {
@@ -675,7 +964,7 @@ impl<M: Send + 'static> MailboxCell<M> {
                     Err(SendError {
                         actor_id: self.actor_id.clone(),
                         incarnation_observed: Some(incarnation),
-                        message,
+                        payload: SendPayload::Recovered(message),
                         kind: SendErrorKind::Full,
                     })
                 }
@@ -710,7 +999,7 @@ impl<M: Send + 'static> MailboxCell<M> {
                     Err(SendError {
                         actor_id: self.actor_id.clone(),
                         incarnation_observed: None,
-                        message,
+                        payload: SendPayload::Recovered(message),
                         kind: SendErrorKind::NotRunning,
                     })
                 }
@@ -768,12 +1057,11 @@ impl<M: Send + 'static> MailboxCell<M> {
         message
     }
 
-    fn current_observation(&self) -> Option<Incarnation> {
+    fn binding_observation(&self) -> BindingObservation {
         match self.state.lock().expect("mailbox mutex poisoned").status {
-            BindingStatus::Bound(incarnation) | BindingStatus::Frozen(incarnation) => {
-                Some(incarnation)
-            }
-            BindingStatus::Unbound | BindingStatus::Terminal(_) => None,
+            BindingStatus::Bound(incarnation) => BindingObservation::Accepting(incarnation),
+            BindingStatus::Unbound | BindingStatus::Frozen(_) => BindingObservation::NotAccepting,
+            BindingStatus::Terminal(last) => BindingObservation::Terminal(last),
         }
     }
 
@@ -818,17 +1106,22 @@ impl<M> MailboxCell<M> {
                     let observed = *newest_observed;
                     state.outcome = OperationOutcome::Withdrawn;
                     state.waker = None;
-                    Withdrawal::Withdrawn { message, observed }
+                    Withdrawal::Withdrawn {
+                        payload: SendPayload::Recovered(message),
+                        observed,
+                    }
                 }
                 OperationOutcome::Accepted(incarnation) => Withdrawal::Accepted(*incarnation),
-                OperationOutcome::Terminated {
-                    message,
-                    final_incarnation,
-                } => Withdrawal::Terminated {
-                    message: message
+                OperationOutcome::Failed {
+                    payload,
+                    observed,
+                    kind,
+                } => Withdrawal::Failed {
+                    payload: payload
                         .take()
-                        .expect("a terminal operation must retain its message"),
-                    observed: *final_incarnation,
+                        .expect("a failed operation must retain its payload"),
+                    observed: *observed,
+                    kind: *kind,
                 },
                 OperationOutcome::Withdrawn => {
                     panic!("a send operation was withdrawn more than once")
@@ -876,8 +1169,23 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         if state.status == BindingStatus::Bound(incarnation) {
             state.status = BindingStatus::Frozen(incarnation);
+            let mut retained = VecDeque::with_capacity(state.waiters.len());
+            let mut wakers = Vec::new();
+            while let Some(waiter) = state.waiters.pop_front() {
+                if waiter.pinned() == Some(incarnation) {
+                    if let Some(waker) = waiter.fail(Some(incarnation), SendErrorKind::NotRunning) {
+                        wakers.push(waker);
+                    }
+                } else {
+                    retained.push_back(waiter);
+                }
+            }
+            state.waiters = retained;
             drop(state);
             self.changed.pulse();
+            for waker in wakers {
+                waker.wake();
+            }
         }
     }
 
@@ -893,8 +1201,29 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         state.status = BindingStatus::Unbound;
         let queue = std::mem::take(&mut state.queue);
         let latest = state.latest.take();
+        let mut retained = VecDeque::with_capacity(state.waiters.len());
+        let mut wakers = Vec::new();
+        while let Some(waiter) = state.waiters.pop_front() {
+            if let Some(pinned) = waiter.pinned() {
+                if let Some(waker) = waiter.fail(
+                    None,
+                    SendErrorKind::Superseded {
+                        pinned,
+                        newest_observed: None,
+                    },
+                ) {
+                    wakers.push(waker);
+                }
+            } else {
+                retained.push_back(waiter);
+            }
+        }
+        state.waiters = retained;
         drop(state);
         self.changed.pulse();
+        for waker in wakers {
+            waker.wake();
+        }
         drop(queue);
         drop(latest);
     }
@@ -910,10 +1239,16 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         let latest = state.latest.take();
         let waiters = std::mem::take(&mut state.waiters);
         drop(state);
+        let mut wakers = Vec::new();
         for waiter in waiters {
-            waiter.terminate(final_incarnation);
+            if let Some(waker) = waiter.terminate(final_incarnation) {
+                wakers.push(waker);
+            }
         }
         self.changed.pulse();
+        for waker in wakers {
+            waker.wake();
+        }
         drop(queue);
         drop(latest);
     }
@@ -940,6 +1275,22 @@ fn promote_waiters<M>(state: &mut MailboxState<M>) -> Promotion<M> {
         let Some(operation) = state.waiters.pop_front() else {
             break;
         };
+        if operation
+            .pinned()
+            .is_some_and(|pinned| pinned != incarnation)
+        {
+            let pinned = operation.pinned().expect("checked pinned incarnation");
+            if let Some(waker) = operation.fail(
+                Some(incarnation),
+                SendErrorKind::Superseded {
+                    pinned,
+                    newest_observed: Some(incarnation),
+                },
+            ) {
+                promotion.wakers.push(waker);
+            }
+            continue;
+        }
         operation.observe(incarnation);
         let Some((message, wake)) = operation.accept(incarnation) else {
             continue;
@@ -971,27 +1322,107 @@ fn promote_waiters<M>(state: &mut MailboxState<M>) -> Promotion<M> {
 
 enum Withdrawal<M> {
     Withdrawn {
-        message: M,
+        payload: SendPayload<M>,
         observed: Option<Incarnation>,
     },
     Accepted(Incarnation),
-    Terminated {
-        message: M,
+    Failed {
+        payload: SendPayload<M>,
         observed: Option<Incarnation>,
+        kind: SendErrorKind,
     },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BindingObservation {
+    Accepting(Incarnation),
+    NotAccepting,
+    Terminal(Option<Incarnation>),
+}
+
+trait SendDriver<M>: Send + Unpin {
+    fn poll_send(
+        self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Result<Incarnation, SendError<M>>>;
+    fn withdraw(&mut self) -> Withdrawal<M>;
+}
+
+trait ActorIngress<M>: Send + Sync {
+    fn start_send(&self, message: M, pinned: Option<Incarnation>) -> SendFuture<M>;
+    fn try_send(
+        &self,
+        message: M,
+        pinned: Option<Incarnation>,
+    ) -> Result<Incarnation, SendError<M>>;
+    fn binding_observation(&self) -> BindingObservation;
+    fn watcher(&self) -> SignalWatcher;
+}
+
+struct MappedIngress<N, M> {
+    outer: ActorRef<M>,
+    wrap: Arc<dyn Fn(N) -> M + Send + Sync + 'static>,
+}
+
+impl<N: Send + 'static, M: Send + 'static> ActorIngress<N> for MappedIngress<N, M> {
+    fn start_send(&self, message: N, pinned: Option<Incarnation>) -> SendFuture<N> {
+        let message = (self.wrap)(message);
+        SendFuture::from_driver(ProjectedSend::<N, M> {
+            outer: self.outer.start_send(message, pinned),
+            marker: std::marker::PhantomData,
+        })
+    }
+
+    fn try_send(
+        &self,
+        message: N,
+        pinned: Option<Incarnation>,
+    ) -> Result<Incarnation, SendError<N>> {
+        let message = (self.wrap)(message);
+        self.outer
+            .try_send_with_pin(message, pinned)
+            .map_err(project_send_error)
+    }
+
+    fn binding_observation(&self) -> BindingObservation {
+        self.outer.binding_observation()
+    }
+
+    fn watcher(&self) -> SignalWatcher {
+        self.outer.binding_watcher()
+    }
+}
+
+fn project_send_error<N, M>(error: SendError<M>) -> SendError<N> {
+    SendError {
+        actor_id: error.actor_id,
+        incarnation_observed: error.incarnation_observed,
+        payload: SendPayload::Projected,
+        kind: error.kind,
+    }
 }
 
 /// A cheap membership-addressed actor handle.
 pub struct ActorRef<M> {
     member: Arc<MemberCell>,
-    mailbox: Arc<MailboxCell<M>>,
+    ingress: Ingress<M>,
+}
+
+enum Ingress<M> {
+    Direct(Arc<MailboxCell<M>>),
+    Mapped(Arc<dyn ActorIngress<M>>),
+}
+
+impl<M> Clone for Ingress<M> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Direct(mailbox) => Self::Direct(Arc::clone(mailbox)),
+            Self::Mapped(ingress) => Self::Mapped(Arc::clone(ingress)),
+        }
+    }
 }
 
 impl<M> ActorRef<M> {
-    pub(crate) fn new(member: Arc<MemberCell>, mailbox: Arc<MailboxCell<M>>) -> Self {
-        Self { member, mailbox }
-    }
-
     /// Returns the actor's child id.
     #[must_use]
     pub fn id(&self) -> &ChildId {
@@ -1006,19 +1437,65 @@ impl<M> ActorRef<M> {
 }
 
 impl<M: Send + 'static> ActorRef<M> {
+    pub(crate) fn new(member: Arc<MemberCell>, mailbox: Arc<MailboxCell<M>>) -> Self {
+        Self {
+            member,
+            ingress: Ingress::Direct(mailbox),
+        }
+    }
+
+    fn start_send(&self, message: M, pinned: Option<Incarnation>) -> SendFuture<M> {
+        match &self.ingress {
+            Ingress::Direct(mailbox) => SendFuture::from_direct(DirectSend {
+                actor_id: self.id().clone(),
+                mailbox: Arc::clone(mailbox),
+                operation: SendOperation::new(message, pinned),
+                submitted: false,
+                done: false,
+            }),
+            Ingress::Mapped(ingress) => ingress.start_send(message, pinned),
+        }
+    }
+
+    fn try_send_with_pin(
+        &self,
+        message: M,
+        pinned: Option<Incarnation>,
+    ) -> Result<Incarnation, SendError<M>> {
+        match &self.ingress {
+            Ingress::Direct(mailbox) => mailbox.try_send(message, pinned),
+            Ingress::Mapped(ingress) => ingress.try_send(message, pinned),
+        }
+    }
+
+    fn binding_observation(&self) -> BindingObservation {
+        match &self.ingress {
+            Ingress::Direct(mailbox) => mailbox.binding_observation(),
+            Ingress::Mapped(ingress) => ingress.binding_observation(),
+        }
+    }
+
+    fn binding_watcher(&self) -> SignalWatcher {
+        match &self.ingress {
+            Ingress::Direct(mailbox) => mailbox.watcher(),
+            Ingress::Mapped(ingress) => ingress.watcher(),
+        }
+    }
+
     /// Sends with backpressure and transparently waits through rebind windows.
     pub fn send(&self, message: M) -> SendFuture<M> {
-        SendFuture::new(self.clone(), message)
+        self.start_send(message, None)
     }
 
     /// Attempts immediate acceptance without parking.
     pub fn try_send(&self, message: M) -> Result<Incarnation, SendError<M>> {
-        self.mailbox.try_send(message)
+        self.try_send_with_pin(message, None)
     }
 
     /// Sends within one acceptance budget, recovering an unaccepted message.
     pub fn send_timeout(&self, message: M, deadline: Duration) -> SendTimeout<M> {
         SendTimeout {
+            actor: self.clone(),
             send: Some(self.send(message)),
             deadline,
             timer: None,
@@ -1048,7 +1525,10 @@ impl<M: Send + 'static> ActorRef<M> {
     ) -> CallFuture<M, T> {
         CallFuture {
             actor: self.clone(),
+            pinned: None,
             make_msg: Some(Box::new(make_msg)),
+            prepared_message: None,
+            prepared_reply: None,
             deadline,
             timer: None,
             send: None,
@@ -1058,13 +1538,91 @@ impl<M: Send + 'static> ActorRef<M> {
             done: false,
         }
     }
+
+    /// Waits for an acceptance-open incarnation strictly newer than `after`.
+    pub fn next_incarnation(&self, after: Incarnation, deadline: Duration) -> NextIncarnation {
+        let actor = self.clone();
+        let mut watcher = actor.binding_watcher();
+        NextIncarnation {
+            inner: Box::pin(async move {
+                if deadline.is_zero() {
+                    return Err(NextIncarnationError::TimedOut);
+                }
+                let wait = async {
+                    loop {
+                        match actor.binding_observation() {
+                            BindingObservation::Accepting(current) if current.supersedes(after) => {
+                                return Ok(current);
+                            }
+                            BindingObservation::Terminal(last) => {
+                                return Err(NextIncarnationError::Terminated { last });
+                            }
+                            BindingObservation::Accepting(_) | BindingObservation::NotAccepting => {
+                                watcher.changed().await
+                            }
+                        }
+                    }
+                };
+                match crate::driver::select(wait, crate::driver::sleep(deadline)).await {
+                    crate::driver::Selected::First(result) => result,
+                    crate::driver::Selected::Second(()) => Err(NextIncarnationError::TimedOut),
+                }
+            }),
+        }
+    }
+
+    /// Repeats an explicitly idempotent call under one overall deadline.
+    ///
+    /// Only guaranteed-unaccepted attempts and reply loss followed by a
+    /// strictly newer accepting incarnation retry. A response timeout or
+    /// terminal membership returns immediately with attempt history.
+    pub fn call_idempotent<T: Send + 'static>(
+        &self,
+        make_msg: impl Fn(Reply<T>) -> M + Send + 'static,
+        policy: RetryPolicy,
+        overall_deadline: Duration,
+    ) -> IdempotentCallFuture<T> {
+        IdempotentCallFuture {
+            inner: Box::pin(run_idempotent_call(
+                self.clone(),
+                make_msg,
+                policy,
+                overall_deadline,
+            )),
+        }
+    }
+
+    /// Creates a ref that accepts an input type mapped into this actor's
+    /// message type on the sender's ingress path.
+    pub fn contramap<N: Send + 'static>(
+        &self,
+        wrap: impl Fn(N) -> M + Send + Sync + 'static,
+    ) -> ActorRef<N> {
+        let ingress: Arc<dyn ActorIngress<N>> = Arc::new(MappedIngress {
+            outer: self.clone(),
+            wrap: Arc::new(wrap),
+        });
+        ActorRef {
+            member: Arc::clone(&self.member),
+            ingress: Ingress::Mapped(ingress),
+        }
+    }
+
+    /// Pins this membership-addressed ref to one exact incarnation.
+    #[must_use]
+    pub fn pinned(&self, incarnation: Incarnation) -> PinnedRef<M> {
+        PinnedRef {
+            actor: self.clone(),
+            incarnation,
+        }
+    }
 }
 
 impl<M> Clone for ActorRef<M> {
     fn clone(&self) -> Self {
         Self {
             member: Arc::clone(&self.member),
-            mailbox: Arc::clone(&self.mailbox),
+            ingress: self.ingress.clone(),
         }
     }
 }
@@ -1092,27 +1650,318 @@ impl<M> Hash for ActorRef<M> {
     }
 }
 
+/// A cheap actor handle constrained to one exact incarnation.
+pub struct PinnedRef<M> {
+    actor: ActorRef<M>,
+    incarnation: Incarnation,
+}
+
+impl<M: Send + 'static> PinnedRef<M> {
+    /// Returns the actor's child id.
+    #[must_use]
+    pub fn id(&self) -> &ChildId {
+        self.actor.id()
+    }
+
+    /// Returns the actor membership identity.
+    #[must_use]
+    pub fn membership(&self) -> Membership {
+        self.actor.membership()
+    }
+
+    /// Returns the incarnation this ref is constrained to.
+    #[must_use]
+    pub fn incarnation(&self) -> Incarnation {
+        self.incarnation
+    }
+
+    /// Recovers the membership-addressed actor ref.
+    #[must_use]
+    pub fn unpinned(&self) -> ActorRef<M> {
+        self.actor.clone()
+    }
+
+    /// Sends with backpressure only while this incarnation remains current.
+    pub fn send(&self, message: M) -> SendFuture<M> {
+        self.actor.start_send(message, Some(self.incarnation))
+    }
+
+    /// Attempts immediate acceptance by this exact incarnation.
+    pub fn try_send(&self, message: M) -> Result<Incarnation, SendError<M>> {
+        self.actor
+            .try_send_with_pin(message, Some(self.incarnation))
+    }
+
+    /// Sends within one acceptance budget without riding through a rebind.
+    pub fn send_timeout(&self, message: M, deadline: Duration) -> SendTimeout<M> {
+        SendTimeout {
+            actor: self.actor.clone(),
+            send: Some(self.send(message)),
+            deadline,
+            timer: None,
+            started: false,
+            done: false,
+        }
+    }
+
+    /// Calls this exact incarnation within one acceptance-and-response budget.
+    pub fn call<T: Send + 'static>(
+        &self,
+        make_msg: impl FnOnce(Reply<T>) -> M + Send + 'static,
+        deadline: Duration,
+    ) -> CallFuture<M, T> {
+        CallFuture {
+            actor: self.actor.clone(),
+            pinned: Some(self.incarnation),
+            make_msg: Some(Box::new(make_msg)),
+            prepared_message: None,
+            prepared_reply: None,
+            deadline,
+            timer: None,
+            send: None,
+            reply: None,
+            accepted: None,
+            started: false,
+            done: false,
+        }
+    }
+}
+
+impl<M> Clone for PinnedRef<M> {
+    fn clone(&self) -> Self {
+        Self {
+            actor: self.actor.clone(),
+            incarnation: self.incarnation,
+        }
+    }
+}
+
+impl<M> fmt::Debug for PinnedRef<M> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PinnedRef")
+            .field("membership", &self.actor.membership())
+            .field("incarnation", &self.incarnation)
+            .finish()
+    }
+}
+
+/// Future returned by [`ActorRef::next_incarnation`].
+#[must_use]
+pub struct NextIncarnation {
+    inner:
+        Pin<Box<dyn Future<Output = Result<Incarnation, NextIncarnationError>> + Send + 'static>>,
+}
+
+impl fmt::Debug for NextIncarnation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NextIncarnation")
+            .finish_non_exhaustive()
+    }
+}
+
+impl Future for NextIncarnation {
+    type Output = Result<Incarnation, NextIncarnationError>;
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(context)
+    }
+}
+
+/// Future returned by [`ActorRef::call_idempotent`].
+#[must_use]
+pub struct IdempotentCallFuture<T> {
+    inner: Pin<Box<dyn Future<Output = Result<Replied<T>, IdempotentCallError>> + Send + 'static>>,
+}
+
+impl<T> fmt::Debug for IdempotentCallFuture<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IdempotentCallFuture")
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> Future for IdempotentCallFuture<T> {
+    type Output = Result<Replied<T>, IdempotentCallError>;
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(context)
+    }
+}
+
+async fn run_idempotent_call<M, T, F>(
+    actor: ActorRef<M>,
+    make_msg: F,
+    policy: RetryPolicy,
+    overall_deadline: Duration,
+) -> Result<Replied<T>, IdempotentCallError>
+where
+    M: Send + 'static,
+    T: Send + 'static,
+    F: Fn(Reply<T>) -> M + Send + 'static,
+{
+    let started = crate::driver::now();
+    let mut attempts = Vec::new();
+    let mut retry_number = 0u64;
+
+    loop {
+        let remaining = overall_remaining(started, overall_deadline);
+        if remaining.is_zero() {
+            return Err(IdempotentCallError {
+                attempts,
+                kind: IdempotentCallErrorKind::BudgetExhausted,
+            });
+        }
+        let slice = policy.per_attempt.min(remaining);
+        let (reply, mut receiver) = Reply::channel();
+        let message = make_msg(reply);
+        let reply = receiver
+            .shared
+            .take()
+            .expect("a fresh reply receiver owns its shared state");
+        let result = CallFuture::prepared(actor.clone(), message, reply, slice).await;
+        match result {
+            Ok(replied) => return Ok(replied),
+            Err(error) => match error.kind {
+                CallErrorKind::AcceptanceTimedOut => {
+                    attempts.push(Attempt {
+                        incarnation: error.incarnation_observed,
+                        ended: AttemptEnd::AcceptanceTimedOut,
+                    });
+                }
+                CallErrorKind::ReplyDropped => {
+                    let accepting = error
+                        .incarnation_observed
+                        .expect("reply loss carries the accepting incarnation");
+                    attempts.push(Attempt {
+                        incarnation: Some(accepting),
+                        ended: AttemptEnd::ReplyDropped,
+                    });
+                    let remaining = overall_remaining(started, overall_deadline);
+                    if remaining.is_zero() {
+                        return Err(IdempotentCallError {
+                            attempts,
+                            kind: IdempotentCallErrorKind::BudgetExhausted,
+                        });
+                    }
+                    match actor.next_incarnation(accepting, remaining).await {
+                        Ok(_) => {}
+                        Err(NextIncarnationError::TimedOut) => {
+                            return Err(IdempotentCallError {
+                                attempts,
+                                kind: IdempotentCallErrorKind::BudgetExhausted,
+                            });
+                        }
+                        Err(NextIncarnationError::Terminated { .. }) => {
+                            return Err(IdempotentCallError {
+                                attempts,
+                                kind: IdempotentCallErrorKind::Terminated,
+                            });
+                        }
+                    }
+                }
+                CallErrorKind::ResponseTimedOut => {
+                    attempts.push(Attempt {
+                        incarnation: error.incarnation_observed,
+                        ended: AttemptEnd::ResponseTimedOut,
+                    });
+                    return Err(IdempotentCallError {
+                        attempts,
+                        kind: IdempotentCallErrorKind::ResponseTimedOut,
+                    });
+                }
+                CallErrorKind::Terminated => {
+                    attempts.push(Attempt {
+                        incarnation: error.incarnation_observed,
+                        ended: AttemptEnd::Terminated,
+                    });
+                    return Err(IdempotentCallError {
+                        attempts,
+                        kind: IdempotentCallErrorKind::Terminated,
+                    });
+                }
+                CallErrorKind::Superseded { .. } => {
+                    unreachable!("membership-addressed idempotent calls are never pinned")
+                }
+            },
+        }
+
+        retry_number = retry_number.saturating_add(1);
+        let delay = policy
+            .backoff
+            .next_delay(retry_number, crate::driver::jitter_sample());
+        let remaining = overall_remaining(started, overall_deadline);
+        if remaining.is_zero() {
+            return Err(IdempotentCallError {
+                attempts,
+                kind: IdempotentCallErrorKind::BudgetExhausted,
+            });
+        }
+        if !delay.is_zero() {
+            crate::driver::sleep(delay.min(remaining)).await;
+            if delay >= remaining {
+                return Err(IdempotentCallError {
+                    attempts,
+                    kind: IdempotentCallErrorKind::BudgetExhausted,
+                });
+            }
+        }
+    }
+}
+
+fn overall_remaining(started: std::time::Instant, overall: Duration) -> Duration {
+    overall.saturating_sub(crate::driver::now().saturating_duration_since(started))
+}
+
 /// Cancellation-safe future returned by [`ActorRef::send`].
 #[must_use]
 pub struct SendFuture<M> {
-    actor: ActorRef<M>,
-    operation: Arc<SendOperation<M>>,
-    submitted: bool,
+    inner: SendFutureInner<M>,
     done: bool,
 }
 
-impl<M: Send + 'static> SendFuture<M> {
-    fn new(actor: ActorRef<M>, message: M) -> Self {
+enum SendFutureInner<M> {
+    Direct(DirectSend<M>),
+    Mapped(Pin<Box<dyn SendDriver<M>>>),
+}
+
+impl<M> SendFuture<M> {
+    fn from_direct(driver: DirectSend<M>) -> Self {
         Self {
-            actor,
-            operation: SendOperation::new(message),
-            submitted: false,
+            inner: SendFutureInner::Direct(driver),
+            done: false,
+        }
+    }
+
+    fn from_driver(driver: impl SendDriver<M> + 'static) -> Self {
+        Self {
+            inner: SendFutureInner::Mapped(Box::pin(driver)),
             done: false,
         }
     }
 
     fn withdraw(&mut self) -> Withdrawal<M> {
-        let result = self.actor.mailbox.withdraw(&self.operation);
+        self.done = true;
+        match &mut self.inner {
+            SendFutureInner::Direct(driver) => driver.withdraw_inner(),
+            SendFutureInner::Mapped(driver) => driver.as_mut().get_mut().withdraw(),
+        }
+    }
+}
+
+struct DirectSend<M> {
+    actor_id: ChildId,
+    mailbox: Arc<MailboxCell<M>>,
+    operation: Arc<SendOperation<M>>,
+    submitted: bool,
+    done: bool,
+}
+
+impl<M> DirectSend<M> {
+    fn withdraw_inner(&mut self) -> Withdrawal<M> {
+        let result = self.mailbox.withdraw(&self.operation);
         self.done = true;
         result
     }
@@ -1122,7 +1971,6 @@ impl<M> fmt::Debug for SendFuture<M> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("SendFuture")
-            .field("submitted", &self.submitted)
             .field("done", &self.done)
             .finish_non_exhaustive()
     }
@@ -1132,9 +1980,25 @@ impl<M: Send + 'static> Future for SendFuture<M> {
     type Output = Result<Incarnation, SendError<M>>;
 
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        let result = match &mut self.inner {
+            SendFutureInner::Direct(driver) => Pin::new(driver).poll_send(context),
+            SendFutureInner::Mapped(driver) => driver.as_mut().poll_send(context),
+        };
+        if result.is_ready() {
+            self.done = true;
+        }
+        result
+    }
+}
+
+impl<M: Send + 'static> SendDriver<M> for DirectSend<M> {
+    fn poll_send(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Result<Incarnation, SendError<M>>> {
         if !self.submitted {
             self.submitted = true;
-            self.actor.mailbox.submit(&self.operation);
+            self.mailbox.submit(&self.operation);
         }
         let mut state = self
             .operation
@@ -1148,17 +2012,18 @@ impl<M: Send + 'static> Future for SendFuture<M> {
                 self.done = true;
                 Poll::Ready(Ok(incarnation))
             }
-            OperationOutcome::Terminated {
-                message,
-                final_incarnation,
+            OperationOutcome::Failed {
+                payload,
+                observed,
+                kind,
             } => {
                 let error = SendError {
-                    actor_id: self.actor.id().clone(),
-                    incarnation_observed: *final_incarnation,
-                    message: message
+                    actor_id: self.actor_id.clone(),
+                    incarnation_observed: *observed,
+                    payload: payload
                         .take()
-                        .expect("a terminal operation retains its message until observed"),
-                    kind: SendErrorKind::Terminated,
+                        .expect("a failed operation retains its payload until observed"),
+                    kind: *kind,
                 };
                 drop(state);
                 self.done = true;
@@ -1171,12 +2036,51 @@ impl<M: Send + 'static> Future for SendFuture<M> {
             OperationOutcome::Withdrawn => panic!("a withdrawn send future was polled"),
         }
     }
+
+    fn withdraw(&mut self) -> Withdrawal<M> {
+        self.withdraw_inner()
+    }
 }
 
 impl<M> Drop for SendFuture<M> {
     fn drop(&mut self) {
         if !self.done {
-            let _ = self.actor.mailbox.withdraw(&self.operation);
+            let _ = match &mut self.inner {
+                SendFutureInner::Direct(driver) => driver.withdraw_inner(),
+                SendFutureInner::Mapped(driver) => driver.as_mut().get_mut().withdraw(),
+            };
+        }
+    }
+}
+
+struct ProjectedSend<N, M> {
+    outer: SendFuture<M>,
+    marker: std::marker::PhantomData<fn(N)>,
+}
+
+impl<N: Send + 'static, M: Send + 'static> SendDriver<N> for ProjectedSend<N, M> {
+    fn poll_send(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Result<Incarnation, SendError<N>>> {
+        match Pin::new(&mut self.outer).poll(context) {
+            Poll::Ready(result) => Poll::Ready(result.map_err(project_send_error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn withdraw(&mut self) -> Withdrawal<N> {
+        match self.outer.withdraw() {
+            Withdrawal::Withdrawn { observed, .. } => Withdrawal::Withdrawn {
+                payload: SendPayload::Projected,
+                observed,
+            },
+            Withdrawal::Accepted(incarnation) => Withdrawal::Accepted(incarnation),
+            Withdrawal::Failed { observed, kind, .. } => Withdrawal::Failed {
+                payload: SendPayload::Projected,
+                observed,
+                kind,
+            },
         }
     }
 }
@@ -1184,6 +2088,7 @@ impl<M> Drop for SendFuture<M> {
 /// Cancellation-safe future returned by [`ActorRef::send_timeout`].
 #[must_use]
 pub struct SendTimeout<M> {
+    actor: ActorRef<M>,
     send: Option<SendFuture<M>>,
     deadline: Duration,
     timer: Option<crate::driver::DriverSleep>,
@@ -1208,33 +2113,24 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
         if !self.started {
             self.started = true;
             if self.deadline.is_zero() {
-                let actor_id = self
-                    .send
-                    .as_ref()
-                    .expect("pending timed send retains send")
-                    .actor
-                    .id()
-                    .clone();
-                let current = self
-                    .send
-                    .as_ref()
-                    .expect("pending timed send retains send")
-                    .actor
-                    .mailbox
-                    .current_observation();
+                let actor_id = self.actor.id().clone();
+                let current = match self.actor.binding_observation() {
+                    BindingObservation::Accepting(incarnation) => Some(incarnation),
+                    BindingObservation::NotAccepting | BindingObservation::Terminal(_) => None,
+                };
                 let withdrawal = self
                     .send
                     .as_mut()
                     .expect("pending timed send retains send")
                     .withdraw();
-                let Withdrawal::Withdrawn { message, observed } = withdrawal else {
+                let Withdrawal::Withdrawn { payload, observed } = withdrawal else {
                     unreachable!("an unpolled send cannot already be accepted")
                 };
                 self.done = true;
                 return Poll::Ready(Err(SendError {
                     actor_id,
                     incarnation_observed: observed.or(current),
-                    message,
+                    payload,
                     kind: SendErrorKind::TimedOut,
                 }));
             }
@@ -1253,15 +2149,15 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
             .poll(context)
             .is_ready()
         {
+            let actor_id = self.actor.id().clone();
             let send = self.send.as_mut().expect("pending timed send retains send");
-            let actor_id = send.actor.id().clone();
             match send.withdraw() {
-                Withdrawal::Withdrawn { message, observed } => {
+                Withdrawal::Withdrawn { payload, observed } => {
                     self.done = true;
                     Poll::Ready(Err(SendError {
                         actor_id,
                         incarnation_observed: observed,
-                        message,
+                        payload,
                         kind: SendErrorKind::TimedOut,
                     }))
                 }
@@ -1269,13 +2165,17 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
                     self.done = true;
                     Poll::Ready(Ok(incarnation))
                 }
-                Withdrawal::Terminated { message, observed } => {
+                Withdrawal::Failed {
+                    payload,
+                    observed,
+                    kind,
+                } => {
                     self.done = true;
                     Poll::Ready(Err(SendError {
                         actor_id,
                         incarnation_observed: observed,
-                        message,
-                        kind: SendErrorKind::Terminated,
+                        payload,
+                        kind,
                     }))
                 }
             }
@@ -1289,7 +2189,10 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
 #[must_use]
 pub struct CallFuture<M, T> {
     actor: ActorRef<M>,
+    pinned: Option<Incarnation>,
     make_msg: Option<Box<dyn FnOnce(Reply<T>) -> M + Send + 'static>>,
+    prepared_message: Option<M>,
+    prepared_reply: Option<Arc<ReplyShared<T>>>,
     deadline: Duration,
     timer: Option<crate::driver::DriverSleep>,
     send: Option<SendFuture<M>>,
@@ -1297,6 +2200,32 @@ pub struct CallFuture<M, T> {
     accepted: Option<Incarnation>,
     started: bool,
     done: bool,
+}
+
+impl<M, T> Unpin for CallFuture<M, T> {}
+
+impl<M: Send + 'static, T: Send + 'static> CallFuture<M, T> {
+    fn prepared(
+        actor: ActorRef<M>,
+        message: M,
+        reply: Arc<ReplyShared<T>>,
+        deadline: Duration,
+    ) -> Self {
+        Self {
+            actor,
+            pinned: None,
+            make_msg: None,
+            prepared_message: Some(message),
+            prepared_reply: Some(reply),
+            deadline,
+            timer: None,
+            send: None,
+            reply: None,
+            accepted: None,
+            started: false,
+            done: false,
+        }
+    }
 }
 
 impl<M, T> fmt::Debug for CallFuture<M, T> {
@@ -1320,17 +2249,28 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
                 self.done = true;
                 return Poll::Ready(Err(CallError {
                     actor_id: self.actor.id().clone(),
-                    incarnation_observed: self.actor.mailbox.current_observation(),
+                    incarnation_observed: match self.actor.binding_observation() {
+                        BindingObservation::Accepting(incarnation) => Some(incarnation),
+                        BindingObservation::NotAccepting | BindingObservation::Terminal(_) => None,
+                    },
                     kind: CallErrorKind::AcceptanceTimedOut,
                 }));
             }
-            let (reply, mut receiver) = Reply::channel();
-            let message =
-                self.make_msg
+            let message = if let Some(message) = self.prepared_message.take() {
+                self.reply = self.prepared_reply.take();
+                message
+            } else {
+                let (reply, mut receiver) = Reply::channel();
+                let message = self
+                    .make_msg
                     .take()
-                    .expect("unstarted call retains its message constructor")(reply);
-            self.reply = receiver.shared.take();
-            self.send = Some(self.actor.send(message));
+                    .expect("unstarted call retains its message constructor")(
+                    reply
+                );
+                self.reply = receiver.shared.take();
+                message
+            };
+            self.send = Some(self.actor.start_send(message, self.pinned));
             self.timer = Some(crate::driver::sleep(self.deadline));
         }
 
@@ -1352,7 +2292,11 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
                     return Poll::Ready(Err(CallError {
                         actor_id: error.actor_id,
                         incarnation_observed: error.incarnation_observed,
-                        kind: CallErrorKind::Terminated,
+                        kind: call_error_kind_from_send(
+                            error.kind,
+                            self.pinned,
+                            error.incarnation_observed,
+                        ),
                     }));
                 }
                 Poll::Pending => {}
@@ -1465,10 +2409,10 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
                         kind: CallErrorKind::ResponseTimedOut,
                     }
                 }
-                Withdrawal::Terminated { observed, .. } => CallError {
+                Withdrawal::Failed { observed, kind, .. } => CallError {
                     actor_id,
                     incarnation_observed: observed,
-                    kind: CallErrorKind::Terminated,
+                    kind: call_error_kind_from_send(kind, self.pinned, observed),
                 },
             };
             if let Some(reply) = &self.reply {

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -15,7 +15,8 @@ use std::{
 
 use crate::{
     ActorRef, CancellationToken, ChildId, ExitResult, Incarnation, Mailbox, MailboxShutdown,
-    PolicyError, Readiness, ReadinessDeadline, RestartPolicy, Retention, ScopeRef, Shutdown,
+    PolicyError, Readiness, ReadinessDeadline, RestartPolicy, Retention, ScopeRef, SendPayload,
+    Shutdown,
     driver::{ActorWork, Latch, Signal, SignalWatcher},
     mailbox::{MailboxCell, MailboxControl, MailboxReceiver},
     policy::CommonOptions,
@@ -30,10 +31,21 @@ type SharedWork = Arc<Mutex<Option<Pin<Box<dyn Future<Output = ()> + Send + 'sta
 #[error("the offload deadline elapsed")]
 pub struct DeadlineElapsed;
 
-/// An operation rejected because the actor incarnation is already stopping.
+/// The kind of a rejected actor-context operation.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum RejectedKind {
+    /// The actor incarnation is already draining or stopping.
+    Draining,
+}
+
+/// An operation rejected by the actor's current callback stage.
 #[derive(Eq, PartialEq)]
 pub struct Rejected<T> {
-    payload: T,
+    /// Disposition of the rejected operation payload.
+    pub payload: SendPayload<T>,
+    /// Rejection category.
+    pub kind: RejectedKind,
 }
 
 impl<T> fmt::Debug for Rejected<T> {
@@ -44,13 +56,19 @@ impl<T> fmt::Debug for Rejected<T> {
 
 impl<T> Rejected<T> {
     pub(crate) fn new(payload: T) -> Self {
-        Self { payload }
+        Self {
+            payload: SendPayload::Recovered(payload),
+            kind: RejectedKind::Draining,
+        }
     }
 
     /// Recovers the operation payload that was never accepted.
     #[must_use]
-    pub fn into_inner(self) -> T {
-        self.payload
+    pub fn into_payload(self) -> Option<T> {
+        match self.payload {
+            SendPayload::Recovered(payload) => Some(payload),
+            SendPayload::Projected => None,
+        }
     }
 }
 

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -29,6 +29,10 @@ pub(crate) fn now() -> std::time::Instant {
     time::Instant::now().into_std()
 }
 
+pub(crate) fn jitter_sample() -> f64 {
+    fastrand::f64()
+}
+
 pub(crate) fn is_available() -> bool {
     tokio::runtime::Handle::try_current().is_ok()
 }

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -174,7 +174,10 @@ async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction
             || calls.load(Ordering::SeqCst) != 0
     })
     .await;
-    assert!(matches!(timed.message, Message::Value(2)));
+    let timed_message = timed
+        .into_message()
+        .expect("unmapped timed send recovers message");
+    assert!(matches!(timed_message, Message::Value(2)));
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -219,7 +222,11 @@ async fn preacceptance_expiry_and_terminality_follow_the_identity_table() {
 
     drop(tree);
     let terminal_send = actor
-        .send(timed.message)
+        .send(
+            timed
+                .into_message()
+                .expect("unmapped send recovers message"),
+        )
         .await
         .expect_err("never-started actor is terminal");
     assert_eq!(terminal_send.kind, SendErrorKind::Terminated);

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -55,12 +55,15 @@ impl Actor for DrainActor {
                     let continuation = context
                         .continue_with(Message::Deferred)
                         .expect_err("drain rejects continuations");
-                    assert!(matches!(continuation.into_inner(), Message::Deferred));
+                    assert!(matches!(
+                        continuation.into_payload(),
+                        Some(Message::Deferred)
+                    ));
 
                     let timer = context
                         .set_timeout("timer", Message::Timer, Duration::ZERO)
                         .expect_err("drain rejects timers");
-                    assert!(matches!(timer.into_inner().1, Message::Timer));
+                    assert!(matches!(timer.into_payload(), Some((_, Message::Timer))));
 
                     let ran = Arc::clone(&self.0.deferred_ran);
                     let offload = context

--- a/crates/shelterwood/tests/m7.rs
+++ b/crates/shelterwood/tests/m7.rs
@@ -428,6 +428,50 @@ async fn idempotent_reply_drop_retries_only_on_a_superseding_incarnation() {
         .expect("reply-drop actor stops");
 }
 
+#[tokio::test]
+async fn idempotent_constructor_time_cannot_extend_the_overall_budget() {
+    let gate = ReleaseGate::default();
+    gate.release();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "constructor-budget",
+            RawOnceDef::new(MappingActor {
+                gate,
+                values: Arc::new(Mutex::new(Vec::new())),
+            }),
+        )
+        .expect("valid constructor-budget actor");
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("constructor-budget actor starts");
+
+    let error = actor
+        .call_idempotent(
+            |reply| {
+                std::thread::sleep(Duration::from_millis(20));
+                MappingMessage::Ask(1, reply)
+            },
+            RetryPolicy::new(Duration::from_secs(1), Backoff::Immediate)
+                .expect("valid retry policy"),
+            Duration::from_millis(1),
+        )
+        .await
+        .expect_err("message construction cannot create time beyond the overall budget");
+    assert_eq!(error.kind, IdempotentCallErrorKind::BudgetExhausted);
+    assert!(
+        error.attempts.is_empty(),
+        "no request reached actor ingress"
+    );
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("constructor-budget actor stops");
+}
+
 enum SliceMessage {
     Fill,
     Ask(Reply<usize>),

--- a/crates/shelterwood/tests/m7.rs
+++ b/crates/shelterwood/tests/m7.rs
@@ -1,0 +1,591 @@
+use std::{
+    cell::Cell,
+    panic::AssertUnwindSafe,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use shelterwood::{
+    ActorRef, AttemptEnd, Backoff, ExitError, ExitResult, IdempotentCallErrorKind,
+    IdempotentCallFuture, Mailbox, NextIncarnation, NextIncarnationError, PinnedRef, RawActor,
+    RawContext, RawDef, RawOnceDef, Reply, RetryPolicy, SendErrorKind, SendPayload, Tree,
+};
+use shelterwood_test_support::{ReleaseGate, advance_time, poll_until};
+
+enum MappingMessage {
+    Value(u32),
+    Ask(u32, Reply<u32>),
+}
+
+struct MappingActor {
+    gate: ReleaseGate,
+    values: Arc<Mutex<Vec<u32>>>,
+}
+
+fn assert_clone_send_sync<T: Clone + Send + Sync>() {}
+fn assert_send<T: Send>() {}
+
+#[test]
+fn m7_public_handles_and_futures_obey_the_trait_matrix() {
+    assert_clone_send_sync::<ActorRef<u32>>();
+    assert_clone_send_sync::<PinnedRef<u32>>();
+    assert_send::<NextIncarnation>();
+    assert_send::<IdempotentCallFuture<u32>>();
+}
+
+impl RawActor for MappingActor {
+    type Msg = MappingMessage;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        self.gate.wait().await;
+        while let Some(message) = context.recv().await {
+            match message {
+                MappingMessage::Value(value) => self
+                    .values
+                    .lock()
+                    .expect("mapping values mutex poisoned")
+                    .push(value),
+                MappingMessage::Ask(value, reply) => reply.send(value * 2),
+            }
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn contramap_shares_identity_mailbox_and_projected_error_model() {
+    let gate = ReleaseGate::default();
+    let values = Arc::new(Mutex::new(Vec::new()));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "mapped",
+            RawOnceDef::new(MappingActor {
+                gate: gate.clone(),
+                values: Arc::clone(&values),
+            })
+            .mailbox(Mailbox::latest()),
+        )
+        .expect("valid mapped actor");
+    let first_hops = Arc::new(AtomicUsize::new(0));
+    let second_hops = Arc::new(AtomicUsize::new(0));
+    let numbers = actor.contramap({
+        let first_hops = Arc::clone(&first_hops);
+        move |value: u32| {
+            first_hops.fetch_add(1, Ordering::SeqCst);
+            MappingMessage::Value(value)
+        }
+    });
+    let strings = numbers.contramap({
+        let second_hops = Arc::clone(&second_hops);
+        move |value: String| {
+            second_hops.fetch_add(1, Ordering::SeqCst);
+            value.parse::<u32>().expect("test value is numeric")
+        }
+    });
+
+    assert_eq!(strings.id(), actor.id());
+    assert_eq!(strings.membership(), actor.membership());
+    let panicking = actor.contramap(|_: &'static str| -> MappingMessage {
+        panic!("mapping panic stays on the sender stack")
+    });
+    let panic = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let _ = panicking.try_send("boom");
+    }));
+    assert!(panic.is_err());
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("mapped actor starts");
+    assert_eq!(system.scope().snapshot().children.len(), 1);
+
+    strings.try_send("1".to_owned()).expect("accept one");
+    strings.try_send("2".to_owned()).expect("replace one");
+    strings.try_send("3".to_owned()).expect("replace two");
+    assert_eq!(first_hops.load(Ordering::SeqCst), 3);
+    assert_eq!(second_hops.load(Ordering::SeqCst), 3);
+    gate.release();
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            values
+                .lock()
+                .expect("mapping values mutex poisoned")
+                .as_slice()
+                == [3]
+        })
+        .await
+    );
+
+    let calls =
+        actor.contramap(|(value, reply): (u32, Reply<u32>)| MappingMessage::Ask(value, reply));
+    let reply = calls
+        .call(|reply| (7, reply), Duration::from_secs(1))
+        .await
+        .expect("mapped call replies");
+    assert_eq!(reply.value, 14);
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("mapped actor stops");
+    let projected = strings
+        .send("4".to_owned())
+        .await
+        .expect_err("terminal mapped ref rejects");
+    assert_eq!(projected.kind, SendErrorKind::Terminated);
+    assert_eq!(projected.payload, SendPayload::Projected);
+    assert_eq!(projected.into_message(), None);
+
+    let recovered = actor
+        .send(MappingMessage::Value(4))
+        .await
+        .expect_err("terminal direct ref rejects");
+    assert!(matches!(
+        recovered.payload,
+        SendPayload::Recovered(MappingMessage::Value(4))
+    ));
+}
+
+enum RestartMessage {
+    Crash,
+    Value(usize),
+}
+
+struct RestartActor {
+    values: Arc<Mutex<Vec<usize>>>,
+}
+
+impl RawActor for RestartActor {
+    type Msg = RestartMessage;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        while let Some(message) = context.recv().await {
+            match message {
+                RestartMessage::Crash => return Err(ExitError::message("restart now")),
+                RestartMessage::Value(value) => self
+                    .values
+                    .lock()
+                    .expect("restart values mutex poisoned")
+                    .push(value),
+            }
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn pinned_ref_fails_after_restart_while_membership_ref_rides_through() {
+    let values = Arc::new(Mutex::new(Vec::new()));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw(
+            "restart",
+            RawDef::factory({
+                let values = Arc::clone(&values);
+                move || RestartActor {
+                    values: Arc::clone(&values),
+                }
+            }),
+        )
+        .expect("valid restart actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("restart actor starts");
+    let first = actor
+        .try_send(RestartMessage::Crash)
+        .expect("crash accepted");
+    let pinned = actor.pinned(first);
+    assert_eq!(pinned.unpinned(), actor);
+
+    let second = actor
+        .next_incarnation(first, Duration::from_secs(1))
+        .await
+        .expect("replacement becomes accepting");
+    assert!(second.supersedes(first));
+    let error = pinned
+        .try_send(RestartMessage::Value(1))
+        .expect_err("old pin fails fast");
+    assert_eq!(error.incarnation_observed, Some(second));
+    assert_eq!(
+        error.kind,
+        SendErrorKind::Superseded {
+            pinned: first,
+            newest_observed: Some(second),
+        }
+    );
+    assert!(matches!(
+        error.into_message(),
+        Some(RestartMessage::Value(1))
+    ));
+
+    assert_eq!(
+        actor
+            .send(RestartMessage::Value(2))
+            .await
+            .expect("membership ref follows replacement"),
+        second
+    );
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            values
+                .lock()
+                .expect("restart values mutex poisoned")
+                .as_slice()
+                == [2]
+        })
+        .await
+    );
+    assert_eq!(
+        actor.next_incarnation(second, Duration::ZERO).await,
+        Err(NextIncarnationError::TimedOut)
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("restart actor stops");
+    assert_eq!(
+        actor.next_incarnation(second, Duration::from_secs(1)).await,
+        Err(NextIncarnationError::Terminated { last: Some(second) })
+    );
+}
+
+struct ParkedRestartActor {
+    generation: usize,
+    fail_first: ReleaseGate,
+    values: Arc<Mutex<Vec<usize>>>,
+}
+
+impl RawActor for ParkedRestartActor {
+    type Msg = usize;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        if self.generation == 1 {
+            self.fail_first.wait().await;
+            return Err(ExitError::message("replace parked incarnation"));
+        }
+        while let Some(value) = context.recv().await {
+            self.values
+                .lock()
+                .expect("parked values mutex poisoned")
+                .push(value);
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn parked_pinned_send_stops_at_the_incarnation_boundary() {
+    let generations = Arc::new(AtomicUsize::new(0));
+    let fail_first = ReleaseGate::default();
+    let values = Arc::new(Mutex::new(Vec::new()));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw(
+            "parked-pin",
+            RawDef::factory({
+                let generations = Arc::clone(&generations);
+                let fail_first = fail_first.clone();
+                let values = Arc::clone(&values);
+                move || ParkedRestartActor {
+                    generation: generations.fetch_add(1, Ordering::SeqCst) + 1,
+                    fail_first: fail_first.clone(),
+                    values: Arc::clone(&values),
+                }
+            })
+            .mailbox(Mailbox::queue(1).expect("non-zero capacity")),
+        )
+        .expect("valid parked-pin actor");
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("parked-pin actor starts");
+    let first = actor.try_send(0).expect("first mailbox fills");
+    let pinned = actor.pinned(first);
+    let pinned_send = tokio::spawn(async move { pinned.send(1).await });
+    let membership_send = {
+        let actor = actor.clone();
+        tokio::spawn(async move { actor.send(2).await })
+    };
+    tokio::task::yield_now().await;
+    assert!(!pinned_send.is_finished());
+    assert!(!membership_send.is_finished());
+
+    fail_first.release();
+    let pinned_error = pinned_send
+        .await
+        .expect("pinned send task joins")
+        .expect_err("pinned send cannot ride through intake freeze");
+    assert_eq!(pinned_error.kind, SendErrorKind::NotRunning);
+    assert_eq!(pinned_error.incarnation_observed, Some(first));
+    assert_eq!(pinned_error.into_message(), Some(1));
+
+    let second = actor
+        .next_incarnation(first, Duration::from_secs(1))
+        .await
+        .expect("replacement becomes accepting");
+    assert_eq!(
+        membership_send
+            .await
+            .expect("membership send task joins")
+            .expect("membership send rides through restart"),
+        second
+    );
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            values
+                .lock()
+                .expect("parked values mutex poisoned")
+                .as_slice()
+                == [2]
+        })
+        .await
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("parked-pin actor stops");
+}
+
+enum IdempotentMessage {
+    Ask(Reply<usize>),
+}
+
+struct ReplyDropActor {
+    generation: usize,
+    seen: Arc<Mutex<Vec<shelterwood::Incarnation>>>,
+}
+
+impl RawActor for ReplyDropActor {
+    type Msg = IdempotentMessage;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        let Some(IdempotentMessage::Ask(reply)) = context.recv().await else {
+            return Ok(());
+        };
+        self.seen
+            .lock()
+            .expect("reply-drop log mutex poisoned")
+            .push(context.incarnation());
+        if self.generation == 1 {
+            drop(reply);
+            Err(ExitError::message("drop first reply"))
+        } else {
+            reply.send(99);
+            while context.recv().await.is_some() {}
+            Ok(())
+        }
+    }
+}
+
+#[tokio::test]
+async fn idempotent_reply_drop_retries_only_on_a_superseding_incarnation() {
+    let generations = Arc::new(AtomicUsize::new(0));
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw(
+            "reply-drop",
+            RawDef::factory({
+                let generations = Arc::clone(&generations);
+                let seen = Arc::clone(&seen);
+                move || ReplyDropActor {
+                    generation: generations.fetch_add(1, Ordering::SeqCst) + 1,
+                    seen: Arc::clone(&seen),
+                }
+            }),
+        )
+        .expect("valid reply-drop actor");
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("reply-drop actor starts");
+
+    let constructions = Cell::new(0usize);
+    let reply = actor
+        .call_idempotent(
+            move |reply| {
+                constructions.set(constructions.get() + 1);
+                IdempotentMessage::Ask(reply)
+            },
+            RetryPolicy::new(Duration::from_secs(1), Backoff::Immediate)
+                .expect("valid retry policy"),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("idempotent helper retries reply loss");
+    assert_eq!(reply.value, 99);
+    {
+        let seen = seen.lock().expect("reply-drop log mutex poisoned");
+        assert_eq!(seen.len(), 2);
+        assert!(seen[1].supersedes(seen[0]));
+        assert_eq!(reply.incarnation, seen[1]);
+    }
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("reply-drop actor stops");
+}
+
+enum SliceMessage {
+    Fill,
+    Ask(Reply<usize>),
+}
+
+struct SliceActor {
+    start: ReleaseGate,
+}
+
+impl RawActor for SliceActor {
+    type Msg = SliceMessage;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        self.start.wait().await;
+        while let Some(message) = context.recv().await {
+            if let SliceMessage::Ask(reply) = message {
+                reply.send(7);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn per_attempt_slice_makes_acceptance_timeout_retryable_before_overall_expiry() {
+    let start = ReleaseGate::default();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "slice",
+            RawOnceDef::new(SliceActor {
+                start: start.clone(),
+            })
+            .mailbox(Mailbox::queue(1).expect("non-zero capacity")),
+        )
+        .expect("valid slice actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("slice actor starts");
+    actor.try_send(SliceMessage::Fill).expect("queue fills");
+
+    let constructions = Arc::new(AtomicUsize::new(0));
+    let call = {
+        let actor = actor.clone();
+        let constructions = Arc::clone(&constructions);
+        tokio::spawn(async move {
+            actor
+                .call_idempotent(
+                    move |reply| {
+                        constructions.fetch_add(1, Ordering::SeqCst);
+                        SliceMessage::Ask(reply)
+                    },
+                    RetryPolicy::new(Duration::from_secs(5), Backoff::Immediate)
+                        .expect("valid retry policy"),
+                    Duration::from_secs(20),
+                )
+                .await
+        })
+    };
+    tokio::task::yield_now().await;
+    advance_time(Duration::from_secs(5)).await;
+    for _ in 0..8 {
+        if constructions.load(Ordering::SeqCst) >= 2 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        constructions.load(Ordering::SeqCst),
+        2,
+        "the per-attempt slice retries while fifteen seconds remain"
+    );
+    start.release();
+    assert_eq!(
+        call.await
+            .expect("slice call task joins")
+            .expect("second attempt is accepted")
+            .value,
+        7
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("slice actor stops");
+}
+
+struct HoldReplyActor {
+    accepted: ReleaseGate,
+    calls: Arc<AtomicUsize>,
+    held: Option<Reply<usize>>,
+}
+
+impl RawActor for HoldReplyActor {
+    type Msg = IdempotentMessage;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        while let Some(IdempotentMessage::Ask(reply)) = context.recv().await {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.held = Some(reply);
+            self.accepted.release();
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn idempotent_response_timeout_is_terminal_after_exactly_one_send_attempt() {
+    let accepted = ReleaseGate::default();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "response-timeout",
+            RawOnceDef::new(HoldReplyActor {
+                accepted: accepted.clone(),
+                calls: Arc::clone(&calls),
+                held: None,
+            }),
+        )
+        .expect("valid response-timeout actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("response actor starts");
+    let call = {
+        let actor = actor.clone();
+        tokio::spawn(async move {
+            actor
+                .call_idempotent(
+                    IdempotentMessage::Ask,
+                    RetryPolicy::new(Duration::from_secs(5), Backoff::Immediate)
+                        .expect("valid retry policy"),
+                    Duration::from_secs(20),
+                )
+                .await
+        })
+    };
+    accepted.wait().await;
+    advance_time(Duration::from_secs(5)).await;
+    let error = call
+        .await
+        .expect("response-timeout task joins")
+        .expect_err("accepted response timeout is terminal");
+    assert_eq!(error.kind, IdempotentCallErrorKind::ResponseTimedOut);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(error.attempts.len(), 1);
+    assert_eq!(error.attempts[0].ended, AttemptEnd::ResponseTimedOut);
+    assert!(error.attempts[0].incarnation.is_some());
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("response actor stops");
+}
+
+#[test]
+fn retry_policy_rejects_a_zero_attempt_slice() {
+    assert!(RetryPolicy::new(Duration::ZERO, Backoff::Immediate).is_err());
+}
+
+#[allow(dead_code)]
+fn actor_refs_remain_send_sync<M: Send + 'static>() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<ActorRef<M>>();
+}

--- a/crates/shelterwood/tests/mailbox.rs
+++ b/crates/shelterwood/tests/mailbox.rs
@@ -132,7 +132,10 @@ async fn queue_backpressure_and_send_error_identity_are_exact() {
     assert_eq!(full.incarnation_observed, Some(accepting));
 
     let waiting_actor = actor.clone();
-    let waiting = tokio::spawn(async move { waiting_actor.send(full.message).await });
+    let waiting_message = full
+        .into_message()
+        .expect("unmapped error recovers message");
+    let waiting = tokio::spawn(async move { waiting_actor.send(waiting_message).await });
     for _ in 0..4 {
         tokio::task::yield_now().await;
     }
@@ -251,7 +254,11 @@ async fn timed_send_withdraws_and_recovers_the_message() {
         .await
     );
     actor
-        .send(error.message)
+        .send(
+            error
+                .into_message()
+                .expect("unmapped error recovers message"),
+        )
         .await
         .expect("recovered message is safe to resend");
     assert!(

--- a/crates/shelterwood/tests/rebind.rs
+++ b/crates/shelterwood/tests/rebind.rs
@@ -227,7 +227,7 @@ async fn timed_send_withdraws_while_replacement_is_in_backoff() {
         .expect_err("backoff outlives timeout");
     assert_eq!(error.kind, SendErrorKind::TimedOut);
     assert_eq!(error.incarnation_observed, Some(first));
-    assert_eq!(error.message, 42);
+    assert_eq!(error.into_message(), Some(42));
     system.shutdown(Duration::ZERO).await.expect("root stops");
 }
 

--- a/crates/shelterwood/tests/shard_store.rs
+++ b/crates/shelterwood/tests/shard_store.rs
@@ -4,12 +4,13 @@ use std::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     },
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use shelterwood::{
-    Actor, ActorDef, ActorRef, CallErrorKind, Context, DynamicScopeRef, DynamicTree, ExitError,
-    ExitResult, Mailbox, Membership, RemoveOutcome, Reply, ScopeRef, SubtreeOnceDef, Tree,
+    Actor, ActorDef, ActorRef, AttemptEnd, Backoff, Context, DynamicScopeRef, DynamicTree,
+    ExitError, ExitResult, IdempotentCallErrorKind, Incarnation, Mailbox, Membership,
+    RemoveOutcome, Reply, RetryPolicy, ScopeRef, SubtreeOnceDef, Tree,
 };
 use shelterwood_test_support::ReleaseGate;
 
@@ -130,7 +131,8 @@ struct DurableTopology {
     current: Arc<Mutex<Option<Mount>>>,
     faults: Arc<Mutex<HashMap<u64, Fault>>>,
     aborted: Arc<Mutex<Vec<(u64, Mount)>>>,
-    retry_kinds: Arc<Mutex<Vec<(u64, CallErrorKind)>>>,
+    attempt_constructions: Arc<Mutex<HashMap<u64, usize>>>,
+    accepting_incarnations: Arc<Mutex<Vec<(u64, Incarnation)>>>,
     acceptances: Arc<AtomicUsize>,
     response_gate: ReleaseGate,
 }
@@ -162,19 +164,38 @@ impl DurableTopology {
         self.acceptances.load(Ordering::SeqCst)
     }
 
-    fn record_retry(&self, operation: u64, kind: CallErrorKind) {
-        self.retry_kinds
+    fn record_attempt_construction(&self, operation: u64) -> usize {
+        let mut attempts = self
+            .attempt_constructions
             .lock()
-            .expect("retry-kind mutex poisoned")
-            .push((operation, kind));
+            .expect("attempt-construction mutex poisoned");
+        let count = attempts.entry(operation).or_default();
+        *count += 1;
+        *count
     }
 
-    fn retry_kinds(&self, operation: u64) -> Vec<CallErrorKind> {
-        self.retry_kinds
+    fn attempt_constructions(&self, operation: u64) -> usize {
+        self.attempt_constructions
             .lock()
-            .expect("retry-kind mutex poisoned")
+            .expect("attempt-construction mutex poisoned")
+            .get(&operation)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    fn record_acceptance(&self, operation: u64, incarnation: Incarnation) {
+        self.accepting_incarnations
+            .lock()
+            .expect("accepting-incarnation mutex poisoned")
+            .push((operation, incarnation));
+    }
+
+    fn accepting_incarnations(&self, operation: u64) -> Vec<Incarnation> {
+        self.accepting_incarnations
+            .lock()
+            .expect("accepting-incarnation mutex poisoned")
             .iter()
-            .filter_map(|(recorded, kind)| (*recorded == operation).then_some(*kind))
+            .filter_map(|(recorded, incarnation)| (*recorded == operation).then_some(*incarnation))
             .collect()
     }
 
@@ -409,9 +430,12 @@ impl Actor for RouterActor {
         Ok(Self(args))
     }
 
-    async fn handle(&mut self, message: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
         let RouterMessage::Replace { operation, reply } = message;
         self.0.durable.acceptances.fetch_add(1, Ordering::SeqCst);
+        self.0
+            .durable
+            .record_acceptance(operation, context.incarnation());
         let route = self.replace(operation).await?;
         reply.send(route);
         Ok(())
@@ -420,89 +444,52 @@ impl Actor for RouterActor {
 
 async fn replace_with_retry(
     router: &ActorRef<RouterMessage>,
-    root: &ScopeRef,
     args: &RouterArgs,
     operation: u64,
     per_attempt: Duration,
     overall: Duration,
-    acceptance_timeout_observed: Option<ReleaseGate>,
+    retry_started: Option<ReleaseGate>,
 ) -> Route {
-    assert!(!per_attempt.is_zero());
-    assert!(!overall.is_zero());
-    let deadline = Instant::now()
-        .checked_add(overall)
-        .expect("test retry deadline is representable");
-
-    loop {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        assert!(
-            !remaining.is_zero(),
-            "idempotent topology retry budget exhausted"
-        );
-        let slice = per_attempt.min(remaining);
-        match router
-            .call(
-                move |reply| RouterMessage::Replace { operation, reply },
-                slice,
-            )
-            .await
-        {
-            Ok(reply) => return reply.value,
-            Err(error) => {
-                args.durable.record_retry(operation, error.kind);
-                match error.kind {
-                    CallErrorKind::AcceptanceTimedOut => {
-                        // Successful withdrawal is the only arm that may retry
-                        // without reconciliation or an incarnation transition.
-                        if let Some(observed) = &acceptance_timeout_observed {
-                            observed.release();
-                        }
-                    }
-                    CallErrorKind::ReplyDropped => {
-                        let accepting = error
-                            .incarnation_observed
-                            .expect("reply loss carries the accepting incarnation");
-                        let remaining = deadline.saturating_duration_since(Instant::now());
-                        assert!(!remaining.is_zero(), "budget expired before restart wait");
-                        root.wait_for_child(
-                            "topology-writer",
-                            move |child| {
-                                matches!(child.state, shelterwood::ChildState::Running)
-                                    && child
-                                        .incarnation
-                                        .is_some_and(|current| current.supersedes(accepting))
-                            },
-                            remaining,
-                        )
-                        .await
-                        .expect("reply-loss retry observes a superseding incarnation");
-                    }
-                    CallErrorKind::ResponseTimedOut => {
-                        // Acceptance makes resend unsafe. Reconcile the same
-                        // durable journal record outside the parked actor instead.
-                        let record = args
-                            .durable
-                            .operation(operation)
-                            .expect("accepted operation has a journal record");
-                        return match record {
-                            OperationRecord::Committed {
-                                candidate,
-                                previous,
-                            } => reconcile_topology(args, candidate, previous)
-                                .await
-                                .expect("committed response timeout reconciles"),
-                            OperationRecord::Mounted { .. } => {
-                                panic!("response timed out before a durable commit verdict")
-                            }
-                        };
-                    }
-                    CallErrorKind::Terminated => {
-                        panic!("topology writer terminated during retry")
-                    }
-                    _ => panic!("unexpected call error kind"),
+    let durable = args.durable.clone();
+    match router
+        .call_idempotent(
+            move |reply| {
+                let count = durable.record_attempt_construction(operation);
+                if count == 2
+                    && let Some(observed) = &retry_started
+                {
+                    observed.release();
+                }
+                RouterMessage::Replace { operation, reply }
+            },
+            RetryPolicy::new(per_attempt, Backoff::Immediate).expect("valid retry policy"),
+            overall,
+        )
+        .await
+    {
+        Ok(reply) => reply.value,
+        Err(error) if error.kind == IdempotentCallErrorKind::ResponseTimedOut => {
+            assert_eq!(error.attempts.len(), 1);
+            assert_eq!(error.attempts[0].ended, AttemptEnd::ResponseTimedOut);
+            // Acceptance makes resend unsafe. Reconcile the same durable
+            // journal record outside the parked actor instead.
+            let record = args
+                .durable
+                .operation(operation)
+                .expect("accepted operation has a journal record");
+            match record {
+                OperationRecord::Committed {
+                    candidate,
+                    previous,
+                } => reconcile_topology(args, candidate, previous)
+                    .await
+                    .expect("committed response timeout reconciles"),
+                OperationRecord::Mounted { .. } => {
+                    panic!("response timed out before a durable commit verdict")
                 }
             }
         }
+        Err(error) => panic!("idempotent topology call failed unexpectedly: {error}"),
     }
 }
 
@@ -541,12 +528,9 @@ async fn shard_store_reconciles_retry_outcomes_with_one_overall_budget() {
         .expect("valid topology writer");
     let system = root.spawn().expect("runtime is available");
     system.wait_started().await.expect("store starts");
-    let root_scope = system.scope();
-
     durable.inject(1, Fault::BeforeCommit);
     let first = replace_with_retry(
         &router,
-        &root_scope,
         &router_args,
         1,
         Duration::from_millis(500),
@@ -554,11 +538,10 @@ async fn shard_store_reconciles_retry_outcomes_with_one_overall_budget() {
         None,
     )
     .await;
-    assert_eq!(
-        durable.retry_kinds(1),
-        [CallErrorKind::ReplyDropped],
-        "pre-commit fault exercises the superseding-incarnation retry"
-    );
+    let first_acceptances = durable.accepting_incarnations(1);
+    assert_eq!(first_acceptances.len(), 2);
+    assert!(first_acceptances[1].supersedes(first_acceptances[0]));
+    assert_eq!(durable.attempt_constructions(1), 2);
     let failed_candidate = durable.aborted(1);
     assert!(
         first
@@ -580,7 +563,6 @@ async fn shard_store_reconciles_retry_outcomes_with_one_overall_budget() {
     durable.inject(2, Fault::AfterCommitBeforeReply);
     let second = replace_with_retry(
         &router,
-        &root_scope,
         &router_args,
         2,
         Duration::from_millis(500),
@@ -588,11 +570,10 @@ async fn shard_store_reconciles_retry_outcomes_with_one_overall_budget() {
         None,
     )
     .await;
-    assert_eq!(
-        durable.retry_kinds(2),
-        [CallErrorKind::ReplyDropped],
-        "post-commit reply loss also waits for the restarted writer"
-    );
+    let second_acceptances = durable.accepting_incarnations(2);
+    assert_eq!(second_acceptances.len(), 2);
+    assert!(second_acceptances[1].supersedes(second_acceptances[0]));
+    assert_eq!(durable.attempt_constructions(2), 2);
     let committed_candidate = match durable.operation(2).expect("commit was journaled") {
         OperationRecord::Committed { candidate, .. } => candidate,
         OperationRecord::Mounted { .. } => panic!("directory cutover must be committed"),
@@ -609,7 +590,6 @@ async fn shard_store_reconciles_retry_outcomes_with_one_overall_budget() {
     assert_eq!(
         replace_with_retry(
             &router,
-            &root_scope,
             &router_args,
             2,
             Duration::from_millis(500),
@@ -641,7 +621,6 @@ async fn shard_store_reconciles_retry_outcomes_with_one_overall_budget() {
     let accepted_before_timeout = durable.acceptances();
     let third = replace_with_retry(
         &router,
-        &root_scope,
         &router_args,
         3,
         Duration::from_millis(500),
@@ -649,11 +628,7 @@ async fn shard_store_reconciles_retry_outcomes_with_one_overall_budget() {
         None,
     )
     .await;
-    assert_eq!(
-        durable.retry_kinds(3),
-        [CallErrorKind::ResponseTimedOut],
-        "parked accepted request reconciles instead of resending"
-    );
+    assert_eq!(durable.attempt_constructions(3), 1);
     assert_eq!(
         durable.acceptances(),
         accepted_before_timeout + 1,
@@ -694,13 +669,11 @@ async fn shard_store_reconciles_retry_outcomes_with_one_overall_budget() {
     let acceptance_timeout_observed = ReleaseGate::default();
     let retry_task = {
         let router = router.clone();
-        let root_scope = root_scope.clone();
         let router_args = router_args.clone();
         let observed = acceptance_timeout_observed.clone();
         tokio::spawn(async move {
             replace_with_retry(
                 &router,
-                &root_scope,
                 &router_args,
                 4,
                 Duration::from_millis(500),
@@ -714,13 +687,11 @@ async fn shard_store_reconciles_retry_outcomes_with_one_overall_budget() {
     durable.response_gate.release();
     let fourth = retry_task.await.expect("retry task remains joinable");
     assert_eq!(fourth.operation, 4);
-    let fourth_retries = durable.retry_kinds(4);
-    assert!(!fourth_retries.is_empty());
-    assert!(
-        fourth_retries
-            .iter()
-            .all(|kind| *kind == CallErrorKind::AcceptanceTimedOut),
-        "only proven-unaccepted attempts retry without reconciliation"
+    assert!(durable.attempt_constructions(4) >= 2);
+    assert_eq!(
+        durable.accepting_incarnations(4).len(),
+        1,
+        "withdrawn acceptance-timeout attempts never reach the handler"
     );
 
     system

--- a/docs/part-ii-progress.md
+++ b/docs/part-ii-progress.md
@@ -1,0 +1,24 @@
+# Part II progress
+
+This ledger records the stacked implementation work for issue #9. `SPEC.md`
+is authoritative; this file records branch ancestry, evidence-gate outcomes,
+validation, and deviations for review.
+
+## Mandatory M6 base
+
+- PR #10 head selected and fetched on 2026-08-07:
+  `de34ec4d279dc94207a5a0572ad5c057930f6a15`.
+- M7 branch: `agent/issue-9-m7-incarnation-mapping`.
+- M7 starts directly from the selected SHA; no M7 implementation is present
+  on PR #10.
+
+## Milestones
+
+| Milestone | Status | Evidence gates | Validation | Deviations |
+|---|---|---|---|---|
+| M7 — incarnation refinements and `contramap` | complete | `call_idempotent`: **build** — repaired shard-store re-port passed; `project`: open | focused M7 and shard-store tests pass; `just ci` passes with 165 tests | none |
+| M8 — keyed conflation and peer monitoring | pending | control/priority lane remains open until M12 | pending | none |
+| M9 — group strategies | pending | none | pending | none |
+| M10 — observation extensions | pending | none | pending | none |
+| M11 — outline, hosting, conveniences | pending | none | pending | none |
+| M12 — acceptance wave two | pending | control/priority lane and `project` final verdicts due | pending | none |

--- a/docs/retry-and-ordering.md
+++ b/docs/retry-and-ordering.md
@@ -29,11 +29,40 @@ For a safe `ReplyDropped` retry in the core API:
 5. Bound the retry horizon and garbage-collect the application's idempotency
    ledger only after a retry is no longer possible.
 
+`ActorRef::call_idempotent` packages the mechanical parts of that loop. The
+caller supplies a re-mintable `Fn(Reply<T>) -> M`, a non-zero per-attempt
+slice plus `Backoff`, and one overall deadline. `AcceptanceTimedOut` retries
+within the remaining budget; `ReplyDropped` waits for a strictly superseding
+acceptance-open incarnation before retrying. `ResponseTimedOut` and terminal
+membership return immediately with the attempt history and offer no retry
+continuation.
+
+The name is an assertion by the caller: a repeatable constructor proves only
+that a message can be rebuilt, not that repeating its effect is safe. Durable
+reconciliation after `ResponseTimedOut` and a bounded or garbage-collected
+application idempotency ledger remain application obligations. The helper
+does not make delivery durable or at-least-once; it repeats individual
+at-most-once sends under an explicit idempotency claim.
+
 `ResponseTimedOut` deliberately has no equivalent retry recipe. Acceptance
 happened, so only application ground truth can distinguish “not applied,”
 “applied without a reply,” and “still running.” Reconcile first. The shard-store
 acceptance test demonstrates both the post-commit reconciliation case and the
 idempotent `ReplyDropped` loop.
+
+Incarnation-pinned refs are the deliberate exception to membership routing.
+`ActorRef::pinned(incarnation)` accepts only through that exact incarnation;
+it never rides a rebind window. Use `next_incarnation(after, deadline)` when a
+protocol explicitly needs the next acceptance-open incarnation, and keep an
+ordinary `ActorRef` when restart transparency is the desired default.
+
+`contramap` applies its injection eagerly on the sender's ingress path. The
+closure can run concurrently on sender threads and must be cheap and
+non-blocking. A mapped ref shares the outer actor's id, membership, mailbox,
+backpressure, conflation, lifecycle, and statistics. Because eager mapping
+consumes the mapped value, its send failures carry `SendPayload::Projected`;
+ordinary refs continue to return `SendPayload::Recovered` and
+`SendError::into_message()` returns the original value.
 
 Membership and incarnation answer different questions. An `ActorRef` follows
 restarts of one membership. After remove and re-add under the same child id,


### PR DESCRIPTION
## Summary

- add incarnation-pinned actor refs, strict next-incarnation waits, and exact `Superseded` identity evidence
- package the M6 shard-store retry discipline as `call_idempotent` with one overall budget, per-attempt slices, runtime jitter, and complete attempt history
- add eager `ActorRef::contramap` views that share identity/mailbox resources and expose projected-vs-recovered send payloads
- re-port the shard-store artifact and record the §15 evidence-gate verdict as **build**; keep §17 `project` open

## Conformance evidence

- old pinned refs fail closed after replacement while membership refs follow the successor
- parked pinned sends stop at intake freeze and cannot cross the incarnation boundary
- reply loss retries only after a strictly superseding accepting incarnation
- response timeout is terminal after exactly one acceptance and returns to external durable reconciliation
- mapped refs preserve outer identity/conflation; nested views run one eager hop per layer; mapping panics remain on the sender stack

## Adversarial review hardening

- recompute the overall idempotent-call budget after user message construction, so constructor time cannot extend the advertised deadline or permit a late send

## Validation

- `./scripts/dev cargo test --locked -p shelterwood --test m7` — 9 passed
- `./scripts/dev cargo test --locked -p shelterwood --test shard_store` — passed
- `./scripts/dev just ci` — 165 tests passed plus format, clippy, feature lanes, docs, API reachability, runtime/exit path guards, and nixfmt

Stacked directly on PR #10 head `2b1465deb9d1a99f88c95f315138028dfd8b65d2`.

Refs #9
