### PR TITLE
Use Tokio Notify for runtime latches

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     policy::{DefaultsInheritance, ResolvedDefaults},
     raw::{RawRunContext, RawSpawn},
-    runtime,
+    runtime::{self, Latch},
     task::{OnceTaskBody, TaskContext, TaskFactory},
     tree::{
         BuilderCore, ChildConstruction, ChildPlan, NotAdmittingCause, RemoveOutcome, ReserveError,
@@ -276,38 +276,6 @@ impl Future for WaiterFuture {
             Poll::Ready(())
         } else {
             Poll::Pending
-        }
-    }
-}
-
-#[derive(Clone, Debug, Default)]
-pub(crate) struct Latch {
-    fired: Arc<AtomicBool>,
-    signal: Signal,
-}
-
-impl Latch {
-    pub(crate) fn fire(&self) -> bool {
-        if self
-            .fired
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
-        {
-            self.signal.pulse();
-            true
-        } else {
-            false
-        }
-    }
-
-    pub(crate) fn is_fired(&self) -> bool {
-        self.fired.load(Ordering::Acquire)
-    }
-
-    pub(crate) async fn fired(&self) {
-        let mut watcher = self.signal.watcher();
-        while !self.is_fired() {
-            watcher.changed().await;
         }
     }
 }
@@ -3363,11 +3331,12 @@ mod tests {
         exit::RecordedOutcome,
         identity::{FenceCounter, ScopeIdentity},
         mailbox::MailboxCell,
+        runtime::Latch,
         tree::{SlotCell, lower_tree_for_test},
     };
 
     use super::{
-        DynamicControl, DynamicEntry, Latch, MemberCell, MemberStage, Obligation, RemovalResponse,
+        DynamicControl, DynamicEntry, MemberCell, MemberStage, Obligation, RemovalResponse,
         ScopeCell, ScopeFlavor, mint_child_incarnation, report_channel, run_scope_incarnation,
     };
 

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -16,9 +16,10 @@ use std::{
 use crate::{
     ActorRef, CancellationToken, ChildId, ExitResult, Incarnation, Mailbox, MailboxShutdown,
     PolicyError, Readiness, ReadinessDeadline, RestartPolicy, Retention, ScopeRef, Shutdown,
-    driver::{ActorWork, Latch, Signal, SignalWatcher},
+    driver::{ActorWork, Signal, SignalWatcher},
     mailbox::{MailboxCell, MailboxControl, MailboxReceiver},
     policy::CommonOptions,
+    runtime::Latch,
 };
 
 type PanicPayload = Box<dyn Any + Send + 'static>;

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -1,8 +1,19 @@
 //! The only boundary between the library and its async runtime.
 
-use std::{future::Future, ops::RangeBounds, time::Duration};
+use std::{
+    future::Future,
+    ops::RangeBounds,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
-use tokio::{sync::mpsc, task, time};
+use tokio::{
+    sync::{Notify, mpsc},
+    task, time,
+};
 
 #[cfg(test)]
 pub(crate) use tokio::test;
@@ -13,6 +24,67 @@ pub(crate) fn now() -> std::time::Instant {
 
 pub(crate) fn is_available() -> bool {
     tokio::runtime::Handle::try_current().is_ok()
+}
+
+/// A one-shot, multi-waiter signal backed by Tokio's waiter queue.
+///
+/// The atomic provides a linearizable, idempotent transition and retains the
+/// fired state for future waiters. [`Notify`] wakes the waiters that already
+/// exist and removes cancelled waits from its intrusive queue. Creating the
+/// notification before rechecking the atomic is essential: Tokio guarantees
+/// that such a notification observes a subsequent `notify_waiters`, even when
+/// it has not been polled yet.
+///
+/// This deliberately does not use `tokio_util::sync::CancellationToken`.
+/// Shelterwood also uses latches for readiness and completion, needs `fire` to
+/// report which caller performed the transition, and keeps parent and local
+/// cancellation as distinct shared latches. The Tokio-util cancellation tree
+/// would add allocation, locking, and dependencies without replacing those
+/// semantics. A Tokio watch channel similarly adds value locking to the hot
+/// `is_fired` path.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct Latch {
+    state: Arc<LatchState>,
+}
+
+#[derive(Debug, Default)]
+struct LatchState {
+    fired: AtomicBool,
+    notify: Notify,
+}
+
+impl Latch {
+    pub(crate) fn fire(&self) -> bool {
+        if self
+            .state
+            .fired
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            self.state.notify.notify_waiters();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn is_fired(&self) -> bool {
+        self.state.fired.load(Ordering::Acquire)
+    }
+
+    pub(crate) async fn fired(&self) {
+        loop {
+            if self.is_fired() {
+                return;
+            }
+
+            let notified = self.state.notify.notified();
+            if self.is_fired() {
+                return;
+            }
+            notified.await;
+        }
+    }
 }
 
 /// A spawned operation whose identity is retained through joining.
@@ -210,5 +282,120 @@ impl JitterRng {
         R: RangeBounds<u64>,
     {
         self.0.u64(range)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::Future,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        task::Poll,
+        time::Duration,
+    };
+
+    use super::{JoinOutcome, Latch, Timeout, join, spawn, timeout, yield_now};
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn exactly_one_concurrent_fire_performs_the_transition() {
+        const FIRERS: usize = 32;
+
+        let latch = Latch::default();
+        let ready = Arc::new(AtomicUsize::new(0));
+        let mut firers = Vec::with_capacity(FIRERS);
+        for _ in 0..FIRERS {
+            let latch = latch.clone();
+            let ready = Arc::clone(&ready);
+            firers.push(spawn((), async move {
+                ready.fetch_add(1, Ordering::AcqRel);
+                while ready.load(Ordering::Acquire) != FIRERS {
+                    yield_now().await;
+                }
+                latch.fire()
+            }));
+        }
+
+        let mut transitions = 0;
+        for firer in firers {
+            let JoinOutcome::Ok { value } = join(firer).await else {
+                panic!("latch firer must complete normally");
+            };
+            transitions += usize::from(value);
+        }
+
+        assert_eq!(transitions, 1);
+        assert!(latch.is_fired());
+        assert!(!latch.fire());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn all_pre_fire_waiters_wake() {
+        const WAITERS: usize = 32;
+
+        let latch = Latch::default();
+        let parked = Arc::new(AtomicUsize::new(0));
+        let mut waiters = Vec::with_capacity(WAITERS);
+        for _ in 0..WAITERS {
+            let latch = latch.clone();
+            let parked = Arc::clone(&parked);
+            waiters.push(spawn((), async move {
+                let mut fired = Box::pin(latch.fired());
+                let first_poll =
+                    std::future::poll_fn(|context| Poll::Ready(fired.as_mut().poll(context))).await;
+                assert!(first_poll.is_pending());
+                parked.fetch_add(1, Ordering::Release);
+                fired.await;
+            }));
+        }
+
+        while parked.load(Ordering::Acquire) != WAITERS {
+            yield_now().await;
+        }
+        assert!(latch.fire());
+
+        for waiter in waiters {
+            let result = timeout(Duration::from_secs(1), join(waiter)).await;
+            assert!(matches!(
+                result,
+                Timeout::Completed(JoinOutcome::Ok { value: () })
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn post_fire_waiters_complete_immediately() {
+        let latch = Latch::default();
+        assert!(latch.fire());
+
+        assert!(matches!(
+            timeout(Duration::from_secs(1), latch.fired()).await,
+            Timeout::Completed(())
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancelled_waits_do_not_consume_the_signal() {
+        let latch = Latch::default();
+
+        for _ in 0..1_024 {
+            let mut fired = Box::pin(latch.fired());
+            let first_poll =
+                std::future::poll_fn(|context| Poll::Ready(fired.as_mut().poll(context))).await;
+            assert!(first_poll.is_pending());
+            drop(fired);
+        }
+
+        let mut live_waiter = Box::pin(latch.fired());
+        let first_poll =
+            std::future::poll_fn(|context| Poll::Ready(live_waiter.as_mut().poll(context))).await;
+        assert!(first_poll.is_pending());
+        assert!(latch.fire());
+        assert!(matches!(
+            timeout(Duration::from_secs(1), live_waiter).await,
+            Timeout::Completed(())
+        ));
     }
 }

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -73,17 +73,16 @@ impl Latch {
     }
 
     pub(crate) async fn fired(&self) {
-        loop {
-            if self.is_fired() {
-                return;
-            }
-
-            let notified = self.state.notify.notified();
-            if self.is_fired() {
-                return;
-            }
-            notified.await;
+        if self.is_fired() {
+            return;
         }
+
+        let notified = self.state.notify.notified();
+        if self.is_fired() {
+            return;
+        }
+        notified.await;
+        debug_assert!(self.is_fired());
     }
 }
 

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -11,8 +11,9 @@ use std::{
 use crate::{
     ChildId, Exit, ExitError, ExitResult, Incarnation, Membership, PolicyError, Readiness,
     ReadinessDeadline, RestartPolicy, Retention, Shutdown,
-    driver::{Latch, MemberCell, MemberStage, Signal},
+    driver::{MemberCell, MemberStage, Signal},
     policy::CommonOptions,
+    runtime::Latch,
 };
 
 pub(crate) type TaskFuture = Pin<Box<dyn Future<Output = ExitResult> + Send + 'static>>;
@@ -417,6 +418,83 @@ impl<T> Drop for OneShotTaskRef<T> {
             .expect("completion mutex poisoned");
         if matches!(*state, CompletionState::Completed(_)) {
             *state = CompletionState::Discarded;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::runtime::{self, JoinOutcome, Latch, Timeout};
+
+    use super::CancellationToken;
+
+    #[crate::runtime::test]
+    async fn local_cancellation_cancels_only_the_derived_token() {
+        let primary = Latch::default();
+        let local = Latch::default();
+        let supervisor = CancellationToken::from_latch(primary.clone());
+        let operation = supervisor.child(local.clone());
+
+        assert!(local.fire());
+        assert!(matches!(
+            runtime::timeout(Duration::from_secs(1), operation.cancelled()).await,
+            Timeout::Completed(())
+        ));
+        assert!(operation.is_cancelled());
+        assert!(!supervisor.is_cancelled());
+        assert!(!primary.is_fired());
+    }
+
+    #[crate::runtime::test]
+    async fn supervisor_cancellation_cancels_the_derived_token() {
+        let primary = Latch::default();
+        let local = Latch::default();
+        let supervisor = CancellationToken::from_latch(primary.clone());
+        let operation = supervisor.child(local.clone());
+
+        assert!(primary.fire());
+        assert!(matches!(
+            runtime::timeout(Duration::from_secs(1), operation.cancelled()).await,
+            Timeout::Completed(())
+        ));
+        assert!(supervisor.is_cancelled());
+        assert!(operation.is_cancelled());
+        assert!(!local.is_fired());
+    }
+
+    #[crate::runtime::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn simultaneous_supervisor_and_local_cancellation_wake_the_operation() {
+        for _ in 0..128 {
+            let primary = Latch::default();
+            let local = Latch::default();
+            let operation = CancellationToken::from_latch(primary.clone()).child(local.clone());
+            let waiter = runtime::spawn((), async move {
+                operation.cancelled().await;
+            });
+
+            let primary_firer = runtime::spawn((), async move {
+                runtime::yield_now().await;
+                primary.fire()
+            });
+            let local_firer = runtime::spawn((), async move {
+                runtime::yield_now().await;
+                local.fire()
+            });
+
+            assert!(matches!(
+                runtime::join(primary_firer).await,
+                JoinOutcome::Ok { value: true }
+            ));
+            assert!(matches!(
+                runtime::join(local_firer).await,
+                JoinOutcome::Ok { value: true }
+            ));
+            assert!(matches!(
+                runtime::timeout(Duration::from_secs(1), runtime::join(waiter)).await,
+                Timeout::Completed(JoinOutcome::Ok { value: () })
+            ));
         }
     }
 }

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -17,11 +17,12 @@ use crate::{
     LifecycleEvents, Membership, ReadinessDeadline, RestartPolicy, Retention, ScopeDefaults,
     ScopeSnapshot, Shutdown, ShutdownTimeout, SnapshotReceiver, StartupFailure, Strategy,
     WaitError,
-    driver::{DynamicReservation, Latch, MemberCell, ScopeCell},
+    driver::{DynamicReservation, MemberCell, ScopeCell},
     identity::ScopeIdentity,
     mailbox::MailboxCell,
     policy::{CommonOptions, IdError, ResolvedCommonOptions, ResolvedDefaults, resolve_common},
     raw::{RawConstruction, RawDef, RawOnceDef},
+    runtime::Latch,
     task::{Completion, OnceTask, OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
 };
 


### PR DESCRIPTION
## Summary

- move the private one-shot `Latch` behind the runtime boundary
- replace its custom `Signal` waiter bookkeeping with one shared `AtomicBool + tokio::sync::Notify` state
- preserve the public `CancellationToken` primary/secondary OR-composition and all transition semantics
- add focused concurrency coverage for idempotent fire, pre- and post-fire waiters, dropped waits, and parent/local cancellation races

## Design

`tokio_util::sync::CancellationToken` is not a direct semantic match: it does not report the winning cancellation transition, merges parent and local causes, and would reintroduce cancellation-tree allocation/locking plus the dependency set removed by #28. `tokio::sync::watch<bool>` would put locking on the hot `is_fired` path.

The selected design keeps a linearizable atomic transition and retained fired state while delegating waiter registration, broadcast wakeup, and cancelled-wait cleanup to Tokio's `Notify`. Creating `notified()` before rechecking the atomic closes the lost-wakeup window. Existing `Signal` machinery remains for repeatable generation notifications, where it still has consumers.

This changes no public API and adds no dependency.

## Validation

- `./scripts/dev just ci`
- 200 tests passed
- public API runtime reachability: clean
- runtime module path restriction: clean

Closes #29