### PR TITLE
Centralize overflow-safe deadline and duration semantics

### DIFF
--- a/crates/shelterwood/src/deadline.rs
+++ b/crates/shelterwood/src/deadline.rs
@@ -1,0 +1,43 @@
+//! Overflow-safe internal deadline semantics.
+
+use std::time::{Duration, Instant};
+
+/// An absolute deadline, or one too distant for the clock to represent.
+///
+/// Overflow consistently means that the deadline never arrives. In
+/// particular, it must never be substituted with the budget's start time.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct Deadline(Option<Instant>);
+
+impl Deadline {
+    /// Captures a duration budget relative to `started_at`.
+    pub(crate) fn after(started_at: Instant, duration: Duration) -> Self {
+        Self(started_at.checked_add(duration))
+    }
+
+    /// Returns the representable absolute deadline, if there is one.
+    pub(crate) fn instant(self) -> Option<Instant> {
+        self.0
+    }
+
+    /// Reports whether a representable deadline has elapsed.
+    pub(crate) fn is_due(self, now: Instant) -> bool {
+        self.0.is_some_and(|deadline| now >= deadline)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::Deadline;
+
+    #[test]
+    fn overflow_is_never_due() {
+        let now = Instant::now();
+        let deadline = Deadline::after(now, Duration::MAX);
+
+        assert_eq!(deadline.instant(), None);
+        assert!(!deadline.is_due(now));
+    }
+}

--- a/crates/shelterwood/src/deadline.rs
+++ b/crates/shelterwood/src/deadline.rs
@@ -24,6 +24,14 @@ impl Deadline {
     pub(crate) fn is_due(self, now: Instant) -> bool {
         self.0.is_some_and(|deadline| now >= deadline)
     }
+
+    /// Reports whether a representable deadline is strictly in the past.
+    ///
+    /// Exact-boundary arbitration can still let already-ready work win, but
+    /// work that has not started must not begin after its budget has elapsed.
+    pub(crate) fn is_overdue(self, now: Instant) -> bool {
+        self.0.is_some_and(|deadline| now > deadline)
+    }
 }
 
 #[cfg(test)]
@@ -39,5 +47,18 @@ mod tests {
 
         assert_eq!(deadline.instant(), None);
         assert!(!deadline.is_due(now));
+        assert!(!deadline.is_overdue(now));
+    }
+
+    #[test]
+    fn representable_deadline_distinguishes_due_from_overdue() {
+        let now = Instant::now();
+        let deadline = Deadline::after(now, Duration::from_secs(1));
+        let at = now + Duration::from_secs(1);
+
+        assert_eq!(deadline.instant(), Some(at));
+        assert!(deadline.is_due(at));
+        assert!(!deadline.is_overdue(at));
+        assert!(deadline.is_overdue(at + Duration::from_nanos(1)));
     }
 }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2638,6 +2638,12 @@ impl ScopeRuntime {
                     effects.first(),
                     Some(crate::engine::RestartEffect::Scheduled { .. })
                 ));
+                let scheduled_at = match effects.first() {
+                    Some(crate::engine::RestartEffect::Scheduled { restart_at, .. }) => *restart_at,
+                    Some(crate::engine::RestartEffect::IntensityTripped { .. }) | None => {
+                        unreachable!("restart scheduling emits its schedule first")
+                    }
+                };
                 let delay = child
                     .options
                     .restart
@@ -2649,7 +2655,10 @@ impl ScopeRuntime {
                         record.incarnation = None;
                         record.last_exit = Some(exit.clone());
                         record.restart_count = decision.restart_count;
-                        record.restart_at = decision.restart_at;
+                        // Publish the derived schedule even when intensity
+                        // prevents spawning it. `None` then remains reserved
+                        // for an unrepresentable clock deadline.
+                        record.restart_at = scheduled_at;
                         record.stage = MemberStage::Restarting;
                     },
                     LifecycleEventKind::Exited {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -17,6 +17,7 @@ use std::{
 use crate::{
     ChildId, Exit, ExitKind, Incarnation, IntensityTrip, Membership, Readiness, ReadinessDeadline,
     ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure, StartupFailureCause,
+    deadline::Deadline,
     engine::{
         ArbitrationClass, DeadlineQueue, ExitDispatch, IntensityState, MembershipMode,
         ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState, ScopeMode, StopAction,
@@ -48,8 +49,17 @@ static OBSERVATION_GATE: Mutex<()> = Mutex::new(());
 
 pub(crate) type DriverSleep = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 
-pub(crate) fn sleep(duration: Duration) -> DriverSleep {
-    Box::pin(runtime::sleep(duration))
+pub(crate) fn deadline(duration: Duration) -> Deadline {
+    Deadline::after(runtime::now(), duration)
+}
+
+pub(crate) fn sleep_deadline(deadline: Deadline) -> DriverSleep {
+    Box::pin(async move {
+        match deadline.instant() {
+            Some(deadline) => runtime::sleep_until_std(deadline).await,
+            None => std::future::pending().await,
+        }
+    })
 }
 
 pub(crate) fn sleep_until(deadline: Instant) -> DriverSleep {
@@ -2094,10 +2104,12 @@ impl ScopeRuntime {
         } else {
             let deadline = match child.options.readiness_deadline {
                 ReadinessDeadline::Bounded(duration) => {
-                    let deadline = now.checked_add(duration).unwrap_or(now);
-                    self.deadlines
-                        .push(deadline, DeadlineKind::Readiness { index, incarnation });
-                    Some(deadline)
+                    let deadline = Deadline::after(now, duration).instant();
+                    if let Some(deadline) = deadline {
+                        self.deadlines
+                            .push(deadline, DeadlineKind::Readiness { index, incarnation });
+                    }
+                    deadline
                 }
                 ReadinessDeadline::Unbounded | ReadinessDeadline::Inherit => None,
             };
@@ -2356,10 +2368,9 @@ impl ScopeRuntime {
                             active.forced_outcome = Some(RecordedOutcome::Aborted { after_grace });
                         }
                         abort.fire();
-                        active.framework_abort_deadline = Some(
-                            now.checked_add(crate::policy::tidy_abort_beat(Duration::ZERO))
-                                .unwrap_or(now),
-                        );
+                        active.framework_abort_deadline =
+                            Deadline::after(now, crate::policy::tidy_abort_beat(Duration::ZERO))
+                                .instant();
                     } else {
                         active.abort_handle.abort();
                     }
@@ -2482,12 +2493,9 @@ impl ScopeRuntime {
                 became_ready = true;
             } else {
                 let deadline = match child.options.readiness_deadline {
-                    ReadinessDeadline::Bounded(duration) => Some(
-                        active
-                            .started_at
-                            .checked_add(duration)
-                            .unwrap_or(active.started_at),
-                    ),
+                    ReadinessDeadline::Bounded(duration) => {
+                        Deadline::after(active.started_at, duration).instant()
+                    }
                     ReadinessDeadline::Unbounded | ReadinessDeadline::Inherit => None,
                 };
                 active.readiness = ReadinessGate::Waiting { deadline };
@@ -2635,16 +2643,13 @@ impl ScopeRuntime {
                     .restart
                     .backoff()
                     .next_delay(decision.attempt, sample);
-                let restart_at = decision
-                    .restart_at
-                    .unwrap_or_else(|| now.checked_add(delay).unwrap_or(now));
                 self.root.schedule_child_restart(
                     &child.slot.member,
                     |record| {
                         record.incarnation = None;
                         record.last_exit = Some(exit.clone());
                         record.restart_count = decision.restart_count;
-                        record.restart_at = Some(restart_at);
+                        record.restart_at = decision.restart_at;
                         record.stage = MemberStage::Restarting;
                     },
                     LifecycleEventKind::Exited {
@@ -2672,8 +2677,10 @@ impl ScopeRuntime {
                     }
                     self.begin_drain(StopReason::IntensityTripped(trip));
                 } else {
-                    self.deadlines
-                        .push(restart_at, DeadlineKind::Restart { index });
+                    if let Some(restart_at) = decision.restart_at {
+                        self.deadlines
+                            .push(restart_at, DeadlineKind::Restart { index });
+                    }
                 }
             }
         }

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -6,7 +6,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{Exit, Intensity, RestartPolicy, Shutdown, policy::tidy_abort_beat};
+use crate::{
+    Exit, Intensity, RestartPolicy, Shutdown, deadline::Deadline, policy::tidy_abort_beat,
+};
 
 pub(crate) trait EffectSink<E> {
     fn emit(&mut self, effect: E);
@@ -79,7 +81,7 @@ impl StopLadder {
                 self.phase = StopPhase::Cooperative;
                 match self.policy {
                     Shutdown::Graceful { grace } => {
-                        self.deadline = Some(now.checked_add(grace).unwrap_or(now));
+                        self.deadline = Deadline::after(now, grace).instant();
                     }
                     Shutdown::Abort => {
                         self.deadline = Some(now);
@@ -96,7 +98,7 @@ impl StopLadder {
                     Shutdown::Abort => Duration::ZERO,
                 };
                 self.phase = StopPhase::Escalated;
-                self.deadline = Some(now.checked_add(tidy_abort_beat(grace)).unwrap_or(now));
+                self.deadline = Deadline::after(now, tidy_abort_beat(grace)).instant();
                 Some(StopAction::Escalate)
             }
             StopPhase::Escalated if self.deadline.is_some_and(|deadline| now >= deadline) => {
@@ -208,7 +210,7 @@ pub(crate) enum RestartEffect {
         attempt: u64,
         restart_count: u64,
         total_restarts: u64,
-        restart_at: Instant,
+        restart_at: Option<Instant>,
     },
     IntensityTripped {
         in_window: u64,
@@ -235,7 +237,7 @@ pub(crate) fn schedule_restart(
 ) -> RestartDecision {
     let (attempt, restart_count) = restarts.schedule();
     let delay = restart_policy.backoff().next_delay(attempt, jitter_sample);
-    let restart_at = now.checked_add(delay).unwrap_or(now);
+    let restart_at = Deadline::after(now, delay).instant();
     let charge = intensity.charge(intensity_policy, now);
     effects.emit(RestartEffect::Scheduled {
         attempt,
@@ -253,7 +255,7 @@ pub(crate) fn schedule_restart(
         attempt,
         restart_count,
         charge,
-        restart_at: (!charge.tripped).then_some(restart_at),
+        restart_at: (!charge.tripped).then_some(restart_at).flatten(),
     }
 }
 
@@ -429,6 +431,18 @@ mod tests {
     }
 
     #[test]
+    fn overflowing_grace_never_becomes_immediately_due() {
+        let start = Instant::now();
+        let mut ladder = StopLadder::new(Shutdown::Graceful {
+            grace: Duration::MAX,
+        });
+
+        assert_eq!(ladder.advance(start), Some(StopAction::Cancel));
+        assert_eq!(ladder.deadline(), None);
+        assert_eq!(ladder.advance(start), None);
+    }
+
+    #[test]
     fn funnel_dispatch_depends_on_mode_and_membership_state() {
         let failure = Exit::new(ExitKind::Failed(crate::ExitError::message("boom")), false);
         let restart = RestartPolicy::new(RestartCondition::OnFailure, Backoff::Immediate);
@@ -503,6 +517,38 @@ mod tests {
         assert_eq!(decision.restart_at, None);
         assert!(matches!(effects[0], RestartEffect::Scheduled { .. }));
         assert!(matches!(effects[1], RestartEffect::IntensityTripped { .. }));
+    }
+
+    #[test]
+    fn overflowing_restart_delay_has_no_immediate_spawn_deadline() {
+        let now = Instant::now();
+        let intensity_policy = Intensity::new(5, Duration::from_secs(10)).expect("valid intensity");
+        let restart_policy = RestartPolicy::new(
+            RestartCondition::OnFailure,
+            Backoff::fixed(Duration::MAX, crate::Jitter::None).expect("valid backoff"),
+        );
+        let mut restarts = RestartState::new();
+        let mut intensity = IntensityState::default();
+        let mut effects = Vec::new();
+
+        let decision = schedule_restart(
+            &mut restarts,
+            &mut intensity,
+            intensity_policy,
+            restart_policy,
+            now,
+            0.5,
+            &mut effects,
+        );
+
+        assert_eq!(decision.restart_at, None);
+        assert!(matches!(
+            effects[0],
+            RestartEffect::Scheduled {
+                restart_at: None,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -515,7 +515,13 @@ mod tests {
         assert_eq!(decision.charge.total_restarts, 1);
         assert!(decision.charge.tripped);
         assert_eq!(decision.restart_at, None);
-        assert!(matches!(effects[0], RestartEffect::Scheduled { .. }));
+        assert!(matches!(
+            effects[0],
+            RestartEffect::Scheduled {
+                restart_at: Some(restart_at),
+                ..
+            } if restart_at == now
+        ));
         assert!(matches!(effects[1], RestartEffect::IntensityTripped { .. }));
     }
 

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -3,6 +3,7 @@
 //! Structured supervision and actors for asynchronous Rust systems.
 
 mod actor;
+mod deadline;
 mod driver;
 mod engine;
 mod exit;

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -347,6 +347,7 @@ impl<T: Send + 'static> Future for ReplyReceive<T> {
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
         if !self.started {
             self.started = true;
+            let budget = crate::driver::deadline(self.deadline);
             if self.deadline.is_zero() {
                 self.done = true;
                 if let Some(shared) = &self.shared {
@@ -354,7 +355,7 @@ impl<T: Send + 'static> Future for ReplyReceive<T> {
                 }
                 return Poll::Ready(Err(ReplyError::Timeout));
             }
-            self.timer = Some(crate::driver::sleep(self.deadline));
+            self.timer = Some(crate::driver::sleep_deadline(budget));
         }
         let shared = Arc::clone(
             self.shared
@@ -1277,6 +1278,7 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
         if !self.started {
             self.started = true;
+            let budget = crate::driver::deadline(self.deadline);
             if self.deadline.is_zero() {
                 let actor_id = self
                     .send
@@ -1308,7 +1310,7 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
                     kind: SendErrorKind::TimedOut,
                 }));
             }
-            self.timer = Some(crate::driver::sleep(self.deadline));
+            self.timer = Some(crate::driver::sleep_deadline(budget));
         }
         let send = self.send.as_mut().expect("pending timed send retains send");
         if let Poll::Ready(result) = Pin::new(send).poll(context) {
@@ -1386,6 +1388,9 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
         if !self.started {
             self.started = true;
+            // Capture the one overall budget before invoking user code. A
+            // slow message constructor consumes acceptance/response time.
+            let budget = crate::driver::deadline(self.deadline);
             if self.deadline.is_zero() {
                 self.done = true;
                 return Poll::Ready(Err(CallError {
@@ -1401,7 +1406,7 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
                     .expect("unstarted call retains its message constructor")(reply);
             self.reply = receiver.shared.take();
             self.send = Some(self.actor.send(message));
-            self.timer = Some(crate::driver::sleep(self.deadline));
+            self.timer = Some(crate::driver::sleep_deadline(budget));
         }
 
         if self.accepted.is_none() {

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1100,7 +1100,8 @@ impl<M: Send + 'static> ActorRef<M> {
 
     /// Sends a request built around one reply capability and awaits its reply.
     ///
-    /// One deadline covers binding, mailbox acceptance, and response. The
+    /// One deadline covers message construction, binding, mailbox acceptance,
+    /// and response, starting when the returned future is first polled. The
     /// returned [`Replied`] identifies the accepting incarnation; [`CallError`]
     /// distinguishes a guaranteed-unaccepted timeout from an accepted request
     /// with an unknown outcome. See [`CallError`] for the required retry
@@ -1404,6 +1405,18 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
                 self.make_msg
                     .take()
                     .expect("unstarted call retains its message constructor")(reply);
+            // The normal polling order lets an acceptance already available
+            // at the exact deadline win. Construction is different: no send
+            // existed before it completed, so do not start one after the
+            // captured budget is strictly in the past.
+            if budget.is_overdue(crate::driver::now()) {
+                self.done = true;
+                return Poll::Ready(Err(CallError {
+                    actor_id: self.actor.id().clone(),
+                    incarnation_observed: self.actor.mailbox.current_observation(),
+                    kind: CallErrorKind::AcceptanceTimedOut,
+                }));
+            }
             self.reply = receiver.shared.take();
             self.send = Some(self.actor.send(message));
             self.timer = Some(crate::driver::sleep_deadline(budget));

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -213,7 +213,8 @@ pub struct ChildSnapshot {
     pub restart_policy: RestartPolicy,
     /// Resolved terminal-retention policy.
     pub retention: Retention,
-    /// Absolute backoff deadline, present exactly while restarting.
+    /// Absolute backoff deadline while restarting, or `None` when the delay
+    /// is too distant for the clock to represent.
     pub restart_at: Option<Instant>,
     /// Recursive state of a scope child when its incarnation is live or terminal.
     pub nested: Option<Arc<ScopeSnapshot>>,

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -602,16 +602,34 @@ mod tests {
             Backoff::fixed(Duration::from_millis(10), Jitter::Equal).expect("valid backoff");
         assert_eq!(jittered.next_delay(1, 0.0), Duration::from_millis(5));
         assert_eq!(jittered.next_delay(1, 0.5), Duration::from_micros(7_500));
+    }
 
-        let extreme_max = Duration::MAX - Duration::from_nanos(1);
-        let extreme = Backoff::exponential(
-            extreme_max,
-            BackoffFactor::new(1.0).expect("valid factor"),
-            extreme_max,
-            Jitter::None,
-        )
-        .expect("valid extreme backoff");
-        assert_eq!(extreme.next_delay(u64::MAX, 1.0), extreme_max);
+    #[test]
+    fn extreme_backoffs_never_round_above_their_exact_maximum() {
+        let maximum = Duration::MAX - Duration::from_nanos(1);
+        for jitter in [Jitter::None, Jitter::Equal] {
+            let backoff = Backoff::exponential(
+                Duration::from_nanos(1),
+                BackoffFactor::new(f64::MAX).expect("finite factor"),
+                maximum,
+                jitter,
+            )
+            .expect("valid extreme backoff");
+            for sample in [
+                f64::NEG_INFINITY,
+                -1.0,
+                0.0,
+                1.0 - f64::EPSILON,
+                1.0,
+                f64::INFINITY,
+                f64::NAN,
+            ] {
+                assert!(backoff.next_delay(u64::MAX, sample) <= maximum);
+            }
+        }
+
+        let fixed = Backoff::fixed(maximum, Jitter::Equal).expect("valid fixed backoff");
+        assert!(fixed.next_delay(u64::MAX, 1.0) <= maximum);
     }
 
     #[test]

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -175,9 +175,9 @@ impl Backoff {
     #[must_use]
     pub fn next_delay(self, attempt: u64, jitter_sample: f64) -> Duration {
         let attempt = attempt.max(1);
-        let (delay, jitter) = match self {
+        let (delay, jitter, maximum) = match self {
             Self::Immediate => return Duration::ZERO,
-            Self::Fixed { delay, jitter } => (delay, jitter),
+            Self::Fixed { delay, jitter } => (delay, jitter, delay),
             Self::Exponential {
                 base,
                 factor,
@@ -187,10 +187,10 @@ impl Backoff {
                 let exponent = i32::try_from(attempt.saturating_sub(1)).unwrap_or(i32::MAX);
                 let nanos = duration_nanos(base) * factor.get().powi(exponent);
                 let clamped = nanos.min(duration_nanos(max));
-                (duration_from_nanos(clamped), jitter)
+                (duration_from_nanos(clamped), jitter, max)
             }
         };
-        match jitter {
+        let delay = match jitter {
             Jitter::None => delay,
             Jitter::Equal => {
                 let sample = if jitter_sample.is_finite() {
@@ -200,7 +200,11 @@ impl Backoff {
                 };
                 duration_from_nanos(duration_nanos(delay) * (0.5 + sample * 0.5))
             }
-        }
+        };
+        // Floating-point duration conversion can round an extreme value a
+        // few nanoseconds above the configured cap. Reapply the policy bound
+        // with exact Duration ordering after every conversion and jitter.
+        delay.min(maximum)
     }
 }
 
@@ -598,6 +602,16 @@ mod tests {
             Backoff::fixed(Duration::from_millis(10), Jitter::Equal).expect("valid backoff");
         assert_eq!(jittered.next_delay(1, 0.0), Duration::from_millis(5));
         assert_eq!(jittered.next_delay(1, 0.5), Duration::from_micros(7_500));
+
+        let extreme_max = Duration::MAX - Duration::from_nanos(1);
+        let extreme = Backoff::exponential(
+            extreme_max,
+            BackoffFactor::new(1.0).expect("valid factor"),
+            extreme_max,
+            Jitter::None,
+        )
+        .expect("valid extreme backoff");
+        assert_eq!(extreme.next_delay(u64::MAX, 1.0), extreme_max);
     }
 
     #[test]

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -779,7 +779,7 @@ impl<M: Send + 'static> RawContext<M> {
         }
         self.resources.next_timer_order = self.resources.next_timer_order.saturating_add(1);
         let now = crate::driver::now();
-        let deadline = now.checked_add(after);
+        let deadline = crate::deadline::Deadline::after(now, after).instant();
         self.resources.timers.push(TimerEntry {
             key: Box::new(StoredTimerKey(key)),
             deadline,
@@ -838,7 +838,7 @@ impl<M: Send + 'static> RawContext<M> {
 
         let token = self.shutdown.child(cancellation.clone());
         let started_at = crate::driver::now();
-        let expires_at = started_at.checked_add(deadline);
+        let expires_at = crate::deadline::Deadline::after(started_at, deadline).instant();
         let event_cancellation = cancellation.clone();
         let event_finished = finished.clone();
         let operation = async move {
@@ -1031,7 +1031,7 @@ impl<M: Send + 'static> RawContext<M> {
             TimerMessage::Interval(make_message) => {
                 let period = period.expect("an interval timer must retain its period");
                 let now = crate::driver::now();
-                *deadline = now.checked_add(period);
+                *deadline = crate::deadline::Deadline::after(now, period).instant();
                 Some(make_message())
             }
         }

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -401,10 +401,6 @@ fn panic_message(payload: Box<dyn std::any::Any + Send + 'static>) -> Option<Str
     }
 }
 
-pub(crate) async fn sleep(duration: Duration) {
-    time::sleep(duration).await;
-}
-
 #[cfg(test)]
 pub(crate) async fn yield_now() {
     task::yield_now().await;

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -1650,20 +1650,20 @@ impl ScopeRef {
         P: FnMut(&crate::ChildSnapshot) -> bool + Send,
     {
         let id = id.into();
-        // A deadline too large for the clock is a deadline that never
-        // arrives, never one that is already due.
-        let expires = crate::runtime::now().checked_add(deadline);
+        let expires = crate::deadline::Deadline::after(crate::runtime::now(), deadline);
         let mut snapshots = self.subscribe_snapshots();
 
         loop {
-            if deadline.is_zero() {
-                return Err(WaitError::TimedOut);
-            }
             let snapshot = snapshots.borrow_latest();
             if let Some(child) = snapshot.child(id.as_str())
                 && pred(child)
             {
                 return Ok(child.clone());
+            }
+            // Inspect the current snapshot before rejecting even an already
+            // elapsed (including zero-duration) budget.
+            if expires.is_due(crate::runtime::now()) {
+                return Err(WaitError::TimedOut);
             }
             if matches!(
                 self.cell.member.record().stage,
@@ -1674,7 +1674,7 @@ impl ScopeRef {
                 });
             }
             match crate::runtime::select_two(snapshots.changed(), async {
-                match expires {
+                match expires.instant() {
                     Some(expires) => crate::runtime::sleep_until_std(expires).await,
                     None => std::future::pending().await,
                 }

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -283,34 +283,19 @@ async fn call_uses_one_budget_across_acceptance_and_response() {
 
 #[tokio::test(start_paused = true)]
 async fn message_construction_consumes_the_call_budget() {
-    let gate = ReleaseGate::default();
     let values = Arc::new(Mutex::new(Vec::new()));
     let calls = Arc::new(AtomicUsize::new(0));
     let mut tree = Tree::new();
     let actor = tree
         .add_raw_once(
             "constructor-budget",
-            RawOnceDef::new(boundary_actor(Some(gate.clone()), &values, &calls, false))
+            RawOnceDef::new(boundary_actor(None, &values, &calls, false))
                 .mailbox(Mailbox::queue(1).expect("non-zero capacity")),
         )
         .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("actor starts");
-    actor
-        .try_send(Message::Value(1))
-        .expect("the only mailbox slot is occupied");
 
-    // Keep runnable work in the executor so paused time cannot auto-advance
-    // to a timer incorrectly started after construction.
-    let keep_clock_fixed = Arc::new(AtomicBool::new(true));
-    let busy = tokio::spawn({
-        let keep_clock_fixed = Arc::clone(&keep_clock_fixed);
-        async move {
-            while keep_clock_fixed.load(Ordering::SeqCst) {
-                tokio::task::yield_now().await;
-            }
-        }
-    });
     let budget = Duration::from_secs(10);
     let mut call = Box::pin(actor.call(
         move |reply| {
@@ -324,24 +309,21 @@ async fn message_construction_consumes_the_call_budget() {
         budget,
     ));
 
-    assert!(poll_once(call.as_mut()).is_pending());
-    let mut result = None;
-    for _ in 0..16 {
-        tokio::task::yield_now().await;
-        if let Poll::Ready(value) = poll_once(call.as_mut()) {
-            result = Some(value);
-            break;
-        }
-    }
-    keep_clock_fixed.store(false, Ordering::SeqCst);
-    busy.await.expect("busy task joins");
-    let error = result
-        .expect("the captured budget expires without advancing time again")
-        .expect_err("the blocked call times out");
+    let Poll::Ready(result) = poll_once(call.as_mut()) else {
+        panic!("construction itself exhausts the captured budget");
+    };
+    let error = result.expect_err("the over-budget call times out");
     assert_eq!(error.kind, CallErrorKind::AcceptanceTimedOut);
     assert_eq!(calls.load(Ordering::SeqCst), 0);
+    for _ in 0..8 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "an available mailbox must not accept work after construction exhausts the budget"
+    );
 
-    gate.release();
     system
         .shutdown(Duration::from_secs(1))
         .await

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -9,8 +9,9 @@ use std::{
 
 use crate::common::{ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
 use shelterwood::{
-    CallErrorKind, ExitResult, Mailbox, RawActor, RawContext, RawOnceDef, Reply, ReplyError,
-    SendErrorKind, Tree,
+    Backoff, CallErrorKind, ChildState, ExitError, ExitResult, Jitter, Mailbox, RawActor,
+    RawContext, RawOnceDef, Readiness, ReadinessDeadline, Reply, ReplyError, RestartCondition,
+    RestartPolicy, SendErrorKind, Shutdown, TaskDef, Tree,
 };
 
 #[derive(Debug)]
@@ -25,6 +26,14 @@ struct BoundaryActor {
     calls: Arc<AtomicUsize>,
     hold_reply: bool,
     held: Option<Reply<usize>>,
+}
+
+struct DropFlag(Arc<AtomicBool>);
+
+impl Drop for DropFlag {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
 }
 
 impl RawActor for BoundaryActor {
@@ -270,6 +279,235 @@ async fn call_uses_one_budget_across_acceptance_and_response() {
         .shutdown(Duration::from_secs(1))
         .await
         .expect("actor stops");
+}
+
+#[tokio::test(start_paused = true)]
+async fn message_construction_consumes_the_call_budget() {
+    let gate = ReleaseGate::default();
+    let values = Arc::new(Mutex::new(Vec::new()));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "constructor-budget",
+            RawOnceDef::new(boundary_actor(Some(gate.clone()), &values, &calls, false))
+                .mailbox(Mailbox::queue(1).expect("non-zero capacity")),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    actor
+        .try_send(Message::Value(1))
+        .expect("the only mailbox slot is occupied");
+
+    // Keep runnable work in the executor so paused time cannot auto-advance
+    // to a timer incorrectly started after construction.
+    let keep_clock_fixed = Arc::new(AtomicBool::new(true));
+    let busy = tokio::spawn({
+        let keep_clock_fixed = Arc::clone(&keep_clock_fixed);
+        async move {
+            while keep_clock_fixed.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        }
+    });
+    let budget = Duration::from_secs(10);
+    let mut call = Box::pin(actor.call(
+        move |reply| {
+            // Advance the paused clock synchronously while the user
+            // constructor is running. Its first poll advances before the
+            // yield point, so this does not depend on scheduler timing.
+            let mut advance = Box::pin(tokio::time::advance(budget + Duration::from_nanos(1)));
+            assert!(poll_once(advance.as_mut()).is_pending());
+            Message::Ask(reply)
+        },
+        budget,
+    ));
+
+    assert!(poll_once(call.as_mut()).is_pending());
+    let mut result = None;
+    for _ in 0..16 {
+        tokio::task::yield_now().await;
+        if let Poll::Ready(value) = poll_once(call.as_mut()) {
+            result = Some(value);
+            break;
+        }
+    }
+    keep_clock_fixed.store(false, Ordering::SeqCst);
+    busy.await.expect("busy task joins");
+    let error = result
+        .expect("the captured budget expires without advancing time again")
+        .expect_err("the blocked call times out");
+    assert_eq!(error.kind, CallErrorKind::AcceptanceTimedOut);
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+    gate.release();
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("actor stops");
+}
+
+#[tokio::test(start_paused = true)]
+async fn overflowing_readiness_deadline_remains_pending() {
+    let mut tree = Tree::new();
+    tree.add_task(
+        "manual",
+        TaskDef::new(|context| async move {
+            context.shutdown_token().cancelled().await;
+            Ok(())
+        })
+        .readiness(Readiness::Manual)
+        .expect("manual readiness")
+        .readiness_deadline(ReadinessDeadline::bounded(Duration::MAX).expect("non-zero deadline")),
+    )
+    .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+
+    for _ in 0..16 {
+        tokio::task::yield_now().await;
+    }
+    let mut startup = Box::pin(system.wait_started());
+    assert!(poll_once(startup.as_mut()).is_pending());
+    assert!(matches!(
+        system
+            .scope()
+            .child("manual")
+            .expect("manual task is resident")
+            .state,
+        ChildState::Starting
+    ));
+    drop(startup);
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("cooperative task stops");
+}
+
+#[tokio::test(start_paused = true)]
+async fn overflowing_shutdown_grace_does_not_escalate() {
+    let dropped = Arc::new(AtomicBool::new(false));
+    let mut tree = Tree::new();
+    tree.add_task(
+        "stubborn",
+        TaskDef::new({
+            let dropped = Arc::clone(&dropped);
+            move |context| {
+                let dropped = Arc::clone(&dropped);
+                async move {
+                    let _drop = DropFlag(dropped);
+                    context.shutdown_token().cancelled().await;
+                    std::future::pending::<ExitResult>().await
+                }
+            }
+        })
+        .shutdown(Shutdown::Graceful {
+            grace: Duration::MAX,
+        }),
+    )
+    .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("task starts");
+
+    system.scope().request_shutdown();
+    for _ in 0..16 {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        !dropped.load(Ordering::SeqCst),
+        "an overflowing grace must not trigger immediate escalation"
+    );
+
+    let shutdown = system.shutdown(Duration::ZERO).await;
+    assert!(shutdown.is_err(), "forced cleanup reports the straggler");
+    assert!(dropped.load(Ordering::SeqCst));
+}
+
+#[tokio::test(start_paused = true)]
+async fn overflowing_restart_delay_never_restarts_immediately() {
+    let release_failure = ReleaseGate::default();
+    let starts = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    tree.add_task(
+        "restart",
+        TaskDef::new({
+            let release_failure = release_failure.clone();
+            let starts = Arc::clone(&starts);
+            move |_| {
+                let release_failure = release_failure.clone();
+                let attempt = starts.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    if attempt == 0 {
+                        release_failure.wait().await;
+                        Err(ExitError::message("restart me"))
+                    } else {
+                        std::future::pending().await
+                    }
+                }
+            }
+        })
+        .restart(RestartPolicy::new(
+            RestartCondition::OnFailure,
+            Backoff::fixed(Duration::MAX, Jitter::None).expect("non-zero backoff"),
+        )),
+    )
+    .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("first incarnation starts");
+    release_failure.release();
+
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            system.scope().child("restart").is_some_and(|child| {
+                matches!(child.state, ChildState::Restarting) && child.restart_at.is_none()
+            })
+        })
+        .await
+    );
+    for _ in 0..16 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(starts.load(Ordering::SeqCst), 1);
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("restart window shuts down");
+}
+
+#[tokio::test(start_paused = true)]
+async fn zero_duration_wait_observes_an_already_satisfied_child() {
+    let mut tree = Tree::new();
+    tree.add_task(
+        "ready",
+        TaskDef::new(|context| async move {
+            context.shutdown_token().cancelled().await;
+            Ok(())
+        }),
+    )
+    .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("task starts");
+
+    let child = system
+        .scope()
+        .wait_for_child(
+            "ready",
+            |child| matches!(child.state, ChildState::Running),
+            Duration::ZERO,
+        )
+        .await
+        .expect("the current snapshot satisfies the predicate");
+    assert_eq!(child.id.as_str(), "ready");
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("task stops");
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/events.rs
+++ b/crates/shelterwood/tests/events.rs
@@ -393,7 +393,7 @@ impl Actor for OverflowTimerActor {
 
 /// A delay too large for the clock is a deadline that never arrives — not an
 /// immediate fire (and for intervals, not an immediate-fire loop).
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn overflowing_timer_deadlines_never_fire() {
     for interval in [false, true] {
         let fired = Arc::new(AtomicUsize::new(0));
@@ -405,7 +405,8 @@ async fn overflowing_timer_deadlines_never_fire() {
         .expect("valid actor");
         let system = tree.spawn().expect("runtime is available");
         system.wait_started().await.expect("actor starts");
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
         assert_eq!(
             fired.load(Ordering::SeqCst),
             0,

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -973,7 +973,7 @@ async fn descendant_resolves_leaf_and_scope_path_endings() {
 
 /// A wait deadline too large for the clock is a deadline that never
 /// arrives — not one that is already due.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn wait_for_child_with_a_far_future_deadline_stays_pending() {
     let gate = ReleaseGate::default();
     let mut tree = Tree::new();
@@ -1009,7 +1009,10 @@ async fn wait_for_child_with_a_far_future_deadline_stays_pending() {
                 .await
         }
     });
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    for _ in 0..8 {
+        tokio::task::yield_now().await;
+    }
+    assert!(!waiter.is_finished(), "the overflowing wait remains armed");
     gate.release();
     waiter
         .await

--- a/docs/observation.md
+++ b/docs/observation.md
@@ -25,6 +25,11 @@ temporarily absent. For an event emitted by the subscribed scope itself, compare
 `snapshot.watermark(event.scope)` finds the matching watermark. An event is
 already reflected when `event.seq <= watermark`.
 
+A child in `Restarting` normally exposes its absolute backoff deadline through
+`restart_at`. If the requested delay is too large for the platform clock to
+represent, `restart_at` is `None`; the child remains in `Restarting` until
+removal or shutdown rather than restarting immediately.
+
 If the event's scope token is absent from the snapshot, use causal introduction:
 
 - if you applied a later `Added` whose membership is that scope token, the new
@@ -58,9 +63,13 @@ restart wait should accept any incarnation that `supersedes` the saved one.
 Pin the returned `membership` when a same-id replacement would not satisfy the
 logical wait.
 
-All waits need a finite deadline. A missing child does not match yet because a
-future `Added` under that label may satisfy the wait. If the containing scope
-terminalizes first, `wait_for_child` returns its terminal scope state.
+Use a finite deadline for operational waits. `Duration::ZERO` still examines
+the current snapshot once, so an already-satisfied predicate succeeds. A
+duration too large for the platform clock to represent (including
+`Duration::MAX`) behaves as an unbounded wait rather than an immediate timeout.
+A missing child does not match yet because a future `Added` under that label may
+satisfy the wait. If the containing scope terminalizes first, `wait_for_child`
+returns its terminal scope state.
 
 ## Terminal state is not pruning
 

--- a/docs/retry-and-ordering.md
+++ b/docs/retry-and-ordering.md
@@ -1,10 +1,12 @@
 # Calls, retries, and message ordering
 
-`ActorRef::call` uses one deadline for both mailbox acceptance and the reply.
-Its result always carries identity evidence: `Replied<T>` identifies the
-incarnation that accepted a successful request, while `CallError` records the
-accepting or observed incarnation when one exists. Treat these tokens as part
-of the protocol, not merely diagnostic metadata.
+`ActorRef::call` uses one deadline for message construction, mailbox acceptance,
+and the reply. The budget starts when the call future is first polled, before
+the user-supplied message constructor runs, so slow construction consumes the
+same budget. Its result always carries identity evidence: `Replied<T>`
+identifies the incarnation that accepted a successful request, while
+`CallError` records the accepting or observed incarnation when one exists.
+Treat these tokens as part of the protocol, not merely diagnostic metadata.
 
 ## The retry decision
 


### PR DESCRIPTION
Part of #35 (item 5)

## Summary

- add one internal overflow-safe `Deadline` policy where unrepresentable deadlines mean “never”
- apply it to readiness, shutdown escalation, restart scheduling, mailbox budgets, actor timers/offloads, and snapshot waits
- capture `call` budgets before invoking the user message constructor
- check the current child snapshot before rejecting an elapsed zero-duration wait
- reapply an exact `Duration` clamp after floating-point backoff conversion and jitter

## Why

Several time paths converted `Instant::checked_add` overflow into `now`, causing very long readiness, shutdown, and restart policies to fire immediately. Calls also started their timer after running user construction code, zero-duration child waits rejected an already-satisfied predicate, and extreme floating-point backoff values could round above their configured maximum.

## User impact

`Duration::MAX` supervision policies now remain pending instead of firing immediately, call deadlines cover message construction, already-satisfied zero-duration waits succeed, and generated backoffs never exceed `max`.

## Validation

- `./scripts/dev cargo test -p shelterwood --test integration deadlines::` (10 passed)
- `./scripts/dev just ci` (217 tests passed; formatting, Clippy, docs, API/runtime/exit path checks, and Nix formatting all passed)

