### PR TITLE
Refresh parked mailbox incarnation evidence

### DIFF
--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -932,6 +932,14 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         }
         state.status = BindingStatus::Bound(incarnation);
         state.last_bound = Some(incarnation);
+        // Binding is an observation edge for every operation that remained
+        // parked through it, including FIFO overflow that cannot be promoted
+        // into the current capacity. Withdrawal takes the mailbox lock before
+        // the operation lock, so a concurrent timeout sees either the prior
+        // evidence or this incarnation consistently with which edge won.
+        for operation in &state.waiters {
+            operation.observe(incarnation);
+        }
         let promotion = promote_waiters(&mut state);
         drop(state);
         self.changed.pulse();

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -71,6 +71,54 @@ fn boundary_actor(
 }
 
 #[tokio::test(start_paused = true)]
+async fn prebind_overflow_timeouts_observe_the_bound_incarnation() {
+    let gate = ReleaseGate::default();
+    let values = Arc::new(Mutex::new(Vec::new()));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "prebind-overflow",
+            RawOnceDef::new(boundary_actor(Some(gate.clone()), &values, &calls, false))
+                .mailbox(Mailbox::queue(1).expect("non-zero capacity")),
+        )
+        .expect("valid actor");
+    let width = Duration::from_secs(10);
+    let mut accepted = Box::pin(actor.send_timeout(Message::Value(1), width));
+    let mut overflow = Box::pin(actor.send_timeout(Message::Value(2), width));
+    let mut call = Box::pin(actor.call(Message::Ask, width));
+    assert!(poll_once(accepted.as_mut()).is_pending());
+    assert!(poll_once(overflow.as_mut()).is_pending());
+    assert!(poll_once(call.as_mut()).is_pending());
+
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    let Poll::Ready(Ok(incarnation)) = poll_once(accepted.as_mut()) else {
+        panic!("the first prebind operation must fill the queue");
+    };
+    assert!(poll_once(overflow.as_mut()).is_pending());
+    assert!(poll_once(call.as_mut()).is_pending());
+
+    advance_time(width).await;
+    let Poll::Ready(Err(send_error)) = poll_once(overflow.as_mut()) else {
+        panic!("overflow send must time out");
+    };
+    assert_eq!(send_error.kind, SendErrorKind::TimedOut);
+    assert_eq!(send_error.incarnation_observed, Some(incarnation));
+    let Poll::Ready(Err(call_error)) = poll_once(call.as_mut()) else {
+        panic!("overflow call must time out before acceptance");
+    };
+    assert_eq!(call_error.kind, CallErrorKind::AcceptanceTimedOut);
+    assert_eq!(call_error.incarnation_observed, Some(incarnation));
+
+    gate.release();
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("actor stops");
+}
+
+#[tokio::test(start_paused = true)]
 async fn acceptance_winning_the_deadline_withdrawal_race_succeeds() {
     let gate = ReleaseGate::default();
     let values = Arc::new(Mutex::new(Vec::new()));
@@ -108,6 +156,45 @@ async fn acceptance_winning_the_deadline_withdrawal_race_succeeds() {
         })
         .await
     );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("actor stops");
+}
+
+#[tokio::test(start_paused = true)]
+async fn call_promotion_winning_the_deadline_race_reports_response_timeout() {
+    let gate = ReleaseGate::default();
+    let values = Arc::new(Mutex::new(Vec::new()));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "call-deadline-race",
+            RawOnceDef::new(boundary_actor(Some(gate.clone()), &values, &calls, true))
+                .mailbox(Mailbox::queue(1).expect("non-zero capacity")),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    let accepting = actor.try_send(Message::Value(1)).expect("queue fills");
+    let deadline = Duration::from_secs(10);
+    let mut call = Box::pin(actor.call(Message::Ask, deadline));
+    assert!(poll_once(call.as_mut()).is_pending());
+
+    advance_time(deadline).await;
+    gate.release();
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            calls.load(Ordering::SeqCst) == 1
+        })
+        .await
+    );
+    let Poll::Ready(Err(error)) = poll_once(call.as_mut()) else {
+        panic!("promotion must win before deadline withdrawal");
+    };
+    assert_eq!(error.kind, CallErrorKind::ResponseTimedOut);
+    assert_eq!(error.incarnation_observed, Some(accepting));
     system
         .shutdown(Duration::from_secs(1))
         .await

--- a/crates/shelterwood/tests/rebind.rs
+++ b/crates/shelterwood/tests/rebind.rs
@@ -141,48 +141,41 @@ async fn rebind_refreshes_all_overflow_waiter_incarnation_evidence() {
         .expect("first incarnation queue fills");
     let width = Duration::from_secs(10);
 
-    let promoted_actor = actor.clone();
-    let promoted = tokio::spawn(async move {
-        promoted_actor
-            .send_timeout(EvidenceMessage::Value, width)
-            .await
-    });
-    tokio::task::yield_now().await;
-    let overflow_actor = actor.clone();
-    let overflow = tokio::spawn(async move {
-        overflow_actor
-            .send_timeout(EvidenceMessage::Value, width)
-            .await
-    });
-    tokio::task::yield_now().await;
-    let call_actor = actor.clone();
-    let call = tokio::spawn(async move { call_actor.call(EvidenceMessage::Ask, width).await });
-    tokio::task::yield_now().await;
-    assert!(!promoted.is_finished());
-    assert!(!overflow.is_finished());
-    assert!(!call.is_finished());
+    let mut promoted = Box::pin(actor.send_timeout(EvidenceMessage::Value, width));
+    let mut overflow = Box::pin(actor.send_timeout(EvidenceMessage::Value, width));
+    let mut call = Box::pin(actor.call(EvidenceMessage::Ask, width));
+    assert!(poll_once(promoted.as_mut()).is_pending());
+    assert!(poll_once(overflow.as_mut()).is_pending());
+    assert!(poll_once(call.as_mut()).is_pending());
 
     fail_first.release();
-    let replacement = promoted
+    let mut replacement = None;
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            if let std::task::Poll::Ready(result) = poll_once(promoted.as_mut()) {
+                replacement = Some(result.expect("first waiter enters replacement capacity"));
+                true
+            } else {
+                false
+            }
+        })
         .await
-        .expect("promoted send task joins")
-        .expect("first waiter enters replacement capacity");
+    );
+    let replacement = replacement.expect("replacement bind promotes the first waiter");
     assert!(replacement.supersedes(first));
     assert_eq!(factories.load(Ordering::SeqCst), 2);
-    assert!(!overflow.is_finished());
-    assert!(!call.is_finished());
+    assert!(poll_once(overflow.as_mut()).is_pending());
+    assert!(poll_once(call.as_mut()).is_pending());
 
     tokio::time::advance(width).await;
-    let send_error = overflow
-        .await
-        .expect("overflow send task joins")
-        .expect_err("overflow send times out");
+    let std::task::Poll::Ready(Err(send_error)) = poll_once(overflow.as_mut()) else {
+        panic!("overflow send times out");
+    };
     assert_eq!(send_error.kind, SendErrorKind::TimedOut);
     assert_eq!(send_error.incarnation_observed, Some(replacement));
-    let call_error = call
-        .await
-        .expect("overflow call task joins")
-        .expect_err("overflow call times out before acceptance");
+    let std::task::Poll::Ready(Err(call_error)) = poll_once(call.as_mut()) else {
+        panic!("overflow call times out before acceptance");
+    };
     assert_eq!(call_error.kind, CallErrorKind::AcceptanceTimedOut);
     assert_eq!(call_error.incarnation_observed, Some(replacement));
 

--- a/crates/shelterwood/tests/rebind.rs
+++ b/crates/shelterwood/tests/rebind.rs
@@ -10,8 +10,8 @@ use crate::common::{
     DestructorBlocker, DestructorGate, ReleaseGate, policy::never, poll_once, poll_until,
 };
 use shelterwood::{
-    Backoff, ExitError, ExitResult, Jitter, Mailbox, RawActor, RawContext, RawDef,
-    RestartCondition, RestartPolicy, SendErrorKind, Tree,
+    Backoff, CallErrorKind, ExitError, ExitResult, Jitter, Mailbox, RawActor, RawContext, RawDef,
+    Reply, RestartCondition, RestartPolicy, SendErrorKind, Tree,
 };
 
 struct RestartActor {
@@ -66,11 +66,131 @@ fn restarting_definition(
     .restart(restart)
 }
 
+enum EvidenceMessage {
+    Value,
+    Ask(Reply<usize>),
+}
+
+struct EvidenceRestartActor {
+    generation: usize,
+    fail_first: ReleaseGate,
+    hold_replacement: ReleaseGate,
+}
+
+impl RawActor for EvidenceRestartActor {
+    type Msg = EvidenceMessage;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        if self.generation == 1 {
+            self.fail_first.wait().await;
+            return Err(ExitError::message("replace first incarnation"));
+        }
+        self.hold_replacement.wait().await;
+        while let Some(message) = context.recv().await {
+            match message {
+                EvidenceMessage::Value => {}
+                EvidenceMessage::Ask(reply) => reply.send(17),
+            }
+        }
+        Ok(())
+    }
+}
+
+fn evidence_restarting_definition(
+    factories: &Arc<AtomicUsize>,
+    fail_first: &ReleaseGate,
+    hold_replacement: &ReleaseGate,
+) -> RawDef<EvidenceRestartActor> {
+    RawDef::factory({
+        let factories = Arc::clone(factories);
+        let fail_first = fail_first.clone();
+        let hold_replacement = hold_replacement.clone();
+        move || EvidenceRestartActor {
+            generation: factories.fetch_add(1, Ordering::SeqCst) + 1,
+            fail_first: fail_first.clone(),
+            hold_replacement: hold_replacement.clone(),
+        }
+    })
+    .mailbox(Mailbox::queue(1).expect("non-zero capacity"))
+    .restart(RestartPolicy::default())
+}
+
 async fn wait_for_destructor(destructor: &DestructorGate) {
     let destructor = destructor.clone();
     tokio::task::spawn_blocking(move || destructor.wait_entered())
         .await
         .expect("destructor waiter joins");
+}
+
+#[tokio::test(start_paused = true)]
+async fn rebind_refreshes_all_overflow_waiter_incarnation_evidence() {
+    let factories = Arc::new(AtomicUsize::new(0));
+    let fail_first = ReleaseGate::default();
+    let hold_replacement = ReleaseGate::default();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw(
+            "evidence-worker",
+            evidence_restarting_definition(&factories, &fail_first, &hold_replacement),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("first actor starts");
+    let first = actor
+        .try_send(EvidenceMessage::Value)
+        .expect("first incarnation queue fills");
+    let width = Duration::from_secs(10);
+
+    let promoted_actor = actor.clone();
+    let promoted = tokio::spawn(async move {
+        promoted_actor
+            .send_timeout(EvidenceMessage::Value, width)
+            .await
+    });
+    tokio::task::yield_now().await;
+    let overflow_actor = actor.clone();
+    let overflow = tokio::spawn(async move {
+        overflow_actor
+            .send_timeout(EvidenceMessage::Value, width)
+            .await
+    });
+    tokio::task::yield_now().await;
+    let call_actor = actor.clone();
+    let call = tokio::spawn(async move { call_actor.call(EvidenceMessage::Ask, width).await });
+    tokio::task::yield_now().await;
+    assert!(!promoted.is_finished());
+    assert!(!overflow.is_finished());
+    assert!(!call.is_finished());
+
+    fail_first.release();
+    let replacement = promoted
+        .await
+        .expect("promoted send task joins")
+        .expect("first waiter enters replacement capacity");
+    assert!(replacement.supersedes(first));
+    assert_eq!(factories.load(Ordering::SeqCst), 2);
+    assert!(!overflow.is_finished());
+    assert!(!call.is_finished());
+
+    tokio::time::advance(width).await;
+    let send_error = overflow
+        .await
+        .expect("overflow send task joins")
+        .expect_err("overflow send times out");
+    assert_eq!(send_error.kind, SendErrorKind::TimedOut);
+    assert_eq!(send_error.incarnation_observed, Some(replacement));
+    let call_error = call
+        .await
+        .expect("overflow call task joins")
+        .expect_err("overflow call times out before acceptance");
+    assert_eq!(call_error.kind, CallErrorKind::AcceptanceTimedOut);
+    assert_eq!(call_error.incarnation_observed, Some(replacement));
+
+    hold_replacement.release();
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("actor stops");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]


### PR DESCRIPTION
Part of #35 (item 3)

## Summary

- Record each bind or rebind incarnation on every live parked mailbox operation, including FIFO overflow that cannot yet be promoted.
- Preserve timeout-versus-promotion consistency through the mailbox/operation lock ordering.
- Add deterministic coverage for capacity-one pre-bind overflow, rebind overflow, `send_timeout`, `call`, and deadline/promotion races.

## Why

Binding previously updated incarnation evidence only for waiters promoted into available capacity. Operations that remained parked could therefore time out with `None` or an older incarnation even though they stayed pending through a newer bind.

## Validation

- `./scripts/dev cargo test -p shelterwood --test integration` (161 passed)
- `./scripts/dev just ci` (210 tests passed; formatting, Clippy, docs, API/runtime/exit path checks, and Nix formatting all passed)

