### PR TITLE
Remove obsolete runtime dead-code allowance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,58 +3,10 @@
 version = 4
 
 [[package]]
-name = "bytes"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
-
-[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
-
-[[package]]
-name = "futures-core"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
-
-[[package]]
-name = "futures-task"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
-
-[[package]]
-name = "futures-util"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
-dependencies = [
- "futures-core",
- "futures-macro",
- "futures-task",
- "pin-project-lite",
- "slab",
-]
 
 [[package]]
 name = "itoa"
@@ -147,7 +99,6 @@ dependencies = [
  "fastrand",
  "thiserror",
  "tokio",
- "tokio-util",
  "tracing",
 ]
 
@@ -157,12 +108,6 @@ version = "0.1.0"
 dependencies = [
  "serde_json",
 ]
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
@@ -225,20 +170,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "futures-util",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,4 @@ fastrand = "2.5.0"
 serde_json = "1.0.151"
 thiserror = "2.0.19"
 tokio = { version = "1.53.1", features = ["macros", "rt-multi-thread", "sync", "time"] }
-tokio-util = { version = "0.7.19", features = ["rt"] }
 tracing = "0.1.44"

--- a/crates/shelterwood/Cargo.toml
+++ b/crates/shelterwood/Cargo.toml
@@ -10,7 +10,6 @@ autotests = false
 fastrand.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-tokio-util.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1558,7 +1558,7 @@ impl SystemRun {
                 self.root
                     .finish_live_root_incarnation(StopReason::ShutdownRequested, exit);
             }
-            runtime::JoinOutcome::Cancelled { .. } => {
+            runtime::JoinOutcome::Cancelled => {
                 self.root.set_startup(Err(StartupError::ShutdownRequested));
                 self.root.finish_live_root_incarnation(
                     StopReason::ShutdownRequested,
@@ -1658,7 +1658,7 @@ pub(crate) fn spawn_system(plan: ScopePlan) -> SystemRun {
                 monitor_root.finish_live_root_incarnation(StopReason::ShutdownRequested, exit);
                 StopReason::ShutdownRequested
             }
-            runtime::JoinOutcome::Cancelled { .. } => {
+            runtime::JoinOutcome::Cancelled => {
                 monitor_root.set_startup(Err(StartupError::ShutdownRequested));
                 monitor_root.finish_live_root_incarnation(
                     StopReason::ShutdownRequested,
@@ -2200,9 +2200,7 @@ impl ScopeRuntime {
             let join = match runtime::join(handle).await {
                 runtime::JoinOutcome::Ok { .. } => JoinVerdict::Completed,
                 runtime::JoinOutcome::Panic { message, .. } => JoinVerdict::Panicked { message },
-                runtime::JoinOutcome::Cancelled { .. } => {
-                    JoinVerdict::Cancelled { after_grace: false }
-                }
+                runtime::JoinOutcome::Cancelled => JoinVerdict::Cancelled { after_grace: false },
             };
             exit_ended.fire();
             let report = report_receiver.receive();

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -11,13 +11,9 @@ mod mailbox;
 mod observe;
 mod policy;
 mod raw;
+mod runtime;
 mod task;
 mod tree;
-
-// M0 deliberately establishes the complete runtime boundary before its first
-// consumer lands in M1.
-#[allow(dead_code)]
-mod runtime;
 
 pub use actor::{Actor, ActorDef, ActorOnceDef, Context, Handler, StopContext};
 pub use exit::{

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -2,31 +2,10 @@
 
 use std::{future::Future, ops::RangeBounds, time::Duration};
 
-use tokio::{
-    sync::{mpsc, oneshot, watch},
-    task, time,
-};
+use tokio::{sync::mpsc, task, time};
 
 #[cfg(test)]
 pub(crate) use tokio::test;
-
-/// A runtime-owned monotonic instant.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub(crate) struct Instant(time::Instant);
-
-impl Instant {
-    pub(crate) fn now() -> Self {
-        Self(time::Instant::now())
-    }
-
-    pub(crate) fn checked_add(self, duration: Duration) -> Option<Self> {
-        self.0.checked_add(duration).map(Self)
-    }
-
-    pub(crate) fn saturating_duration_since(self, earlier: Self) -> Duration {
-        self.0.saturating_duration_since(earlier.0)
-    }
-}
 
 pub(crate) fn now() -> std::time::Instant {
     time::Instant::now().into_std()
@@ -52,14 +31,6 @@ impl AbortHandle {
 }
 
 impl<I, T> JoinHandle<I, T> {
-    pub(crate) fn id(&self) -> &I {
-        &self.id
-    }
-
-    pub(crate) fn abort(&self) {
-        self.inner.abort();
-    }
-
     pub(crate) fn abort_handle(&self) -> AbortHandle {
         AbortHandle(self.inner.abort_handle())
     }
@@ -85,10 +56,10 @@ where
 }
 
 /// The runtime-level outcome consumed by the exit classifier.
-pub(crate) enum JoinOutcome<I, T> {
-    Ok { id: I, value: T },
-    Panic { id: I, message: Option<String> },
-    Cancelled { id: I },
+pub(crate) enum JoinOutcome<T> {
+    Ok { value: T },
+    Panic { message: Option<String> },
+    Cancelled,
 }
 
 pub(crate) fn spawn<I, F>(id: I, future: F) -> JoinHandle<I, F::Output>
@@ -113,17 +84,16 @@ where
     }
 }
 
-pub(crate) async fn join<I, T>(handle: JoinHandle<I, T>) -> JoinOutcome<I, T> {
-    let JoinHandle { id, inner } = handle;
+pub(crate) async fn join<I, T>(handle: JoinHandle<I, T>) -> JoinOutcome<T> {
+    let JoinHandle { inner, .. } = handle;
     match inner.await {
-        Ok(value) => JoinOutcome::Ok { id, value },
+        Ok(value) => JoinOutcome::Ok { value },
         Err(error) if error.is_panic() => JoinOutcome::Panic {
-            id,
             message: panic_message(error.into_panic()),
         },
         Err(error) => {
             debug_assert!(error.is_cancelled());
-            JoinOutcome::Cancelled { id }
+            JoinOutcome::Cancelled
         }
     }
 }
@@ -152,10 +122,6 @@ pub(crate) async fn sleep(duration: Duration) {
     time::sleep(duration).await;
 }
 
-pub(crate) async fn sleep_until(deadline: Instant) {
-    time::sleep_until(deadline.0).await;
-}
-
 pub(crate) async fn sleep_until_std(deadline: std::time::Instant) {
     time::sleep_until(time::Instant::from_std(deadline)).await;
 }
@@ -173,20 +139,6 @@ where
         Ok(value) => Timeout::Completed(value),
         Err(_) => Timeout::Elapsed,
     }
-}
-
-pub(crate) type WatchSender<T> = watch::Sender<T>;
-pub(crate) type WatchReceiver<T> = watch::Receiver<T>;
-
-pub(crate) fn watch_channel<T>(initial: T) -> (WatchSender<T>, WatchReceiver<T>) {
-    watch::channel(initial)
-}
-
-pub(crate) type OneshotSender<T> = oneshot::Sender<T>;
-pub(crate) type OneshotReceiver<T> = oneshot::Receiver<T>;
-
-pub(crate) fn oneshot_channel<T>() -> (OneshotSender<T>, OneshotReceiver<T>) {
-    oneshot::channel()
 }
 
 pub(crate) type MpscSender<T> = mpsc::Sender<T>;
@@ -240,31 +192,6 @@ where
     }
 }
 
-#[derive(Clone, Debug, Default)]
-pub(crate) struct CancellationToken(tokio_util::sync::CancellationToken);
-
-impl CancellationToken {
-    pub(crate) fn new() -> Self {
-        Self(tokio_util::sync::CancellationToken::new())
-    }
-
-    pub(crate) fn child_token(&self) -> Self {
-        Self(self.0.child_token())
-    }
-
-    pub(crate) fn cancel(&self) {
-        self.0.cancel();
-    }
-
-    pub(crate) fn is_cancelled(&self) -> bool {
-        self.0.is_cancelled()
-    }
-
-    pub(crate) async fn cancelled(&self) {
-        self.0.cancelled().await;
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct JitterRng(fastrand::Rng);
 
@@ -279,8 +206,4 @@ impl JitterRng {
     {
         self.0.u64(range)
     }
-}
-
-pub(crate) async fn yield_now() {
-    task::yield_now().await;
 }


### PR DESCRIPTION
## What changed

- remove the obsolete M0 comment and module-level `#[allow(dead_code)]`
- prune runtime-boundary helpers that remained unused once the blanket allowance was removed
- simplify `JoinOutcome` by dropping identity payloads that no consumer reads
- remove the resulting unused `tokio-util` dependency and its unreachable lockfile entries

## Why

The runtime boundary now has active consumers, so the M0-era blanket dead-code allowance and its staging comment are stale. The allowance also masked a small set of internal APIs that never gained consumers, including the sole `tokio-util`-backed helper.

## Impact

There is no public API or intended runtime behavior change. Shelterwood's public `CancellationToken` remains intact; only the unused private runtime wrapper and dependency are removed. This restores normal dead-code checking for the runtime module and reduces unused internal and dependency surface area.

## Validation

- `./scripts/dev just ci`