### PR TITLE
Anchor mailbox terminality to member ownership

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -414,12 +414,14 @@ impl MemberCell {
     }
 
     pub(crate) fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
-        let previous = self
-            .mailbox
-            .lock()
-            .expect("member mailbox mutex poisoned")
-            .replace(mailbox);
-        assert!(previous.is_none(), "a member can own only one mailbox");
+        {
+            let mut current = self.mailbox.lock().expect("member mailbox mutex poisoned");
+            assert!(current.is_none(), "a member can own only one mailbox");
+            *current = Some(Arc::clone(&mailbox));
+        }
+        if matches!(self.record().stage, MemberStage::Terminal(_)) {
+            mailbox.terminate();
+        }
     }
 
     pub(crate) fn mailbox(&self) -> Option<Arc<dyn MailboxControl>> {
@@ -445,7 +447,6 @@ impl MemberCell {
         if !changed {
             return;
         }
-        self.changed.pulse();
         if let Some(mailbox) = self.mailbox() {
             mailbox.terminate();
             let stats = mailbox.stats();
@@ -454,6 +455,7 @@ impl MemberCell {
             debug_assert!(stats.depth <= stats.capacity);
             let _ = stats.sends_rejected;
         }
+        self.changed.pulse();
     }
 
     pub(crate) async fn wait_terminal(&self) -> Exit {
@@ -3326,13 +3328,14 @@ enum Pending {
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
+    use std::{future::Future, sync::Arc, task::Poll, time::Duration};
 
     use crate::{
-        ChildId, DynamicTree, Exit, ExitError, ExitKind, LifecycleEventKind, LifecycleItem,
-        RemoveOutcome, ScopeState,
+        ActorRef, ChildId, DynamicTree, Exit, ExitError, ExitKind, LifecycleEventKind,
+        LifecycleItem, RemoveOutcome, ScopeState, SendErrorKind,
         exit::RecordedOutcome,
         identity::{FenceCounter, ScopeIdentity},
+        mailbox::MailboxCell,
         tree::SlotCell,
     };
 
@@ -3385,6 +3388,29 @@ mod tests {
         local_stop.fire();
         token.record(RecordedOutcome::Returned(Ok(())));
         assert!(receiver.receive().cancelled);
+    }
+
+    #[crate::runtime::test]
+    async fn attaching_after_terminality_closes_the_mailbox() {
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let member = MemberCell::new(
+            ChildId::from("worker"),
+            identity.mint_membership().expect("membership available"),
+        );
+        let mailbox = MailboxCell::new(member.id().clone());
+        let actor = ActorRef::new(Arc::clone(&member), Arc::clone(&mailbox));
+        let mut parked = Box::pin(actor.send(1));
+        let first_poll =
+            std::future::poll_fn(|context| Poll::Ready(parked.as_mut().poll(context))).await;
+        assert!(first_poll.is_pending());
+
+        member.terminalize(Exit::never_started());
+        member.attach_mailbox(mailbox);
+
+        let parked = parked.await.expect_err("parked send is terminated");
+        assert_eq!(parked.kind, SendErrorKind::Terminated);
+        let immediate = actor.try_send(2).expect_err("terminal send is rejected");
+        assert_eq!(immediate.kind, SendErrorKind::Terminated);
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -3328,7 +3328,12 @@ enum Pending {
 
 #[cfg(test)]
 mod tests {
-    use std::{future::Future, sync::Arc, task::Poll, time::Duration};
+    use std::{
+        future::Future,
+        sync::{Arc, Mutex},
+        task::{Context, Poll, Wake, Waker},
+        time::Duration,
+    };
 
     use crate::{
         ActorRef, ChildId, DynamicTree, Exit, ExitError, ExitKind, LifecycleEventKind,
@@ -3407,10 +3412,70 @@ mod tests {
         member.terminalize(Exit::never_started());
         member.attach_mailbox(mailbox);
 
-        let parked = parked.await.expect_err("parked send is terminated");
+        let parked = match crate::runtime::timeout(Duration::from_secs(1), parked).await {
+            crate::runtime::Timeout::Completed(result) => {
+                result.expect_err("parked send is terminated")
+            }
+            crate::runtime::Timeout::Elapsed => panic!("parked send must not remain pending"),
+        };
         assert_eq!(parked.kind, SendErrorKind::Terminated);
         let immediate = actor.try_send(2).expect_err("terminal send is rejected");
         assert_eq!(immediate.kind, SendErrorKind::Terminated);
+    }
+
+    struct TrySendOnWake {
+        actor: ActorRef<u8>,
+        observed: Mutex<Option<SendErrorKind>>,
+    }
+
+    impl TrySendOnWake {
+        fn observe(&self) {
+            let error = self
+                .actor
+                .try_send(1)
+                .expect_err("a terminality-derived wake observes a closed mailbox");
+            *self.observed.lock().expect("observation mutex poisoned") = Some(error.kind);
+        }
+    }
+
+    impl Wake for TrySendOnWake {
+        fn wake(self: Arc<Self>) {
+            self.observe();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.observe();
+        }
+    }
+
+    #[test]
+    fn terminality_signal_follows_mailbox_termination() {
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let member = MemberCell::new(
+            ChildId::from("worker"),
+            identity.mint_membership().expect("membership available"),
+        );
+        let mailbox = MailboxCell::new(member.id().clone());
+        let actor = ActorRef::new(Arc::clone(&member), Arc::clone(&mailbox));
+        member.attach_mailbox(mailbox);
+
+        let probe = Arc::new(TrySendOnWake {
+            actor,
+            observed: Mutex::new(None),
+        });
+        let waker = Waker::from(Arc::clone(&probe));
+        let mut context = Context::from_waker(&waker);
+        let mut watcher = member.change_signal().watcher();
+        let mut changed = Box::pin(watcher.changed());
+        assert!(changed.as_mut().poll(&mut context).is_pending());
+
+        member.terminalize(Exit::never_started());
+
+        assert_eq!(
+            *probe.observed.lock().expect("observation mutex poisoned"),
+            Some(SendErrorKind::Terminated)
+        );
+        assert!(changed.as_mut().poll(&mut context).is_ready());
     }
 
     #[test]


### PR DESCRIPTION
Closes #23.

## What changed

- terminate an attached mailbox before publishing the member's terminal change
- make mailbox attachment immediately observe already-terminal membership
- add regressions for late attachment, terminal wake ordering, parked sends, and immediate sends

## Why

Mailbox terminality is a membership-owned promise. The former attachment race could leave a late-attached mailbox open forever after its member had already become terminal.

## Impact

Late attachment and terminal publication now commute: whichever happens first, the mailbox reaches terminal state and wakes blocked senders.

## Adversarial review

A fresh reviewer found that the initial regression did not directly prove mailbox termination preceded the terminality-derived member wake and could hang if it regressed. Commit `9cf35b1` adds a wake-time `try_send` probe and bounds the parked-send assertion.

## Verification

- `./scripts/dev just ci`
- stack tip: `./scripts/dev just ci-nix`
- GitHub Actions: passing

Stack: 1/5; targets `main`.