### PR TITLE
Close residual owned-promise gaps

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -996,6 +996,10 @@ handlers non-blocking. Contracts:
   'static` with `T: Send + 'static`; the continuation is
   `FnOnce(Result<T, DeadlineElapsed>) -> Msg + Send + 'static` and runs
   on the actor task.
+  `Guard::is_finished` / `finished()` report either ordinary work
+  completion or an incarnation-teardown cancellation request. They are not
+  a join guarantee: a hard-aborted task can still be unwinding after the
+  notification.
 - Any higher-level helper that composes `call` inside `offload` MUST
   preserve: incarnation ownership; completion through the actor loop; a
   total timeout continuation; and no await inside the handler.
@@ -1012,9 +1016,15 @@ handlers non-blocking. Contracts:
   where the future is awaited — on the actor task, the ordinary
   actor-panic path (§7) — while a future dropped before completion
   discards a later panic along with the detached thread (documented).
-- Offloads, lifetime tasks, and monitor leases are destroyed before actor
-  state on incarnation teardown, and the mailbox binding outlives actor
-  destruction.
+- On orderly return, error, or caught-panic teardown, offloads, lifetime
+  tasks, and monitor leases are frozen, cancelled, and joined before actor
+  state is dropped. Hard abort necessarily drops the handler future (and
+  therefore handler-owned actor state) before `RawResources::drop` can
+  synchronously cancel the remaining async resources; it cannot join from
+  `Drop`. `run_blocking` is outside the resource ledger by design and its
+  thread detaches after a cancellation request; `StopContext::run_blocking`
+  may therefore start work after the async-resource freeze. The mailbox
+  binding outlives actor destruction on every path.
 
 ## 6. Readiness [#363]
 
@@ -3012,6 +3022,10 @@ events it replaces may have come from many scopes, so it can truthfully
 carry no `scope_path` and no `seq` — only the per-subscriber dropped
 count. One leading, coalesced marker per overflow episode (§12); the
 aligned snapshot is the resync.
+The retained events delivered after that leading marker may be older than
+the resync snapshot. This is intentional: the post-`Lagged` watermark
+protocol below discards those already-reflected events and applies only the
+newer suffix.
 
 Ordering and delivery contract:
 
@@ -3236,6 +3250,9 @@ Scheduled/owned work (scoped offloads; with Part II: cross-actor timers,
 scoped watches) returns a `Guard`: consuming `cancel(self)` and
 `detach(self)`; by-reference probes `is_cancelled()`, `is_finished()`,
 and the awaitable `finished()`; **drop = cancel**.
+For core offloads, "finished" is a completion-or-cancellation notification,
+not a hard-abort join: incarnation teardown may fire it when cancellation is
+requested while the task is still unwinding (§5.5).
 `detach(self)` releases only the guard's cancel-on-drop; the underlying
 facility's ownership rule is unchanged (offloads stay incarnation-owned,
 §5.5; cross-actor timers stay sender-incarnation-owned, §23).

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -417,7 +417,7 @@ impl<A: Actor> RawActor for Handler<A> {
     }
 }
 
-/// Propagates a handler error after §5.5's teardown order: incarnation-owned
+/// Propagates a handler error after §5.5's orderly teardown order: incarnation-owned
 /// work is frozen, cancelled, and joined before actor state — which the
 /// caller still owns — is dropped at its frame's exit.
 async fn fail_after_teardown<M: Send + 'static>(
@@ -429,7 +429,7 @@ async fn fail_after_teardown<M: Send + 'static>(
     Err(error)
 }
 
-/// Resumes a caught callback panic after §5.5's teardown order: offloads and
+/// Resumes a caught callback panic after §5.5's orderly teardown order: offloads and
 /// other incarnation-owned work are destroyed (frozen, cancelled, joined)
 /// before actor state, and the destructor runs outside the callback's unwind
 /// per §7's containment boundary.

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1135,7 +1135,7 @@ impl ScopeCell {
         });
     }
 
-    fn clear_residents(&self) {
+    pub(crate) fn clear_residents(&self) {
         let _gate = OBSERVATION_GATE
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -1785,26 +1785,34 @@ struct ChildRuntime {
 
 impl ChildRuntime {
     fn from_plan(plan: ChildPlan, scope: &Arc<ScopeCell>) -> Self {
+        let ChildPlan {
+            slot,
+            construction,
+            options,
+        } = plan;
+        // Arm terminality before any fallible setup. If a poisoned lock or
+        // mailbox callback unwinds construction, this child has already left
+        // ScopePlan and therefore needs its own synchronous fallback.
+        let terminality = Obligation::new(
+            ChildTerminality {
+                root: Arc::clone(scope),
+                slot: Arc::clone(&slot),
+            },
+            discharge_child_terminality,
+        );
         let incarnations = scope
             .child_identity
             .lock()
             .expect("scope identity mutex poisoned")
-            .incarnation_counter(plan.slot.member.membership());
-        if let Some(mailbox) = plan.slot.member.mailbox() {
-            mailbox.configure(plan.options.mailbox);
+            .incarnation_counter(slot.member.membership());
+        if let Some(mailbox) = slot.member.mailbox() {
+            mailbox.configure(options.mailbox);
         }
-        let slot = plan.slot;
         Self {
-            terminality: Obligation::new(
-                ChildTerminality {
-                    root: Arc::clone(scope),
-                    slot: Arc::clone(&slot),
-                },
-                discharge_child_terminality,
-            ),
+            terminality,
             slot,
-            construction: Some(plan.construction),
-            options: plan.options,
+            construction: Some(construction),
+            options,
             incarnations,
             restarts: RestartState::new(),
             active: None,
@@ -3101,10 +3109,15 @@ async fn run_scope_incarnation(
             .map(|child| Arc::clone(&child.slot))
             .collect(),
     );
-    let children = std::mem::take(&mut plan.children)
-        .into_iter()
-        .map(|child| ChildRuntime::from_plan(child, &root))
-        .collect();
+    // Transfer children one at a time. The not-yet-converted suffix remains
+    // owned by ScopePlan, while ChildRuntime::from_plan arms the current
+    // child's obligation before fallible setup. Thus a panic at any point has
+    // exactly one terminality owner for every child.
+    let mut children = Vec::with_capacity(plan.children.len());
+    plan.children.reverse();
+    while let Some(child) = plan.children.pop() {
+        children.push(ChildRuntime::from_plan(child, &root));
+    }
     let mut scope = ScopeRuntime {
         root: Arc::clone(&root),
         flavor: plan.flavor,
@@ -3341,12 +3354,19 @@ enum Pending {
 
 #[cfg(test)]
 mod tests {
-    use std::{future, future::Future, sync::Arc, task::Poll, time::Duration};
+    use std::{
+        future,
+        future::Future,
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::Arc,
+        task::{Context, Poll, Waker},
+        time::Duration,
+    };
 
     use crate::{
         ActorRef, ChildId, DynamicTree, Exit, ExitError, ExitKind, LifecycleEventKind,
         LifecycleItem, LifecycleTryRecvError, Readiness, RemoveOutcome, ScopeState, SendErrorKind,
-        StopReason, TaskDef, Tree,
+        StopReason, SubtreeOnceDef, TaskDef, Tree,
         exit::RecordedOutcome,
         identity::{FenceCounter, ScopeIdentity},
         mailbox::MailboxCell,
@@ -3485,6 +3505,125 @@ mod tests {
             Err(crate::StartupError::ShutdownRequested)
         );
         assert_eq!(root.wait_stopped().await, StopReason::NeverStarted);
+    }
+
+    #[crate::runtime::test]
+    async fn dropped_unpolled_scope_plan_terminalizes_nested_declarations() {
+        let mut inner = Tree::new();
+        let leaf = inner
+            .add_task("leaf", TaskDef::new(|_| future::pending()))
+            .expect("valid nested task");
+        let mut outer = Tree::new();
+        let nested = outer
+            .add_subtree_once("nested", SubtreeOnceDef::new(inner))
+            .expect("valid nested scope");
+        let mut snapshots = nested.subscribe_snapshots();
+        let mut events = nested.subscribe_lifecycle();
+        let plan = lower_tree_for_test(outer);
+
+        drop(plan);
+
+        assert_eq!(nested.wait_stopped().await, StopReason::NeverStarted);
+        snapshots
+            .changed()
+            .await
+            .expect("the final nested snapshot is delivered before closure");
+        assert!(matches!(
+            snapshots.borrow_latest().state,
+            ScopeState::Stopped {
+                reason: StopReason::NeverStarted
+            }
+        ));
+        assert!(snapshots.changed().await.is_err());
+        assert!(matches!(leaf.wait().await.kind(), ExitKind::NeverStarted));
+        let mut saw_stopped = false;
+        while let Some(item) = events.recv().await {
+            saw_stopped |= matches!(
+                item,
+                LifecycleItem::Event(crate::LifecycleEvent {
+                    kind: LifecycleEventKind::ScopeState {
+                        state: ScopeState::Stopped {
+                            reason: StopReason::NeverStarted
+                        }
+                    },
+                    ..
+                })
+            );
+        }
+        assert!(
+            saw_stopped,
+            "nested observation closes after its final event"
+        );
+    }
+
+    #[crate::runtime::test]
+    async fn scope_plan_conversion_panic_terminalizes_every_child() {
+        let mut tree = Tree::new();
+        for id in ["first", "second"] {
+            tree.add_task(id, TaskDef::new(|_| future::pending()))
+                .expect("valid task");
+        }
+        let plan = lower_tree_for_test(tree);
+        let root = Arc::clone(&plan.root);
+        let mut events = root.subscribe_lifecycle();
+        let children: Vec<_> = plan
+            .children
+            .iter()
+            .map(|child| Arc::clone(&child.slot.member))
+            .collect();
+        let epoch = root.begin_incarnation();
+
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                let _identity = root
+                    .child_identity
+                    .lock()
+                    .expect("scope identity mutex starts healthy");
+                panic!("inject child conversion failure");
+            }))
+            .is_err()
+        );
+
+        let mut driver = Box::pin(run_scope_incarnation(
+            plan, false, None, None, None, None, epoch,
+        ));
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                let mut context = Context::from_waker(Waker::noop());
+                let _ = driver.as_mut().poll(&mut context);
+            }))
+            .is_err()
+        );
+        drop(driver);
+
+        for child in children {
+            assert!(
+                matches!(child.record().stage, MemberStage::Terminal(_)),
+                "every transferred or pending child must terminalize"
+            );
+        }
+        assert_eq!(
+            root.wait_started().await,
+            Err(crate::StartupError::ShutdownRequested)
+        );
+        assert_eq!(root.wait_stopped().await, StopReason::NeverStarted);
+        assert!(
+            root.snapshot().children.is_empty(),
+            "the fallback must release every admitted residency"
+        );
+        let mut removed = 0;
+        while let Some(item) = events.recv().await {
+            if matches!(
+                item,
+                LifecycleItem::Event(crate::LifecycleEvent {
+                    kind: LifecycleEventKind::Removed { .. },
+                    ..
+                })
+            ) {
+                removed += 1;
+            }
+        }
+        assert_eq!(removed, 2, "every Added edge needs a matching Removed edge");
     }
 
     #[test]
@@ -3627,9 +3766,33 @@ mod tests {
             record.last_incarnation = Some(first);
             record.last_exit = Some(Exit::new(ExitKind::Completed, false));
         });
+        scope.set_state(ScopeState::Stopped {
+            reason: StopReason::Finished,
+        });
 
         assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+        assert!(matches!(
+            events.try_recv(),
+            Ok(LifecycleItem::Event(crate::LifecycleEvent {
+                kind: LifecycleEventKind::ScopeState {
+                    state: ScopeState::Stopped {
+                        reason: StopReason::Finished
+                    }
+                },
+                ..
+            }))
+        ));
         assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Closed));
+        snapshots
+            .changed()
+            .await
+            .expect("the prior incarnation's final snapshot remains observable");
+        assert!(matches!(
+            snapshots.borrow_latest().state,
+            ScopeState::Stopped {
+                reason: StopReason::Finished
+            }
+        ));
         assert!(snapshots.changed().await.is_err());
     }
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1941,18 +1941,12 @@ impl ScopeRuntime {
             return;
         }
         let child = &mut self.children[index];
-        let Some(incarnation) = mint_child_incarnation(&child.slot.member, &mut child.incarnations)
-        else {
+        let Some(incarnation) = mint_child_incarnation(&child.slot, &mut child.incarnations) else {
             child.complete_terminality();
             // Incarnation exhaustion terminalized the membership (§3.1):
             // publish the observation edges, then route the terminal outcome
             // through the same paths as a terminal exit so ordered startup
             // fails or draining advances instead of wedging the scope.
-            if child.slot.member.record().last_incarnation.is_none()
-                && let Some(scope) = &child.slot.scope
-            {
-                scope.terminalize_never_started();
-            }
             self.root.transition_child(&child.slot.member, |_| {}, None);
             if child.options.retention == crate::Retention::Remove {
                 self.root.prune_child(&child.slot.member);
@@ -2997,17 +2991,23 @@ impl ScopeRuntime {
     }
 }
 
-fn mint_child_incarnation(
-    member: &Arc<MemberCell>,
-    counter: &mut FenceCounter,
-) -> Option<Incarnation> {
+fn mint_child_incarnation(slot: &Arc<SlotCell>, counter: &mut FenceCounter) -> Option<Incarnation> {
+    let member = &slot.member;
     let incarnation = ScopeIdentity::mint_incarnation(member.membership(), counter);
     if incarnation.is_none() {
-        let exit = member
-            .record()
-            .last_exit
-            .unwrap_or_else(Exit::never_started);
+        let record = member.record();
+        let exit = record.last_exit.unwrap_or_else(Exit::never_started);
         member.terminalize(exit);
+        if let Some(scope) = &slot.scope {
+            if record.last_incarnation.is_none() {
+                scope.terminalize_never_started();
+            } else {
+                let _gate = OBSERVATION_GATE
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                scope.close_observation_locked();
+            }
+        }
     }
     incarnation
 }
@@ -3058,7 +3058,7 @@ async fn run_scope(plan: ScopePlan, is_root: bool, parent_ready: Option<Latch>) 
 }
 
 async fn run_scope_incarnation(
-    plan: ScopePlan,
+    mut plan: ScopePlan,
     is_root: bool,
     parent_ready: Option<Latch>,
     incarnation_cancel: Option<Latch>,
@@ -3101,15 +3101,14 @@ async fn run_scope_incarnation(
             .map(|child| Arc::clone(&child.slot))
             .collect(),
     );
-    let children = plan
-        .children
+    let children = std::mem::take(&mut plan.children)
         .into_iter()
         .map(|child| ChildRuntime::from_plan(child, &root))
         .collect();
     let mut scope = ScopeRuntime {
         root: Arc::clone(&root),
         flavor: plan.flavor,
-        defaults: plan.defaults,
+        defaults: plan.defaults.clone(),
         intensity_policy: plan.config.intensity,
         intensity: IntensityState::default(),
         children,
@@ -3131,6 +3130,8 @@ async fn run_scope_incarnation(
         ancestor_abort_seen: false,
         completion: None,
     };
+    plan.armed = false;
+    drop(plan);
 
     match scope.flavor {
         ScopeFlavor::Ordered => scope.progress_startup(),
@@ -3344,7 +3345,8 @@ mod tests {
 
     use crate::{
         ActorRef, ChildId, DynamicTree, Exit, ExitError, ExitKind, LifecycleEventKind,
-        LifecycleItem, Readiness, RemoveOutcome, ScopeState, SendErrorKind, TaskDef, Tree,
+        LifecycleItem, LifecycleTryRecvError, Readiness, RemoveOutcome, ScopeState, SendErrorKind,
+        StopReason, TaskDef, Tree,
         exit::RecordedOutcome,
         identity::{FenceCounter, ScopeIdentity},
         mailbox::MailboxCell,
@@ -3471,6 +3473,20 @@ mod tests {
         assert!(scope.record().startup.is_some());
     }
 
+    #[crate::runtime::test]
+    async fn dropped_unpolled_scope_plan_terminalizes_its_root() {
+        let plan = lower_tree_for_test(Tree::new());
+        let root = Arc::clone(&plan.root);
+
+        drop(plan);
+
+        assert_eq!(
+            root.wait_started().await,
+            Err(crate::StartupError::ShutdownRequested)
+        );
+        assert_eq!(root.wait_stopped().await, StopReason::NeverStarted);
+    }
+
     #[test]
     fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
@@ -3579,15 +3595,42 @@ mod tests {
             record.stage = MemberStage::Restarting;
             record.last_exit = Some(previous.clone());
         });
+        let slot = SlotCell::new(Arc::clone(&member), None);
         let mut counter = FenceCounter::near_exhaustion(71);
 
-        assert!(mint_child_incarnation(&member, &mut counter).is_some());
-        assert!(mint_child_incarnation(&member, &mut counter).is_none());
+        assert!(mint_child_incarnation(&slot, &mut counter).is_some());
+        assert!(mint_child_incarnation(&slot, &mut counter).is_none());
         assert!(matches!(
             member.record().stage,
             MemberStage::Terminal(ref exit) if exit == &previous
         ));
-        assert!(mint_child_incarnation(&member, &mut counter).is_none());
+        assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+    }
+
+    #[crate::runtime::test]
+    async fn scope_incarnation_exhaustion_closes_nested_observation() {
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let membership = identity.mint_membership().expect("membership available");
+        let member = MemberCell::new(ChildId::from("nested"), membership);
+        let scope = ScopeCell::new(
+            Arc::clone(&member),
+            ScopeFlavor::Ordered,
+            ScopeIdentity::new().expect("child identity available"),
+        );
+        let slot = SlotCell::new(Arc::clone(&member), Some(Arc::clone(&scope)));
+        let mut snapshots = scope.subscribe_snapshots();
+        let mut events = scope.subscribe_lifecycle();
+        let mut counter = FenceCounter::near_exhaustion(83);
+        let first = mint_child_incarnation(&slot, &mut counter).expect("last incarnation mints");
+        member.update(|record| {
+            record.stage = MemberStage::Restarting;
+            record.last_incarnation = Some(first);
+            record.last_exit = Some(Exit::new(ExitKind::Completed, false));
+        });
+
+        assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+        assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Closed));
+        assert!(snapshots.changed().await.is_err());
     }
 
     #[test]

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1623,15 +1623,18 @@ mod tests {
     }
 
     #[test]
-    fn promotion_wakes_every_sender_when_one_waker_panics() {
+    fn promotion_wakes_every_sender_when_multiple_wakers_panic() {
         let (mailbox, actor) = actor();
         let mut first = Box::pin(actor.send(1));
         let mut second = Box::pin(actor.send(2));
-        let panicking = Waker::from(Arc::new(PanicWake));
+        let mut third = Box::pin(actor.send(3));
+        let first_panicking = Waker::from(Arc::new(PanicWake));
+        let second_panicking = Waker::from(Arc::new(PanicWake));
         let wakes = Arc::new(AtomicUsize::new(0));
         let counting = Waker::from(Arc::new(CountWake(Arc::clone(&wakes))));
-        park_with(&mut first, &panicking);
-        park_with(&mut second, &counting);
+        park_with(&mut first, &first_panicking);
+        park_with(&mut second, &second_panicking);
+        park_with(&mut third, &counting);
         MailboxControl::configure(&*mailbox, Mailbox::default());
         let mut generations = {
             let mut identity = ScopeIdentity::new().expect("scope identity available");
@@ -1658,18 +1661,25 @@ mod tests {
                 .poll(&mut Context::from_waker(Waker::noop())),
             Poll::Ready(Ok(_))
         ));
+        assert!(matches!(
+            third.as_mut().poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Ready(Ok(_))
+        ));
     }
 
     #[test]
-    fn termination_discharge_reaches_every_sender_when_one_waker_panics() {
+    fn termination_discharge_reaches_every_sender_when_multiple_wakers_panic() {
         let (mailbox, actor) = actor();
         let mut first = Box::pin(actor.send(1));
         let mut second = Box::pin(actor.send(2));
-        let panicking = Waker::from(Arc::new(PanicWake));
+        let mut third = Box::pin(actor.send(3));
+        let first_panicking = Waker::from(Arc::new(PanicWake));
+        let second_panicking = Waker::from(Arc::new(PanicWake));
         let wakes = Arc::new(AtomicUsize::new(0));
         let counting = Waker::from(Arc::new(CountWake(Arc::clone(&wakes))));
-        park_with(&mut first, &panicking);
-        park_with(&mut second, &counting);
+        park_with(&mut first, &first_panicking);
+        park_with(&mut second, &second_panicking);
+        park_with(&mut third, &counting);
 
         assert!(
             catch_unwind(AssertUnwindSafe(|| {
@@ -1678,7 +1688,7 @@ mod tests {
             .is_err()
         );
         assert_eq!(wakes.load(Ordering::SeqCst), 1);
-        for future in [&mut first, &mut second] {
+        for future in [&mut first, &mut second, &mut third] {
             let Poll::Ready(Err(error)) = future
                 .as_mut()
                 .poll(&mut Context::from_waker(Waker::noop()))

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -6,6 +6,7 @@ use std::{
     future::Future,
     hash::{Hash, Hasher},
     num::NonZeroUsize,
+    panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll, Waker},
@@ -524,11 +525,54 @@ impl<M> Default for Promotion<M> {
 }
 
 impl<M> Promotion<M> {
-    fn finish(self) {
-        for waker in self.wakers {
-            waker.wake();
+    fn finish(self) {}
+}
+
+impl<M> Drop for Promotion<M> {
+    fn drop(&mut self) {
+        let already_panicking = std::thread::panicking();
+        let mut first_panic = None;
+        for waker in self.wakers.drain(..) {
+            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| waker.wake()))
+                && first_panic.is_none()
+            {
+                first_panic = Some(payload);
+            }
         }
-        drop(self.displaced);
+        if !already_panicking && let Some(payload) = first_panic {
+            resume_unwind(payload);
+        }
+    }
+}
+
+struct Termination<M> {
+    waiters: VecDeque<Arc<SendOperation<M>>>,
+    final_incarnation: Option<Incarnation>,
+}
+
+impl<M> Termination<M> {
+    fn finish(self) {}
+
+    fn drain(&mut self) {
+        let already_panicking = std::thread::panicking();
+        let mut first_panic = None;
+        while let Some(waiter) = self.waiters.pop_front() {
+            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| {
+                waiter.terminate(self.final_incarnation);
+            })) && first_panic.is_none()
+            {
+                first_panic = Some(payload);
+            }
+        }
+        if !already_panicking && let Some(payload) = first_panic {
+            resume_unwind(payload);
+        }
+    }
+}
+
+impl<M> Drop for Termination<M> {
+    fn drop(&mut self) {
+        self.drain();
     }
 }
 
@@ -909,13 +953,15 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         let queue = std::mem::take(&mut state.queue);
         let latest = state.latest.take();
         let waiters = std::mem::take(&mut state.waiters);
+        let termination = Termination {
+            waiters,
+            final_incarnation,
+        };
         drop(state);
-        for waiter in waiters {
-            waiter.terminate(final_incarnation);
-        }
         self.changed.pulse();
         drop(queue);
         drop(latest);
+        termination.finish();
     }
 
     fn stats(&self) -> MailboxStats {
@@ -1525,5 +1571,121 @@ impl<M: Send + 'static> MailboxReceiver<M> {
 
     pub(crate) async fn changed(&mut self) {
         self.watcher.changed().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::Future,
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        task::{Context, Poll, Wake, Waker},
+    };
+
+    use crate::{ChildId, Mailbox, SendErrorKind, driver::MemberCell, identity::ScopeIdentity};
+
+    use super::{ActorRef, MailboxCell, MailboxControl};
+
+    struct PanicWake;
+
+    impl Wake for PanicWake {
+        fn wake(self: Arc<Self>) {
+            panic!("injected waker panic");
+        }
+    }
+
+    struct CountWake(Arc<AtomicUsize>);
+
+    impl Wake for CountWake {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn actor() -> (Arc<MailboxCell<u8>>, ActorRef<u8>) {
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let member = MemberCell::new(
+            ChildId::from("actor"),
+            identity.mint_membership().expect("membership available"),
+        );
+        let mailbox = MailboxCell::new(member.id().clone());
+        member.attach_mailbox(mailbox.clone());
+        (Arc::clone(&mailbox), ActorRef::new(member, mailbox))
+    }
+
+    fn park_with(future: &mut std::pin::Pin<Box<super::SendFuture<u8>>>, waker: &Waker) {
+        let mut context = Context::from_waker(waker);
+        assert!(future.as_mut().poll(&mut context).is_pending());
+    }
+
+    #[test]
+    fn promotion_wakes_every_sender_when_one_waker_panics() {
+        let (mailbox, actor) = actor();
+        let mut first = Box::pin(actor.send(1));
+        let mut second = Box::pin(actor.send(2));
+        let panicking = Waker::from(Arc::new(PanicWake));
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let counting = Waker::from(Arc::new(CountWake(Arc::clone(&wakes))));
+        park_with(&mut first, &panicking);
+        park_with(&mut second, &counting);
+        MailboxControl::configure(&*mailbox, Mailbox::default());
+        let mut generations = {
+            let mut identity = ScopeIdentity::new().expect("scope identity available");
+            let membership = identity.mint_membership().expect("membership available");
+            (membership, identity.incarnation_counter(membership))
+        };
+        let incarnation = ScopeIdentity::mint_incarnation(generations.0, &mut generations.1)
+            .expect("incarnation available");
+
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                MailboxControl::bind(&*mailbox, incarnation);
+            }))
+            .is_err()
+        );
+        assert_eq!(wakes.load(Ordering::SeqCst), 1);
+        assert!(matches!(
+            first.as_mut().poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Ready(Ok(_))
+        ));
+        assert!(matches!(
+            second
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Ready(Ok(_))
+        ));
+    }
+
+    #[test]
+    fn termination_discharge_reaches_every_sender_when_one_waker_panics() {
+        let (mailbox, actor) = actor();
+        let mut first = Box::pin(actor.send(1));
+        let mut second = Box::pin(actor.send(2));
+        let panicking = Waker::from(Arc::new(PanicWake));
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let counting = Waker::from(Arc::new(CountWake(Arc::clone(&wakes))));
+        park_with(&mut first, &panicking);
+        park_with(&mut second, &counting);
+
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                MailboxControl::terminate(&*mailbox);
+            }))
+            .is_err()
+        );
+        assert_eq!(wakes.load(Ordering::SeqCst), 1);
+        for future in [&mut first, &mut second] {
+            let Poll::Ready(Err(error)) = future
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+            else {
+                panic!("every parked send must be discharged");
+            };
+            assert_eq!(error.kind, SendErrorKind::Terminated);
+        }
     }
 }

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -492,6 +492,9 @@ impl LifecycleEvents {
             .state
             .lock()
             .expect("lifecycle queue mutex poisoned");
+        // The marker leads the overflow episode deliberately. A consumer
+        // snapshots here, then discards retained events at or below that
+        // watermark before applying the newer suffix.
         if let Some(dropped) = state.lagged.take() {
             return Ok(LifecycleItem::Lagged { dropped });
         }

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -78,13 +78,18 @@ impl Guard {
         self.cancellation.is_fired()
     }
 
-    /// Reports whether the guarded work has stopped running.
+    /// Reports whether the work completed or incarnation teardown requested cancellation.
+    ///
+    /// A teardown notification is not a join: under hard abort the task may
+    /// still be unwinding when this becomes true.
     #[must_use]
     pub fn is_finished(&self) -> bool {
         self.finished.is_fired()
     }
 
-    /// Waits until the guarded work has stopped running.
+    /// Waits for work completion or an incarnation-teardown cancellation request.
+    ///
+    /// This notification does not join work that is being hard-aborted.
     pub async fn finished(&self) {
         self.finished.fired().await;
     }

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -354,6 +354,10 @@ impl Drop for ScopePlan {
                 scope.terminalize_never_started();
             }
         }
+        // Lowering can publish the planned children before ScopeRuntime takes
+        // ownership. If construction then unwinds, the plan fallback also
+        // owns those residencies and their matching Removed edges.
+        self.root.clear_residents();
         self.root.terminalize_never_started();
     }
 }

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -311,6 +311,7 @@ impl BuilderCore {
             config: self.config.clone(),
             defaults,
             children,
+            armed: true,
         })
     }
 
@@ -339,6 +340,22 @@ pub(crate) struct ScopePlan {
     pub(crate) config: ScopeConfig,
     pub(crate) defaults: ResolvedDefaults,
     pub(crate) children: Vec<ChildPlan>,
+    pub(crate) armed: bool,
+}
+
+impl Drop for ScopePlan {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        for child in &self.children {
+            child.slot.member.terminalize(Exit::never_started());
+            if let Some(scope) = &child.slot.scope {
+                scope.terminalize_never_started();
+            }
+        }
+        self.root.terminalize_never_started();
+    }
 }
 
 pub(crate) struct ChildPlan {


### PR DESCRIPTION
Closes #27.

## What changed

- add an armed `ScopePlan` drop fallback for unpolled root/child plans
- transfer and arm child terminality obligations one at a time during runtime conversion
- close scope observation when incarnation minting exhausts
- make mailbox promotion and termination discharge unwind-safe across panicking wakers
- clarify `Guard::finished` and hard-abort/run-blocking semantics
- codify lag recovery ordering and its retained-event watermark
- add targeted regressions for unpolled plans, conversion panic, exhaustion, and panicking wakers

## Why

These were the remaining promises whose completion depended on a live polling path, a non-panicking waker, or documentation stronger than the implementation.

## Impact

Owned cleanup now closes the residual observation and waiter gaps, while API/spec text accurately scopes hard-abort guarantees.

## Adversarial review

A fresh reviewer found a conversion window where all children were removed from `ScopePlan` before their runtime obligations were armed, so a panic could strand children and residency edges. Commit `d18b340` transfers children one at a time and clears published residencies in the fallback.

## Verification

- `./scripts/dev just ci`
- `./scripts/dev just ci-nix`
- GitHub Actions: passing

Stack: 5/5; stacked on #26 via `agent/issue-26-owned-offload-panics`.