### PR TITLE
Resolve scope startup in the owned driver epilogue

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1568,12 +1568,10 @@ impl SystemRun {
             runtime::JoinOutcome::Ok { .. } => {}
             runtime::JoinOutcome::Panic { message, .. } => {
                 let exit = Exit::new(ExitKind::Panicked { message }, false);
-                self.root.set_startup(Err(StartupError::ShutdownRequested));
                 self.root
                     .finish_live_root_incarnation(StopReason::ShutdownRequested, exit);
             }
             runtime::JoinOutcome::Cancelled { .. } => {
-                self.root.set_startup(Err(StartupError::ShutdownRequested));
                 self.root.finish_live_root_incarnation(
                     StopReason::ShutdownRequested,
                     Exit::new(ExitKind::Aborted { after_grace: false }, true),
@@ -1668,12 +1666,10 @@ pub(crate) fn spawn_system(plan: ScopePlan) -> SystemRun {
             runtime::JoinOutcome::Ok { value, .. } => value,
             runtime::JoinOutcome::Panic { message, .. } => {
                 let exit = Exit::new(ExitKind::Panicked { message }, false);
-                monitor_root.set_startup(Err(StartupError::ShutdownRequested));
                 monitor_root.finish_live_root_incarnation(StopReason::ShutdownRequested, exit);
                 StopReason::ShutdownRequested
             }
             runtime::JoinOutcome::Cancelled { .. } => {
-                monitor_root.set_startup(Err(StartupError::ShutdownRequested));
                 monitor_root.finish_live_root_incarnation(
                     StopReason::ShutdownRequested,
                     Exit::new(ExitKind::Aborted { after_grace: false }, true),
@@ -3454,19 +3450,21 @@ mod tests {
             crate::runtime::Timeout::Completed(())
         ));
         let waiter_scope = Arc::clone(&scope);
-        let waiter = crate::runtime::spawn((), async move { waiter_scope.wait_started().await });
-        crate::runtime::yield_now().await;
+        let mut waiter = Box::pin(waiter_scope.wait_started());
+        let first_poll =
+            std::future::poll_fn(|context| Poll::Ready(waiter.as_mut().poll(context))).await;
+        assert!(first_poll.is_pending());
 
         abort.abort();
         assert!(matches!(
             crate::runtime::join(driver).await,
             crate::runtime::JoinOutcome::Cancelled { .. }
         ));
-        let crate::runtime::JoinOutcome::Ok { value, .. } = crate::runtime::join(waiter).await
-        else {
-            panic!("startup waiter must join normally");
-        };
-        assert_eq!(value, Err(crate::StartupError::ShutdownRequested));
+        let result = crate::runtime::timeout(Duration::from_secs(1), waiter).await;
+        assert!(matches!(
+            result,
+            crate::runtime::Timeout::Completed(Err(crate::StartupError::ShutdownRequested))
+        ));
         assert!(matches!(scope.record().state, ScopeState::Stopped { .. }));
         assert!(scope.record().startup.is_some());
     }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -972,7 +972,13 @@ impl ScopeCell {
         let state = ScopeState::Stopped {
             reason: reason.clone(),
         };
-        self.record.lock().expect("scope mutex poisoned").state = state.clone();
+        {
+            let mut record = self.record.lock().expect("scope mutex poisoned");
+            if record.startup.is_none() {
+                record.startup = Some(Err(StartupError::ShutdownRequested));
+            }
+            record.state = state.clone();
+        }
         let terminal = terminal_exit.is_some();
         if let Some(exit) = terminal_exit {
             self.member.terminalize(exit);
@@ -1011,7 +1017,13 @@ impl ScopeCell {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             let state = ScopeState::Stopped { reason };
-            self.record.lock().expect("scope mutex poisoned").state = state.clone();
+            {
+                let mut record = self.record.lock().expect("scope mutex poisoned");
+                if record.startup.is_none() {
+                    record.startup = Some(Err(StartupError::ShutdownRequested));
+                }
+                record.state = state.clone();
+            }
             self.member.terminalize(exit);
             self.member.changed.pulse();
             self.emit_locked(LifecycleEventKind::ScopeState { state });
@@ -3328,20 +3340,20 @@ enum Pending {
 
 #[cfg(test)]
 mod tests {
-    use std::{future::Future, sync::Arc, task::Poll, time::Duration};
+    use std::{future, future::Future, sync::Arc, task::Poll, time::Duration};
 
     use crate::{
         ActorRef, ChildId, DynamicTree, Exit, ExitError, ExitKind, LifecycleEventKind,
-        LifecycleItem, RemoveOutcome, ScopeState, SendErrorKind,
+        LifecycleItem, Readiness, RemoveOutcome, ScopeState, SendErrorKind, TaskDef, Tree,
         exit::RecordedOutcome,
         identity::{FenceCounter, ScopeIdentity},
         mailbox::MailboxCell,
-        tree::SlotCell,
+        tree::{SlotCell, lower_tree_for_test},
     };
 
     use super::{
         DynamicControl, DynamicEntry, Latch, MemberCell, MemberStage, Obligation, RemovalResponse,
-        ScopeCell, ScopeFlavor, mint_child_incarnation, report_channel,
+        ScopeCell, ScopeFlavor, mint_child_incarnation, report_channel, run_scope_incarnation,
     };
 
     #[test]
@@ -3411,6 +3423,49 @@ mod tests {
         assert_eq!(parked.kind, SendErrorKind::Terminated);
         let immediate = actor.try_send(2).expect_err("terminal send is rejected");
         assert_eq!(immediate.kind, SendErrorKind::Terminated);
+    }
+
+    #[crate::runtime::test]
+    async fn task_aborted_scope_driver_resolves_startup() {
+        let mut tree = Tree::new();
+        tree.add_task(
+            "not-ready",
+            TaskDef::new(|_| future::pending())
+                .readiness(Readiness::Manual)
+                .expect("manual readiness is valid"),
+        )
+        .expect("valid task");
+        let plan = lower_tree_for_test(tree);
+        let scope = Arc::clone(&plan.root);
+        let epoch = scope.begin_incarnation();
+        let driver = crate::runtime::spawn(
+            (),
+            run_scope_incarnation(plan, false, Some(Latch::default()), None, None, None, epoch),
+        );
+        let abort = driver.abort_handle();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !matches!(scope.record().state, ScopeState::Starting) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("scope driver reaches startup");
+        let waiter_scope = Arc::clone(&scope);
+        let waiter = crate::runtime::spawn((), async move { waiter_scope.wait_started().await });
+        tokio::task::yield_now().await;
+
+        abort.abort();
+        assert!(matches!(
+            crate::runtime::join(driver).await,
+            crate::runtime::JoinOutcome::Cancelled { .. }
+        ));
+        let crate::runtime::JoinOutcome::Ok { value, .. } = crate::runtime::join(waiter).await
+        else {
+            panic!("startup waiter must join normally");
+        };
+        assert_eq!(value, Err(crate::StartupError::ShutdownRequested));
+        assert!(matches!(scope.record().state, ScopeState::Stopped { .. }));
+        assert!(scope.record().startup.is_some());
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -3443,16 +3443,19 @@ mod tests {
             run_scope_incarnation(plan, false, Some(Latch::default()), None, None, None, epoch),
         );
         let abort = driver.abort_handle();
-        tokio::time::timeout(Duration::from_secs(1), async {
+        let reached_startup = crate::runtime::timeout(Duration::from_secs(1), async {
             while !matches!(scope.record().state, ScopeState::Starting) {
-                tokio::task::yield_now().await;
+                crate::runtime::yield_now().await;
             }
         })
-        .await
-        .expect("scope driver reaches startup");
+        .await;
+        assert!(matches!(
+            reached_startup,
+            crate::runtime::Timeout::Completed(())
+        ));
         let waiter_scope = Arc::clone(&scope);
         let waiter = crate::runtime::spawn((), async move { waiter_scope.wait_started().await });
-        tokio::task::yield_now().await;
+        crate::runtime::yield_now().await;
 
         abort.abort();
         assert!(matches!(

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -122,6 +122,11 @@ pub(crate) async fn sleep(duration: Duration) {
     time::sleep(duration).await;
 }
 
+#[cfg(test)]
+pub(crate) async fn yield_now() {
+    task::yield_now().await;
+}
+
 pub(crate) async fn sleep_until_std(deadline: std::time::Instant) {
     time::sleep_until(time::Instant::from_std(deadline)).await;
 }

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -690,6 +690,13 @@ fn spawn_builder<R>(
     })
 }
 
+#[cfg(test)]
+pub(crate) fn lower_tree_for_test(tree: Tree) -> ScopePlan {
+    tree.core
+        .lower(ResolvedDefaults::default(), None)
+        .expect("test tree must be fully defined")
+}
+
 /// An owned pre-spawn actor slot with a stable mailbox binding.
 pub struct ActorSlot<M> {
     slot: Arc<SlotCell>,


### PR DESCRIPTION
Closes #25.

## What changed

- resolve an unset startup result as `ShutdownRequested` in the owned scope-driver terminal epilogue
- publish startup resolution atomically with terminal scope state, including the live-root fallback
- add a hard-abort regression with a proven-pending startup waiter and bounded completion
- keep the regression's timing primitives behind the crate runtime boundary

## Why

A hard-aborted scope driver could terminalize its scope while leaving `wait_started` pending forever because startup resolution lived only on cooperative paths.

## Impact

Every owned driver exit now resolves startup and terminal observation together.

## Adversarial review

A fresh reviewer found root panic/cancel monitors still prewrote startup outside the atomic epilogue and that the initial test did not prove its waiter was pending. Commit `aaa94cb` funnels those exits through the epilogue and strengthens the regression.

## Verification

- `./scripts/dev just ci`
- stack tip: `./scripts/dev just ci-nix`
- GitHub Actions: passing

Stack: 3/5; stacked on #24 via `agent/issue-24-system-drop-shutdown`.