### PR TITLE
Keep System drop shutdown armed across awaits

### DIFF
--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -2008,8 +2008,8 @@ impl<R: Clone> System<R> {
         match self.wait_started().await {
             Ok(()) => Ok(self),
             Err(startup) => {
-                self.armed = false;
                 let rollback_timeout = self.run.shutdown(timeout).await.err();
+                self.armed = false;
                 Err(StartOrShutdownError {
                     startup,
                     rollback_timeout,
@@ -2024,14 +2024,16 @@ impl<R: Clone> System<R> {
     /// wall-clock return: after escalation every actor future is still joined.
     /// Blocking threads created by `run_blocking` detach past hard abort.
     pub async fn shutdown(mut self, timeout: Duration) -> Result<(), ShutdownTimeout> {
+        let result = self.run.shutdown(timeout).await;
         self.armed = false;
-        self.run.shutdown(timeout).await
+        result
     }
 
     /// Waits for natural or externally requested terminal state.
     pub async fn wait(mut self) -> StopReason {
+        let reason = self.run.wait().await;
         self.armed = false;
-        self.run.wait().await
+        reason
     }
 }
 

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -145,3 +145,36 @@ async fn dropping_the_owner_requests_cooperative_shutdown() {
     .await
     .expect("task future dropped");
 }
+
+#[tokio::test]
+async fn cancelling_system_wait_keeps_drop_shutdown_armed() {
+    let mut tree = Tree::new();
+    let task = tree
+        .add_task(
+            "worker",
+            TaskDef::new(|context| async move {
+                context.shutdown_token().cancelled().await;
+                Ok(())
+            }),
+        )
+        .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("tree starts");
+    let scope = system.scope();
+    let mut waiting = Box::pin(system.wait());
+
+    tokio::select! {
+        biased;
+        _ = &mut waiting => panic!("live system must not stop naturally"),
+        () = std::future::ready(()) => {}
+    }
+    drop(waiting);
+
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), scope.wait_stopped())
+            .await
+            .expect("dropping the cancelled wait requests shutdown"),
+        StopReason::ShutdownRequested
+    );
+    assert!(task.wait().await.cancelled());
+}


### PR DESCRIPTION
Closes #24.

## What changed

- keep the `System` drop-shutdown guard armed while `start_or_shutdown`, `shutdown`, and `wait` are awaiting completion
- disarm only after the awaited shutdown/join obligation is complete
- add a cancellation regression that drops a pending `wait` future and verifies owner drop still requests shutdown

## Why

Disarming before an await created a cancellation window: dropping the future could also drop the last owner without issuing the shutdown request guaranteed by `System`.

## Impact

The owner-level shutdown guarantee now remains active across cancellation points.

## Adversarial review

A fresh reviewer audited every suspension point, ownership/drop order, startup-error path, and the regression's first poll. No additional defect was found.

## Verification

- `./scripts/dev just ci`
- stack tip: `./scripts/dev just ci-nix`
- GitHub Actions: passing

Stack: 2/5; stacked on #23 via `agent/issue-23-mailbox-terminality`.