### PR TITLE
Use Tokio oneshots for single-delivery results

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -78,9 +78,9 @@ impl<T> Obligation<T> {
         }
     }
 
-    fn payload(&self) -> &T {
+    fn payload_mut(&mut self) -> &mut T {
         self.payload
-            .as_ref()
+            .as_mut()
             .expect("a completed obligation has no payload")
     }
 
@@ -346,10 +346,6 @@ impl MemberCell {
 
     pub(crate) fn record(&self) -> MemberRecord {
         self.record.lock().expect("member mutex poisoned").clone()
-    }
-
-    pub(crate) fn change_signal(&self) -> Signal {
-        self.changed.clone()
     }
 
     pub(crate) fn update(&self, update: impl FnOnce(&mut MemberRecord)) {
@@ -1196,89 +1192,42 @@ pub(crate) struct SystemRun {
     driver: Option<runtime::JoinHandle<(), StopReason>>,
 }
 
-pub(crate) struct AdmissionResponse {
-    result: Mutex<Option<Result<(), ReserveError>>>,
-    changed: Signal,
-}
+pub(crate) type RemovalResponse = runtime::OneShotReceiver<RemoveOutcome>;
 
-impl AdmissionResponse {
-    fn new() -> Arc<Self> {
-        Arc::new(Self {
-            result: Mutex::new(None),
-            changed: Signal::default(),
-        })
+#[derive(Default)]
+struct RemovalResponses(Vec<runtime::OneShotSender<RemoveOutcome>>);
+
+impl RemovalResponses {
+    fn subscribe(&mut self) -> RemovalResponse {
+        let (sender, receiver) = runtime::oneshot();
+        self.0.push(sender);
+        receiver
     }
 
-    fn complete(&self, result: Result<(), ReserveError>) {
-        let mut current = self.result.lock().expect("admission mutex poisoned");
-        if current.is_none() {
-            *current = Some(result);
-            drop(current);
-            self.changed.pulse();
-        }
-    }
-
-    pub(crate) async fn wait(&self) -> Result<(), ReserveError> {
-        let mut watcher = self.changed.watcher();
-        loop {
-            if let Some(result) = self
-                .result
-                .lock()
-                .expect("admission mutex poisoned")
-                .clone()
-            {
-                return result;
-            }
-            watcher.changed().await;
+    fn complete(self, outcome: RemoveOutcome) {
+        for sender in self.0 {
+            let _ = sender.send(outcome);
         }
     }
 }
 
-#[derive(Debug)]
-pub(crate) struct RemovalResponse {
-    result: Mutex<Option<RemoveOutcome>>,
-    changed: Signal,
+fn complete_removals(responses: RemovalResponses) {
+    responses.complete(RemoveOutcome::Removed);
 }
 
-impl RemovalResponse {
-    fn pending() -> Arc<Self> {
-        Arc::new(Self {
-            result: Mutex::new(None),
-            changed: Signal::default(),
-        })
-    }
-
-    fn completed(outcome: RemoveOutcome) -> Arc<Self> {
-        let response = Self::pending();
-        response.complete(outcome);
-        response
-    }
-
-    fn complete(&self, outcome: RemoveOutcome) {
-        let mut current = self.result.lock().expect("removal mutex poisoned");
-        if current.is_none() {
-            *current = Some(outcome);
-            drop(current);
-            self.changed.pulse();
-        }
-    }
-
-    pub(crate) async fn wait(&self) -> RemoveOutcome {
-        let mut watcher = self.changed.watcher();
-        loop {
-            if let Some(result) = *self.result.lock().expect("removal mutex poisoned") {
-                return result;
-            }
-            watcher.changed().await;
-        }
-    }
+fn completed_removal(outcome: RemoveOutcome) -> RemovalResponse {
+    let (sender, receiver) = runtime::oneshot();
+    sender
+        .send(outcome)
+        .expect("a fresh removal receiver must be open");
+    receiver
 }
 
 struct DynamicEntry {
     slot: Arc<SlotCell>,
     admitted: bool,
     fused_cancel: Option<Latch>,
-    removal: Obligation<Arc<RemovalResponse>>,
+    removal: Obligation<RemovalResponses>,
     removal_started: bool,
 }
 
@@ -1384,9 +1333,7 @@ pub(crate) fn reserve_dynamic(
             slot: Arc::clone(&slot),
             admitted: false,
             fused_cancel: None,
-            removal: Obligation::new(RemovalResponse::pending(), |response| {
-                response.complete(RemoveOutcome::Removed);
-            }),
+            removal: Obligation::new(RemovalResponses::default(), complete_removals),
             removal_started: false,
         },
     );
@@ -1400,14 +1347,14 @@ pub(crate) fn start_admission(
     control: Arc<DynamicControl>,
     slot: Arc<SlotCell>,
     fused_cancel: Option<Latch>,
-) -> Arc<AdmissionResponse> {
-    let response = AdmissionResponse::new();
+) -> runtime::OneShotReceiver<Result<(), ReserveError>> {
+    let (sender, response) = runtime::oneshot();
     let request = AdmissionRequest {
         control: Arc::downgrade(&control),
         slot,
         fused_cancel,
-        response: Obligation::new(Arc::clone(&response), |response| {
-            response.complete(Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal)));
+        response: Obligation::new(sender, |sender| {
+            let _ = sender.send(Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal)));
         }),
     };
     runtime::spawn((), async move {
@@ -1447,24 +1394,24 @@ pub(crate) fn remove_dynamic(
     scope: &Arc<ScopeCell>,
     id: &ChildId,
     exact: Option<Membership>,
-) -> Arc<RemovalResponse> {
+) -> RemovalResponse {
     if matches!(
         scope.record().state,
         ScopeState::Draining | ScopeState::Stopped { .. }
     ) {
-        return RemovalResponse::completed(RemoveOutcome::AlreadyAbsent);
+        return completed_removal(RemoveOutcome::AlreadyAbsent);
     }
     let Some(control) = scope.dynamic() else {
-        return RemovalResponse::completed(RemoveOutcome::AlreadyAbsent);
+        return completed_removal(RemoveOutcome::AlreadyAbsent);
     };
     let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
     let Some(entry) = state.entries.get_mut(id) else {
-        return RemovalResponse::completed(RemoveOutcome::AlreadyAbsent);
+        return completed_removal(RemoveOutcome::AlreadyAbsent);
     };
     if exact.is_some_and(|membership| membership != entry.slot.member.membership()) {
-        return RemovalResponse::completed(RemoveOutcome::AlreadyAbsent);
+        return completed_removal(RemoveOutcome::AlreadyAbsent);
     }
-    let response = Arc::clone(entry.removal.payload());
+    let response = entry.removal.payload_mut().subscribe();
     if !entry.admitted {
         let entry = state.entries.remove(id).expect("entry was just resolved");
         drop(state);
@@ -1497,12 +1444,14 @@ struct AdmissionRequest {
     control: Weak<DynamicControl>,
     slot: Arc<SlotCell>,
     fused_cancel: Option<Latch>,
-    response: Obligation<Arc<AdmissionResponse>>,
+    response: Obligation<runtime::OneShotSender<Result<(), ReserveError>>>,
 }
 
 impl AdmissionRequest {
     fn complete(&mut self, result: Result<(), ReserveError>) {
-        self.response.complete(|response| response.complete(result));
+        self.response.complete(|sender| {
+            let _ = sender.send(result);
+        });
     }
 }
 
@@ -3048,9 +2997,7 @@ async fn run_scope_incarnation(
                     slot: Arc::clone(&child.slot),
                     admitted: true,
                     fused_cancel: None,
-                    removal: Obligation::new(RemovalResponse::pending(), |response| {
-                        response.complete(RemoveOutcome::Removed);
-                    }),
+                    removal: Obligation::new(RemovalResponses::default(), complete_removals),
                     removal_started: false,
                 },
             );
@@ -3329,8 +3276,9 @@ mod tests {
     };
 
     use super::{
-        DynamicControl, DynamicEntry, MemberCell, MemberStage, Obligation, RemovalResponse,
-        ScopeCell, ScopeFlavor, mint_child_incarnation, report_channel, run_scope_incarnation,
+        DynamicControl, DynamicEntry, MemberCell, MemberStage, Obligation, RemovalResponses,
+        ScopeCell, ScopeFlavor, complete_removals, mint_child_incarnation, report_channel,
+        run_scope_incarnation,
     };
 
     #[test]
@@ -3630,7 +3578,7 @@ mod tests {
         });
         let waker = Waker::from(Arc::clone(&probe));
         let mut context = Context::from_waker(&waker);
-        let mut watcher = member.change_signal().watcher();
+        let mut watcher = member.changed.watcher();
         let mut changed = Box::pin(watcher.changed());
         assert!(changed.as_mut().poll(&mut context).is_pending());
 
@@ -3669,7 +3617,9 @@ mod tests {
         root.set_admitted_children(vec![Arc::clone(&slot)]);
         let (events, _receiver) = crate::runtime::bounded_mpsc(1);
         let control = DynamicControl::new(&root, events);
-        let response = RemovalResponse::pending();
+        let (sender, mut response) = crate::runtime::oneshot();
+        let mut responses = RemovalResponses::default();
+        responses.0.push(sender);
         control
             .state
             .lock()
@@ -3681,37 +3631,24 @@ mod tests {
                     slot,
                     admitted: true,
                     fused_cancel: None,
-                    removal: Obligation::new(Arc::clone(&response), |response| {
-                        response.complete(RemoveOutcome::Removed);
-                    }),
+                    removal: Obligation::new(responses, complete_removals),
                     removal_started: true,
                 },
             );
 
         let entries = control.close();
         assert!(
-            response
-                .result
-                .lock()
-                .expect("removal mutex poisoned")
-                .is_none(),
+            response.try_receive().is_none(),
             "closing admission must not complete removal before teardown"
         );
         member.terminalize(Exit::never_started());
         assert!(root.prune_child(&member));
         assert!(
-            response
-                .result
-                .lock()
-                .expect("removal mutex poisoned")
-                .is_none(),
+            response.try_receive().is_none(),
             "terminality and Removed precede removal completion"
         );
         drop(entries);
-        assert_eq!(
-            *response.result.lock().expect("removal mutex poisoned"),
-            Some(RemoveOutcome::Removed)
-        );
+        assert_eq!(response.try_receive(), Some(RemoveOutcome::Removed));
     }
 
     #[crate::runtime::test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1199,6 +1199,10 @@ struct RemovalResponses(Vec<runtime::OneShotSender<RemoveOutcome>>);
 
 impl RemovalResponses {
     fn subscribe(&mut self) -> RemovalResponse {
+        // Callers may re-request removal and drop the returned future while
+        // the child is still stopping; discard those abandoned senders so the
+        // entry retains space proportional to live waiters only.
+        self.0.retain(|sender| !sender.is_closed());
         let (sender, receiver) = runtime::oneshot();
         self.0.push(sender);
         receiver
@@ -3589,6 +3593,22 @@ mod tests {
             Some(SendErrorKind::Terminated)
         );
         assert!(changed.as_mut().poll(&mut context).is_ready());
+    }
+
+    #[test]
+    fn removal_subscription_discards_abandoned_waiters() {
+        let mut responses = RemovalResponses::default();
+        for _ in 0..8 {
+            drop(responses.subscribe());
+        }
+        let mut retained = responses.subscribe();
+        assert_eq!(
+            responses.0.len(),
+            1,
+            "abandoned removal waiters are pruned on subscription"
+        );
+        responses.complete(RemoveOutcome::Removed);
+        assert_eq!(retained.try_receive(), Some(RemoveOutcome::Removed));
     }
 
     #[test]

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use tokio::{
-    sync::{Notify, mpsc},
+    sync::{Notify, mpsc, oneshot},
     task, time,
 };
 
@@ -83,6 +83,34 @@ impl Latch {
         }
         notified.await;
         debug_assert!(self.is_fired());
+    }
+}
+
+/// Sending half of a runtime-backed single-delivery channel.
+pub(crate) struct OneShotSender<T>(oneshot::Sender<T>);
+
+/// Receiving half of a runtime-backed single-delivery channel.
+pub(crate) struct OneShotReceiver<T>(oneshot::Receiver<T>);
+
+pub(crate) fn oneshot<T>() -> (OneShotSender<T>, OneShotReceiver<T>) {
+    let (sender, receiver) = oneshot::channel();
+    (OneShotSender(sender), OneShotReceiver(receiver))
+}
+
+impl<T> OneShotSender<T> {
+    pub(crate) fn send(self, value: T) -> Result<(), T> {
+        self.0.send(value)
+    }
+}
+
+impl<T> OneShotReceiver<T> {
+    pub(crate) async fn receive(self) -> Option<T> {
+        self.0.await.ok()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn try_receive(&mut self) -> Option<T> {
+        self.0.try_recv().ok()
     }
 }
 

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -101,6 +101,10 @@ impl<T> OneShotSender<T> {
     pub(crate) fn send(self, value: T) -> Result<(), T> {
         self.0.send(value)
     }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
 }
 
 impl<T> OneShotReceiver<T> {

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -5,15 +5,15 @@ use std::{
     future::Future,
     hash::{Hash, Hasher},
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 use crate::{
     ChildId, Exit, ExitError, ExitResult, Incarnation, Membership, PolicyError, Readiness,
     ReadinessDeadline, RestartPolicy, Retention, Shutdown,
-    driver::{MemberCell, MemberStage, Signal},
+    driver::MemberCell,
     policy::CommonOptions,
-    runtime::Latch,
+    runtime::{self, Latch},
 };
 
 pub(crate) type TaskFuture = Pin<Box<dyn Future<Output = ExitResult> + Send + 'static>>;
@@ -248,14 +248,14 @@ impl<T: Send + 'static> TaskOnceDef<T> {
         self
     }
 
-    pub(crate) fn erase(self, completion: Arc<Completion<T>>) -> OnceTask {
+    pub(crate) fn erase(self, completion: runtime::OneShotSender<T>) -> OnceTask {
         let body = self.body;
         OnceTask {
             body: OnceTaskBody::Available(Box::new(move |context| {
                 Box::pin(async move {
                     match body(context).await {
                         Ok(value) => {
-                            completion.complete(value);
+                            let _ = completion.send(value);
                             Ok(())
                         }
                         Err(error) => Err(error),
@@ -330,39 +330,10 @@ impl Hash for TaskRef {
     }
 }
 
-enum CompletionState<T> {
-    Pending,
-    Completed(T),
-    Discarded,
-}
-
-pub(crate) struct Completion<T> {
-    state: Mutex<CompletionState<T>>,
-    changed: Signal,
-}
-
-impl<T> Completion<T> {
-    pub(crate) fn new(changed: Signal) -> Arc<Self> {
-        Arc::new(Self {
-            state: Mutex::new(CompletionState::Pending),
-            changed,
-        })
-    }
-
-    fn complete(&self, value: T) {
-        let mut state = self.state.lock().expect("completion mutex poisoned");
-        if matches!(*state, CompletionState::Pending) {
-            *state = CompletionState::Completed(value);
-            drop(state);
-            self.changed.pulse();
-        }
-    }
-}
-
 /// The sole claim to a one-shot task's typed completion value.
 #[must_use]
 pub struct OneShotTaskRef<T> {
-    completion: Arc<Completion<T>>,
+    completion: runtime::OneShotReceiver<T>,
     task: TaskRef,
 }
 
@@ -376,46 +347,17 @@ impl<T> fmt::Debug for OneShotTaskRef<T> {
 }
 
 impl<T> OneShotTaskRef<T> {
-    pub(crate) fn new(completion: Arc<Completion<T>>, task: TaskRef) -> Self {
+    pub(crate) fn new(completion: runtime::OneShotReceiver<T>, task: TaskRef) -> Self {
         Self { completion, task }
     }
 
     /// Consumes the claim and waits for the typed value or terminal exit.
     pub async fn wait(self) -> Result<T, Exit> {
-        let mut watcher = self.completion.changed.watcher();
-        loop {
-            {
-                let mut state = self
-                    .completion
-                    .state
-                    .lock()
-                    .expect("completion mutex poisoned");
-                if matches!(*state, CompletionState::Completed(_)) {
-                    let CompletionState::Completed(value) =
-                        std::mem::replace(&mut *state, CompletionState::Discarded)
-                    else {
-                        unreachable!()
-                    };
-                    return Ok(value);
-                }
-            }
-            if let MemberStage::Terminal(exit) = self.task.cell.record().stage {
-                return Err(exit);
-            }
-            watcher.changed().await;
-        }
-    }
-}
-
-impl<T> Drop for OneShotTaskRef<T> {
-    fn drop(&mut self) {
-        let mut state = self
-            .completion
-            .state
-            .lock()
-            .expect("completion mutex poisoned");
-        if matches!(*state, CompletionState::Completed(_)) {
-            *state = CompletionState::Discarded;
+        let Self { completion, task } = self;
+        if let Some(value) = completion.receive().await {
+            Ok(value)
+        } else {
+            Err(task.wait().await)
         }
     }
 }

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -22,8 +22,8 @@ use crate::{
     mailbox::MailboxCell,
     policy::{CommonOptions, IdError, ResolvedCommonOptions, ResolvedDefaults, resolve_common},
     raw::{RawConstruction, RawDef, RawOnceDef},
-    runtime::Latch,
-    task::{Completion, OnceTask, OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
+    runtime::{self, Latch},
+    task::{OnceTask, OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
 };
 
 /// Whether a scope has fixed ordered membership or runtime-dynamic membership.
@@ -819,8 +819,8 @@ impl TaskSlot {
         definition: TaskOnceDef<T>,
     ) -> (TaskRef, OneShotTaskRef<T>) {
         let task = self.task_ref();
-        let completion = Completion::new(self.slot.member.change_signal());
-        let claim = OneShotTaskRef::new(Arc::clone(&completion), task.clone());
+        let (completion, receiver) = runtime::oneshot();
+        let claim = OneShotTaskRef::new(receiver, task.clone());
         self.slot
             .define(ChildConstruction::TaskOnce(definition.erase(completion)));
         (task, claim)
@@ -928,7 +928,12 @@ impl<H: Unpin> Future for Admission<H> {
                 Arc::clone(&reservation.slot),
                 self.fused_cancel.clone(),
             );
-            self.inner = Some(Box::pin(async move { response.wait().await }));
+            self.inner = Some(Box::pin(async move {
+                response
+                    .receive()
+                    .await
+                    .expect("admission response obligation must complete")
+            }));
         }
         let poll = self
             .inner
@@ -1166,9 +1171,9 @@ impl DynamicTaskSlot {
         definition: TaskOnceDef<T>,
     ) -> Admission<(TaskRef, OneShotTaskRef<T>)> {
         let task = self.task_ref();
-        let completion = Completion::new(self.reservation().slot.member.change_signal());
+        let (completion, receiver) = runtime::oneshot();
         let reservation = self.take_reservation();
-        let claim = OneShotTaskRef::new(Arc::clone(&completion), task.clone());
+        let claim = OneShotTaskRef::new(receiver, task.clone());
         reservation
             .slot
             .define(ChildConstruction::TaskOnce(definition.erase(completion)));
@@ -1180,9 +1185,9 @@ impl DynamicTaskSlot {
         definition: TaskOnceDef<T>,
     ) -> Admission<(TaskRef, OneShotTaskRef<T>)> {
         let task = self.task_ref();
-        let completion = Completion::new(self.reservation().slot.member.change_signal());
+        let (completion, receiver) = runtime::oneshot();
         let reservation = self.take_reservation();
-        let claim = OneShotTaskRef::new(Arc::clone(&completion), task.clone());
+        let claim = OneShotTaskRef::new(receiver, task.clone());
         reservation
             .slot
             .define(ChildConstruction::TaskOnce(definition.erase(completion)));
@@ -1300,9 +1305,14 @@ impl fmt::Debug for Removal {
 }
 
 impl Removal {
-    fn new(response: Arc<crate::driver::RemovalResponse>) -> Self {
+    fn new(response: crate::driver::RemovalResponse) -> Self {
         Self {
-            inner: Box::pin(async move { response.wait().await }),
+            inner: Box::pin(async move {
+                response
+                    .receive()
+                    .await
+                    .expect("removal response obligation must complete")
+            }),
         }
     }
 }


### PR DESCRIPTION
## Summary

- add runtime-boundary wrappers around `tokio::sync::oneshot`
- replace the hand-rolled admission response and typed one-shot task completion state
- give each dynamic-removal observer its own Tokio oneshot while preserving shared removal completion

## Semantic mapping

Admissions and typed task completions have one producer and one consumer, so their `Mutex<Option<_>> + Signal` state maps directly to a Tokio oneshot. Dropping the owned sender closes the receiver; task claims then await membership terminality to return the existing typed `Exit`.

Dynamic removal permits multiple concurrent observers. Each `remove*` call now registers a dedicated oneshot sender inside the entry while the existing dynamic-state lock is held. The entry's owned obligation fulfills every registered sender only after member terminality and the `Removed` observation edge, preserving detached and shared-removal semantics without a response mutex or custom signal.

All Tokio types remain confined to `runtime.rs`; callers use crate-private wrappers.

## Impact

This removes three hand-rolled single-delivery state machines and their custom wake loops. Public behavior and ordering are unchanged.

## Validation

- `./scripts/dev just ci`
- 200 tests passed, including concurrent shared removal and one-shot completion paths
- public API runtime reachability: clean
- runtime module path restriction: clean
- exit-path downcast restriction: clean

Stacked on #40.

Part of #37 (Cluster 2).