### PR TITLE
M12: complete Part II acceptance wave two

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ shutdown, and observation. Stable membership and incarnation identities make
 failure recovery explicit without a global registry.
 
 The current `0.1` surface is the core described by [SPEC.md](SPEC.md) plus the
-accepted Part II milestones through M11: incarnation-aware calls and mapping,
+complete Part II implementation: incarnation-aware calls and mapping,
 keyed conflation and peer monitoring, ordered group strategies, structured
 observation extensions, resolved outlines, one-incarnation hosting, and finite
-lifetime conveniences. The final acceptance wave remains staged by its status
-marker in the specification.
+lifetime conveniences. Five application-scale acceptance ports validate the
+combined surface. Their final evidence gates rejected a first-class priority
+lane and mapped actor context as unjustified additions.
 
 ## Getting started
 
@@ -66,11 +67,14 @@ scope, and subtrees compose both recursively.
 - [Actor statistics and loss-recovering reducers](docs/observation-extensions.md)
 - [Outlines, direct hosting, and finite lifetimes](docs/outline-hosting-and-lifetime.md)
 - [Embedding Shelterwood in a host process](docs/embedding.md)
+- [Part II acceptance evidence](docs/part-ii-acceptance.md)
 
-The executable application-scale examples live in the M5 acceptance tests:
+The executable application-scale examples live in the acceptance tests:
 [shard store](crates/shelterwood/tests/shard_store.rs),
 [sidecar](crates/shelterwood/tests/sidecar.rs), and
-[assistant control plane](crates/shelterwood/tests/assistant.rs).
+[assistant control plane](crates/shelterwood/tests/assistant.rs),
+[trading engine](crates/shelterwood/tests/trading_engine.rs), and
+[build farm](crates/shelterwood/tests/build_farm.rs).
 
 ## Operational preconditions
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -946,11 +946,10 @@ stage. Within one callback, stage narrowing is value-level; a stage earns a
 context type only by arriving with its own callback. Revisit only if
 value-level checking demonstrably causes a shipped bug. `Rejected`
 outcomes use B.3's `SendPayload`-shaped carrier: ordinary context operations
-return `Recovered(payload)`, while a mapped `project` path may return
-`Projected` after its injection consumed the inner value. Thus an unmapped
-rejection returns the continuation or timer message, or the not-yet-started
-offload work, rather than dropping it. Exact types are per-operation; the
-recovery/projected distinction is normative. The
+return `Recovered(payload)`. Thus a rejection returns the continuation or
+timer message, or the not-yet-started offload work, rather than dropping it.
+Exact types are per-operation. B.3's `Projected` arm remains necessary for
+eagerly mapped `contramap` ingress, not actor-context mapping. The
 full per-stage capability matrix is Appendix B.1.
 
 **`for_actor` — same-`Msg` re-entry — is core, and its contract lives
@@ -960,8 +959,9 @@ Context<'_, B>` — the same operation on the drain series (yielding the
 drain-stage context), and on `StopContext` yielding `StopContext<'_, B>`,
 the only re-entry `on_stop` has (B.1); absent from `RawContext`. It is a
 zero-cost reborrow of the same underlying context — no boxing, no
-mapping layer (Part II §17's `project` is the paying, boxed cousin; the
-`Msg`-equality bound is what makes the free identity possible). The
+mapping layer (the rejected Part II §17 `project` candidate would have been
+the paying, boxed cousin; the `Msg`-equality bound is what makes the free
+identity possible). The
 returned context therefore *is* the outer actor's: same incarnation and
 identity (`id()`, `incarnation()`, `myself()`), same mailbox and shared
 resources, same incarnation-owned timer table (§5.3's heterogeneous keys
@@ -2505,8 +2505,8 @@ the status line in each section is the detailed authority.
 | Section | M6 status | Implementation boundary |
 |---|---|---|
 | §15 incarnation refinements | **Accepted (M7)** | pinning, next-incarnation wait, and the bounded idempotent-call helper are implemented; the helper's shard-store gate verdict is **build** |
-| §16 keyed conflation | **Accepted (M8)** | keyed latest-wins only; a priority/control lane is evidence-gated to M12 |
-| §17 message mapping | **Accepted (M7) / Evidence-gated** | `contramap` is accepted; `project` waits for the durability consumer |
+| §16 keyed conflation | **Accepted (M8); gate closed (M12)** | keyed latest-wins only; the trading-engine port closes the priority/control-lane gate **do not build** |
+| §17 message mapping | **Accepted (M7); gate closed (M12)** | `contramap` is accepted; all five acceptance ports close `project` **do not build** |
 | §18 peer monitoring | **Accepted (M8)** | actor, task, and scope memberships through a separate event source |
 | §19 group strategies | **Accepted (M9)** | one non-merging group cycle through the existing exit funnel |
 | §20 observation extensions | **Accepted (M10)** | cumulative stats, reducer views, and optional metric emission |
@@ -2520,8 +2520,8 @@ ported, and the implementation plus this row change together.
 | Gate | Deciding artifact | Verdict |
 |---|---|---|
 | §15 `call_idempotent` | repaired shard-store retry loop re-ported onto the candidate API in M7 | **build** — the synchronous constructor closure carries the operation ledger id without friction; response timeout remains an external reconciliation arm |
-| §17 `project` | provenance-sensitive durability prototype | open; no consumer has yet demonstrated the provenance wall |
-| §16 control/priority lane | M12 trading-engine urgent-control-under-flood port | open |
+| §17 `project` | provenance-sensitive durability prototype, including all five full-fidelity acceptance ports in M12 | **do not build** — the durability-bearing shard-store, build-farm, and assistant ports preserve their required provenance with actor boundaries, `for_actor`, and `contramap`; no consumer demonstrates the provenance wall |
+| §16 control/priority lane | M12 trading-engine urgent-control-under-flood port | **do not build** — a keyed capacity equal to the expected data/control cardinality admits urgent control with `try_send` under same-key data flood; this is an admission guarantee, not priority ordering |
 
 ## 15. Incarnation refinements
 
@@ -2659,16 +2659,17 @@ Activates the pinning clause of invariant §13.2.
 
 ## 16. Keyed conflation: `latest_by_key`
 
-**Status: Accepted (M8).** The keyed mailbox is implementable; a
-first-class control/priority lane is *Evidence-gated (M12)* unless the trading-engine
-acceptance scenario produces contrary evidence.
+**Status: Accepted (M8); control/priority-lane gate closed (M12): do not
+build.** The keyed mailbox is implemented. The full trading-engine acceptance
+port demonstrated that `try_send` plus a capacity sized to the expected
+data/control key cardinality admits urgent control under same-key data flood.
+That is an admission guarantee only; it does not add priority ordering.
 
 **M8 implementation evidence.** The typed raw and handler definition
 surfaces, inherited and explicit capacity resolution, sender-path key
 extraction, in-place conflation, oldest-key eviction, and the internal
 eviction counter are implemented and covered by `tests/m8.rs`. The public
-counter remains intentionally deferred to §20; the control/priority gate
-remains open for M12.
+counter remained intentionally deferred to §20 and shipped there in M10.
 
 `latest_by_key(capacity, key_fn)` — a typed extension on `ActorDef<A>` and
 `RawActorDef<M>`, with `K: Eq + Hash + Send + 'static` and
@@ -2715,33 +2716,35 @@ where
 `RawActorDef<M>`. `KeyedCapacity::Explicit` is already non-zero, so the method
 has no deferred validation error.
 
-Decided: documentation-guided — no first-class control/priority lane,
-gated the same way as `project` (§17). If the trading-engine port's
-urgent-control-under-flood pattern cannot be written acceptably with
-`try_send` plus adequate key capacity, that artifact justifies a lane;
-otherwise it never gets built. Already decided either way: per-view
-conflation machinery is rejected (§17), and the state-plane/control-plane
-split is real — a barrier cannot safely share a keyed conflating mailbox
+M12 gate verdict: documentation-guided — no first-class control/priority
+lane. The trading-engine port's urgent-control-under-flood pattern composes
+with `try_send` plus adequate key capacity, so the lane does not get built.
+Per-view conflation machinery remains rejected (§17), and the
+state-plane/control-plane split is real: a barrier that must never be
+replaced or evicted still cannot safely share a keyed conflating mailbox
 with replaceable state.
 
 ## 17. Message mapping: `contramap` and `project` [#351]
 
-**Status: Accepted (M7) / Evidence-gated.** `contramap` is accepted; `project` remains
-*Evidence-gated* on a durability consumer that needs provenance-preserving
-context mapping; it is absent until that artifact exists.
+**Status: `contramap` accepted (M7); `project` gate closed (M12): do not
+build.** All five full-fidelity acceptance ports, including the
+durability-bearing shard store, build farm, and assistant journal, compose
+with explicit actor boundaries, same-message `for_actor`, and `contramap`.
+No consumer demonstrates the provenance wall required to justify mapped
+actor context.
 
-Two primitives, preserving identity and fencing semantics of the underlying
-ref. Their settled design decisions are normative for whoever implements
-them:
+The accepted reference primitive preserves identity and fencing semantics of
+the underlying ref:
 
 ```rust
 impl<M: Send + 'static> ActorRef<M> {
     fn contramap<N: Send + 'static>(&self, wrap: impl Fn(N) -> M + Send + Sync + 'static) -> ActorRef<N>;
 }
-impl<'a, A: Actor + ?Sized> Context<'a, A> {
-    fn project<B: Actor + ?Sized>(&mut self, wrap: impl Fn(B::Msg) -> A::Msg + Send + Sync + 'static) -> Context<'_, B>;
-}
 ```
+
+The rejected `project` candidate would have extended the same mapping into a
+borrowed actor context. The design constraints below remain the record of the
+gate evaluation, but they do not specify a public `project` API.
 
 - The wrap is a **pure, cheap injection executed eagerly at every ingress
   point**; everything stateful, ordered, or observable belongs to the outer
@@ -2775,12 +2778,13 @@ impl<'a, A: Actor + ?Sized> Context<'a, A> {
   same-`Msg` re-entry (`for_actor`, core) stays as the zero-cost identity
   case.
 - Sequence: `contramap` first (independently motivated, testable in
-  isolation). **Gate `project` on a concrete consumer** that demonstrates
+  isolation). The M12 gate required a concrete consumer that demonstrates
   the provenance wall: an origin-blind journal (same-`Msg` middleware)
   cannot distinguish externally-sent messages from self-regenerated
   effects, which breaks replay-correct durability (a replayed `Compact`
   both replays and regenerates — the effect runs twice). If a durability
-  prototype gets by origin-blind, `project` never gets built.
+  prototype gets by origin-blind, `project` never gets built. Every retained
+  acceptance consumer does, so the gate is closed **do not build**.
 
 ## 18. Peer monitoring
 
@@ -3304,7 +3308,7 @@ the same series during shutdown drain; **Stop** = `StopContext<'_, A>` in
 | `watch` / `watch_scoped` *(II §18)* | ✓ | ✓ | **R** | — |
 | `await_sibling_ready` *(II §23)* | ✓ | ✓ | **R** | — |
 | `offload` / `offload_scoped` (§5.5) | ✓ | ✓ | **R** | — |
-| Re-entry/mapping: `for_actor` (same-`Msg`, core); `project` *(II §17)* | — | ✓ | ✓ | `for_actor` only |
+| Re-entry: `for_actor` (same-`Msg`, core); mapped `project` rejected by the M12 evidence gate | — | ✓ | ✓ | ✓ |
 
 `StopContext` withholds everything that queues future work for this
 incarnation — there is no one left to deliver to; `myself()` is present but
@@ -3972,10 +3976,11 @@ this spec's API-shape requirements. Port them early; they are executable
 acceptance tests, not demos — every wait in them is a bounded event,
 lifecycle, snapshot, or state poll, never a sleep-and-hope.
 
-**Wave mapping:** scenarios 1, 2, and 5 validate core (with their Part II
-touches — peer watches, keyed conflation, metrics — stubbed or simplified
-until those land); scenarios 3 and 4 exercise Part II surface (watch, keyed
-conflation, outlines, metrics) and port in full alongside it.
+**Wave mapping:** M5 first retained scenarios 1, 2, and 5 with their then-later
+Part II touches stubbed or simplified. M12 completes the full-fidelity suite:
+scenarios 1–5 now exercise their accepted Part II surfaces, and scenarios 3
+and 4 are retained as executable application-scale tests rather than compile
+spikes.
 
 1. **Shard store — deliberate topology change over durable state.** An
    ordered root of a directory actor (atomic rebind registry), a dynamic
@@ -4035,18 +4040,21 @@ conflation, outlines, metrics) and port in full alongside it.
    `RestForOne` scope flavors and peer watches join with Part II §18/§19;
    the core port uses `OneForOne` scopes and lifecycle subscriptions.)
 
-**M6 compile-spike findings.** Throwaway, type-only trading-engine and
-build-farm skeletons were checked against the candidate shapes and then
-discarded; they are not a retained probe suite. The trading skeleton confirmed
-that typed keyed-mailbox extractors, `contramap`, all-three-kind watch targets,
-membership-cumulative stats, and the restart reducer compose without a
-registry or priority lane. The build-farm skeleton confirmed that keeping
+**M6 compile-spike and M12 port findings.** Throwaway, type-only
+trading-engine and build-farm skeletons first checked the candidate shapes;
+M12 replaces them with retained, full-fidelity executable ports. The trading
+port confirms that typed keyed-mailbox extractors, `contramap`, peer watches,
+membership-cumulative stats, metrics, and the restart reducer compose without
+a registry or priority lane. The build-farm port confirms that keeping
 `TaskRef` as the non-owning completion input while retaining the separate
 owned `OneShotTaskRef<T>` result capability makes `run_until_all` compose;
 outlining by shared borrow before `Tree::spawn` avoids consuming or invoking
 declaration code. It also exposed the outline asymmetry now made normative:
 restartable factory interiors cannot be inspected without executing code and
-must serialize as `Opaque`.
+must serialize as `Opaque`. Across all five ports, no durability consumer
+requires provenance-preserving context mapping, closing §17's `project` gate
+**do not build**; the trading urgent-control-under-flood evidence likewise
+closes §16's first-class control/priority-lane gate **do not build**.
 
 **Patterns that must remain expressible** (they composed well in the origin
 and later designs must not regress them): slot-before-define wiring for

--- a/crates/shelterwood/tests/assistant.rs
+++ b/crates/shelterwood/tests/assistant.rs
@@ -11,7 +11,7 @@ use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, Backoff, ChildState, Context, DeadlineElapsed,
     DynamicScopeRef, DynamicTree, ExitError, ExitResult, LifecycleEvent, LifecycleEventKind,
     LifecycleEvents, LifecycleItem, Mailbox, Membership, RemoveOutcome, Reply, ReserveError,
-    RestartCondition, RestartPolicy, ScopeState, StopContext, SubtreeOnceDef, Tree,
+    RestartCondition, RestartPolicy, ScopeState, StopContext, Strategy, SubtreeOnceDef, Tree,
 };
 use shelterwood_test_support::{ReleaseGate, poll_until};
 
@@ -37,11 +37,13 @@ struct TransportState {
     processed: Arc<AtomicUsize>,
     duplicate_notices: Arc<AtomicUsize>,
     fail_once: Arc<AtomicBool>,
+    journal_events: Arc<AtomicUsize>,
 }
 
 enum IngressMessage {
     Deliver { id: u64, reply: Reply<()> },
     DuplicateObserved,
+    JournalEvent,
 }
 
 enum JournalMessage {
@@ -52,6 +54,7 @@ enum JournalMessage {
 struct IngressArgs {
     journal: ActorRef<JournalMessage>,
     duplicate_notices: Arc<AtomicUsize>,
+    journal_events: Arc<AtomicUsize>,
 }
 
 struct IngressActor(IngressArgs);
@@ -60,7 +63,10 @@ impl Actor for IngressActor {
     type Msg = IngressMessage;
     type Args = IngressArgs;
 
-    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+    async fn init(args: Self::Args, context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        context
+            .watch(&args.journal, |_| IngressMessage::JournalEvent)
+            .map_err(|_| ExitError::message("journal peer watch rejected"))?;
         Ok(Self(args))
     }
 
@@ -84,6 +90,9 @@ impl Actor for IngressActor {
             }
             IngressMessage::DuplicateObserved => {
                 self.0.duplicate_notices.fetch_add(1, Ordering::SeqCst);
+            }
+            IngressMessage::JournalEvent => {
+                self.0.journal_events.fetch_add(1, Ordering::SeqCst);
             }
         }
         Ok(())
@@ -177,6 +186,7 @@ struct GatewayFixture {
 
 fn gateway(state: TransportState) -> GatewayFixture {
     let mut tree = Tree::new();
+    tree.strategy(Strategy::OneForAll);
     let ingress_slot = tree
         .reserve_actor::<IngressMessage>("ingress")
         .expect("ingress slot reserved");
@@ -191,6 +201,7 @@ fn gateway(state: TransportState) -> GatewayFixture {
     let _defined_ingress = ingress_slot.define(ActorDef::<IngressActor>::cloned(IngressArgs {
         journal: journal.clone(),
         duplicate_notices: Arc::clone(&state.duplicate_notices),
+        journal_events: Arc::clone(&state.journal_events),
     }));
     let _defined_journal = journal_slot.define(ActorDef::<JournalActor>::cloned(JournalArgs {
         ingress: ingress.clone(),
@@ -348,6 +359,7 @@ struct SessionFixture {
 fn session_fixture() -> SessionFixture {
     let tools_tree = DynamicTree::new();
     let mut tree = Tree::new();
+    tree.strategy(Strategy::RestForOne);
     let tools = tree
         .add_subtree_once("tools", SubtreeOnceDef::new(tools_tree))
         .expect("nested tool scope declared");
@@ -620,6 +632,10 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
             transport.duplicate_notices.load(Ordering::SeqCst) == 1
         })
         .await
+    );
+    assert!(
+        transport.journal_events.load(Ordering::SeqCst) >= 2,
+        "peer watch observes journal lifecycle across group recovery"
     );
 
     let mut saw_control_restart = false;

--- a/crates/shelterwood/tests/build_farm.rs
+++ b/crates/shelterwood/tests/build_farm.rs
@@ -1,0 +1,362 @@
+#![cfg(feature = "serde")]
+
+use std::{
+    collections::BTreeMap,
+    num::NonZeroUsize,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use shelterwood::{
+    Actor, ActorOnceDef, Backoff, Context, DynamicScopeRef, DynamicTree, ExitError, ExitKind,
+    ExitResult, Jitter, KeyedCapacity, Outline, OutlineInterior, Readiness, RemoveOutcome,
+    ResolvedMailbox, RestartCondition, RestartPolicy, StopContext, SubtreeOnceDef, TaskDef,
+    TaskOnceDef, TaskRef, Tree,
+};
+use shelterwood_test_support::{ReleaseGate, poll_until};
+
+#[derive(Clone, Default)]
+struct DurableFarm {
+    runs: Arc<AtomicUsize>,
+    completed: Arc<Mutex<Vec<(usize, usize)>>>,
+    payloads_consumed: Arc<AtomicUsize>,
+    wedged_retired: Arc<AtomicUsize>,
+    lease_starts: Arc<AtomicUsize>,
+}
+
+struct OwnedJob {
+    run: usize,
+    job: usize,
+    payload: Vec<u8>,
+    consumed: Arc<AtomicUsize>,
+}
+
+impl OwnedJob {
+    fn execute(self, durable: &DurableFarm) -> usize {
+        assert_eq!(self.payload, vec![self.job as u8; self.job + 1]);
+        self.consumed.fetch_add(1, Ordering::SeqCst);
+        durable
+            .completed
+            .lock()
+            .expect("durable completion mutex poisoned")
+            .push((self.run, self.job));
+        self.job
+    }
+}
+
+#[derive(Clone)]
+struct ProgressUpdate {
+    job: String,
+    percent: u8,
+}
+
+struct ProgressActor {
+    block_once: Arc<AtomicBool>,
+    entered: Arc<AtomicBool>,
+    release: ReleaseGate,
+    log: Arc<Mutex<Vec<ProgressUpdate>>>,
+}
+
+impl Actor for ProgressActor {
+    type Msg = ProgressUpdate;
+    type Args = (
+        Arc<AtomicBool>,
+        Arc<AtomicBool>,
+        ReleaseGate,
+        Arc<Mutex<Vec<ProgressUpdate>>>,
+    );
+
+    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self {
+            block_once: args.0,
+            entered: args.1,
+            release: args.2,
+            log: args.3,
+        })
+    }
+
+    async fn handle(&mut self, update: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+        if self.block_once.swap(false, Ordering::SeqCst) {
+            self.entered.store(true, Ordering::SeqCst);
+            self.release.wait().await;
+        }
+        self.log
+            .lock()
+            .expect("progress log mutex poisoned")
+            .push(update);
+        Ok(())
+    }
+
+    async fn on_stop(&mut self, _: &mut StopContext<'_, Self>) {}
+}
+
+struct FarmCycle {
+    tree: Tree,
+    outline: Outline,
+    workers: DynamicScopeRef,
+    progress: shelterwood::ActorRef<ProgressUpdate>,
+    progress_entered: Arc<AtomicBool>,
+    progress_release: ReleaseGate,
+    progress_log: Arc<Mutex<Vec<ProgressUpdate>>>,
+    scheduler: TaskRef,
+}
+
+fn build_cycle(durable: DurableFarm) -> FarmCycle {
+    let mut tree = Tree::new();
+
+    let fail_first_lease = Arc::new(AtomicBool::new(true));
+    tree.add_task(
+        "lease",
+        TaskDef::new({
+            let durable = durable.clone();
+            let fail_first_lease = Arc::clone(&fail_first_lease);
+            move |context| {
+                let durable = durable.clone();
+                let fail_first_lease = Arc::clone(&fail_first_lease);
+                async move {
+                    durable.lease_starts.fetch_add(1, Ordering::SeqCst);
+                    context.mark_ready();
+                    if fail_first_lease.swap(false, Ordering::SeqCst) {
+                        return Err(ExitError::message("lease acquisition retry"));
+                    }
+                    context.shutdown_token().cancelled().await;
+                    Ok(())
+                }
+            }
+        })
+        .restart(RestartPolicy::new(
+            RestartCondition::OnFailure,
+            Backoff::fixed(Duration::from_millis(1), Jitter::None).expect("non-zero lease backoff"),
+        ))
+        .readiness(Readiness::Manual)
+        .expect("manual task readiness is valid"),
+    )
+    .expect("lease id is valid");
+
+    let workers = tree
+        .add_subtree_once("workers", SubtreeOnceDef::new(DynamicTree::new()))
+        .expect("dynamic worker scope is declared");
+
+    let progress_entered = Arc::new(AtomicBool::new(false));
+    let progress_release = ReleaseGate::default();
+    let progress_log = Arc::new(Mutex::new(Vec::new()));
+    let progress = tree
+        .add_actor_once(
+            "progress",
+            ActorOnceDef::<ProgressActor>::new((
+                Arc::new(AtomicBool::new(true)),
+                Arc::clone(&progress_entered),
+                progress_release.clone(),
+                Arc::clone(&progress_log),
+            ))
+            .latest_by_key(
+                KeyedCapacity::Explicit(NonZeroUsize::new(3).expect("three concurrent job keys")),
+                |update| update.job.clone(),
+            ),
+        )
+        .expect("progress id is valid");
+
+    let (scheduler, _) = tree
+        .add_task_once(
+            "scheduler",
+            TaskOnceDef::new({
+                let durable = durable.clone();
+                let workers = workers.clone();
+                let progress = progress.clone();
+                move |_| async move {
+                    let run = durable.runs.fetch_add(1, Ordering::SeqCst);
+                    let mut claims = Vec::new();
+                    for job in 0..3 {
+                        let owned = OwnedJob {
+                            run,
+                            job,
+                            payload: vec![job as u8; job + 1],
+                            consumed: Arc::clone(&durable.payloads_consumed),
+                        };
+                        let job_id = format!("run-{run}-job-{job}");
+                        let progress = progress.clone();
+                        let durable_for_job = durable.clone();
+                        let (task, claim) = workers
+                            .add_task_once(
+                                job_id,
+                                TaskOnceDef::new(move |_| async move {
+                                    let key = format!("run-{run}-job-{job}");
+                                    for percent in [0, 50, 100] {
+                                        progress
+                                            .send(ProgressUpdate {
+                                                job: key.clone(),
+                                                percent,
+                                            })
+                                            .await
+                                            .map_err(|_| {
+                                                ExitError::message(
+                                                    "progress mailbox terminated during job",
+                                                )
+                                            })?;
+                                    }
+                                    Ok(owned.execute(&durable_for_job))
+                                }),
+                            )
+                            .await
+                            .map_err(|error| {
+                                ExitError::message(format!("worker admission failed: {error}"))
+                            })?
+                            .into_handles();
+                        claims.push((task, claim));
+                    }
+
+                    let wedged_started = ReleaseGate::default();
+                    let (wedged, wedged_claim) = workers
+                        .add_task_once(
+                            format!("run-{run}-wedged"),
+                            TaskOnceDef::new({
+                                let wedged_started = wedged_started.clone();
+                                move |context| async move {
+                                    wedged_started.release();
+                                    context.shutdown_token().cancelled().await;
+                                    Ok::<_, ExitError>(())
+                                }
+                            }),
+                        )
+                        .await
+                        .map_err(|error| {
+                            ExitError::message(format!("wedged admission failed: {error}"))
+                        })?
+                        .into_handles();
+                    wedged_started.wait().await;
+                    assert_eq!(workers.remove_task(&wedged).await, RemoveOutcome::Removed);
+                    let _ = wedged_claim.wait().await;
+                    durable.wedged_retired.fetch_add(1, Ordering::SeqCst);
+
+                    for (task, claim) in claims {
+                        let expected = task
+                            .id()
+                            .as_str()
+                            .rsplit('-')
+                            .next()
+                            .expect("job id has a numeric suffix")
+                            .parse::<usize>()
+                            .expect("job suffix is numeric");
+                        assert_eq!(
+                            claim
+                                .wait()
+                                .await
+                                .map_err(|exit| ExitError::message(format!(
+                                    "one-shot worker {} failed: {exit:?}",
+                                    task.id()
+                                )))?,
+                            expected
+                        );
+                    }
+                    Ok::<_, ExitError>(())
+                }
+            }),
+        )
+        .expect("scheduler id is valid");
+
+    let outline = tree.outline().expect("farm declaration is complete");
+    FarmCycle {
+        tree,
+        outline,
+        workers,
+        progress,
+        progress_entered,
+        progress_release,
+        progress_log,
+        scheduler,
+    }
+}
+
+async fn run_cycle(durable: DurableFarm) -> Outline {
+    let cycle = build_cycle(durable.clone());
+    assert_eq!(
+        cycle
+            .outline
+            .root
+            .children
+            .iter()
+            .map(|child| child.id.as_str())
+            .collect::<Vec<_>>(),
+        ["lease", "workers", "progress", "scheduler"]
+    );
+    let workers_outline = &cycle.outline.root.children[1];
+    assert!(matches!(
+        workers_outline.interior,
+        Some(OutlineInterior::Recursive(ref scope))
+            if scope.kind == shelterwood::ScopeKind::Dynamic
+    ));
+    assert_eq!(
+        cycle.outline.root.children[2].mailbox,
+        Some(ResolvedMailbox::LatestByKey {
+            capacity: NonZeroUsize::new(3).expect("non-zero capacity"),
+        })
+    );
+
+    let outline = cycle.outline.clone();
+    let system = cycle.tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("farm starts");
+    let runner =
+        tokio::spawn(system.run_until_all([cycle.scheduler.clone()], Duration::from_secs(1)));
+
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            cycle.progress_entered.load(Ordering::SeqCst)
+                && cycle.progress.stats().stats.messages_accepted == 9
+                && cycle.progress.stats().stats.messages_conflated >= 5
+        })
+        .await,
+        "latest-by-job progress must conflate while its handler is wedged"
+    );
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            cycle.workers.snapshot().children.is_empty()
+        })
+        .await,
+        "one-shot workers auto-remove and the wedged worker retires exactly"
+    );
+    cycle.progress_release.release();
+    let result = runner.await.expect("run-until runner joins");
+    assert!(result.shutdown.is_ok());
+    assert_eq!(result.tasks.len(), 1);
+    assert_eq!(result.tasks[0].membership, cycle.scheduler.membership());
+    assert!(matches!(result.tasks[0].exit.kind(), ExitKind::Completed));
+
+    let mut latest = BTreeMap::new();
+    for update in cycle
+        .progress_log
+        .lock()
+        .expect("progress log mutex poisoned")
+        .iter()
+    {
+        latest.insert(update.job.clone(), update.percent);
+    }
+    assert_eq!(latest.len(), 3);
+    assert!(latest.values().all(|percent| *percent == 100));
+    outline
+}
+
+#[tokio::test]
+async fn build_farm_runs_a_finite_batch_then_warm_rebuilds_from_durable_state() {
+    let durable = DurableFarm::default();
+    let first = run_cycle(durable.clone()).await;
+    let second = run_cycle(durable.clone()).await;
+
+    assert_eq!(
+        first, second,
+        "fresh declarations have stable resolved outlines"
+    );
+    assert_eq!(durable.runs.load(Ordering::SeqCst), 2);
+    assert_eq!(durable.payloads_consumed.load(Ordering::SeqCst), 6);
+    assert_eq!(durable.wedged_retired.load(Ordering::SeqCst), 2);
+    assert!(durable.lease_starts.load(Ordering::SeqCst) >= 4);
+    let mut completed = durable
+        .completed
+        .lock()
+        .expect("durable completion mutex poisoned")
+        .clone();
+    completed.sort_unstable();
+    assert_eq!(completed, [(0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)]);
+}

--- a/crates/shelterwood/tests/trading_engine.rs
+++ b/crates/shelterwood/tests/trading_engine.rs
@@ -1,0 +1,489 @@
+#![cfg(feature = "metrics")]
+
+use std::{
+    collections::HashSet,
+    num::NonZeroUsize,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use shelterwood::{
+    Actor, ActorDef, Backoff, Context, ExitError, ExitResult, Intensity, KeyedCapacity, Mailbox,
+    MonitorEvent, MonitorEventKind, Reply, RestartCondition, RestartPolicy, ScopeState,
+    StopContext, SubtreeOnceDef, Tree,
+};
+use shelterwood_test_support::{ReleaseGate, poll_until};
+
+#[derive(Debug)]
+struct MetricHandle;
+
+impl metrics::CounterFn for MetricHandle {
+    fn increment(&self, _: u64) {}
+    fn absolute(&self, _: u64) {}
+}
+
+impl metrics::GaugeFn for MetricHandle {
+    fn increment(&self, _: f64) {}
+    fn decrement(&self, _: f64) {}
+    fn set(&self, _: f64) {}
+}
+
+impl metrics::HistogramFn for MetricHandle {
+    fn record(&self, _: f64) {}
+}
+
+#[derive(Debug)]
+struct RecordingMetrics {
+    keys: Arc<Mutex<Vec<metrics::Key>>>,
+}
+
+impl metrics::Recorder for RecordingMetrics {
+    fn describe_counter(
+        &self,
+        _: metrics::KeyName,
+        _: Option<metrics::Unit>,
+        _: metrics::SharedString,
+    ) {
+    }
+
+    fn describe_gauge(
+        &self,
+        _: metrics::KeyName,
+        _: Option<metrics::Unit>,
+        _: metrics::SharedString,
+    ) {
+    }
+
+    fn describe_histogram(
+        &self,
+        _: metrics::KeyName,
+        _: Option<metrics::Unit>,
+        _: metrics::SharedString,
+    ) {
+    }
+
+    fn register_counter(&self, key: &metrics::Key, _: &metrics::Metadata<'_>) -> metrics::Counter {
+        self.keys
+            .lock()
+            .expect("metrics key mutex poisoned")
+            .push(key.clone());
+        metrics::Counter::from_arc(Arc::new(MetricHandle))
+    }
+
+    fn register_gauge(&self, key: &metrics::Key, _: &metrics::Metadata<'_>) -> metrics::Gauge {
+        self.keys
+            .lock()
+            .expect("metrics key mutex poisoned")
+            .push(key.clone());
+        metrics::Gauge::from_arc(Arc::new(MetricHandle))
+    }
+
+    fn register_histogram(
+        &self,
+        key: &metrics::Key,
+        _: &metrics::Metadata<'_>,
+    ) -> metrics::Histogram {
+        self.keys
+            .lock()
+            .expect("metrics key mutex poisoned")
+            .push(key.clone());
+        metrics::Histogram::from_arc(Arc::new(MetricHandle))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum FeedKey {
+    Symbol(&'static str),
+    Control,
+}
+
+enum FeedMessage {
+    Price { symbol: &'static str, value: u64 },
+    UrgentControl,
+    Crash,
+}
+
+#[derive(Clone)]
+struct FeedArgs {
+    first_init: Arc<AtomicBool>,
+    initial_gate: ReleaseGate,
+    crash_once: Arc<AtomicBool>,
+    handled: Arc<Mutex<Vec<&'static str>>>,
+}
+
+struct FeedActor(FeedArgs);
+
+impl Actor for FeedActor {
+    type Msg = FeedMessage;
+    type Args = FeedArgs;
+
+    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        if args.first_init.swap(false, Ordering::SeqCst) {
+            args.initial_gate.wait().await;
+        }
+        Ok(Self(args))
+    }
+
+    async fn handle(&mut self, message: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            FeedMessage::Price { symbol, value } => {
+                let _ = value;
+                self.0
+                    .handled
+                    .lock()
+                    .expect("feed log mutex poisoned")
+                    .push(symbol);
+            }
+            FeedMessage::UrgentControl => {
+                self.0
+                    .handled
+                    .lock()
+                    .expect("feed log mutex poisoned")
+                    .push("control");
+            }
+            FeedMessage::Crash => {
+                if self.0.crash_once.swap(false, Ordering::SeqCst) {
+                    return Err(ExitError::message("feed disconnected"));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+enum VenueMessage {
+    Pause,
+    Execute { order: u64, reply: Reply<u64> },
+}
+
+#[derive(Clone)]
+struct VenueArgs {
+    coordinator: shelterwood::ActorRef<CoordinatorMessage>,
+    pause_entered: Arc<AtomicBool>,
+    pause_release: ReleaseGate,
+}
+
+struct VenueActor(VenueArgs);
+
+impl Actor for VenueActor {
+    type Msg = VenueMessage;
+    type Args = VenueArgs;
+
+    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self(args))
+    }
+
+    async fn handle(&mut self, message: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            VenueMessage::Pause => {
+                self.0.pause_entered.store(true, Ordering::SeqCst);
+                self.0.pause_release.wait().await;
+            }
+            VenueMessage::Execute { order, reply } => {
+                self.0
+                    .coordinator
+                    .try_send(CoordinatorMessage::VenueObserved(order))
+                    .map_err(|_| ExitError::message("coordinator mailbox rejected venue event"))?;
+                reply.send(order * 2);
+            }
+        }
+        Ok(())
+    }
+}
+
+enum CoordinatorMessage {
+    BeginBatch,
+    Completed { ok: bool },
+    VenueObserved(u64),
+    FeedEvent(MonitorEvent),
+}
+
+#[derive(Clone)]
+struct CoordinatorArgs {
+    feed: shelterwood::ActorRef<FeedMessage>,
+    venue: shelterwood::ActorRef<VenueMessage>,
+    completions: Arc<AtomicUsize>,
+    observations: Arc<AtomicUsize>,
+    stale_events: Arc<AtomicUsize>,
+}
+
+struct CoordinatorActor(CoordinatorArgs);
+
+impl Actor for CoordinatorActor {
+    type Msg = CoordinatorMessage;
+    type Args = CoordinatorArgs;
+
+    async fn init(args: Self::Args, context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        context
+            .watch(&args.feed, CoordinatorMessage::FeedEvent)
+            .map_err(|_| ExitError::message("feed watch rejected during coordinator init"))?;
+        Ok(Self(args))
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            CoordinatorMessage::BeginBatch => {
+                for order in 1..=3 {
+                    let venue = self.0.venue.clone();
+                    context
+                        .offload(
+                            async move {
+                                venue
+                                    .call(
+                                        move |reply| VenueMessage::Execute { order, reply },
+                                        Duration::from_secs(1),
+                                    )
+                                    .await
+                            },
+                            move |result| {
+                                let ok = matches!(
+                                    result,
+                                    Ok(Ok(reply)) if reply.value == order * 2
+                                );
+                                CoordinatorMessage::Completed { ok }
+                            },
+                            Duration::from_secs(1),
+                        )
+                        .expect("live coordinator accepts deadline-owned call offload");
+                }
+            }
+            CoordinatorMessage::Completed { ok } => {
+                if !ok {
+                    return Err(ExitError::message("venue call failed its shared budget"));
+                }
+                self.0.completions.fetch_add(1, Ordering::SeqCst);
+            }
+            CoordinatorMessage::VenueObserved(order) => {
+                assert!((1..=3).contains(&order));
+                self.0.observations.fetch_add(1, Ordering::SeqCst);
+            }
+            CoordinatorMessage::FeedEvent(event) => {
+                if matches!(event.kind, MonitorEventKind::Exited { .. }) {
+                    self.0.stale_events.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn on_stop(&mut self, _: &mut StopContext<'_, Self>) {}
+}
+
+fn restart_on_failure() -> RestartPolicy {
+    RestartPolicy::new(RestartCondition::OnFailure, Backoff::Immediate)
+}
+
+#[tokio::test]
+async fn trading_engine_composes_part_two_without_a_registry_or_priority_lane() {
+    let metric_keys = Arc::new(Mutex::new(Vec::new()));
+    metrics::set_global_recorder(RecordingMetrics {
+        keys: Arc::clone(&metric_keys),
+    })
+    .expect("trading test installs its process-global recorder once");
+    let initial_gate = ReleaseGate::default();
+    let feed_log = Arc::new(Mutex::new(Vec::new()));
+    let completions = Arc::new(AtomicUsize::new(0));
+    let observations = Arc::new(AtomicUsize::new(0));
+    let stale_events = Arc::new(AtomicUsize::new(0));
+    let pause_entered = Arc::new(AtomicBool::new(false));
+    let pause_release = ReleaseGate::default();
+
+    let mut root_tree = Tree::new();
+    let feed_slot = root_tree
+        .reserve_actor::<FeedMessage>("feed")
+        .expect("feed slot is reserved before its factory exists");
+    let feed = feed_slot.actor_ref();
+    let coordinator_slot = root_tree
+        .reserve_actor::<CoordinatorMessage>("coordinator")
+        .expect("coordinator slot is reserved before its factory exists");
+    let coordinator = coordinator_slot.actor_ref();
+    let venue_scope_slot = root_tree
+        .reserve_subtree::<Tree>("venues")
+        .expect("venue scope is reserved before its declaration exists");
+
+    let venue_intensity =
+        Intensity::new(2, Duration::from_secs(5)).expect("non-zero intensity window");
+    let mut venue_tree = Tree::new();
+    venue_tree.intensity(venue_intensity);
+    let venue_slot = venue_tree
+        .reserve_actor::<VenueMessage>("primary")
+        .expect("venue ref is minted before coordinator definition");
+    let venue = venue_slot.actor_ref();
+
+    // Every reference is now real, so the cyclic factories can be defined
+    // without a registry or an Option<ActorRef> initialization phase.
+    let _ = feed_slot.define(
+        ActorDef::<FeedActor>::cloned(FeedArgs {
+            first_init: Arc::new(AtomicBool::new(true)),
+            initial_gate: initial_gate.clone(),
+            crash_once: Arc::new(AtomicBool::new(true)),
+            handled: Arc::clone(&feed_log),
+        })
+        .latest_by_key(
+            KeyedCapacity::Explicit(NonZeroUsize::new(2).expect("two expected key classes")),
+            |message| match message {
+                FeedMessage::Price { symbol, .. } => FeedKey::Symbol(symbol),
+                FeedMessage::UrgentControl | FeedMessage::Crash => FeedKey::Control,
+            },
+        )
+        .restart(restart_on_failure()),
+    );
+    let _ = venue_slot.define(
+        ActorDef::<VenueActor>::cloned(VenueArgs {
+            coordinator: coordinator.clone(),
+            pause_entered: Arc::clone(&pause_entered),
+            pause_release: pause_release.clone(),
+        })
+        .restart(restart_on_failure()),
+    );
+    let _ = coordinator_slot.define(
+        ActorDef::<CoordinatorActor>::cloned(CoordinatorArgs {
+            feed: feed.clone(),
+            venue: venue.clone(),
+            completions: Arc::clone(&completions),
+            observations: Arc::clone(&observations),
+            stale_events: Arc::clone(&stale_events),
+        })
+        .mailbox(Mailbox::queue(8).expect("bounded coordinator FIFO")),
+    );
+    let venues = venue_scope_slot.define_once(SubtreeOnceDef::new(venue_tree));
+
+    let system = root_tree.spawn().expect("runtime is available");
+    let root = system.scope();
+
+    // The first feed incarnation is parked in init. A flood for one data key
+    // conflates to one slot, so try_send can still accept the distinct urgent
+    // control key at the explicitly sized cardinality. No priority lane is
+    // needed or implied; this only proves admission under flood.
+    for value in 0..8 {
+        feed.send(FeedMessage::Price {
+            symbol: "EURUSD",
+            value,
+        })
+        .await
+        .expect("feed price is accepted while init is parked");
+    }
+    feed.try_send(FeedMessage::UrgentControl)
+        .expect("adequately sized keyed mailbox admits control under data flood");
+    let flooded = feed.stats().stats;
+    assert_eq!(flooded.messages_accepted, 9);
+    assert_eq!(flooded.messages_conflated, 7);
+    assert_eq!(flooded.mailbox_depth, 2);
+    assert_eq!(flooded.mailbox_capacity, 2);
+
+    initial_gate.release();
+    system.wait_started().await.expect("trading tree starts");
+    assert_eq!(venues.snapshot().intensity, venue_intensity);
+    assert_eq!(venues.snapshot().state, ScopeState::Running);
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            feed_log
+                .lock()
+                .expect("feed log mutex poisoned")
+                .contains(&"control")
+        })
+        .await
+    );
+
+    // Park the venue handler, then launch three call futures from independent
+    // incarnation-owned offloads. All three accept into its FIFO before the
+    // first reply can exist, demonstrating genuine pipelining under one
+    // deadline budget per offload/call pair.
+    venue
+        .send(VenueMessage::Pause)
+        .await
+        .expect("venue pause is accepted");
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            pause_entered.load(Ordering::SeqCst)
+        })
+        .await
+    );
+    coordinator
+        .send(CoordinatorMessage::BeginBatch)
+        .await
+        .expect("coordinator starts a batch");
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            coordinator.stats().stats.outstanding_offloads == 3
+                && venue.stats().stats.mailbox_depth == 3
+        })
+        .await,
+        "all calls must be in flight before venue processing resumes"
+    );
+    pause_release.release();
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            completions.load(Ordering::SeqCst) == 3
+                && observations.load(Ordering::SeqCst) == 3
+                && coordinator.stats().stats.outstanding_offloads == 0
+        })
+        .await
+    );
+
+    // The health breaker consumes the packaged cumulative restart reducer,
+    // while the coordinator independently receives peer-watch staleness.
+    let mut restarts = root.restart_counts();
+    assert_eq!(
+        restarts.next().await.expect("initial breaker sample").total,
+        0
+    );
+    let breaker_open = Arc::new(AtomicBool::new(false));
+    let breaker = {
+        let breaker_open = Arc::clone(&breaker_open);
+        tokio::spawn(async move {
+            while let Some(sample) = restarts.next().await {
+                if sample.total >= 1 {
+                    breaker_open.store(true, Ordering::SeqCst);
+                    return sample;
+                }
+            }
+            panic!("restart stream closed before breaker input")
+        })
+    };
+    let failed = feed
+        .send(FeedMessage::Crash)
+        .await
+        .expect("feed crash request is accepted");
+    feed.next_incarnation(failed, Duration::from_secs(1))
+        .await
+        .expect("feed membership rebinds after failure");
+    let sample = breaker.await.expect("breaker consumer joins");
+    assert_eq!(sample.total, 1);
+    assert_eq!(sample.delta, 1);
+    assert!(breaker_open.load(Ordering::SeqCst));
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            stale_events.load(Ordering::SeqCst) >= 1
+        })
+        .await,
+        "peer watch marks the failed feed incarnation stale"
+    );
+
+    let recorded = metric_keys
+        .lock()
+        .expect("metrics key mutex poisoned")
+        .clone();
+    let names = recorded
+        .iter()
+        .map(|key| key.name())
+        .collect::<HashSet<_>>();
+    assert!(names.contains("shelterwood.actor.messages_accepted"));
+    assert!(names.contains("shelterwood.actor.messages_conflated"));
+    assert!(names.contains("shelterwood.actor.outstanding_offloads"));
+    assert!(names.contains("shelterwood.actor.mailbox_capacity"));
+    assert!(recorded.iter().any(|key| {
+        key.name() == "shelterwood.actor.messages_accepted"
+            && key
+                .labels()
+                .any(|label| label.key() == "actor.id" && label.value() == "feed")
+    }));
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("trading engine shuts down");
+}

--- a/docs/keyed-mailboxes-and-monitoring.md
+++ b/docs/keyed-mailboxes-and-monitoring.md
@@ -37,9 +37,12 @@ not accepted and the actor does not exit.
 
 A keyed mailbox is not a priority or control lane. A reserved “control” key
 can still be evicted by enough distinct data keys, and an older pending key is
-not delivered ahead of newer keys by priority. Put barriers and urgent control
-traffic on a non-conflating protocol path. The first-class control-lane design
-remains evidence-gated until M12.
+not delivered ahead of newer keys by priority. M12's trading-engine acceptance
+port showed that a capacity sized to the expected data/control key cardinality
+admits an urgent `try_send` under same-key data flood, so the evidence gate
+closed **do not build** for a first-class control lane. This does not make a
+keyed mailbox safe for irreplaceable barriers: put traffic that must never be
+replaced or evicted on a non-conflating protocol path.
 
 ## Peer watches
 

--- a/docs/part-ii-acceptance.md
+++ b/docs/part-ii-acceptance.md
@@ -1,0 +1,38 @@
+# Part II acceptance evidence
+
+Shelterwood's five application-scale acceptance tests exercise the combined
+core and Part II surface. They use bounded observations and deterministic
+gates instead of timing sleeps.
+
+## Full-fidelity scenarios
+
+- `shard_store.rs` covers planned topology replacement, durable operation
+  identities, incarnation-aware idempotent calls, reply-loss reconciliation,
+  and exact membership retirement.
+- `sidecar.rs` covers task-first embedding, readiness-ordered startup,
+  host-owned rollback, bounded shutdown escalation, and repeated host cycles.
+- `assistant.rs` covers nested dynamic scopes, group restart strategies, peer
+  watches, journal-boundary redelivery, conflated streaming, idle eviction,
+  and remove/re-add races.
+- `trading_engine.rs` covers slot-before-define cyclic wiring, a
+  restart-budgeted subtree, FIFO and keyed mailboxes, pipelined
+  deadline-budgeted calls, peer-watch staleness, restart-count health
+  breaking, and metric names and labels.
+- `build_farm.rs` covers dynamic consuming one-shot workers, auto-removal,
+  readiness retry with backoff, keyed progress, exact wedged-worker
+  retirement, completion-driven lifetime, outlines, and warm durable rebuild.
+
+## Final evidence-gate verdicts
+
+The control/priority-lane gate is **do not build**. In the trading port, eight
+updates for one parked data key conflate to one pending slot. A control
+`try_send` is then admitted as the second key when capacity equals the two
+expected key classes. This proves admission under that flood without
+promising priority order. Irreplaceable barriers still belong on a separate,
+non-conflating protocol path.
+
+The mapped-context `project` gate is **do not build**. The durability-bearing
+shard-store, build-farm, and assistant scenarios all preserve the provenance
+they need with explicit actor boundaries, same-message `for_actor`, and
+`ActorRef::contramap`. None demonstrates the provenance wall that was required
+to justify another context type and its boxed mapping layer.

--- a/docs/part-ii-progress.md
+++ b/docs/part-ii-progress.md
@@ -16,9 +16,36 @@ validation, and deviations for review.
 
 | Milestone | Status | Evidence gates | Validation | Deviations |
 |---|---|---|---|---|
-| M7 — incarnation refinements and `contramap` | complete | `call_idempotent`: **build** — repaired shard-store re-port passed; `project`: open | focused M7 and shard-store tests pass; `just ci` passes with 165 tests | none |
-| M8 — keyed conflation and peer monitoring | complete | control/priority lane remains open until M12 | focused M8 tests pass; `just ci` passes with 172 tests; rustdoc/API reachability clean | none |
+| M7 — incarnation refinements and `contramap` | complete | `call_idempotent`: **build** — repaired shard-store re-port passed; `project` deferred to M12 | focused M7 and shard-store tests pass; `just ci` passes with 165 tests | none |
+| M8 — keyed conflation and peer monitoring | complete | control/priority lane deferred to M12 | focused M8 tests pass; `just ci` passes with 172 tests; rustdoc/API reachability clean | none |
 | M9 — group strategies | complete | none | focused M9 tests pass; `just ci` passes with 179 tests; rustdoc/API reachability clean | none |
 | M10 — observation extensions | complete | none | focused M10 tests pass; `just ci` passes with 186 tests; rustdoc/API reachability and every feature lane clean | none |
 | M11 — outline, hosting, conveniences | complete | none | 21 focused M11 tests pass; `just ci` passes with 207 tests; serde/host isolation, rustdoc, and API reachability clean | none |
-| M12 — acceptance wave two | pending | control/priority lane and `project` final verdicts due | pending | none |
+| M12 — acceptance wave two | complete | control/priority lane: **do not build** — adequate keyed capacity admits urgent control under same-key flood; `project`: **do not build** — no full-fidelity durability consumer demonstrates the provenance wall | trading-engine, build-farm, and upgraded assistant acceptance tests pass; no-default-feature all-target check passes; full `just ci` and `just ci-nix` recorded below | none |
+
+## M12 acceptance evidence
+
+- The trading engine uses slot-before-define cyclic wiring, a
+  restart-budgeted venue subtree, bounded FIFO and keyed mailboxes, three
+  simultaneously outstanding deadline-budgeted calls, feed peer watches, a
+  restart-count breaker, and the metrics feature. With the feed parked in
+  initialization, eight same-key updates conflate to one slot and urgent
+  control is admitted as the second expected key.
+- The build farm dynamically admits consuming one-shot workers, automatically
+  removes completed workers, restarts a readiness-gated lease task with
+  backoff, conflates progress by key, retires one exact wedged worker, uses
+  `run_until_all`, verifies its pre-spawn outline, and performs a warm rebuild
+  over retained durable state.
+- The assistant port now exercises `OneForAll`, `RestForOne`, and peer watches.
+  Along with the repaired shard store and warm build farm, it supplies the
+  durability evidence for closing `project` without adding an API.
+
+## Final validation
+
+Validated on 2026-08-07 from the M12 tree:
+
+- `./scripts/dev just ci`: clean; 209/209 tests passed, with every locked
+  feature lane, warnings-denied clippy, rustdoc, public-API reachability,
+  runtime/exit path enforcement, and formatting checks passing.
+- `./scripts/dev just ci-nix`: clean; all nine authoritative flake checks
+  passed on `x86_64-linux`.


### PR DESCRIPTION
## Stack

Depends on #15. This branch is a literal one-commit child of M11:

- base: `620edd482b5fd410561343c2a8b3efe441b1848e`
- head: `afd86710fc8e71416e93b8df5e9103752c1a52d2`

## Summary

- retain full-fidelity trading-engine and build-farm acceptance ports
- upgrade the assistant port with `OneForAll`, `RestForOne`, and peer watches
- exercise the metrics feature from the trading port, including stable metric names and actor labels
- close the two final evidence gates in `SPEC.md` and the operational guides

## Acceptance evidence

The trading engine covers slot-before-define cyclic wiring, a restart-budgeted venue subtree, bounded FIFO plus keyed conflation, three simultaneously outstanding calls in incarnation-owned deadline offloads, peer-watch staleness, and a restart-count breaker.

The build farm covers dynamic consuming one-shot workers and auto-removal, readiness retry with backoff, keyed progress, exact wedged-worker retirement, `run_until_all`, pre-spawn outline verification, and a warm rebuild over retained durable state.

## Final gate verdicts

- **control/priority lane: do not build** — with capacity equal to expected data/control key cardinality, urgent `try_send` remains admissible under same-key data flood; this proves admission, not priority ordering
- **mapped-context `project`: do not build** — none of the five full-fidelity acceptance consumers demonstrates the provenance wall needed to justify another context type

## Validation

- `./scripts/dev just ci` — 232/232 tests; formatting, warnings-denied clippy, every feature lane, rustdoc, API reachability, runtime/exit path checks, and Nix formatting pass
- `./scripts/dev just ci-nix` — all authoritative `x86_64-linux` flake checks pass

Tracks #9.