### PR TITLE
Remove unused slab dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,6 @@ name = "shelterwood"
 version = "0.1.0"
 dependencies = [
  "fastrand",
- "slab",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ name = "shelterwood"
 [workspace.dependencies]
 fastrand = "2.5.0"
 serde_json = "1.0.151"
-slab = "0.4.12"
 thiserror = "2.0.19"
 tokio = { version = "1.53.1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tokio-util = { version = "0.7.19", features = ["rt"] }

--- a/crates/shelterwood/Cargo.toml
+++ b/crates/shelterwood/Cargo.toml
@@ -8,7 +8,6 @@ autotests = false
 
 [dependencies]
 fastrand.workspace = true
-slab.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true


### PR DESCRIPTION
## Summary

- remove `slab` from the workspace dependency catalog
- remove the unused direct `shelterwood` dependency
- refresh the package dependency list in `Cargo.lock`

## Why

The crate has no direct `slab` usage, including in the completed Part II implementation. The dependency was carried forward from the initial bootstrap without a consumer.

`slab` remains in the resolved graph transitively through `tokio-util` and `futures-util`, so this changes only Shelterwood's declared direct dependencies and has no runtime behavior impact.

## Validation

- `./scripts/dev just ci`
- `./scripts/dev cargo tree --workspace --invert slab` (shows only `futures-util -> tokio-util -> shelterwood`)