### PR TITLE
M10: add observation extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ the tree owns startup order, readiness, restart policy, bounded mailboxes,
 shutdown, and observation. Stable membership and incarnation identities make
 failure recovery explicit without a global registry.
 
-The current `0.1` surface is the core described by [SPEC.md](SPEC.md): ordered
-and dynamic scopes, `OneForOne` supervision, handler and raw actors, supervised
-tasks, queue and latest-value mailboxes, lifecycle events, and recursive
-snapshots. Part II features in the specification are intentionally not part of
-the core API yet.
+The current `0.1` surface is the core described by [SPEC.md](SPEC.md) plus the
+accepted Part II milestones through M10: incarnation-aware calls and mapping,
+keyed conflation and peer monitoring, ordered group strategies, and structured
+observation extensions. Later Part II sections remain staged by their status
+markers in the specification.
 
 ## Getting started
 
@@ -62,6 +62,7 @@ scope, and subtrees compose both recursively.
 - [Group restart strategies](docs/group-restart-strategies.md)
 - [Shutdown and resource ownership](docs/shutdown-and-resources.md)
 - [Snapshots and lifecycle events](docs/observation.md)
+- [Actor statistics and loss-recovering reducers](docs/observation-extensions.md)
 - [Embedding Shelterwood in a host process](docs/embedding.md)
 
 The executable application-scale examples live in the M5 acceptance tests:

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -15,7 +15,9 @@ use crate::{
     Incarnation, KeyedCapacity, Mailbox, MailboxShutdown, MonitorEvent, RawActor, RawContext,
     RawDef, RawOnceDef, Readiness, ReadinessDeadline, Rejected, RestartPolicy, Retention, ScopeRef,
     Shutdown, WatchTarget,
-    mailbox::{MailboxKeyExtractor, mailbox_key_extractor},
+    mailbox::{
+        MailboxKeyExtractor, MessageSizeObserver, mailbox_key_extractor, message_size_observer,
+    },
     policy::CommonOptions,
     raw::CatchUnwindFuture,
 };
@@ -485,6 +487,7 @@ pub struct ActorDef<A: Actor> {
     factory: ArgsFactory<A>,
     pub(crate) options: CommonOptions,
     mailbox_key: Option<MailboxKeyExtractor<A::Msg>>,
+    message_size: Option<MessageSizeObserver<A::Msg>>,
 }
 
 impl<A: Actor> fmt::Debug for ActorDef<A> {
@@ -511,6 +514,7 @@ impl<A: Actor> ActorDef<A> {
             factory: Arc::new(Mutex::new(Box::new(factory))),
             options: CommonOptions::default(),
             mailbox_key: None,
+            message_size: None,
         }
     }
 
@@ -556,6 +560,16 @@ impl<A: Actor> ActorDef<A> {
         self
     }
 
+    /// Observes accepted message sizes on the sender's ingress stack.
+    #[must_use]
+    pub fn message_size(
+        mut self,
+        measure: impl Fn(&A::Msg) -> usize + Send + Sync + 'static,
+    ) -> Self {
+        self.message_size = Some(message_size_observer(measure));
+        self
+    }
+
     /// Overrides frozen-prefix drain versus discard behavior.
     #[must_use]
     pub fn mailbox_shutdown(mut self, shutdown: MailboxShutdown) -> Self {
@@ -595,6 +609,7 @@ impl<A: Actor> ActorDef<A> {
         });
         raw.options = self.options;
         raw.mailbox_key = self.mailbox_key;
+        raw.message_size = self.message_size;
         raw
     }
 }
@@ -607,6 +622,7 @@ pub struct ActorOnceDef<A: Actor> {
     args: A::Args,
     pub(crate) options: CommonOptions,
     mailbox_key: Option<MailboxKeyExtractor<A::Msg>>,
+    message_size: Option<MessageSizeObserver<A::Msg>>,
 }
 
 impl<A: Actor> fmt::Debug for ActorOnceDef<A> {
@@ -626,6 +642,7 @@ impl<A: Actor> ActorOnceDef<A> {
             args,
             options: CommonOptions::default(),
             mailbox_key: None,
+            message_size: None,
         }
     }
 
@@ -664,6 +681,16 @@ impl<A: Actor> ActorOnceDef<A> {
         self
     }
 
+    /// Observes accepted message sizes on the sender's ingress stack.
+    #[must_use]
+    pub fn message_size(
+        mut self,
+        measure: impl Fn(&A::Msg) -> usize + Send + Sync + 'static,
+    ) -> Self {
+        self.message_size = Some(message_size_observer(measure));
+        self
+    }
+
     /// Overrides frozen-prefix drain versus discard behavior.
     #[must_use]
     pub fn mailbox_shutdown(mut self, shutdown: MailboxShutdown) -> Self {
@@ -697,6 +724,7 @@ impl<A: Actor> ActorOnceDef<A> {
         let mut raw = RawOnceDef::new(Handler::with_readiness(self.args, readiness));
         raw.options = self.options;
         raw.mailbox_key = self.mailbox_key;
+        raw.message_size = self.message_size;
         raw
     }
 }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -305,6 +305,7 @@ pub(crate) struct MemberCell {
     terminal_signals: Mutex<Vec<Signal>>,
     monitors: Mutex<Vec<Weak<dyn MonitorSubscriber>>>,
     mailbox: Mutex<Option<Arc<dyn MailboxControl>>>,
+    parent_scope: Mutex<Option<Weak<ScopeCell>>>,
     options: Mutex<Option<crate::policy::ResolvedCommonOptions>>,
     pub(crate) removal: Latch,
 }
@@ -328,6 +329,7 @@ impl MemberCell {
             terminal_signals: Mutex::new(Vec::new()),
             monitors: Mutex::new(Vec::new()),
             mailbox: Mutex::new(None),
+            parent_scope: Mutex::new(None),
             options: Mutex::new(None),
             removal: Latch::default(),
         })
@@ -432,6 +434,66 @@ impl MemberCell {
             .clone()
     }
 
+    pub(crate) fn set_parent_scope(&self, scope: &Arc<ScopeCell>) {
+        *self
+            .parent_scope
+            .lock()
+            .expect("member parent-scope mutex poisoned") = Some(Arc::downgrade(scope));
+    }
+
+    #[cfg(feature = "metrics")]
+    pub(crate) fn scope_path_label(&self) -> String {
+        let mut ids = Vec::new();
+        let mut current = self
+            .parent_scope
+            .lock()
+            .expect("member parent-scope mutex poisoned")
+            .as_ref()
+            .and_then(Weak::upgrade);
+        while let Some(scope) = current {
+            if scope
+                .parent
+                .lock()
+                .expect("scope parent mutex poisoned")
+                .is_some()
+            {
+                ids.push(scope.member.id().as_str().to_owned());
+            }
+            current = scope
+                .parent
+                .lock()
+                .expect("scope parent mutex poisoned")
+                .as_ref()
+                .and_then(Weak::upgrade);
+        }
+        ids.reverse();
+        if ids.is_empty() {
+            String::from("/")
+        } else {
+            format!("/{}", ids.join("/"))
+        }
+    }
+
+    pub(crate) fn actor_stats(&self) -> Option<crate::ActorStatsSnapshot> {
+        let mailbox = self.mailbox()?;
+        let stats = mailbox.stats();
+        Some(crate::ActorStatsSnapshot {
+            membership: self.membership,
+            observed_incarnation: stats.observed_incarnation,
+            stats: crate::ActorStats {
+                messages_received: stats.received,
+                messages_accepted: stats.accepted,
+                messages_conflated: stats.conflated,
+                messages_evicted: stats.evicted,
+                message_bytes_accepted: stats.message_bytes_accepted,
+                sends_rejected: stats.sends_rejected,
+                outstanding_offloads: stats.outstanding_offloads,
+                mailbox_depth: stats.depth,
+                mailbox_capacity: stats.capacity,
+            },
+        })
+    }
+
     pub(crate) fn terminalize(&self, exit: Exit) {
         let changed = {
             let mut record = self.record.lock().expect("member mutex poisoned");
@@ -455,12 +517,11 @@ impl MemberCell {
         if let Some(mailbox) = self.mailbox() {
             mailbox.terminate();
             let stats = mailbox.stats();
-            debug_assert!(stats.delivered <= stats.accepted);
             debug_assert!(stats.conflated <= stats.accepted);
             debug_assert!(stats.evicted <= stats.accepted);
             debug_assert!(stats.depth <= stats.capacity);
             let _ = stats.sends_rejected;
-            let _ = stats.local_delivered;
+            let _ = stats.received;
         }
         for signal in self
             .terminal_signals
@@ -846,6 +907,43 @@ impl ScopeCell {
         events
     }
 
+    pub(crate) fn stats_recursive(&self) -> Vec<crate::RecursiveActorStats> {
+        let mut rows = Vec::new();
+        self.collect_actor_stats(&mut Vec::new(), &mut rows);
+        rows
+    }
+
+    fn collect_actor_stats(
+        &self,
+        path: &mut Vec<ChildId>,
+        rows: &mut Vec<crate::RecursiveActorStats>,
+    ) {
+        let children = self
+            .current_children
+            .lock()
+            .expect("scope children mutex poisoned")
+            .clone();
+        for slot in children {
+            if let Some(kind) = slot.actor_kind()
+                && let Some(sample) = slot.member.actor_stats()
+            {
+                rows.push(crate::RecursiveActorStats {
+                    path: path.clone(),
+                    id: slot.member.id().clone(),
+                    kind,
+                    membership: sample.membership,
+                    observed_incarnation: sample.observed_incarnation,
+                    stats: sample.stats,
+                });
+            }
+            if let Some(scope) = &slot.scope {
+                path.push(slot.member.id().clone());
+                scope.collect_actor_stats(path, rows);
+                path.pop();
+            }
+        }
+    }
+
     fn snapshot_locked(&self) -> Arc<ScopeSnapshot> {
         let record = self.record();
         let config = self
@@ -1175,6 +1273,7 @@ impl ScopeCell {
             .expect("scope children mutex poisoned")
             .clear();
         for child in children {
+            child.member.set_parent_scope(self);
             if let Some(scope) = &child.scope {
                 *scope.parent.lock().expect("scope parent mutex poisoned") =
                     Some(Arc::downgrade(self));
@@ -1197,6 +1296,7 @@ impl ScopeCell {
         let _gate = OBSERVATION_GATE
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        child.member.set_parent_scope(self);
         if let Some(scope) = &child.scope {
             *scope.parent.lock().expect("scope parent mutex poisoned") = Some(Arc::downgrade(self));
         }

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -36,9 +36,11 @@ pub use monitor::{
     MONITOR_EVENT_CAPACITY, MonitorEvent, MonitorEventKind, MonitorMemberKind, WatchTarget,
 };
 pub use observe::{
-    ChildSnapshot, ChildState, LIFECYCLE_EVENT_CAPACITY, LifecycleEvent, LifecycleEventKind,
-    LifecycleEvents, LifecycleItem, LifecycleTryRecvError, MembershipStatus, ScopeKind,
-    ScopeSnapshot, ScopeState, SnapshotClosed, SnapshotReceiver, WaitError,
+    ActorKind, ActorStats, ActorStatsSnapshot, ChildObservation, ChildObserver, ChildSnapshot,
+    ChildState, LIFECYCLE_EVENT_CAPACITY, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
+    LifecycleItem, LifecycleTryRecvError, MembershipStatus, RecursiveActorStats, RestartCount,
+    RestartCounter, ScopeKind, ScopeSnapshot, ScopeState, SnapshotClosed, SnapshotReceiver,
+    WaitError,
 };
 pub use policy::{
     Backoff, BackoffFactor, ChildId, DefaultsInheritance, Intensity, Jitter, KeyedCapacity,

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -14,8 +14,8 @@ use std::{
     panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     pin::Pin,
     sync::{
-        Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+        Arc, Mutex, Weak,
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     task::{Context, Poll, Waker},
     time::Duration,
@@ -666,6 +666,16 @@ where
 
 pub(crate) type MailboxKeyExtractor<M> = Arc<dyn MailboxKeyFn<M> + 'static>;
 
+pub(crate) type MessageSizeObserver<M> = Arc<dyn Fn(&M) -> usize + Send + Sync + 'static>;
+
+pub(crate) fn message_size_observer<M, F>(measure: F) -> MessageSizeObserver<M>
+where
+    M: Send + 'static,
+    F: Fn(&M) -> usize + Send + Sync + 'static,
+{
+    Arc::new(measure)
+}
+
 pub(crate) fn mailbox_key_extractor<M, K, F>(key_fn: F) -> MailboxKeyExtractor<M>
 where
     M: Send + 'static,
@@ -706,7 +716,16 @@ struct SendOperation<M> {
     pinned: Option<Incarnation>,
     key: Mutex<Option<MailboxKey>>,
     key_preparation_requested: AtomicBool,
+    measured_size: Mutex<Option<u64>>,
+    size_preparation_requested: AtomicBool,
     state: Mutex<OperationState<M>>,
+}
+
+struct AcceptedMessage<M> {
+    message: M,
+    key: Option<MailboxKey>,
+    measured_size: Option<u64>,
+    waker: Option<Waker>,
 }
 
 impl<M> SendOperation<M> {
@@ -715,6 +734,8 @@ impl<M> SendOperation<M> {
             pinned,
             key: Mutex::new(key),
             key_preparation_requested: AtomicBool::new(false),
+            measured_size: Mutex::new(None),
+            size_preparation_requested: AtomicBool::new(false),
             state: Mutex::new(OperationState {
                 outcome: OperationOutcome::Waiting {
                     message: Some(message),
@@ -735,18 +756,35 @@ impl<M> SendOperation<M> {
         }
     }
 
-    fn accept(&self, incarnation: Incarnation) -> Option<(M, Option<MailboxKey>, Option<Waker>)> {
-        let (message, key, wake) = {
+    fn is_waiting(&self) -> bool {
+        matches!(
+            &self
+                .state
+                .lock()
+                .expect("send operation mutex poisoned")
+                .outcome,
+            OperationOutcome::Waiting { .. }
+        )
+    }
+
+    fn accept(&self, incarnation: Incarnation) -> Option<AcceptedMessage<M>> {
+        let (message, key, measured_size, wake) = {
             let mut state = self.state.lock().expect("send operation mutex poisoned");
             let OperationOutcome::Waiting { message, .. } = &mut state.outcome else {
                 return None;
             };
             let message = message.take()?;
             let key = self.take_key();
+            let measured_size = self.measured_size();
             state.outcome = OperationOutcome::Accepted(incarnation);
-            (message, key, state.waker.take())
+            (message, key, measured_size, state.waker.take())
         };
-        Some((message, key, wake))
+        Some(AcceptedMessage {
+            message,
+            key,
+            measured_size,
+            waker: wake,
+        })
     }
 
     fn fail(&self, observed: Option<Incarnation>, kind: SendErrorKind) -> Option<Waker> {
@@ -832,6 +870,61 @@ impl<M> SendOperation<M> {
             false
         }
     }
+
+    fn measured_size(&self) -> Option<u64> {
+        *self
+            .measured_size
+            .lock()
+            .expect("send operation size mutex poisoned")
+    }
+
+    fn has_measured_size(&self) -> bool {
+        self.measured_size().is_some()
+    }
+
+    fn request_size_preparation(&self) -> Option<Waker> {
+        self.size_preparation_requested
+            .store(true, Ordering::Release);
+        self.state
+            .lock()
+            .expect("send operation mutex poisoned")
+            .waker
+            .take()
+    }
+
+    fn prepare_size_if_missing(&self, observer: &MessageSizeObserver<M>) -> bool {
+        if self.has_measured_size() {
+            return false;
+        }
+        let measured = {
+            let state = self.state.lock().expect("send operation mutex poisoned");
+            let OperationOutcome::Waiting {
+                message: Some(message),
+                ..
+            } = &state.outcome
+            else {
+                return false;
+            };
+            let measured = catch_unwind(AssertUnwindSafe(|| observer(message)));
+            drop(state);
+            match measured {
+                Ok(bytes) => u64::try_from(bytes).unwrap_or(u64::MAX),
+                Err(payload) => resume_unwind(payload),
+            }
+        };
+        let mut stored = self
+            .measured_size
+            .lock()
+            .expect("send operation size mutex poisoned");
+        if stored.is_none() {
+            *stored = Some(measured);
+            self.size_preparation_requested
+                .store(false, Ordering::Release);
+            true
+        } else {
+            false
+        }
+    }
 }
 
 struct MailboxState<M> {
@@ -843,23 +936,25 @@ struct MailboxState<M> {
     keyed: VecDeque<KeyedEnvelope<M>>,
     waiters: VecDeque<Arc<SendOperation<M>>>,
     accepted: u64,
-    delivered: u64,
-    local_delivered: u64,
+    received: u64,
     conflated: u64,
     evicted: u64,
+    message_bytes_accepted: u64,
     sends_rejected: u64,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(crate) struct MailboxStats {
     pub(crate) accepted: u64,
-    pub(crate) delivered: u64,
-    pub(crate) local_delivered: u64,
+    pub(crate) received: u64,
     pub(crate) conflated: u64,
     pub(crate) evicted: u64,
+    pub(crate) message_bytes_accepted: Option<u64>,
     pub(crate) sends_rejected: u64,
-    pub(crate) depth: usize,
-    pub(crate) capacity: usize,
+    pub(crate) outstanding_offloads: u64,
+    pub(crate) observed_incarnation: Option<Incarnation>,
+    pub(crate) depth: u64,
+    pub(crate) capacity: u64,
 }
 
 struct Promotion<M> {
@@ -893,12 +988,16 @@ pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
     fn close(&self, incarnation: Incarnation);
     fn terminate(&self);
     fn stats(&self) -> MailboxStats;
+    fn record_rejection(&self);
 }
 
 pub(crate) struct MailboxCell<M> {
     actor_id: ChildId,
+    member: Weak<MemberCell>,
     state: Mutex<MailboxState<M>>,
     key_extractor: Mutex<Option<MailboxKeyExtractor<M>>>,
+    size_observer: Mutex<Option<MessageSizeObserver<M>>>,
+    outstanding_offloads: AtomicU64,
     changed: Signal,
 }
 
@@ -912,9 +1011,10 @@ impl<M> fmt::Debug for MailboxCell<M> {
 }
 
 impl<M: Send + 'static> MailboxCell<M> {
-    pub(crate) fn new(actor_id: ChildId) -> Arc<Self> {
+    pub(crate) fn new(member: &Arc<MemberCell>) -> Arc<Self> {
         Arc::new(Self {
-            actor_id,
+            actor_id: member.id().clone(),
+            member: Arc::downgrade(member),
             state: Mutex::new(MailboxState {
                 kind: None,
                 status: BindingStatus::Unbound,
@@ -924,13 +1024,15 @@ impl<M: Send + 'static> MailboxCell<M> {
                 keyed: VecDeque::new(),
                 waiters: VecDeque::new(),
                 accepted: 0,
-                delivered: 0,
-                local_delivered: 0,
+                received: 0,
                 conflated: 0,
                 evicted: 0,
+                message_bytes_accepted: 0,
                 sends_rejected: 0,
             }),
             key_extractor: Mutex::new(None),
+            size_observer: Mutex::new(None),
+            outstanding_offloads: AtomicU64::new(0),
             changed: Signal::default(),
         })
     }
@@ -960,6 +1062,31 @@ impl<M: Send + 'static> MailboxCell<M> {
         }
     }
 
+    pub(crate) fn install_size_observer(&self, observer: MessageSizeObserver<M>) {
+        let previous = self
+            .size_observer
+            .lock()
+            .expect("mailbox size-observer mutex poisoned")
+            .replace(observer);
+        assert!(
+            previous.is_none(),
+            "a mailbox can own only one message-size observer"
+        );
+        let waiters = self
+            .state
+            .lock()
+            .expect("mailbox mutex poisoned")
+            .waiters
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        for waiter in waiters {
+            if let Some(waker) = waiter.request_size_preparation() {
+                waker.wake();
+            }
+        }
+    }
+
     fn prepare_key(&self, message: &M) -> Option<MailboxKey> {
         let extractor = self
             .key_extractor
@@ -977,13 +1104,37 @@ impl<M: Send + 'static> MailboxCell<M> {
         }
     }
 
+    fn cloned_size_observer(&self) -> Option<MessageSizeObserver<M>> {
+        self.size_observer
+            .lock()
+            .expect("mailbox size-observer mutex poisoned")
+            .clone()
+    }
+
+    fn prepare_operation_size(&self, operation: &SendOperation<M>) -> bool {
+        self.cloned_size_observer()
+            .is_some_and(|observer| operation.prepare_size_if_missing(&observer))
+    }
+
+    fn measure_message(&self, message: &M) -> Option<u64> {
+        self.cloned_size_observer().map(|observer| {
+            let measured = catch_unwind(AssertUnwindSafe(|| observer(message)));
+            match measured {
+                Ok(bytes) => u64::try_from(bytes).unwrap_or(u64::MAX),
+                Err(payload) => resume_unwind(payload),
+            }
+        })
+    }
+
     fn promote_bound_waiters(&self) {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         let extractor = self.cloned_key_extractor();
-        let promotion = promote_waiters(&mut state, extractor.as_deref());
+        let size_observer = self.cloned_size_observer();
+        let promotion = promote_waiters(&mut state, extractor.as_deref(), size_observer.as_ref());
         drop(state);
         self.changed.pulse();
         promotion.finish();
+        self.publish_stats();
     }
 
     fn keys_equal(&self, left: &MailboxKey, right: &MailboxKey) -> bool {
@@ -1034,10 +1185,14 @@ impl<M: Send + 'static> MailboxCell<M> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         match state.status {
             BindingStatus::Terminal(final_incarnation) => {
+                state.sends_rejected = state
+                    .sends_rejected
+                    .saturating_add(u64::from(operation.is_waiting()));
                 drop(state);
                 if let Some(waker) = operation.terminate(final_incarnation) {
                     waker.wake();
                 }
+                self.publish_stats();
             }
             BindingStatus::Bound(incarnation) => {
                 if operation
@@ -1045,6 +1200,9 @@ impl<M: Send + 'static> MailboxCell<M> {
                     .is_some_and(|pinned| pinned != incarnation)
                 {
                     let pinned = operation.pinned().expect("checked pinned incarnation");
+                    state.sends_rejected = state
+                        .sends_rejected
+                        .saturating_add(u64::from(operation.is_waiting()));
                     drop(state);
                     if let Some(waker) = operation.fail(
                         Some(incarnation),
@@ -1055,6 +1213,7 @@ impl<M: Send + 'static> MailboxCell<M> {
                     ) {
                         waker.wake();
                     }
+                    self.publish_stats();
                     return;
                 }
                 operation.observe(incarnation);
@@ -1067,10 +1226,27 @@ impl<M: Send + 'static> MailboxCell<M> {
                     None => false,
                 };
                 if can_accept {
-                    let (message, key, wake) = operation
+                    if self.cloned_size_observer().is_some() && !operation.has_measured_size() {
+                        let wake = operation.request_size_preparation();
+                        state.waiters.push_back(Arc::clone(operation));
+                        drop(state);
+                        if let Some(waker) = wake {
+                            waker.wake();
+                        }
+                        return;
+                    }
+                    let AcceptedMessage {
+                        message,
+                        key,
+                        measured_size,
+                        waker: wake,
+                    } = operation
                         .accept(incarnation)
                         .expect("a newly submitted operation still owns its message");
                     state.accepted = state.accepted.saturating_add(1);
+                    state.message_bytes_accepted = state
+                        .message_bytes_accepted
+                        .saturating_add(measured_size.unwrap_or(0));
                     let accepted_sequence = state.accepted;
                     let displaced = match state.kind {
                         Some(MailboxKind::Queue(_)) => {
@@ -1103,6 +1279,7 @@ impl<M: Send + 'static> MailboxCell<M> {
                     };
                     drop(state);
                     self.changed.pulse();
+                    self.publish_stats();
                     if let Some(waker) = wake {
                         waker.wake();
                     }
@@ -1122,16 +1299,23 @@ impl<M: Send + 'static> MailboxCell<M> {
                             newest_observed: Some(incarnation),
                         }
                     };
+                    state.sends_rejected = state
+                        .sends_rejected
+                        .saturating_add(u64::from(operation.is_waiting()));
                     drop(state);
                     if let Some(waker) = operation.fail(Some(incarnation), kind) {
                         waker.wake();
                     }
+                    self.publish_stats();
                 } else {
                     state.waiters.push_back(Arc::clone(operation));
                 }
             }
             BindingStatus::Unbound => {
                 if let Some(pinned) = operation.pinned() {
+                    state.sends_rejected = state
+                        .sends_rejected
+                        .saturating_add(u64::from(operation.is_waiting()));
                     drop(state);
                     if let Some(waker) = operation.fail(
                         None,
@@ -1142,6 +1326,7 @@ impl<M: Send + 'static> MailboxCell<M> {
                     ) {
                         waker.wake();
                     }
+                    self.publish_stats();
                 } else {
                     state.waiters.push_back(Arc::clone(operation));
                 }
@@ -1155,15 +1340,31 @@ impl<M: Send + 'static> MailboxCell<M> {
         pinned: Option<Incarnation>,
     ) -> Result<Incarnation, SendError<M>> {
         let mut key = None;
+        let mut measured_size = None;
         let mut state = loop {
             let state = self.state.lock().expect("mailbox mutex poisoned");
-            let needs_key = key.is_none()
-                && matches!(state.status, BindingStatus::Bound(incarnation)
-                    if pinned.is_none_or(|pinned| pinned == incarnation))
+            let can_accept = matches!(state.status, BindingStatus::Bound(incarnation)
+                if pinned.is_none_or(|pinned| pinned == incarnation))
+                && match state.kind {
+                    Some(MailboxKind::Queue(capacity)) => {
+                        state.waiters.is_empty() && state.queue.len() < capacity.get()
+                    }
+                    Some(MailboxKind::Latest | MailboxKind::LatestByKey(_)) => true,
+                    None => false,
+                };
+            let needs_key = can_accept
+                && key.is_none()
                 && matches!(state.kind, Some(MailboxKind::LatestByKey(_)));
-            if needs_key {
+            let needs_size =
+                can_accept && measured_size.is_none() && self.cloned_size_observer().is_some();
+            if needs_key || needs_size {
                 drop(state);
-                key = self.prepare_key(&message);
+                if needs_key {
+                    key = self.prepare_key(&message);
+                }
+                if needs_size {
+                    measured_size = self.measure_message(&message);
+                }
                 continue;
             }
             break state;
@@ -1171,6 +1372,8 @@ impl<M: Send + 'static> MailboxCell<M> {
         match state.status {
             BindingStatus::Terminal(final_incarnation) => {
                 state.sends_rejected = state.sends_rejected.saturating_add(1);
+                drop(state);
+                self.publish_stats();
                 Err(SendError {
                     actor_id: self.actor_id.clone(),
                     incarnation_observed: final_incarnation,
@@ -1180,6 +1383,8 @@ impl<M: Send + 'static> MailboxCell<M> {
             }
             BindingStatus::Unbound => {
                 state.sends_rejected = state.sends_rejected.saturating_add(1);
+                drop(state);
+                self.publish_stats();
                 Err(SendError {
                     actor_id: self.actor_id.clone(),
                     incarnation_observed: None,
@@ -1194,6 +1399,8 @@ impl<M: Send + 'static> MailboxCell<M> {
             }
             BindingStatus::Frozen(incarnation) => {
                 state.sends_rejected = state.sends_rejected.saturating_add(1);
+                drop(state);
+                self.publish_stats();
                 Err(SendError {
                     actor_id: self.actor_id.clone(),
                     incarnation_observed: Some(incarnation),
@@ -1212,6 +1419,8 @@ impl<M: Send + 'static> MailboxCell<M> {
             {
                 state.sends_rejected = state.sends_rejected.saturating_add(1);
                 let pinned = pinned.expect("checked pinned incarnation");
+                drop(state);
+                self.publish_stats();
                 Err(SendError {
                     actor_id: self.actor_id.clone(),
                     incarnation_observed: Some(incarnation),
@@ -1227,6 +1436,8 @@ impl<M: Send + 'static> MailboxCell<M> {
                     if !state.waiters.is_empty() || state.queue.len() >= capacity.get() =>
                 {
                     state.sends_rejected = state.sends_rejected.saturating_add(1);
+                    drop(state);
+                    self.publish_stats();
                     Err(SendError {
                         actor_id: self.actor_id.clone(),
                         incarnation_observed: Some(incarnation),
@@ -1236,6 +1447,9 @@ impl<M: Send + 'static> MailboxCell<M> {
                 }
                 Some(MailboxKind::Queue(_)) => {
                     state.accepted = state.accepted.saturating_add(1);
+                    state.message_bytes_accepted = state
+                        .message_bytes_accepted
+                        .saturating_add(measured_size.unwrap_or(0));
                     let accepted_sequence = state.accepted;
                     state.queue.push_back(Envelope {
                         message,
@@ -1243,10 +1457,14 @@ impl<M: Send + 'static> MailboxCell<M> {
                     });
                     drop(state);
                     self.changed.pulse();
+                    self.publish_stats();
                     Ok(incarnation)
                 }
                 Some(MailboxKind::Latest) => {
                     state.accepted = state.accepted.saturating_add(1);
+                    state.message_bytes_accepted = state
+                        .message_bytes_accepted
+                        .saturating_add(measured_size.unwrap_or(0));
                     let accepted_sequence = state.accepted;
                     let displaced = state.latest.replace(Envelope {
                         message,
@@ -1257,11 +1475,15 @@ impl<M: Send + 'static> MailboxCell<M> {
                         .saturating_add(u64::from(displaced.is_some()));
                     drop(state);
                     self.changed.pulse();
+                    self.publish_stats();
                     drop(displaced);
                     Ok(incarnation)
                 }
                 Some(MailboxKind::LatestByKey(capacity)) => {
                     state.accepted = state.accepted.saturating_add(1);
+                    state.message_bytes_accepted = state
+                        .message_bytes_accepted
+                        .saturating_add(measured_size.unwrap_or(0));
                     let accepted_sequence = state.accepted;
                     let displaced = self.insert_keyed(
                         &mut state,
@@ -1274,11 +1496,14 @@ impl<M: Send + 'static> MailboxCell<M> {
                     );
                     drop(state);
                     self.changed.pulse();
+                    self.publish_stats();
                     drop(displaced);
                     Ok(incarnation)
                 }
                 None => {
                     state.sends_rejected = state.sends_rejected.saturating_add(1);
+                    drop(state);
+                    self.publish_stats();
                     Err(SendError {
                         actor_id: self.actor_id.clone(),
                         incarnation_observed: None,
@@ -1339,16 +1564,20 @@ impl<M: Send + 'static> MailboxCell<M> {
         };
         let promotion = if message.is_some() && matches!(state.status, BindingStatus::Bound(_)) {
             let extractor = self.cloned_key_extractor();
-            promote_waiters(&mut state, extractor.as_deref())
+            let size_observer = self.cloned_size_observer();
+            promote_waiters(&mut state, extractor.as_deref(), size_observer.as_ref())
         } else {
             Promotion::default()
         };
-        state.delivered = state.delivered.saturating_add(u64::from(message.is_some()));
+        state.received = state.received.saturating_add(u64::from(message.is_some()));
         drop(state);
         if message.is_some() {
             self.changed.pulse();
         }
         promotion.finish();
+        if message.is_some() {
+            self.publish_stats();
+        }
         message
     }
 
@@ -1374,19 +1603,175 @@ impl<M: Send + 'static> MailboxCell<M> {
         };
         MailboxStats {
             accepted: state.accepted,
-            delivered: state.delivered,
-            local_delivered: state.local_delivered,
+            received: state.received,
             conflated: state.conflated,
             evicted: state.evicted,
+            message_bytes_accepted: self
+                .size_observer
+                .lock()
+                .expect("mailbox size-observer mutex poisoned")
+                .as_ref()
+                .map(|_| state.message_bytes_accepted),
             sends_rejected: state.sends_rejected,
-            depth,
-            capacity,
+            outstanding_offloads: self.outstanding_offloads.load(Ordering::Acquire),
+            observed_incarnation: match state.status {
+                BindingStatus::Bound(incarnation) | BindingStatus::Frozen(incarnation) => {
+                    Some(incarnation)
+                }
+                BindingStatus::Unbound | BindingStatus::Terminal(_) => None,
+            },
+            depth: u64::try_from(depth).unwrap_or(u64::MAX),
+            capacity: u64::try_from(capacity).unwrap_or(u64::MAX),
         }
     }
 
     pub(crate) fn record_local_delivery(&self) {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
-        state.local_delivered = state.local_delivered.saturating_add(1);
+        state.received = state.received.saturating_add(1);
+        drop(state);
+        self.publish_stats();
+    }
+
+    fn record_rejection(&self) {
+        let mut state = self.state.lock().expect("mailbox mutex poisoned");
+        state.sends_rejected = state.sends_rejected.saturating_add(1);
+        drop(state);
+        self.publish_stats();
+    }
+
+    pub(crate) fn begin_offload(self: &Arc<Self>) -> OutstandingOffload<M> {
+        let _ =
+            self.outstanding_offloads
+                .try_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                    Some(current.saturating_add(1))
+                });
+        self.publish_stats();
+        OutstandingOffload {
+            mailbox: Arc::downgrade(self),
+        }
+    }
+
+    fn finish_offload(&self) {
+        let _ =
+            self.outstanding_offloads
+                .try_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                    Some(current.saturating_sub(1))
+                });
+        self.publish_stats();
+    }
+
+    fn publish_stats(&self) {
+        let stats = self.stats();
+        tracing::trace!(
+            actor.id = %self.actor_id,
+            actor.membership = ?self.member.upgrade().map(|member| member.membership()),
+            messages_accepted = stats.accepted,
+            messages_received = stats.received,
+            messages_conflated = stats.conflated,
+            messages_evicted = stats.evicted,
+            sends_rejected = stats.sends_rejected,
+            outstanding_offloads = stats.outstanding_offloads,
+            mailbox_depth = stats.depth,
+            mailbox_capacity = stats.capacity,
+            "actor statistics changed"
+        );
+        self.emit_metrics(stats);
+    }
+
+    #[cfg(not(feature = "metrics"))]
+    fn emit_metrics(&self, _stats: MailboxStats) {}
+
+    #[cfg(feature = "metrics")]
+    fn emit_metrics(&self, stats: MailboxStats) {
+        static DESCRIBE: std::sync::Once = std::sync::Once::new();
+        DESCRIBE.call_once(|| {
+            metrics::describe_counter!(
+                "shelterwood.actor.messages_accepted",
+                metrics::Unit::Count,
+                "Messages accepted by an actor membership"
+            );
+            metrics::describe_counter!(
+                "shelterwood.actor.messages_received",
+                metrics::Unit::Count,
+                "Messages received by an actor loop"
+            );
+            metrics::describe_counter!(
+                "shelterwood.actor.messages_conflated",
+                metrics::Unit::Count,
+                "Messages replaced by conflation"
+            );
+            metrics::describe_counter!(
+                "shelterwood.actor.messages_evicted",
+                metrics::Unit::Count,
+                "Messages evicted by keyed conflation"
+            );
+            metrics::describe_counter!(
+                "shelterwood.actor.message_bytes_accepted",
+                metrics::Unit::Bytes,
+                "Message bytes accepted by an actor membership"
+            );
+            metrics::describe_counter!(
+                "shelterwood.actor.sends_rejected",
+                metrics::Unit::Count,
+                "Actor ingress operations rejected before acceptance"
+            );
+            metrics::describe_gauge!(
+                "shelterwood.actor.outstanding_offloads",
+                metrics::Unit::Count,
+                "Current outstanding actor offloads"
+            );
+            metrics::describe_gauge!(
+                "shelterwood.actor.mailbox_depth",
+                metrics::Unit::Count,
+                "Current actor mailbox depth"
+            );
+            metrics::describe_gauge!(
+                "shelterwood.actor.mailbox_capacity",
+                metrics::Unit::Count,
+                "Resolved actor mailbox capacity"
+            );
+        });
+
+        let (scope_path, membership) = self.member.upgrade().map_or_else(
+            || (String::from("/"), String::from("unbound")),
+            |member| {
+                (
+                    member.scope_path_label(),
+                    format!("{:?}", member.membership()),
+                )
+            },
+        );
+        let labels = [
+            ("scope.path", scope_path),
+            ("actor.id", self.actor_id.as_str().to_owned()),
+            ("actor.membership", membership),
+        ];
+        metrics::counter!("shelterwood.actor.messages_accepted", &labels).absolute(stats.accepted);
+        metrics::counter!("shelterwood.actor.messages_received", &labels).absolute(stats.received);
+        metrics::counter!("shelterwood.actor.messages_conflated", &labels)
+            .absolute(stats.conflated);
+        metrics::counter!("shelterwood.actor.messages_evicted", &labels).absolute(stats.evicted);
+        if let Some(bytes) = stats.message_bytes_accepted {
+            metrics::counter!("shelterwood.actor.message_bytes_accepted", &labels).absolute(bytes);
+        }
+        metrics::counter!("shelterwood.actor.sends_rejected", &labels)
+            .absolute(stats.sends_rejected);
+        metrics::gauge!("shelterwood.actor.outstanding_offloads", &labels)
+            .set(stats.outstanding_offloads as f64);
+        metrics::gauge!("shelterwood.actor.mailbox_depth", &labels).set(stats.depth as f64);
+        metrics::gauge!("shelterwood.actor.mailbox_capacity", &labels).set(stats.capacity as f64);
+    }
+}
+
+pub(crate) struct OutstandingOffload<M: Send + 'static> {
+    mailbox: Weak<MailboxCell<M>>,
+}
+
+impl<M: Send + 'static> Drop for OutstandingOffload<M> {
+    fn drop(&mut self) {
+        if let Some(mailbox) = self.mailbox.upgrade() {
+            mailbox.finish_offload();
+        }
     }
 }
 
@@ -1465,6 +1850,8 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             Some(existing) => debug_assert_eq!(existing, kind),
             None => state.kind = Some(kind),
         }
+        drop(state);
+        self.publish_stats();
     }
 
     fn bind(&self, incarnation: Incarnation) {
@@ -1475,10 +1862,12 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         state.status = BindingStatus::Bound(incarnation);
         state.last_bound = Some(incarnation);
         let extractor = self.cloned_key_extractor();
-        let promotion = promote_waiters(&mut state, extractor.as_deref());
+        let size_observer = self.cloned_size_observer();
+        let promotion = promote_waiters(&mut state, extractor.as_deref(), size_observer.as_ref());
         drop(state);
         self.changed.pulse();
         promotion.finish();
+        self.publish_stats();
     }
 
     fn freeze(&self, incarnation: Incarnation) {
@@ -1489,6 +1878,9 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             let mut wakers = Vec::new();
             while let Some(waiter) = state.waiters.pop_front() {
                 if waiter.pinned() == Some(incarnation) {
+                    state.sends_rejected = state
+                        .sends_rejected
+                        .saturating_add(u64::from(waiter.is_waiting()));
                     if let Some(waker) = waiter.fail(Some(incarnation), SendErrorKind::NotRunning) {
                         wakers.push(waker);
                     }
@@ -1502,6 +1894,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             for waker in wakers {
                 waker.wake();
             }
+            self.publish_stats();
         }
     }
 
@@ -1522,6 +1915,9 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         let mut wakers = Vec::new();
         while let Some(waiter) = state.waiters.pop_front() {
             if let Some(pinned) = waiter.pinned() {
+                state.sends_rejected = state
+                    .sends_rejected
+                    .saturating_add(u64::from(waiter.is_waiting()));
                 if let Some(waker) = waiter.fail(
                     None,
                     SendErrorKind::Superseded {
@@ -1544,6 +1940,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         drop(queue);
         drop(latest);
         drop(keyed);
+        self.publish_stats();
     }
 
     fn terminate(&self) {
@@ -1557,6 +1954,9 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         let latest = state.latest.take();
         let keyed = std::mem::take(&mut state.keyed);
         let waiters = std::mem::take(&mut state.waiters);
+        state.sends_rejected = state
+            .sends_rejected
+            .saturating_add(waiters.iter().filter(|waiter| waiter.is_waiting()).count() as u64);
         drop(state);
         let mut wakers = Vec::new();
         for waiter in waiters {
@@ -1571,16 +1971,22 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         drop(queue);
         drop(latest);
         drop(keyed);
+        self.publish_stats();
     }
 
     fn stats(&self) -> MailboxStats {
         self.stats()
+    }
+
+    fn record_rejection(&self) {
+        self.record_rejection();
     }
 }
 
 fn promote_waiters<M>(
     state: &mut MailboxState<M>,
     key_extractor: Option<&dyn MailboxKeyFn<M>>,
+    size_observer: Option<&MessageSizeObserver<M>>,
 ) -> Promotion<M> {
     let mut promotion = Promotion::default();
     let Some(kind) = state.kind else {
@@ -1607,6 +2013,9 @@ fn promote_waiters<M>(
             .is_some_and(|pinned| pinned != incarnation)
         {
             let pinned = operation.pinned().expect("checked pinned incarnation");
+            state.sends_rejected = state
+                .sends_rejected
+                .saturating_add(u64::from(operation.is_waiting()));
             if let Some(waker) = operation.fail(
                 Some(incarnation),
                 SendErrorKind::Superseded {
@@ -1626,13 +2035,29 @@ fn promote_waiters<M>(
             state.waiters.push_back(operation);
             continue;
         }
-        let Some((message, key, wake)) = operation.accept(incarnation) else {
+        if size_observer.is_some() && !operation.has_measured_size() {
+            if let Some(waker) = operation.request_size_preparation() {
+                promotion.wakers.push(waker);
+            }
+            state.waiters.push_back(operation);
+            continue;
+        }
+        let Some(AcceptedMessage {
+            message,
+            key,
+            measured_size,
+            waker: wake,
+        }) = operation.accept(incarnation)
+        else {
             continue;
         };
         if let Some(waker) = wake {
             promotion.wakers.push(waker);
         }
         state.accepted = state.accepted.saturating_add(1);
+        state.message_bytes_accepted = state
+            .message_bytes_accepted
+            .saturating_add(measured_size.unwrap_or(0));
         let accepted_sequence = state.accepted;
         match kind {
             MailboxKind::Queue(_) => state.queue.push_back(Envelope {
@@ -1802,6 +2227,21 @@ impl<M> ActorRef<M> {
     #[must_use]
     pub fn membership(&self) -> Membership {
         self.member.membership()
+    }
+
+    /// Samples membership-cumulative actor counters and current gauges.
+    #[must_use]
+    pub fn stats(&self) -> crate::ActorStatsSnapshot {
+        self.member
+            .actor_stats()
+            .expect("an actor reference always owns mailbox metadata")
+    }
+
+    fn record_rejection(&self) {
+        self.member
+            .mailbox()
+            .expect("an actor reference always owns mailbox metadata")
+            .record_rejection();
     }
 }
 
@@ -2376,10 +2816,15 @@ impl<M: Send + 'static> SendDriver<M> for DirectSend<M> {
         context: &mut Context<'_>,
     ) -> Poll<Result<Incarnation, SendError<M>>> {
         let prepared_key = self.mailbox.prepare_operation_key(&self.operation);
+        let prepared_size = self
+            .operation
+            .size_preparation_requested
+            .load(Ordering::Acquire)
+            && self.mailbox.prepare_operation_size(&self.operation);
         if !self.submitted {
             self.submitted = true;
             self.mailbox.submit(&self.operation);
-        } else if prepared_key {
+        } else if prepared_key || prepared_size {
             self.mailbox.promote_bound_waiters();
         }
         let mut state = self
@@ -2418,8 +2863,13 @@ impl<M: Send + 'static> SendDriver<M> for DirectSend<M> {
                     .key_preparation_requested
                     .load(Ordering::Acquire)
                     && !self.operation.has_key();
+                let wake_for_size = self
+                    .operation
+                    .size_preparation_requested
+                    .load(Ordering::Acquire)
+                    && !self.operation.has_measured_size();
                 drop(state);
-                if wake_for_key {
+                if wake_for_key || wake_for_size {
                     context.waker().wake_by_ref();
                 }
                 Poll::Pending
@@ -2517,6 +2967,7 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
                 let Withdrawal::Withdrawn { payload, observed } = withdrawal else {
                     unreachable!("an unpolled send cannot already be accepted")
                 };
+                self.actor.record_rejection();
                 self.done = true;
                 return Poll::Ready(Err(SendError {
                     actor_id,
@@ -2544,6 +2995,7 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
             let send = self.send.as_mut().expect("pending timed send retains send");
             match send.withdraw() {
                 Withdrawal::Withdrawn { payload, observed } => {
+                    self.actor.record_rejection();
                     self.done = true;
                     Poll::Ready(Err(SendError {
                         actor_id,
@@ -2637,6 +3089,7 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
         if !self.started {
             self.started = true;
             if self.deadline.is_zero() {
+                self.actor.record_rejection();
                 self.done = true;
                 return Poll::Ready(Err(CallError {
                     actor_id: self.actor.id().clone(),
@@ -2770,11 +3223,14 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
                 .as_mut()
                 .expect("unaccepted call retains send future");
             let result = match send.withdraw() {
-                Withdrawal::Withdrawn { observed, .. } => CallError {
-                    actor_id,
-                    incarnation_observed: observed,
-                    kind: CallErrorKind::AcceptanceTimedOut,
-                },
+                Withdrawal::Withdrawn { observed, .. } => {
+                    self.actor.record_rejection();
+                    CallError {
+                        actor_id,
+                        incarnation_observed: observed,
+                        kind: CallErrorKind::AcceptanceTimedOut,
+                    }
+                }
                 Withdrawal::Accepted(incarnation) => {
                     if let Some(reply) = &self.reply {
                         match reply.poll(context) {
@@ -2868,7 +3324,7 @@ mod tests {
     use std::{num::NonZeroUsize, sync::Arc};
 
     use super::{MailboxCell, MailboxControl, mailbox_key_extractor};
-    use crate::{ChildId, Mailbox, identity::ScopeIdentity};
+    use crate::{ChildId, Mailbox, driver::MemberCell, identity::ScopeIdentity};
 
     #[test]
     fn keyed_eviction_has_a_dedicated_internal_counter() {
@@ -2877,7 +3333,8 @@ mod tests {
         let mut incarnations = identity.incarnation_counter(membership);
         let incarnation = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
             .expect("incarnation available");
-        let mailbox = MailboxCell::new(ChildId::from("keyed-counter"));
+        let member = MemberCell::new(ChildId::from("keyed-counter"), membership);
+        let mailbox = MailboxCell::new(&member);
         mailbox.install_key_extractor(mailbox_key_extractor(|message: &(usize, usize)| message.0));
         mailbox.configure(Mailbox::latest(), NonZeroUsize::new(2));
         mailbox.bind(incarnation);

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -16,6 +16,66 @@ use crate::{
 /// Number of lifecycle events retained independently for each subscriber.
 pub const LIFECYCLE_EVENT_CAPACITY: usize = 128;
 
+/// Membership-cumulative actor counters and current gauges.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActorStats {
+    /// Messages dequeued by the actor loop, including offload, timer, and monitor deliveries.
+    pub messages_received: u64,
+    /// Messages accepted through actor ingress.
+    pub messages_accepted: u64,
+    /// Accepted messages that replaced a pending same-slot or same-key message.
+    pub messages_conflated: u64,
+    /// Pending keyed messages evicted by acceptance of a different key.
+    pub messages_evicted: u64,
+    /// Bytes accepted through ingress, or `None` when no size observer is installed.
+    pub message_bytes_accepted: Option<u64>,
+    /// Immediate ingress operations rejected before acceptance.
+    pub sends_rejected: u64,
+    /// Incarnation-owned offloads that have not finished yet.
+    pub outstanding_offloads: u64,
+    /// Current number of messages pending in the mailbox.
+    pub mailbox_depth: u64,
+    /// Resolved mailbox capacity.
+    pub mailbox_capacity: u64,
+}
+
+/// An on-demand actor statistics sample fenced by membership and incarnation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActorStatsSnapshot {
+    /// Actor membership whose cumulative counters are sampled.
+    pub membership: Membership,
+    /// Incarnation bound to the mailbox at sampling time, if any.
+    pub observed_incarnation: Option<Incarnation>,
+    /// Membership-cumulative counters and current gauges.
+    pub stats: ActorStats,
+}
+
+/// Typed actor flavor retained by recursive statistics metadata.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ActorKind {
+    /// Callback-oriented [`crate::Actor`].
+    Actor,
+    /// Loop-owning [`crate::RawActor`].
+    RawActor,
+}
+
+/// One actor row returned by [`crate::ScopeRef::stats_recursive`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RecursiveActorStats {
+    /// Path from the queried scope to the actor's containing scope.
+    pub path: Vec<ChildId>,
+    /// Actor id within its containing scope.
+    pub id: ChildId,
+    /// Typed actor flavor from its declaration.
+    pub kind: ActorKind,
+    /// Actor membership identity.
+    pub membership: Membership,
+    /// Incarnation bound to the mailbox at sampling time, if any.
+    pub observed_incarnation: Option<Incarnation>,
+    /// Membership-cumulative counters and current gauges.
+    pub stats: ActorStats,
+}
+
 /// One item read from a lifecycle subscription.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
@@ -518,6 +578,135 @@ impl fmt::Debug for LifecycleEvents {
             .field("queued", &state.events.len())
             .field("lagged", &state.lagged)
             .field("closed", &state.closed)
+            .finish()
+    }
+}
+
+/// Self-recovering child-observation item.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ChildObservation {
+    /// Authoritative replacement state, initially or after subscriber loss.
+    Reset {
+        /// Fresh recursive scope snapshot.
+        snapshot: Arc<ScopeSnapshot>,
+        /// Lifecycle events lost since the prior authoritative state.
+        dropped: u64,
+    },
+    /// One lifecycle cause paired with consistent-or-newer authoritative state.
+    Changed {
+        /// Fresh recursive scope snapshot.
+        snapshot: Arc<ScopeSnapshot>,
+        /// Ordered lifecycle edge that caused this observation.
+        cause: LifecycleEvent,
+    },
+}
+
+/// Library-owned child observer that hides raw lifecycle lag markers.
+pub struct ChildObserver {
+    scope: crate::ScopeRef,
+    events: LifecycleEvents,
+    initial: Option<Arc<ScopeSnapshot>>,
+}
+
+impl ChildObserver {
+    pub(crate) fn new(
+        scope: crate::ScopeRef,
+        events: LifecycleEvents,
+        initial: Arc<ScopeSnapshot>,
+    ) -> Self {
+        Self {
+            scope,
+            events,
+            initial: Some(initial),
+        }
+    }
+
+    /// Returns the next reduced observation, or `None` after scope terminality.
+    pub async fn next(&mut self) -> Option<ChildObservation> {
+        if let Some(snapshot) = self.initial.take() {
+            return Some(ChildObservation::Reset {
+                snapshot,
+                dropped: 0,
+            });
+        }
+        match self.events.recv().await? {
+            LifecycleItem::Event(cause) => Some(ChildObservation::Changed {
+                snapshot: self.scope.snapshot(),
+                cause,
+            }),
+            LifecycleItem::Lagged { dropped } => Some(ChildObservation::Reset {
+                snapshot: self.scope.snapshot(),
+                dropped,
+            }),
+        }
+    }
+}
+
+impl fmt::Debug for ChildObserver {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ChildObserver")
+            .field("scope", &self.scope)
+            .field("initial_pending", &self.initial.is_some())
+            .field("events", &self.events)
+            .finish()
+    }
+}
+
+/// One deduplicated cumulative restart-counter sample.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RestartCount {
+    /// Authoritative cumulative restart total.
+    pub total: u64,
+    /// Saturating increase since the prior emitted total.
+    pub delta: u64,
+    /// Whether this sample followed an initial or lag-recovery reset.
+    pub resynced: bool,
+}
+
+/// Library-owned restart counter derived from authoritative scope snapshots.
+pub struct RestartCounter {
+    observer: ChildObserver,
+    prior: Option<u64>,
+}
+
+impl RestartCounter {
+    pub(crate) fn new(observer: ChildObserver) -> Self {
+        Self {
+            observer,
+            prior: None,
+        }
+    }
+
+    /// Returns the next changed or resynchronized restart total.
+    pub async fn next(&mut self) -> Option<RestartCount> {
+        loop {
+            let observation = self.observer.next().await?;
+            let (total, resynced) = match observation {
+                ChildObservation::Reset { snapshot, .. } => (snapshot.total_restarts, true),
+                ChildObservation::Changed { snapshot, .. } => (snapshot.total_restarts, false),
+            };
+            let prior = self.prior.unwrap_or(0);
+            if !resynced && self.prior == Some(total) {
+                continue;
+            }
+            self.prior = Some(total);
+            return Some(RestartCount {
+                total,
+                delta: total.saturating_sub(prior),
+                resynced,
+            });
+        }
+    }
+}
+
+impl fmt::Debug for RestartCounter {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestartCounter")
+            .field("prior", &self.prior)
+            .field("observer", &self.observer)
             .finish()
     }
 }

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -19,7 +19,8 @@ use crate::{
     SendPayload, Shutdown, WatchTarget,
     driver::{ActorWork, Latch, Signal, SignalWatcher},
     mailbox::{
-        MailboxCell, MailboxControl, MailboxKeyExtractor, MailboxReceiver, mailbox_key_extractor,
+        MailboxCell, MailboxControl, MailboxKeyExtractor, MailboxReceiver, MessageSizeObserver,
+        mailbox_key_extractor, message_size_observer,
     },
     monitor::{MonitorDelivery, MonitorEvent, MonitorSink, MonitorSource, MonitorSubscriber},
     policy::CommonOptions,
@@ -909,7 +910,9 @@ impl<M: Send + 'static> RawContext<M> {
         let expires_at = started_at.checked_add(deadline);
         let event_cancellation = cancellation.clone();
         let event_finished = finished.clone();
+        let outstanding = self.mailbox.begin_offload();
         let operation = async move {
+            let _outstanding = outstanding;
             let completion = async move {
                 let work = CatchUnwindFuture::new(work);
                 if let Some(expires_at) = expires_at {
@@ -1041,6 +1044,7 @@ impl<M: Send + 'static> RawContext<M> {
                         self.resources.events.pop_through(batch.offloads_through)
                     {
                         if let Some(message) = Self::materialize_event(event) {
+                            self.mailbox.record_local_delivery();
                             self.resources.continuation_needs_external = false;
                             self.resources.fired_batch = Some(batch);
                             return Some(message);
@@ -1073,6 +1077,7 @@ impl<M: Send + 'static> RawContext<M> {
 
                 while let Some(arming) = batch.armings.pop_front() {
                     if let Some(message) = self.deliver_timer(arming) {
+                        self.mailbox.record_local_delivery();
                         self.resources.continuation_needs_external = false;
                         self.resources.fired_batch = Some(batch);
                         return Some(message);
@@ -1101,6 +1106,7 @@ impl<M: Send + 'static> RawContext<M> {
 
             while let Some(event) = self.resources.events.pop() {
                 if let Some(message) = Self::materialize_event(event) {
+                    self.mailbox.record_local_delivery();
                     self.resources.continuation_needs_external = false;
                     return Some(message);
                 }
@@ -1257,6 +1263,7 @@ pub struct RawDef<R: RawActor> {
     factory: Arc<Mutex<Box<dyn Fn() -> R + Send + 'static>>>,
     pub(crate) options: CommonOptions,
     pub(crate) mailbox_key: Option<MailboxKeyExtractor<R::Msg>>,
+    pub(crate) message_size: Option<MessageSizeObserver<R::Msg>>,
 }
 
 impl<R: RawActor> fmt::Debug for RawDef<R> {
@@ -1275,6 +1282,7 @@ impl<R: RawActor> RawDef<R> {
             factory: Arc::new(Mutex::new(Box::new(factory))),
             options: CommonOptions::default(),
             mailbox_key: None,
+            message_size: None,
         }
     }
 
@@ -1320,6 +1328,16 @@ impl<R: RawActor> RawDef<R> {
         self
     }
 
+    /// Observes accepted message sizes on the sender's ingress stack.
+    #[must_use]
+    pub fn message_size(
+        mut self,
+        measure: impl Fn(&R::Msg) -> usize + Send + Sync + 'static,
+    ) -> Self {
+        self.message_size = Some(message_size_observer(measure));
+        self
+    }
+
     /// Overrides frozen-prefix drain versus discard behavior.
     #[must_use]
     pub fn mailbox_shutdown(mut self, shutdown: MailboxShutdown) -> Self {
@@ -1354,6 +1372,9 @@ impl<R: RawActor> RawDef<R> {
         if let Some(extractor) = self.mailbox_key {
             mailbox.install_key_extractor(extractor);
         }
+        if let Some(observer) = self.message_size {
+            mailbox.install_size_observer(observer);
+        }
         let factory = self.factory;
         RawConstruction {
             source: RawSource::Restartable(Arc::new(Mutex::new(Box::new(move || {
@@ -1376,6 +1397,7 @@ pub struct RawOnceDef<R: RawActor> {
     actor: R,
     pub(crate) options: CommonOptions,
     pub(crate) mailbox_key: Option<MailboxKeyExtractor<R::Msg>>,
+    pub(crate) message_size: Option<MessageSizeObserver<R::Msg>>,
 }
 
 impl<R: RawActor> fmt::Debug for RawOnceDef<R> {
@@ -1395,6 +1417,7 @@ impl<R: RawActor> RawOnceDef<R> {
             actor,
             options: CommonOptions::default(),
             mailbox_key: None,
+            message_size: None,
         }
     }
 
@@ -1433,6 +1456,16 @@ impl<R: RawActor> RawOnceDef<R> {
         self
     }
 
+    /// Observes accepted message sizes on the sender's ingress stack.
+    #[must_use]
+    pub fn message_size(
+        mut self,
+        measure: impl Fn(&R::Msg) -> usize + Send + Sync + 'static,
+    ) -> Self {
+        self.message_size = Some(message_size_observer(measure));
+        self
+    }
+
     /// Overrides frozen-prefix drain versus discard behavior.
     #[must_use]
     pub fn mailbox_shutdown(mut self, shutdown: MailboxShutdown) -> Self {
@@ -1466,6 +1499,9 @@ impl<R: RawActor> RawOnceDef<R> {
     pub(crate) fn erase(self, mailbox: Arc<MailboxCell<R::Msg>>) -> RawConstruction {
         if let Some(extractor) = self.mailbox_key {
             mailbox.install_key_extractor(extractor);
+        }
+        if let Some(observer) = self.message_size {
+            mailbox.install_size_observer(observer);
         }
         RawConstruction {
             source: RawSource::OneShot(Some(Box::new(RawInstance {

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -157,6 +157,7 @@ enum DefinitionState {
 pub(crate) struct SlotCell {
     pub(crate) member: Arc<MemberCell>,
     pub(crate) scope: Option<Arc<ScopeCell>>,
+    actor_kind: Mutex<Option<crate::ActorKind>>,
     definition: Mutex<DefinitionState>,
 }
 
@@ -165,6 +166,7 @@ impl SlotCell {
         Arc::new(Self {
             member,
             scope,
+            actor_kind: Mutex::new(None),
             definition: Mutex::new(DefinitionState::Undefined),
         })
     }
@@ -177,6 +179,19 @@ impl SlotCell {
                 panic!("a child slot was defined more than once")
             }
         }
+    }
+
+    pub(crate) fn set_actor_kind(&self, kind: crate::ActorKind) {
+        let mut stored = self.actor_kind.lock().expect("actor-kind mutex poisoned");
+        assert!(
+            stored.is_none(),
+            "an actor slot can have only one typed kind"
+        );
+        *stored = Some(kind);
+    }
+
+    pub(crate) fn actor_kind(&self) -> Option<crate::ActorKind> {
+        *self.actor_kind.lock().expect("actor-kind mutex poisoned")
     }
 
     pub(crate) fn is_undefined(&self) -> bool {
@@ -355,7 +370,7 @@ fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError> {
 }
 
 fn attach_actor_slot<M: Send + 'static>(slot: Arc<SlotCell>) -> ActorSlot<M> {
-    let mailbox = MailboxCell::new(slot.member.id().clone());
+    let mailbox = MailboxCell::new(&slot.member);
     slot.member.attach_mailbox(mailbox.clone());
     ActorSlot { slot, mailbox }
 }
@@ -718,7 +733,12 @@ impl<M: Send + 'static> ActorSlot<M> {
     where
         A: crate::Actor<Msg = M>,
     {
-        self.define_raw(definition.into_raw())
+        let actor = self.actor_ref();
+        self.slot.set_actor_kind(crate::ActorKind::Actor);
+        self.slot.define(ChildConstruction::Raw(
+            definition.into_raw().erase(self.mailbox),
+        ));
+        actor
     }
 
     /// Defines a consuming one-shot callback-oriented actor and consumes the slot.
@@ -727,7 +747,12 @@ impl<M: Send + 'static> ActorSlot<M> {
     where
         A: crate::Actor<Msg = M>,
     {
-        self.define_once_raw(definition.into_raw())
+        let actor = self.actor_ref();
+        self.slot.set_actor_kind(crate::ActorKind::Actor);
+        self.slot.define(ChildConstruction::Raw(
+            definition.into_raw().erase(self.mailbox),
+        ));
+        actor
     }
 
     /// Defines a restartable raw actor and consumes the slot.
@@ -737,6 +762,7 @@ impl<M: Send + 'static> ActorSlot<M> {
         R: crate::RawActor<Msg = M>,
     {
         let actor = self.actor_ref();
+        self.slot.set_actor_kind(crate::ActorKind::RawActor);
         self.slot
             .define(ChildConstruction::Raw(definition.erase(self.mailbox)));
         actor
@@ -749,6 +775,7 @@ impl<M: Send + 'static> ActorSlot<M> {
         R: crate::RawActor<Msg = M>,
     {
         let actor = self.actor_ref();
+        self.slot.set_actor_kind(crate::ActorKind::RawActor);
         self.slot
             .define(ChildConstruction::Raw(definition.erase(self.mailbox)));
         actor
@@ -992,14 +1019,16 @@ impl<M: Send + 'static> DynamicActorSlot<M> {
     where
         A: crate::Actor<Msg = M>,
     {
-        self.define_raw(definition.into_raw())
+        let mut this = self;
+        this.define_raw_with(definition.into_raw(), false, crate::ActorKind::Actor)
     }
 
     fn define_fused<A>(self, definition: ActorDef<A>) -> Admission<ActorRef<M>>
     where
         A: crate::Actor<Msg = M>,
     {
-        self.define_raw_fused(definition.into_raw())
+        let mut this = self;
+        this.define_raw_with(definition.into_raw(), true, crate::ActorKind::Actor)
     }
 
     /// Defines a one-shot callback-oriented actor; dropping after first poll detaches.
@@ -1007,14 +1036,16 @@ impl<M: Send + 'static> DynamicActorSlot<M> {
     where
         A: crate::Actor<Msg = M>,
     {
-        self.define_once_raw(definition.into_raw())
+        let mut this = self;
+        this.define_once_raw_with(definition.into_raw(), false, crate::ActorKind::Actor)
     }
 
     fn define_once_fused<A>(self, definition: ActorOnceDef<A>) -> Admission<ActorRef<M>>
     where
         A: crate::Actor<Msg = M>,
     {
-        self.define_once_raw_fused(definition.into_raw())
+        let mut this = self;
+        this.define_once_raw_with(definition.into_raw(), true, crate::ActorKind::Actor)
     }
 
     /// Defines a restartable raw actor; dropping after first poll detaches.
@@ -1022,22 +1053,28 @@ impl<M: Send + 'static> DynamicActorSlot<M> {
     where
         R: crate::RawActor<Msg = M>,
     {
-        self.define_raw_with(definition, false)
+        self.define_raw_with(definition, false, crate::ActorKind::RawActor)
     }
 
     fn define_raw_fused<R>(mut self, definition: RawDef<R>) -> Admission<ActorRef<M>>
     where
         R: crate::RawActor<Msg = M>,
     {
-        self.define_raw_with(definition, true)
+        self.define_raw_with(definition, true, crate::ActorKind::RawActor)
     }
 
-    fn define_raw_with<R>(&mut self, definition: RawDef<R>, fused: bool) -> Admission<ActorRef<M>>
+    fn define_raw_with<R>(
+        &mut self,
+        definition: RawDef<R>,
+        fused: bool,
+        kind: crate::ActorKind,
+    ) -> Admission<ActorRef<M>>
     where
         R: crate::RawActor<Msg = M>,
     {
         let actor = self.actor_ref();
         let reservation = self.take_reservation();
+        reservation.slot.set_actor_kind(kind);
         reservation.slot.define(ChildConstruction::Raw(
             definition.erase(Arc::clone(&self.mailbox)),
         ));
@@ -1049,26 +1086,28 @@ impl<M: Send + 'static> DynamicActorSlot<M> {
     where
         R: crate::RawActor<Msg = M>,
     {
-        self.define_once_raw_with(definition, false)
+        self.define_once_raw_with(definition, false, crate::ActorKind::RawActor)
     }
 
     fn define_once_raw_fused<R>(mut self, definition: RawOnceDef<R>) -> Admission<ActorRef<M>>
     where
         R: crate::RawActor<Msg = M>,
     {
-        self.define_once_raw_with(definition, true)
+        self.define_once_raw_with(definition, true, crate::ActorKind::RawActor)
     }
 
     fn define_once_raw_with<R>(
         &mut self,
         definition: RawOnceDef<R>,
         fused: bool,
+        kind: crate::ActorKind,
     ) -> Admission<ActorRef<M>>
     where
         R: crate::RawActor<Msg = M>,
     {
         let actor = self.actor_ref();
         let reservation = self.take_reservation();
+        reservation.slot.set_actor_kind(kind);
         reservation.slot.define(ChildConstruction::Raw(
             definition.erase(Arc::clone(&self.mailbox)),
         ));
@@ -1589,6 +1628,26 @@ impl ScopeRef {
         self.cell.subscribe_lifecycle()
     }
 
+    /// Samples all resident actors recursively in snapshot child order.
+    #[must_use]
+    pub fn stats_recursive(&self) -> Vec<crate::RecursiveActorStats> {
+        self.cell.stats_recursive()
+    }
+
+    /// Observes child changes with automatic authoritative resets after loss.
+    #[must_use]
+    pub fn observe_children(&self) -> crate::ChildObserver {
+        let events = self.subscribe_lifecycle();
+        let initial = self.snapshot();
+        crate::ChildObserver::new(self.clone(), events, initial)
+    }
+
+    /// Observes deduplicated cumulative restart counts with loss recovery.
+    #[must_use]
+    pub fn restart_counts(&self) -> crate::RestartCounter {
+        crate::RestartCounter::new(self.observe_children())
+    }
+
     /// Looks up a direct child in an authoritative current snapshot.
     #[must_use]
     pub fn child(&self, id: impl AsRef<str>) -> Option<crate::ChildSnapshot> {
@@ -1762,6 +1821,24 @@ impl DynamicScopeRef {
         self.0.subscribe_lifecycle()
     }
 
+    /// Samples all resident actors recursively in snapshot child order.
+    #[must_use]
+    pub fn stats_recursive(&self) -> Vec<crate::RecursiveActorStats> {
+        self.0.stats_recursive()
+    }
+
+    /// Observes child changes with automatic authoritative resets after loss.
+    #[must_use]
+    pub fn observe_children(&self) -> crate::ChildObserver {
+        self.0.observe_children()
+    }
+
+    /// Observes deduplicated cumulative restart counts with loss recovery.
+    #[must_use]
+    pub fn restart_counts(&self) -> crate::RestartCounter {
+        self.0.restart_counts()
+    }
+
     /// Looks up a direct child in an authoritative current snapshot.
     #[must_use]
     pub fn child(&self, id: impl AsRef<str>) -> Option<crate::ChildSnapshot> {
@@ -1813,7 +1890,7 @@ impl DynamicScopeRef {
     ) -> Result<DynamicActorSlot<M>, ReserveError> {
         let id = checked_id(id)?;
         crate::driver::reserve_dynamic(&self.0.cell, id, None).map(|reservation| {
-            let mailbox = MailboxCell::new(reservation.slot.member.id().clone());
+            let mailbox = MailboxCell::new(&reservation.slot.member);
             reservation.slot.member.attach_mailbox(mailbox.clone());
             DynamicActorSlot {
                 reservation: Some(reservation),

--- a/crates/shelterwood/tests/m10.rs
+++ b/crates/shelterwood/tests/m10.rs
@@ -1,0 +1,488 @@
+use std::{
+    fmt::Debug,
+    future::Future,
+    num::NonZeroUsize,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::Poll,
+    time::Duration,
+};
+
+use shelterwood::{
+    Actor, ActorKind, ActorOnceDef, ActorStats, ActorStatsSnapshot, Backoff, ChildObservation,
+    ChildObserver, Context, DynamicTree, ExitError, ExitResult, KeyedCapacity, RawActor,
+    RawContext, RawDef, RawOnceDef, RecursiveActorStats, RestartCondition, RestartCount,
+    RestartCounter, RestartPolicy, ScopeState, StopContext, SubtreeOnceDef, TaskDef, Tree,
+};
+use shelterwood_test_support::{ReleaseGate, poll_until};
+
+fn assert_clone_eq_debug_send_sync<T: Clone + Eq + Debug + Send + Sync>() {}
+fn assert_copy_eq_debug_send_sync<T: Copy + Eq + Debug + Send + Sync>() {}
+fn assert_send<T: Send>() {}
+
+#[test]
+fn milestone_ten_public_types_keep_their_trait_contracts() {
+    assert_clone_eq_debug_send_sync::<ActorStats>();
+    assert_clone_eq_debug_send_sync::<ActorStatsSnapshot>();
+    assert_copy_eq_debug_send_sync::<ActorKind>();
+    assert_clone_eq_debug_send_sync::<RecursiveActorStats>();
+    assert_clone_eq_debug_send_sync::<ChildObservation>();
+    assert_copy_eq_debug_send_sync::<RestartCount>();
+    assert_send::<ChildObserver>();
+    assert_send::<RestartCounter>();
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SizedMessage {
+    key: &'static str,
+    body: &'static str,
+}
+
+struct ParkedSizedActor;
+
+impl RawActor for ParkedSizedActor {
+    type Msg = SizedMessage;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        context.shutdown_token().cancelled().await;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn actor_stats_count_replacement_eviction_bytes_and_rejection_exactly() {
+    let measurements = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "sized",
+            RawOnceDef::new(ParkedSizedActor)
+                .latest_by_key(
+                    KeyedCapacity::Explicit(NonZeroUsize::new(2).expect("non-zero capacity")),
+                    |message: &SizedMessage| message.key,
+                )
+                .message_size({
+                    let measurements = Arc::clone(&measurements);
+                    move |message| {
+                        measurements.fetch_add(1, Ordering::SeqCst);
+                        message.body.len()
+                    }
+                }),
+        )
+        .expect("valid sized actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("sized actor starts");
+
+    actor
+        .try_send(SizedMessage {
+            key: "a",
+            body: "aa",
+        })
+        .expect("a accepted");
+    actor
+        .try_send(SizedMessage {
+            key: "b",
+            body: "bbb",
+        })
+        .expect("b accepted");
+    actor
+        .try_send(SizedMessage {
+            key: "a",
+            body: "cccc",
+        })
+        .expect("same key replaced");
+    actor
+        .try_send(SizedMessage {
+            key: "c",
+            body: "d",
+        })
+        .expect("new key evicted oldest");
+    actor
+        .send_timeout(
+            SizedMessage {
+                key: "timeout",
+                body: "not measured",
+            },
+            Duration::ZERO,
+        )
+        .await
+        .expect_err("zero-budget ingress rejects before measurement");
+
+    let live = actor.stats();
+    assert_eq!(live.membership, actor.membership());
+    assert!(live.observed_incarnation.is_some());
+    assert_eq!(live.stats.messages_accepted, 4);
+    assert_eq!(live.stats.messages_received, 0);
+    assert_eq!(live.stats.messages_conflated, 1);
+    assert_eq!(live.stats.messages_evicted, 1);
+    assert_eq!(live.stats.message_bytes_accepted, Some(10));
+    assert_eq!(live.stats.sends_rejected, 1);
+    assert_eq!(live.stats.mailbox_depth, 2);
+    assert_eq!(live.stats.mailbox_capacity, 2);
+    assert_eq!(measurements.load(Ordering::SeqCst), 4);
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("sized actor stops");
+    actor
+        .try_send(SizedMessage {
+            key: "terminal",
+            body: "not measured",
+        })
+        .expect_err("terminal ingress rejects");
+    let terminal = actor.stats();
+    assert_eq!(terminal.observed_incarnation, None);
+    assert_eq!(terminal.stats.messages_accepted, 4);
+    assert_eq!(terminal.stats.message_bytes_accepted, Some(10));
+    assert_eq!(terminal.stats.sends_rejected, 2);
+    assert_eq!(terminal.stats.mailbox_depth, 0);
+    assert_eq!(measurements.load(Ordering::SeqCst), 4);
+}
+
+#[tokio::test]
+async fn split_definition_keeps_size_panics_on_the_parked_sender() {
+    let measurements = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let slot = tree
+        .reserve_actor::<SizedMessage>("split-sized")
+        .expect("sized slot reserved");
+    let actor = slot.actor_ref();
+    let mut send = Box::pin(actor.send(SizedMessage {
+        key: "panic",
+        body: "panic",
+    }));
+    let first_poll = std::future::poll_fn(|context| Poll::Ready(send.as_mut().poll(context))).await;
+    assert!(first_poll.is_pending(), "undefined actor parks the send");
+
+    let actor = slot.define_once_raw(RawOnceDef::new(ParkedSizedActor).message_size({
+        let measurements = Arc::clone(&measurements);
+        move |message| {
+            measurements.fetch_add(1, Ordering::SeqCst);
+            assert_ne!(message.body, "panic", "size panic remains on sender");
+            message.body.len()
+        }
+    }));
+    let sender = tokio::spawn(send);
+    assert!(
+        sender
+            .await
+            .expect_err("measurement panics on sender task")
+            .is_panic()
+    );
+
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("sized actor starts");
+    actor
+        .send(SizedMessage {
+            key: "ok",
+            body: "good",
+        })
+        .await
+        .expect("mailbox remains usable after measurement panic");
+    assert_eq!(actor.stats().stats.message_bytes_accepted, Some(4));
+    assert_eq!(measurements.load(Ordering::SeqCst), 2);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("sized actor stops");
+}
+
+struct CallbackActor;
+
+impl Actor for CallbackActor {
+    type Msg = ();
+    type Args = ();
+
+    async fn init(_: (), _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): (), context: &mut Context<'_, Self>) -> ExitResult {
+        context.stop();
+        Ok(())
+    }
+
+    async fn on_stop(&mut self, _: &mut StopContext<'_, Self>) {}
+}
+
+struct IdleRaw;
+
+impl RawActor for IdleRaw {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        while context.recv().await.is_some() {}
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn recursive_stats_use_typed_metadata_snapshot_order_and_scope_paths() {
+    let mut nested = Tree::new();
+    let nested_raw = nested
+        .add_raw_once("raw", RawOnceDef::new(IdleRaw))
+        .expect("nested raw actor valid");
+
+    let mut tree = Tree::new();
+    let callback = tree
+        .add_actor_once("callback", ActorOnceDef::<CallbackActor>::new(()))
+        .expect("callback actor valid");
+    tree.add_subtree_once("nested", SubtreeOnceDef::new(nested))
+        .expect("nested tree valid");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("tree starts");
+
+    let rows = system.scope().stats_recursive();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].path, []);
+    assert_eq!(rows[0].id.as_str(), "callback");
+    assert_eq!(rows[0].kind, ActorKind::Actor);
+    assert_eq!(rows[0].membership, callback.membership());
+    assert_eq!(rows[0].stats, callback.stats().stats);
+    assert_eq!(rows[1].path.len(), 1);
+    assert_eq!(rows[1].path[0].as_str(), "nested");
+    assert_eq!(rows[1].id.as_str(), "raw");
+    assert_eq!(rows[1].kind, ActorKind::RawActor);
+    assert_eq!(rows[1].membership, nested_raw.membership());
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("tree stops");
+}
+
+#[tokio::test]
+async fn child_and_restart_reducers_reset_after_loss_and_close_after_final_state() {
+    let tree = DynamicTree::new();
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+    let mut children = scope.observe_children();
+    let mut restarts = scope.restart_counts();
+
+    assert!(matches!(
+        children.next().await,
+        Some(ChildObservation::Reset { dropped: 0, .. })
+    ));
+    assert_eq!(
+        restarts.next().await,
+        Some(RestartCount {
+            total: 0,
+            delta: 0,
+            resynced: true,
+        })
+    );
+
+    for index in 0..129 {
+        let id = format!("task-{index}");
+        scope
+            .add_task(
+                id,
+                TaskDef::new(|context| async move {
+                    context.shutdown_token().cancelled().await;
+                    Ok(())
+                }),
+            )
+            .await
+            .expect("dynamic task admitted");
+    }
+
+    let Some(ChildObservation::Reset { snapshot, dropped }) = children.next().await else {
+        panic!("child reducer must replace state after lag");
+    };
+    assert!(dropped > 0);
+    assert_eq!(snapshot.children.len(), 129);
+    assert_eq!(
+        restarts.next().await,
+        Some(RestartCount {
+            total: 0,
+            delta: 0,
+            resynced: true,
+        })
+    );
+
+    system
+        .shutdown(Duration::from_secs(2))
+        .await
+        .expect("dynamic tree stops");
+    let saw_final = tokio::time::timeout(Duration::from_secs(2), async {
+        let mut saw_final = false;
+        while let Some(observation) = children.next().await {
+            let snapshot = match observation {
+                ChildObservation::Reset { snapshot, .. }
+                | ChildObservation::Changed { snapshot, .. } => snapshot,
+                _ => continue,
+            };
+            saw_final |= matches!(snapshot.state, ScopeState::Stopped { .. });
+        }
+        saw_final
+    })
+    .await
+    .expect("child observer closes");
+    assert!(
+        saw_final,
+        "final scope state precedes child-observer closure"
+    );
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while restarts.next().await.is_some() {}
+    })
+    .await
+    .expect("restart counter closes");
+}
+
+enum CrashMessage {
+    Crash,
+}
+
+struct CrashActor;
+
+impl RawActor for CrashActor {
+    type Msg = CrashMessage;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        match context.recv().await {
+            Some(CrashMessage::Crash) => Err(ExitError::message("restart counter trigger")),
+            None => Ok(()),
+        }
+    }
+}
+
+#[tokio::test]
+async fn restart_counter_reports_authoritative_deltas_without_event_double_charge() {
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw(
+            "crasher",
+            RawDef::factory(|| CrashActor).restart(RestartPolicy::new(
+                RestartCondition::Always,
+                Backoff::Immediate,
+            )),
+        )
+        .expect("crash actor valid");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("crash actor starts");
+    let first = actor
+        .stats()
+        .observed_incarnation
+        .expect("first incarnation bound");
+    let mut counter = system.scope().restart_counts();
+    assert_eq!(
+        counter.next().await,
+        Some(RestartCount {
+            total: 0,
+            delta: 0,
+            resynced: true,
+        })
+    );
+
+    actor.try_send(CrashMessage::Crash).expect("crash accepted");
+    assert_eq!(
+        counter.next().await,
+        Some(RestartCount {
+            total: 1,
+            delta: 1,
+            resynced: false,
+        })
+    );
+    actor
+        .next_incarnation(first, Duration::from_secs(1))
+        .await
+        .expect("actor restarts");
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("crash actor stops");
+}
+
+#[derive(Clone, Copy)]
+enum LocalMessage {
+    Start,
+    Continuation,
+    Timer,
+    Offload,
+}
+
+struct LocalSourceActor {
+    release: ReleaseGate,
+    delivered: Arc<AtomicUsize>,
+}
+
+impl RawActor for LocalSourceActor {
+    type Msg = LocalMessage;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        while let Some(message) = context.recv().await {
+            match message {
+                LocalMessage::Start => {
+                    context
+                        .continue_with(LocalMessage::Continuation)
+                        .expect("continuation accepted");
+                    context
+                        .set_timeout("timer", LocalMessage::Timer, Duration::ZERO)
+                        .expect("timer accepted");
+                    let release = self.release.clone();
+                    context
+                        .offload(
+                            async move { release.wait().await },
+                            |result| {
+                                result.expect("offload completes before deadline");
+                                LocalMessage::Offload
+                            },
+                            Duration::from_secs(1),
+                        )
+                        .expect("offload accepted");
+                }
+                LocalMessage::Continuation | LocalMessage::Timer | LocalMessage::Offload => {
+                    self.delivered.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn local_delivery_counters_and_outstanding_offload_gauge_are_exact() {
+    let release = ReleaseGate::default();
+    let delivered = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "local",
+            RawOnceDef::new(LocalSourceActor {
+                release: release.clone(),
+                delivered: Arc::clone(&delivered),
+            }),
+        )
+        .expect("local source actor valid");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("local actor starts");
+    actor.try_send(LocalMessage::Start).expect("start accepted");
+
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            actor.stats().stats.outstanding_offloads == 1 && delivered.load(Ordering::SeqCst) >= 2
+        })
+        .await
+    );
+    release.release();
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            delivered.load(Ordering::SeqCst) == 3 && actor.stats().stats.outstanding_offloads == 0
+        })
+        .await
+    );
+    let stats = actor.stats().stats;
+    assert_eq!(stats.messages_accepted, 1);
+    assert_eq!(stats.messages_received, 3);
+    assert_eq!(stats.messages_conflated, 0);
+    assert_eq!(stats.messages_evicted, 0);
+    assert_eq!(stats.message_bytes_accepted, None);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("local actor stops");
+}

--- a/docs/observation-extensions.md
+++ b/docs/observation-extensions.md
@@ -1,0 +1,89 @@
+# Actor statistics and loss-recovering reducers
+
+The M10 observation layer packages common projections over Shelterwood's
+membership identities, authoritative scope snapshots, and bounded lifecycle
+subscriptions. The adapters are runtime-agnostic library types: they are
+`Send`, expose `next()` directly, and close only after their scope membership
+has published its final state.
+
+## Actor statistics
+
+`ActorRef::stats()` reads one `ActorStatsSnapshot` on demand. Counters saturate
+at `u64::MAX` and belong to the membership, so they survive incarnation
+restarts. `observed_incarnation` identifies the mailbox binding sampled with
+the counters. Attribute work to one incarnation by differencing snapshots only
+when their tokens provide the fence the application needs.
+
+`ScopeRef::stats_recursive()` returns actors in recursive snapshot child order.
+Each row retains declaration metadata distinguishing callback `Actor` children
+from loop-owning `RawActor` children. `path` identifies the containing scope
+relative to the queried scope; `id` is the actor's id in that scope. Tasks and
+scope rows are not guessed from runtime attachments.
+
+Message byte accounting is opt-in and typed:
+
+```rust
+let definition = shelterwood::RawOnceDef::new(actor)
+    .message_size(|message: &Request| message.encoded_len());
+```
+
+The observer executes on the sender's ingress stack. A panic resumes there
+without poisoning the mailbox, as for `latest_by_key` extraction and
+`ActorRef::contramap`. Rejected ingress contributes no bytes, and
+`message_bytes_accepted` is `None` when no observer is installed.
+
+Counter edges are deliberately narrow:
+
+| Edge | Effect |
+|---|---|
+| FIFO or non-replacing conflating acceptance | `messages_accepted += 1`; add measured bytes |
+| actor loop dequeues a mailbox message | `messages_received += 1` |
+| latest or same-key replacement | accepted and bytes as above; `messages_conflated += 1` |
+| new-key acceptance evicts another key | accepted and bytes as above; `messages_evicted += 1` |
+| offload, timer, or monitor delivery dequeues | `messages_received += 1`, never accepted |
+| ingress rejects before acceptance | `sends_rejected += 1`, never bytes |
+
+Actor-local `continue_with` work is intentionally outside received ingress and
+external-delivery accounting. `mailbox_depth`, `mailbox_capacity`, and
+`outstanding_offloads` are current gauges rather than cumulative counters.
+
+## Child observation
+
+`ScopeRef::observe_children()` performs the subscribe-then-snapshot catch-up
+protocol. Its first item is always:
+
+```text
+Reset { snapshot, dropped: 0 }
+```
+
+Ordinary lifecycle edges become `Changed { snapshot, cause }`, pairing the
+cause with consistent-or-newer authoritative state. Subscriber overflow is
+never exposed as raw `LifecycleItem::Lagged`: the observer reads a fresh
+snapshot and returns only `Reset { snapshot, dropped }`. Replace reducer state
+wholesale on every reset.
+
+`ScopeRef::restart_counts()` applies the same recovery protocol to
+`ScopeSnapshot.total_restarts`. It suppresses lifecycle edges that do not
+change the total. Every result contains the authoritative `total`, a saturating
+`delta` from the prior emitted total, and `resynced = true` for the initial
+sample or a loss-recovery reset. A lag therefore cannot double-charge a
+restart or hide cumulative work.
+
+## Metrics feature
+
+The disabled-by-default `metrics` feature emits the same structured samples
+through the `metrics` facade. Every instrument carries `scope.path`,
+`actor.id`, and `actor.membership`. The exported names are exactly:
+
+- counters: `shelterwood.actor.messages_accepted`,
+  `shelterwood.actor.messages_received`,
+  `shelterwood.actor.messages_conflated`,
+  `shelterwood.actor.messages_evicted`,
+  `shelterwood.actor.message_bytes_accepted`, and
+  `shelterwood.actor.sends_rejected`;
+- gauges: `shelterwood.actor.outstanding_offloads`,
+  `shelterwood.actor.mailbox_depth`, and
+  `shelterwood.actor.mailbox_capacity`.
+
+The byte counter is emitted only for actors with a size observer. With no
+global recorder installed, the facade keeps the observation path inert.

--- a/docs/part-ii-progress.md
+++ b/docs/part-ii-progress.md
@@ -19,6 +19,6 @@ validation, and deviations for review.
 | M7 — incarnation refinements and `contramap` | complete | `call_idempotent`: **build** — repaired shard-store re-port passed; `project`: open | focused M7 and shard-store tests pass; `just ci` passes with 165 tests | none |
 | M8 — keyed conflation and peer monitoring | complete | control/priority lane remains open until M12 | focused M8 tests pass; `just ci` passes with 172 tests; rustdoc/API reachability clean | none |
 | M9 — group strategies | complete | none | focused M9 tests pass; `just ci` passes with 179 tests; rustdoc/API reachability clean | none |
-| M10 — observation extensions | pending | none | pending | none |
+| M10 — observation extensions | complete | none | focused M10 tests pass; `just ci` passes with 186 tests; rustdoc/API reachability and every feature lane clean | none |
 | M11 — outline, hosting, conveniences | pending | none | pending | none |
 | M12 — acceptance wave two | pending | control/priority lane and `project` final verdicts due | pending | none |


### PR DESCRIPTION
## Summary

Implements issue #9 milestone M10 on top of the literal M9 commit (`9836ddba8d8a7f9fc55196d6cd4b144d5fd83123`).

- adds membership-cumulative `ActorRef::stats()` snapshots and typed, snapshot-ordered `ScopeRef::stats_recursive()` traversal
- adds sender-stack `message_size` observers to restartable/one-shot handler and raw definitions, with exact acceptance/replacement/eviction/rejection accounting
- counts mailbox plus offload/timer/monitor dequeue edges, preserves actor-local continuation exclusion, and samples outstanding-offload/mailbox gauges
- adds loss-recovering `ChildObserver` and deduplicated `RestartCounter`, including initial/reset semantics and terminal closure
- emits the stable §B.6 name/label/unit surface behind the additive, disabled-by-default `metrics` feature
- documents the observation surface and updates the Part II ledger

## Adversarial review hardening

- sender-side key and size hooks share an acceptance-linearized preparation loop, preserving exact byte accounting if mailbox binding changes while `try_send` is in flight and avoiding user hook execution for sequential rejections

## Validation

- focused M10 suite: 7 passed
- `./scripts/dev just ci`: 186 tests passed
- all no-default/serde/host/metrics/all feature lanes clean
- clippy, rustdoc, public API reachability, runtime/exit path guards, formatting, and nixfmt clean

No M11 implementation is included.