### PR TITLE
M9: add ordered group restart strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ scope, and subtrees compose both recursively.
 
 - [Calls, retries, and message ordering](docs/retry-and-ordering.md)
 - [Keyed mailboxes and peer monitoring](docs/keyed-mailboxes-and-monitoring.md)
+- [Group restart strategies](docs/group-restart-strategies.md)
 - [Shutdown and resource ownership](docs/shutdown-and-resources.md)
 - [Snapshots and lifecycle events](docs/observation.md)
 - [Embedding Shelterwood in a host process](docs/embedding.md)

--- a/SPEC.md
+++ b/SPEC.md
@@ -1627,10 +1627,9 @@ Rules (normative):
 
 ### 9.1 Fate-sharing strategy
 
-Core ships `OneForOne` only: a child's exit affects that child alone. The
-group strategies (`OneForAll`, `RestForOne`) are Part II §19 — they are the
-single largest block of deferred engine complexity, and §10's mode-based
-exit funnel is designed so they land without restructuring. The `Strategy`
+`OneForOne` is the baseline: a child's exit affects that child alone. The
+group strategies (`OneForAll`, `RestForOne`) are implemented by Part II §19
+through §10's mode-based exit funnel. The `Strategy`
 type is non-exhaustive from day one, is a property of **ordered** scopes
 only (§2), and does not exist on dynamic scope builders, configs, or
 snapshots.
@@ -2852,6 +2851,13 @@ membership publication sources. `unwatch` returns whether the key existed.
 
 **Status: Accepted (M9).** Exactly one group cycle may own an affected
 subset; concurrent exits do not merge, widen, or recursively schedule it.
+
+**M9 implementation evidence.** Both public strategy variants run through a
+single frozen cycle in the existing exit funnel. `tests/m9.rs` covers resident
+selection, `Never` exclusion, reverse ladder drain, trigger backoff,
+declared-order readiness, non-merging outside exits, readiness-failure
+re-entry, per-sibling accounting, and atomic over-budget failure without a
+partial respawn.
 
 New variants on the non-exhaustive `Strategy` (§9.1). Group restarts drain
 the affected set, re-mint the group cancellation context, and respawn in

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1,7 +1,7 @@
 //! Mutable runtime shell and shared handle state.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     future::Future,
     pin::Pin,
     sync::{
@@ -29,7 +29,7 @@ use crate::{
         ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
         LifecycleHub, MembershipStatus, ScopeKind, ScopeSnapshot, SnapshotHub, SnapshotReceiver,
     },
-    policy::{DefaultsInheritance, ResolvedDefaults},
+    policy::{DefaultsInheritance, ResolvedDefaults, Strategy},
     raw::{RawRunContext, RawSpawn},
     runtime,
     task::{OnceTaskBody, TaskContext, TaskFactory},
@@ -713,6 +713,41 @@ impl ScopeCell {
             member.publish_monitor_exited(*incarnation, exit.clone());
         }
         self.emit_locked(exited);
+        self.emit_locked(scheduled);
+    }
+
+    pub(crate) fn record_group_restart_charges(&self, count: usize) {
+        let _gate = OBSERVATION_GATE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut scope = self.record.lock().expect("scope mutex poisoned");
+        scope.total_restarts = scope
+            .total_restarts
+            .saturating_add(u64::try_from(count).unwrap_or(u64::MAX));
+        drop(scope);
+        self.publish_snapshot_chain_locked();
+    }
+
+    pub(crate) fn schedule_group_restart(
+        &self,
+        member: &MemberCell,
+        update: impl FnOnce(&mut MemberRecord),
+        exited: Option<LifecycleEventKind>,
+        scheduled: LifecycleEventKind,
+    ) {
+        let _gate = OBSERVATION_GATE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        member.update_locked(update);
+        if let Some(LifecycleEventKind::Exited {
+            incarnation, exit, ..
+        }) = &exited
+        {
+            member.publish_monitor_exited(*incarnation, exit.clone());
+        }
+        if let Some(exited) = exited {
+            self.emit_locked(exited);
+        }
         self.emit_locked(scheduled);
     }
 
@@ -1718,6 +1753,9 @@ enum DeadlineKind {
     Restart {
         index: usize,
     },
+    GroupRestart {
+        generation: u64,
+    },
     Stop {
         index: usize,
         incarnation: Incarnation,
@@ -1748,6 +1786,50 @@ struct ChildRuntime {
     initial_ready: bool,
     initial: bool,
     spawned_once: bool,
+}
+
+struct PendingChildExit {
+    index: usize,
+    incarnation: Incarnation,
+    exit: Exit,
+    pre_ready: bool,
+}
+
+#[derive(Clone, Copy)]
+struct GroupRestartPlan {
+    index: usize,
+    attempt: u64,
+    restart_count: u64,
+    delay: Duration,
+    restart_at: Instant,
+}
+
+enum GroupPhase {
+    Draining,
+    Backoff,
+    Starting { next: usize, waiting: Option<usize> },
+}
+
+struct GroupCycle {
+    generation: u64,
+    trigger: usize,
+    plans: Vec<GroupRestartPlan>,
+    phase: GroupPhase,
+    trip: Option<IntensityTrip>,
+}
+
+impl GroupCycle {
+    fn contains(&self, index: usize) -> bool {
+        self.plans.iter().any(|plan| plan.index == index)
+    }
+
+    fn plan(&self, index: usize) -> GroupRestartPlan {
+        *self
+            .plans
+            .iter()
+            .find(|plan| plan.index == index)
+            .expect("group member has a restart plan")
+    }
 }
 
 impl ChildRuntime {
@@ -1784,6 +1866,7 @@ struct ScopeRuntime {
     defaults: ResolvedDefaults,
     intensity_policy: crate::Intensity,
     intensity: IntensityState,
+    strategy: Strategy,
     children: Vec<ChildRuntime>,
     events: runtime::MpscSender<DriverEvent>,
     deadlines: DeadlineQueue<DeadlineKind>,
@@ -1792,6 +1875,9 @@ struct ScopeRuntime {
     startup_failed: bool,
     next_ordered_start: usize,
     draining: Option<StopReason>,
+    group: Option<GroupCycle>,
+    deferred_exits: VecDeque<PendingChildExit>,
+    next_group_generation: u64,
     is_root: bool,
     parent_ready: Option<Latch>,
     dynamic: Option<Arc<DynamicControl>>,
@@ -1867,7 +1953,10 @@ enum SpawnBody {
 
 impl ScopeRuntime {
     fn spawn_child(&mut self, index: usize) {
-        if self.draining.is_some() || self.children[index].is_terminal() {
+        if self.draining.is_some()
+            || self.children[index].is_terminal()
+            || self.children[index].active.is_some()
+        {
             return;
         }
         let child = &mut self.children[index];
@@ -2198,7 +2287,11 @@ impl ScopeRuntime {
     }
 
     fn progress_startup(&mut self) {
-        if self.startup_complete || self.startup_failed || self.draining.is_some() {
+        if self.startup_complete
+            || self.startup_failed
+            || self.draining.is_some()
+            || self.group.is_some()
+        {
             return;
         }
         match self.flavor {
@@ -2329,6 +2422,8 @@ impl ScopeRuntime {
         }
         self.draining = Some(reason);
         self.root.set_state(ScopeState::Draining);
+        self.group = None;
+        self.process_deferred_exits();
         match self.flavor {
             ScopeFlavor::Ordered => self.stop_next_ordered(),
             ScopeFlavor::Dynamic => {
@@ -2430,6 +2525,7 @@ impl ScopeRuntime {
         }
         if became_ready {
             self.progress_startup();
+            self.progress_group_start();
         }
     }
 
@@ -2459,6 +2555,7 @@ impl ScopeRuntime {
             }),
         );
         self.progress_startup();
+        self.progress_group_start();
     }
 
     fn handle_self_stop(&mut self, index: usize, incarnation: Incarnation) {
@@ -2467,7 +2564,13 @@ impl ScopeRuntime {
             .as_ref()
             .is_some_and(|active| active.incarnation == incarnation)
         {
-            self.begin_stop_child(index, None);
+            if self.group.as_ref().is_some_and(|group| {
+                matches!(group.phase, GroupPhase::Draining) && group.contains(index)
+            }) {
+                self.stop_next_group_member();
+            } else {
+                self.begin_stop_child(index, None);
+            }
         }
     }
 
@@ -2502,7 +2605,31 @@ impl ScopeRuntime {
         if ran_for >= self.intensity_policy.within {
             child.restarts.settled();
         }
+        let pending = PendingChildExit {
+            index,
+            incarnation,
+            exit,
+            pre_ready: child.initial && !self.startup_complete && !child.initial_ready,
+        };
 
+        if let Some(group) = &self.group {
+            if matches!(group.phase, GroupPhase::Draining) && group.contains(index) {
+                self.record_group_drain_exit(pending);
+                self.stop_next_group_member();
+            } else {
+                self.deferred_exits.push_back(pending);
+                if matches!(group.phase, GroupPhase::Starting { .. }) {
+                    self.progress_group_start();
+                }
+            }
+            return;
+        }
+        self.dispatch_pending_exit(pending);
+    }
+
+    fn dispatch_pending_exit(&mut self, pending: PendingChildExit) {
+        let index = pending.index;
+        let child = &self.children[index];
         let mode = if self.draining.is_some() {
             ScopeMode::Draining
         } else {
@@ -2513,103 +2640,394 @@ impl ScopeRuntime {
         } else {
             MembershipMode::Active
         };
-        match dispatch_exit(&exit, child.options.restart, mode, member_mode) {
-            ExitDispatch::Terminal => {
-                // §6's startup abort is a startup-sequence property: the
-                // membership failed before its *initial* readiness edge. A
-                // later incarnation stopped pre-ready (e.g. during drain)
-                // does not rewind it.
-                let pre_ready = child.initial && !self.startup_complete && !child.initial_ready;
-                self.root.terminalize_child(
-                    &child.slot.member,
-                    exit.clone(),
-                    Some(incarnation),
-                    pre_ready,
-                );
-                child.construction.take();
-                let removing = child.slot.member.record().removing;
-                if removing {
-                    self.finalize_removal(index);
-                } else if pre_ready && self.draining.is_none() {
-                    self.fail_startup(index, exit);
-                    if self.children[index].options.retention == crate::Retention::Remove {
-                        self.prune_terminal(index);
-                    }
-                } else {
-                    if child.options.retention == crate::Retention::Remove {
-                        self.prune_terminal(index);
-                    }
-                    if self.draining.is_some() {
-                        self.stop_next_ordered();
-                    }
-                }
-            }
+        match dispatch_exit(&pending.exit, child.options.restart, mode, member_mode) {
+            ExitDispatch::Terminal => self.terminalize_pending_exit(pending),
             ExitDispatch::ScheduleRestart => {
-                if !self.startup_complete {
-                    child.initial_ready = false;
-                }
-                let sample = self.jitter.sample(0..u64::MAX) as f64 / u64::MAX as f64;
-                let now = runtime::now();
-                let mut effects = Vec::new();
-                let decision = schedule_restart(
-                    &mut child.restarts,
-                    &mut self.intensity,
-                    self.intensity_policy,
-                    child.options.restart,
-                    now,
-                    sample,
-                    &mut effects,
-                );
-                debug_assert!(matches!(
-                    effects.first(),
-                    Some(crate::engine::RestartEffect::Scheduled { .. })
-                ));
-                let delay = child
-                    .options
-                    .restart
-                    .backoff()
-                    .next_delay(decision.attempt, sample);
-                let restart_at = decision
-                    .restart_at
-                    .unwrap_or_else(|| now.checked_add(delay).unwrap_or(now));
-                self.root.schedule_child_restart(
-                    &child.slot.member,
-                    |record| {
-                        record.incarnation = None;
-                        record.last_exit = Some(exit.clone());
-                        record.restart_count = decision.restart_count;
-                        record.restart_at = Some(restart_at);
-                        record.stage = MemberStage::Restarting;
-                    },
-                    LifecycleEventKind::Exited {
-                        id: child.slot.member.id().clone(),
-                        membership: child.slot.member.membership(),
-                        incarnation,
-                        exit: exit.clone(),
-                    },
-                    LifecycleEventKind::RestartScheduled {
-                        id: child.slot.member.id().clone(),
-                        membership: child.slot.member.membership(),
-                        attempt: decision.attempt,
-                        delay,
-                    },
-                );
-                if decision.charge.tripped {
-                    let trip = IntensityTrip {
-                        max_restarts: self.intensity_policy.max_restarts,
-                        observed_restarts: decision.charge.in_window,
-                        within: self.intensity_policy.within,
-                    };
-                    if !self.startup_complete && !self.startup_failed {
-                        self.root
-                            .set_startup(Err(StartupError::IntensityTripped(trip.clone())));
-                    }
-                    self.begin_drain(StopReason::IntensityTripped(trip));
+                if self.flavor == ScopeFlavor::Ordered && self.strategy != Strategy::OneForOne {
+                    self.start_group_restart(pending);
                 } else {
-                    self.deadlines
-                        .push(restart_at, DeadlineKind::Restart { index });
+                    self.schedule_one_for_one(pending);
                 }
             }
+        }
+    }
+
+    fn terminalize_pending_exit(&mut self, pending: PendingChildExit) {
+        let index = pending.index;
+        let child = &mut self.children[index];
+        self.root.terminalize_child(
+            &child.slot.member,
+            pending.exit.clone(),
+            Some(pending.incarnation),
+            pending.pre_ready,
+        );
+        child.construction.take();
+        let removing = child.slot.member.record().removing;
+        if removing {
+            self.finalize_removal(index);
+        } else if pending.pre_ready && self.draining.is_none() {
+            self.fail_startup(index, pending.exit);
+            if self.children[index].options.retention == crate::Retention::Remove {
+                self.prune_terminal(index);
+            }
+        } else {
+            if child.options.retention == crate::Retention::Remove {
+                self.prune_terminal(index);
+            }
+            if self.draining.is_some() {
+                self.stop_next_ordered();
+            }
+        }
+    }
+
+    fn schedule_one_for_one(&mut self, pending: PendingChildExit) {
+        let index = pending.index;
+        let child = &mut self.children[index];
+        if !self.startup_complete {
+            child.initial_ready = false;
+        }
+        let sample = self.jitter.sample(0..u64::MAX) as f64 / u64::MAX as f64;
+        let now = runtime::now();
+        let mut effects = Vec::new();
+        let decision = schedule_restart(
+            &mut child.restarts,
+            &mut self.intensity,
+            self.intensity_policy,
+            child.options.restart,
+            now,
+            sample,
+            &mut effects,
+        );
+        debug_assert!(matches!(
+            effects.first(),
+            Some(crate::engine::RestartEffect::Scheduled { .. })
+        ));
+        let delay = child
+            .options
+            .restart
+            .backoff()
+            .next_delay(decision.attempt, sample);
+        let restart_at = decision
+            .restart_at
+            .unwrap_or_else(|| now.checked_add(delay).unwrap_or(now));
+        self.root.schedule_child_restart(
+            &child.slot.member,
+            |record| {
+                record.incarnation = None;
+                record.last_exit = Some(pending.exit.clone());
+                record.restart_count = decision.restart_count;
+                record.restart_at = Some(restart_at);
+                record.stage = MemberStage::Restarting;
+            },
+            LifecycleEventKind::Exited {
+                id: child.slot.member.id().clone(),
+                membership: child.slot.member.membership(),
+                incarnation: pending.incarnation,
+                exit: pending.exit.clone(),
+            },
+            LifecycleEventKind::RestartScheduled {
+                id: child.slot.member.id().clone(),
+                membership: child.slot.member.membership(),
+                attempt: decision.attempt,
+                delay,
+            },
+        );
+        if decision.charge.tripped {
+            self.trip_intensity(decision.charge.in_window);
+        } else {
+            self.deadlines
+                .push(restart_at, DeadlineKind::Restart { index });
+        }
+    }
+
+    fn trip_intensity(&mut self, observed_restarts: u64) {
+        let trip = IntensityTrip {
+            max_restarts: self.intensity_policy.max_restarts,
+            observed_restarts,
+            within: self.intensity_policy.within,
+        };
+        if !self.startup_complete && !self.startup_failed {
+            self.root
+                .set_startup(Err(StartupError::IntensityTripped(trip.clone())));
+        }
+        self.begin_drain(StopReason::IntensityTripped(trip));
+    }
+
+    fn start_group_restart(&mut self, pending: PendingChildExit) {
+        debug_assert!(self.group.is_none());
+        let trigger = pending.index;
+        let members = self
+            .children
+            .iter()
+            .enumerate()
+            .filter_map(|(index, child)| {
+                if index == trigger {
+                    return Some(index);
+                }
+                let in_strategy = match self.strategy {
+                    Strategy::OneForAll => true,
+                    Strategy::RestForOne => index > trigger,
+                    Strategy::OneForOne => false,
+                };
+                let resident = child.active.is_some()
+                    || matches!(child.slot.member.record().stage, MemberStage::Restarting);
+                (in_strategy
+                    && resident
+                    && !child.is_terminal()
+                    && !child.options.restart.is_never())
+                .then_some(index)
+            })
+            .collect::<Vec<_>>();
+
+        let now = runtime::now();
+        let sample = self.jitter.sample(0..u64::MAX) as f64 / u64::MAX as f64;
+        let (trigger_attempt, trigger_restart_count) = self.children[trigger].restarts.schedule();
+        let delay = self.children[trigger]
+            .options
+            .restart
+            .backoff()
+            .next_delay(trigger_attempt, sample);
+        let restart_at = now.checked_add(delay).unwrap_or(now);
+        let plans = members
+            .iter()
+            .map(|index| {
+                let (attempt, restart_count) = if *index == trigger {
+                    (trigger_attempt, trigger_restart_count)
+                } else {
+                    self.children[*index].restarts.schedule_forced()
+                };
+                GroupRestartPlan {
+                    index: *index,
+                    attempt,
+                    restart_count,
+                    delay,
+                    restart_at,
+                }
+            })
+            .collect::<Vec<_>>();
+        let charge = self
+            .intensity
+            .charge_batch(self.intensity_policy, now, plans.len())
+            .expect("a group restart always contains its trigger");
+        self.root.record_group_restart_charges(plans.len());
+
+        for plan in &plans {
+            let child = &mut self.children[plan.index];
+            if !self.startup_complete {
+                child.initial_ready = false;
+            }
+            let inactive = child.active.is_none();
+            let exit = (plan.index == trigger).then(|| LifecycleEventKind::Exited {
+                id: child.slot.member.id().clone(),
+                membership: child.slot.member.membership(),
+                incarnation: pending.incarnation,
+                exit: pending.exit.clone(),
+            });
+            if plan.index != trigger && !inactive {
+                continue;
+            }
+            self.root.schedule_group_restart(
+                &child.slot.member,
+                |record| {
+                    record.restart_count = plan.restart_count;
+                    if plan.index == trigger {
+                        record.incarnation = None;
+                        record.last_exit = Some(pending.exit.clone());
+                        record.restart_at = Some(plan.restart_at);
+                        record.stage = MemberStage::Restarting;
+                    } else if inactive {
+                        record.incarnation = None;
+                        record.restart_at = Some(plan.restart_at);
+                        record.stage = MemberStage::Restarting;
+                    }
+                },
+                exit,
+                LifecycleEventKind::RestartScheduled {
+                    id: child.slot.member.id().clone(),
+                    membership: child.slot.member.membership(),
+                    attempt: plan.attempt,
+                    delay: plan.delay,
+                },
+            );
+        }
+
+        let trip = charge.tripped.then_some(IntensityTrip {
+            max_restarts: self.intensity_policy.max_restarts,
+            observed_restarts: charge.in_window,
+            within: self.intensity_policy.within,
+        });
+        if let Some(trip) = &trip
+            && !self.startup_complete
+            && !self.startup_failed
+        {
+            self.root
+                .set_startup(Err(StartupError::IntensityTripped(trip.clone())));
+        }
+
+        self.next_group_generation = self.next_group_generation.saturating_add(1);
+        self.group = Some(GroupCycle {
+            generation: self.next_group_generation,
+            trigger,
+            plans,
+            phase: GroupPhase::Draining,
+            trip,
+        });
+        self.stop_next_group_member();
+    }
+
+    fn record_group_drain_exit(&mut self, pending: PendingChildExit) {
+        let plan = self
+            .group
+            .as_ref()
+            .expect("group drain owns this exit")
+            .plan(pending.index);
+        let child = &mut self.children[pending.index];
+        let record_exit = pending.exit.clone();
+        self.root.schedule_group_restart(
+            &child.slot.member,
+            move |record| {
+                record.incarnation = None;
+                record.last_exit = Some(record_exit);
+                record.restart_count = plan.restart_count;
+                record.restart_at = Some(plan.restart_at);
+                record.stage = MemberStage::Restarting;
+            },
+            Some(LifecycleEventKind::Exited {
+                id: child.slot.member.id().clone(),
+                membership: child.slot.member.membership(),
+                incarnation: pending.incarnation,
+                exit: pending.exit,
+            }),
+            LifecycleEventKind::RestartScheduled {
+                id: child.slot.member.id().clone(),
+                membership: child.slot.member.membership(),
+                attempt: plan.attempt,
+                delay: plan.delay,
+            },
+        );
+    }
+
+    fn stop_next_group_member(&mut self) {
+        loop {
+            let Some(group) = &self.group else {
+                return;
+            };
+            if !matches!(group.phase, GroupPhase::Draining) {
+                return;
+            }
+            let next = group
+                .plans
+                .iter()
+                .rev()
+                .map(|plan| plan.index)
+                .find(|index| self.children[*index].active.is_some());
+            let Some(index) = next else {
+                if let Some(trip) = self
+                    .group
+                    .as_ref()
+                    .expect("group still exists")
+                    .trip
+                    .clone()
+                {
+                    self.group = None;
+                    self.begin_drain(StopReason::IntensityTripped(trip));
+                    return;
+                }
+                let group = self.group.as_mut().expect("group still exists");
+                group.phase = GroupPhase::Backoff;
+                let restart_at = group
+                    .plans
+                    .iter()
+                    .find(|plan| plan.index == group.trigger)
+                    .expect("group retains trigger plan")
+                    .restart_at;
+                self.deadlines.push(
+                    restart_at,
+                    DeadlineKind::GroupRestart {
+                        generation: group.generation,
+                    },
+                );
+                return;
+            };
+            if self.children[index]
+                .active
+                .as_ref()
+                .is_some_and(|active| active.ladder.is_some())
+            {
+                return;
+            }
+            self.begin_stop_child(index, None);
+            if self.children[index].active.is_some() {
+                return;
+            }
+        }
+    }
+
+    fn begin_group_start(&mut self, generation: u64) {
+        let Some(group) = self.group.as_mut() else {
+            return;
+        };
+        if group.generation != generation || !matches!(group.phase, GroupPhase::Backoff) {
+            return;
+        }
+        group.phase = GroupPhase::Starting {
+            next: 0,
+            waiting: None,
+        };
+        self.progress_group_start();
+    }
+
+    fn progress_group_start(&mut self) {
+        loop {
+            let mut spawn = None;
+            let mut finished = false;
+            {
+                let Some(group) = self.group.as_mut() else {
+                    return;
+                };
+                let GroupPhase::Starting { next, waiting } = &mut group.phase else {
+                    return;
+                };
+                if let Some(index) = *waiting {
+                    let ready_or_exited =
+                        self.children[index].active.as_ref().is_none_or(|active| {
+                            matches!(
+                                active.readiness,
+                                ReadinessGate::Immediate | ReadinessGate::Ready
+                            )
+                        });
+                    if !ready_or_exited {
+                        return;
+                    }
+                    *waiting = None;
+                }
+                if *next == group.plans.len() {
+                    finished = true;
+                } else {
+                    let index = group.plans[*next].index;
+                    *next += 1;
+                    *waiting = Some(index);
+                    spawn = Some(index);
+                }
+            }
+            if finished {
+                self.group = None;
+                self.progress_startup();
+                self.process_deferred_exits();
+                return;
+            }
+            if let Some(index) = spawn {
+                self.spawn_child(index);
+            }
+        }
+    }
+
+    fn process_deferred_exits(&mut self) {
+        while self.group.is_none() {
+            let Some(pending) = self.deferred_exits.pop_front() else {
+                return;
+            };
+            self.dispatch_pending_exit(pending);
         }
     }
 
@@ -2675,7 +3093,24 @@ impl ScopeRuntime {
                 };
                 self.begin_stop_child(index, Some(RecordedOutcome::ReadinessTimedOut { deadline }));
             }
-            DeadlineKind::Restart { index } => self.spawn_child(index),
+            DeadlineKind::Restart { index } => {
+                if self
+                    .group
+                    .as_ref()
+                    .is_some_and(|group| group.contains(index))
+                {
+                    return;
+                }
+                if self.children[index].active.is_none()
+                    && matches!(
+                        self.children[index].slot.member.record().stage,
+                        MemberStage::Restarting
+                    )
+                {
+                    self.spawn_child(index);
+                }
+            }
+            DeadlineKind::GroupRestart { generation } => self.begin_group_start(generation),
             DeadlineKind::Stop { index, incarnation } => {
                 if self.children[index]
                     .active
@@ -2995,6 +3430,7 @@ async fn run_scope_incarnation(
         defaults: plan.defaults,
         intensity_policy: plan.config.intensity,
         intensity: IntensityState::default(),
+        strategy: plan.config.strategy,
         children,
         events,
         deadlines: DeadlineQueue::default(),
@@ -3003,6 +3439,9 @@ async fn run_scope_incarnation(
         startup_failed: false,
         next_ordered_start: 0,
         draining: None,
+        group: None,
+        deferred_exits: VecDeque::new(),
+        next_group_generation: 0,
         is_root,
         parent_ready,
         dynamic,
@@ -3061,7 +3500,9 @@ async fn run_scope_incarnation(
         while let Some(deadline) = scope.deadlines.pop_due(now) {
             let class = match deadline {
                 DeadlineKind::Readiness { .. } => ArbitrationClass::ReadinessDeadline,
-                DeadlineKind::Restart { .. } => ArbitrationClass::BackoffDue,
+                DeadlineKind::Restart { .. } | DeadlineKind::GroupRestart { .. } => {
+                    ArbitrationClass::BackoffDue
+                }
                 DeadlineKind::Stop { .. } => ArbitrationClass::StopDeadline,
             };
             pending.push((class, Pending::Deadline(deadline)));

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -175,6 +175,15 @@ impl IntensityState {
             tripped: in_window > policy.max_restarts,
         }
     }
+
+    pub(crate) fn charge_batch(
+        &mut self,
+        policy: Intensity,
+        now: Instant,
+        count: usize,
+    ) -> Option<IntensityCharge> {
+        (0..count).map(|_| self.charge(policy, now)).last()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -193,6 +202,11 @@ impl RestartState {
 
     pub(crate) fn schedule(&mut self) -> (u64, u64) {
         self.attempt = self.attempt.saturating_add(1);
+        self.cumulative = self.cumulative.saturating_add(1);
+        (self.attempt, self.cumulative)
+    }
+
+    pub(crate) fn schedule_forced(&mut self) -> (u64, u64) {
         self.cumulative = self.cumulative.saturating_add(1);
         (self.attempt, self.cumulative)
     }
@@ -476,6 +490,25 @@ mod tests {
         assert!(!aged.tripped);
         assert_eq!(aged.in_window, 1);
         assert_eq!(aged.total_restarts, 3);
+    }
+
+    #[test]
+    fn group_batch_charges_atomically_without_advancing_sibling_attempts() {
+        let now = Instant::now();
+        let policy = Intensity::new(2, Duration::from_secs(10)).expect("valid intensity");
+        let mut intensity = IntensityState::default();
+        let charge = intensity
+            .charge_batch(policy, now, 3)
+            .expect("non-empty group has a final charge");
+        assert!(charge.tripped);
+        assert_eq!(charge.in_window, 3);
+        assert_eq!(charge.total_restarts, 3);
+
+        let mut trigger = RestartState::new();
+        let mut sibling = RestartState::new();
+        assert_eq!(trigger.schedule(), (1, 1));
+        assert_eq!(sibling.schedule_forced(), (0, 1));
+        assert_eq!(sibling.schedule_forced(), (0, 2));
     }
 
     #[test]

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -426,6 +426,10 @@ pub enum Strategy {
     /// Restart only the exiting child.
     #[default]
     OneForOne,
+    /// Restart every resident restartable child when one would restart.
+    OneForAll,
+    /// Restart the trigger and later resident restartable children.
+    RestForOne,
 }
 
 /// Scope defaults inherited by child declarations.

--- a/crates/shelterwood/tests/m9.rs
+++ b/crates/shelterwood/tests/m9.rs
@@ -142,6 +142,92 @@ async fn wait_for_count(counter: &AtomicUsize, expected: usize) {
     );
 }
 
+struct LaterUnreadyActor {
+    generation: usize,
+    finish_unready: ReleaseGate,
+}
+
+impl RawActor for LaterUnreadyActor {
+    type Msg = GroupMessage;
+
+    fn readiness(&self) -> Readiness {
+        Readiness::Manual
+    }
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        if self.generation == 1 {
+            context.mark_ready();
+            let Some(GroupMessage::Crash) = context.recv().await else {
+                return Ok(());
+            };
+            Err(ExitError::message("restart into an unready incarnation"))
+        } else {
+            self.finish_unready.wait().await;
+            Ok(())
+        }
+    }
+}
+
+#[tokio::test]
+async fn stopping_a_later_unready_incarnation_does_not_rewind_startup_state() {
+    let constructions = Arc::new(AtomicUsize::new(0));
+    let finish_unready = ReleaseGate::default();
+    let hold_constructions = Arc::new(AtomicUsize::new(0));
+    let ready = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.strategy(Strategy::OneForAll);
+    let actor = tree
+        .add_raw(
+            "later-unready",
+            RawDef::factory({
+                let constructions = Arc::clone(&constructions);
+                let finish_unready = finish_unready.clone();
+                move || LaterUnreadyActor {
+                    generation: constructions.fetch_add(1, Ordering::SeqCst) + 1,
+                    finish_unready: finish_unready.clone(),
+                }
+            }),
+        )
+        .expect("valid later-unready actor");
+    tree.add_raw(
+        "hold",
+        group_actor(&hold_constructions, &ready, false).restart(RestartPolicy::new(
+            RestartCondition::Never,
+            Backoff::Immediate,
+        )),
+    )
+    .expect("valid holding actor");
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("first incarnation starts");
+    let scope = system.scope().clone();
+
+    actor
+        .send(GroupMessage::Crash)
+        .await
+        .expect("restart trigger accepted");
+    wait_for_count(&constructions, 2).await;
+    finish_unready.release();
+    let terminal = scope
+        .wait_for_child(
+            "later-unready",
+            |child| child.state.is_terminal(),
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("terminal membership remains observable");
+    assert!(
+        matches!(terminal.state, shelterwood::ChildState::Stopped { .. }),
+        "unexpected terminal snapshot: {terminal:#?}"
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("group fixture stops");
+}
+
 #[tokio::test]
 async fn one_for_all_drains_restartable_residents_and_respawns_in_ready_order() {
     let first = Arc::new(AtomicUsize::new(0));

--- a/crates/shelterwood/tests/m9.rs
+++ b/crates/shelterwood/tests/m9.rs
@@ -1,0 +1,471 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use shelterwood::{
+    Backoff, ExitError, ExitResult, Intensity, Jitter, LifecycleEventKind, LifecycleItem, RawActor,
+    RawContext, RawDef, Readiness, ReadinessDeadline, RestartCondition, RestartPolicy, StopReason,
+    Strategy, Tree,
+};
+use shelterwood_test_support::{ReleaseGate, poll_until};
+
+enum GroupMessage {
+    Crash,
+}
+
+struct GroupActor {
+    generation: usize,
+    delay_second_ready: bool,
+    second_ready: ReleaseGate,
+}
+
+struct HoldingActor {
+    generation: usize,
+    shutdown_entered: ReleaseGate,
+    shutdown_release: ReleaseGate,
+}
+
+struct ReadinessFailureActor {
+    generation: usize,
+}
+
+impl RawActor for ReadinessFailureActor {
+    type Msg = GroupMessage;
+
+    fn readiness(&self) -> Readiness {
+        Readiness::Manual
+    }
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        if self.generation != 2 {
+            context.mark_ready();
+        }
+        match context.recv().await {
+            Some(GroupMessage::Crash) => Err(ExitError::message("readiness trigger")),
+            None => Ok(()),
+        }
+    }
+}
+
+fn readiness_failure_actor(constructions: &Arc<AtomicUsize>) -> RawDef<ReadinessFailureActor> {
+    RawDef::factory({
+        let constructions = Arc::clone(constructions);
+        move || ReadinessFailureActor {
+            generation: constructions.fetch_add(1, Ordering::SeqCst) + 1,
+        }
+    })
+    .readiness_deadline(
+        ReadinessDeadline::bounded(Duration::from_millis(1)).expect("valid readiness deadline"),
+    )
+}
+
+impl RawActor for HoldingActor {
+    type Msg = GroupMessage;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        match context.recv().await {
+            Some(GroupMessage::Crash) => Err(ExitError::message("holding trigger")),
+            None => {
+                if self.generation == 1 {
+                    self.shutdown_entered.release();
+                    self.shutdown_release.wait().await;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+fn holding_actor(
+    constructions: &Arc<AtomicUsize>,
+    shutdown_entered: &ReleaseGate,
+    shutdown_release: &ReleaseGate,
+) -> RawDef<HoldingActor> {
+    RawDef::factory({
+        let constructions = Arc::clone(constructions);
+        let shutdown_entered = shutdown_entered.clone();
+        let shutdown_release = shutdown_release.clone();
+        move || HoldingActor {
+            generation: constructions.fetch_add(1, Ordering::SeqCst) + 1,
+            shutdown_entered: shutdown_entered.clone(),
+            shutdown_release: shutdown_release.clone(),
+        }
+    })
+}
+
+impl RawActor for GroupActor {
+    type Msg = GroupMessage;
+
+    fn readiness(&self) -> Readiness {
+        Readiness::Manual
+    }
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        if self.generation == 2 && self.delay_second_ready {
+            self.second_ready.wait().await;
+        }
+        context.mark_ready();
+        match context.recv().await {
+            Some(GroupMessage::Crash) => Err(ExitError::message("group trigger")),
+            None => Ok(()),
+        }
+    }
+}
+
+fn group_actor(
+    constructions: &Arc<AtomicUsize>,
+    second_ready: &ReleaseGate,
+    delay_second_ready: bool,
+) -> RawDef<GroupActor> {
+    RawDef::factory({
+        let constructions = Arc::clone(constructions);
+        let second_ready = second_ready.clone();
+        move || GroupActor {
+            generation: constructions.fetch_add(1, Ordering::SeqCst) + 1,
+            delay_second_ready,
+            second_ready: second_ready.clone(),
+        }
+    })
+}
+
+async fn wait_for_count(counter: &AtomicUsize, expected: usize) {
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            counter.load(Ordering::SeqCst) == expected
+        })
+        .await,
+        "construction count did not reach {expected}"
+    );
+}
+
+#[tokio::test]
+async fn one_for_all_drains_restartable_residents_and_respawns_in_ready_order() {
+    let first = Arc::new(AtomicUsize::new(0));
+    let trigger_count = Arc::new(AtomicUsize::new(0));
+    let last = Arc::new(AtomicUsize::new(0));
+    let never = Arc::new(AtomicUsize::new(0));
+    let release_first = ReleaseGate::default();
+    let ready = ReleaseGate::default();
+
+    let mut tree = Tree::new();
+    tree.strategy(Strategy::OneForAll);
+    let _first = tree
+        .add_raw("first", group_actor(&first, &release_first, true))
+        .expect("valid first actor");
+    let trigger = tree
+        .add_raw("trigger", group_actor(&trigger_count, &ready, false))
+        .expect("valid trigger actor");
+    let _last = tree
+        .add_raw("last", group_actor(&last, &ready, false))
+        .expect("valid last actor");
+    let _never_ref = tree
+        .add_raw(
+            "never",
+            group_actor(&never, &ready, false).restart(RestartPolicy::new(
+                RestartCondition::Never,
+                Backoff::Immediate,
+            )),
+        )
+        .expect("valid never actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("group starts");
+    let never_incarnation = system
+        .scope()
+        .snapshot()
+        .child("never")
+        .expect("never resident exists")
+        .incarnation
+        .expect("never resident is live");
+
+    trigger
+        .send(GroupMessage::Crash)
+        .await
+        .expect("trigger crash accepted");
+    wait_for_count(&first, 2).await;
+    assert_eq!(trigger_count.load(Ordering::SeqCst), 1);
+    assert_eq!(last.load(Ordering::SeqCst), 1);
+    assert_eq!(never.load(Ordering::SeqCst), 1);
+
+    release_first.release();
+    wait_for_count(&trigger_count, 2).await;
+    wait_for_count(&last, 2).await;
+    assert_eq!(never.load(Ordering::SeqCst), 1);
+
+    let snapshot = system.scope().snapshot();
+    assert_eq!(snapshot.strategy, Some(Strategy::OneForAll));
+    assert_eq!(
+        snapshot
+            .child("never")
+            .expect("never member retained")
+            .incarnation,
+        Some(never_incarnation)
+    );
+    assert_eq!(snapshot.total_restarts, 3);
+    for id in ["first", "trigger", "last"] {
+        assert_eq!(
+            snapshot
+                .child(id)
+                .expect("group member retained")
+                .restart_count,
+            1
+        );
+    }
+    assert_eq!(
+        snapshot
+            .child("never")
+            .expect("never member retained")
+            .restart_count,
+        0
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("group stops");
+}
+
+#[tokio::test]
+async fn rest_for_one_keeps_earlier_members_and_restarts_the_declared_suffix() {
+    let first = Arc::new(AtomicUsize::new(0));
+    let trigger_count = Arc::new(AtomicUsize::new(0));
+    let last = Arc::new(AtomicUsize::new(0));
+    let ready = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.strategy(Strategy::RestForOne);
+    tree.add_raw("first", group_actor(&first, &ready, false))
+        .expect("valid first actor");
+    let trigger = tree
+        .add_raw("trigger", group_actor(&trigger_count, &ready, false))
+        .expect("valid trigger actor");
+    tree.add_raw("last", group_actor(&last, &ready, false))
+        .expect("valid last actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("suffix group starts");
+
+    trigger
+        .send(GroupMessage::Crash)
+        .await
+        .expect("suffix trigger accepted");
+    wait_for_count(&trigger_count, 2).await;
+    wait_for_count(&last, 2).await;
+    assert_eq!(first.load(Ordering::SeqCst), 1);
+    let snapshot = system.scope().snapshot();
+    assert_eq!(snapshot.strategy, Some(Strategy::RestForOne));
+    assert_eq!(snapshot.total_restarts, 2);
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("suffix group stops");
+}
+
+#[tokio::test]
+async fn an_outside_exit_waits_for_the_frozen_cycle_and_never_widens_it() {
+    let outside_count = Arc::new(AtomicUsize::new(0));
+    let trigger_count = Arc::new(AtomicUsize::new(0));
+    let last_count = Arc::new(AtomicUsize::new(0));
+    let ready = ReleaseGate::default();
+    let shutdown_entered = ReleaseGate::default();
+    let shutdown_release = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.strategy(Strategy::RestForOne);
+    let outside = tree
+        .add_raw("outside", group_actor(&outside_count, &ready, false))
+        .expect("valid outside actor");
+    let trigger = tree
+        .add_raw("trigger", group_actor(&trigger_count, &ready, false))
+        .expect("valid trigger actor");
+    tree.add_raw(
+        "last",
+        holding_actor(&last_count, &shutdown_entered, &shutdown_release),
+    )
+    .expect("valid holding actor");
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("deferred-exit group starts");
+
+    trigger
+        .send(GroupMessage::Crash)
+        .await
+        .expect("first group trigger accepted");
+    shutdown_entered.wait().await;
+    outside
+        .send(GroupMessage::Crash)
+        .await
+        .expect("outside exit accepted during group drain");
+    shutdown_release.release();
+
+    wait_for_count(&outside_count, 2).await;
+    wait_for_count(&trigger_count, 3).await;
+    wait_for_count(&last_count, 3).await;
+    assert_eq!(system.scope().snapshot().total_restarts, 5);
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("deferred-exit group stops");
+}
+
+#[tokio::test(start_paused = true)]
+async fn the_trigger_backoff_delays_the_entire_group() {
+    let first_count = Arc::new(AtomicUsize::new(0));
+    let trigger_count = Arc::new(AtomicUsize::new(0));
+    let ready = ReleaseGate::default();
+    let shutdown_entered = ReleaseGate::default();
+    let shutdown_release = ReleaseGate::default();
+    let backoff = Duration::from_secs(10);
+    let mut tree = Tree::new();
+    tree.strategy(Strategy::OneForAll);
+    tree.add_raw(
+        "first",
+        holding_actor(&first_count, &shutdown_entered, &shutdown_release),
+    )
+    .expect("valid first actor");
+    let trigger = tree
+        .add_raw(
+            "trigger",
+            group_actor(&trigger_count, &ready, false).restart(RestartPolicy::new(
+                RestartCondition::OnFailure,
+                Backoff::fixed(backoff, Jitter::None).expect("valid fixed backoff"),
+            )),
+        )
+        .expect("valid delayed trigger");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("delayed group starts");
+    let mut events = system.scope().subscribe_lifecycle();
+
+    let first_incarnation = trigger
+        .send(GroupMessage::Crash)
+        .await
+        .expect("delayed trigger accepted");
+    shutdown_entered.wait().await;
+    shutdown_release.release();
+    loop {
+        let Some(item) = events.recv().await else {
+            panic!("lifecycle remains open during group restart");
+        };
+        if matches!(
+            item,
+            LifecycleItem::Event(event)
+                if matches!(event.kind, LifecycleEventKind::Exited { ref id, .. } if id.as_str() == "first")
+        ) {
+            break;
+        }
+    }
+
+    assert_eq!(first_count.load(Ordering::SeqCst), 1);
+    assert_eq!(trigger_count.load(Ordering::SeqCst), 1);
+    tokio::time::advance(backoff - Duration::from_secs(1)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(first_count.load(Ordering::SeqCst), 1);
+    assert_eq!(trigger_count.load(Ordering::SeqCst), 1);
+
+    tokio::time::advance(Duration::from_secs(1)).await;
+    trigger
+        .next_incarnation(first_incarnation, Duration::from_secs(1))
+        .await
+        .expect("whole group restarts after trigger backoff");
+    wait_for_count(&first_count, 2).await;
+    wait_for_count(&trigger_count, 2).await;
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("delayed group stops");
+}
+
+#[tokio::test(start_paused = true)]
+async fn readiness_failure_reenters_the_funnel_after_the_current_cycle() {
+    let first_count = Arc::new(AtomicUsize::new(0));
+    let trigger_count = Arc::new(AtomicUsize::new(0));
+    let ready = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.strategy(Strategy::OneForAll);
+    tree.add_raw("first", readiness_failure_actor(&first_count))
+        .expect("valid readiness-failure actor");
+    let trigger = tree
+        .add_raw("trigger", group_actor(&trigger_count, &ready, false))
+        .expect("valid readiness trigger");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("readiness group starts");
+
+    trigger
+        .send(GroupMessage::Crash)
+        .await
+        .expect("readiness group trigger accepted");
+    wait_for_count(&first_count, 3).await;
+    wait_for_count(&trigger_count, 3).await;
+    assert_eq!(system.scope().snapshot().total_restarts, 4);
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("readiness group stops");
+}
+
+#[tokio::test]
+async fn group_intensity_is_one_atomic_batch_with_no_partial_respawn() {
+    let first = Arc::new(AtomicUsize::new(0));
+    let trigger_count = Arc::new(AtomicUsize::new(0));
+    let last = Arc::new(AtomicUsize::new(0));
+    let ready = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.strategy(Strategy::OneForAll);
+    tree.intensity(Intensity::new(2, Duration::from_secs(60)).expect("valid intensity"));
+    tree.add_raw("first", group_actor(&first, &ready, false))
+        .expect("valid first actor");
+    let trigger = tree
+        .add_raw("trigger", group_actor(&trigger_count, &ready, false))
+        .expect("valid trigger actor");
+    tree.add_raw("last", group_actor(&last, &ready, false))
+        .expect("valid last actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("intensity group starts");
+    let scope = system.scope().clone();
+    let mut events = scope.subscribe_lifecycle();
+
+    trigger
+        .send(GroupMessage::Crash)
+        .await
+        .expect("intensity trigger accepted");
+    let reason = system.wait().await;
+    let StopReason::IntensityTripped(trip) = reason else {
+        panic!("expected group intensity trip");
+    };
+    assert_eq!(trip.max_restarts, 2);
+    assert_eq!(trip.observed_restarts, 3);
+    assert_eq!(scope.snapshot().total_restarts, 3);
+    assert_eq!(first.load(Ordering::SeqCst), 1);
+    assert_eq!(trigger_count.load(Ordering::SeqCst), 1);
+    assert_eq!(last.load(Ordering::SeqCst), 1);
+
+    let mut order = Vec::new();
+    while let Some(item) = events.recv().await {
+        let LifecycleItem::Event(event) = item else {
+            continue;
+        };
+        match event.kind {
+            LifecycleEventKind::Exited { id, .. } => order.push((id, "exited")),
+            LifecycleEventKind::RestartScheduled { id, .. } => {
+                order.push((id, "scheduled"));
+            }
+            _ => {}
+        }
+    }
+    for id in ["first", "trigger", "last"] {
+        let exited = order
+            .iter()
+            .position(|(event_id, kind)| event_id.as_str() == id && *kind == "exited")
+            .expect("charged group member publishes exit");
+        let scheduled = order
+            .iter()
+            .position(|(event_id, kind)| event_id.as_str() == id && *kind == "scheduled")
+            .expect("charged group member publishes schedule");
+        assert!(exited < scheduled, "{id} schedules only after its exit");
+    }
+}

--- a/docs/group-restart-strategies.md
+++ b/docs/group-restart-strategies.md
@@ -1,0 +1,41 @@
+# Group restart strategies
+
+Ordered scopes can select how one restartable child failure affects its
+resident siblings:
+
+```rust
+tree.strategy(Strategy::OneForAll);
+tree.strategy(Strategy::RestForOne);
+```
+
+`OneForOne` remains the default. `OneForAll` restarts the trigger and every
+other resident restartable membership. `RestForOne` restarts the trigger and
+resident restartable memberships declared after it. Dynamic scopes do not
+expose a group strategy.
+
+A group cycle begins only when the triggering exit would have restarted under
+`OneForOne`. A one-shot child or a child with `RestartCondition::Never` cannot
+trigger a cycle and is never pulled into one. Terminal tombstones remain
+terminal. Apart from the trigger, an unstarted declaration is not resident and
+is not started early merely because a group cycle occurred.
+
+The affected set is frozen once per cycle. Its live members stop in reverse
+declaration order through their ordinary shutdown ladders, so configured grace
+and abort behavior does not change. The trigger's backoff delays the whole
+group. Survivors then respawn in declaration order, and each member must pass
+its normal readiness gate before the next is spawned. Every incarnation gets
+fresh shutdown and abort tokens; nothing from the previous cycle is reused.
+
+Each planned respawn consumes one scope intensity charge, including forced
+sibling respawns. The complete batch is charged before any spawn. If that
+batch exceeds the budget, every charge and `RestartScheduled` edge is retained,
+the scope fails, and no member partially respawns. The trigger's backoff
+attempt advances; a forced sibling's attempt does not, although its cumulative
+`restart_count` and the scope's `total_restarts` both advance.
+
+Exits that arrive from outside the frozen set are recorded but wait until the
+active cycle finishes. They are then processed as fresh funnel input and may
+start a later, independently frozen cycle; they never merge into or widen the
+current one. An exit or readiness failure during group respawn follows the
+same rule, allowing the current declared-order pass to finish before ordinary
+supervision handles that outcome.

--- a/docs/part-ii-progress.md
+++ b/docs/part-ii-progress.md
@@ -18,7 +18,7 @@ validation, and deviations for review.
 |---|---|---|---|---|
 | M7 — incarnation refinements and `contramap` | complete | `call_idempotent`: **build** — repaired shard-store re-port passed; `project`: open | focused M7 and shard-store tests pass; `just ci` passes with 165 tests | none |
 | M8 — keyed conflation and peer monitoring | complete | control/priority lane remains open until M12 | focused M8 tests pass; `just ci` passes with 172 tests; rustdoc/API reachability clean | none |
-| M9 — group strategies | pending | none | pending | none |
+| M9 — group strategies | complete | none | focused M9 tests pass; `just ci` passes with 179 tests; rustdoc/API reachability clean | none |
 | M10 — observation extensions | pending | none | pending | none |
 | M11 — outline, hosting, conveniences | pending | none | pending | none |
 | M12 — acceptance wave two | pending | control/priority lane and `project` final verdicts due | pending | none |


### PR DESCRIPTION
## Summary

- add public ordered-scope `Strategy::OneForAll` and `Strategy::RestForOne`
- run affected memberships through one frozen, non-merging group cycle with reverse ladder drain, trigger-owned backoff, and declared-order readiness-gated respawn
- defer outside and respawn-time exits until the current cycle completes, then re-enter the ordinary exit funnel
- batch-charge every planned sibling respawn atomically while leaving forced sibling attempt counters unchanged

## Conformance evidence

- `OneForAll` selects all resident restartable memberships; `RestForOne` selects the trigger and declared suffix
- `Never` members, one-shot policy, tombstones, and unstarted declarations do not revive
- trigger backoff delays the full group; each replacement gets fresh incarnation resources
- an outside exit cannot merge into or widen an active cycle
- a readiness failure finishes the current group start pass before re-entering supervision
- an over-budget group emits each member's exit before its schedule and terminates with no partial respawn

## Adversarial review hardening

- group-cycle terminalization preserves the membership's initial-startup state across later replacements; stopping a later unready incarnation no longer rewinds a successfully started child to `StartupAborted`

## Validation

- `./scripts/dev cargo test --locked -p shelterwood --test m9` — 7 passed
- `./scripts/dev just ci` — 179 tests passed plus format, clippy, feature lanes, docs, API reachability, runtime/exit path guards, and nixfmt

Stacked directly on M8 PR #12 head `f740d6c63e80c5a20c2bfe996652a5d93caf0911`.

Refs #9
