### PR TITLE
M8: add keyed mailboxes and peer monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ scope, and subtrees compose both recursively.
 ## Operational guides
 
 - [Calls, retries, and message ordering](docs/retry-and-ordering.md)
+- [Keyed mailboxes and peer monitoring](docs/keyed-mailboxes-and-monitoring.md)
 - [Shutdown and resource ownership](docs/shutdown-and-resources.md)
 - [Snapshots and lifecycle events](docs/observation.md)
 - [Embedding Shelterwood in a host process](docs/embedding.md)

--- a/SPEC.md
+++ b/SPEC.md
@@ -2664,6 +2664,13 @@ Activates the pinning clause of invariant §13.2.
 first-class control/priority lane is *Evidence-gated (M12)* unless the trading-engine
 acceptance scenario produces contrary evidence.
 
+**M8 implementation evidence.** The typed raw and handler definition
+surfaces, inherited and explicit capacity resolution, sender-path key
+extraction, in-place conflation, oldest-key eviction, and the internal
+eviction counter are implemented and covered by `tests/m8.rs`. The public
+counter remains intentionally deferred to §20; the control/priority gate
+remains open for M12.
+
 `latest_by_key(capacity, key_fn)` — a typed extension on `ActorDef<A>` and
 `RawActorDef<M>`, with `K: Eq + Hash + Send + 'static` and
 `key_fn: impl Fn(&M) -> K + Send + Sync + 'static` — provides conflation per key with a bounded key
@@ -2780,6 +2787,11 @@ impl<'a, A: Actor + ?Sized> Context<'a, A> {
 
 **Status: Accepted (M8).** Watches target actor, task, and scope
 memberships. They are actor-loop input, never user-mailbox entries.
+
+**M8 implementation evidence.** The sealed three-handle target surface,
+incarnation-owned registration, immediate and transition edges, replacement,
+synchronous cancellation, bounded per-watch overflow, coalesced `Lagged`, and
+terminal `Removed` retention are implemented and covered by `tests/m8.rs`.
 
 `ctx.watch(&ref, wrap)` (and a cancel-on-drop `watch_scoped`) — where
 `wrap: impl Fn(MonitorEvent) -> A::Msg + Send + Sync + 'static`, the §17

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -12,9 +12,12 @@ use std::{
 
 use crate::{
     ActorRef, Blocking, CancellationToken, ChildId, DeadlineElapsed, ExitError, ExitResult, Guard,
-    Incarnation, Mailbox, MailboxShutdown, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
-    ReadinessDeadline, Rejected, RestartPolicy, Retention, ScopeRef, Shutdown,
-    policy::CommonOptions, raw::CatchUnwindFuture,
+    Incarnation, KeyedCapacity, Mailbox, MailboxShutdown, MonitorEvent, RawActor, RawContext,
+    RawDef, RawOnceDef, Readiness, ReadinessDeadline, Rejected, RestartPolicy, Retention, ScopeRef,
+    Shutdown, WatchTarget,
+    mailbox::{MailboxKeyExtractor, mailbox_key_extractor},
+    policy::CommonOptions,
+    raw::CatchUnwindFuture,
 };
 
 /// Callback-oriented actor contract.
@@ -186,6 +189,37 @@ impl<'a, A: Actor> Context<'a, A> {
         } else {
             Ok(self.raw.clear_timer(key))
         }
+    }
+
+    /// Watches a peer membership for this actor incarnation.
+    pub fn watch<T, W>(&mut self, target: &T, wrap: W) -> Result<(), Rejected<W>>
+    where
+        T: WatchTarget,
+        W: Fn(MonitorEvent) -> A::Msg + Send + Sync + 'static,
+    {
+        if self.draining {
+            Err(Rejected::new(wrap))
+        } else {
+            self.raw.watch(target, wrap)
+        }
+    }
+
+    /// Watches a peer membership with an additional cancel-on-drop lease.
+    pub fn watch_scoped<T, W>(&mut self, target: &T, wrap: W) -> Result<Guard, Rejected<W>>
+    where
+        T: WatchTarget,
+        W: Fn(MonitorEvent) -> A::Msg + Send + Sync + 'static,
+    {
+        if self.draining {
+            Err(Rejected::new(wrap))
+        } else {
+            self.raw.watch_scoped(target, wrap)
+        }
+    }
+
+    /// Cancels this incarnation's watch of `target` and drops queued edges.
+    pub fn unwatch<T: WatchTarget>(&mut self, target: &T) -> bool {
+        self.raw.unwatch(target)
     }
 
     /// Starts incarnation-owned async work with one total deadline budget.
@@ -450,6 +484,7 @@ type ArgsFactory<A> = Arc<Mutex<Box<dyn Fn() -> <A as Actor>::Args + Send + 'sta
 pub struct ActorDef<A: Actor> {
     factory: ArgsFactory<A>,
     pub(crate) options: CommonOptions,
+    mailbox_key: Option<MailboxKeyExtractor<A::Msg>>,
 }
 
 impl<A: Actor> fmt::Debug for ActorDef<A> {
@@ -475,6 +510,7 @@ impl<A: Actor> ActorDef<A> {
         Self {
             factory: Arc::new(Mutex::new(Box::new(factory))),
             options: CommonOptions::default(),
+            mailbox_key: None,
         }
     }
 
@@ -496,6 +532,27 @@ impl<A: Actor> ActorDef<A> {
     #[must_use]
     pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
         self.options.mailbox = Some(mailbox);
+        self.options.keyed_capacity = None;
+        self.mailbox_key = None;
+        self
+    }
+
+    /// Selects bounded per-key latest-value conflation.
+    ///
+    /// A new key at capacity evicts the oldest pending key. Size capacity for
+    /// the expected key cardinality; this is not a priority/control lane.
+    #[must_use]
+    pub fn latest_by_key<K>(
+        mut self,
+        capacity: KeyedCapacity,
+        key_fn: impl Fn(&A::Msg) -> K + Send + Sync + 'static,
+    ) -> Self
+    where
+        K: Eq + Hash + Send + 'static,
+    {
+        self.options.mailbox = None;
+        self.options.keyed_capacity = Some(capacity);
+        self.mailbox_key = Some(mailbox_key_extractor(key_fn));
         self
     }
 
@@ -537,6 +594,7 @@ impl<A: Actor> ActorDef<A> {
             Handler::with_readiness(args, readiness)
         });
         raw.options = self.options;
+        raw.mailbox_key = self.mailbox_key;
         raw
     }
 }
@@ -548,6 +606,7 @@ impl<A: Actor> ActorDef<A> {
 pub struct ActorOnceDef<A: Actor> {
     args: A::Args,
     pub(crate) options: CommonOptions,
+    mailbox_key: Option<MailboxKeyExtractor<A::Msg>>,
 }
 
 impl<A: Actor> fmt::Debug for ActorOnceDef<A> {
@@ -566,6 +625,7 @@ impl<A: Actor> ActorOnceDef<A> {
         Self {
             args,
             options: CommonOptions::default(),
+            mailbox_key: None,
         }
     }
 
@@ -580,6 +640,27 @@ impl<A: Actor> ActorOnceDef<A> {
     #[must_use]
     pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
         self.options.mailbox = Some(mailbox);
+        self.options.keyed_capacity = None;
+        self.mailbox_key = None;
+        self
+    }
+
+    /// Selects bounded per-key latest-value conflation.
+    ///
+    /// A new key at capacity evicts the oldest pending key. Size capacity for
+    /// the expected key cardinality; this is not a priority/control lane.
+    #[must_use]
+    pub fn latest_by_key<K>(
+        mut self,
+        capacity: KeyedCapacity,
+        key_fn: impl Fn(&A::Msg) -> K + Send + Sync + 'static,
+    ) -> Self
+    where
+        K: Eq + Hash + Send + 'static,
+    {
+        self.options.mailbox = None;
+        self.options.keyed_capacity = Some(capacity);
+        self.mailbox_key = Some(mailbox_key_extractor(key_fn));
         self
     }
 
@@ -615,6 +696,7 @@ impl<A: Actor> ActorOnceDef<A> {
         let readiness = self.options.readiness.unwrap_or(Readiness::AfterInit);
         let mut raw = RawOnceDef::new(Handler::with_readiness(self.args, readiness));
         raw.options = self.options;
+        raw.mailbox_key = self.mailbox_key;
         raw
     }
 }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -24,6 +24,7 @@ use crate::{
     exit::{JoinVerdict, RecordedOutcome, classify_exit},
     identity::{FenceCounter, ScopeIdentity},
     mailbox::MailboxControl,
+    monitor::{MonitorEventKind, MonitorSubscriber},
     observe::{
         ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
         LifecycleHub, MembershipStatus, ScopeKind, ScopeSnapshot, SnapshotHub, SnapshotReceiver,
@@ -302,6 +303,7 @@ pub(crate) struct MemberCell {
     record: Mutex<MemberRecord>,
     changed: Signal,
     terminal_signals: Mutex<Vec<Signal>>,
+    monitors: Mutex<Vec<Weak<dyn MonitorSubscriber>>>,
     mailbox: Mutex<Option<Arc<dyn MailboxControl>>>,
     options: Mutex<Option<crate::policy::ResolvedCommonOptions>>,
     pub(crate) removal: Latch,
@@ -324,6 +326,7 @@ impl MemberCell {
             }),
             changed: Signal::default(),
             terminal_signals: Mutex::new(Vec::new()),
+            monitors: Mutex::new(Vec::new()),
             mailbox: Mutex::new(None),
             options: Mutex::new(None),
             removal: Latch::default(),
@@ -378,6 +381,41 @@ impl MemberCell {
             .push(signal);
     }
 
+    pub(crate) fn register_monitor(&self, subscriber: Arc<dyn MonitorSubscriber>) {
+        let mut monitors = self.monitors.lock().expect("member monitor mutex poisoned");
+        let record = self.record();
+        monitors.push(Arc::downgrade(&subscriber));
+        match record.stage {
+            MemberStage::Terminal(_) => subscriber.publish(MonitorEventKind::Removed {
+                last_incarnation: record.last_incarnation,
+            }),
+            _ => {
+                if let Some(incarnation) = record.incarnation {
+                    subscriber.publish(MonitorEventKind::Started { incarnation });
+                }
+            }
+        }
+    }
+
+    fn publish_monitor(&self, kind: MonitorEventKind) {
+        let mut monitors = self.monitors.lock().expect("member monitor mutex poisoned");
+        monitors.retain(|subscriber| {
+            let Some(subscriber) = subscriber.upgrade() else {
+                return false;
+            };
+            subscriber.publish(kind.clone());
+            true
+        });
+    }
+
+    fn publish_monitor_started(&self, incarnation: Incarnation) {
+        self.publish_monitor(MonitorEventKind::Started { incarnation });
+    }
+
+    fn publish_monitor_exited(&self, incarnation: Incarnation, exit: Exit) {
+        self.publish_monitor(MonitorEventKind::Exited { incarnation, exit });
+    }
+
     pub(crate) fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
         let previous = self
             .mailbox
@@ -411,13 +449,18 @@ impl MemberCell {
             return;
         }
         self.changed.pulse();
+        self.publish_monitor(MonitorEventKind::Removed {
+            last_incarnation: self.record().last_incarnation,
+        });
         if let Some(mailbox) = self.mailbox() {
             mailbox.terminate();
             let stats = mailbox.stats();
             debug_assert!(stats.delivered <= stats.accepted);
             debug_assert!(stats.conflated <= stats.accepted);
+            debug_assert!(stats.evicted <= stats.accepted);
             debug_assert!(stats.depth <= stats.capacity);
             let _ = stats.sends_rejected;
+            let _ = stats.local_delivered;
         }
         for signal in self
             .terminal_signals
@@ -538,6 +581,7 @@ pub(crate) struct ScopeCell {
     current_children: Mutex<Vec<Arc<SlotCell>>>,
     parent: Mutex<Option<Weak<ScopeCell>>>,
     lifecycle_sequence: Mutex<FenceCounter>,
+    root_incarnations: Mutex<FenceCounter>,
     lifecycle_seq: AtomicU64,
     lifecycle: LifecycleHub,
     snapshots: SnapshotHub,
@@ -586,6 +630,7 @@ impl ScopeCell {
             current_children: Mutex::new(Vec::new()),
             parent: Mutex::new(None),
             lifecycle_sequence: Mutex::new(FenceCounter::new(0)),
+            root_incarnations: Mutex::new(FenceCounter::new(0)),
             lifecycle_seq: AtomicU64::new(0),
             lifecycle: LifecycleHub::default(),
             snapshots: SnapshotHub::default(),
@@ -629,6 +674,9 @@ impl ScopeCell {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         member.update_locked(update);
+        if let Some(LifecycleEventKind::Started { incarnation, .. }) = &event {
+            member.publish_monitor_started(*incarnation);
+        }
         if let Some(event) = event {
             self.emit_locked(event);
         } else {
@@ -658,6 +706,12 @@ impl ScopeCell {
         scope.total_restarts = scope.total_restarts.saturating_add(1);
         drop(scope);
         member.update_locked(update);
+        if let LifecycleEventKind::Exited {
+            incarnation, exit, ..
+        } = &exited
+        {
+            member.publish_monitor_exited(*incarnation, exit.clone());
+        }
         self.emit_locked(exited);
         self.emit_locked(scheduled);
     }
@@ -676,6 +730,9 @@ impl ScopeCell {
             return false;
         }
         member.update_locked(|record| record.startup_aborted = startup_aborted);
+        if let Some(incarnation) = exited_incarnation {
+            member.publish_monitor_exited(incarnation, exit.clone());
+        }
         member.terminalize(exit.clone());
         if let Some(incarnation) = exited_incarnation {
             self.emit_locked(LifecycleEventKind::Exited {
@@ -902,6 +959,21 @@ impl ScopeCell {
     }
 
     fn begin_incarnation(&self) -> u64 {
+        if self.member.record().incarnation.is_none() {
+            let incarnation = ScopeIdentity::mint_incarnation(
+                self.member.membership(),
+                &mut self
+                    .root_incarnations
+                    .lock()
+                    .expect("root incarnation mutex poisoned"),
+            )
+            .expect("scope incarnation identity space exhausted");
+            self.member.update(|record| {
+                record.incarnation = Some(incarnation);
+                record.last_incarnation = Some(incarnation);
+            });
+            self.member.publish_monitor_started(incarnation);
+        }
         let mut control = self.control.lock().expect("scope control mutex poisoned");
         control.current_epoch = control.current_epoch.saturating_add(1);
         control.live = true;
@@ -934,6 +1006,10 @@ impl ScopeCell {
         self.record.lock().expect("scope mutex poisoned").state = state.clone();
         let terminal = terminal_exit.is_some();
         if let Some(exit) = terminal_exit {
+            if let Some(incarnation) = self.member.record().incarnation {
+                self.member
+                    .publish_monitor_exited(incarnation, exit.clone());
+            }
             self.member.terminalize(exit);
         }
         let mut control = self.control.lock().expect("scope control mutex poisoned");
@@ -971,6 +1047,10 @@ impl ScopeCell {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             let state = ScopeState::Stopped { reason };
             self.record.lock().expect("scope mutex poisoned").state = state.clone();
+            if let Some(incarnation) = self.member.record().incarnation {
+                self.member
+                    .publish_monitor_exited(incarnation, exit.clone());
+            }
             self.member.terminalize(exit);
             self.changed.pulse();
             self.emit_locked(LifecycleEventKind::ScopeState { state });
@@ -1678,7 +1758,7 @@ impl ChildRuntime {
             .expect("scope identity mutex poisoned")
             .incarnation_counter(plan.slot.member.membership());
         if let Some(mailbox) = plan.slot.member.mailbox() {
-            mailbox.configure(plan.options.mailbox);
+            mailbox.configure(plan.options.mailbox, plan.options.keyed_capacity);
         }
         Self {
             slot: plan.slot,

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -8,6 +8,7 @@ mod engine;
 mod exit;
 mod identity;
 mod mailbox;
+mod monitor;
 mod observe;
 mod policy;
 mod raw;
@@ -31,15 +32,18 @@ pub use mailbox::{
     PinnedRef, Replied, Reply, ReplyError, ReplyReceive, ReplyReceiver, RetryPolicy, SendError,
     SendErrorKind, SendFuture, SendPayload, SendTimeout,
 };
+pub use monitor::{
+    MONITOR_EVENT_CAPACITY, MonitorEvent, MonitorEventKind, MonitorMemberKind, WatchTarget,
+};
 pub use observe::{
     ChildSnapshot, ChildState, LIFECYCLE_EVENT_CAPACITY, LifecycleEvent, LifecycleEventKind,
     LifecycleEvents, LifecycleItem, LifecycleTryRecvError, MembershipStatus, ScopeKind,
     ScopeSnapshot, ScopeState, SnapshotClosed, SnapshotReceiver, WaitError,
 };
 pub use policy::{
-    Backoff, BackoffFactor, ChildId, DefaultsInheritance, Intensity, Jitter, Mailbox,
-    MailboxShutdown, PolicyError, Readiness, ReadinessDeadline, RestartCondition, RestartPolicy,
-    Retention, ScopeDefaults, Shutdown, Strategy,
+    Backoff, BackoffFactor, ChildId, DefaultsInheritance, Intensity, Jitter, KeyedCapacity,
+    Mailbox, MailboxShutdown, PolicyError, Readiness, ReadinessDeadline, RestartCondition,
+    RestartPolicy, Retention, ScopeDefaults, Shutdown, Strategy,
 };
 pub use raw::{
     Blocking, DeadlineElapsed, Guard, RawActor, RawContext, RawDef, RawOnceDef, Rejected,

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1154,8 +1154,20 @@ impl<M: Send + 'static> MailboxCell<M> {
         message: M,
         pinned: Option<Incarnation>,
     ) -> Result<Incarnation, SendError<M>> {
-        let key = self.prepare_key(&message);
-        let mut state = self.state.lock().expect("mailbox mutex poisoned");
+        let mut key = None;
+        let mut state = loop {
+            let state = self.state.lock().expect("mailbox mutex poisoned");
+            let needs_key = key.is_none()
+                && matches!(state.status, BindingStatus::Bound(incarnation)
+                    if pinned.is_none_or(|pinned| pinned == incarnation))
+                && matches!(state.kind, Some(MailboxKind::LatestByKey(_)));
+            if needs_key {
+                drop(state);
+                key = self.prepare_key(&message);
+                continue;
+            }
+            break state;
+        };
         match state.status {
             BindingStatus::Terminal(final_incarnation) => {
                 state.sends_rejected = state.sends_rejected.saturating_add(1);

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -5,13 +5,18 @@
 #![allow(clippy::result_large_err)]
 
 use std::{
-    collections::VecDeque,
+    any::Any,
+    collections::{VecDeque, hash_map::DefaultHasher},
     fmt,
     future::Future,
     hash::{Hash, Hasher},
     num::NonZeroUsize,
+    panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
     task::{Context, Poll, Waker},
     time::Duration,
 };
@@ -603,11 +608,79 @@ enum BindingStatus {
 enum MailboxKind {
     Queue(NonZeroUsize),
     Latest,
+    LatestByKey(NonZeroUsize),
 }
 
 struct Envelope<M> {
     message: M,
     accepted_sequence: u64,
+}
+
+trait ErasedMailboxKey: Send {
+    fn as_any(&self) -> &dyn Any;
+}
+
+struct StoredMailboxKey<K>(K);
+
+impl<K: Send + 'static> ErasedMailboxKey for StoredMailboxKey<K> {
+    fn as_any(&self) -> &dyn Any {
+        &self.0
+    }
+}
+
+pub(crate) struct MailboxKey {
+    hash: u64,
+    value: Box<dyn ErasedMailboxKey>,
+}
+
+pub(crate) trait MailboxKeyFn<M>: Send + Sync {
+    fn extract(&self, message: &M) -> MailboxKey;
+    fn equals(&self, left: &MailboxKey, right: &MailboxKey) -> bool;
+}
+
+struct TypedMailboxKeyFn<F, K> {
+    key_fn: F,
+    marker: std::marker::PhantomData<fn() -> K>,
+}
+
+impl<M, F, K> MailboxKeyFn<M> for TypedMailboxKeyFn<F, K>
+where
+    F: Fn(&M) -> K + Send + Sync,
+    K: Eq + Hash + Send + 'static,
+{
+    fn extract(&self, message: &M) -> MailboxKey {
+        let key = (self.key_fn)(message);
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        MailboxKey {
+            hash: hasher.finish(),
+            value: Box::new(StoredMailboxKey(key)),
+        }
+    }
+
+    fn equals(&self, left: &MailboxKey, right: &MailboxKey) -> bool {
+        left.hash == right.hash
+            && left.value.as_any().downcast_ref::<K>() == right.value.as_any().downcast_ref::<K>()
+    }
+}
+
+pub(crate) type MailboxKeyExtractor<M> = Arc<dyn MailboxKeyFn<M> + 'static>;
+
+pub(crate) fn mailbox_key_extractor<M, K, F>(key_fn: F) -> MailboxKeyExtractor<M>
+where
+    M: Send + 'static,
+    K: Eq + Hash + Send + 'static,
+    F: Fn(&M) -> K + Send + Sync + 'static,
+{
+    Arc::new(TypedMailboxKeyFn {
+        key_fn,
+        marker: std::marker::PhantomData,
+    })
+}
+
+struct KeyedEnvelope<M> {
+    envelope: Envelope<M>,
+    key: MailboxKey,
 }
 
 enum OperationOutcome<M> {
@@ -631,13 +704,17 @@ struct OperationState<M> {
 
 struct SendOperation<M> {
     pinned: Option<Incarnation>,
+    key: Mutex<Option<MailboxKey>>,
+    key_preparation_requested: AtomicBool,
     state: Mutex<OperationState<M>>,
 }
 
 impl<M> SendOperation<M> {
-    fn new(message: M, pinned: Option<Incarnation>) -> Arc<Self> {
+    fn new(message: M, pinned: Option<Incarnation>, key: Option<MailboxKey>) -> Arc<Self> {
         Arc::new(Self {
             pinned,
+            key: Mutex::new(key),
+            key_preparation_requested: AtomicBool::new(false),
             state: Mutex::new(OperationState {
                 outcome: OperationOutcome::Waiting {
                     message: Some(message),
@@ -658,17 +735,18 @@ impl<M> SendOperation<M> {
         }
     }
 
-    fn accept(&self, incarnation: Incarnation) -> Option<(M, Option<Waker>)> {
-        let (message, wake) = {
+    fn accept(&self, incarnation: Incarnation) -> Option<(M, Option<MailboxKey>, Option<Waker>)> {
+        let (message, key, wake) = {
             let mut state = self.state.lock().expect("send operation mutex poisoned");
             let OperationOutcome::Waiting { message, .. } = &mut state.outcome else {
                 return None;
             };
             let message = message.take()?;
+            let key = self.take_key();
             state.outcome = OperationOutcome::Accepted(incarnation);
-            (message, state.waker.take())
+            (message, key, state.waker.take())
         };
-        Some((message, wake))
+        Some((message, key, wake))
     }
 
     fn fail(&self, observed: Option<Incarnation>, kind: SendErrorKind) -> Option<Waker> {
@@ -694,6 +772,66 @@ impl<M> SendOperation<M> {
     fn pinned(&self) -> Option<Incarnation> {
         self.pinned
     }
+
+    fn take_key(&self) -> Option<MailboxKey> {
+        self.key
+            .lock()
+            .expect("send operation key mutex poisoned")
+            .take()
+    }
+
+    fn has_key(&self) -> bool {
+        self.key
+            .lock()
+            .expect("send operation key mutex poisoned")
+            .is_some()
+    }
+
+    fn request_key_preparation(&self) -> Option<Waker> {
+        self.key_preparation_requested
+            .store(true, Ordering::Release);
+        self.state
+            .lock()
+            .expect("send operation mutex poisoned")
+            .waker
+            .take()
+    }
+
+    fn prepare_key_if_missing(&self, extractor: &dyn MailboxKeyFn<M>) -> bool {
+        if self
+            .key
+            .lock()
+            .expect("send operation key mutex poisoned")
+            .is_some()
+        {
+            return false;
+        }
+        let key = {
+            let state = self.state.lock().expect("send operation mutex poisoned");
+            let OperationOutcome::Waiting {
+                message: Some(message),
+                ..
+            } = &state.outcome
+            else {
+                return false;
+            };
+            let extracted = catch_unwind(AssertUnwindSafe(|| extractor.extract(message)));
+            drop(state);
+            match extracted {
+                Ok(key) => key,
+                Err(payload) => resume_unwind(payload),
+            }
+        };
+        let mut stored = self.key.lock().expect("send operation key mutex poisoned");
+        if stored.is_none() {
+            *stored = Some(key);
+            self.key_preparation_requested
+                .store(false, Ordering::Release);
+            true
+        } else {
+            false
+        }
+    }
 }
 
 struct MailboxState<M> {
@@ -702,10 +840,13 @@ struct MailboxState<M> {
     last_bound: Option<Incarnation>,
     queue: VecDeque<Envelope<M>>,
     latest: Option<Envelope<M>>,
+    keyed: VecDeque<KeyedEnvelope<M>>,
     waiters: VecDeque<Arc<SendOperation<M>>>,
     accepted: u64,
     delivered: u64,
+    local_delivered: u64,
     conflated: u64,
+    evicted: u64,
     sends_rejected: u64,
 }
 
@@ -713,7 +854,9 @@ struct MailboxState<M> {
 pub(crate) struct MailboxStats {
     pub(crate) accepted: u64,
     pub(crate) delivered: u64,
+    pub(crate) local_delivered: u64,
     pub(crate) conflated: u64,
+    pub(crate) evicted: u64,
     pub(crate) sends_rejected: u64,
     pub(crate) depth: usize,
     pub(crate) capacity: usize,
@@ -744,7 +887,7 @@ impl<M> Promotion<M> {
 
 /// Type-erased control used by the supervision driver.
 pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
-    fn configure(&self, mailbox: Mailbox);
+    fn configure(&self, mailbox: Mailbox, keyed_capacity: Option<NonZeroUsize>);
     fn bind(&self, incarnation: Incarnation);
     fn freeze(&self, incarnation: Incarnation);
     fn close(&self, incarnation: Incarnation);
@@ -755,6 +898,7 @@ pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
 pub(crate) struct MailboxCell<M> {
     actor_id: ChildId,
     state: Mutex<MailboxState<M>>,
+    key_extractor: Mutex<Option<MailboxKeyExtractor<M>>>,
     changed: Signal,
 }
 
@@ -777,14 +921,113 @@ impl<M: Send + 'static> MailboxCell<M> {
                 last_bound: None,
                 queue: VecDeque::new(),
                 latest: None,
+                keyed: VecDeque::new(),
                 waiters: VecDeque::new(),
                 accepted: 0,
                 delivered: 0,
+                local_delivered: 0,
                 conflated: 0,
+                evicted: 0,
                 sends_rejected: 0,
             }),
+            key_extractor: Mutex::new(None),
             changed: Signal::default(),
         })
+    }
+
+    pub(crate) fn install_key_extractor(&self, extractor: MailboxKeyExtractor<M>) {
+        let previous = self
+            .key_extractor
+            .lock()
+            .expect("mailbox key-extractor mutex poisoned")
+            .replace(extractor);
+        assert!(
+            previous.is_none(),
+            "a mailbox can own only one key extractor"
+        );
+        let waiters = self
+            .state
+            .lock()
+            .expect("mailbox mutex poisoned")
+            .waiters
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        for waiter in waiters {
+            if let Some(waker) = waiter.request_key_preparation() {
+                waker.wake();
+            }
+        }
+    }
+
+    fn prepare_key(&self, message: &M) -> Option<MailboxKey> {
+        let extractor = self
+            .key_extractor
+            .lock()
+            .expect("mailbox key-extractor mutex poisoned")
+            .clone();
+        extractor.map(|extractor| extractor.extract(message))
+    }
+
+    fn prepare_operation_key(&self, operation: &SendOperation<M>) -> bool {
+        if let Some(extractor) = self.cloned_key_extractor() {
+            operation.prepare_key_if_missing(&*extractor)
+        } else {
+            false
+        }
+    }
+
+    fn promote_bound_waiters(&self) {
+        let mut state = self.state.lock().expect("mailbox mutex poisoned");
+        let extractor = self.cloned_key_extractor();
+        let promotion = promote_waiters(&mut state, extractor.as_deref());
+        drop(state);
+        self.changed.pulse();
+        promotion.finish();
+    }
+
+    fn keys_equal(&self, left: &MailboxKey, right: &MailboxKey) -> bool {
+        self.key_extractor
+            .lock()
+            .expect("mailbox key-extractor mutex poisoned")
+            .as_ref()
+            .expect("a keyed mailbox has a key extractor")
+            .equals(left, right)
+    }
+
+    fn cloned_key_extractor(&self) -> Option<MailboxKeyExtractor<M>> {
+        self.key_extractor
+            .lock()
+            .expect("mailbox key-extractor mutex poisoned")
+            .clone()
+    }
+
+    fn insert_keyed(
+        &self,
+        state: &mut MailboxState<M>,
+        capacity: NonZeroUsize,
+        envelope: Envelope<M>,
+        key: MailboxKey,
+    ) -> Option<Envelope<M>> {
+        if let Some(index) = state
+            .keyed
+            .iter()
+            .position(|entry| self.keys_equal(&entry.key, &key))
+        {
+            state.conflated = state.conflated.saturating_add(1);
+            return Some(std::mem::replace(
+                &mut state.keyed[index].envelope,
+                envelope,
+            ));
+        }
+        let displaced = if state.keyed.len() == capacity.get() {
+            state.evicted = state.evicted.saturating_add(1);
+            state.keyed.pop_front().map(|entry| entry.envelope)
+        } else {
+            None
+        };
+        state.keyed.push_back(KeyedEnvelope { envelope, key });
+        displaced
     }
 
     fn submit(&self, operation: &Arc<SendOperation<M>>) {
@@ -820,10 +1063,11 @@ impl<M: Send + 'static> MailboxCell<M> {
                         state.waiters.is_empty() && state.queue.len() < capacity.get()
                     }
                     Some(MailboxKind::Latest) => true,
+                    Some(MailboxKind::LatestByKey(_)) => true,
                     None => false,
                 };
                 if can_accept {
-                    let (message, wake) = operation
+                    let (message, key, wake) = operation
                         .accept(incarnation)
                         .expect("a newly submitted operation still owns its message");
                     state.accepted = state.accepted.saturating_add(1);
@@ -846,6 +1090,15 @@ impl<M: Send + 'static> MailboxCell<M> {
                                 .saturating_add(u64::from(displaced.is_some()));
                             displaced
                         }
+                        Some(MailboxKind::LatestByKey(capacity)) => self.insert_keyed(
+                            &mut state,
+                            capacity,
+                            Envelope {
+                                message,
+                                accepted_sequence,
+                            },
+                            key.expect("a keyed send has a prepared key"),
+                        ),
                         None => unreachable!(),
                     };
                     drop(state);
@@ -901,6 +1154,7 @@ impl<M: Send + 'static> MailboxCell<M> {
         message: M,
         pinned: Option<Incarnation>,
     ) -> Result<Incarnation, SendError<M>> {
+        let key = self.prepare_key(&message);
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         match state.status {
             BindingStatus::Terminal(final_incarnation) => {
@@ -994,6 +1248,23 @@ impl<M: Send + 'static> MailboxCell<M> {
                     drop(displaced);
                     Ok(incarnation)
                 }
+                Some(MailboxKind::LatestByKey(capacity)) => {
+                    state.accepted = state.accepted.saturating_add(1);
+                    let accepted_sequence = state.accepted;
+                    let displaced = self.insert_keyed(
+                        &mut state,
+                        capacity,
+                        Envelope {
+                            message,
+                            accepted_sequence,
+                        },
+                        key.expect("a keyed send has a prepared key"),
+                    );
+                    drop(state);
+                    self.changed.pulse();
+                    drop(displaced);
+                    Ok(incarnation)
+                }
                 None => {
                     state.sends_rejected = state.sends_rejected.saturating_add(1);
                     Err(SendError {
@@ -1041,10 +1312,22 @@ impl<M: Send + 'static> MailboxCell<M> {
                     .flatten()
                     .map(|item| item.message)
             }
+            Some(MailboxKind::LatestByKey(_)) => {
+                let eligible = accepted_through.map_or(Some(0), |limit| {
+                    state
+                        .keyed
+                        .iter()
+                        .position(|item| item.envelope.accepted_sequence <= limit)
+                });
+                eligible
+                    .and_then(|index| state.keyed.remove(index))
+                    .map(|item| item.envelope.message)
+            }
             None => None,
         };
         let promotion = if message.is_some() && matches!(state.status, BindingStatus::Bound(_)) {
-            promote_waiters(&mut state)
+            let extractor = self.cloned_key_extractor();
+            promote_waiters(&mut state, extractor.as_deref())
         } else {
             Promotion::default()
         };
@@ -1074,16 +1357,24 @@ impl<M: Send + 'static> MailboxCell<M> {
         let (depth, capacity) = match state.kind {
             Some(MailboxKind::Queue(capacity)) => (state.queue.len(), capacity.get()),
             Some(MailboxKind::Latest) => (usize::from(state.latest.is_some()), 1),
+            Some(MailboxKind::LatestByKey(capacity)) => (state.keyed.len(), capacity.get()),
             None => (0, 0),
         };
         MailboxStats {
             accepted: state.accepted,
             delivered: state.delivered,
+            local_delivered: state.local_delivered,
             conflated: state.conflated,
+            evicted: state.evicted,
             sends_rejected: state.sends_rejected,
             depth,
             capacity,
         }
+    }
+
+    pub(crate) fn record_local_delivery(&self) {
+        let mut state = self.state.lock().expect("mailbox mutex poisoned");
+        state.local_delivered = state.local_delivered.saturating_add(1);
     }
 }
 
@@ -1136,15 +1427,27 @@ impl<M> MailboxCell<M> {
 }
 
 impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
-    fn configure(&self, mailbox: Mailbox) {
-        let kind = match mailbox {
-            Mailbox::Queue(Some(capacity)) => MailboxKind::Queue(capacity),
-            Mailbox::Queue(None) => MailboxKind::Queue(
-                NonZeroUsize::new(crate::policy::DEFAULT_MAILBOX_CAPACITY)
-                    .expect("library mailbox capacity is non-zero"),
-            ),
-            Mailbox::Latest => MailboxKind::Latest,
-        };
+    fn configure(&self, mailbox: Mailbox, keyed_capacity: Option<NonZeroUsize>) {
+        let kind = keyed_capacity.map_or_else(
+            || match mailbox {
+                Mailbox::Queue(Some(capacity)) => MailboxKind::Queue(capacity),
+                Mailbox::Queue(None) => MailboxKind::Queue(
+                    NonZeroUsize::new(crate::policy::DEFAULT_MAILBOX_CAPACITY)
+                        .expect("library mailbox capacity is non-zero"),
+                ),
+                Mailbox::Latest => MailboxKind::Latest,
+            },
+            MailboxKind::LatestByKey,
+        );
+        if matches!(kind, MailboxKind::LatestByKey(_)) {
+            assert!(
+                self.key_extractor
+                    .lock()
+                    .expect("mailbox key-extractor mutex poisoned")
+                    .is_some(),
+                "a keyed mailbox requires a typed key extractor"
+            );
+        }
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         match state.kind {
             Some(existing) => debug_assert_eq!(existing, kind),
@@ -1159,7 +1462,8 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         }
         state.status = BindingStatus::Bound(incarnation);
         state.last_bound = Some(incarnation);
-        let promotion = promote_waiters(&mut state);
+        let extractor = self.cloned_key_extractor();
+        let promotion = promote_waiters(&mut state, extractor.as_deref());
         drop(state);
         self.changed.pulse();
         promotion.finish();
@@ -1201,6 +1505,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         state.status = BindingStatus::Unbound;
         let queue = std::mem::take(&mut state.queue);
         let latest = state.latest.take();
+        let keyed = std::mem::take(&mut state.keyed);
         let mut retained = VecDeque::with_capacity(state.waiters.len());
         let mut wakers = Vec::new();
         while let Some(waiter) = state.waiters.pop_front() {
@@ -1226,6 +1531,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         }
         drop(queue);
         drop(latest);
+        drop(keyed);
     }
 
     fn terminate(&self) {
@@ -1237,6 +1543,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         state.status = BindingStatus::Terminal(final_incarnation);
         let queue = std::mem::take(&mut state.queue);
         let latest = state.latest.take();
+        let keyed = std::mem::take(&mut state.keyed);
         let waiters = std::mem::take(&mut state.waiters);
         drop(state);
         let mut wakers = Vec::new();
@@ -1251,6 +1558,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         }
         drop(queue);
         drop(latest);
+        drop(keyed);
     }
 
     fn stats(&self) -> MailboxStats {
@@ -1258,7 +1566,10 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
     }
 }
 
-fn promote_waiters<M>(state: &mut MailboxState<M>) -> Promotion<M> {
+fn promote_waiters<M>(
+    state: &mut MailboxState<M>,
+    key_extractor: Option<&dyn MailboxKeyFn<M>>,
+) -> Promotion<M> {
     let mut promotion = Promotion::default();
     let Some(kind) = state.kind else {
         return promotion;
@@ -1269,12 +1580,16 @@ fn promote_waiters<M>(state: &mut MailboxState<M>) -> Promotion<M> {
     let available = match kind {
         MailboxKind::Queue(capacity) => capacity.get().saturating_sub(state.queue.len()),
         MailboxKind::Latest => usize::MAX,
+        MailboxKind::LatestByKey(_) => usize::MAX,
     };
     let mut accepted = 0usize;
-    while accepted < available {
+    let candidates = state.waiters.len();
+    let mut examined = 0usize;
+    while accepted < available && examined < candidates {
         let Some(operation) = state.waiters.pop_front() else {
             break;
         };
+        examined += 1;
         if operation
             .pinned()
             .is_some_and(|pinned| pinned != incarnation)
@@ -1292,7 +1607,14 @@ fn promote_waiters<M>(state: &mut MailboxState<M>) -> Promotion<M> {
             continue;
         }
         operation.observe(incarnation);
-        let Some((message, wake)) = operation.accept(incarnation) else {
+        if matches!(kind, MailboxKind::LatestByKey(_)) && !operation.has_key() {
+            if let Some(waker) = operation.request_key_preparation() {
+                promotion.wakers.push(waker);
+            }
+            state.waiters.push_back(operation);
+            continue;
+        }
+        let Some((message, key, wake)) = operation.accept(incarnation) else {
             continue;
         };
         if let Some(waker) = wake {
@@ -1312,6 +1634,37 @@ fn promote_waiters<M>(state: &mut MailboxState<M>) -> Promotion<M> {
                 }) {
                     state.conflated = state.conflated.saturating_add(1);
                     promotion.displaced.push(displaced);
+                }
+            }
+            MailboxKind::LatestByKey(capacity) => {
+                if let Some(displaced) = state.keyed.iter().position(|entry| {
+                    let key = key.as_ref().expect("a keyed send has a prepared key");
+                    key_extractor
+                        .expect("a keyed mailbox has a key extractor")
+                        .equals(&entry.key, key)
+                }) {
+                    state.conflated = state.conflated.saturating_add(1);
+                    promotion.displaced.push(std::mem::replace(
+                        &mut state.keyed[displaced].envelope,
+                        Envelope {
+                            message,
+                            accepted_sequence,
+                        },
+                    ));
+                } else {
+                    if state.keyed.len() == capacity.get()
+                        && let Some(displaced) = state.keyed.pop_front()
+                    {
+                        state.evicted = state.evicted.saturating_add(1);
+                        promotion.displaced.push(displaced.envelope);
+                    }
+                    state.keyed.push_back(KeyedEnvelope {
+                        envelope: Envelope {
+                            message,
+                            accepted_sequence,
+                        },
+                        key: key.expect("a keyed send has a prepared key"),
+                    });
                 }
             }
         }
@@ -1423,6 +1776,10 @@ impl<M> Clone for Ingress<M> {
 }
 
 impl<M> ActorRef<M> {
+    pub(crate) fn member_cell(&self) -> Arc<MemberCell> {
+        Arc::clone(&self.member)
+    }
+
     /// Returns the actor's child id.
     #[must_use]
     pub fn id(&self) -> &ChildId {
@@ -1447,9 +1804,12 @@ impl<M: Send + 'static> ActorRef<M> {
     fn start_send(&self, message: M, pinned: Option<Incarnation>) -> SendFuture<M> {
         match &self.ingress {
             Ingress::Direct(mailbox) => SendFuture::from_direct(DirectSend {
+                operation: {
+                    let key = mailbox.prepare_key(&message);
+                    SendOperation::new(message, pinned, key)
+                },
                 actor_id: self.id().clone(),
                 mailbox: Arc::clone(mailbox),
-                operation: SendOperation::new(message, pinned),
                 submitted: false,
                 done: false,
             }),
@@ -2003,9 +2363,12 @@ impl<M: Send + 'static> SendDriver<M> for DirectSend<M> {
         mut self: Pin<&mut Self>,
         context: &mut Context<'_>,
     ) -> Poll<Result<Incarnation, SendError<M>>> {
+        let prepared_key = self.mailbox.prepare_operation_key(&self.operation);
         if !self.submitted {
             self.submitted = true;
             self.mailbox.submit(&self.operation);
+        } else if prepared_key {
+            self.mailbox.promote_bound_waiters();
         }
         let mut state = self
             .operation
@@ -2038,6 +2401,15 @@ impl<M: Send + 'static> SendDriver<M> for DirectSend<M> {
             }
             OperationOutcome::Waiting { .. } => {
                 state.waker = Some(context.waker().clone());
+                let wake_for_key = self
+                    .operation
+                    .key_preparation_requested
+                    .load(Ordering::Acquire)
+                    && !self.operation.has_key();
+                drop(state);
+                if wake_for_key {
+                    context.waker().wake_by_ref();
+                }
                 Poll::Pending
             }
             OperationOutcome::Withdrawn => panic!("a withdrawn send future was polled"),
@@ -2476,5 +2848,38 @@ impl<M: Send + 'static> MailboxReceiver<M> {
 
     pub(crate) async fn changed(&mut self) {
         self.watcher.changed().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{num::NonZeroUsize, sync::Arc};
+
+    use super::{MailboxCell, MailboxControl, mailbox_key_extractor};
+    use crate::{ChildId, Mailbox, identity::ScopeIdentity};
+
+    #[test]
+    fn keyed_eviction_has_a_dedicated_internal_counter() {
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let membership = identity.mint_membership().expect("membership available");
+        let mut incarnations = identity.incarnation_counter(membership);
+        let incarnation = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
+            .expect("incarnation available");
+        let mailbox = MailboxCell::new(ChildId::from("keyed-counter"));
+        mailbox.install_key_extractor(mailbox_key_extractor(|message: &(usize, usize)| message.0));
+        mailbox.configure(Mailbox::latest(), NonZeroUsize::new(2));
+        mailbox.bind(incarnation);
+
+        mailbox.try_send((1, 1), None).expect("a accepted");
+        mailbox.try_send((2, 2), None).expect("b accepted");
+        mailbox.try_send((1, 3), None).expect("a replaced");
+        mailbox.try_send((3, 4), None).expect("c evicts a");
+
+        let stats = mailbox.stats();
+        assert_eq!(stats.accepted, 4);
+        assert_eq!(stats.conflated, 1);
+        assert_eq!(stats.evicted, 1);
+        assert_eq!(stats.depth, 2);
+        let _keep_type_inference_honest: Arc<MailboxCell<(usize, usize)>> = mailbox;
     }
 }

--- a/crates/shelterwood/src/monitor.rs
+++ b/crates/shelterwood/src/monitor.rs
@@ -308,6 +308,9 @@ impl<M> MonitorSink<M> {
             None
         }?;
         let terminal = matches!(event.kind, MonitorEventKind::Removed { .. });
+        if terminal {
+            state.active = false;
+        }
         let wrap = Arc::clone(&state.wrap);
         drop(state);
         if terminal {

--- a/crates/shelterwood/src/monitor.rs
+++ b/crates/shelterwood/src/monitor.rs
@@ -1,0 +1,371 @@
+//! Incarnation-owned peer monitoring and its separate actor-loop source.
+
+use std::{
+    collections::VecDeque,
+    fmt,
+    sync::{Arc, Mutex},
+};
+
+use crate::{
+    ActorRef, ChildId, Exit, Incarnation, Membership, ScopeRef, TaskRef,
+    driver::{Latch, MemberCell, Signal, SignalWatcher},
+};
+
+/// Number of raw monitor edges retained independently for each watch.
+pub const MONITOR_EVENT_CAPACITY: usize = 128;
+
+/// Kind of membership named by a monitor event.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum MonitorMemberKind {
+    /// Actor membership.
+    Actor,
+    /// Task membership.
+    Task,
+    /// Scope membership.
+    Scope,
+}
+
+/// One peer-membership event delivered through an actor's monitor source.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MonitorEvent {
+    /// Target's child id in its supervising scope.
+    pub member_id: ChildId,
+    /// Target handle kind.
+    pub member_kind: MonitorMemberKind,
+    /// Stable target membership identity.
+    pub membership: Membership,
+    /// Target transition or loss marker.
+    pub kind: MonitorEventKind,
+}
+
+/// Peer-monitor event inventory.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum MonitorEventKind {
+    /// A target incarnation started.
+    Started {
+        /// Newly running incarnation.
+        incarnation: Incarnation,
+    },
+    /// A target incarnation exited.
+    Exited {
+        /// Exited incarnation.
+        incarnation: Incarnation,
+        /// Classified exit.
+        exit: Exit,
+    },
+    /// Older events were dropped from this watch's private queue.
+    Lagged {
+        /// Exact number of dropped events in this overflow episode.
+        dropped: u64,
+    },
+    /// The target membership terminalized.
+    Removed {
+        /// Last target incarnation, or `None` when it never started.
+        last_incarnation: Option<Incarnation>,
+    },
+}
+
+/// Sealed membership target accepted by actor-context watch operations.
+pub trait WatchTarget: sealed::Sealed {}
+
+impl<M> WatchTarget for ActorRef<M> {}
+impl WatchTarget for TaskRef {}
+impl WatchTarget for ScopeRef {}
+
+pub struct MonitorTarget {
+    pub(crate) member: Arc<MemberCell>,
+    pub(crate) kind: MonitorMemberKind,
+}
+
+pub(crate) mod sealed {
+    use super::MonitorTarget;
+
+    pub trait Sealed {
+        fn monitor_target(&self) -> MonitorTarget;
+    }
+}
+
+impl<M> sealed::Sealed for ActorRef<M> {
+    fn monitor_target(&self) -> MonitorTarget {
+        MonitorTarget {
+            member: self.member_cell(),
+            kind: MonitorMemberKind::Actor,
+        }
+    }
+}
+
+impl sealed::Sealed for TaskRef {
+    fn monitor_target(&self) -> MonitorTarget {
+        MonitorTarget {
+            member: Arc::clone(&self.cell),
+            kind: MonitorMemberKind::Task,
+        }
+    }
+}
+
+impl sealed::Sealed for ScopeRef {
+    fn monitor_target(&self) -> MonitorTarget {
+        MonitorTarget {
+            member: Arc::clone(&self.cell.member),
+            kind: MonitorMemberKind::Scope,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct MonitorSource {
+    next_sequence: Mutex<u64>,
+    signal: Signal,
+}
+
+impl Default for MonitorSource {
+    fn default() -> Self {
+        Self {
+            next_sequence: Mutex::new(0),
+            signal: Signal::default(),
+        }
+    }
+}
+
+impl MonitorSource {
+    fn next_sequence(&self) -> u64 {
+        let mut sequence = self
+            .next_sequence
+            .lock()
+            .expect("monitor sequence mutex poisoned");
+        *sequence = sequence.saturating_add(1);
+        *sequence
+    }
+
+    pub(crate) fn watermark(&self) -> u64 {
+        *self
+            .next_sequence
+            .lock()
+            .expect("monitor sequence mutex poisoned")
+    }
+
+    pub(crate) fn watcher(&self) -> SignalWatcher {
+        self.signal.watcher()
+    }
+
+    fn pulse(&self) {
+        self.signal.pulse();
+    }
+}
+
+type MonitorWrap<M> = Arc<dyn Fn(MonitorEvent) -> M + Send + Sync + 'static>;
+
+struct SequencedMonitorEvent {
+    sequence: u64,
+    event: MonitorEvent,
+}
+
+struct LagMarker {
+    sequence: u64,
+    dropped: u64,
+}
+
+struct MonitorQueueState<M> {
+    wrap: MonitorWrap<M>,
+    events: VecDeque<SequencedMonitorEvent>,
+    lagged: Option<LagMarker>,
+    active: bool,
+    terminal: bool,
+    last_started: Option<Incarnation>,
+    last_exited: Option<Incarnation>,
+}
+
+pub(crate) struct MonitorDelivery<M> {
+    pub(crate) event: MonitorEvent,
+    pub(crate) wrap: MonitorWrap<M>,
+}
+
+pub(crate) trait MonitorSubscriber: fmt::Debug + Send + Sync {
+    fn publish(&self, kind: MonitorEventKind);
+}
+
+pub(crate) struct MonitorSink<M> {
+    member_id: ChildId,
+    member_kind: MonitorMemberKind,
+    membership: Membership,
+    source: Arc<MonitorSource>,
+    state: Mutex<MonitorQueueState<M>>,
+    finished: Latch,
+}
+
+impl<M> fmt::Debug for MonitorSink<M> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = self.state.lock().expect("monitor queue mutex poisoned");
+        formatter
+            .debug_struct("MonitorSink")
+            .field("membership", &self.membership)
+            .field("queued", &state.events.len())
+            .field(
+                "lagged",
+                &state.lagged.as_ref().map(|lagged| lagged.dropped),
+            )
+            .field("active", &state.active)
+            .field("terminal", &state.terminal)
+            .finish()
+    }
+}
+
+impl<M> MonitorSink<M> {
+    pub(crate) fn new<W>(
+        target: &MonitorTarget,
+        source: Arc<MonitorSource>,
+        wrap: W,
+        finished: Latch,
+    ) -> Arc<Self>
+    where
+        W: Fn(MonitorEvent) -> M + Send + Sync + 'static,
+    {
+        Arc::new(Self {
+            member_id: target.member.id().clone(),
+            member_kind: target.kind,
+            membership: target.member.membership(),
+            source,
+            state: Mutex::new(MonitorQueueState {
+                wrap: Arc::new(wrap),
+                events: VecDeque::new(),
+                lagged: None,
+                active: true,
+                terminal: false,
+                last_started: None,
+                last_exited: None,
+            }),
+            finished,
+        })
+    }
+
+    pub(crate) fn membership(&self) -> Membership {
+        self.membership
+    }
+
+    pub(crate) fn finished_latch(&self) -> Latch {
+        self.finished.clone()
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        self.state
+            .lock()
+            .expect("monitor queue mutex poisoned")
+            .active
+    }
+
+    pub(crate) fn replace<W>(&self, wrap: W)
+    where
+        W: Fn(MonitorEvent) -> M + Send + Sync + 'static,
+    {
+        let mut state = self.state.lock().expect("monitor queue mutex poisoned");
+        state.wrap = Arc::new(wrap);
+        state.events.clear();
+        state.lagged = None;
+        self.source.pulse();
+    }
+
+    pub(crate) fn cancel(&self) -> bool {
+        let mut state = self.state.lock().expect("monitor queue mutex poisoned");
+        if !state.active {
+            return false;
+        }
+        state.active = false;
+        state.events.clear();
+        state.lagged = None;
+        drop(state);
+        self.finished.fire();
+        self.source.pulse();
+        true
+    }
+
+    pub(crate) fn pop_through(&self, limit: u64) -> Option<MonitorDelivery<M>> {
+        let mut state = self.state.lock().expect("monitor queue mutex poisoned");
+        if !state.active {
+            return None;
+        }
+        let event = if state
+            .lagged
+            .as_ref()
+            .is_some_and(|lagged| lagged.sequence <= limit)
+        {
+            let lagged = state.lagged.take().expect("checked lag marker");
+            Some(MonitorEvent {
+                member_id: self.member_id.clone(),
+                member_kind: self.member_kind,
+                membership: self.membership,
+                kind: MonitorEventKind::Lagged {
+                    dropped: lagged.dropped,
+                },
+            })
+        } else if state
+            .events
+            .front()
+            .is_some_and(|event| event.sequence <= limit)
+        {
+            state.events.pop_front().map(|event| event.event)
+        } else {
+            None
+        }?;
+        let terminal = matches!(event.kind, MonitorEventKind::Removed { .. });
+        let wrap = Arc::clone(&state.wrap);
+        drop(state);
+        if terminal {
+            self.finished.fire();
+        }
+        Some(MonitorDelivery { event, wrap })
+    }
+}
+
+impl<M: Send + 'static> MonitorSubscriber for MonitorSink<M> {
+    fn publish(&self, kind: MonitorEventKind) {
+        let terminal = matches!(kind, MonitorEventKind::Removed { .. });
+        let sequence = self.source.next_sequence();
+        let mut state = self.state.lock().expect("monitor queue mutex poisoned");
+        if !state.active || state.terminal {
+            return;
+        }
+        match &kind {
+            MonitorEventKind::Started { incarnation } => {
+                if state.last_started == Some(*incarnation) {
+                    return;
+                }
+                state.last_started = Some(*incarnation);
+            }
+            MonitorEventKind::Exited { incarnation, .. } => {
+                if state.last_exited == Some(*incarnation) {
+                    return;
+                }
+                state.last_exited = Some(*incarnation);
+            }
+            MonitorEventKind::Lagged { .. } | MonitorEventKind::Removed { .. } => {}
+        }
+        if state.events.len() == MONITOR_EVENT_CAPACITY {
+            let dropped = state
+                .events
+                .pop_front()
+                .expect("a full monitor queue has a front event");
+            match &mut state.lagged {
+                Some(lagged) => lagged.dropped = lagged.dropped.saturating_add(1),
+                None => {
+                    state.lagged = Some(LagMarker {
+                        sequence: dropped.sequence,
+                        dropped: 1,
+                    });
+                }
+            }
+        }
+        state.events.push_back(SequencedMonitorEvent {
+            sequence,
+            event: MonitorEvent {
+                member_id: self.member_id.clone(),
+                member_kind: self.member_kind,
+                membership: self.membership,
+                kind,
+            },
+        });
+        state.terminal = terminal;
+        drop(state);
+        self.source.pulse();
+    }
+}

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -364,6 +364,15 @@ pub enum Mailbox {
     Latest,
 }
 
+/// Capacity selection for a keyed latest-value mailbox.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum KeyedCapacity {
+    /// Use the resolved scope or library mailbox capacity.
+    Inherit,
+    /// Keep at most this many distinct pending keys.
+    Explicit(NonZeroUsize),
+}
+
 impl Mailbox {
     /// Constructs a FIFO mailbox with an explicit capacity.
     pub fn queue(capacity: usize) -> Result<Self, PolicyError> {
@@ -474,6 +483,7 @@ pub(crate) struct CommonOptions {
     pub(crate) restart: Option<RestartPolicy>,
     pub(crate) shutdown: Option<Shutdown>,
     pub(crate) mailbox: Option<Mailbox>,
+    pub(crate) keyed_capacity: Option<KeyedCapacity>,
     pub(crate) mailbox_shutdown: Option<MailboxShutdown>,
     pub(crate) readiness: Option<Readiness>,
     pub(crate) readiness_deadline: ReadinessDeadline,
@@ -532,6 +542,7 @@ pub(crate) struct ResolvedCommonOptions {
     pub(crate) restart: RestartPolicy,
     pub(crate) shutdown: Shutdown,
     pub(crate) mailbox: Mailbox,
+    pub(crate) keyed_capacity: Option<NonZeroUsize>,
     pub(crate) mailbox_shutdown: MailboxShutdown,
     pub(crate) readiness: Readiness,
     pub(crate) readiness_override: Option<Readiness>,
@@ -557,6 +568,10 @@ pub(crate) fn resolve_common(
         },
         shutdown: options.shutdown.unwrap_or(defaults.child_shutdown),
         mailbox: resolve_default_mailbox(options.mailbox, defaults.mailbox),
+        keyed_capacity: options.keyed_capacity.map(|capacity| match capacity {
+            KeyedCapacity::Explicit(capacity) => capacity,
+            KeyedCapacity::Inherit => mailbox_capacity(defaults.mailbox),
+        }),
         mailbox_shutdown: options
             .mailbox_shutdown
             .unwrap_or(defaults.mailbox_shutdown),
@@ -571,13 +586,22 @@ pub(crate) fn resolve_common(
     }
 }
 
+fn mailbox_capacity(mailbox: Mailbox) -> NonZeroUsize {
+    match mailbox {
+        Mailbox::Queue(Some(capacity)) => capacity,
+        Mailbox::Queue(None) => NonZeroUsize::new(DEFAULT_MAILBOX_CAPACITY)
+            .expect("library mailbox capacity is non-zero"),
+        Mailbox::Latest => NonZeroUsize::MIN,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{num::NonZeroUsize, time::Duration};
 
     use super::{
-        Backoff, BackoffFactor, Intensity, Jitter, Mailbox, PolicyError, ReadinessDeadline,
-        ResolvedDefaults, ScopeDefaults,
+        Backoff, BackoffFactor, CommonOptions, Intensity, Jitter, KeyedCapacity, Mailbox,
+        PolicyError, Readiness, ReadinessDeadline, ResolvedDefaults, ScopeDefaults, resolve_common,
     };
 
     #[test]
@@ -650,5 +674,23 @@ mod tests {
         assert_eq!(deferred_queue.mailbox, Mailbox::default());
         assert_eq!(deferred_queue.child_restart, latest.child_restart);
         assert_eq!(deferred_queue.child_shutdown, latest.child_shutdown);
+
+        let inherited_keyed = resolve_common(
+            &CommonOptions {
+                keyed_capacity: Some(KeyedCapacity::Inherit),
+                ..CommonOptions::default()
+            },
+            &ResolvedDefaults {
+                mailbox: Mailbox::queue(3).expect("non-zero capacity"),
+                ..ResolvedDefaults::default()
+            },
+            false,
+            Readiness::Immediate,
+        );
+        assert_eq!(
+            inherited_keyed.keyed_capacity,
+            NonZeroUsize::new(3),
+            "keyed kind inherits the resolved capacity without inheriting the mailbox kind"
+        );
     }
 }

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -14,11 +14,14 @@ use std::{
 };
 
 use crate::{
-    ActorRef, CancellationToken, ChildId, ExitResult, Incarnation, Mailbox, MailboxShutdown,
-    PolicyError, Readiness, ReadinessDeadline, RestartPolicy, Retention, ScopeRef, SendPayload,
-    Shutdown,
+    ActorRef, CancellationToken, ChildId, ExitResult, Incarnation, KeyedCapacity, Mailbox,
+    MailboxShutdown, PolicyError, Readiness, ReadinessDeadline, RestartPolicy, Retention, ScopeRef,
+    SendPayload, Shutdown, WatchTarget,
     driver::{ActorWork, Latch, Signal, SignalWatcher},
-    mailbox::{MailboxCell, MailboxControl, MailboxReceiver},
+    mailbox::{
+        MailboxCell, MailboxControl, MailboxKeyExtractor, MailboxReceiver, mailbox_key_extractor,
+    },
+    monitor::{MonitorDelivery, MonitorEvent, MonitorSink, MonitorSource, MonitorSubscriber},
     policy::CommonOptions,
 };
 
@@ -72,11 +75,12 @@ impl<T> Rejected<T> {
     }
 }
 
-/// An owned cancel-on-drop lease for a scoped offload.
-#[must_use = "dropping the guard cancels its offload; call detach to keep only incarnation ownership"]
+/// An owned cancel-on-drop lease for an incarnation-scoped resource.
+#[must_use = "dropping the guard cancels its resource; call detach to keep only incarnation ownership"]
 pub struct Guard {
     cancellation: Latch,
     finished: Latch,
+    cancel_action: Option<Arc<dyn Fn() + Send + Sync + 'static>>,
     armed: bool,
 }
 
@@ -90,6 +94,13 @@ impl fmt::Debug for Guard {
 }
 
 impl Guard {
+    fn request_cancel(&self) {
+        self.cancellation.fire();
+        if let Some(cancel) = &self.cancel_action {
+            cancel();
+        }
+    }
+
     /// Reports whether cancellation has been requested for this lease.
     #[must_use]
     pub fn is_cancelled(&self) -> bool {
@@ -107,9 +118,9 @@ impl Guard {
         self.finished.fired().await;
     }
 
-    /// Cancels the guarded offload immediately and consumes the guard.
+    /// Cancels the guarded resource immediately and consumes the guard.
     pub fn cancel(mut self) {
-        self.cancellation.fire();
+        self.request_cancel();
         self.armed = false;
     }
 
@@ -122,7 +133,7 @@ impl Guard {
 impl Drop for Guard {
     fn drop(&mut self) {
         if self.armed {
-            self.cancellation.fire();
+            self.request_cancel();
         }
     }
 }
@@ -328,6 +339,8 @@ struct FiredTimerBatch {
     mailbox_complete: bool,
     offloads_through: u64,
     offloads_complete: bool,
+    monitors_through: u64,
+    monitors_complete: bool,
 }
 
 struct SharedOffloadFuture(SharedWork);
@@ -356,6 +369,10 @@ struct OffloadResource {
     task: Option<ActorWork>,
 }
 
+struct WatchResource<M> {
+    sink: Arc<MonitorSink<M>>,
+}
+
 impl OffloadResource {
     fn cancel(&mut self) {
         self.cancellation.fire();
@@ -380,12 +397,18 @@ struct RawResources<M> {
     events: Arc<EventQueue<M>>,
     event_watcher: SignalWatcher,
     offloads: Vec<OffloadResource>,
+    monitors: Arc<MonitorSource>,
+    monitor_watcher: SignalWatcher,
+    watches: Vec<WatchResource<M>>,
+    next_watch: usize,
 }
 
 impl<M> Default for RawResources<M> {
     fn default() -> Self {
         let events = Arc::new(EventQueue::default());
         let event_watcher = events.signal.watcher();
+        let monitors = Arc::new(MonitorSource::default());
+        let monitor_watcher = monitors.watcher();
         Self {
             accepting: true,
             continuations: VecDeque::new(),
@@ -396,11 +419,32 @@ impl<M> Default for RawResources<M> {
             events,
             event_watcher,
             offloads: Vec::new(),
+            monitors,
+            monitor_watcher,
+            watches: Vec::new(),
+            next_watch: 0,
         }
     }
 }
 
 impl<M> RawResources<M> {
+    fn pop_monitor_through(&mut self, limit: u64) -> Option<MonitorDelivery<M>> {
+        self.watches.retain(|watch| watch.sink.is_active());
+        if self.watches.is_empty() {
+            self.next_watch = 0;
+            return None;
+        }
+        self.next_watch %= self.watches.len();
+        for offset in 0..self.watches.len() {
+            let index = (self.next_watch + offset) % self.watches.len();
+            if let Some(delivery) = self.watches[index].sink.pop_through(limit) {
+                self.next_watch = (index + 1) % self.watches.len();
+                return Some(delivery);
+            }
+        }
+        None
+    }
+
     fn freeze(&mut self) -> usize {
         if !self.accepting {
             return 0;
@@ -414,6 +458,11 @@ impl<M> RawResources<M> {
         for offload in &mut self.offloads {
             offload.cancel();
         }
+        for watch in &self.watches {
+            watch.sink.cancel();
+        }
+        self.watches.clear();
+        self.next_watch = 0;
         dropped_continuations
     }
 
@@ -663,6 +712,42 @@ impl<M: Send + 'static> RawContext<M> {
         true
     }
 
+    /// Watches a peer membership for this actor incarnation.
+    pub fn watch<T, W>(&mut self, target: &T, wrap: W) -> Result<(), Rejected<W>>
+    where
+        T: WatchTarget,
+        W: Fn(MonitorEvent) -> M + Send + Sync + 'static,
+    {
+        self.start_watch(target, wrap, false).map(|_| ())
+    }
+
+    /// Watches a peer membership with an additional cancel-on-drop lease.
+    pub fn watch_scoped<T, W>(&mut self, target: &T, wrap: W) -> Result<Guard, Rejected<W>>
+    where
+        T: WatchTarget,
+        W: Fn(MonitorEvent) -> M + Send + Sync + 'static,
+    {
+        self.start_watch(target, wrap, true)
+            .map(|guard| guard.expect("a scoped watch produces a guard"))
+    }
+
+    /// Cancels this incarnation's watch of `target`, discarding queued edges.
+    pub fn unwatch<T: WatchTarget>(&mut self, target: &T) -> bool {
+        let target = <T as crate::monitor::sealed::Sealed>::monitor_target(target);
+        let membership = target.member.membership();
+        let Some(index) = self
+            .resources
+            .watches
+            .iter()
+            .position(|watch| watch.sink.membership() == membership)
+        else {
+            return false;
+        };
+        let watch = self.resources.watches.swap_remove(index);
+        self.resources.next_watch = 0;
+        watch.sink.cancel()
+    }
+
     /// Starts incarnation-owned async work with one total deadline budget.
     pub fn offload<F, T, C>(
         &mut self,
@@ -799,6 +884,7 @@ impl<M: Send + 'static> RawContext<M> {
         let guard = scoped.then(|| Guard {
             cancellation: cancellation.clone(),
             finished: finished.clone(),
+            cancel_action: None,
             armed: true,
         });
         let events = Arc::clone(&self.resources.events);
@@ -864,6 +950,64 @@ impl<M: Send + 'static> RawContext<M> {
         Ok(guard)
     }
 
+    fn start_watch<T, W>(
+        &mut self,
+        target: &T,
+        wrap: W,
+        scoped: bool,
+    ) -> Result<Option<Guard>, Rejected<W>>
+    where
+        T: WatchTarget,
+        W: Fn(MonitorEvent) -> M + Send + Sync + 'static,
+    {
+        if self.is_stopping() || !self.resources.accepting {
+            return Err(Rejected::new(wrap));
+        }
+        let target = <T as crate::monitor::sealed::Sealed>::monitor_target(target);
+        let membership = target.member.membership();
+        self.resources
+            .watches
+            .retain(|watch| watch.sink.is_active());
+        if let Some(watch) = self
+            .resources
+            .watches
+            .iter()
+            .find(|watch| watch.sink.membership() == membership)
+        {
+            watch.sink.replace(wrap);
+            return Ok(scoped.then(|| Self::watch_guard(&watch.sink)));
+        }
+
+        let finished = Latch::default();
+        let sink = MonitorSink::new(
+            &target,
+            Arc::clone(&self.resources.monitors),
+            wrap,
+            finished.clone(),
+        );
+        self.resources.watches.push(WatchResource {
+            sink: Arc::clone(&sink),
+        });
+        let subscriber: Arc<dyn MonitorSubscriber> = sink.clone();
+        target.member.register_monitor(subscriber);
+
+        let guard = scoped.then(|| Self::watch_guard(&sink));
+        Ok(guard)
+    }
+
+    fn watch_guard(sink: &Arc<MonitorSink<M>>) -> Guard {
+        let cancellation = Latch::default();
+        let cancel_sink = Arc::clone(sink);
+        Guard {
+            cancellation,
+            finished: sink.finished_latch(),
+            cancel_action: Some(Arc::new(move || {
+                cancel_sink.cancel();
+            })),
+            armed: true,
+        }
+    }
+
     fn next_ready(&mut self, allow_frozen_mailbox: bool) -> Option<M> {
         loop {
             self.begin_fired_batch();
@@ -903,6 +1047,18 @@ impl<M: Send + 'static> RawContext<M> {
                         }
                     }
                     batch.offloads_complete = true;
+                }
+
+                if !batch.monitors_complete {
+                    if let Some(delivery) =
+                        self.resources.pop_monitor_through(batch.monitors_through)
+                    {
+                        self.mailbox.record_local_delivery();
+                        self.resources.continuation_needs_external = false;
+                        self.resources.fired_batch = Some(batch);
+                        return Some((delivery.wrap)(delivery.event));
+                    }
+                    batch.monitors_complete = true;
                 }
 
                 if batch.continuations_remaining > 0
@@ -948,6 +1104,12 @@ impl<M: Send + 'static> RawContext<M> {
                     self.resources.continuation_needs_external = false;
                     return Some(message);
                 }
+            }
+
+            if let Some(delivery) = self.resources.pop_monitor_through(u64::MAX) {
+                self.mailbox.record_local_delivery();
+                self.resources.continuation_needs_external = false;
+                return Some((delivery.wrap)(delivery.event));
             }
 
             if let Some(message) = self.resources.continuations.pop_front() {
@@ -1000,6 +1162,8 @@ impl<M: Send + 'static> RawContext<M> {
             mailbox_complete: false,
             offloads_through: self.resources.events.watermark(),
             offloads_complete: false,
+            monitors_through: self.resources.monitors.watermark(),
+            monitors_complete: false,
         });
     }
 
@@ -1047,10 +1211,14 @@ impl<M: Send + 'static> RawContext<M> {
         let local_stop = self.local_stop.clone();
         let mailbox = &mut self.receiver;
         let event_watcher = &mut self.resources.event_watcher;
+        let monitor_watcher = &mut self.resources.monitor_watcher;
         let delivery = async move {
             let _ = crate::driver::select(
                 mailbox.changed(),
-                crate::driver::select(event_watcher.changed(), sleep),
+                crate::driver::select(
+                    event_watcher.changed(),
+                    crate::driver::select(monitor_watcher.changed(), sleep),
+                ),
             )
             .await;
         };
@@ -1088,6 +1256,7 @@ impl<M: Send + 'static> RawContext<M> {
 pub struct RawDef<R: RawActor> {
     factory: Arc<Mutex<Box<dyn Fn() -> R + Send + 'static>>>,
     pub(crate) options: CommonOptions,
+    pub(crate) mailbox_key: Option<MailboxKeyExtractor<R::Msg>>,
 }
 
 impl<R: RawActor> fmt::Debug for RawDef<R> {
@@ -1105,6 +1274,7 @@ impl<R: RawActor> RawDef<R> {
         Self {
             factory: Arc::new(Mutex::new(Box::new(factory))),
             options: CommonOptions::default(),
+            mailbox_key: None,
         }
     }
 
@@ -1126,6 +1296,27 @@ impl<R: RawActor> RawDef<R> {
     #[must_use]
     pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
         self.options.mailbox = Some(mailbox);
+        self.options.keyed_capacity = None;
+        self.mailbox_key = None;
+        self
+    }
+
+    /// Selects bounded per-key latest-value conflation.
+    ///
+    /// A new key at capacity evicts the oldest pending key. Size capacity for
+    /// the expected key cardinality; this is not a priority/control lane.
+    #[must_use]
+    pub fn latest_by_key<K>(
+        mut self,
+        capacity: KeyedCapacity,
+        key_fn: impl Fn(&R::Msg) -> K + Send + Sync + 'static,
+    ) -> Self
+    where
+        K: Eq + Hash + Send + 'static,
+    {
+        self.options.mailbox = None;
+        self.options.keyed_capacity = Some(capacity);
+        self.mailbox_key = Some(mailbox_key_extractor(key_fn));
         self
     }
 
@@ -1160,6 +1351,9 @@ impl<R: RawActor> RawDef<R> {
     }
 
     pub(crate) fn erase(self, mailbox: Arc<MailboxCell<R::Msg>>) -> RawConstruction {
+        if let Some(extractor) = self.mailbox_key {
+            mailbox.install_key_extractor(extractor);
+        }
         let factory = self.factory;
         RawConstruction {
             source: RawSource::Restartable(Arc::new(Mutex::new(Box::new(move || {
@@ -1181,6 +1375,7 @@ impl<R: RawActor> RawDef<R> {
 pub struct RawOnceDef<R: RawActor> {
     actor: R,
     pub(crate) options: CommonOptions,
+    pub(crate) mailbox_key: Option<MailboxKeyExtractor<R::Msg>>,
 }
 
 impl<R: RawActor> fmt::Debug for RawOnceDef<R> {
@@ -1199,6 +1394,7 @@ impl<R: RawActor> RawOnceDef<R> {
         Self {
             actor,
             options: CommonOptions::default(),
+            mailbox_key: None,
         }
     }
 
@@ -1213,6 +1409,27 @@ impl<R: RawActor> RawOnceDef<R> {
     #[must_use]
     pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
         self.options.mailbox = Some(mailbox);
+        self.options.keyed_capacity = None;
+        self.mailbox_key = None;
+        self
+    }
+
+    /// Selects bounded per-key latest-value conflation.
+    ///
+    /// A new key at capacity evicts the oldest pending key. Size capacity for
+    /// the expected key cardinality; this is not a priority/control lane.
+    #[must_use]
+    pub fn latest_by_key<K>(
+        mut self,
+        capacity: KeyedCapacity,
+        key_fn: impl Fn(&R::Msg) -> K + Send + Sync + 'static,
+    ) -> Self
+    where
+        K: Eq + Hash + Send + 'static,
+    {
+        self.options.mailbox = None;
+        self.options.keyed_capacity = Some(capacity);
+        self.mailbox_key = Some(mailbox_key_extractor(key_fn));
         self
     }
 
@@ -1247,6 +1464,9 @@ impl<R: RawActor> RawOnceDef<R> {
     }
 
     pub(crate) fn erase(self, mailbox: Arc<MailboxCell<R::Msg>>) -> RawConstruction {
+        if let Some(extractor) = self.mailbox_key {
+            mailbox.install_key_extractor(extractor);
+        }
         RawConstruction {
             source: RawSource::OneShot(Some(Box::new(RawInstance {
                 actor: self.actor,

--- a/crates/shelterwood/tests/m8.rs
+++ b/crates/shelterwood/tests/m8.rs
@@ -185,6 +185,7 @@ enum WatchMessage {
     UnwatchTask,
     CancelScope,
     WatchTerminalTask,
+    WatchTerminalTaskAgain,
     WatchTerminalScope,
 }
 
@@ -239,6 +240,11 @@ impl RawActor for WatchAllActor {
                     context
                         .watch(&self.task, |event| WatchMessage::Event(3, event))
                         .expect("terminal task watch accepted");
+                }
+                WatchMessage::WatchTerminalTaskAgain => {
+                    context
+                        .watch(&self.task, |event| WatchMessage::Event(5, event))
+                        .expect("terminal task re-watch accepted");
                 }
                 WatchMessage::WatchTerminalScope => {
                     context
@@ -447,6 +453,24 @@ async fn watches_cover_all_handle_kinds_replace_cancel_and_report_terminal_targe
                     && event.membership == task.membership()
                     && !matches!(event.kind, MonitorEventKind::Started { .. })
             })
+    );
+    watcher
+        .send(WatchMessage::WatchTerminalTaskAgain)
+        .await
+        .expect("terminal-task re-watch command accepted");
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            events
+                .lock()
+                .expect("monitor event log mutex poisoned")
+                .iter()
+                .any(|(generation, event)| {
+                    *generation == 5
+                        && event.membership == task.membership()
+                        && matches!(event.kind, MonitorEventKind::Removed { .. })
+                })
+        })
+        .await
     );
 
     watcher

--- a/crates/shelterwood/tests/m8.rs
+++ b/crates/shelterwood/tests/m8.rs
@@ -14,7 +14,7 @@ use std::{
 use shelterwood::{
     ActorRef, ExitError, ExitResult, Guard, Intensity, KeyedCapacity, MonitorEvent,
     MonitorEventKind, MonitorMemberKind, RawActor, RawContext, RawDef, RawOnceDef, ScopeRef,
-    SubtreeOnceDef, TaskDef, TaskRef, Tree, WatchTarget,
+    SendErrorKind, SubtreeOnceDef, TaskDef, TaskRef, Tree, WatchTarget,
 };
 use shelterwood_test_support::{ReleaseGate, poll_until};
 
@@ -127,6 +127,15 @@ async fn latest_by_key_replaces_in_place_and_evicts_the_oldest_distinct_key() {
         .shutdown(Duration::from_secs(1))
         .await
         .expect("keyed actor stops");
+    let calls_before_terminal_send = key_calls.load(Ordering::SeqCst);
+    let error = actor
+        .try_send(KeyedMessage {
+            key: "panic",
+            value: 7,
+        })
+        .expect_err("terminal keyed actor rejects without key extraction");
+    assert_eq!(error.kind, SendErrorKind::Terminated);
+    assert_eq!(key_calls.load(Ordering::SeqCst), calls_before_terminal_send);
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/m8.rs
+++ b/crates/shelterwood/tests/m8.rs
@@ -1,0 +1,674 @@
+use std::{
+    fmt::Debug,
+    future::Future,
+    num::NonZeroUsize,
+    panic::AssertUnwindSafe,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::Poll,
+    time::Duration,
+};
+
+use shelterwood::{
+    ActorRef, ExitError, ExitResult, Guard, Intensity, KeyedCapacity, MonitorEvent,
+    MonitorEventKind, MonitorMemberKind, RawActor, RawContext, RawDef, RawOnceDef, ScopeRef,
+    SubtreeOnceDef, TaskDef, TaskRef, Tree, WatchTarget,
+};
+use shelterwood_test_support::{ReleaseGate, poll_until};
+
+fn assert_copy_eq_debug_send_sync<T: Copy + Eq + Debug + Send + Sync>() {}
+fn assert_clone_eq_debug_send_sync<T: Clone + Eq + Debug + Send + Sync>() {}
+
+#[test]
+fn milestone_eight_public_data_types_keep_their_trait_contracts() {
+    assert_copy_eq_debug_send_sync::<KeyedCapacity>();
+    assert_copy_eq_debug_send_sync::<MonitorMemberKind>();
+    assert_clone_eq_debug_send_sync::<MonitorEvent>();
+    assert_clone_eq_debug_send_sync::<MonitorEventKind>();
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct KeyedMessage {
+    key: &'static str,
+    value: usize,
+}
+
+struct KeyedActor {
+    start: ReleaseGate,
+    received: Arc<Mutex<Vec<KeyedMessage>>>,
+}
+
+impl RawActor for KeyedActor {
+    type Msg = KeyedMessage;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        self.start.wait().await;
+        while let Some(message) = context.recv().await {
+            self.received
+                .lock()
+                .expect("keyed receive log mutex poisoned")
+                .push(message);
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn latest_by_key_replaces_in_place_and_evicts_the_oldest_distinct_key() {
+    let start = ReleaseGate::default();
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let key_calls = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "keyed",
+            RawOnceDef::new(KeyedActor {
+                start: start.clone(),
+                received: Arc::clone(&received),
+            })
+            .latest_by_key(
+                KeyedCapacity::Explicit(NonZeroUsize::new(2).expect("non-zero capacity")),
+                {
+                    let key_calls = Arc::clone(&key_calls);
+                    move |message: &KeyedMessage| {
+                        key_calls.fetch_add(1, Ordering::SeqCst);
+                        assert_ne!(message.key, "panic", "key panic remains on sender");
+                        message.key
+                    }
+                },
+            ),
+        )
+        .expect("valid keyed actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("keyed actor starts");
+
+    actor
+        .try_send(KeyedMessage { key: "a", value: 1 })
+        .expect("first key accepted");
+    actor
+        .try_send(KeyedMessage { key: "b", value: 2 })
+        .expect("second key accepted");
+    actor
+        .try_send(KeyedMessage { key: "a", value: 3 })
+        .expect("same key replaces without refreshing age");
+    actor
+        .try_send(KeyedMessage { key: "c", value: 4 })
+        .expect("new key evicts instead of backpressuring");
+    assert_eq!(key_calls.load(Ordering::SeqCst), 4);
+
+    let panic = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let _ = actor.try_send(KeyedMessage {
+            key: "panic",
+            value: 5,
+        });
+    }));
+    assert!(panic.is_err());
+    actor
+        .try_send(KeyedMessage { key: "d", value: 6 })
+        .expect("extractor panic did not poison the mailbox");
+
+    start.release();
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            received
+                .lock()
+                .expect("keyed receive log mutex poisoned")
+                .as_slice()
+                == [
+                    KeyedMessage { key: "c", value: 4 },
+                    KeyedMessage { key: "d", value: 6 },
+                ]
+        })
+        .await
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("keyed actor stops");
+}
+
+#[tokio::test]
+async fn split_definition_keeps_key_panics_on_the_parked_sender() {
+    let mut tree = Tree::new();
+    let slot = tree
+        .reserve_actor::<KeyedMessage>("split-keyed")
+        .expect("keyed slot reserved");
+    let actor = slot.actor_ref();
+    let mut send = Box::pin(actor.send(KeyedMessage {
+        key: "panic",
+        value: 1,
+    }));
+    let first_poll = std::future::poll_fn(|context| Poll::Ready(send.as_mut().poll(context))).await;
+    assert!(first_poll.is_pending(), "undefined actor parks the send");
+
+    let _defined = slot.define_once_raw(
+        RawOnceDef::new(KeyedActor {
+            start: ReleaseGate::default(),
+            received: Arc::new(Mutex::new(Vec::new())),
+        })
+        .latest_by_key(KeyedCapacity::Inherit, |message: &KeyedMessage| {
+            assert_ne!(message.key, "panic", "key panic remains on sender");
+            message.key
+        }),
+    );
+
+    let sender = tokio::spawn(send);
+    let panic = sender
+        .await
+        .expect_err("key extraction panics on sender task");
+    assert!(panic.is_panic());
+}
+
+enum TargetMessage {
+    Crash,
+    Stop,
+}
+
+struct TargetActor;
+
+impl RawActor for TargetActor {
+    type Msg = TargetMessage;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        match context.recv().await {
+            Some(TargetMessage::Crash) => Err(ExitError::message("restart target")),
+            Some(TargetMessage::Stop) | None => Ok(()),
+        }
+    }
+}
+
+enum WatchMessage {
+    Event(u8, MonitorEvent),
+    ReregisterActor,
+    UnwatchTask,
+    CancelScope,
+    WatchTerminalTask,
+    WatchTerminalScope,
+}
+
+struct WatchAllActor {
+    actor: ActorRef<TargetMessage>,
+    task: TaskRef,
+    scope: ScopeRef,
+    events: Arc<Mutex<Vec<(u8, MonitorEvent)>>>,
+    reregistered: Arc<AtomicUsize>,
+    task_unwatched: Arc<AtomicUsize>,
+    scope_cancelled: Arc<AtomicUsize>,
+}
+
+impl RawActor for WatchAllActor {
+    type Msg = WatchMessage;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        context
+            .watch(&self.actor, |event| WatchMessage::Event(1, event))
+            .expect("actor watch accepted");
+        context
+            .watch(&self.task, |event| WatchMessage::Event(1, event))
+            .expect("task watch accepted");
+        let mut scope_guard: Option<Guard> = Some(
+            context
+                .watch_scoped(&self.scope, |event| WatchMessage::Event(1, event))
+                .expect("scope watch accepted"),
+        );
+        while let Some(message) = context.recv().await {
+            match message {
+                WatchMessage::Event(generation, event) => self
+                    .events
+                    .lock()
+                    .expect("monitor event log mutex poisoned")
+                    .push((generation, event)),
+                WatchMessage::ReregisterActor => {
+                    context
+                        .watch(&self.actor, |event| WatchMessage::Event(2, event))
+                        .expect("actor watch replacement accepted");
+                    self.reregistered.store(1, Ordering::SeqCst);
+                }
+                WatchMessage::UnwatchTask => {
+                    let removed = context.unwatch(&self.task);
+                    self.task_unwatched
+                        .store(if removed { 2 } else { 1 }, Ordering::SeqCst);
+                }
+                WatchMessage::CancelScope => {
+                    drop(scope_guard.take());
+                    self.scope_cancelled.store(1, Ordering::SeqCst);
+                }
+                WatchMessage::WatchTerminalTask => {
+                    context
+                        .watch(&self.task, |event| WatchMessage::Event(3, event))
+                        .expect("terminal task watch accepted");
+                }
+                WatchMessage::WatchTerminalScope => {
+                    context
+                        .watch(&self.scope, |event| WatchMessage::Event(4, event))
+                        .expect("terminal scope watch accepted");
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn assert_watch_target<T: WatchTarget>() {}
+
+#[tokio::test]
+async fn watches_cover_all_handle_kinds_replace_cancel_and_report_terminal_targets() {
+    assert_watch_target::<ActorRef<TargetMessage>>();
+    assert_watch_target::<TaskRef>();
+    assert_watch_target::<ScopeRef>();
+
+    let task_release = ReleaseGate::default();
+    let mut nested = Tree::new();
+    nested
+        .add_task(
+            "hold",
+            TaskDef::new(|context| async move {
+                context.shutdown_token().cancelled().await;
+                Ok(())
+            }),
+        )
+        .expect("valid nested hold task");
+
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let reregistered = Arc::new(AtomicUsize::new(0));
+    let task_unwatched = Arc::new(AtomicUsize::new(0));
+    let scope_cancelled = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let target = tree
+        .add_raw("target", RawDef::factory(|| TargetActor))
+        .expect("valid target actor");
+    let task = tree
+        .add_task(
+            "task",
+            TaskDef::new({
+                let task_release = task_release.clone();
+                move |_| {
+                    let task_release = task_release.clone();
+                    async move {
+                        task_release.wait().await;
+                        Ok(())
+                    }
+                }
+            }),
+        )
+        .expect("valid task target");
+    let scope = tree
+        .add_subtree_once("scope", SubtreeOnceDef::new(nested))
+        .expect("valid scope target");
+    let watcher = tree
+        .add_raw_once(
+            "watcher",
+            RawOnceDef::new(WatchAllActor {
+                actor: target.clone(),
+                task: task.clone(),
+                scope: scope.clone(),
+                events: Arc::clone(&events),
+                reregistered: Arc::clone(&reregistered),
+                task_unwatched: Arc::clone(&task_unwatched),
+                scope_cancelled: Arc::clone(&scope_cancelled),
+            }),
+        )
+        .expect("valid watcher actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("watch tree starts");
+
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            events
+                .lock()
+                .expect("monitor event log mutex poisoned")
+                .len()
+                >= 3
+        })
+        .await
+    );
+    let first = events
+        .lock()
+        .expect("monitor event log mutex poisoned")
+        .clone();
+    for (kind, membership) in [
+        (MonitorMemberKind::Actor, target.membership()),
+        (MonitorMemberKind::Task, task.membership()),
+        (MonitorMemberKind::Scope, scope.membership()),
+    ] {
+        assert!(first.iter().any(|(generation, event)| {
+            *generation == 1
+                && event.member_kind == kind
+                && event.membership == membership
+                && matches!(event.kind, MonitorEventKind::Started { .. })
+        }));
+    }
+    let first_actor = first
+        .iter()
+        .find_map(|(_, event)| match event.kind {
+            MonitorEventKind::Started { incarnation }
+                if event.membership == target.membership() =>
+            {
+                Some(incarnation)
+            }
+            _ => None,
+        })
+        .expect("initial actor edge exists");
+    events
+        .lock()
+        .expect("monitor event log mutex poisoned")
+        .clear();
+
+    watcher
+        .send(WatchMessage::ReregisterActor)
+        .await
+        .expect("watch replacement command accepted");
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            reregistered.load(Ordering::SeqCst) == 1
+        })
+        .await
+    );
+    target
+        .send(TargetMessage::Crash)
+        .await
+        .expect("crash command accepted");
+    let second_actor = target
+        .next_incarnation(first_actor, Duration::from_secs(1))
+        .await
+        .expect("target restarts");
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            events
+                .lock()
+                .expect("monitor event log mutex poisoned")
+                .iter()
+                .filter(|(generation, event)| {
+                    *generation == 2 && event.membership == target.membership()
+                })
+                .count()
+                == 2
+        })
+        .await
+    );
+    let actor_edges: Vec<_> = events
+        .lock()
+        .expect("monitor event log mutex poisoned")
+        .iter()
+        .filter(|(generation, event)| *generation == 2 && event.membership == target.membership())
+        .map(|(_, event)| event.kind.clone())
+        .collect();
+    assert!(matches!(
+        &actor_edges[0],
+        MonitorEventKind::Exited { incarnation, .. } if *incarnation == first_actor
+    ));
+    assert_eq!(
+        actor_edges[1],
+        MonitorEventKind::Started {
+            incarnation: second_actor,
+        }
+    );
+
+    watcher
+        .send(WatchMessage::UnwatchTask)
+        .await
+        .expect("unwatch command accepted");
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            task_unwatched.load(Ordering::SeqCst) != 0
+        })
+        .await
+    );
+    assert_eq!(task_unwatched.load(Ordering::SeqCst), 2);
+    task_release.release();
+    let _ = task.wait().await;
+    watcher
+        .send(WatchMessage::WatchTerminalTask)
+        .await
+        .expect("terminal-task watch command accepted");
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            events
+                .lock()
+                .expect("monitor event log mutex poisoned")
+                .iter()
+                .any(|(generation, event)| {
+                    *generation == 3
+                        && event.membership == task.membership()
+                        && matches!(event.kind, MonitorEventKind::Removed { .. })
+                })
+        })
+        .await
+    );
+    assert!(
+        !events
+            .lock()
+            .expect("monitor event log mutex poisoned")
+            .iter()
+            .any(|(generation, event)| {
+                *generation == 1
+                    && event.membership == task.membership()
+                    && !matches!(event.kind, MonitorEventKind::Started { .. })
+            })
+    );
+
+    watcher
+        .send(WatchMessage::CancelScope)
+        .await
+        .expect("scope-cancel command accepted");
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            scope_cancelled.load(Ordering::SeqCst) == 1
+        })
+        .await
+    );
+    scope
+        .shutdown_and_wait(Duration::from_secs(1))
+        .await
+        .expect("nested scope stops");
+    watcher
+        .send(WatchMessage::WatchTerminalScope)
+        .await
+        .expect("terminal-scope watch command accepted");
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            events
+                .lock()
+                .expect("monitor event log mutex poisoned")
+                .iter()
+                .any(|(generation, event)| {
+                    *generation == 4
+                        && event.membership == scope.membership()
+                        && matches!(event.kind, MonitorEventKind::Removed { .. })
+                })
+        })
+        .await
+    );
+    assert!(
+        !events
+            .lock()
+            .expect("monitor event log mutex poisoned")
+            .iter()
+            .any(|(generation, event)| {
+                *generation == 1
+                    && event.membership == scope.membership()
+                    && !matches!(event.kind, MonitorEventKind::Started { .. })
+            })
+    );
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("watch tree stops");
+}
+
+struct PreSpawnWatcher {
+    target: ActorRef<TargetMessage>,
+    events: Arc<Mutex<Vec<MonitorEvent>>>,
+}
+
+impl RawActor for PreSpawnWatcher {
+    type Msg = MonitorEvent;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        context
+            .watch(&self.target, std::convert::identity)
+            .expect("pre-spawn watch accepted");
+        while let Some(event) = context.recv().await {
+            self.events
+                .lock()
+                .expect("pre-spawn event log mutex poisoned")
+                .push(event);
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn pre_spawn_watch_waits_for_the_first_real_started_edge() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let mut tree = Tree::new();
+    let watcher_slot = tree
+        .reserve_actor::<MonitorEvent>("watcher")
+        .expect("watcher slot reserved first");
+    let target = tree
+        .add_raw("target", RawDef::factory(|| TargetActor))
+        .expect("target is declared after watcher");
+    let _watcher = watcher_slot.define_once_raw(RawOnceDef::new(PreSpawnWatcher {
+        target: target.clone(),
+        events: Arc::clone(&events),
+    }));
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("pre-spawn tree starts");
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            events
+                .lock()
+                .expect("pre-spawn event log mutex poisoned")
+                .len()
+                == 1
+        })
+        .await
+    );
+    {
+        let events = events.lock().expect("pre-spawn event log mutex poisoned");
+        assert_eq!(events[0].membership, target.membership());
+        assert!(matches!(events[0].kind, MonitorEventKind::Started { .. }));
+    }
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("pre-spawn tree stops");
+}
+
+struct BlockedWatcher {
+    target: ActorRef<TargetMessage>,
+    registered: ReleaseGate,
+    deliver: ReleaseGate,
+    events: Arc<Mutex<Vec<MonitorEvent>>>,
+}
+
+impl RawActor for BlockedWatcher {
+    type Msg = MonitorEvent;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        context
+            .watch(&self.target, std::convert::identity)
+            .expect("overflow watch accepted");
+        self.registered.release();
+        self.deliver.wait().await;
+        while let Some(event) = context.recv().await {
+            self.events
+                .lock()
+                .expect("overflow event log mutex poisoned")
+                .push(event);
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn monitor_overflow_coalesces_lag_and_never_drops_terminal_removed() {
+    const RESTARTS: usize = 65;
+    let registered = ReleaseGate::default();
+    let deliver = ReleaseGate::default();
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let mut tree = Tree::new();
+    tree.intensity(
+        Intensity::new(100, Duration::from_secs(3600)).expect("valid restart intensity"),
+    );
+    let target = tree
+        .add_raw("target", RawDef::factory(|| TargetActor))
+        .expect("valid overflow target");
+    tree.add_raw_once(
+        "watcher",
+        RawOnceDef::new(BlockedWatcher {
+            target: target.clone(),
+            registered: registered.clone(),
+            deliver: deliver.clone(),
+            events: Arc::clone(&events),
+        }),
+    )
+    .expect("valid blocked watcher");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("overflow tree starts");
+    registered.wait().await;
+
+    let mut incarnation = target
+        .try_send(TargetMessage::Crash)
+        .expect("first crash accepted");
+    for _ in 1..RESTARTS {
+        incarnation = target
+            .next_incarnation(incarnation, Duration::from_secs(1))
+            .await
+            .expect("next overflow incarnation starts");
+        target
+            .try_send(TargetMessage::Crash)
+            .expect("next crash accepted");
+    }
+    incarnation = target
+        .next_incarnation(incarnation, Duration::from_secs(1))
+        .await
+        .expect("final overflow incarnation starts");
+    assert_eq!(
+        target
+            .try_send(TargetMessage::Stop)
+            .expect("terminal completion accepted"),
+        incarnation
+    );
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            system
+                .scope()
+                .child("target")
+                .is_some_and(|child| child.incarnation.is_none())
+        })
+        .await
+    );
+
+    deliver.release();
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            events
+                .lock()
+                .expect("overflow event log mutex poisoned")
+                .last()
+                .is_some_and(|event| matches!(event.kind, MonitorEventKind::Removed { .. }))
+        })
+        .await
+    );
+    {
+        let events = events.lock().expect("overflow event log mutex poisoned");
+        assert_eq!(
+            events.first().map(|event| &event.kind),
+            Some(&MonitorEventKind::Lagged { dropped: 5 })
+        );
+        assert!(matches!(
+            events.last().map(|event| &event.kind),
+            Some(MonitorEventKind::Removed {
+                last_incarnation: Some(last),
+            }) if *last == incarnation
+        ));
+    }
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("overflow tree stops");
+}

--- a/docs/keyed-mailboxes-and-monitoring.md
+++ b/docs/keyed-mailboxes-and-monitoring.md
@@ -1,0 +1,73 @@
+# Keyed mailboxes and peer monitoring
+
+Keyed latest-value mailboxes and peer watches are deliberately separate
+tools. A keyed mailbox bounds state-like application traffic by key. A watch
+delivers membership transitions through a separate actor-loop source, so
+those transitions do not consume mailbox capacity or participate in mailbox
+conflation.
+
+## Keyed latest-value mailboxes
+
+Use `latest_by_key` when each key represents replaceable state and only its
+newest pending value matters:
+
+```rust
+let definition = RawDef::factory(make_worker).latest_by_key(
+    KeyedCapacity::Explicit(NonZeroUsize::new(256).unwrap()),
+    |update: &Update| update.instrument_id,
+);
+```
+
+The capacity is the maximum number of distinct pending keys. Size it to at
+least the expected key cardinality. `KeyedCapacity::Inherit` uses the resolved
+scope or library mailbox capacity.
+
+An update for an existing key replaces that key's pending message in place.
+Replacement does not refresh its eviction age. An update for a new key when
+the mailbox is full evicts the oldest pending key and is accepted immediately;
+it never waits for capacity and never returns a full-mailbox error. Both
+replacement and eviction can drop an embedded `Reply`, so calls require the
+same explicit idempotency and reconciliation discipline as calls through a
+single-slot latest-value mailbox.
+
+The key function runs synchronously on the sender's acceptance path and may
+run concurrently on several sender threads. Keep it pure, cheap, and
+non-blocking. If it panics, the panic stays on the sender stack: the message is
+not accepted and the actor does not exit.
+
+A keyed mailbox is not a priority or control lane. A reserved “control” key
+can still be evicted by enough distinct data keys, and an older pending key is
+not delivered ahead of newer keys by priority. Put barriers and urgent control
+traffic on a non-conflating protocol path. The first-class control-lane design
+remains evidence-gated until M12.
+
+## Peer watches
+
+An actor can watch the membership behind an `ActorRef`, `TaskRef`, or
+`ScopeRef`:
+
+```rust
+context.watch(&peer, Message::PeerEvent)?;
+let lease = context.watch_scoped(&task, Message::TaskEvent)?;
+let removed = context.unwatch(&peer);
+```
+
+Each watch owns an independent bounded queue of 128 raw `MonitorEvent`s.
+Events preserve FIFO order within that watch. When the queue overflows, the
+oldest edges are dropped and one leading `Lagged { dropped }` marker reports
+the exact loss; a terminal `Removed` edge is always retained as the newest
+edge. The mapping closure runs only when the watcher actor dequeues an event.
+Monitor delivery counts as received work, but never as mailbox acceptance.
+
+Watching a currently running target queues an immediate `Started`. Watching a
+membership that has not spawned waits for its first real `Started`; it does
+not invent an incarnation. Watching an already-terminal membership queues its
+final `Removed`. Actor, task, and scope events all carry the target's stable
+membership token, member kind, child id, and incarnation evidence.
+
+A watch belongs to the watcher incarnation and is cancelled when that
+incarnation stops. Registering the same target again replaces the queued
+events and mapping closure without adding another immediate edge.
+`unwatch` and dropping a `watch_scoped` guard synchronously close the watch and
+discard queued edges. If cancellation races a dequeue, at most the one event
+already owned by the actor loop can still invoke its mapping closure.

--- a/docs/part-ii-progress.md
+++ b/docs/part-ii-progress.md
@@ -17,7 +17,7 @@ validation, and deviations for review.
 | Milestone | Status | Evidence gates | Validation | Deviations |
 |---|---|---|---|---|
 | M7 — incarnation refinements and `contramap` | complete | `call_idempotent`: **build** — repaired shard-store re-port passed; `project`: open | focused M7 and shard-store tests pass; `just ci` passes with 165 tests | none |
-| M8 — keyed conflation and peer monitoring | pending | control/priority lane remains open until M12 | pending | none |
+| M8 — keyed conflation and peer monitoring | complete | control/priority lane remains open until M12 | focused M8 tests pass; `just ci` passes with 172 tests; rustdoc/API reachability clean | none |
 | M9 — group strategies | pending | none | pending | none |
 | M10 — observation extensions | pending | none | pending | none |
 | M11 — outline, hosting, conveniences | pending | none | pending | none |


### PR DESCRIPTION
## Summary

- add typed `latest_by_key` definitions with inherited/explicit capacity, exact per-key equality, in-place replacement age, oldest-key eviction, and sender-path panic discipline
- add incarnation-owned peer watches for actor, task, and scope memberships through a separate bounded class-3 source
- implement watch replacement, synchronous cancellation, immediate live/terminal edges, exact lag coalescing, and never-dropped terminal removal
- document keyed sizing, call/conflation hazards, monitor ordering, and keep the control/priority-lane evidence gate open for M12

## Conformance evidence

- same-key replacement preserves eviction age; new keys evict rather than backpressure
- key extraction remains on the sender even for a send parked before split definition, and extractor panic does not poison the mailbox
- actor/task/scope watches cover live, pre-spawn, restart, cancellation, re-registration, and terminal states
- monitor overflow reports exact loss while retaining the final `Removed` edge
- public M8 data types retain their documented trait contracts

## Adversarial review hardening

- terminal monitor deliveries now close their sink, so watching the same terminal membership again receives a fresh immediate `Removed`
- synchronous keyed sends prepare the user extractor only after an acceptance state is linearized; terminal and otherwise rejected sends cannot run or panic in key code

## Validation

- `./scripts/dev cargo test --locked -p shelterwood --test m8` — 6 passed
- `./scripts/dev just ci` — 172 tests passed plus format, clippy, feature lanes, docs, API reachability, runtime/exit path guards, and nixfmt

Stacked directly on M7 PR #11 head `e2d767695ba07a2453d7c2694da8f1a2d193858a`.

Refs #9
