### PR TITLE
M11: add outlines, hosting, and lifetime conveniences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "fastrand",
  "metrics",
  "serde",
+ "serde_json",
  "shelterwood-test-support",
  "slab",
  "thiserror",

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ shutdown, and observation. Stable membership and incarnation identities make
 failure recovery explicit without a global registry.
 
 The current `0.1` surface is the core described by [SPEC.md](SPEC.md) plus the
-accepted Part II milestones through M10: incarnation-aware calls and mapping,
-keyed conflation and peer monitoring, ordered group strategies, and structured
-observation extensions. Later Part II sections remain staged by their status
-markers in the specification.
+accepted Part II milestones through M11: incarnation-aware calls and mapping,
+keyed conflation and peer monitoring, ordered group strategies, structured
+observation extensions, resolved outlines, one-incarnation hosting, and finite
+lifetime conveniences. The final acceptance wave remains staged by its status
+marker in the specification.
 
 ## Getting started
 
@@ -63,6 +64,7 @@ scope, and subtrees compose both recursively.
 - [Shutdown and resource ownership](docs/shutdown-and-resources.md)
 - [Snapshots and lifecycle events](docs/observation.md)
 - [Actor statistics and loss-recovering reducers](docs/observation-extensions.md)
+- [Outlines, direct hosting, and finite lifetimes](docs/outline-hosting-and-lifetime.md)
 - [Embedding Shelterwood in a host process](docs/embedding.md)
 
 The executable application-scale examples live in the M5 acceptance tests:

--- a/crates/shelterwood/Cargo.toml
+++ b/crates/shelterwood/Cargo.toml
@@ -23,3 +23,4 @@ tracing.workspace = true
 
 [dev-dependencies]
 shelterwood-test-support = { path = "../test-support" }
+serde_json.workspace = true

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -181,6 +181,41 @@ impl<'a, A: Actor> Context<'a, A> {
         }
     }
 
+    /// Sends one message to another actor after a delay.
+    pub fn send_after_to<M>(
+        &mut self,
+        target: &ActorRef<M>,
+        message: M,
+        after: Duration,
+    ) -> Result<Guard, Rejected<M>>
+    where
+        M: Send + 'static,
+    {
+        self.raw.send_after_to(target, message, after)
+    }
+
+    /// Tries to send a cloned message to another actor once per period.
+    pub fn interval_to<M>(
+        &mut self,
+        target: &ActorRef<M>,
+        message: M,
+        period: Duration,
+    ) -> Result<Guard, Rejected<M>>
+    where
+        M: Clone + Send + 'static,
+    {
+        self.raw.interval_to(target, message, period)
+    }
+
+    /// Waits for a named sibling's readiness relative to this actor's scope.
+    pub async fn await_sibling_ready(
+        &mut self,
+        id: impl Into<ChildId>,
+        deadline: Duration,
+    ) -> Result<crate::ChildSnapshot, crate::SiblingReadyError> {
+        self.raw.await_sibling_ready(id, deadline).await
+    }
+
     /// Retracts a keyed timer or rejects the operation while draining.
     pub fn clear_timer<K>(&mut self, key: &K) -> Result<bool, Rejected<()>>
     where

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -640,6 +640,7 @@ pub(crate) struct ScopeCell {
     control: Mutex<ScopeControl>,
     current_dynamic: Mutex<Option<Arc<DynamicControl>>>,
     current_children: Mutex<Vec<Arc<SlotCell>>>,
+    declaration_order: Mutex<Vec<ChildId>>,
     parent: Mutex<Option<Weak<ScopeCell>>>,
     lifecycle_sequence: Mutex<FenceCounter>,
     root_incarnations: Mutex<FenceCounter>,
@@ -689,6 +690,7 @@ impl ScopeCell {
             control: Mutex::new(ScopeControl::default()),
             current_dynamic: Mutex::new(None),
             current_children: Mutex::new(Vec::new()),
+            declaration_order: Mutex::new(Vec::new()),
             parent: Mutex::new(None),
             lifecycle_sequence: Mutex::new(FenceCounter::new(0)),
             root_incarnations: Mutex::new(FenceCounter::new(0)),
@@ -1268,6 +1270,13 @@ impl ScopeCell {
                 "scope restart found unpruned residents of a previous incarnation"
             );
         }
+        *self
+            .declaration_order
+            .lock()
+            .expect("scope declaration-order mutex poisoned") = children
+            .iter()
+            .map(|child| child.member.id().clone())
+            .collect();
         self.current_children
             .lock()
             .expect("scope children mutex poisoned")
@@ -1290,6 +1299,20 @@ impl ScopeCell {
                 membership: child.member.membership(),
             });
         }
+    }
+
+    pub(crate) fn sibling_order(
+        &self,
+        own: &ChildId,
+        target: &ChildId,
+    ) -> Option<std::cmp::Ordering> {
+        let declared = self
+            .declaration_order
+            .lock()
+            .expect("scope declaration-order mutex poisoned");
+        let own = declared.iter().position(|id| id == own)?;
+        let target = declared.iter().position(|id| id == target)?;
+        Some(target.cmp(&own))
     }
 
     fn admit_child(self: &Arc<Self>, child: &Arc<SlotCell>) {

--- a/crates/shelterwood/src/host.rs
+++ b/crates/shelterwood/src/host.rs
@@ -1,0 +1,351 @@
+//! Degenerate one-incarnation hosting on the ordinary supervision runner.
+
+use std::{future::Future, marker::PhantomData, time::Duration};
+
+use crate::{
+    Actor, ActorOnceDef, ActorRef, BuildError, Exit, ExitResult, Mailbox, PolicyError, RawActor,
+    RawOnceDef, Readiness, ReadinessDeadline, ReserveError, ScopeRef, Shutdown, System,
+    TaskContext, TaskOnceDef, TaskRef, Tree,
+};
+
+const HOSTED_ID: &str = "hosted";
+
+/// Validated policy data for a structurally non-restarting hosted incarnation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HostOptions {
+    mailbox: Mailbox,
+    readiness: Option<Readiness>,
+    readiness_deadline: ReadinessDeadline,
+    shutdown: Shutdown,
+    shutdown_grace: Duration,
+}
+
+impl Default for HostOptions {
+    fn default() -> Self {
+        Self {
+            mailbox: Mailbox::default(),
+            readiness: None,
+            readiness_deadline: ReadinessDeadline::Bounded(
+                crate::policy::DEFAULT_READINESS_DEADLINE,
+            ),
+            shutdown: Shutdown::default(),
+            shutdown_grace: crate::policy::DEFAULT_SHUTDOWN_GRACE,
+        }
+    }
+}
+
+impl HostOptions {
+    /// Creates host options with the ordinary library policy defaults.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Selects the actor mailbox policy. Hosted tasks ignore this field.
+    #[must_use]
+    pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
+        self.mailbox = mailbox;
+        self
+    }
+
+    /// Overrides the child-kind default readiness mode.
+    #[must_use]
+    pub fn readiness(mut self, readiness: Readiness) -> Self {
+        self.readiness = Some(readiness);
+        self
+    }
+
+    /// Sets the structural readiness deadline.
+    #[must_use]
+    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
+        self.readiness_deadline = deadline;
+        self
+    }
+
+    /// Sets the incarnation's cooperative shutdown policy.
+    #[must_use]
+    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
+        self.shutdown = shutdown;
+        self
+    }
+
+    /// Sets the owning handle's overall drop-time shutdown grace.
+    #[must_use]
+    pub fn shutdown_grace(mut self, grace: Duration) -> Self {
+        self.shutdown_grace = grace;
+        self
+    }
+
+    /// Returns the actor mailbox policy.
+    #[must_use]
+    pub const fn mailbox_policy(&self) -> Mailbox {
+        self.mailbox
+    }
+
+    /// Returns the explicit readiness override, if any.
+    #[must_use]
+    pub const fn readiness_mode(&self) -> Option<Readiness> {
+        self.readiness
+    }
+
+    /// Returns the readiness deadline.
+    #[must_use]
+    pub const fn readiness_deadline_policy(&self) -> ReadinessDeadline {
+        self.readiness_deadline
+    }
+
+    /// Returns the child shutdown policy.
+    #[must_use]
+    pub const fn shutdown_policy(&self) -> Shutdown {
+        self.shutdown
+    }
+
+    /// Returns the owning handle's drop-time shutdown grace.
+    #[must_use]
+    pub const fn configured_shutdown_grace(&self) -> Duration {
+        self.shutdown_grace
+    }
+
+    fn validate(&self, kind: HostedKind) -> Result<(), HostError> {
+        if kind == HostedKind::Task && self.mailbox != Mailbox::default() {
+            return Err(HostError::TaskMailbox);
+        }
+        if matches!(self.readiness_deadline, ReadinessDeadline::Inherit) {
+            return Err(HostError::UnresolvedReadinessDeadline);
+        }
+        if matches!(
+            self.readiness_deadline,
+            ReadinessDeadline::Bounded(deadline) if deadline.is_zero()
+        ) {
+            return Err(HostError::InvalidPolicy(PolicyError::ZeroDuration));
+        }
+        if kind != HostedKind::Actor && self.readiness == Some(Readiness::AfterInit) {
+            return Err(HostError::InvalidPolicy(PolicyError::UnsupportedReadiness));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum HostedKind {
+    Actor,
+    Raw,
+    Task,
+}
+
+/// Failure to validate or start a hosted incarnation.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum HostError {
+    /// No ambient supported async runtime exists.
+    #[error("no ambient Tokio runtime is available")]
+    NoRuntime,
+    /// The standalone host cannot resolve an inherited readiness deadline.
+    #[error("hosted readiness deadline must be bounded or unbounded")]
+    UnresolvedReadinessDeadline,
+    /// A supplied policy is invalid for the hosted child kind.
+    #[error("invalid host policy: {0}")]
+    InvalidPolicy(PolicyError),
+    /// A mailbox policy was supplied for a hosted task.
+    #[error("hosted tasks do not have mailboxes")]
+    TaskMailbox,
+    /// The private one-child declaration could not be built.
+    #[error("host declaration failed: {0}")]
+    Declaration(ReserveError),
+    /// The ordinary supervision runner could not be started.
+    #[error("host runner failed: {0}")]
+    Build(BuildError),
+}
+
+/// A hosted incarnation exited before satisfying its readiness contract.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("hosted incarnation exited before becoming ready")]
+pub struct HostedReadyError {
+    /// Classified incarnation exit.
+    pub exit: Exit,
+}
+
+/// Namespace for hosting one callback-oriented actor incarnation.
+pub struct Hosted<A: Actor>(PhantomData<fn() -> A>);
+
+impl<A: Actor> Hosted<A> {
+    /// Starts one callback-oriented actor incarnation on the ordinary runner.
+    pub fn spawn(
+        args: A::Args,
+        options: HostOptions,
+    ) -> Result<(ActorRef<A::Msg>, HostedHandle), HostError> {
+        options.validate(HostedKind::Actor)?;
+        let mut definition = ActorOnceDef::<A>::new(args)
+            .mailbox(options.mailbox)
+            .shutdown(options.shutdown)
+            .readiness_deadline(options.readiness_deadline);
+        if let Some(readiness) = options.readiness {
+            definition = definition.readiness(readiness);
+        }
+        let mut tree = Tree::new();
+        let actor = tree
+            .add_actor_once(HOSTED_ID, definition)
+            .map_err(HostError::Declaration)?;
+        let task = TaskRef::new(actor.member_cell());
+        let system = tree.spawn().map_err(map_build_error)?;
+        Ok((
+            actor,
+            HostedHandle::new(system, task, options.shutdown_grace),
+        ))
+    }
+}
+
+/// Namespace for hosting one loop-owning raw actor incarnation.
+pub struct HostedRaw<M>(PhantomData<fn(M)>);
+
+impl<M: Send + 'static> HostedRaw<M> {
+    /// Starts one owned raw actor incarnation on the ordinary runner.
+    pub fn spawn<R>(
+        raw_actor: R,
+        options: HostOptions,
+    ) -> Result<(ActorRef<M>, HostedHandle), HostError>
+    where
+        R: RawActor<Msg = M>,
+    {
+        options.validate(HostedKind::Raw)?;
+        let mut definition = RawOnceDef::new(raw_actor)
+            .mailbox(options.mailbox)
+            .shutdown(options.shutdown)
+            .readiness_deadline(options.readiness_deadline);
+        if let Some(readiness) = options.readiness {
+            definition = definition
+                .readiness(readiness)
+                .map_err(HostError::InvalidPolicy)?;
+        }
+        let mut tree = Tree::new();
+        let actor = tree
+            .add_raw_once(HOSTED_ID, definition)
+            .map_err(HostError::Declaration)?;
+        let task = TaskRef::new(actor.member_cell());
+        let system = tree.spawn().map_err(map_build_error)?;
+        Ok((
+            actor,
+            HostedHandle::new(system, task, options.shutdown_grace),
+        ))
+    }
+}
+
+/// Namespace for hosting one supervised task incarnation.
+pub struct HostedTask;
+
+impl HostedTask {
+    /// Starts one consuming task body on the ordinary runner.
+    pub fn spawn<F, Fut>(
+        task_factory: F,
+        options: HostOptions,
+    ) -> Result<(TaskRef, HostedHandle), HostError>
+    where
+        F: FnOnce(TaskContext) -> Fut + Send + 'static,
+        Fut: Future<Output = ExitResult> + Send + 'static,
+    {
+        options.validate(HostedKind::Task)?;
+        let mut definition = TaskOnceDef::new(task_factory)
+            .shutdown(options.shutdown)
+            .readiness_deadline(options.readiness_deadline);
+        if let Some(readiness) = options.readiness {
+            definition = definition
+                .readiness(readiness)
+                .map_err(HostError::InvalidPolicy)?;
+        }
+        let mut tree = Tree::new();
+        let (task, completion) = tree
+            .add_task_once(HOSTED_ID, definition)
+            .map_err(HostError::Declaration)?;
+        drop(completion);
+        let system = tree.spawn().map_err(map_build_error)?;
+        Ok((
+            task.clone(),
+            HostedHandle::new(system, task, options.shutdown_grace),
+        ))
+    }
+}
+
+fn map_build_error(error: BuildError) -> HostError {
+    match error {
+        BuildError::NoRuntime => HostError::NoRuntime,
+        other => HostError::Build(other),
+    }
+}
+
+/// Sole owning handle for a hosted one-incarnation runner.
+#[must_use = "dropping the hosted owner begins configured graceful shutdown"]
+pub struct HostedHandle {
+    system: Option<System<ScopeRef>>,
+    task: TaskRef,
+    drop_grace: Duration,
+    spawner: crate::runtime::RuntimeSpawner,
+}
+
+impl std::fmt::Debug for HostedHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HostedHandle")
+            .field("membership", &self.task.membership())
+            .field("drop_grace", &self.drop_grace)
+            .finish_non_exhaustive()
+    }
+}
+
+impl HostedHandle {
+    fn new(system: System<ScopeRef>, task: TaskRef, drop_grace: Duration) -> Self {
+        Self {
+            system: Some(system),
+            task,
+            drop_grace,
+            spawner: crate::runtime::RuntimeSpawner::current()
+                .expect("a hosted system is constructed inside its originating runtime"),
+        }
+    }
+
+    /// Waits until the hosted incarnation becomes ready.
+    pub async fn wait_ready(&self) -> Result<(), HostedReadyError> {
+        let system = self
+            .system
+            .as_ref()
+            .expect("an unconsumed hosted handle retains its system");
+        match system.wait_started().await {
+            Ok(()) => Ok(()),
+            Err(_) => Err(HostedReadyError {
+                exit: self.task.wait().await,
+            }),
+        }
+    }
+
+    /// Requests shutdown, escalates at `grace`, joins, and returns the child exit.
+    pub async fn shutdown(mut self, grace: Duration) -> Result<Exit, crate::ShutdownTimeout> {
+        let system = self
+            .system
+            .take()
+            .expect("an unconsumed hosted handle retains its system");
+        system.shutdown(grace).await?;
+        Ok(self.task.wait().await)
+    }
+
+    /// Waits for natural or externally requested completion and returns the child exit.
+    pub async fn wait(mut self) -> Exit {
+        let system = self
+            .system
+            .take()
+            .expect("an unconsumed hosted handle retains its system");
+        let exit = self.task.wait().await;
+        let _ = system.shutdown(self.drop_grace).await;
+        exit
+    }
+}
+
+impl Drop for HostedHandle {
+    fn drop(&mut self) {
+        let Some(system) = self.system.take() else {
+            return;
+        };
+        let grace = self.drop_grace;
+        let _ = self.spawner.spawn((), async move {
+            let _ = system.shutdown(grace).await;
+        });
+    }
+}

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -6,10 +6,14 @@ mod actor;
 mod driver;
 mod engine;
 mod exit;
+#[cfg(feature = "host")]
+pub mod host;
 mod identity;
 mod mailbox;
 mod monitor;
 mod observe;
+#[cfg(feature = "serde")]
+mod outline;
 mod policy;
 mod raw;
 mod task;
@@ -24,6 +28,10 @@ pub use actor::{Actor, ActorDef, ActorOnceDef, Context, Handler, StopContext};
 pub use exit::{
     Exit, ExitError, ExitKind, ExitResult, IntensityTrip, ShutdownStraggler, ShutdownTimeout,
     StartupFailure, StartupFailureCause,
+};
+#[cfg(feature = "host")]
+pub use host::{
+    HostError, HostOptions, Hosted, HostedHandle, HostedRaw, HostedReadyError, HostedTask,
 };
 pub use identity::{Incarnation, Membership};
 pub use mailbox::{
@@ -42,6 +50,11 @@ pub use observe::{
     RestartCounter, ScopeKind, ScopeSnapshot, ScopeState, SnapshotClosed, SnapshotReceiver,
     WaitError,
 };
+#[cfg(feature = "serde")]
+pub use outline::{
+    ChildOutline, Outline, OutlineChildKind, OutlineError, OutlineInterior, ResolvedMailbox,
+    ResolvedScopeDefaults, ScopeOutline,
+};
 pub use policy::{
     Backoff, BackoffFactor, ChildId, DefaultsInheritance, Intensity, Jitter, KeyedCapacity,
     Mailbox, MailboxShutdown, PolicyError, Readiness, ReadinessDeadline, RestartCondition,
@@ -49,9 +62,12 @@ pub use policy::{
 };
 pub use raw::{
     Blocking, DeadlineElapsed, Guard, RawActor, RawContext, RawDef, RawOnceDef, Rejected,
-    RejectedKind,
+    RejectedKind, SiblingReadyError,
 };
-pub use task::{CancellationToken, OneShotTaskRef, TaskContext, TaskDef, TaskOnceDef, TaskRef};
+pub use task::{
+    CancellationToken, OneShotTaskRef, RunUntilAllResult, TaskCompletion, TaskContext, TaskDef,
+    TaskOnceDef, TaskRef,
+};
 pub use tree::{
     ActorSlot, Admission, AdmissionReceipt, BuildError, DynamicActorSlot, DynamicScopeRef,
     DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, NotAdmittingCause, Removal, RemoveOutcome,

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -246,6 +246,8 @@ impl ScopeState {
 }
 
 /// Static flavor of a scope snapshot.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum ScopeKind {
     /// Fixed, readiness-ordered membership.

--- a/crates/shelterwood/src/outline.rs
+++ b/crates/shelterwood/src/outline.rs
@@ -1,0 +1,135 @@
+//! Serializable, resolved tree declarations.
+//!
+//! An outline is a policy/topology fingerprint, not a tree constructor or a
+//! distribution format. It contains no implementation, arguments, closures,
+//! or runtime state. Restartable subtree factories remain deliberately opaque
+//! so producing one never invokes user code.
+
+use std::num::NonZeroUsize;
+
+use crate::{
+    ChildId, Intensity, MailboxShutdown, Readiness, ReadinessDeadline, RestartPolicy, Retention,
+    ScopeKind, Shutdown, Strategy,
+};
+
+/// Serializable projection of one fully resolved tree declaration.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Outline {
+    /// Resolved root scope and its declaration-ordered children.
+    pub root: ScopeOutline,
+}
+
+/// Resolved scope policy and topology.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScopeOutline {
+    /// Ordered or dynamic scope flavor.
+    pub kind: ScopeKind,
+    /// Fate-sharing strategy for ordered scopes; `None` for dynamic scopes.
+    pub strategy: Option<Strategy>,
+    /// Scope-wide restart intensity.
+    pub intensity: Intensity,
+    /// Every effective default inherited by child declarations.
+    pub defaults: ResolvedScopeDefaults,
+    /// Children in declaration order.
+    pub children: Vec<ChildOutline>,
+}
+
+/// Fully resolved scope defaults carried by an outline.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResolvedScopeDefaults {
+    /// Default child restart policy.
+    pub child_restart: RestartPolicy,
+    /// Default child shutdown policy.
+    pub child_shutdown: Shutdown,
+    /// Default actor mailbox kind and capacity.
+    pub mailbox: ResolvedMailbox,
+    /// Default frozen-prefix mailbox behavior.
+    pub mailbox_shutdown: MailboxShutdown,
+    /// Default gated-readiness deadline.
+    pub readiness_deadline: ReadinessDeadline,
+}
+
+/// Actor mailbox policy with every inherited capacity resolved.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub enum ResolvedMailbox {
+    /// Bounded FIFO mailbox.
+    Queue {
+        /// Resolved non-zero message capacity.
+        capacity: NonZeroUsize,
+    },
+    /// Single latest-value slot.
+    Latest,
+    /// Bounded latest-value-by-key mailbox.
+    LatestByKey {
+        /// Resolved non-zero distinct-key capacity.
+        capacity: NonZeroUsize,
+    },
+}
+
+/// Typed child flavor retained in a resolved outline.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub enum OutlineChildKind {
+    /// Callback-oriented actor.
+    Actor,
+    /// Loop-owning raw actor.
+    RawActor,
+    /// Supervised async task.
+    Task,
+    /// Nested ordered scope.
+    OrderedScope,
+    /// Nested dynamic scope.
+    DynamicScope,
+}
+
+/// One child row with every inherited policy field resolved.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChildOutline {
+    /// Child id within this scope.
+    pub id: ChildId,
+    /// Typed declaration flavor.
+    pub kind: OutlineChildKind,
+    /// Effective restart policy.
+    pub restart: RestartPolicy,
+    /// Effective shutdown policy.
+    pub shutdown: Shutdown,
+    /// Effective readiness mode.
+    pub readiness: Readiness,
+    /// Effective readiness deadline.
+    pub readiness_deadline: ReadinessDeadline,
+    /// Effective terminal-membership retention.
+    pub retention: Retention,
+    /// Effective mailbox policy for actor children only.
+    pub mailbox: Option<ResolvedMailbox>,
+    /// Effective mailbox shutdown behavior for actor children only.
+    pub mailbox_shutdown: Option<MailboxShutdown>,
+    /// Nested topology for scope children only.
+    pub interior: Option<OutlineInterior>,
+}
+
+/// Visibility of a nested scope declaration.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub enum OutlineInterior {
+    /// Recursively carried one-shot subtree declaration.
+    Recursive(ScopeOutline),
+    /// Restartable subtree factory whose code is deliberately never invoked.
+    Opaque,
+}
+
+/// Failure to outline an incomplete declaration.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum OutlineError {
+    /// Every unresolved reservation, expressed as a root-relative child path.
+    #[error("tree contains unfilled reservations")]
+    UnfilledReservations {
+        /// Deterministic declaration-order paths to unresolved slots.
+        paths: Vec<Vec<ChildId>>,
+    },
+}

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -10,6 +10,7 @@ pub const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 pub const DEFAULT_READINESS_DEADLINE: Duration = Duration::from_secs(30);
 
 /// A child identifier within one scope.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ChildId(String);
 
@@ -54,6 +55,8 @@ pub(crate) enum IdError {
 }
 
 /// The condition under which an exited child is restarted.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum RestartCondition {
     /// Restart after every exit, including successful completion.
@@ -65,6 +68,8 @@ pub enum RestartCondition {
 }
 
 /// Whether equal jitter is applied to a backoff delay.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Jitter {
     /// Use the derived delay exactly.
@@ -74,6 +79,7 @@ pub enum Jitter {
 }
 
 /// A validated exponential-backoff multiplier.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone, Copy)]
 pub struct BackoffFactor(f64);
 
@@ -113,6 +119,8 @@ impl std::hash::Hash for BackoffFactor {
 }
 
 /// Delay policy for a scheduled restart.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Backoff {
     /// Restart without a delay.
@@ -222,6 +230,8 @@ fn duration_from_nanos(nanos: f64) -> Duration {
 }
 
 /// Restart condition and delay policy for one child.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct RestartPolicy {
     condition: RestartCondition,
@@ -269,6 +279,8 @@ impl Default for RestartPolicy {
 }
 
 /// Per-child shutdown behavior.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Shutdown {
     /// Request cooperative shutdown for up to the supplied grace.
@@ -289,6 +301,8 @@ impl Default for Shutdown {
 }
 
 /// A child's readiness mode.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Readiness {
     /// Ready as soon as the incarnation starts.
@@ -300,6 +314,8 @@ pub enum Readiness {
 }
 
 /// Resolution state for a gated-readiness deadline.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub enum ReadinessDeadline {
     /// Resolve from the nearest scope default.
@@ -323,6 +339,8 @@ impl ReadinessDeadline {
 }
 
 /// The scope-wide restart budget.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Intensity {
     /// Maximum restart charges allowed inside the rolling window.
@@ -355,6 +373,8 @@ impl Default for Intensity {
 }
 
 /// Core mailbox declarations carried as L1 policy data.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum Mailbox {
@@ -401,6 +421,8 @@ impl Default for Mailbox {
 }
 
 /// Fate of the frozen accepted mailbox prefix during shutdown.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub enum MailboxShutdown {
     /// Deliver the frozen accepted prefix before stopping.
@@ -411,6 +433,8 @@ pub enum MailboxShutdown {
 }
 
 /// Whether a terminal child remains resident as a tombstone.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Retention {
     /// Retain the terminal membership until explicit removal or scope exit.
@@ -420,6 +444,8 @@ pub enum Retention {
 }
 
 /// Ordered-scope fate-sharing strategy.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum Strategy {

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -16,7 +16,7 @@ use std::{
 use crate::{
     ActorRef, CancellationToken, ChildId, ExitResult, Incarnation, KeyedCapacity, Mailbox,
     MailboxShutdown, PolicyError, Readiness, ReadinessDeadline, RestartPolicy, Retention, ScopeRef,
-    SendPayload, Shutdown, WatchTarget,
+    ScopeState, SendErrorKind, SendPayload, Shutdown, WaitError, WatchTarget,
     driver::{ActorWork, Latch, Signal, SignalWatcher},
     mailbox::{
         MailboxCell, MailboxControl, MailboxKeyExtractor, MailboxReceiver, MessageSizeObserver,
@@ -35,12 +35,38 @@ type SharedWork = Arc<Mutex<Option<Pin<Box<dyn Future<Output = ()> + Send + 'sta
 #[error("the offload deadline elapsed")]
 pub struct DeadlineElapsed;
 
+/// Failure to observe a scope-relative sibling readiness barrier.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum SiblingReadyError {
+    /// The calling incarnation is already draining or stopping.
+    #[error("actor incarnation is draining")]
+    Draining,
+    /// An ordered child tried to await itself or a later declaration.
+    #[error("ordered sibling wait would deadlock startup")]
+    WouldDeadlock,
+    /// No such sibling is declared in this ordered scope.
+    #[error("unknown sibling in ordered scope")]
+    UnknownSibling,
+    /// The deadline elapsed before the sibling became ready.
+    #[error("sibling readiness wait timed out")]
+    TimedOut,
+    /// The containing scope terminated before the sibling became ready.
+    #[error("scope terminated before sibling readiness")]
+    ScopeTerminated {
+        /// Final scope state.
+        state: ScopeState,
+    },
+}
+
 /// The kind of a rejected actor-context operation.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum RejectedKind {
     /// The actor incarnation is already draining or stopping.
     Draining,
+    /// An interval period was zero.
+    ZeroPeriod,
 }
 
 /// An operation rejected by the actor's current callback stage.
@@ -60,9 +86,13 @@ impl<T> fmt::Debug for Rejected<T> {
 
 impl<T> Rejected<T> {
     pub(crate) fn new(payload: T) -> Self {
+        Self::with_kind(payload, RejectedKind::Draining)
+    }
+
+    fn with_kind(payload: T, kind: RejectedKind) -> Self {
         Self {
             payload: SendPayload::Recovered(payload),
-            kind: RejectedKind::Draining,
+            kind,
         }
     }
 
@@ -696,6 +726,128 @@ impl<M: Send + 'static> RawContext<M> {
         Ok(())
     }
 
+    /// Sends one message to another actor after a delay.
+    ///
+    /// The send uses ordinary backpressure and rebind semantics. The returned
+    /// guard and this sender incarnation jointly own the timer.
+    pub fn send_after_to<T>(
+        &mut self,
+        target: &ActorRef<T>,
+        message: T,
+        after: Duration,
+    ) -> Result<Guard, Rejected<T>>
+    where
+        T: Send + 'static,
+    {
+        if self.is_stopping() || !self.resources.accepting {
+            return Err(Rejected::new(message));
+        }
+        let cancellation = Latch::default();
+        let finished = Latch::default();
+        let token = self.shutdown.child(cancellation.clone());
+        let target = target.clone();
+        let target_member = target.member_cell();
+        let operation_finished = finished.clone();
+        let operation = async move {
+            let delivery = async move {
+                crate::driver::sleep(after).await;
+                let _ = target.send(message).await;
+            };
+            let delivery_or_terminal =
+                async move { crate::driver::select(delivery, target_member.wait_terminal()).await };
+            let _ = crate::driver::select(token.cancelled(), delivery_or_terminal).await;
+            operation_finished.fire();
+        };
+        Ok(self.start_cross_timer(cancellation, finished, operation))
+    }
+
+    /// Tries to send a cloned message to another actor once per period.
+    ///
+    /// The first tick occurs after one full period. Full or temporarily
+    /// unbound targets skip a tick, and no missed ticks are replayed.
+    pub fn interval_to<T>(
+        &mut self,
+        target: &ActorRef<T>,
+        message: T,
+        period: Duration,
+    ) -> Result<Guard, Rejected<T>>
+    where
+        T: Clone + Send + 'static,
+    {
+        if period.is_zero() {
+            return Err(Rejected::with_kind(message, RejectedKind::ZeroPeriod));
+        }
+        if self.is_stopping() || !self.resources.accepting {
+            return Err(Rejected::new(message));
+        }
+        let cancellation = Latch::default();
+        let finished = Latch::default();
+        let token = self.shutdown.child(cancellation.clone());
+        let target = target.clone();
+        let target_member = target.member_cell();
+        let operation_finished = finished.clone();
+        let operation = async move {
+            loop {
+                let tick_or_terminal = async {
+                    crate::driver::select(
+                        crate::driver::sleep(period),
+                        target_member.wait_terminal(),
+                    )
+                    .await
+                };
+                match crate::driver::select(token.cancelled(), tick_or_terminal).await {
+                    crate::driver::Selected::First(())
+                    | crate::driver::Selected::Second(crate::driver::Selected::Second(_)) => break,
+                    crate::driver::Selected::Second(crate::driver::Selected::First(())) => {}
+                }
+                match target.try_send(message.clone()) {
+                    Ok(_) => {}
+                    Err(error) if error.kind == SendErrorKind::Terminated => break,
+                    Err(_) => {}
+                }
+            }
+            operation_finished.fire();
+        };
+        Ok(self.start_cross_timer(cancellation, finished, operation))
+    }
+
+    /// Waits for a named sibling's readiness relative to this actor's scope.
+    pub async fn await_sibling_ready(
+        &mut self,
+        id: impl Into<ChildId>,
+        deadline: Duration,
+    ) -> Result<crate::ChildSnapshot, SiblingReadyError> {
+        if self.is_stopping() || !self.resources.accepting {
+            return Err(SiblingReadyError::Draining);
+        }
+        let id = id.into();
+        if self.scope.cell.flavor == crate::tree::ScopeFlavor::Ordered {
+            match self.scope.cell.sibling_order(&self.id, &id) {
+                Some(std::cmp::Ordering::Less) => {}
+                Some(std::cmp::Ordering::Equal | std::cmp::Ordering::Greater) => {
+                    return Err(SiblingReadyError::WouldDeadlock);
+                }
+                None => return Err(SiblingReadyError::UnknownSibling),
+            }
+        }
+        let scope = self.scope.clone();
+        let shutdown = self.shutdown.clone();
+        let wait = scope.wait_for_child(
+            id,
+            |child| matches!(child.state, crate::ChildState::Running),
+            deadline,
+        );
+        match crate::driver::select(shutdown.cancelled(), wait).await {
+            crate::driver::Selected::First(()) => Err(SiblingReadyError::Draining),
+            crate::driver::Selected::Second(result) => result.map_err(|error| match error {
+                WaitError::TimedOut => SiblingReadyError::TimedOut,
+                WaitError::ScopeTerminated { state } => {
+                    SiblingReadyError::ScopeTerminated { state }
+                }
+            }),
+        }
+    }
+
     /// Retracts a keyed timer, including an elapsed timer not yet delivered.
     pub fn clear_timer<K>(&mut self, key: &K) -> bool
     where
@@ -951,6 +1103,28 @@ impl<M: Send + 'static> RawContext<M> {
             task: Some(task),
         });
         Ok(guard)
+    }
+
+    fn start_cross_timer(
+        &mut self,
+        cancellation: Latch,
+        finished: Latch,
+        operation: impl Future<Output = ()> + Send + 'static,
+    ) -> Guard {
+        let state: SharedWork = Arc::new(Mutex::new(Some(Box::pin(operation))));
+        let task = crate::driver::spawn_actor_work(SharedOffloadFuture(Arc::clone(&state)));
+        self.resources.offloads.push(OffloadResource {
+            cancellation: cancellation.clone(),
+            finished: finished.clone(),
+            state: Some(state),
+            task: Some(task),
+        });
+        Guard {
+            cancellation,
+            finished,
+            cancel_action: None,
+            armed: true,
+        }
     }
 
     fn start_watch<T, W>(

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -459,6 +459,10 @@ impl<M> Default for RawResources<M> {
 }
 
 impl<M> RawResources<M> {
+    fn prune_finished_offloads(&mut self) {
+        self.offloads.retain(|offload| !offload.finished.is_fired());
+    }
+
     fn pop_monitor_through(&mut self, limit: u64) -> Option<MonitorDelivery<M>> {
         self.watches.retain(|watch| watch.sink.is_active());
         if self.watches.is_empty() {
@@ -1028,9 +1032,7 @@ impl<M: Send + 'static> RawContext<M> {
         // Completed offloads no longer need their resources; prune them here
         // so a long-lived incarnation's ledger stays O(in-flight), not
         // O(offloads-ever-issued).
-        self.resources
-            .offloads
-            .retain(|offload| !offload.finished.is_fired());
+        self.resources.prune_finished_offloads();
 
         let cancellation = Latch::default();
         let finished = Latch::default();
@@ -1111,6 +1113,10 @@ impl<M: Send + 'static> RawContext<M> {
         finished: Latch,
         operation: impl Future<Output = ()> + Send + 'static,
     ) -> Guard {
+        // Cross-incarnation timers share the offload ledger. Prune completed
+        // entries here too so sequential timers do not retain their tasks for
+        // the rest of a long-lived incarnation.
+        self.resources.prune_finished_offloads();
         let state: SharedWork = Arc::new(Mutex::new(Some(Box::pin(operation))));
         let task = crate::driver::spawn_actor_work(SharedOffloadFuture(Arc::clone(&state)));
         self.resources.offloads.push(OffloadResource {
@@ -1790,4 +1796,26 @@ pub(crate) struct RawRunContext {
     pub(crate) local_stop: Latch,
     pub(crate) readiness_override: Option<Readiness>,
     pub(crate) mailbox_shutdown: MailboxShutdown,
+}
+
+#[cfg(test)]
+mod resource_tests {
+    use super::{Latch, OffloadResource, RawResources};
+
+    #[test]
+    fn pruning_drops_finished_incarnation_resources() {
+        let finished = Latch::default();
+        finished.fire();
+        let mut resources = RawResources::<()>::default();
+        resources.offloads.push(OffloadResource {
+            cancellation: Latch::default(),
+            finished,
+            state: None,
+            task: None,
+        });
+
+        resources.prune_finished_offloads();
+
+        assert!(resources.offloads.is_empty());
+    }
 }

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -37,6 +37,26 @@ pub(crate) fn is_available() -> bool {
     tokio::runtime::Handle::try_current().is_ok()
 }
 
+#[derive(Clone)]
+pub(crate) struct RuntimeSpawner(tokio::runtime::Handle);
+
+impl RuntimeSpawner {
+    pub(crate) fn current() -> Option<Self> {
+        tokio::runtime::Handle::try_current().ok().map(Self)
+    }
+
+    pub(crate) fn spawn<I, F>(&self, id: I, future: F) -> JoinHandle<I, F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        JoinHandle {
+            id,
+            inner: self.0.spawn(future),
+        }
+    }
+}
+
 /// A spawned operation whose identity is retained through joining.
 pub(crate) struct JoinHandle<I, T> {
     id: I,

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -331,6 +331,24 @@ impl Hash for TaskRef {
     }
 }
 
+/// One selected task's retained completion, in caller input order.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TaskCompletion {
+    /// Stable task membership identity.
+    pub membership: Membership,
+    /// Terminal task exit.
+    pub exit: Exit,
+}
+
+/// Result of awaiting selected tasks and then shutting their owning system down.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RunUntilAllResult {
+    /// Selected completions in caller input order, including duplicates.
+    pub tasks: Vec<TaskCompletion>,
+    /// Outcome of the ensuing structured system shutdown.
+    pub shutdown: Result<(), crate::ShutdownTimeout>,
+}
+
 enum CompletionState<T> {
     Pending,
     Completed(T),

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -329,6 +329,140 @@ impl BuilderCore {
         })
     }
 
+    #[cfg(feature = "serde")]
+    fn outline_scope(
+        &self,
+        inherited: ResolvedDefaults,
+        prefix: &mut Vec<ChildId>,
+        unfilled: &mut Vec<Vec<ChildId>>,
+    ) -> crate::ScopeOutline {
+        let defaults = inherited.overlay(&self.config.defaults);
+        let mut children = Vec::with_capacity(self.slots.len());
+        for slot in &self.slots {
+            let state = slot.definition.lock().expect("definition mutex poisoned");
+            let DefinitionState::Defined(definition) = &*state else {
+                match &*state {
+                    DefinitionState::Undefined => {
+                        prefix.push(slot.member.id().clone());
+                        unfilled.push(prefix.clone());
+                        prefix.pop();
+                        continue;
+                    }
+                    DefinitionState::Lowered => {
+                        unreachable!("an owned declaration cannot be outlined after lowering")
+                    }
+                    DefinitionState::Defined(_) => unreachable!(),
+                }
+            };
+            children.push(self.outline_child(slot, definition, &defaults, prefix, unfilled));
+        }
+        crate::ScopeOutline {
+            kind: match self.flavor {
+                ScopeFlavor::Ordered => crate::ScopeKind::Ordered,
+                ScopeFlavor::Dynamic => crate::ScopeKind::Dynamic,
+            },
+            strategy: (self.flavor == ScopeFlavor::Ordered).then_some(self.config.strategy),
+            intensity: self.config.intensity,
+            defaults: outline_defaults(&defaults),
+            children,
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    fn outline_child(
+        &self,
+        slot: &SlotCell,
+        definition: &ChildConstruction,
+        defaults: &ResolvedDefaults,
+        prefix: &mut Vec<ChildId>,
+        unfilled: &mut Vec<Vec<ChildId>>,
+    ) -> crate::ChildOutline {
+        let (options, one_shot, default_readiness, kind) = match definition {
+            ChildConstruction::Raw(definition) => {
+                let kind = match slot
+                    .actor_kind()
+                    .expect("raw construction retains typed actor metadata")
+                {
+                    crate::ActorKind::Actor => crate::OutlineChildKind::Actor,
+                    crate::ActorKind::RawActor => crate::OutlineChildKind::RawActor,
+                };
+                let readiness = if kind == crate::OutlineChildKind::Actor {
+                    crate::Readiness::AfterInit
+                } else {
+                    crate::Readiness::Immediate
+                };
+                (&definition.options, definition.one_shot(), readiness, kind)
+            }
+            ChildConstruction::Task(definition) => (
+                &definition.options,
+                false,
+                crate::Readiness::Immediate,
+                crate::OutlineChildKind::Task,
+            ),
+            ChildConstruction::TaskOnce(definition) => (
+                &definition.options,
+                true,
+                crate::Readiness::Immediate,
+                crate::OutlineChildKind::Task,
+            ),
+            ChildConstruction::Scope(definition) => {
+                let kind = match slot
+                    .scope
+                    .as_ref()
+                    .expect("scope construction retains a scope cell")
+                    .flavor
+                {
+                    ScopeFlavor::Ordered => crate::OutlineChildKind::OrderedScope,
+                    ScopeFlavor::Dynamic => crate::OutlineChildKind::DynamicScope,
+                };
+                (
+                    &definition.options,
+                    definition.one_shot(),
+                    crate::Readiness::Manual,
+                    kind,
+                )
+            }
+        };
+        let resolved = resolve_common(options, defaults, one_shot, default_readiness);
+        let actor = matches!(
+            kind,
+            crate::OutlineChildKind::Actor | crate::OutlineChildKind::RawActor
+        );
+        let interior = match definition {
+            ChildConstruction::Scope(definition) => Some(match &definition.source {
+                ScopeSource::Restartable(_) => crate::OutlineInterior::Opaque,
+                ScopeSource::OneShot(tree) => {
+                    let inherited = match definition.defaults {
+                        DefaultsInheritance::Inherit => defaults.clone(),
+                        DefaultsInheritance::Reset => ResolvedDefaults::default(),
+                    };
+                    prefix.push(slot.member.id().clone());
+                    let nested = tree.outline_scope(inherited, prefix, unfilled);
+                    prefix.pop();
+                    crate::OutlineInterior::Recursive(nested)
+                }
+                ScopeSource::Spent => {
+                    unreachable!("an owned declaration cannot contain a spent subtree")
+                }
+            }),
+            ChildConstruction::Raw(_)
+            | ChildConstruction::Task(_)
+            | ChildConstruction::TaskOnce(_) => None,
+        };
+        crate::ChildOutline {
+            id: slot.member.id().clone(),
+            kind,
+            restart: resolved.restart,
+            shutdown: resolved.shutdown,
+            readiness: resolved.readiness,
+            readiness_deadline: resolved.readiness_deadline,
+            retention: resolved.retention,
+            mailbox: actor.then(|| outline_mailbox(&resolved)),
+            mailbox_shutdown: actor.then_some(resolved.mailbox_shutdown),
+            interior,
+        }
+    }
+
     fn terminalize(&self) {
         for slot in &self.slots {
             slot.member.terminalize(Exit::never_started());
@@ -338,6 +472,38 @@ impl BuilderCore {
         }
         self.root.terminalize_never_started();
     }
+}
+
+#[cfg(feature = "serde")]
+fn outline_defaults(defaults: &ResolvedDefaults) -> crate::ResolvedScopeDefaults {
+    crate::ResolvedScopeDefaults {
+        child_restart: defaults.child_restart,
+        child_shutdown: defaults.child_shutdown,
+        mailbox: outline_core_mailbox(defaults.mailbox),
+        mailbox_shutdown: defaults.mailbox_shutdown,
+        readiness_deadline: defaults.readiness_deadline,
+    }
+}
+
+#[cfg(feature = "serde")]
+fn outline_core_mailbox(mailbox: crate::Mailbox) -> crate::ResolvedMailbox {
+    match mailbox {
+        crate::Mailbox::Queue(capacity) => crate::ResolvedMailbox::Queue {
+            capacity: capacity.unwrap_or_else(|| {
+                std::num::NonZeroUsize::new(crate::policy::DEFAULT_MAILBOX_CAPACITY)
+                    .expect("library mailbox capacity is non-zero")
+            }),
+        },
+        crate::Mailbox::Latest => crate::ResolvedMailbox::Latest,
+    }
+}
+
+#[cfg(feature = "serde")]
+fn outline_mailbox(options: &ResolvedCommonOptions) -> crate::ResolvedMailbox {
+    options.keyed_capacity.map_or_else(
+        || outline_core_mailbox(options.mailbox),
+        |capacity| crate::ResolvedMailbox::LatestByKey { capacity },
+    )
 }
 
 impl Drop for BuilderCore {
@@ -421,6 +587,20 @@ impl Tree {
     pub fn defaults(&mut self, defaults: ScopeDefaults) -> &mut Self {
         self.core.config.defaults = defaults;
         self
+    }
+
+    /// Borrows this declaration as a fully resolved serializable outline.
+    #[cfg(feature = "serde")]
+    pub fn outline(&self) -> Result<crate::Outline, crate::OutlineError> {
+        let mut unfilled = Vec::new();
+        let root =
+            self.core
+                .outline_scope(ResolvedDefaults::default(), &mut Vec::new(), &mut unfilled);
+        if unfilled.is_empty() {
+            Ok(crate::Outline { root })
+        } else {
+            Err(crate::OutlineError::UnfilledReservations { paths: unfilled })
+        }
     }
 
     /// Reserves an actor membership and returns its pre-spawn handle slot.
@@ -573,6 +753,20 @@ impl DynamicTree {
     pub fn defaults(&mut self, defaults: ScopeDefaults) -> &mut Self {
         self.core.config.defaults = defaults;
         self
+    }
+
+    /// Borrows this declaration as a fully resolved serializable outline.
+    #[cfg(feature = "serde")]
+    pub fn outline(&self) -> Result<crate::Outline, crate::OutlineError> {
+        let mut unfilled = Vec::new();
+        let root =
+            self.core
+                .outline_scope(ResolvedDefaults::default(), &mut Vec::new(), &mut unfilled);
+        if unfilled.is_empty() {
+            Ok(crate::Outline { root })
+        } else {
+            Err(crate::OutlineError::UnfilledReservations { paths: unfilled })
+        }
     }
 
     /// Reserves an initial actor membership.
@@ -2080,6 +2274,36 @@ impl<R: Clone> System<R> {
     /// Waits until the declared tree is ready or startup terminally fails.
     pub async fn wait_started(&self) -> Result<(), StartupError> {
         self.run.root.wait_started().await
+    }
+
+    /// Waits for every selected task, then shuts down and consumes the system.
+    ///
+    /// Completion rows retain caller input order. An empty selection proceeds
+    /// directly to shutdown.
+    pub fn run_until_all<I>(
+        self,
+        tasks: I,
+        grace: Duration,
+    ) -> impl Future<Output = crate::RunUntilAllResult> + Send
+    where
+        I: IntoIterator<Item = TaskRef>,
+        R: Send + 'static,
+    {
+        let tasks = tasks.into_iter().collect::<Vec<_>>();
+        async move {
+            let mut completions = Vec::with_capacity(tasks.len());
+            for task in tasks {
+                completions.push(crate::TaskCompletion {
+                    membership: task.membership(),
+                    exit: task.wait().await,
+                });
+            }
+            let shutdown = self.shutdown(grace).await;
+            crate::RunUntilAllResult {
+                tasks: completions,
+                shutdown,
+            }
+        }
     }
 
     /// Rolls a startup failure back through full shutdown.

--- a/crates/shelterwood/tests/host.rs
+++ b/crates/shelterwood/tests/host.rs
@@ -1,0 +1,311 @@
+#![cfg(feature = "host")]
+
+use std::{
+    fmt::Debug,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use shelterwood::{
+    Actor, Context, Exit, ExitError, ExitKind, ExitResult, HostError, HostOptions, Hosted,
+    HostedHandle, HostedRaw, HostedTask, LifecycleEventKind, LifecycleItem, Mailbox, PolicyError,
+    RawActor, RawContext, RawOnceDef, Readiness, ReadinessDeadline, Shutdown, StopContext, Tree,
+};
+use shelterwood_test_support::ReleaseGate;
+
+fn assert_clone_eq_debug_send_sync<T: Clone + Eq + Debug + Send + Sync>() {}
+fn assert_send<T: Send>() {}
+
+#[test]
+fn host_public_data_and_owner_keep_their_trait_contracts() {
+    assert_clone_eq_debug_send_sync::<HostOptions>();
+    assert_clone_eq_debug_send_sync::<HostError>();
+    assert_send::<HostedHandle>();
+}
+
+struct StopOnMessage;
+
+impl Actor for StopOnMessage {
+    type Msg = ();
+    type Args = ();
+
+    async fn init(_: (), _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): (), context: &mut Context<'_, Self>) -> ExitResult {
+        context.stop();
+        Ok(())
+    }
+
+    async fn on_stop(&mut self, _: &mut StopContext<'_, Self>) {}
+}
+
+#[tokio::test]
+async fn hosted_actor_uses_real_membership_readiness_and_exit_classification() {
+    let options = HostOptions::new()
+        .mailbox(Mailbox::queue(4).expect("non-zero mailbox"))
+        .readiness_deadline(
+            ReadinessDeadline::bounded(Duration::from_secs(1)).expect("non-zero deadline"),
+        )
+        .shutdown(Shutdown::Graceful {
+            grace: Duration::from_millis(50),
+        });
+    let (actor, handle) = Hosted::<StopOnMessage>::spawn((), options).expect("host starts");
+    assert_eq!(actor.id().as_str(), "hosted");
+    handle
+        .wait_ready()
+        .await
+        .expect("after-init readiness passes");
+    actor.send(()).await.expect("hosted mailbox accepts work");
+    let exit = handle.wait().await;
+    assert!(matches!(exit.kind(), ExitKind::Completed));
+    assert!(
+        exit.cancelled(),
+        "a local actor stop fires its cancellation token"
+    );
+}
+
+struct FailsInit;
+
+impl Actor for FailsInit {
+    type Msg = ();
+    type Args = ();
+
+    async fn init(_: (), _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Err(ExitError::message("hosted init failed"))
+    }
+
+    async fn handle(&mut self, (): (), _: &mut Context<'_, Self>) -> ExitResult {
+        unreachable!("failed initialization never handles messages")
+    }
+
+    async fn on_stop(&mut self, _: &mut StopContext<'_, Self>) {}
+}
+
+#[tokio::test]
+async fn hosted_wait_joins_and_returns_an_initialization_failure() {
+    let (_, handle) = Hosted::<FailsInit>::spawn((), HostOptions::new()).expect("host starts");
+    let ready = handle
+        .wait_ready()
+        .await
+        .expect_err("initialization never becomes ready");
+    let exit = tokio::time::timeout(Duration::from_secs(1), handle.wait())
+        .await
+        .expect("host wait must not inherit root startup-failure parking");
+    assert_eq!(exit, ready.exit);
+    assert!(matches!(exit.kind(), ExitKind::Failed(_)));
+}
+
+struct CooperativeRaw;
+
+impl RawActor for CooperativeRaw {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        context.shutdown_token().cancelled().await;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn hosted_raw_and_task_share_supervised_shutdown_and_panic_paths() {
+    let (actor, raw_handle) =
+        HostedRaw::<()>::spawn(CooperativeRaw, HostOptions::new()).expect("raw host starts");
+    raw_handle
+        .wait_ready()
+        .await
+        .expect("raw is immediately ready");
+    let membership = actor.membership();
+    let exit = raw_handle
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("cooperative raw host stops");
+    assert!(matches!(exit.kind(), ExitKind::Completed));
+    assert!(exit.cancelled());
+    assert_eq!(actor.membership(), membership);
+
+    let (task, task_handle) = HostedTask::spawn(
+        |_| async move { panic!("hosted-task-panic") },
+        HostOptions::new(),
+    )
+    .expect("task host starts");
+    let membership = task.membership();
+    let exit = task_handle.wait().await;
+    assert_eq!(task.membership(), membership);
+    assert!(matches!(
+        exit.kind(),
+        ExitKind::Panicked {
+            message: Some(message)
+        } if message.contains("hosted-task-panic")
+    ));
+}
+
+#[tokio::test]
+async fn hosted_manual_readiness_and_owner_drop_are_structured() {
+    let stopped = Arc::new(AtomicBool::new(false));
+    let (task, handle) = HostedTask::spawn(
+        {
+            let stopped = Arc::clone(&stopped);
+            move |context| async move {
+                context.mark_ready();
+                context.shutdown_token().cancelled().await;
+                stopped.store(true, Ordering::SeqCst);
+                Ok(())
+            }
+        },
+        HostOptions::new()
+            .readiness(Readiness::Manual)
+            .shutdown_grace(Duration::from_secs(1)),
+    )
+    .expect("manual task host starts");
+    handle
+        .wait_ready()
+        .await
+        .expect("manual readiness is observed");
+    drop(handle);
+    let exit = task.wait().await;
+    assert!(matches!(exit.kind(), ExitKind::Completed));
+    assert!(exit.cancelled());
+    assert!(stopped.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn host_options_reject_unresolved_and_child_incompatible_readiness() {
+    let unresolved = HostedTask::spawn(
+        |_| async { Ok(()) },
+        HostOptions::new().readiness_deadline(ReadinessDeadline::Inherit),
+    )
+    .expect_err("standalone hosting has no inherited default");
+    assert_eq!(unresolved, HostError::UnresolvedReadinessDeadline);
+
+    let incompatible = HostedRaw::<()>::spawn(
+        CooperativeRaw,
+        HostOptions::new().readiness(Readiness::AfterInit),
+    )
+    .expect_err("after-init is callback-actor-only");
+    assert_eq!(
+        incompatible,
+        HostError::InvalidPolicy(PolicyError::UnsupportedReadiness)
+    );
+
+    let task_mailbox = HostedTask::spawn(
+        |_| async { Ok(()) },
+        HostOptions::new().mailbox(Mailbox::latest()),
+    )
+    .expect_err("tasks do not have actor mailboxes");
+    assert_eq!(task_mailbox, HostError::TaskMailbox);
+}
+
+#[test]
+fn host_reports_missing_ambient_runtime_without_panicking() {
+    let error = HostedTask::spawn(|_| async { Ok(()) }, HostOptions::new())
+        .expect_err("plain test has no ambient Tokio runtime");
+    assert_eq!(error, HostError::NoRuntime);
+}
+
+#[test]
+fn hosted_drop_uses_the_originating_runtime_outside_its_entered_context() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .expect("test runtime builds");
+    let (task, handle) = runtime.block_on(async {
+        let hosted = HostedTask::spawn(
+            |context| async move {
+                context.shutdown_token().cancelled().await;
+                Ok(())
+            },
+            HostOptions::new(),
+        )
+        .expect("host starts");
+        hosted.1.wait_ready().await.expect("task becomes ready");
+        hosted
+    });
+    drop(handle);
+    let exit = runtime.block_on(task.wait());
+    assert!(matches!(exit.kind(), ExitKind::Completed));
+    assert!(exit.cancelled());
+}
+
+#[derive(Clone)]
+enum ParityOutcome {
+    Completed,
+    Failed(ExitError),
+    Panicked,
+}
+
+struct ParityRaw {
+    release: ReleaseGate,
+    outcome: ParityOutcome,
+}
+
+impl RawActor for ParityRaw {
+    type Msg = ();
+
+    async fn run(&mut self, _: &mut RawContext<Self::Msg>) -> ExitResult {
+        self.release.wait().await;
+        match &self.outcome {
+            ParityOutcome::Completed => Ok(()),
+            ParityOutcome::Failed(error) => Err(error.clone()),
+            ParityOutcome::Panicked => panic!("shared-runner-parity-panic"),
+        }
+    }
+}
+
+async fn supervised_exit(outcome: ParityOutcome) -> Exit {
+    let release = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.add_raw_once(
+        "parity",
+        RawOnceDef::new(ParityRaw {
+            release: release.clone(),
+            outcome,
+        }),
+    )
+    .expect("parity id is valid");
+    let system = tree.spawn().expect("runtime is available");
+    let mut events = system.scope().subscribe_lifecycle();
+    release.release();
+    let exit = loop {
+        let item = events
+            .recv()
+            .await
+            .expect("lifecycle remains open through exit");
+        if let LifecycleItem::Event(event) = item
+            && let LifecycleEventKind::Exited { id, exit, .. } = event.kind
+            && id.as_str() == "parity"
+        {
+            break exit;
+        }
+    };
+    let _ = system.wait().await;
+    exit
+}
+
+#[tokio::test]
+async fn hosted_and_supervised_runner_classify_completion_failure_and_panic_identically() {
+    let failure = ExitError::message("shared-runner-parity-failure");
+    for outcome in [
+        ParityOutcome::Completed,
+        ParityOutcome::Failed(failure),
+        ParityOutcome::Panicked,
+    ] {
+        let supervised = supervised_exit(outcome.clone()).await;
+        let release = ReleaseGate::default();
+        let (_, hosted) = HostedRaw::<()>::spawn(
+            ParityRaw {
+                release: release.clone(),
+                outcome,
+            },
+            HostOptions::new(),
+        )
+        .expect("host starts");
+        release.release();
+        let hosted = hosted.wait().await;
+        assert_eq!(hosted, supervised);
+    }
+}

--- a/crates/shelterwood/tests/m11.rs
+++ b/crates/shelterwood/tests/m11.rs
@@ -1,0 +1,532 @@
+use std::{fmt::Debug, time::Duration};
+
+use shelterwood::{
+    ActorRef, ChildSnapshot, ChildState, DynamicTree, ExitError, ExitKind, ExitResult, Guard,
+    Mailbox, RawActor, RawContext, RawOnceDef, Readiness, Rejected, RejectedKind, Retention,
+    RunUntilAllResult, SiblingReadyError, TaskCompletion, TaskOnceDef, Tree,
+};
+use shelterwood_test_support::ReleaseGate;
+use tokio::sync::oneshot;
+
+fn assert_clone_eq_debug_send_sync<T: Clone + Eq + Debug + Send + Sync>() {}
+
+#[test]
+fn milestone_eleven_convenience_data_keeps_its_trait_contracts() {
+    assert_clone_eq_debug_send_sync::<TaskCompletion>();
+    assert_clone_eq_debug_send_sync::<RunUntilAllResult>();
+    assert_clone_eq_debug_send_sync::<SiblingReadyError>();
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Tick(u64);
+
+struct ParkedTarget(ReleaseGate);
+
+impl RawActor for ParkedTarget {
+    type Msg = Tick;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        self.0.wait().await;
+        while context.recv().await.is_some() {}
+        Ok(())
+    }
+}
+
+enum TimerCommand {
+    After {
+        target: ActorRef<Tick>,
+        message: Tick,
+        after: Duration,
+        reply: oneshot::Sender<Result<Guard, Rejected<Tick>>>,
+    },
+    Interval {
+        target: ActorRef<Tick>,
+        message: Tick,
+        period: Duration,
+        reply: oneshot::Sender<Result<Guard, Rejected<Tick>>>,
+    },
+    Stop,
+}
+
+struct TimerSource;
+
+impl RawActor for TimerSource {
+    type Msg = TimerCommand;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        while let Some(command) = context.recv().await {
+            match command {
+                TimerCommand::After {
+                    target,
+                    message,
+                    after,
+                    reply,
+                } => {
+                    let _ = reply.send(context.send_after_to(&target, message, after));
+                }
+                TimerCommand::Interval {
+                    target,
+                    message,
+                    period,
+                    reply,
+                } => {
+                    let _ = reply.send(context.interval_to(&target, message, period));
+                }
+                TimerCommand::Stop => break,
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn arm_after(
+    source: &ActorRef<TimerCommand>,
+    target: &ActorRef<Tick>,
+    message: Tick,
+    after: Duration,
+) -> Result<Guard, Rejected<Tick>> {
+    let (reply, response) = oneshot::channel();
+    source
+        .send(TimerCommand::After {
+            target: target.clone(),
+            message,
+            after,
+            reply,
+        })
+        .await
+        .expect("timer source accepts command");
+    response.await.expect("timer source replies")
+}
+
+async fn arm_interval(
+    source: &ActorRef<TimerCommand>,
+    target: &ActorRef<Tick>,
+    message: Tick,
+    period: Duration,
+) -> Result<Guard, Rejected<Tick>> {
+    let (reply, response) = oneshot::channel();
+    source
+        .send(TimerCommand::Interval {
+            target: target.clone(),
+            message,
+            period,
+            reply,
+        })
+        .await
+        .expect("timer source accepts command");
+    response.await.expect("timer source replies")
+}
+
+#[tokio::test(start_paused = true)]
+async fn cross_actor_timers_use_mailbox_semantics_and_incarnation_ownership() {
+    let target_gate = ReleaseGate::default();
+    let mut tree = Tree::new();
+    let target = tree
+        .add_raw_once(
+            "target",
+            RawOnceDef::new(ParkedTarget(target_gate.clone()))
+                .mailbox(Mailbox::latest())
+                .retention(Retention::Retain),
+        )
+        .expect("target id is valid");
+    let source = tree
+        .add_raw_once(
+            "source",
+            RawOnceDef::new(TimerSource).retention(Retention::Retain),
+        )
+        .expect("source id is valid");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actors start");
+
+    let after = arm_after(&source, &target, Tick(1), Duration::from_secs(2))
+        .await
+        .expect("one-shot timer arms");
+    assert_eq!(target.stats().stats.messages_accepted, 0);
+    tokio::time::advance(Duration::from_secs(2)).await;
+    after.finished().await;
+    assert_eq!(target.stats().stats.messages_accepted, 1);
+    assert_eq!(target.stats().stats.mailbox_depth, 1);
+
+    let cancelled = arm_after(&source, &target, Tick(2), Duration::from_secs(20))
+        .await
+        .expect("cancelled timer arms");
+    drop(cancelled);
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(20)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(target.stats().stats.messages_accepted, 1);
+
+    let zero = arm_interval(&source, &target, Tick(3), Duration::ZERO)
+        .await
+        .expect_err("zero interval is rejected eagerly");
+    assert_eq!(zero.kind, RejectedKind::ZeroPeriod);
+    assert_eq!(zero.into_payload(), Some(Tick(3)));
+
+    let interval = arm_interval(&source, &target, Tick(4), Duration::from_secs(1))
+        .await
+        .expect("interval arms");
+    for _ in 0..3 {
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(target.stats().stats.messages_accepted, 4);
+    assert_eq!(target.stats().stats.messages_conflated, 3);
+    interval.cancel();
+
+    let detached = arm_after(&source, &target, Tick(5), Duration::from_secs(10))
+        .await
+        .expect("detached timer arms");
+    detached.detach();
+    source
+        .send(TimerCommand::Stop)
+        .await
+        .expect("source accepts stop");
+    system
+        .scope()
+        .wait_for_child(
+            "source",
+            |child| child.state.is_terminal(),
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("source membership terminalizes");
+    tokio::time::advance(Duration::from_secs(10)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(
+        target.stats().stats.messages_accepted,
+        4,
+        "sender incarnation owns even a detached timer"
+    );
+
+    target_gate.release();
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("timer tree stops");
+}
+
+struct ImmediateTarget;
+
+impl RawActor for ImmediateTarget {
+    type Msg = Tick;
+
+    async fn run(&mut self, _: &mut RawContext<Self::Msg>) -> ExitResult {
+        Ok(())
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn terminal_target_finishes_a_delayed_guard_without_waiting_for_deadline() {
+    let mut tree = Tree::new();
+    let target = tree
+        .add_raw_once(
+            "target",
+            RawOnceDef::new(ImmediateTarget).retention(Retention::Retain),
+        )
+        .expect("target id is valid");
+    let source = tree
+        .add_raw_once(
+            "source",
+            RawOnceDef::new(TimerSource).retention(Retention::Retain),
+        )
+        .expect("source id is valid");
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .scope()
+        .wait_for_child(
+            "target",
+            |child| child.state.is_terminal(),
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("target terminalizes");
+
+    let guard = arm_after(&source, &target, Tick(9), Duration::from_secs(100))
+        .await
+        .expect("timer registration itself is valid");
+    guard.finished().await;
+    assert_eq!(target.stats().stats.messages_accepted, 0);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("tree stops");
+}
+
+struct EarlierSibling {
+    release: ReleaseGate,
+}
+
+impl RawActor for EarlierSibling {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        self.release.wait().await;
+        context.mark_ready();
+        context.shutdown_token().cancelled().await;
+        Ok(())
+    }
+}
+
+struct SiblingWaiter {
+    id: &'static str,
+    result: Option<oneshot::Sender<Result<ChildSnapshot, SiblingReadyError>>>,
+}
+
+impl RawActor for SiblingWaiter {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        let result = context
+            .await_sibling_ready(self.id, Duration::from_secs(5))
+            .await;
+        let _ = self.result.take().expect("waiter runs once").send(result);
+        context.shutdown_token().cancelled().await;
+        Ok(())
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn sibling_barrier_observes_earlier_readiness_and_rejects_later_waits() {
+    let release = ReleaseGate::default();
+    let (result, mut readiness) = oneshot::channel();
+    let mut tree = Tree::new();
+    let earlier = tree
+        .add_raw_once(
+            "earlier",
+            RawOnceDef::new(EarlierSibling {
+                release: release.clone(),
+            })
+            .readiness(Readiness::Manual)
+            .expect("manual raw readiness is valid"),
+        )
+        .expect("earlier id is valid");
+    tree.add_raw_once(
+        "waiter",
+        RawOnceDef::new(SiblingWaiter {
+            id: "earlier",
+            result: Some(result),
+        }),
+    )
+    .expect("waiter id is valid");
+    let system = tree.spawn().expect("runtime is available");
+    assert!(
+        readiness.try_recv().is_err(),
+        "later child is not spawned before earlier readiness"
+    );
+    release.release();
+    system
+        .wait_started()
+        .await
+        .expect("ordered startup completes");
+    let snapshot = readiness
+        .await
+        .expect("waiter reports")
+        .expect("earlier sibling is ready");
+    assert_eq!(snapshot.membership, earlier.membership());
+    assert_eq!(snapshot.state, ChildState::Running);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("sibling tree stops");
+
+    let (result, deadlock) = oneshot::channel();
+    let later_release = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.add_raw_once(
+        "first",
+        RawOnceDef::new(SiblingWaiter {
+            id: "later",
+            result: Some(result),
+        }),
+    )
+    .expect("first id is valid");
+    tree.add_raw_once(
+        "later",
+        RawOnceDef::new(EarlierSibling {
+            release: later_release.clone(),
+        }),
+    )
+    .expect("later id is valid");
+    let system = tree.spawn().expect("runtime is available");
+    assert_eq!(
+        deadlock.await.expect("first child reports"),
+        Err(SiblingReadyError::WouldDeadlock)
+    );
+    later_release.release();
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("deadlock fixture stops");
+}
+
+#[tokio::test(start_paused = true)]
+async fn dynamic_sibling_barrier_waits_for_later_admission() {
+    let (result, readiness) = oneshot::channel();
+    let mut tree = DynamicTree::new();
+    tree.add_raw_once(
+        "waiter",
+        RawOnceDef::new(SiblingWaiter {
+            id: "late",
+            result: Some(result),
+        }),
+    )
+    .expect("waiter id is valid");
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("initial dynamic tree starts");
+
+    let release = ReleaseGate::default();
+    let target = system
+        .scope()
+        .add_raw_once(
+            "late",
+            RawOnceDef::new(EarlierSibling {
+                release: release.clone(),
+            })
+            .readiness(Readiness::Manual)
+            .expect("manual raw readiness is valid"),
+        )
+        .await
+        .expect("late sibling is admitted");
+    release.release();
+    let snapshot = readiness
+        .await
+        .expect("waiter reports")
+        .expect("dynamic wait survives absence until admission");
+    assert_eq!(snapshot.membership, target.membership());
+    assert_eq!(snapshot.state, ChildState::Running);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic sibling tree stops");
+}
+
+struct DrainWaiter(Option<oneshot::Sender<Result<ChildSnapshot, SiblingReadyError>>>);
+
+impl RawActor for DrainWaiter {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        while context.recv().await.is_some() {}
+        let result = context
+            .await_sibling_ready("missing", Duration::from_secs(1))
+            .await;
+        let _ = self.0.take().expect("waiter runs once").send(result);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn sibling_barrier_rejects_the_raw_drain_stage() {
+    let (result, drained) = oneshot::channel();
+    let mut tree = Tree::new();
+    tree.add_raw_once("draining", RawOnceDef::new(DrainWaiter(Some(result))))
+        .expect("draining id is valid");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("drain waiter starts");
+    let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(1)));
+    assert_eq!(
+        drained.await.expect("drain waiter reports"),
+        Err(SiblingReadyError::Draining)
+    );
+    shutdown
+        .await
+        .expect("shutdown task joins")
+        .expect("drain waiter stops");
+}
+
+#[tokio::test]
+async fn in_flight_dynamic_sibling_wait_is_cancelled_by_shutdown() {
+    let (result, waiting) = oneshot::channel();
+    let mut tree = DynamicTree::new();
+    tree.add_raw_once(
+        "waiting",
+        RawOnceDef::new(SiblingWaiter {
+            id: "never-admitted",
+            result: Some(result),
+        }),
+    )
+    .expect("waiter id is valid");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic waiter starts");
+    let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(1)));
+    assert_eq!(
+        waiting.await.expect("waiter reports cancellation"),
+        Err(SiblingReadyError::Draining)
+    );
+    shutdown
+        .await
+        .expect("shutdown task joins")
+        .expect("in-flight wait stops promptly");
+}
+
+#[tokio::test]
+async fn run_until_all_retains_input_order_and_every_task_exit() {
+    let first_release = ReleaseGate::default();
+    let second_release = ReleaseGate::default();
+    let mut tree = Tree::new();
+    let (first, _) = tree
+        .add_task_once(
+            "first",
+            TaskOnceDef::<()>::new({
+                let release = first_release.clone();
+                move |_| async move {
+                    release.wait().await;
+                    Ok(())
+                }
+            }),
+        )
+        .expect("first id is valid");
+    let (second, _) = tree
+        .add_task_once(
+            "second",
+            TaskOnceDef::<()>::new({
+                let release = second_release.clone();
+                move |_| async move {
+                    release.wait().await;
+                    Err(ExitError::message("selected failure"))
+                }
+            }),
+        )
+        .expect("second id is valid");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("tasks start");
+
+    let runner =
+        tokio::spawn(system.run_until_all([second.clone(), first.clone()], Duration::from_secs(1)));
+    first_release.release();
+    tokio::task::yield_now().await;
+    assert!(
+        !runner.is_finished(),
+        "all-of waits for the other selected task"
+    );
+    second_release.release();
+    let result = runner.await.expect("run-until task joins");
+    assert!(result.shutdown.is_ok());
+    assert_eq!(
+        result
+            .tasks
+            .iter()
+            .map(|completion| completion.membership)
+            .collect::<Vec<_>>(),
+        [second.membership(), first.membership()]
+    );
+    assert!(matches!(result.tasks[0].exit.kind(), ExitKind::Failed(_)));
+    assert!(matches!(result.tasks[1].exit.kind(), ExitKind::Completed));
+}
+
+#[tokio::test]
+async fn run_until_all_accepts_an_empty_selection() {
+    let release = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.add_raw_once("idle", RawOnceDef::new(ParkedTarget(release.clone())))
+        .expect("idle id is valid");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("idle child starts");
+    release.release();
+    let result = system.run_until_all([], Duration::from_secs(1)).await;
+    assert!(result.tasks.is_empty());
+    assert!(result.shutdown.is_ok());
+}

--- a/crates/shelterwood/tests/outline.rs
+++ b/crates/shelterwood/tests/outline.rs
@@ -1,0 +1,330 @@
+#![cfg(feature = "serde")]
+
+use std::{
+    num::NonZeroUsize,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use shelterwood::{
+    Actor, ActorDef, Backoff, ChildId, Context, DefaultsInheritance, DynamicTree, ExitError,
+    ExitResult, Intensity, Jitter, KeyedCapacity, Mailbox, MailboxShutdown, OutlineChildKind,
+    OutlineError, OutlineInterior, RawActor, RawContext, RawDef, Readiness, ReadinessDeadline,
+    ResolvedMailbox, RestartCondition, RestartPolicy, Retention, ScopeDefaults, ScopeKind,
+    Shutdown, StopContext, Strategy, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
+};
+
+struct Callback;
+
+impl Actor for Callback {
+    type Msg = (&'static str, usize);
+    type Args = ();
+
+    async fn init(_: (), _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, _: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+
+    async fn on_stop(&mut self, _: &mut StopContext<'_, Self>) {}
+}
+
+struct Raw;
+
+impl RawActor for Raw {
+    type Msg = ();
+
+    async fn run(&mut self, _: &mut RawContext<Self::Msg>) -> ExitResult {
+        Ok(())
+    }
+}
+
+fn never() -> RestartPolicy {
+    RestartPolicy::new(RestartCondition::Never, Backoff::Immediate)
+}
+
+#[test]
+fn outline_is_a_pure_resolved_declaration_ordered_projection() {
+    let factory_calls = Arc::new(AtomicUsize::new(0));
+    let mut nested = DynamicTree::new();
+    nested.defaults(ScopeDefaults {
+        mailbox_shutdown: Some(MailboxShutdown::Discard),
+        ..ScopeDefaults::default()
+    });
+    nested
+        .add_raw(
+            "nested-raw",
+            RawDef::factory(|| Raw)
+                .readiness(Readiness::Manual)
+                .expect("manual raw readiness is valid"),
+        )
+        .expect("nested raw id is valid");
+
+    let bounded = ReadinessDeadline::bounded(Duration::from_secs(9)).expect("non-zero deadline");
+    let mut tree = Tree::new();
+    tree.strategy(Strategy::RestForOne)
+        .intensity(Intensity::new(11, Duration::from_secs(17)).expect("valid intensity"))
+        .defaults(ScopeDefaults {
+            child_restart: Some(RestartPolicy::new(
+                RestartCondition::Always,
+                Backoff::fixed(Duration::from_millis(4), Jitter::Equal).expect("non-zero backoff"),
+            )),
+            child_shutdown: Some(Shutdown::Abort),
+            mailbox: Some(Mailbox::queue(7).expect("non-zero mailbox")),
+            mailbox_shutdown: Some(MailboxShutdown::Drain),
+            readiness_deadline: Some(bounded),
+        });
+    tree.add_actor(
+        "callback",
+        ActorDef::<Callback>::cloned(())
+            .latest_by_key(
+                KeyedCapacity::Explicit(NonZeroUsize::new(3).expect("non-zero capacity")),
+                |message| message.0,
+            )
+            .readiness(Readiness::Manual)
+            .retention(Retention::Remove),
+    )
+    .expect("callback id is valid");
+    tree.add_raw(
+        "raw",
+        RawDef::factory(|| Raw)
+            .mailbox(Mailbox::latest())
+            .shutdown(Shutdown::Graceful {
+                grace: Duration::from_millis(23),
+            }),
+    )
+    .expect("raw id is valid");
+    tree.add_task("task", TaskDef::new(|_| async { Ok(()) }).restart(never()))
+        .expect("task id is valid");
+    tree.add_subtree_once(
+        "recursive",
+        SubtreeOnceDef::new(nested).defaults(DefaultsInheritance::Inherit),
+    )
+    .expect("one-shot subtree id is valid");
+    tree.add_subtree(
+        "opaque",
+        SubtreeDef::<Tree>::factory({
+            let factory_calls = Arc::clone(&factory_calls);
+            move || {
+                factory_calls.fetch_add(1, Ordering::SeqCst);
+                panic!("an outline must not execute a subtree factory")
+            }
+        })
+        .defaults(DefaultsInheritance::Reset),
+    )
+    .expect("restartable subtree id is valid");
+
+    let outline = tree.outline().expect("tree is fully declared");
+    assert_eq!(factory_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(outline.root.kind, ScopeKind::Ordered);
+    assert_eq!(outline.root.strategy, Some(Strategy::RestForOne));
+    assert_eq!(
+        outline
+            .root
+            .children
+            .iter()
+            .map(|child| child.id.as_str())
+            .collect::<Vec<_>>(),
+        ["callback", "raw", "task", "recursive", "opaque"]
+    );
+
+    let callback = &outline.root.children[0];
+    assert_eq!(callback.kind, OutlineChildKind::Actor);
+    assert_eq!(callback.readiness, Readiness::Manual);
+    assert_eq!(callback.readiness_deadline, bounded);
+    assert_eq!(callback.retention, Retention::Remove);
+    assert_eq!(
+        callback.mailbox,
+        Some(ResolvedMailbox::LatestByKey {
+            capacity: NonZeroUsize::new(3).expect("non-zero capacity"),
+        })
+    );
+
+    let raw = &outline.root.children[1];
+    assert_eq!(raw.kind, OutlineChildKind::RawActor);
+    assert_eq!(raw.mailbox, Some(ResolvedMailbox::Latest));
+    assert_eq!(raw.readiness, Readiness::Immediate);
+
+    let task = &outline.root.children[2];
+    assert_eq!(task.kind, OutlineChildKind::Task);
+    assert_eq!(task.mailbox, None);
+    assert_eq!(task.restart, never());
+
+    let recursive = &outline.root.children[3];
+    let Some(OutlineInterior::Recursive(nested)) = &recursive.interior else {
+        panic!("one-shot subtree must be recursively projected");
+    };
+    assert_eq!(nested.kind, ScopeKind::Dynamic);
+    assert_eq!(nested.strategy, None);
+    assert_eq!(nested.children[0].kind, OutlineChildKind::RawActor);
+    assert_eq!(
+        nested.children[0].mailbox,
+        Some(ResolvedMailbox::Queue {
+            capacity: NonZeroUsize::new(7).expect("non-zero capacity"),
+        })
+    );
+    assert_eq!(
+        nested.children[0].mailbox_shutdown,
+        Some(MailboxShutdown::Discard)
+    );
+    assert_eq!(
+        outline.root.children[4].interior,
+        Some(OutlineInterior::Opaque)
+    );
+
+    let json = serde_json::to_value(&outline).expect("outline serializes");
+    let round_trip = serde_json::from_value(json.clone()).expect("outline deserializes");
+    assert_eq!(outline, round_trip);
+
+    let mut unknown = json.clone();
+    unknown
+        .as_object_mut()
+        .expect("outline is an object")
+        .insert("unexpected".to_owned(), serde_json::Value::Null);
+    assert!(
+        serde_json::from_value::<shelterwood::Outline>(unknown).is_err(),
+        "unknown outline fields must fail loudly"
+    );
+
+    let mut missing = json;
+    missing["root"]
+        .as_object_mut()
+        .expect("root is an object")
+        .remove("children");
+    assert!(
+        serde_json::from_value::<shelterwood::Outline>(missing).is_err(),
+        "missing outline fields must fail loudly"
+    );
+}
+
+#[test]
+fn outline_reports_every_unfilled_reservation_with_its_full_path() {
+    let mut nested = Tree::new();
+    nested
+        .reserve_task("deep")
+        .expect("nested reservation is valid");
+
+    let mut tree = Tree::new();
+    tree.reserve_actor::<()>("first")
+        .expect("root reservation is valid");
+    tree.add_subtree_once("nested", SubtreeOnceDef::new(nested))
+        .expect("nested id is valid");
+    tree.reserve_task("last")
+        .expect("root reservation is valid");
+
+    assert_eq!(
+        tree.outline(),
+        Err(OutlineError::UnfilledReservations {
+            paths: vec![
+                vec![ChildId::from("first")],
+                vec![ChildId::from("nested"), ChildId::from("deep")],
+                vec![ChildId::from("last")],
+            ],
+        })
+    );
+}
+
+#[derive(Clone, Copy)]
+enum OutlineDifference {
+    Baseline,
+    ScopeDefault,
+    MailboxKind,
+    MailboxCapacity,
+    ReadinessDeadline,
+    RestartPolicy,
+}
+
+fn one_child_outline(difference: OutlineDifference) -> serde_json::Value {
+    let mut tree = Tree::new();
+    if matches!(difference, OutlineDifference::ScopeDefault) {
+        tree.defaults(ScopeDefaults {
+            child_shutdown: Some(Shutdown::Abort),
+            ..ScopeDefaults::default()
+        });
+    }
+    let mut definition = RawDef::factory(|| Raw);
+    definition = match difference {
+        OutlineDifference::MailboxKind => definition.mailbox(Mailbox::latest()),
+        OutlineDifference::MailboxCapacity => {
+            definition.mailbox(Mailbox::queue(5).expect("non-zero mailbox capacity"))
+        }
+        OutlineDifference::ReadinessDeadline => definition.readiness_deadline(
+            ReadinessDeadline::bounded(Duration::from_secs(3)).expect("non-zero deadline"),
+        ),
+        OutlineDifference::RestartPolicy => definition.restart(never()),
+        OutlineDifference::Baseline | OutlineDifference::ScopeDefault => definition,
+    };
+    tree.add_raw("worker", definition)
+        .expect("worker id is valid");
+    serde_json::to_value(tree.outline().expect("tree is complete")).expect("outline serializes")
+}
+
+#[test]
+fn carried_dimensions_are_injective_and_the_baseline_is_a_golden_example() {
+    let variants = [
+        OutlineDifference::Baseline,
+        OutlineDifference::ScopeDefault,
+        OutlineDifference::MailboxKind,
+        OutlineDifference::MailboxCapacity,
+        OutlineDifference::ReadinessDeadline,
+        OutlineDifference::RestartPolicy,
+    ]
+    .map(one_child_outline);
+    for (index, left) in variants.iter().enumerate() {
+        for right in &variants[index + 1..] {
+            assert_ne!(left, right, "one carried dimension must change the outline");
+        }
+    }
+
+    assert_eq!(
+        variants[0],
+        serde_json::json!({
+            "root": {
+                "kind": "Ordered",
+                "strategy": "OneForOne",
+                "intensity": {
+                    "max_restarts": 5,
+                    "within": { "secs": 30, "nanos": 0 }
+                },
+                "defaults": {
+                    "child_restart": {
+                        "condition": "OnFailure",
+                        "backoff": "Immediate"
+                    },
+                    "child_shutdown": {
+                        "Graceful": { "grace": { "secs": 5, "nanos": 0 } }
+                    },
+                    "mailbox": { "Queue": { "capacity": 64 } },
+                    "mailbox_shutdown": "Drain",
+                    "readiness_deadline": {
+                        "Bounded": { "secs": 30, "nanos": 0 }
+                    }
+                },
+                "children": [{
+                    "id": "worker",
+                    "kind": "RawActor",
+                    "restart": {
+                        "condition": "OnFailure",
+                        "backoff": "Immediate"
+                    },
+                    "shutdown": {
+                        "Graceful": { "grace": { "secs": 5, "nanos": 0 } }
+                    },
+                    "readiness": "Immediate",
+                    "readiness_deadline": {
+                        "Bounded": { "secs": 30, "nanos": 0 }
+                    },
+                    "retention": "Retain",
+                    "mailbox": { "Queue": { "capacity": 64 } },
+                    "mailbox_shutdown": "Drain",
+                    "interior": null
+                }]
+            }
+        })
+    );
+}

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -6,6 +6,12 @@ then consume the `System` with bounded shutdown. A fresh tree can repeat that
 cycle in the same process; the sidecar acceptance test runs two complete
 embed/start/stop cycles over shared host-owned state.
 
+For a single structurally non-restarting actor or task, enable the `host`
+feature and use `Hosted`, `HostedRaw`, or `HostedTask`. Their owner exposes the
+same readiness, typed exit (including panic classification), and joined
+shutdown behavior without requiring an application tree. See
+[outlines, direct hosting, and finite lifetimes](outline-hosting-and-lifetime.md).
+
 Plain `TaskDef` and `TaskOnceDef` children are first-class siblings of actors
 and subtrees. A task-first service can therefore supervise config loading,
 telemetry, serving, and cleanup directly, adding an actor subtree only where a

--- a/docs/outline-hosting-and-lifetime.md
+++ b/docs/outline-hosting-and-lifetime.md
@@ -1,0 +1,69 @@
+# Outlines, direct hosting, and finite lifetimes
+
+M11 adds three small seams over the same declaration, incarnation, mailbox,
+and shutdown machinery used by supervised trees. None introduces a registry or
+an alternate actor runner.
+
+## Resolved declaration outlines
+
+With the `serde` feature, `Tree::outline()` and `DynamicTree::outline()` borrow
+a declaration and return its fully resolved policy/topology projection. The
+projection includes inherited scope defaults, concrete mailbox capacities,
+every child policy, declaration order, and child kind. It neither lowers nor
+spawns the tree.
+
+A concrete one-shot subtree is represented recursively. A restartable subtree
+factory is deliberately `Opaque`: outlining never invokes user code, so policy
+inside such a factory cannot be fingerprinted. An outline contains no actor
+implementation, arguments, closure, or state. It describes a declaration; it
+cannot rebuild one and is not a transport or distribution format.
+
+Outlines are suitable for golden tests and startup logging. Their serde schema
+is intentionally strict: unknown fields and missing required fields are
+errors. A new declaration option therefore has to add its resolved outline
+field in the same change.
+
+## One-incarnation hosting
+
+With the `host` feature, `Hosted`, `HostedRaw`, and `HostedTask` expose exactly
+one structurally non-restarting incarnation. The returned actor or task ref has
+ordinary membership and incarnation tokens. `HostedHandle::wait_ready()`
+observes the ordinary readiness gate; `shutdown(grace)` applies the usual
+cooperative/escalation ladder and joins; `wait()` joins natural completion.
+
+Hosted code receives the same typed `Exit` as supervised code, including
+`Failed`, `ReadinessTimedOut`, `Aborted`, and `Panicked`. Do not add a local
+`catch_unwind` around hosted user code. Dropping the non-clone owner starts
+shutdown with `HostOptions`' configured grace; explicitly await `shutdown` when
+resource teardown must be known complete.
+
+## Cross-actor timers are mailbox traffic
+
+`send_after_to` waits for its delay and then performs a full mailbox `send`.
+`interval_to` starts after one period and performs one `try_send` per tick; a
+full or temporarily unbound target skips that tick, with no catch-up burst.
+Zero interval periods are rejected. A zero one-shot delay is an asynchronous
+ordinary turn.
+
+This differs from keyed self-timers: cross-actor deliveries transit the target
+mailbox, so its capacity and conflation policy apply and its accepted counters
+advance. The returned `Guard` is owned jointly by its lease and the sender
+incarnation. Guard drop means cancel; `detach()` removes only lease ownership,
+so sender restart or exit still cancels the timer. Once mailbox acceptance
+wins, that message is no longer retractable.
+
+## Finite systems and sibling barriers
+
+`System::run_until_all(tasks, grace)` consumes the owner, waits for every
+selected `TaskRef` in input order, then shuts the root down. The result always
+retains every selected membership and exit, even when shutdown reports forced
+stragglers. An empty selection proceeds immediately to shutdown. Any-of remains
+an ordinary user-level `select`.
+
+`await_sibling_ready(id, deadline)` replaces an offloaded snapshot wait. It is
+scope-relative and returns the ready sibling snapshot, whose membership fences
+later same-id reuse. An ordered child may await only an earlier declaration;
+self or later waits return `WouldDeadlock`, and undeclared ids return
+`UnknownSibling`. Dynamic scopes allow an absent id to remain pending for later
+admission. The operation is rejected while an actor is draining and is absent
+from `StopContext`.

--- a/docs/part-ii-progress.md
+++ b/docs/part-ii-progress.md
@@ -20,5 +20,5 @@ validation, and deviations for review.
 | M8 — keyed conflation and peer monitoring | complete | control/priority lane remains open until M12 | focused M8 tests pass; `just ci` passes with 172 tests; rustdoc/API reachability clean | none |
 | M9 — group strategies | complete | none | focused M9 tests pass; `just ci` passes with 179 tests; rustdoc/API reachability clean | none |
 | M10 — observation extensions | complete | none | focused M10 tests pass; `just ci` passes with 186 tests; rustdoc/API reachability and every feature lane clean | none |
-| M11 — outline, hosting, conveniences | pending | none | pending | none |
+| M11 — outline, hosting, conveniences | complete | none | 21 focused M11 tests pass; `just ci` passes with 207 tests; serde/host isolation, rustdoc, and API reachability clean | none |
 | M12 — acceptance wave two | pending | control/priority lane and `project` final verdicts due | pending | none |


### PR DESCRIPTION
## Summary

Implements issue #9 milestone M11 on top of the literal M10 commit (`4c0160650dcc850b2b10fb35b0fcedc783b3ad15`).

- adds strict, resolved `serde` outlines with complete inherited policy data, recursive one-shot subtrees, opaque restartable factories, deterministic unfilled paths, and a golden injectivity fixture
- adds `host`-gated typed, raw, and task one-incarnation hosting with genuine identities, ordinary readiness/exit/panic semantics, configured drop shutdown, and joined consuming operations
- adds sender-incarnation-owned `send_after_to` and `interval_to` guards using target mailbox semantics, cancellation withdrawal, terminal-target completion, and skipped interval ticks
- adds all-of `System::run_until_all` completion-driven lifetime with input-order task exits preserved alongside shutdown outcome
- adds scope-relative sibling readiness barriers with ordered deadlock rejection, dynamic late admission, drain rejection, and shutdown cancellation
- documents outline non-goals, hosted parity, cross-actor mailbox semantics, and finite lifetime composition

## Adversarial review hardening

- cross-actor timer creation now prunes completed entries from the shared incarnation offload ledger, keeping long-lived actors at O(in-flight) retained timer resources rather than O(all timers ever issued)

## Validation

- focused M11 suites: 22 passed
- `./scripts/dev just ci`: 207 tests passed
- all no-default/serde/host/metrics/all feature lanes clean
- clippy, rustdoc, public API reachability, runtime/exit path guards, formatting, and nixfmt clean

No M12 implementation is included.