### PR TITLE
Preserve membership supersession across nested scopes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3487,9 +3487,12 @@ least these. Policy/config data additionally follows §1's plain-data rule
 - **Non-owning handles** — `ActorRef<M>`, `TaskRef`, `ScopeRef`,
   `DynamicScopeRef`, snapshot receivers, lifecycle subscriptions:
   `Send + Sync`; the refs additionally cheap `Clone` with `Eq` + `Hash`
-  **by membership identity** — two handles to one membership compare
-  equal and collide as map keys, which is what makes userland
-  registries and routing tables ordinary code.
+  **by slot identity** — two handles to one slot (equivalently, at any
+  instant, to one membership) compare equal and collide as map keys,
+  which is what makes userland registries and routing tables ordinary
+  code. Slot identity is what stays fixed when lowering rebases a
+  rebuilt declaration's membership (§3.4): the token read through the
+  handle refreshes; the handle's map identity MUST NOT change.
 - **Cancellation tokens** (B.9 — `shutdown_token()`, `abort_token()`,
   `run_blocking`'s child token): `Clone + Send + Sync` — they are held
   across awaits inside `Send`-declared callback futures (§4.1) and

--- a/SPEC.md
+++ b/SPEC.md
@@ -321,13 +321,13 @@ error payloads. Both tokens are views of §3.1's one fencing primitive;
 `Incarnation::membership()` projects an incarnation's owning membership,
 and equality between an incarnation's projection and a held membership
 token is the "same slot?" question answered exactly. `supersedes` on
-`Membership` is scope-relative creation order: for two memberships of
-the same scope it answers "was `a` created after `b`" — the
-replacement-detection question of §3.4, meaningful whether or not the id
-was reused — and for tokens of different scopes it is `false` in both
-directions (fail closed, §3.1's rule; never a panic). Equality is exact
-identity; there is deliberately no total `Ord` — cross-scope comparison
-has no meaning.
+`Membership` is replacement order for one child id under one stable owning
+scope: it answers whether `a` is a later membership for the same logical
+slot than `b` (§3.4). Different child ids and different owning scopes are
+incomparable and return `false` in both directions (fail closed, §3.1's
+rule; never a panic). Equality is exact identity; there is deliberately no
+total `Ord` — comparison outside one stable `(scope, child-id)` domain has no
+meaning.
 
 Consequences (normative):
 
@@ -443,9 +443,14 @@ An `ActorRef` follows incarnations of **its** membership, never a same-id
 replacement membership. This boundary is kept (it is what makes identity
 exact), but it MUST be discoverable: removal-then-re-add under the same id
 yields a fresh membership whose handles come from the new insertion, and the
-old handles report terminal. A small routing/registry adapter for planned
-handoff (a `ServiceRef`/route-cell that the application repoints at cutover)
-is non-core (§24) — it must not weaken exact membership identity.
+old handles report terminal. The replacement membership supersedes its
+removed predecessor. The ordering domain belongs to the stable scope cell,
+not to a temporary builder: an initially declared child and its later runtime
+replacement compare, as do corresponding descendants rebuilt across
+incarnations of one nested scope membership. Different ids and different
+owning scope memberships remain incomparable. A small routing/registry adapter
+for planned handoff (a `ServiceRef`/route-cell that the application repoints at
+cutover) is non-core (§24) — it must not weaken exact membership identity.
 
 ## 4. Construction and restart [#360]
 
@@ -2252,12 +2257,16 @@ integration toolkit for the driver shell and the end-to-end invariants.
    child with the same id (and, by construction, colliding internal
    coordinates), then present scope A's handle to scope B and require
    rejection. Replay remove→re-add under one id and assert the stale handle
-   fails while the replacement is untouched. Exhaustion mints nothing
-   (§3.1): drive a counter to saturation and assert no duplicate token
-   is ever issued — an unmintable incarnation terminalizes the
-   membership as under `Never`; an unmintable membership is the
-   enumerated reservation rejection (B.8). The structural half is
-   enforced by API shape (no public bare integers) and review, not tests.
+   fails while the replacement is untouched and supersedes it; assert that
+   different ids and different owning scopes are incomparable. Repeat the
+   ordering check for a declared child replaced at runtime and for a
+   corresponding descendant rebuilt after a nested-scope restart. Exhaustion
+   mints nothing (§3.1): drive a counter to saturation and assert no duplicate
+   token is ever issued — an unmintable incarnation terminalizes the
+   membership as under `Never`; an unmintable membership is the enumerated
+   reservation rejection (B.8), or structured nested-startup provenance when
+   a stable scope cannot rebase a produced declaration. The structural half
+   is enforced by API shape (no public bare integers) and review, not tests.
 5. **One-shot construction drops its resources exactly once across: init
    panic, startup failure, shutdown-before-start, normal exit.** One
    drop-counting guard type owned by the args, four tests asserting exactly
@@ -3472,8 +3481,9 @@ least these. Policy/config data additionally follows §1's plain-data rule
 
 - **Identity tokens** — `Membership`, `Incarnation`: `Copy`, `Eq`,
   `Hash`, `Send`, `Sync`. Ordering is `supersedes` (§3.1–§3.3),
-  deliberately not `Ord`: cross-scope and cross-membership comparison
-  has no meaning and fails closed.
+  deliberately not `Ord`: membership comparison across owning scopes or
+  child ids, and incarnation comparison across memberships, has no meaning
+  and fails closed.
 - **Non-owning handles** — `ActorRef<M>`, `TaskRef`, `ScopeRef`,
   `DynamicScopeRef`, snapshot receivers, lifecycle subscriptions:
   `Send + Sync`; the refs additionally cheap `Clone` with `Eq` + `Hash`

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -3406,6 +3406,41 @@ mod tests {
         assert!(receiver.receive().cancelled);
     }
 
+    #[test]
+    fn handle_identity_is_stable_across_membership_rebase() {
+        fn hashed(value: &impl std::hash::Hash) -> u64 {
+            use std::hash::Hasher;
+            let mut hasher = std::hash::DefaultHasher::new();
+            value.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let id = ChildId::from("worker");
+        let member = MemberCell::new(
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
+        );
+        let mailbox: Arc<MailboxCell<u8>> = MailboxCell::new(member.id().clone());
+        let actor = ActorRef::new(Arc::clone(&member), mailbox);
+        let peer = actor.clone();
+        let task = crate::TaskRef::new(Arc::clone(&member));
+        let declared = actor.membership();
+        let actor_hash = hashed(&actor);
+        let task_hash = hashed(&task);
+
+        member.rebase_membership(
+            identity
+                .mint_membership(&id)
+                .expect("successor membership available"),
+        );
+
+        assert!(actor.membership().supersedes(declared));
+        assert_eq!(actor, peer);
+        assert_eq!(hashed(&actor), actor_hash);
+        assert_eq!(hashed(&task), task_hash);
+    }
+
     #[crate::runtime::test]
     async fn attaching_after_terminality_closes_the_mailbox() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -34,8 +34,9 @@ use crate::{
     runtime::{self, Latch},
     task::{OnceTaskBody, TaskContext, TaskFactory},
     tree::{
-        BuilderCore, ChildConstruction, ChildPlan, NotAdmittingCause, RemoveOutcome, ReserveError,
-        ScopeFactory, ScopeFlavor, ScopePlan, ScopeSource, SlotCell, StartupError, StopReason,
+        BuilderCore, ChildConstruction, ChildPlan, LowerError, NotAdmittingCause, RemoveOutcome,
+        ReserveError, ScopeFactory, ScopeFlavor, ScopePlan, ScopeSource, SlotCell, StartupError,
+        StopReason,
     },
 };
 
@@ -307,7 +308,7 @@ pub(crate) struct MemberRecord {
 #[derive(Debug)]
 pub(crate) struct MemberCell {
     id: ChildId,
-    membership: Membership,
+    membership: Mutex<Membership>,
     record: runtime::WatchSender<MemberRecord>,
     mailbox: Mutex<MemberMailbox>,
     options: Mutex<Option<crate::policy::ResolvedCommonOptions>>,
@@ -346,7 +347,7 @@ impl MemberCell {
         });
         Arc::new(Self {
             id,
-            membership,
+            membership: Mutex::new(membership),
             record,
             mailbox: Mutex::new(MemberMailbox::default()),
             options: Mutex::new(None),
@@ -359,7 +360,24 @@ impl MemberCell {
     }
 
     pub(crate) fn membership(&self) -> Membership {
-        self.membership
+        *self
+            .membership
+            .lock()
+            .expect("member identity mutex poisoned")
+    }
+
+    pub(crate) fn rebase_membership(&self, membership: Membership) {
+        let record = self.record();
+        assert!(
+            matches!(record.stage, MemberStage::Reserved)
+                && record.incarnation.is_none()
+                && record.last_incarnation.is_none(),
+            "only an unstarted reservation can be rebased"
+        );
+        *self
+            .membership
+            .lock()
+            .expect("member identity mutex poisoned") = membership;
     }
 
     pub(crate) fn record(&self) -> MemberRecord {
@@ -1376,7 +1394,7 @@ pub(crate) fn reserve_dynamic(
         .child_identity
         .lock()
         .expect("scope identity mutex poisoned")
-        .mint_membership()
+        .mint_membership(&id)
         .ok_or(ReserveError::IdentityExhausted)?;
     let member = MemberCell::new(id.clone(), membership);
     let child_scope = child_scope.map(|flavor| {
@@ -2992,9 +3010,14 @@ async fn run_nested_tree(
     let epoch = scope.begin_incarnation();
     let plan = match tree.lower(inherited, Some(Arc::clone(&scope))) {
         Ok(plan) => plan,
-        Err(undefined) => {
+        Err(error) => {
             let failure = StartupFailure {
-                cause: StartupFailureCause::Lowering { undefined },
+                cause: match error {
+                    LowerError::Undefined(undefined) => StartupFailureCause::Lowering { undefined },
+                    LowerError::IdentityExhausted(id) => {
+                        StartupFailureCause::IdentityExhausted { id }
+                    }
+                },
             };
             scope.set_startup(Err(StartupError::StartupFailed(failure.clone())));
             scope.finish_incarnation(epoch, StopReason::StartupFailed(failure.clone()));
@@ -3386,9 +3409,10 @@ mod tests {
     #[crate::runtime::test]
     async fn attaching_after_terminality_closes_the_mailbox() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let id = ChildId::from("worker");
         let member = MemberCell::new(
-            ChildId::from("worker"),
-            identity.mint_membership().expect("membership available"),
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
         );
         let mailbox = MailboxCell::new(member.id().clone());
         let actor = ActorRef::new(Arc::clone(&member), Arc::clone(&mailbox));
@@ -3672,9 +3696,10 @@ mod tests {
     #[test]
     fn terminality_signal_follows_mailbox_termination() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let id = ChildId::from("worker");
         let member = MemberCell::new(
-            ChildId::from("worker"),
-            identity.mint_membership().expect("membership available"),
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
         );
         let mailbox = MailboxCell::new(member.id().clone());
         let actor = ActorRef::new(Arc::clone(&member), Arc::clone(&mailbox));
@@ -3925,10 +3950,11 @@ mod tests {
     #[test]
     fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let root_id = ChildId::from("root");
         let root_member = MemberCell::new(
-            ChildId::from("root"),
+            root_id.clone(),
             identity
-                .mint_membership()
+                .mint_membership(&root_id)
                 .expect("root membership available"),
         );
         let root = ScopeCell::new(
@@ -3936,12 +3962,13 @@ mod tests {
             ScopeFlavor::Dynamic,
             ScopeIdentity::new().expect("child identity available"),
         );
+        let child_id = ChildId::from("worker");
         let member = MemberCell::new(
-            ChildId::from("worker"),
+            child_id.clone(),
             root.child_identity
                 .lock()
                 .expect("scope identity mutex poisoned")
-                .mint_membership()
+                .mint_membership(&child_id)
                 .expect("child membership available"),
         );
         let slot = SlotCell::new(Arc::clone(&member), None);
@@ -4009,8 +4036,9 @@ mod tests {
     #[test]
     fn incarnation_exhaustion_terminalizes_the_membership_as_never_restart() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
-        let membership = identity.mint_membership().expect("membership available");
-        let member = MemberCell::new(ChildId::from("worker"), membership);
+        let id = ChildId::from("worker");
+        let membership = identity.mint_membership(&id).expect("membership available");
+        let member = MemberCell::new(id, membership);
         let previous = Exit::new(
             ExitKind::Failed(ExitError::message("last completed incarnation")),
             false,
@@ -4034,8 +4062,9 @@ mod tests {
     #[crate::runtime::test]
     async fn scope_incarnation_exhaustion_closes_nested_observation() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
-        let membership = identity.mint_membership().expect("membership available");
-        let member = MemberCell::new(ChildId::from("nested"), membership);
+        let id = ChildId::from("nested");
+        let membership = identity.mint_membership(&id).expect("membership available");
+        let member = MemberCell::new(id, membership);
         let scope = ScopeCell::new(
             Arc::clone(&member),
             ScopeFlavor::Ordered,
@@ -4084,8 +4113,9 @@ mod tests {
     #[test]
     fn lifecycle_sequence_exhaustion_poison_is_never_minted_and_becomes_lag() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
-        let membership = identity.mint_membership().expect("membership available");
-        let member = MemberCell::new(ChildId::from("scope"), membership);
+        let id = ChildId::from("scope");
+        let membership = identity.mint_membership(&id).expect("membership available");
+        let member = MemberCell::new(id, membership);
         let scope = ScopeCell::new(
             member,
             ScopeFlavor::Ordered,

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -3346,18 +3346,18 @@ mod tests {
     use crate::{
         ActorRef, ChildId, DynamicTree, Exit, ExitError, ExitKind, LifecycleEventKind,
         LifecycleItem, LifecycleTryRecvError, Readiness, RemoveOutcome, ScopeState, SendErrorKind,
-        StopReason, SubtreeOnceDef, TaskDef, Tree,
+        StartupError, StartupFailureCause, StopReason, SubtreeOnceDef, TaskDef, Tree,
         exit::RecordedOutcome,
         identity::{FenceCounter, ScopeIdentity},
         mailbox::MailboxCell,
         runtime::Latch,
-        tree::{SlotCell, lower_tree_for_test},
+        tree::{SlotCell, into_core_for_test, lower_tree_for_test},
     };
 
     use super::{
         DynamicControl, DynamicEntry, MemberCell, MemberStage, Obligation, RemovalResponses,
         ScopeCell, ScopeFlavor, complete_removals, mint_child_incarnation, report_channel,
-        run_scope_incarnation,
+        run_nested_tree, run_scope_incarnation,
     };
 
     #[test]
@@ -3727,9 +3727,10 @@ mod tests {
     #[test]
     fn mailbox_wake_observes_terminal_record_and_reentrant_terminality_is_idempotent() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let id = ChildId::from("worker");
         let member = MemberCell::new(
-            ChildId::from("worker"),
-            identity.mint_membership().expect("membership available"),
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
         );
         let mailbox = MailboxCell::new(member.id().clone());
         let actor = ActorRef::new(Arc::clone(&member), Arc::clone(&mailbox));
@@ -3767,9 +3768,10 @@ mod tests {
     #[test]
     fn attach_during_terminal_publication_finishes_record_before_mailbox_wake() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let id = ChildId::from("worker");
         let member = MemberCell::new(
-            ChildId::from("worker"),
-            identity.mint_membership().expect("membership available"),
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
         );
         let mailbox = MailboxCell::new(member.id().clone());
         let actor = ActorRef::new(Arc::clone(&member), Arc::clone(&mailbox));
@@ -3811,9 +3813,10 @@ mod tests {
     #[test]
     fn concurrent_terminalizers_return_after_one_consistent_record_is_visible() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let id = ChildId::from("worker");
         let member = MemberCell::new(
-            ChildId::from("worker"),
-            identity.mint_membership().expect("membership available"),
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
         );
         let start = Arc::new(Barrier::new(3));
         let workers = [Exit::never_started(), Exit::new(ExitKind::Completed, false)]
@@ -3843,9 +3846,10 @@ mod tests {
     #[test]
     fn terminal_startup_wake_follows_member_and_incarnation_publication() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let id = ChildId::from("root");
         let member = MemberCell::new(
-            ChildId::from("root"),
-            identity.mint_membership().expect("membership available"),
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
         );
         let scope = ScopeCell::new(
             member,
@@ -3889,9 +3893,10 @@ mod tests {
     #[test]
     fn no_live_root_startup_wake_follows_member_publication() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let id = ChildId::from("root");
         let member = MemberCell::new(
-            ChildId::from("root"),
-            identity.mint_membership().expect("membership available"),
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
         );
         let scope = ScopeCell::new(
             member,
@@ -4057,6 +4062,65 @@ mod tests {
             MemberStage::Terminal(ref exit) if exit == &previous
         ));
         assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+    }
+
+    #[crate::runtime::test]
+    async fn nested_membership_exhaustion_is_structured_and_fail_closed() {
+        let nested_id = ChildId::from("nested");
+        let mut parent_identity = ScopeIdentity::new().expect("parent identity available");
+        let nested_membership = parent_identity
+            .mint_membership(&nested_id)
+            .expect("nested membership available");
+        let nested_member = MemberCell::new(nested_id, nested_membership);
+
+        let worker_id = ChildId::from("worker");
+        let mut child_identity =
+            ScopeIdentity::with_counter(worker_id.clone(), FenceCounter::near_exhaustion(7));
+        child_identity
+            .mint_membership(&worker_id)
+            .expect("last usable membership is minted before the rebuild");
+        let scope = ScopeCell::new(nested_member, ScopeFlavor::Ordered, child_identity);
+
+        let mut tree = Tree::new();
+        let worker = tree
+            .add_task(
+                worker_id.clone(),
+                TaskDef::new(|_| future::pending::<crate::ExitResult>()),
+            )
+            .expect("provisional declaration succeeds");
+        let ready = Latch::default();
+        let error = run_nested_tree(
+            into_core_for_test(tree),
+            Arc::clone(&scope),
+            crate::policy::ResolvedDefaults::default(),
+            ready.clone(),
+            Latch::default(),
+            Latch::default(),
+            Latch::default(),
+        )
+        .await
+        .expect_err("the stable child-id domain is exhausted");
+
+        let failure = error
+            .startup_failure()
+            .expect("framework provenance is retained");
+        assert!(matches!(
+            failure.cause,
+            StartupFailureCause::IdentityExhausted { ref id } if id == &worker_id
+        ));
+        assert!(matches!(
+            scope.record().startup,
+            Some(Err(StartupError::StartupFailed(ref failure)))
+                if matches!(failure.cause, StartupFailureCause::IdentityExhausted { ref id } if id == &worker_id)
+        ));
+        assert!(matches!(
+            scope.record().state,
+            ScopeState::Stopped {
+                reason: StopReason::StartupFailed(_)
+            }
+        ));
+        assert!(!ready.is_fired());
+        assert!(matches!(worker.wait().await.kind(), ExitKind::NeverStarted));
     }
 
     #[crate::runtime::test]

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -163,6 +163,11 @@ pub enum StartupFailureCause {
         /// Undefined child-id paths relative to the subtree root.
         undefined: Vec<Vec<ChildId>>,
     },
+    /// The stable scope could mint no identity for a declared child.
+    IdentityExhausted {
+        /// Child whose stable membership could not be minted.
+        id: ChildId,
+    },
 }
 
 #[derive(Debug)]
@@ -176,6 +181,12 @@ impl fmt::Display for StructuredStartupFailure {
             }
             StartupFailureCause::Lowering { undefined } => {
                 write!(formatter, "subtree has {} undefined slots", undefined.len())
+            }
+            StartupFailureCause::IdentityExhausted { id } => {
+                write!(
+                    formatter,
+                    "membership identity space is exhausted for child `{id}`"
+                )
             }
         }
     }

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -227,7 +227,7 @@ mod tests {
     }
 
     #[test]
-    fn membership_and_incarnation_order_is_scoped() {
+    fn membership_and_incarnation_order_is_scoped_by_owner_and_id() {
         let mut scope = ScopeIdentity::new().expect("scope identity available");
         let id = ChildId::from("worker");
         let first = scope.mint_membership(&id).expect("membership available");
@@ -257,6 +257,45 @@ mod tests {
     }
 
     #[test]
+    fn stable_scope_adopts_the_first_declaration_then_orders_rebuilds() {
+        let id = ChildId::from("worker");
+        let other_id = ChildId::from("other");
+        let mut first_builder = ScopeIdentity::new().expect("builder identity available");
+        let first = first_builder
+            .mint_membership(&id)
+            .expect("first provisional membership available");
+        let other = first_builder
+            .mint_membership(&other_id)
+            .expect("other provisional membership available");
+        let mut rebuilt_builder = ScopeIdentity::new().expect("builder identity available");
+        let rebuilt = rebuilt_builder
+            .mint_membership(&id)
+            .expect("rebuilt provisional membership available");
+
+        let mut stable = ScopeIdentity::new().expect("stable identity available");
+        assert_eq!(
+            stable.adopt_or_mint_membership(&id, first),
+            Some(first),
+            "first lowering preserves pre-spawn identity"
+        );
+        assert_eq!(
+            stable.adopt_or_mint_membership(&other_id, other),
+            Some(other),
+            "each id adopts its own provisional lineage"
+        );
+        let successor = stable
+            .adopt_or_mint_membership(&id, rebuilt)
+            .expect("stable identity mints a rebuilt successor");
+
+        assert!(successor.supersedes(first));
+        assert!(!first.supersedes(successor));
+        assert!(!successor.supersedes(rebuilt));
+        assert!(!rebuilt.supersedes(successor));
+        assert!(!successor.supersedes(other));
+        assert!(!other.supersedes(successor));
+    }
+
+    #[test]
     fn exhaustion_never_mints_the_poison_value_or_a_duplicate() {
         let id = ChildId::from("worker");
         let counter = FenceCounter::near_exhaustion(7);
@@ -271,6 +310,32 @@ mod tests {
         assert_ne!(last, other);
         assert!(!last.supersedes(other));
         assert!(!other.supersedes(last));
+
+        let unrelated = scope
+            .mint_membership(&ChildId::from("other"))
+            .expect("one exhausted id does not poison an unrelated domain");
+        assert!(!unrelated.supersedes(last));
+        assert!(!last.supersedes(unrelated));
+    }
+
+    #[test]
+    fn exhausted_stable_domain_rejects_a_rebuilt_declaration() {
+        let id = ChildId::from("worker");
+        let mut stable = ScopeIdentity::with_counter(id.clone(), FenceCounter::near_exhaustion(7));
+        stable
+            .mint_membership(&id)
+            .expect("last usable stable membership is minted");
+        let mut builder = ScopeIdentity::new().expect("builder identity available");
+        let provisional = builder
+            .mint_membership(&id)
+            .expect("provisional membership available");
+
+        assert_eq!(stable.adopt_or_mint_membership(&id, provisional), None);
+        assert_eq!(stable.adopt_or_mint_membership(&id, provisional), None);
+        assert!(
+            stable.mint_membership(&ChildId::from("other")).is_some(),
+            "exhaustion remains local to one child id"
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -1,11 +1,14 @@
 //! Membership and incarnation identity.
 
 use std::{
+    collections::{HashMap, hash_map::Entry},
     hash::Hash,
     sync::atomic::{AtomicU64, Ordering},
 };
 
-static NEXT_SCOPE: AtomicU64 = AtomicU64::new(0);
+use crate::ChildId;
+
+static NEXT_LINEAGE: AtomicU64 = AtomicU64::new(0);
 
 /// A child's identity within one supervising scope.
 ///
@@ -15,9 +18,11 @@ static NEXT_SCOPE: AtomicU64 = AtomicU64::new(0);
 pub struct Membership(Fence);
 
 impl Membership {
-    /// Returns `true` when `self` was minted after `other` in the same scope.
+    /// Returns `true` when `self` replaced `other` under the same child id and
+    /// stable owning scope.
     ///
-    /// Tokens from different scopes are incomparable and return `false`.
+    /// Tokens for different child ids or owning scopes are incomparable and
+    /// return `false`.
     #[must_use]
     pub fn supersedes(self, other: Self) -> bool {
         self.0.supersedes(other.0)
@@ -115,36 +120,74 @@ impl FenceCounter {
 /// The identity domain owned by one scope membership.
 #[derive(Debug)]
 pub(crate) struct ScopeIdentity {
-    memberships: FenceCounter,
+    memberships: HashMap<ChildId, FenceCounter>,
 }
 
 impl ScopeIdentity {
     pub(crate) fn new() -> Option<Self> {
-        let lineage = NEXT_SCOPE
+        Some(Self {
+            memberships: HashMap::new(),
+        })
+    }
+
+    fn fresh_counter() -> Option<FenceCounter> {
+        let lineage = NEXT_LINEAGE
             .try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
                 let next = current.checked_add(1)?;
                 (next != u64::MAX).then_some(next)
             })
             .ok()?
             + 1;
-        Some(Self {
-            memberships: FenceCounter::new(lineage),
-        })
+        Some(FenceCounter::new(lineage))
     }
 
     #[cfg(test)]
-    pub(crate) fn with_counter(_lineage: u64, memberships: FenceCounter) -> Self {
-        Self { memberships }
+    pub(crate) fn with_counter(id: ChildId, memberships: FenceCounter) -> Self {
+        Self {
+            memberships: HashMap::from([(id, memberships)]),
+        }
     }
 
-    pub(crate) fn mint_membership(&mut self) -> Option<Membership> {
-        self.memberships.mint().map(Membership)
+    pub(crate) fn mint_membership(&mut self, id: &ChildId) -> Option<Membership> {
+        match self.memberships.entry(id.clone()) {
+            Entry::Occupied(mut entry) => entry.get_mut().mint().map(Membership),
+            Entry::Vacant(entry) => {
+                let mut counter = Self::fresh_counter()?;
+                let membership = counter.mint().map(Membership)?;
+                entry.insert(counter);
+                Some(membership)
+            }
+        }
+    }
+
+    /// Reconciles a declaration-time membership with this stable scope.
+    ///
+    /// The first declaration of an id donates its already-minted lineage so
+    /// pre-spawn handles retain their identity. Later declarations of that id
+    /// (including declarations produced after a scope restart) mint from the
+    /// retained counter and therefore supersede their predecessors.
+    pub(crate) fn adopt_or_mint_membership(
+        &mut self,
+        id: &ChildId,
+        provisional: Membership,
+    ) -> Option<Membership> {
+        match self.memberships.entry(id.clone()) {
+            Entry::Occupied(mut entry) => entry.get_mut().mint().map(Membership),
+            Entry::Vacant(entry) => {
+                debug_assert_ne!(provisional.0.generation, u64::MAX);
+                entry.insert(FenceCounter {
+                    lineage: provisional.0.lineage,
+                    current: provisional.0.generation,
+                });
+                Some(provisional)
+            }
+        }
     }
 
     pub(crate) fn incarnation_counter(&self, membership: Membership) -> FenceCounter {
         // The membership's complete fence is compressed into a unique local
         // lineage. The membership scope lineage remains part of the mixing, so
-        // two colliding child ids in different scopes cannot compare equal.
+        // matching child ids in different scopes cannot compare equal.
         //
         // A nested builder mints its public handles before it is attached to
         // the parent scope. Deriving from the membership itself keeps those
@@ -166,14 +209,17 @@ impl ScopeIdentity {
 
 #[cfg(test)]
 mod tests {
+    use crate::ChildId;
+
     use super::{FenceCounter, ScopeIdentity};
 
     #[test]
     fn cross_scope_tokens_fail_closed() {
         let mut left = ScopeIdentity::new().expect("scope identity available");
         let mut right = ScopeIdentity::new().expect("scope identity available");
-        let left_member = left.mint_membership().expect("membership available");
-        let right_member = right.mint_membership().expect("membership available");
+        let id = ChildId::from("worker");
+        let left_member = left.mint_membership(&id).expect("membership available");
+        let right_member = right.mint_membership(&id).expect("membership available");
 
         assert_ne!(left_member, right_member);
         assert!(!left_member.supersedes(right_member));
@@ -183,10 +229,17 @@ mod tests {
     #[test]
     fn membership_and_incarnation_order_is_scoped() {
         let mut scope = ScopeIdentity::new().expect("scope identity available");
-        let first = scope.mint_membership().expect("membership available");
-        let second = scope.mint_membership().expect("membership available");
+        let id = ChildId::from("worker");
+        let first = scope.mint_membership(&id).expect("membership available");
+        let second = scope.mint_membership(&id).expect("membership available");
         assert!(second.supersedes(first));
         assert!(!first.supersedes(second));
+
+        let other = scope
+            .mint_membership(&ChildId::from("other"))
+            .expect("other membership available");
+        assert!(!other.supersedes(first));
+        assert!(!first.supersedes(other));
 
         let mut generations = scope.incarnation_counter(first);
         let a = ScopeIdentity::mint_incarnation(first, &mut generations)
@@ -205,13 +258,14 @@ mod tests {
 
     #[test]
     fn exhaustion_never_mints_the_poison_value_or_a_duplicate() {
+        let id = ChildId::from("worker");
         let counter = FenceCounter::near_exhaustion(7);
-        let mut scope = ScopeIdentity::with_counter(7, counter);
+        let mut scope = ScopeIdentity::with_counter(id.clone(), counter);
         let last = scope
-            .mint_membership()
+            .mint_membership(&id)
             .expect("last usable membership is minted");
-        assert!(scope.mint_membership().is_none());
-        assert!(scope.mint_membership().is_none());
+        assert!(scope.mint_membership(&id).is_none());
+        assert!(scope.mint_membership(&id).is_none());
 
         let other = MembershipFixture::at(7, u64::MAX);
         assert_ne!(last, other);
@@ -222,7 +276,9 @@ mod tests {
     #[test]
     fn incarnation_exhaustion_also_mints_nothing() {
         let mut scope = ScopeIdentity::new().expect("scope identity available");
-        let membership = scope.mint_membership().expect("membership available");
+        let membership = scope
+            .mint_membership(&ChildId::from("worker"))
+            .expect("membership available");
         let mut incarnations = FenceCounter::near_exhaustion(91);
         let last = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
             .expect("last usable incarnation is minted");

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1148,9 +1148,12 @@ impl<M> fmt::Debug for ActorRef<M> {
     }
 }
 
+// Handle identity is the slot cell, not the membership token: lowering a
+// rebuilt nested declaration rebases the token behind live pre-spawn handles,
+// and a token-value hash would strand entries keyed before the rebase.
 impl<M> PartialEq for ActorRef<M> {
     fn eq(&self, other: &Self) -> bool {
-        self.membership() == other.membership()
+        Arc::ptr_eq(&self.member, &other.member)
     }
 }
 
@@ -1158,7 +1161,7 @@ impl<M> Eq for ActorRef<M> {}
 
 impl<M> Hash for ActorRef<M> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.membership().hash(state);
+        Arc::as_ptr(&self.member).hash(state);
     }
 }
 

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1632,9 +1632,10 @@ mod tests {
 
     fn actor() -> (Arc<MailboxCell<u8>>, ActorRef<u8>) {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let id = ChildId::from("actor");
         let member = MemberCell::new(
-            ChildId::from("actor"),
-            identity.mint_membership().expect("membership available"),
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
         );
         let mailbox = MailboxCell::new(member.id().clone());
         member.attach_mailbox(mailbox.clone());
@@ -1662,7 +1663,9 @@ mod tests {
         MailboxControl::configure(&*mailbox, Mailbox::default());
         let mut generations = {
             let mut identity = ScopeIdentity::new().expect("scope identity available");
-            let membership = identity.mint_membership().expect("membership available");
+            let membership = identity
+                .mint_membership(&ChildId::from("actor"))
+                .expect("membership available");
             (membership, identity.incarnation_counter(membership))
         };
         let incarnation = ScopeIdentity::mint_incarnation(generations.0, &mut generations.1)

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -607,7 +607,9 @@ mod tests {
     #[test]
     fn a_retained_event_after_explicit_lag_remains_subject_to_later_overflow() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
-        let membership = identity.mint_membership().expect("membership available");
+        let membership = identity
+            .mint_membership(&crate::ChildId::from("scope"))
+            .expect("membership available");
         let event = |seq| LifecycleEvent {
             scope_path: Vec::new(),
             scope: membership,

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -316,9 +316,12 @@ impl fmt::Debug for TaskRef {
     }
 }
 
+// Handle identity is the slot cell, not the membership token: lowering a
+// rebuilt nested declaration rebases the token behind live pre-spawn handles,
+// and a token-value hash would strand entries keyed before the rebase.
 impl PartialEq for TaskRef {
     fn eq(&self, other: &Self) -> bool {
-        self.membership() == other.membership()
+        Arc::ptr_eq(&self.cell, &other.cell)
     }
 }
 
@@ -326,7 +329,7 @@ impl Eq for TaskRef {}
 
 impl Hash for TaskRef {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.membership().hash(state);
+        Arc::as_ptr(&self.cell).hash(state);
     }
 }
 

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -747,6 +747,11 @@ pub(crate) fn lower_tree_for_test(tree: Tree) -> ScopePlan {
         .expect("test tree must be fully defined")
 }
 
+#[cfg(test)]
+pub(crate) fn into_core_for_test(tree: Tree) -> BuilderCore {
+    tree.core
+}
+
 /// An owned pre-spawn actor slot with a stable mailbox binding.
 pub struct ActorSlot<M> {
     slot: Arc<SlotCell>,

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -1770,9 +1770,12 @@ impl fmt::Debug for ScopeRef {
     }
 }
 
+// Handle identity is the slot cell, not the membership token: lowering a
+// rebuilt nested declaration rebases the token behind live pre-spawn handles,
+// and a token-value hash would strand entries keyed before the rebase.
 impl PartialEq for ScopeRef {
     fn eq(&self, other: &Self) -> bool {
-        self.membership() == other.membership()
+        Arc::ptr_eq(&self.cell, &other.cell)
     }
 }
 
@@ -1780,7 +1783,7 @@ impl Eq for ScopeRef {}
 
 impl Hash for ScopeRef {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.membership().hash(state);
+        Arc::as_ptr(&self.cell).hash(state);
     }
 }
 

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -126,6 +126,12 @@ pub enum BuildError {
     },
 }
 
+#[derive(Debug)]
+pub(crate) enum LowerError {
+    Undefined(Vec<Vec<ChildId>>),
+    IdentityExhausted(ChildId),
+}
+
 /// Outcome of an idempotent dynamic removal.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RemoveOutcome {
@@ -223,12 +229,15 @@ pub(crate) struct BuilderCore {
 
 impl BuilderCore {
     fn new(flavor: ScopeFlavor) -> Self {
-        let mut identity = ScopeIdentity::new().expect("global scope identity space exhausted");
-        let membership = identity
-            .mint_membership()
+        let root_id = ChildId::from("$root");
+        let mut root_identity =
+            ScopeIdentity::new().expect("global scope identity space exhausted");
+        let membership = root_identity
+            .mint_membership(&root_id)
             .expect("fresh scope identity must mint its root membership");
-        let member = MemberCell::new(ChildId::from("$root"), membership);
-        let root = ScopeCell::new(member, flavor, identity);
+        let member = MemberCell::new(root_id, membership);
+        let child_identity = ScopeIdentity::new().expect("global scope identity space exhausted");
+        let root = ScopeCell::new(member, flavor, child_identity);
         Self {
             root,
             flavor,
@@ -253,7 +262,7 @@ impl BuilderCore {
             .child_identity
             .lock()
             .expect("scope identity mutex poisoned")
-            .mint_membership()
+            .mint_membership(&id)
             .ok_or(ReserveError::IdentityExhausted)?;
         let member = MemberCell::new(id.clone(), membership);
         let scope = scope.map(|flavor| {
@@ -270,9 +279,8 @@ impl BuilderCore {
         mut self,
         inherited: ResolvedDefaults,
         root_override: Option<Arc<ScopeCell>>,
-    ) -> Result<ScopePlan, Vec<Vec<ChildId>>> {
+    ) -> Result<ScopePlan, LowerError> {
         let root = root_override.unwrap_or_else(|| Arc::clone(&self.root));
-        root.set_config(self.config.clone());
         let undefined: Vec<_> = self
             .slots
             .iter()
@@ -280,8 +288,23 @@ impl BuilderCore {
             .map(|slot| vec![slot.member.id().clone()])
             .collect();
         if !undefined.is_empty() {
-            return Err(undefined);
+            return Err(LowerError::Undefined(undefined));
         }
+        if !Arc::ptr_eq(&root, &self.root) {
+            let mut identity = root
+                .child_identity
+                .lock()
+                .expect("scope identity mutex poisoned");
+            for slot in &self.slots {
+                let membership = identity
+                    .adopt_or_mint_membership(slot.member.id(), slot.member.membership())
+                    .ok_or_else(|| LowerError::IdentityExhausted(slot.member.id().clone()))?;
+                if membership != slot.member.membership() {
+                    slot.member.rebase_membership(membership);
+                }
+            }
+        }
+        root.set_config(self.config.clone());
         let defaults = inherited.overlay(&self.config.defaults);
         let mut children = Vec::with_capacity(self.slots.len());
         for slot in &self.slots {
@@ -702,7 +725,12 @@ fn spawn_builder<R>(
     let root = Arc::clone(&core.root);
     let plan = core
         .lower(ResolvedDefaults::default(), None)
-        .map_err(|paths| BuildError::UnfilledReservations { paths })?;
+        .map_err(|error| match error {
+            LowerError::Undefined(paths) => BuildError::UnfilledReservations { paths },
+            LowerError::IdentityExhausted(_) => {
+                unreachable!("root lowering does not mint memberships")
+            }
+        })?;
     let scope_ref = ScopeRef { cell: root };
     let run = crate::driver::spawn_system(plan);
     Ok(System {

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -15,8 +15,8 @@ use crate::common::{
 use shelterwood::{
     Actor, ActorOnceDef, Backoff, Context as ActorContext, DynamicTree, ExitError, ExitKind,
     ExitResult, NotAdmittingCause, Readiness, RemoveOutcome, ReserveError, RestartCondition,
-    RestartPolicy, Retention, Shutdown, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef,
-    TaskOnceDef, Tree,
+    RestartPolicy, Retention, SendErrorKind, Shutdown, StopReason, SubtreeDef, SubtreeOnceDef,
+    TaskDef, TaskOnceDef, Tree,
 };
 
 struct DropProbe(Arc<AtomicBool>);
@@ -35,6 +35,21 @@ impl Actor for GatedDynamicActor {
 
     async fn init(gate: Self::Args, _: &mut ActorContext<'_, Self>) -> Result<Self, ExitError> {
         gate.wait().await;
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): (), _: &mut ActorContext<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+}
+
+struct EvidenceActor;
+
+impl Actor for EvidenceActor {
+    type Msg = ();
+    type Args = ();
+
+    async fn init((): (), _: &mut ActorContext<'_, Self>) -> Result<Self, ExitError> {
         Ok(Self)
     }
 
@@ -186,6 +201,53 @@ async fn nested_declared_membership_is_superseded_by_its_runtime_replacement() {
         !unrelated_worker
             .membership()
             .supersedes(replacement.membership())
+    );
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("tree shuts down");
+}
+
+#[tokio::test]
+async fn nested_actor_replacement_keeps_mailbox_evidence_in_each_exact_membership() {
+    let mut nested = DynamicTree::new();
+    let declared = nested
+        .add_actor("worker", shelterwood::ActorDef::<EvidenceActor>::cloned(()))
+        .expect("valid declared actor");
+    let mut root = Tree::new();
+    let nested_scope = root
+        .add_subtree_once("nested", SubtreeOnceDef::new(nested))
+        .expect("valid nested scope");
+    let system = root.spawn().expect("runtime is available");
+    system.wait_started().await.expect("tree starts");
+
+    let declared_incarnation = declared.try_send(()).expect("declared actor accepts");
+    assert_eq!(declared_incarnation.membership(), declared.membership());
+    assert_eq!(
+        nested_scope.remove_actor(&declared).await,
+        RemoveOutcome::Removed
+    );
+    let terminal = declared
+        .try_send(())
+        .expect_err("the declared handle remains pinned to its removed membership");
+    assert_eq!(terminal.kind, SendErrorKind::Terminated);
+    assert_eq!(terminal.incarnation_observed, Some(declared_incarnation));
+
+    let replacement = nested_scope
+        .add_actor("worker", shelterwood::ActorDef::<EvidenceActor>::cloned(()))
+        .await
+        .expect("runtime replacement is admitted")
+        .into_handles();
+    let replacement_incarnation = replacement.try_send(()).expect("replacement actor accepts");
+    assert!(replacement.membership().supersedes(declared.membership()));
+    assert_eq!(
+        replacement_incarnation.membership(),
+        replacement.membership()
+    );
+    assert!(
+        !replacement_incarnation.supersedes(declared_incarnation),
+        "incarnation retry order never crosses membership replacement"
     );
 
     system

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -126,6 +126,75 @@ async fn exact_handles_reject_cross_scope_and_same_id_successors() {
 }
 
 #[tokio::test]
+async fn nested_declared_membership_is_superseded_by_its_runtime_replacement() {
+    let mut nested = DynamicTree::new();
+    let declared = nested
+        .add_task("worker", waiting_task())
+        .expect("valid declared task");
+    let different_id = nested
+        .add_task("other", waiting_task())
+        .expect("valid unrelated task");
+    let declared_membership = declared.membership();
+
+    let mut unrelated = DynamicTree::new();
+    let unrelated_worker = unrelated
+        .add_task("worker", waiting_task())
+        .expect("valid task in unrelated scope");
+
+    let mut root = Tree::new();
+    let nested_scope = root
+        .add_subtree_once("nested", SubtreeOnceDef::new(nested))
+        .expect("valid nested scope");
+    root.add_subtree_once("unrelated", SubtreeOnceDef::new(unrelated))
+        .expect("valid unrelated scope");
+    let system = root.spawn().expect("runtime is available");
+    system.wait_started().await.expect("tree starts");
+
+    assert_eq!(
+        declared.membership(),
+        declared_membership,
+        "first lowering preserves the declared handle's identity"
+    );
+    assert_eq!(
+        nested_scope.remove_task(&declared).await,
+        RemoveOutcome::Removed
+    );
+    let replacement = nested_scope
+        .add_task("worker", waiting_task())
+        .await
+        .expect("runtime replacement is admitted")
+        .into_handles();
+
+    assert!(replacement.membership().supersedes(declared_membership));
+    assert!(!declared_membership.supersedes(replacement.membership()));
+    assert!(
+        !replacement
+            .membership()
+            .supersedes(different_id.membership())
+    );
+    assert!(
+        !different_id
+            .membership()
+            .supersedes(replacement.membership())
+    );
+    assert!(
+        !replacement
+            .membership()
+            .supersedes(unrelated_worker.membership())
+    );
+    assert!(
+        !unrelated_worker
+            .membership()
+            .supersedes(replacement.membership())
+    );
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("tree shuts down");
+}
+
+#[tokio::test]
 async fn exact_scope_removal_does_not_touch_a_same_id_successor() {
     let system = DynamicTree::new().spawn().expect("runtime is available");
     system.wait_started().await.expect("root starts");

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
@@ -15,7 +15,7 @@ use shelterwood::{
     Backoff, ChildState, DynamicScopeRef, DynamicTree, Jitter, LifecycleEvent, LifecycleEventKind,
     LifecycleEvents, LifecycleItem, LifecycleTryRecvError, RemoveOutcome, RestartCondition,
     RestartPolicy, Retention, ScopeRef, ScopeState, StopReason, SubtreeDef, SubtreeOnceDef,
-    TaskDef, TaskOnceDef, Tree, WaitError,
+    TaskDef, TaskOnceDef, TaskRef, Tree, WaitError,
 };
 
 async fn next_item(events: &mut LifecycleEvents) -> LifecycleItem {
@@ -627,6 +627,88 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
         })
         .await
     );
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("tree shuts down");
+}
+
+#[tokio::test]
+async fn rebased_declared_handles_keep_their_map_identity() {
+    fn hashed(value: &impl std::hash::Hash) -> u64 {
+        use std::hash::Hasher;
+        let mut hasher = std::hash::DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    let stash: Arc<Mutex<Vec<(TaskRef, u64, shelterwood::Membership)>>> =
+        Arc::new(Mutex::new(Vec::new()));
+    let builds = Arc::new(AtomicUsize::new(0));
+    let mut outer = Tree::new();
+    let nested = outer
+        .add_subtree(
+            "nested",
+            SubtreeDef::factory({
+                let stash = Arc::clone(&stash);
+                let builds = Arc::clone(&builds);
+                move || {
+                    let mut tree = Tree::new();
+                    let handle = if builds.fetch_add(1, Ordering::SeqCst) == 0 {
+                        tree.add_task("worker", TaskDef::new(|_| async { Ok(()) }))
+                            .expect("valid finishing task")
+                    } else {
+                        tree.add_task("worker", waiting_task())
+                            .expect("valid waiting task")
+                    };
+                    // Capture identity before lowering rebases a rebuilt
+                    // declaration onto the stable scope.
+                    stash.lock().expect("stash mutex intact").push((
+                        handle.clone(),
+                        hashed(&handle),
+                        handle.membership(),
+                    ));
+                    tree
+                }
+            })
+            .restart(RestartPolicy::new(
+                RestartCondition::Always,
+                Backoff::Immediate,
+            )),
+        )
+        .expect("valid subtree");
+    let mut events = nested.subscribe_lifecycle();
+    let system = outer.spawn().expect("runtime is available");
+
+    let mut admissions = Vec::new();
+    while admissions.len() < 2 {
+        if let LifecycleEventKind::Added { membership, .. } = next_event(&mut events).await.kind {
+            admissions.push(membership);
+        }
+    }
+
+    let (first, first_hash, first_declared) = {
+        let stash = stash.lock().expect("stash mutex intact");
+        assert_eq!(stash.len(), 2);
+        stash[0].clone()
+    };
+    let (second, second_hash, second_declared) =
+        stash.lock().expect("stash mutex intact")[1].clone();
+
+    assert_eq!(first.membership(), first_declared);
+    assert_eq!(hashed(&first), first_hash);
+    assert!(
+        second.membership().supersedes(first.membership()),
+        "the rebuilt declaration is rebased onto the stable scope"
+    );
+    assert_ne!(second.membership(), second_declared);
+    assert_eq!(
+        hashed(&second),
+        second_hash,
+        "handle identity survives the rebase that refreshed its membership"
+    );
+    assert_eq!(second.membership(), admissions[1]);
 
     system
         .shutdown(Duration::from_secs(1))

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -611,7 +611,11 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
             break membership;
         }
     };
-    assert_ne!(Some(second_child), first_child);
+    let first_child = first_child.expect("first incarnation admits its child");
+    assert!(
+        second_child.supersedes(first_child),
+        "corresponding descendants retain ordering across a scope restart"
+    );
     assert_eq!(nested.membership(), scope_membership);
     assert_eq!(nested.snapshot().total_restarts, 0);
     assert!(nested.snapshot().lifecycle_seq >= starting.seq);

--- a/docs/observation.md
+++ b/docs/observation.md
@@ -79,7 +79,8 @@ For planned replacement, retain the admission receipt or exact handle, remove
 that membership, await `RemoveOutcome::Removed`, then add the replacement. An
 add racing an in-progress same-id removal fails with `RemovalInProgress`; await
 the removal and retry. The replacement's membership is distinct rather than a
-new incarnation of the old one.
+new incarnation of the old one, and it supersedes the removed same-id
+membership. Different ids and different owning scopes remain incomparable.
 
 ## Pre-spawn observation
 

--- a/docs/retry-and-ordering.md
+++ b/docs/retry-and-ordering.md
@@ -37,9 +37,17 @@ idempotent `ReplyDropped` loop.
 
 Membership and incarnation answer different questions. An `ActorRef` follows
 restarts of one membership. After remove and re-add under the same child id,
-the replacement has a new `Membership`; neither membership supersedes the
-other, and an old handle never retargets it. Within one membership,
-`Incarnation::supersedes` is the correct restart ordering test.
+the replacement has a new `Membership` that supersedes the removed membership,
+while the old handle remains pinned to the removed one and never retargets.
+Membership ordering is narrow: only replacements of the same child id in the
+same stable scope compare. Different child ids and memberships owned by
+different scopes remain incomparable.
+
+The stable scope identity also spans declaration and runtime boundaries.
+Replacing an initially declared child dynamically therefore supersedes that
+declared membership, and a corresponding descendant produced after a nested
+scope restart supersedes its predecessor. Within one membership,
+`Incarnation::supersedes` remains the correct restart ordering test.
 
 ## Latest-value mailboxes and calls
 

--- a/docs/retry-and-ordering.md
+++ b/docs/retry-and-ordering.md
@@ -46,8 +46,12 @@ different scopes remain incomparable.
 The stable scope identity also spans declaration and runtime boundaries.
 Replacing an initially declared child dynamically therefore supersedes that
 declared membership, and a corresponding descendant produced after a nested
-scope restart supersedes its predecessor. Within one membership,
-`Incarnation::supersedes` remains the correct restart ordering test.
+scope restart supersedes its predecessor. A rebuilt declaration's handle
+observes that rebased membership, but the handle's own `Eq`/`Hash` identity
+is the slot itself: a handle stashed in a map before lowering remains
+addressable afterward. Read `membership()` when the exact token matters.
+Within one membership, `Incarnation::supersedes` remains the correct restart
+ordering test.
 
 ## Latest-value mailboxes and calls
 


### PR DESCRIPTION
Part of #35 (item 2)

## Summary

- retain membership ordering in the stable parent-owned scope identity when nested declarations are lowered
- use a distinct membership lineage for each child ID so different IDs and unrelated scopes remain incomparable
- preserve first-incarnation pre-spawn memberships while rebasing later declarations, including descendants rebuilt after a nested-scope restart
- report stable-identity exhaustion as structured nested startup provenance
- align the normative spec, retry guidance, and observation docs with same-ID replacement ordering
- cover stable adoption, per-ID exhaustion, structured provenance, and exact mailbox/incarnation evidence

## Impact

A runtime replacement of an initially declared nested child now supersedes the removed membership. Corresponding descendants rebuilt after their nested scope restarts also supersede their predecessors, while exact handles remain pinned to their original memberships.

## Validation

- `./scripts/dev cargo test -p shelterwood membership` (9 focused unit/integration tests passed)
- `./scripts/dev just ci` (212 tests passed; formatting, Clippy, docs, API/runtime/exit path checks, and Nix formatting all passed)

