### PR TITLE
Simplify duplicated supervision scaffolding

### DIFF
--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -368,51 +368,51 @@ impl<A: Actor> RawActor for Handler<A> {
             raw.mark_ready();
         }
 
-        loop {
+        let live_failure = loop {
             let received = CatchUnwindFuture::new(raw.recv()).await;
             let message = match received {
                 Ok(Some(message)) => message,
-                Ok(None) => break,
+                Ok(None) => break None,
                 Err(payload) => resume_unwind(payload),
             };
-            let handled = {
-                let actor = self
-                    .actor
-                    .as_mut()
-                    .expect("initialized handler retains its actor");
-                let mut context = Context::<A>::new(raw, false);
-                CatchUnwindFuture::new(actor.handle(message, &mut context)).await
-            };
-            match handled {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) => return fail_after_teardown(raw, error).await,
-                Err(payload) => resume_unwind(payload),
+            let actor = self
+                .actor
+                .as_mut()
+                .expect("initialized handler retains its actor");
+            if let Err(failure) = handle_message(actor, raw, message, false).await {
+                break Some(failure);
             }
-        }
+        };
 
-        match raw.mailbox_shutdown() {
-            MailboxShutdown::Drain => {
+        let failure = match (live_failure, raw.mailbox_shutdown()) {
+            (Some(failure), _) => Some(failure),
+            (None, MailboxShutdown::Drain) => {
+                let mut failure = None;
                 while let Some(message) = raw.try_recv() {
-                    let handled = {
-                        let actor = self
-                            .actor
-                            .as_mut()
-                            .expect("initialized handler retains its actor");
-                        let mut context = Context::<A>::new(raw, true);
-                        CatchUnwindFuture::new(actor.handle(message, &mut context)).await
-                    };
-                    match handled {
-                        Ok(Ok(())) => {}
-                        Ok(Err(error)) => return fail_after_teardown(raw, error).await,
-                        Err(payload) => resume_unwind(payload),
+                    let actor = self
+                        .actor
+                        .as_mut()
+                        .expect("initialized handler retains its actor");
+                    if let Err(current) = handle_message(actor, raw, message, true).await {
+                        failure = Some(current);
+                        break;
                     }
                 }
+                failure
             }
-            MailboxShutdown::Discard => {
+            (None, MailboxShutdown::Discard) => {
                 while let Some(message) = raw.try_recv() {
                     drop(message);
                 }
+                None
             }
+        };
+
+        if let Some(failure) = failure {
+            return match failure {
+                HandlerFailure::Returned(error) => fail_after_teardown(raw, error).await,
+                HandlerFailure::Panicked(payload) => resume_unwind(payload),
+            };
         }
 
         let mut context = StopContext::<A>::new(raw);
@@ -424,6 +424,25 @@ impl<A: Actor> RawActor for Handler<A> {
             resume_unwind(payload);
         }
         Ok(())
+    }
+}
+
+enum HandlerFailure {
+    Returned(ExitError),
+    Panicked(Box<dyn std::any::Any + Send + 'static>),
+}
+
+async fn handle_message<A: Actor>(
+    actor: &mut A,
+    raw: &mut RawContext<A::Msg>,
+    message: A::Msg,
+    draining: bool,
+) -> Result<(), HandlerFailure> {
+    let mut context = Context::<A>::new(raw, draining);
+    match CatchUnwindFuture::new(actor.handle(message, &mut context)).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(HandlerFailure::Returned(error)),
+        Err(payload) => Err(HandlerFailure::Panicked(payload)),
     }
 }
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -740,9 +740,10 @@ impl ScopeCell {
         self.emit_locked(event);
     }
 
-    pub(crate) fn schedule_child_restart(
+    pub(crate) fn publish_child_restart(
         &self,
         member: &MemberCell,
+        total_restarts: u64,
         update: impl FnOnce(&mut MemberRecord),
         exited: LifecycleEventKind,
         scheduled: LifecycleEventKind,
@@ -751,7 +752,7 @@ impl ScopeCell {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.record.send_modify(|scope| {
-            scope.total_restarts = scope.total_restarts.saturating_add(1);
+            scope.total_restarts = total_restarts;
         });
         member.update_locked(update);
         self.emit_locked(exited);
@@ -1843,6 +1844,72 @@ impl ChildRuntime {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StartupPhase {
+    Pending,
+    Complete,
+    Failed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Driver-loop lifecycle state. `ScopeRecord` remains the observation projection and
+/// `ScopeControl` remains the epoch-tagged request plane; neither duplicates these phases.
+enum ScopePhase {
+    Starting,
+    Running,
+    StartupFailed,
+    Draining {
+        reason: StopReason,
+        startup: StartupPhase,
+    },
+}
+
+impl ScopePhase {
+    fn startup_complete(&self) -> bool {
+        matches!(
+            self,
+            Self::Running
+                | Self::Draining {
+                    startup: StartupPhase::Complete,
+                    ..
+                }
+        )
+    }
+
+    fn startup_failed(&self) -> bool {
+        matches!(
+            self,
+            Self::StartupFailed
+                | Self::Draining {
+                    startup: StartupPhase::Failed,
+                    ..
+                }
+        )
+    }
+
+    fn is_draining(&self) -> bool {
+        matches!(self, Self::Draining { .. })
+    }
+
+    fn draining_reason(&self) -> Option<&StopReason> {
+        match self {
+            Self::Draining { reason, .. } => Some(reason),
+            Self::Starting | Self::Running | Self::StartupFailed => None,
+        }
+    }
+
+    fn begin_drain(&mut self, reason: StopReason) -> bool {
+        let startup = match self {
+            Self::Starting => StartupPhase::Pending,
+            Self::Running => StartupPhase::Complete,
+            Self::StartupFailed => StartupPhase::Failed,
+            Self::Draining { .. } => return false,
+        };
+        *self = Self::Draining { reason, startup };
+        true
+    }
+}
+
 struct ScopeRuntime {
     root: Arc<ScopeCell>,
     flavor: ScopeFlavor,
@@ -1853,10 +1920,8 @@ struct ScopeRuntime {
     events: runtime::MpscSender<DriverEvent>,
     deadlines: DeadlineQueue<DeadlineKind>,
     jitter: runtime::JitterRng,
-    startup_complete: bool,
-    startup_failed: bool,
+    phase: ScopePhase,
     next_ordered_start: usize,
-    draining: Option<StopReason>,
     is_root: bool,
     parent_ready: Option<Latch>,
     dynamic: Option<Arc<DynamicControl>>,
@@ -1910,7 +1975,7 @@ impl Drop for ScopeRuntime {
             let reason = completion
                 .as_ref()
                 .map(|completion| completion.reason.clone())
-                .or_else(|| self.draining.clone())
+                .or_else(|| self.phase.draining_reason().cloned())
                 .unwrap_or(StopReason::ShutdownRequested);
             if let Some(exit) = completion.and_then(|completion| completion.root_exit) {
                 self.root.finish_root_incarnation(self.epoch, reason, exit);
@@ -1942,7 +2007,7 @@ enum SpawnBody {
 
 impl ScopeRuntime {
     fn spawn_child(&mut self, index: usize) {
-        if self.draining.is_some() || self.children[index].is_terminal() {
+        if self.phase.is_draining() || self.children[index].is_terminal() {
             return;
         }
         let child = &mut self.children[index];
@@ -1961,18 +2026,18 @@ impl ScopeRuntime {
                 MemberStage::Terminal(exit) => exit,
                 _ => Exit::never_started(),
             };
-            let pre_ready = child.initial && !self.startup_complete && !child.initial_ready;
+            let pre_ready = child.initial && !self.phase.startup_complete() && !child.initial_ready;
             let removing = child.slot.member.record().removing;
             let retention_remove = child.options.retention == crate::Retention::Remove;
             if removing {
                 self.finalize_removal(index);
-            } else if pre_ready && self.draining.is_none() {
+            } else if pre_ready && !self.phase.is_draining() {
                 self.fail_startup(index, exit);
             } else {
                 if retention_remove {
                     self.prune_terminal(index);
                 }
-                if self.draining.is_some() {
+                if self.phase.is_draining() {
                     self.stop_next_ordered();
                 }
             }
@@ -2275,7 +2340,7 @@ impl ScopeRuntime {
     }
 
     fn progress_startup(&mut self) {
-        if self.startup_complete || self.startup_failed || self.draining.is_some() {
+        if self.phase != ScopePhase::Starting {
             return;
         }
         match self.flavor {
@@ -2314,7 +2379,7 @@ impl ScopeRuntime {
     }
 
     fn complete_startup(&mut self) {
-        self.startup_complete = true;
+        self.phase = ScopePhase::Running;
         self.root.set_state(ScopeState::Running);
         self.root.set_startup(Ok(()));
         if let Some(parent_ready) = &self.parent_ready {
@@ -2421,13 +2486,13 @@ impl ScopeRuntime {
     }
 
     fn begin_drain(&mut self, reason: StopReason) {
-        if self.draining.is_some() {
+        let startup_pending = self.phase == ScopePhase::Starting;
+        if !self.phase.begin_drain(reason) {
             return;
         }
-        if !self.startup_complete && !self.startup_failed {
+        if startup_pending {
             self.root.set_startup(Err(StartupError::ShutdownRequested));
         }
-        self.draining = Some(reason);
         self.root.set_state(ScopeState::Draining);
         match self.flavor {
             ScopeFlavor::Ordered => self.stop_next_ordered(),
@@ -2440,7 +2505,7 @@ impl ScopeRuntime {
     }
 
     fn stop_next_ordered(&mut self) {
-        if self.flavor != ScopeFlavor::Ordered || self.draining.is_none() {
+        if self.flavor != ScopeFlavor::Ordered || !self.phase.is_draining() {
             return;
         }
         loop {
@@ -2458,7 +2523,7 @@ impl ScopeRuntime {
     }
 
     fn force_all(&mut self) {
-        if self.draining.is_none() {
+        if !self.phase.is_draining() {
             self.begin_drain(StopReason::ShutdownRequested);
         }
         let now = runtime::now();
@@ -2496,7 +2561,7 @@ impl ScopeRuntime {
             if readiness == Readiness::Immediate {
                 active.readiness = ReadinessGate::Immediate;
                 active.ready_signal.fire();
-                if !self.startup_complete {
+                if !self.phase.startup_complete() {
                     child.initial_ready = true;
                 }
                 self.root.transition_child(
@@ -2543,7 +2608,7 @@ impl ScopeRuntime {
         {
             return;
         }
-        if !self.startup_complete {
+        if !self.phase.startup_complete() {
             child.initial_ready = true;
         }
         self.root.transition_child(
@@ -2600,7 +2665,7 @@ impl ScopeRuntime {
             child.restarts.settled();
         }
 
-        let mode = if self.draining.is_some() {
+        let mode = if self.phase.is_draining() {
             ScopeMode::Draining
         } else {
             ScopeMode::Running
@@ -2616,13 +2681,14 @@ impl ScopeRuntime {
                 // membership failed before its *initial* readiness edge. A
                 // later incarnation stopped pre-ready (e.g. during drain)
                 // does not rewind it.
-                let pre_ready = child.initial && !self.startup_complete && !child.initial_ready;
+                let pre_ready =
+                    child.initial && !self.phase.startup_complete() && !child.initial_ready;
                 child.terminalize(&self.root, exit.clone(), Some(incarnation), pre_ready);
                 child.construction.take();
                 let removing = child.slot.member.record().removing;
                 if removing {
                     self.finalize_removal(index);
-                } else if pre_ready && self.draining.is_none() {
+                } else if pre_ready && !self.phase.is_draining() {
                     self.fail_startup(index, exit);
                     if self.children[index].options.retention == crate::Retention::Remove {
                         self.prune_terminal(index);
@@ -2631,18 +2697,17 @@ impl ScopeRuntime {
                     if child.options.retention == crate::Retention::Remove {
                         self.prune_terminal(index);
                     }
-                    if self.draining.is_some() {
+                    if self.phase.is_draining() {
                         self.stop_next_ordered();
                     }
                 }
             }
             ExitDispatch::ScheduleRestart => {
-                if !self.startup_complete {
+                if !self.phase.startup_complete() {
                     child.initial_ready = false;
                 }
                 let sample = self.jitter.sample(0..u64::MAX) as f64 / u64::MAX as f64;
                 let now = runtime::now();
-                let mut effects = Vec::new();
                 let decision = schedule_restart(
                     &mut child.restarts,
                     &mut self.intensity,
@@ -2650,33 +2715,18 @@ impl ScopeRuntime {
                     child.options.restart,
                     now,
                     sample,
-                    &mut effects,
                 );
-                debug_assert!(matches!(
-                    effects.first(),
-                    Some(crate::engine::RestartEffect::Scheduled { .. })
-                ));
-                let scheduled_at = match effects.first() {
-                    Some(crate::engine::RestartEffect::Scheduled { restart_at, .. }) => *restart_at,
-                    Some(crate::engine::RestartEffect::IntensityTripped { .. }) | None => {
-                        unreachable!("restart scheduling emits its schedule first")
-                    }
-                };
-                let delay = child
-                    .options
-                    .restart
-                    .backoff()
-                    .next_delay(decision.attempt, sample);
-                self.root.schedule_child_restart(
+                self.root.publish_child_restart(
                     &child.slot.member,
+                    decision.charge.total_restarts,
                     |record| {
                         record.incarnation = None;
                         record.last_exit = Some(exit.clone());
                         record.restart_count = decision.restart_count;
                         // Publish the derived schedule even when intensity
-                        // prevents spawning it. `None` then remains reserved
-                        // for an unrepresentable clock deadline.
-                        record.restart_at = scheduled_at;
+                        // prevents spawning it. `None` remains reserved for
+                        // an unrepresentable clock deadline.
+                        record.restart_at = decision.restart_at;
                         record.stage = MemberStage::Restarting;
                     },
                     LifecycleEventKind::Exited {
@@ -2689,7 +2739,7 @@ impl ScopeRuntime {
                         id: child.slot.member.id().clone(),
                         membership: child.slot.member.membership(),
                         attempt: decision.attempt,
-                        delay,
+                        delay: decision.delay,
                     },
                 );
                 if decision.charge.tripped {
@@ -2698,7 +2748,7 @@ impl ScopeRuntime {
                         observed_restarts: decision.charge.in_window,
                         within: self.intensity_policy.within,
                     };
-                    if !self.startup_complete && !self.startup_failed {
+                    if self.phase == ScopePhase::Starting {
                         self.root
                             .set_startup(Err(StartupError::IntensityTripped(trip.clone())));
                     }
@@ -2722,7 +2772,7 @@ impl ScopeRuntime {
                 exit,
             },
         };
-        self.startup_failed = true;
+        self.phase = ScopePhase::StartupFailed;
         self.root
             .set_startup(Err(StartupError::StartupFailed(failure.clone())));
         if self.flavor == ScopeFlavor::Ordered {
@@ -2789,13 +2839,13 @@ impl ScopeRuntime {
     }
 
     fn finish_if_ready(&mut self) -> Option<StopReason> {
-        if let Some(reason) = &self.draining {
+        if let Some(reason) = self.phase.draining_reason() {
             if self.children.iter().all(ChildRuntime::is_terminal) {
                 return Some(reason.clone());
             }
             return None;
         }
-        if !self.startup_failed
+        if !self.phase.startup_failed()
             && self.flavor == ScopeFlavor::Ordered
             && !self.children.is_empty()
             && self.children.iter().all(ChildRuntime::is_terminal)
@@ -2814,13 +2864,13 @@ impl ScopeRuntime {
             .dynamic
             .as_ref()
             .is_none_or(|current| !Arc::ptr_eq(current, &control))
-            || self.draining.is_some()
-            || self.startup_failed
+            || self.phase.is_draining()
+            || self.phase.startup_failed()
         {
             cancel_dynamic_reservation(&control, &request.slot);
-            let cause = if self.draining.is_some() {
+            let cause = if self.phase.is_draining() {
                 NotAdmittingCause::Draining
-            } else if self.startup_failed {
+            } else if self.phase.startup_failed() {
                 NotAdmittingCause::StartupFailed
             } else {
                 NotAdmittingCause::NoLiveIncarnation
@@ -3125,10 +3175,8 @@ async fn run_scope_incarnation(
         events,
         deadlines: DeadlineQueue::default(),
         jitter: runtime::JitterRng::from_system_entropy(),
-        startup_complete: false,
-        startup_failed: false,
+        phase: ScopePhase::Starting,
         next_ordered_start: 0,
-        draining: None,
         is_root,
         parent_ready,
         dynamic,
@@ -3372,9 +3420,28 @@ mod tests {
 
     use super::{
         DynamicControl, DynamicEntry, MemberCell, MemberStage, Obligation, RemovalResponses,
-        ScopeCell, ScopeFlavor, complete_removals, mint_child_incarnation, report_channel,
-        run_nested_tree, run_scope_incarnation,
+        ScopeCell, ScopeFlavor, ScopePhase, StartupPhase, complete_removals,
+        mint_child_incarnation, report_channel, run_nested_tree, run_scope_incarnation,
     };
+
+    #[test]
+    fn scope_phase_preserves_startup_status_while_draining() {
+        for (mut phase, startup) in [
+            (ScopePhase::Starting, StartupPhase::Pending),
+            (ScopePhase::Running, StartupPhase::Complete),
+            (ScopePhase::StartupFailed, StartupPhase::Failed),
+        ] {
+            assert!(phase.begin_drain(StopReason::ShutdownRequested));
+            assert_eq!(
+                phase,
+                ScopePhase::Draining {
+                    reason: StopReason::ShutdownRequested,
+                    startup,
+                }
+            );
+            assert!(!phase.begin_drain(StopReason::Finished));
+        }
+    }
 
     #[test]
     fn owned_report_token_consumes_or_falls_back_once() {

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -10,16 +10,6 @@ use crate::{
     Exit, Intensity, RestartPolicy, Shutdown, deadline::Deadline, policy::tidy_abort_beat,
 };
 
-pub(crate) trait EffectSink<E> {
-    fn emit(&mut self, effect: E);
-}
-
-impl<E> EffectSink<E> for Vec<E> {
-    fn emit(&mut self, effect: E) {
-        self.push(effect);
-    }
-}
-
 /// Deterministic priority when one driver wake exposes several events.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) enum ArbitrationClass {
@@ -204,26 +194,14 @@ impl RestartState {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum RestartEffect {
-    Scheduled {
-        attempt: u64,
-        restart_count: u64,
-        total_restarts: u64,
-        restart_at: Option<Instant>,
-    },
-    IntensityTripped {
-        in_window: u64,
-        total_restarts: u64,
-    },
-}
-
+/// Complete restart verdict consumed verbatim by the scope driver.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct RestartDecision {
     pub(crate) attempt: u64,
     pub(crate) restart_count: u64,
-    pub(crate) charge: IntensityCharge,
+    pub(crate) delay: Duration,
     pub(crate) restart_at: Option<Instant>,
+    pub(crate) charge: IntensityCharge,
 }
 
 pub(crate) fn schedule_restart(
@@ -233,29 +211,17 @@ pub(crate) fn schedule_restart(
     restart_policy: RestartPolicy,
     now: Instant,
     jitter_sample: f64,
-    effects: &mut impl EffectSink<RestartEffect>,
 ) -> RestartDecision {
     let (attempt, restart_count) = restarts.schedule();
     let delay = restart_policy.backoff().next_delay(attempt, jitter_sample);
     let restart_at = Deadline::after(now, delay).instant();
     let charge = intensity.charge(intensity_policy, now);
-    effects.emit(RestartEffect::Scheduled {
-        attempt,
-        restart_count,
-        total_restarts: charge.total_restarts,
-        restart_at,
-    });
-    if charge.tripped {
-        effects.emit(RestartEffect::IntensityTripped {
-            in_window: charge.in_window,
-            total_restarts: charge.total_restarts,
-        });
-    }
     RestartDecision {
         attempt,
         restart_count,
+        delay,
+        restart_at,
         charge,
-        restart_at: (!charge.tripped).then_some(restart_at).flatten(),
     }
 }
 
@@ -384,8 +350,8 @@ mod tests {
 
     use super::{
         ArbitrationClass, DeadlineQueue, ExitDispatch, IntensityState, MembershipMode,
-        ReadinessEffect, ReadinessEvent, ReadinessGate, RestartEffect, RestartState, ScopeMode,
-        StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart,
+        ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState, ScopeMode, StopAction,
+        StopLadder, arbitrate, dispatch_exit, schedule_restart,
     };
 
     #[test]
@@ -493,13 +459,12 @@ mod tests {
     }
 
     #[test]
-    fn over_budget_restart_emits_schedule_before_trip_and_has_no_spawn_deadline() {
+    fn restart_decision_owns_the_backoff_and_intensity_verdict() {
         let now = Instant::now();
         let intensity_policy = Intensity::new(0, Duration::from_secs(10)).expect("valid intensity");
         let restart_policy = RestartPolicy::new(RestartCondition::OnFailure, Backoff::Immediate);
         let mut restarts = RestartState::new();
         let mut intensity = IntensityState::default();
-        let mut effects = Vec::new();
         let decision = schedule_restart(
             &mut restarts,
             &mut intensity,
@@ -507,22 +472,14 @@ mod tests {
             restart_policy,
             now,
             0.5,
-            &mut effects,
         );
 
         assert_eq!(decision.attempt, 1);
         assert_eq!(decision.restart_count, 1);
+        assert_eq!(decision.delay, Duration::ZERO);
+        assert_eq!(decision.restart_at, Some(now));
         assert_eq!(decision.charge.total_restarts, 1);
         assert!(decision.charge.tripped);
-        assert_eq!(decision.restart_at, None);
-        assert!(matches!(
-            effects[0],
-            RestartEffect::Scheduled {
-                restart_at: Some(restart_at),
-                ..
-            } if restart_at == now
-        ));
-        assert!(matches!(effects[1], RestartEffect::IntensityTripped { .. }));
     }
 
     #[test]
@@ -535,8 +492,6 @@ mod tests {
         );
         let mut restarts = RestartState::new();
         let mut intensity = IntensityState::default();
-        let mut effects = Vec::new();
-
         let decision = schedule_restart(
             &mut restarts,
             &mut intensity,
@@ -544,17 +499,9 @@ mod tests {
             restart_policy,
             now,
             0.5,
-            &mut effects,
         );
 
         assert_eq!(decision.restart_at, None);
-        assert!(matches!(
-            effects[0],
-            RestartEffect::Scheduled {
-                restart_at: None,
-                ..
-            }
-        ));
     }
 
     #[test]

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -6,9 +6,17 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
+#[cfg(test)]
+use std::cell::Cell;
+
 use crate::ChildId;
 
 static NEXT_LINEAGE: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(test)]
+thread_local! {
+    static CURRENT_THREAD_SCOPE_CREATIONS: Cell<u64> = const { Cell::new(0) };
+}
 
 /// A child's identity within one supervising scope.
 ///
@@ -125,6 +133,10 @@ pub(crate) struct ScopeIdentity {
 
 impl ScopeIdentity {
     pub(crate) fn new() -> Option<Self> {
+        #[cfg(test)]
+        CURRENT_THREAD_SCOPE_CREATIONS.with(|creations| {
+            creations.set(creations.get().saturating_add(1));
+        });
         Some(Self {
             memberships: HashMap::new(),
         })
@@ -139,6 +151,11 @@ impl ScopeIdentity {
             .ok()?
             + 1;
         Some(FenceCounter::new(lineage))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_thread_creations() -> u64 {
+        CURRENT_THREAD_SCOPE_CREATIONS.with(Cell::get)
     }
 
     #[cfg(test)]

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1394,6 +1394,38 @@ impl<M, T> fmt::Debug for CallFuture<M, T> {
     }
 }
 
+impl<M, T> CallFuture<M, T> {
+    fn poll_reply(
+        &self,
+        context: &mut Context<'_>,
+        incarnation: Incarnation,
+        deadline_elapsed: bool,
+    ) -> Poll<Result<Replied<T>, CallError>> {
+        let reply = self
+            .reply
+            .as_ref()
+            .expect("accepted call retains reply state");
+        match reply.poll(context) {
+            Poll::Ready(Ok(value)) => Poll::Ready(Ok(Replied { value, incarnation })),
+            Poll::Ready(Err(ReplyError::Dropped)) => Poll::Ready(Err(CallError {
+                actor_id: self.actor.id().clone(),
+                incarnation_observed: Some(incarnation),
+                kind: CallErrorKind::ReplyDropped,
+            })),
+            Poll::Ready(Err(ReplyError::Timeout)) => unreachable!(),
+            Poll::Pending if deadline_elapsed => {
+                reply.close_receiver();
+                Poll::Ready(Err(CallError {
+                    actor_id: self.actor.id().clone(),
+                    incarnation_observed: Some(incarnation),
+                    kind: CallErrorKind::ResponseTimedOut,
+                }))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
 impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
     type Output = Result<Replied<T>, CallError>;
 
@@ -1458,30 +1490,11 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
             }
         }
 
-        if let Some(accepted) = self.accepted {
-            let reply = self
-                .reply
-                .as_ref()
-                .expect("accepted call retains reply state");
-            match reply.poll(context) {
-                Poll::Ready(Ok(value)) => {
-                    self.done = true;
-                    return Poll::Ready(Ok(Replied {
-                        value,
-                        incarnation: accepted,
-                    }));
-                }
-                Poll::Ready(Err(ReplyError::Dropped)) => {
-                    self.done = true;
-                    return Poll::Ready(Err(CallError {
-                        actor_id: self.actor.id().clone(),
-                        incarnation_observed: Some(accepted),
-                        kind: CallErrorKind::ReplyDropped,
-                    }));
-                }
-                Poll::Ready(Err(ReplyError::Timeout)) => unreachable!(),
-                Poll::Pending => {}
-            }
+        if let Some(accepted) = self.accepted
+            && let Poll::Ready(result) = self.poll_reply(context, accepted, false)
+        {
+            self.done = true;
+            return Poll::Ready(result);
         }
 
         if self
@@ -1496,37 +1509,9 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
         }
 
         if let Some(accepted) = self.accepted {
-            let reply = self
-                .reply
-                .as_ref()
-                .expect("accepted call retains reply state");
-            match reply.poll(context) {
-                Poll::Ready(Ok(value)) => {
-                    self.done = true;
-                    Poll::Ready(Ok(Replied {
-                        value,
-                        incarnation: accepted,
-                    }))
-                }
-                Poll::Ready(Err(ReplyError::Dropped)) => {
-                    self.done = true;
-                    Poll::Ready(Err(CallError {
-                        actor_id: self.actor.id().clone(),
-                        incarnation_observed: Some(accepted),
-                        kind: CallErrorKind::ReplyDropped,
-                    }))
-                }
-                Poll::Ready(Err(ReplyError::Timeout)) => unreachable!(),
-                Poll::Pending => {
-                    reply.close_receiver();
-                    self.done = true;
-                    Poll::Ready(Err(CallError {
-                        actor_id: self.actor.id().clone(),
-                        incarnation_observed: Some(accepted),
-                        kind: CallErrorKind::ResponseTimedOut,
-                    }))
-                }
-            }
+            let result = self.poll_reply(context, accepted, true);
+            self.done = true;
+            result
         } else {
             let actor_id = self.actor.id().clone();
             let send = self
@@ -1540,29 +1525,9 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
                     kind: CallErrorKind::AcceptanceTimedOut,
                 },
                 Withdrawal::Accepted(incarnation) => {
-                    if let Some(reply) = &self.reply {
-                        match reply.poll(context) {
-                            Poll::Ready(Ok(value)) => {
-                                self.done = true;
-                                return Poll::Ready(Ok(Replied { value, incarnation }));
-                            }
-                            Poll::Ready(Err(ReplyError::Dropped)) => {
-                                self.done = true;
-                                return Poll::Ready(Err(CallError {
-                                    actor_id,
-                                    incarnation_observed: Some(incarnation),
-                                    kind: CallErrorKind::ReplyDropped,
-                                }));
-                            }
-                            Poll::Ready(Err(ReplyError::Timeout)) => unreachable!(),
-                            Poll::Pending => reply.close_receiver(),
-                        }
-                    }
-                    CallError {
-                        actor_id,
-                        incarnation_observed: Some(incarnation),
-                        kind: CallErrorKind::ResponseTimedOut,
-                    }
+                    let result = self.poll_reply(context, incarnation, true);
+                    self.done = true;
+                    return result;
                 }
                 Withdrawal::Terminated { observed, .. } => CallError {
                     actor_id,

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -1581,10 +1581,8 @@ mod sealed {
         type Ref = ScopeRef;
         const FLAVOR: ScopeFlavor = ScopeFlavor::Ordered;
 
-        fn into_core(mut self) -> BuilderCore {
-            let mut replacement = BuilderCore::new(ScopeFlavor::Ordered);
-            replacement.armed = false;
-            std::mem::replace(&mut self.core, replacement)
+        fn into_core(self) -> BuilderCore {
+            self.core
         }
 
         fn make_ref(scope: ScopeRef) -> Self::Ref {
@@ -1596,10 +1594,8 @@ mod sealed {
         type Ref = DynamicScopeRef;
         const FLAVOR: ScopeFlavor = ScopeFlavor::Dynamic;
 
-        fn into_core(mut self) -> BuilderCore {
-            let mut replacement = BuilderCore::new(ScopeFlavor::Dynamic);
-            replacement.armed = false;
-            std::mem::replace(&mut self.core, replacement)
+        fn into_core(self) -> BuilderCore {
+            self.core
         }
 
         fn make_ref(scope: ScopeRef) -> Self::Ref {
@@ -1614,6 +1610,27 @@ pub trait Subtree: sealed::Sealed + fmt::Debug + Send + 'static {}
 impl Subtree for Tree {}
 
 impl Subtree for DynamicTree {}
+
+#[cfg(test)]
+mod tests {
+    use super::{DynamicTree, Tree, sealed::Sealed};
+    use crate::identity::ScopeIdentity;
+
+    #[test]
+    fn subtree_conversion_moves_without_minting_a_phantom_scope() {
+        let tree = Tree::new();
+        let after_tree = ScopeIdentity::current_thread_creations();
+        let core = <Tree as Sealed>::into_core(tree);
+        assert_eq!(ScopeIdentity::current_thread_creations(), after_tree);
+        drop(core);
+
+        let tree = DynamicTree::new();
+        let after_tree = ScopeIdentity::current_thread_creations();
+        let core = <DynamicTree as Sealed>::into_core(tree);
+        assert_eq!(ScopeIdentity::current_thread_creations(), after_tree);
+        drop(core);
+    }
+}
 
 /// A cheap, membership-addressed ordered scope handle.
 #[derive(Clone)]


### PR DESCRIPTION
## Summary

- make the engine's `RestartDecision` the single source of restart attempt, delay, deadline, intensity, and cumulative-count data consumed by the driver
- move ordered and dynamic builders directly when they become subtrees, without allocating, minting, terminalizing, and discarding a replacement root
- funnel callback-handler live/drain verdicts and `CallFuture` reply verdicts through shared transition helpers
- replace `ScopeRuntime`'s synchronized startup/draining booleans and optional reason with one internal `ScopePhase` model

## Why

Item 9 identified implementation-only duplication that made equivalent transitions easier to drift apart. Restart scheduling was the clearest example: the engine calculated a schedule and emitted effects into a vector, while the driver ignored those values and recomputed the delay/deadline. Tree consumption also created a complete rooted builder solely to satisfy `mem::replace`, spending a scope identity and immediately discarding its cells.

The shared helpers retain the existing callback failure/panic and call timeout/race ordering. The lifecycle phase records whether draining began while startup was pending, complete, or failed, so the refactor preserves admission, startup-abort, and completion behavior without parallel fields.

## Prior merged evidence

This diff intentionally does not repeat cleanup that is already on `main`:

- #28 removed the module-wide dead-code allowance, unused runtime wrappers/exit scaffolding, and the resulting `tokio-util` dependency.
- #22 removed the unused direct `slab` declaration.

Those merged PRs satisfy item 9's dead-code and unused-dependency acceptance. This PR completes the remaining scaffolding work.

## Relationship to merged changes

Rebased onto the mainline through #37, #42, and #45. Restart publication uses #37's watch-backed observation record, retains #45's overflow-safe optional deadline, and consumes the scheduler decision as the authoritative attempt, delay, deadline, intensity, and cumulative count.

## Impact

No public API or intended runtime behavior changes. New unit coverage proves subtree conversion mints no phantom scope and that the consolidated lifecycle phase preserves startup status across drain entry.

## Validation

- `./scripts/dev cargo test -p shelterwood --lib` (54 passed)
- `./scripts/dev cargo test -p shelterwood --test integration` (166 passed)
- `./scripts/dev just ci` (222 tests passed; formatting, Clippy with `-D warnings`, docs, API/runtime/exit path checks, and Nix formatting all passed)
- `./scripts/dev just ci-nix` (all clean-Nix checks passed)

Part of #35 (item 9).
