### PR TITLE
Replace synchronization-only factory locks

### DIFF
--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -6,7 +6,7 @@ use std::{
     hash::Hash,
     marker::PhantomData,
     panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::Duration,
 };
 
@@ -444,7 +444,7 @@ async fn resume_after_teardown<A, M: Send + 'static>(
     resume_unwind(payload)
 }
 
-type ArgsFactory<A> = Arc<Mutex<Box<dyn Fn() -> <A as Actor>::Args + Send + 'static>>>;
+type ArgsFactory<A> = Arc<dyn Fn() -> <A as Actor>::Args + Send + Sync + 'static>;
 
 /// Restartable handler-actor definition.
 pub struct ActorDef<A: Actor> {
@@ -465,15 +465,15 @@ impl<A: Actor> ActorDef<A> {
     /// Creates a restartable definition by cloning args inside each incarnation.
     pub fn cloned(args: A::Args) -> Self
     where
-        A::Args: Clone,
+        A::Args: Clone + Sync,
     {
         Self::factory(move || args.clone())
     }
 
     /// Creates a restartable definition from a fresh per-incarnation args source.
-    pub fn factory(factory: impl Fn() -> A::Args + Send + 'static) -> Self {
+    pub fn factory(factory: impl Fn() -> A::Args + Send + Sync + 'static) -> Self {
         Self {
-            factory: Arc::new(Mutex::new(Box::new(factory))),
+            factory: Arc::new(factory),
             options: CommonOptions::default(),
         }
     }
@@ -531,9 +531,7 @@ impl<A: Actor> ActorDef<A> {
         let factory = self.factory;
         let readiness = self.options.readiness.unwrap_or(Readiness::AfterInit);
         let mut raw = RawDef::factory(move || {
-            let args = (factory
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner))();
+            let args = factory();
             Handler::with_readiness(args, readiness)
         });
         raw.options = self.options;

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2126,11 +2126,7 @@ impl ScopeRuntime {
                     instance.run(context).await
                 }
                 SpawnBody::TaskRestartable(factory) => {
-                    let future = (factory
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner))(
-                        task_context
-                    );
+                    let future = factory(task_context);
                     future.await
                 }
                 SpawnBody::TaskOnce(body) => body(task_context).await,
@@ -2139,10 +2135,7 @@ impl ScopeRuntime {
                     scope,
                     inherited,
                 } => {
-                    let tree = (factory
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner))(
-                    );
+                    let tree = factory();
                     run_nested_tree(
                         tree,
                         scope,

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -1094,7 +1094,7 @@ impl<M: Send + 'static> RawContext<M> {
 
 /// Restartable raw-actor definition.
 pub struct RawDef<R: RawActor> {
-    factory: Arc<Mutex<Box<dyn Fn() -> R + Send + 'static>>>,
+    factory: Arc<dyn Fn() -> R + Send + Sync + 'static>,
     pub(crate) options: CommonOptions,
 }
 
@@ -1109,9 +1109,9 @@ impl<R: RawActor> fmt::Debug for RawDef<R> {
 
 impl<R: RawActor> RawDef<R> {
     /// Creates a restartable definition from a repeatable actor factory.
-    pub fn factory(factory: impl Fn() -> R + Send + 'static) -> Self {
+    pub fn factory(factory: impl Fn() -> R + Send + Sync + 'static) -> Self {
         Self {
-            factory: Arc::new(Mutex::new(Box::new(factory))),
+            factory: Arc::new(factory),
             options: CommonOptions::default(),
         }
     }
@@ -1170,16 +1170,13 @@ impl<R: RawActor> RawDef<R> {
     pub(crate) fn erase(self, mailbox: Arc<MailboxCell<R::Msg>>) -> RawConstruction {
         let factory = self.factory;
         RawConstruction {
-            source: RawSource::Restartable(Arc::new(Mutex::new(Box::new(move || {
-                let actor = (factory
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner))(
-                );
+            source: RawSource::Restartable(Arc::new(move || {
+                let actor = factory();
                 Box::new(RawInstance {
                     actor,
                     mailbox: Arc::clone(&mailbox),
                 })
-            })))),
+            })),
             options: self.options,
         }
     }
@@ -1266,7 +1263,7 @@ impl<R: RawActor> RawOnceDef<R> {
 }
 
 pub(crate) type RawFuture = Pin<Box<dyn Future<Output = ExitResult> + Send + 'static>>;
-type RawFactory = Arc<Mutex<Box<dyn Fn() -> Box<dyn ErasedRawInstance> + Send + 'static>>>;
+type RawFactory = Arc<dyn Fn() -> Box<dyn ErasedRawInstance> + Send + Sync + 'static>;
 
 pub(crate) trait ErasedRawInstance: Send {
     fn readiness(&self) -> Readiness;
@@ -1400,10 +1397,7 @@ pub(crate) enum RawSpawn {
 impl RawSpawn {
     pub(crate) fn construct(self) -> Box<dyn ErasedRawInstance> {
         match self {
-            Self::Restartable(factory) => (factory
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner))(
-            ),
+            Self::Restartable(factory) => factory(),
             Self::OneShot(instance) => instance,
         }
     }

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 pub(crate) type TaskFuture = Pin<Box<dyn Future<Output = ExitResult> + Send + 'static>>;
-pub(crate) type TaskFactory = Arc<Mutex<Box<dyn Fn(TaskContext) -> TaskFuture + Send + 'static>>>;
+pub(crate) type TaskFactory = Arc<dyn Fn(TaskContext) -> TaskFuture + Send + Sync + 'static>;
 
 /// A library-owned cancellation token.
 #[derive(Clone, Debug, Default)]
@@ -138,13 +138,11 @@ impl TaskDef {
     /// Creates a restartable task definition from a repeatable body factory.
     pub fn new<F, Fut>(factory: F) -> Self
     where
-        F: Fn(TaskContext) -> Fut + Send + 'static,
+        F: Fn(TaskContext) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = ExitResult> + Send + 'static,
     {
         Self {
-            factory: Arc::new(Mutex::new(Box::new(move |context| {
-                Box::pin(factory(context))
-            }))),
+            factory: Arc::new(move |context| Box::pin(factory(context))),
             options: CommonOptions::default(),
         }
     }

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -1317,7 +1317,7 @@ impl Future for Removal {
 
 /// A restartable subtree definition.
 pub struct SubtreeDef<T: Subtree> {
-    factory: Box<dyn Fn() -> T + Send + 'static>,
+    factory: Box<dyn Fn() -> T + Send + Sync + 'static>,
     options: CommonOptions,
     defaults: DefaultsInheritance,
 }
@@ -1334,7 +1334,7 @@ impl<T: Subtree> fmt::Debug for SubtreeDef<T> {
 
 impl<T: Subtree> SubtreeDef<T> {
     /// Creates a restartable subtree from a repeatable declaration source.
-    pub fn factory(factory: impl Fn() -> T + Send + 'static) -> Self {
+    pub fn factory(factory: impl Fn() -> T + Send + Sync + 'static) -> Self {
         Self {
             factory: Box::new(factory),
             options: CommonOptions::default(),
@@ -1380,9 +1380,9 @@ impl<T: Subtree> SubtreeDef<T> {
     fn erase(self) -> ScopeConstruction {
         let factory = self.factory;
         ScopeConstruction {
-            source: ScopeSource::Restartable(Arc::new(Mutex::new(Box::new(move || {
+            source: ScopeSource::Restartable(Arc::new(move || {
                 <T as sealed::Sealed>::into_core(factory())
-            })))),
+            })),
             options: self.options,
             defaults: self.defaults,
         }
@@ -1461,7 +1461,7 @@ pub(crate) struct ScopeConstruction {
     pub(crate) defaults: DefaultsInheritance,
 }
 
-pub(crate) type ScopeFactory = Arc<Mutex<Box<dyn Fn() -> BuilderCore + Send + 'static>>>;
+pub(crate) type ScopeFactory = Arc<dyn Fn() -> BuilderCore + Send + Sync + 'static>;
 
 impl ScopeConstruction {
     pub(crate) fn one_shot(&self) -> bool {


### PR DESCRIPTION
## Summary

- tighten restartable task, actor, raw-actor, and subtree factories from `Fn + Send` to `Fn + Send + Sync`
- store the factories directly as `Arc<dyn Fn + Send + Sync>`
- invoke the shared closures without a `Mutex` or boxed-inner indirection

## Semantic mapping

The removed mutexes did not protect mutable state: they existed only to make `Box<dyn Fn + Send>` shareable. Requiring `Sync` on the factory closure makes that shareability contract explicit and preserves repeatable `Fn` invocation semantics. The issue records why this breaking bound is appropriate now and why thread-per-core support would require a separate `!Send` placement mechanism rather than these mutex shims.

`ActorDef::cloned` consequently requires `Args: Sync`, because its factory closure shares the captured clone source.

## Impact

This removes five synchronization-only factory wrappers and their poison-handling paths. Runtime behavior is unchanged for `Sync` closures; closures using `Send`-only interior mutability must move synchronization into their captured state explicitly.

## Validation

- `./scripts/dev just ci`
- 200 tests passed
- public API runtime reachability: clean
- runtime module path restriction: clean
- exit-path downcast restriction: clean

Part of #37 (Cluster 1).