### PR TITLE
Escalate offload panics through owned state

### DIFF
--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -1272,6 +1272,60 @@ struct RawInstance<R: RawActor> {
     mailbox: Arc<MailboxCell<R::Msg>>,
 }
 
+struct RawIncarnationOwner<R: RawActor> {
+    raw: Option<RawContext<R::Msg>>,
+    actor: Option<R>,
+}
+
+impl<R: RawActor> RawIncarnationOwner<R> {
+    fn new(raw: RawContext<R::Msg>, actor: R) -> Self {
+        Self {
+            raw: Some(raw),
+            actor: Some(actor),
+        }
+    }
+
+    fn parts(&mut self) -> (&mut R, &mut RawContext<R::Msg>) {
+        let actor = self.actor.as_mut().expect("raw actor owner is armed");
+        let raw = self.raw.as_mut().expect("raw context owner is armed");
+        (actor, raw)
+    }
+
+    fn raw(&mut self) -> &mut RawContext<R::Msg> {
+        self.raw.as_mut().expect("raw context owner is armed")
+    }
+
+    fn drop_raw(&mut self) {
+        drop(self.raw.take());
+    }
+
+    fn drop_actor(&mut self) {
+        drop(self.actor.take());
+    }
+
+    fn drop_actor_catching(&mut self) {
+        let actor = self.actor.take();
+        let _ = catch_unwind(AssertUnwindSafe(|| drop(actor)));
+    }
+}
+
+impl<R: RawActor> Drop for RawIncarnationOwner<R> {
+    fn drop(&mut self) {
+        // A hard abort destroys the incarnation future instead of polling its
+        // teardown epilogue. Preserve §5.5's resource-before-actor order, but
+        // put a boundary around each destructor so two panics cannot abort the
+        // process. The resource panic is primary: it may be an owned offload
+        // panic that completed before cancellation was requested.
+        let raw_panic = catch_unwind(AssertUnwindSafe(|| self.drop_raw())).err();
+        let actor_panic = catch_unwind(AssertUnwindSafe(|| self.drop_actor())).err();
+        if !std::thread::panicking()
+            && let Some(payload) = raw_panic.or(actor_panic)
+        {
+            resume_unwind(payload);
+        }
+    }
+}
+
 impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
     fn readiness(&self) -> Readiness {
         self.actor.readiness()
@@ -1279,23 +1333,27 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
 
     fn run(self: Box<Self>, context: RawRunContext) -> RawFuture {
         Box::pin(async move {
-            let Self { mut actor, mailbox } = *self;
+            let Self { actor, mailbox } = *self;
             let incarnation = context.incarnation;
             let myself = ActorRef::new(Arc::clone(&context.member), Arc::clone(&mailbox));
             let readiness = context.readiness_override.unwrap_or(actor.readiness());
-            let mut raw = RawContext::new(context, myself, Arc::clone(&mailbox), readiness);
-            let outcome = CatchUnwindFuture::new(actor.run(&mut raw)).await;
+            let raw = RawContext::new(context, myself, Arc::clone(&mailbox), readiness);
+            let mut owner = RawIncarnationOwner::new(raw, actor);
+            let outcome = {
+                let (actor, raw) = owner.parts();
+                CatchUnwindFuture::new(actor.run(raw)).await
+            };
             mailbox.freeze(incarnation);
-            raw.freeze_resources();
-            raw.join_resources().await;
-            drop(raw);
+            owner.raw().freeze_resources();
+            owner.raw().join_resources().await;
+            owner.drop_raw();
             match outcome {
                 Ok(result) => {
-                    drop(actor);
+                    owner.drop_actor();
                     result
                 }
                 Err(payload) => {
-                    let _ = catch_unwind(AssertUnwindSafe(|| drop(actor)));
+                    owner.drop_actor_catching();
                     resume_unwind(payload)
                 }
             }

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -200,10 +200,27 @@ enum QueuedEvent<M> {
         cancellation: Latch,
         make_message: DeferredMessage<M>,
     },
-    Panic {
-        cancellation: Latch,
-        payload: PanicPayload,
-    },
+}
+
+#[derive(Default)]
+struct PanicSlot {
+    payload: Mutex<Option<PanicPayload>>,
+}
+
+impl PanicSlot {
+    fn record(&self, payload: PanicPayload) {
+        let mut pending = self.payload.lock().expect("offload panic mutex poisoned");
+        if pending.is_none() {
+            *pending = Some(payload);
+        }
+    }
+
+    fn take(&self) -> Option<PanicPayload> {
+        self.payload
+            .lock()
+            .expect("offload panic mutex poisoned")
+            .take()
+    }
 }
 
 struct SequencedEvent<M> {
@@ -360,6 +377,7 @@ struct RawResources<M> {
     next_timer_order: u64,
     fired_batch: Option<FiredTimerBatch>,
     events: Arc<EventQueue<M>>,
+    panic: Arc<PanicSlot>,
     event_watcher: SignalWatcher,
     offloads: Vec<OffloadResource>,
 }
@@ -376,6 +394,7 @@ impl<M> Default for RawResources<M> {
             next_timer_order: 0,
             fired_batch: None,
             events,
+            panic: Arc::new(PanicSlot::default()),
             event_watcher,
             offloads: Vec::new(),
         }
@@ -392,11 +411,17 @@ impl<M> RawResources<M> {
         self.continuations.clear();
         self.timers.clear();
         self.fired_batch = None;
-        self.events.clear();
         for offload in &mut self.offloads {
             offload.cancel();
         }
+        self.events.clear();
         dropped_continuations
+    }
+
+    fn resume_pending_panic(&self) {
+        if let Some(payload) = self.panic.take() {
+            resume_unwind(payload);
+        }
     }
 
     async fn join_offloads(&mut self) {
@@ -407,12 +432,16 @@ impl<M> RawResources<M> {
         }
         self.events.clear();
         self.offloads.clear();
+        self.resume_pending_panic();
     }
 }
 
 impl<M> Drop for RawResources<M> {
     fn drop(&mut self) {
         let _ = self.freeze();
+        if !std::thread::panicking() {
+            self.resume_pending_panic();
+        }
     }
 }
 
@@ -784,6 +813,7 @@ impl<M: Send + 'static> RawContext<M> {
             armed: true,
         });
         let events = Arc::clone(&self.resources.events);
+        let panic = Arc::clone(&self.resources.panic);
         if deadline.is_zero() {
             drop(work);
             events.push(QueuedEvent::Deliver {
@@ -827,10 +857,8 @@ impl<M: Send + 'static> RawContext<M> {
                     });
                 }
                 crate::driver::Selected::Second(Err(payload)) => {
-                    events.push(QueuedEvent::Panic {
-                        cancellation: event_cancellation,
-                        payload,
-                    });
+                    panic.record(payload);
+                    events.signal.pulse();
                 }
             }
             event_finished.fire();
@@ -848,6 +876,7 @@ impl<M: Send + 'static> RawContext<M> {
 
     fn next_ready(&mut self, allow_frozen_mailbox: bool) -> Option<M> {
         loop {
+            self.resources.resume_pending_panic();
             self.begin_fired_batch();
             if let Some(mut batch) = self.resources.fired_batch.take() {
                 if !self.resources.continuation_needs_external
@@ -946,16 +975,6 @@ impl<M: Send + 'static> RawContext<M> {
                 cancellation,
                 make_message,
             } => (!cancellation.is_fired()).then(make_message),
-            QueuedEvent::Panic {
-                cancellation,
-                payload,
-            } => {
-                if cancellation.is_fired() {
-                    None
-                } else {
-                    resume_unwind(payload)
-                }
-            }
         }
     }
 
@@ -1059,6 +1078,7 @@ impl<M: Send + 'static> RawContext<M> {
                 "queued continuations discarded at the stop freeze"
             );
         }
+        self.resources.resume_pending_panic();
     }
 
     pub(crate) async fn join_resources(&mut self) {

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -9,7 +9,8 @@ use std::{
 use crate::common::poll_until;
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
-    Readiness, StartupError, StartupFailureCause, Tree,
+    LifecycleEventKind, LifecycleItem, Readiness, Shutdown, StartupError, StartupFailureCause,
+    Tree,
 };
 
 enum ZeroMessage {
@@ -590,6 +591,137 @@ async fn assert_pre_ready_panic(mode: PanicMode, expected: &str, trigger: bool) 
 async fn offload_future_and_continuation_panics_resume_on_actor_task() {
     assert_pre_ready_panic(PanicMode::Future, "offload future panic", false).await;
     assert_pre_ready_panic(PanicMode::Continuation, "offload continuation panic", false).await;
+}
+
+#[derive(Clone, Copy)]
+enum QueuedPanicMode {
+    Stop,
+    HandlerError,
+    HardAbort,
+}
+
+struct QueuedPanicActor {
+    mode: QueuedPanicMode,
+    queued: Arc<AtomicBool>,
+}
+
+impl Actor for QueuedPanicActor {
+    type Msg = PanicMessage;
+    type Args = (QueuedPanicMode, Arc<AtomicBool>);
+
+    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self {
+            mode: args.0,
+            queued: args.1,
+        })
+    }
+
+    async fn handle(&mut self, _: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        let guard = context
+            .offload_scoped(
+                async {
+                    panic!("owned offload panic");
+                    #[allow(unreachable_code)]
+                    ()
+                },
+                |_| PanicMessage::Delivery,
+                Duration::MAX,
+            )
+            .expect("offload accepted");
+        guard.finished().await;
+        self.queued.store(true, Ordering::SeqCst);
+        match self.mode {
+            QueuedPanicMode::Stop => {
+                context.stop();
+                Ok(())
+            }
+            QueuedPanicMode::HandlerError => Err(ExitError::message("secondary handler error")),
+            QueuedPanicMode::HardAbort => std::future::pending().await,
+        }
+    }
+}
+
+async fn assert_queued_panic_beats_orderly_exit(mode: QueuedPanicMode) {
+    let queued = Arc::new(AtomicBool::new(false));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "panic",
+            ActorOnceDef::<QueuedPanicActor>::new((mode, Arc::clone(&queued)))
+                .readiness(Readiness::Manual),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    actor
+        .send(PanicMessage::Trigger)
+        .await
+        .expect("mailbox accepts before readiness");
+    let message = startup_panic_message(
+        system
+            .wait_started()
+            .await
+            .expect_err("queued offload panic fails startup"),
+    );
+    assert_eq!(message.as_deref(), Some("owned offload panic"));
+    assert!(queued.load(Ordering::SeqCst));
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed root shuts down");
+}
+
+#[tokio::test]
+async fn queued_offload_panic_survives_stop_and_handler_error() {
+    assert_queued_panic_beats_orderly_exit(QueuedPanicMode::Stop).await;
+    assert_queued_panic_beats_orderly_exit(QueuedPanicMode::HandlerError).await;
+}
+
+#[tokio::test]
+async fn queued_offload_panic_survives_hard_abort() {
+    let queued = Arc::new(AtomicBool::new(false));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "panic",
+            ActorOnceDef::<QueuedPanicActor>::new((
+                QueuedPanicMode::HardAbort,
+                Arc::clone(&queued),
+            ))
+            .readiness(Readiness::Manual)
+            .shutdown(Shutdown::Abort),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    let mut events = system.scope().subscribe_lifecycle();
+    actor
+        .send(PanicMessage::Trigger)
+        .await
+        .expect("mailbox accepts before readiness");
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            queued.load(Ordering::SeqCst)
+        })
+        .await,
+        "offload panic is queued before hard abort"
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("hard abort bounds shutdown");
+
+    let mut panic_message = None;
+    while let Some(item) = events.recv().await {
+        let LifecycleItem::Event(event) = item else {
+            panic!("small fixture must not lag");
+        };
+        if let LifecycleEventKind::Exited { id, exit, .. } = event.kind
+            && id.as_str() == "panic"
+            && let ExitKind::Panicked { message } = exit.kind()
+        {
+            panic_message = message.clone();
+        }
+    }
+    assert_eq!(panic_message.as_deref(), Some("owned offload panic"));
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -10,7 +10,7 @@ use crate::common::{ReleaseGate, poll_until};
 use shelterwood::{
     DynamicTree, ExitError, ExitResult, Mailbox, MailboxShutdown, PolicyError, RawActor,
     RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline, RemoveOutcome, ScopeDefaults,
-    SendErrorKind, Tree,
+    SendErrorKind, Shutdown, Tree,
 };
 
 struct FactoryTaskActor {
@@ -375,4 +375,75 @@ async fn raw_run_panic_with_panicking_destructor_publishes_one_report() {
         ),
         "the run panic's payload wins: {exit:?}"
     );
+}
+
+struct OffloadDoublePanicActor {
+    queued: Arc<AtomicBool>,
+}
+
+impl RawActor for OffloadDoublePanicActor {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        let guard = context
+            .offload_scoped(
+                async {
+                    panic!("injected offload panic");
+                },
+                |_| (),
+                Duration::MAX,
+            )
+            .expect("offload accepted");
+        guard.finished().await;
+        self.queued.store(true, Ordering::SeqCst);
+        std::future::pending().await
+    }
+}
+
+impl Drop for OffloadDoublePanicActor {
+    fn drop(&mut self) {
+        panic!("injected destructor panic");
+    }
+}
+
+#[tokio::test]
+async fn hard_abort_offload_panic_with_panicking_raw_destructor_is_contained() {
+    let queued = Arc::new(AtomicBool::new(false));
+    let mut tree = Tree::new();
+    tree.add_raw_once(
+        "double-panic",
+        RawOnceDef::new(OffloadDoublePanicActor {
+            queued: Arc::clone(&queued),
+        })
+        .shutdown(Shutdown::Abort),
+    )
+    .expect("valid raw actor");
+    let system = tree.spawn().expect("runtime is available");
+    let mut events = system.scope().subscribe_lifecycle();
+    system.wait_started().await.expect("actor starts");
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            queued.load(Ordering::SeqCst)
+        })
+        .await,
+        "offload panic is queued before hard abort"
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("the two panics remain contained");
+
+    let mut panic_message = None;
+    while let Some(item) = events.recv().await {
+        let shelterwood::LifecycleItem::Event(event) = item else {
+            panic!("small fixture must not lag");
+        };
+        if let shelterwood::LifecycleEventKind::Exited { id, exit, .. } = event.kind
+            && id.as_str() == "double-panic"
+            && let shelterwood::ExitKind::Panicked { message } = exit.kind()
+        {
+            panic_message = message.clone();
+        }
+    }
+    assert_eq!(panic_message.as_deref(), Some("injected offload panic"));
 }


### PR DESCRIPTION
Closes #26.

## What changed

- record offload panics in an owned panic slot shared with the resources epilogue
- wake the resource driver when a panic is recorded
- surface the pending panic from normal driving, freeze/join, or resource drop
- contain simultaneous resource/offload and actor-destructor panics without process abort
- cover stop, handler-error, hard-abort, post-recording cancellation, and double-panic races

## Why

Routing panics only through the live delivery queue allowed stop, error, or hard abort to drop the sole escalation path.

## Impact

Once an offload panic is recorded, later cancellation cannot retroactively erase it; an owned cleanup path will surface it while preserving deterministic teardown.

## Adversarial review

A fresh reviewer reproduced a high-severity hard-abort SIGABRT when an offload panic met a panicking actor destructor. Commit `ae71fac` adds a unified incarnation owner that preserves resource-before-actor teardown and resumes only the primary panic.

## Verification

- `./scripts/dev just ci`
- stack tip: `./scripts/dev just ci-nix`
- GitHub Actions: passing

Stack: 4/5; stacked on #25 via `agent/issue-25-owned-scope-startup`.