### PR TITLE
Use Tokio channels for observed state streams

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -307,8 +307,7 @@ pub(crate) struct MemberRecord {
 pub(crate) struct MemberCell {
     id: ChildId,
     membership: Membership,
-    record: Mutex<MemberRecord>,
-    changed: Signal,
+    record: runtime::WatchSender<MemberRecord>,
     mailbox: Mutex<Option<Arc<dyn MailboxControl>>>,
     options: Mutex<Option<crate::policy::ResolvedCommonOptions>>,
     pub(crate) removal: Latch,
@@ -316,20 +315,20 @@ pub(crate) struct MemberCell {
 
 impl MemberCell {
     pub(crate) fn new(id: ChildId, membership: Membership) -> Arc<Self> {
+        let (record, _) = runtime::watch(MemberRecord {
+            stage: MemberStage::Reserved,
+            incarnation: None,
+            last_incarnation: None,
+            last_exit: None,
+            restart_count: 0,
+            restart_at: None,
+            removing: false,
+            startup_aborted: false,
+        });
         Arc::new(Self {
             id,
             membership,
-            record: Mutex::new(MemberRecord {
-                stage: MemberStage::Reserved,
-                incarnation: None,
-                last_incarnation: None,
-                last_exit: None,
-                restart_count: 0,
-                restart_at: None,
-                removing: false,
-                startup_aborted: false,
-            }),
-            changed: Signal::default(),
+            record,
             mailbox: Mutex::new(None),
             options: Mutex::new(None),
             removal: Latch::default(),
@@ -345,17 +344,15 @@ impl MemberCell {
     }
 
     pub(crate) fn record(&self) -> MemberRecord {
-        self.record.lock().expect("member mutex poisoned").clone()
+        self.record.read_cloned()
     }
 
     pub(crate) fn update(&self, update: impl FnOnce(&mut MemberRecord)) {
-        update(&mut self.record.lock().expect("member mutex poisoned"));
-        self.changed.pulse();
+        self.record.send_modify(update);
     }
 
     fn update_locked(&self, update: impl FnOnce(&mut MemberRecord)) {
-        update(&mut self.record.lock().expect("member mutex poisoned"));
-        self.changed.pulse();
+        self.record.send_modify(update);
     }
 
     pub(crate) fn set_options(&self, options: crate::policy::ResolvedCommonOptions) {
@@ -396,8 +393,7 @@ impl MemberCell {
     }
 
     pub(crate) fn terminalize(&self, exit: Exit) {
-        let changed = {
-            let mut record = self.record.lock().expect("member mutex poisoned");
+        let _ = self.record.send_if_modified(|record| {
             if matches!(record.stage, MemberStage::Terminal(_)) {
                 false
             } else {
@@ -405,27 +401,25 @@ impl MemberCell {
                 record.restart_at = None;
                 record.last_exit = Some(exit.clone());
                 record.stage = MemberStage::Terminal(exit);
+                // Complete mailbox terminality before watch wakes can expose
+                // the terminal member record.
+                if let Some(mailbox) = self.mailbox() {
+                    mailbox.terminate();
+                    let stats = mailbox.stats();
+                    debug_assert!(stats.delivered <= stats.accepted);
+                    debug_assert!(stats.conflated <= stats.accepted);
+                    debug_assert!(stats.depth <= stats.capacity);
+                    let _ = stats.sends_rejected;
+                }
                 true
             }
-        };
-        if !changed {
-            return;
-        }
-        if let Some(mailbox) = self.mailbox() {
-            mailbox.terminate();
-            let stats = mailbox.stats();
-            debug_assert!(stats.delivered <= stats.accepted);
-            debug_assert!(stats.conflated <= stats.accepted);
-            debug_assert!(stats.depth <= stats.capacity);
-            let _ = stats.sends_rejected;
-        }
-        self.changed.pulse();
+        });
     }
 
     pub(crate) async fn wait_terminal(&self) -> Exit {
-        let mut watcher = self.changed.watcher();
+        let mut watcher = self.record.watcher();
         loop {
-            if let MemberStage::Terminal(exit) = self.record().stage {
+            if let MemberStage::Terminal(exit) = watcher.borrow_cloned().stage {
                 return exit;
             }
             watcher.changed().await;
@@ -612,7 +606,7 @@ impl ScopeCell {
         }
         record.state = state.clone();
         drop(record);
-        self.member.changed.pulse();
+        self.member.record.pulse();
         self.emit_locked(LifecycleEventKind::ScopeState { state });
     }
 
@@ -902,7 +896,7 @@ impl ScopeCell {
         if record.startup.is_none() {
             record.startup = Some(startup);
             drop(record);
-            self.member.changed.pulse();
+            self.member.record.pulse();
         }
     }
 
@@ -912,7 +906,7 @@ impl ScopeCell {
         control.live = true;
         let epoch = control.current_epoch;
         drop(control);
-        self.member.changed.pulse();
+        self.member.record.pulse();
         epoch
     }
 
@@ -962,7 +956,7 @@ impl ScopeCell {
             }
         }
         drop(control);
-        self.member.changed.pulse();
+        self.member.record.pulse();
         self.emit_locked(LifecycleEventKind::ScopeState { state });
         if terminal {
             self.close_observation_locked();
@@ -989,7 +983,7 @@ impl ScopeCell {
                 record.state = state.clone();
             }
             self.member.terminalize(exit);
-            self.member.changed.pulse();
+            self.member.record.pulse();
             self.emit_locked(LifecycleEventKind::ScopeState { state });
             self.close_observation_locked();
         }
@@ -1012,7 +1006,7 @@ impl ScopeCell {
             });
         }
         drop(control);
-        self.member.changed.pulse();
+        self.member.record.pulse();
         target
     }
 
@@ -1036,7 +1030,7 @@ impl ScopeCell {
             });
         }
         drop(control);
-        self.member.changed.pulse();
+        self.member.record.pulse();
     }
 
     fn take_force_request(&self, epoch: u64) -> bool {
@@ -1124,7 +1118,7 @@ impl ScopeCell {
             .current_dynamic
             .lock()
             .expect("scope dynamic-control mutex poisoned") = control;
-        self.member.changed.pulse();
+        self.member.record.pulse();
     }
 
     fn dynamic(&self) -> Option<Arc<DynamicControl>> {
@@ -1134,12 +1128,12 @@ impl ScopeCell {
             .clone()
     }
 
-    pub(crate) fn signal(&self) -> &Signal {
-        &self.member.changed
+    pub(crate) fn signal(&self) -> &runtime::WatchSender<MemberRecord> {
+        &self.member.record
     }
 
     pub(crate) async fn wait_started(&self) -> Result<(), StartupError> {
-        let mut watcher = self.member.changed.watcher();
+        let mut watcher = self.member.record.watcher();
         loop {
             if let Some(result) = self.record().startup {
                 return result;
@@ -1177,7 +1171,7 @@ impl ScopeCell {
                 reason: StopReason::NeverStarted,
             };
         }
-        self.member.changed.pulse();
+        self.member.record.pulse();
         self.emit_locked(LifecycleEventKind::ScopeState {
             state: ScopeState::Stopped {
                 reason: StopReason::NeverStarted,
@@ -3578,7 +3572,7 @@ mod tests {
         });
         let waker = Waker::from(Arc::clone(&probe));
         let mut context = Context::from_waker(&waker);
-        let mut watcher = member.changed.watcher();
+        let mut watcher = member.record.watcher();
         let mut changed = Box::pin(watcher.changed());
         assert!(changed.as_mut().poll(&mut context).is_pending());
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -308,9 +308,15 @@ pub(crate) struct MemberCell {
     id: ChildId,
     membership: Membership,
     record: runtime::WatchSender<MemberRecord>,
-    mailbox: Mutex<Option<Arc<dyn MailboxControl>>>,
+    mailbox: Mutex<MemberMailbox>,
     options: Mutex<Option<crate::policy::ResolvedCommonOptions>>,
     pub(crate) removal: Latch,
+}
+
+#[derive(Debug, Default)]
+struct MemberMailbox {
+    control: Option<Arc<dyn MailboxControl>>,
+    terminal: bool,
 }
 
 impl MemberCell {
@@ -329,7 +335,7 @@ impl MemberCell {
             id,
             membership,
             record,
-            mailbox: Mutex::new(None),
+            mailbox: Mutex::new(MemberMailbox::default()),
             options: Mutex::new(None),
             removal: Latch::default(),
         })
@@ -375,12 +381,13 @@ impl MemberCell {
     }
 
     pub(crate) fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
-        {
-            let mut current = self.mailbox.lock().expect("member mailbox mutex poisoned");
-            assert!(current.is_none(), "a member can own only one mailbox");
-            *current = Some(Arc::clone(&mailbox));
-        }
-        if matches!(self.record().stage, MemberStage::Terminal(_)) {
+        let terminal = {
+            let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
+            assert!(state.control.is_none(), "a member can own only one mailbox");
+            state.control = Some(Arc::clone(&mailbox));
+            state.terminal
+        };
+        if terminal {
             mailbox.terminate();
         }
     }
@@ -389,10 +396,27 @@ impl MemberCell {
         self.mailbox
             .lock()
             .expect("member mailbox mutex poisoned")
+            .control
             .clone()
     }
 
     pub(crate) fn terminalize(&self, exit: Exit) {
+        let mailbox = {
+            let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
+            if state.terminal {
+                return;
+            }
+            state.terminal = true;
+            state.control.clone()
+        };
+        if let Some(mailbox) = mailbox {
+            mailbox.terminate();
+            let stats = mailbox.stats();
+            debug_assert!(stats.delivered <= stats.accepted);
+            debug_assert!(stats.conflated <= stats.accepted);
+            debug_assert!(stats.depth <= stats.capacity);
+            let _ = stats.sends_rejected;
+        }
         let _ = self.record.send_if_modified(|record| {
             if matches!(record.stage, MemberStage::Terminal(_)) {
                 false
@@ -401,16 +425,6 @@ impl MemberCell {
                 record.restart_at = None;
                 record.last_exit = Some(exit.clone());
                 record.stage = MemberStage::Terminal(exit);
-                // Complete mailbox terminality before watch wakes can expose
-                // the terminal member record.
-                if let Some(mailbox) = self.mailbox() {
-                    mailbox.terminate();
-                    let stats = mailbox.stats();
-                    debug_assert!(stats.delivered <= stats.accepted);
-                    debug_assert!(stats.conflated <= stats.accepted);
-                    debug_assert!(stats.depth <= stats.capacity);
-                    let _ = stats.sends_rejected;
-                }
                 true
             }
         });

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::HashMap,
+    fmt,
     future::Future,
     pin::Pin,
     sync::{
@@ -23,7 +24,7 @@ use crate::{
     },
     exit::{JoinVerdict, RecordedOutcome, classify_exit},
     identity::{FenceCounter, ScopeIdentity},
-    mailbox::MailboxControl,
+    mailbox::{MailboxControl, MailboxTermination},
     observe::{
         ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
         LifecycleHub, MembershipStatus, ScopeKind, ScopeSnapshot, SnapshotHub, SnapshotReceiver,
@@ -313,10 +314,22 @@ pub(crate) struct MemberCell {
     pub(crate) removal: Latch,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct MemberMailbox {
     control: Option<Arc<dyn MailboxControl>>,
-    terminal: bool,
+    terminal: Option<Exit>,
+    teardown: Option<Box<dyn MailboxTermination>>,
+}
+
+impl fmt::Debug for MemberMailbox {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MemberMailbox")
+            .field("control", &self.control)
+            .field("terminal", &self.terminal)
+            .field("teardown_pending", &self.teardown.is_some())
+            .finish()
+    }
 }
 
 impl MemberCell {
@@ -381,14 +394,19 @@ impl MemberCell {
     }
 
     pub(crate) fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
-        let terminal = {
+        let terminal_exit = {
             let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
             assert!(state.control.is_none(), "a member can own only one mailbox");
             state.control = Some(Arc::clone(&mailbox));
-            state.terminal
+            let terminal_exit = state.terminal.clone();
+            if terminal_exit.is_some() {
+                debug_assert!(state.teardown.is_none());
+                state.teardown = mailbox.prepare_termination();
+            }
+            terminal_exit
         };
-        if terminal {
-            mailbox.terminate();
+        if let Some(terminal_exit) = terminal_exit {
+            self.publish_terminal(terminal_exit);
         }
     }
 
@@ -401,33 +419,52 @@ impl MemberCell {
     }
 
     pub(crate) fn terminalize(&self, exit: Exit) {
-        let mailbox = {
+        let (terminal_exit, mailbox) = {
             let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
-            if state.terminal {
-                return;
-            }
-            state.terminal = true;
-            state.control.clone()
+            let terminal_exit = if let Some(terminal_exit) = &state.terminal {
+                terminal_exit.clone()
+            } else {
+                let teardown = state
+                    .control
+                    .as_ref()
+                    .and_then(|mailbox| mailbox.prepare_termination());
+                state.terminal = Some(exit.clone());
+                state.teardown = teardown;
+                exit
+            };
+            (terminal_exit, state.control.clone())
         };
+        self.publish_terminal(terminal_exit);
         if let Some(mailbox) = mailbox {
-            mailbox.terminate();
             let stats = mailbox.stats();
             debug_assert!(stats.delivered <= stats.accepted);
             debug_assert!(stats.conflated <= stats.accepted);
             debug_assert!(stats.depth <= stats.capacity);
             let _ = stats.sends_rejected;
         }
-        let _ = self.record.send_if_modified(|record| {
-            if matches!(record.stage, MemberStage::Terminal(_)) {
-                false
-            } else {
+    }
+
+    fn publish_terminal(&self, terminal_exit: Exit) {
+        let mut published = false;
+        self.record.modify_silently(|record| {
+            if !matches!(record.stage, MemberStage::Terminal(_)) {
                 record.incarnation = None;
                 record.restart_at = None;
-                record.last_exit = Some(exit.clone());
-                record.stage = MemberStage::Terminal(exit);
-                true
+                record.last_exit = Some(terminal_exit.clone());
+                record.stage = MemberStage::Terminal(terminal_exit);
+                published = true;
             }
         });
+        let teardown = self
+            .mailbox
+            .lock()
+            .expect("member mailbox mutex poisoned")
+            .teardown
+            .take();
+        drop(teardown);
+        if published {
+            self.record.pulse();
+        }
     }
 
     pub(crate) async fn wait_terminal(&self) -> Exit {
@@ -3267,7 +3304,7 @@ mod tests {
     use std::{
         future::{self, Future},
         panic::{AssertUnwindSafe, catch_unwind},
-        sync::{Arc, Mutex},
+        sync::{Arc, Barrier, Mutex},
         task::{Context, Poll, Wake, Waker},
         time::Duration,
     };
@@ -3569,6 +3606,31 @@ mod tests {
         }
     }
 
+    struct ObserveMemberOnMailboxWake {
+        member: Arc<MemberCell>,
+        competing_exit: Exit,
+        observed: Mutex<Option<(MemberStage, MemberStage)>>,
+    }
+
+    impl ObserveMemberOnMailboxWake {
+        fn observe(&self) {
+            let before = self.member.record().stage;
+            self.member.terminalize(self.competing_exit.clone());
+            let after = self.member.record().stage;
+            *self.observed.lock().expect("observation mutex poisoned") = Some((before, after));
+        }
+    }
+
+    impl Wake for ObserveMemberOnMailboxWake {
+        fn wake(self: Arc<Self>) {
+            self.observe();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.observe();
+        }
+    }
+
     #[test]
     fn terminality_signal_follows_mailbox_termination() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
@@ -3597,6 +3659,122 @@ mod tests {
             Some(SendErrorKind::Terminated)
         );
         assert!(changed.as_mut().poll(&mut context).is_ready());
+    }
+
+    #[test]
+    fn mailbox_wake_observes_terminal_record_and_reentrant_terminality_is_idempotent() {
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let member = MemberCell::new(
+            ChildId::from("worker"),
+            identity.mint_membership().expect("membership available"),
+        );
+        let mailbox = MailboxCell::new(member.id().clone());
+        let actor = ActorRef::new(Arc::clone(&member), Arc::clone(&mailbox));
+        member.attach_mailbox(mailbox);
+        let first_exit = Exit::never_started();
+        let probe = Arc::new(ObserveMemberOnMailboxWake {
+            member: Arc::clone(&member),
+            competing_exit: Exit::new(ExitKind::Completed, false),
+            observed: Mutex::new(None),
+        });
+        let waker = Waker::from(Arc::clone(&probe));
+        let mut parked = Box::pin(actor.send(1));
+        assert!(
+            parked
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending()
+        );
+
+        member.terminalize(first_exit.clone());
+
+        assert_eq!(
+            *probe.observed.lock().expect("observation mutex poisoned"),
+            Some((
+                MemberStage::Terminal(first_exit.clone()),
+                MemberStage::Terminal(first_exit.clone())
+            ))
+        );
+        assert!(matches!(
+            member.record().stage,
+            MemberStage::Terminal(exit) if exit == first_exit
+        ));
+    }
+
+    #[test]
+    fn attach_during_terminal_publication_finishes_record_before_mailbox_wake() {
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let member = MemberCell::new(
+            ChildId::from("worker"),
+            identity.mint_membership().expect("membership available"),
+        );
+        let mailbox = MailboxCell::new(member.id().clone());
+        let actor = ActorRef::new(Arc::clone(&member), Arc::clone(&mailbox));
+        let first_exit = Exit::never_started();
+        member
+            .mailbox
+            .lock()
+            .expect("member mailbox mutex poisoned")
+            .terminal = Some(first_exit.clone());
+        let probe = Arc::new(ObserveMemberOnMailboxWake {
+            member: Arc::clone(&member),
+            competing_exit: Exit::new(ExitKind::Completed, false),
+            observed: Mutex::new(None),
+        });
+        let waker = Waker::from(Arc::clone(&probe));
+        let mut parked = Box::pin(actor.send(1));
+        assert!(
+            parked
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending()
+        );
+
+        member.attach_mailbox(mailbox);
+
+        assert_eq!(
+            *probe.observed.lock().expect("observation mutex poisoned"),
+            Some((
+                MemberStage::Terminal(first_exit.clone()),
+                MemberStage::Terminal(first_exit.clone())
+            ))
+        );
+        assert!(matches!(
+            member.record().stage,
+            MemberStage::Terminal(exit) if exit == first_exit
+        ));
+    }
+
+    #[test]
+    fn concurrent_terminalizers_return_after_one_consistent_record_is_visible() {
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let member = MemberCell::new(
+            ChildId::from("worker"),
+            identity.mint_membership().expect("membership available"),
+        );
+        let start = Arc::new(Barrier::new(3));
+        let workers = [Exit::never_started(), Exit::new(ExitKind::Completed, false)]
+            .into_iter()
+            .map(|exit| {
+                let member = Arc::clone(&member);
+                let start = Arc::clone(&start);
+                std::thread::spawn(move || {
+                    start.wait();
+                    member.terminalize(exit);
+                    assert!(matches!(member.record().stage, MemberStage::Terminal(_)));
+                })
+            })
+            .collect::<Vec<_>>();
+        start.wait();
+        for worker in workers {
+            worker.join().expect("terminalizer thread succeeds");
+        }
+
+        let record = member.record();
+        let MemberStage::Terminal(exit) = record.stage else {
+            panic!("one terminal record must be visible");
+        };
+        assert_eq!(record.last_exit, Some(exit));
     }
 
     #[test]

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -576,13 +576,35 @@ impl<M> Drop for Termination<M> {
     }
 }
 
+pub(crate) trait MailboxTermination: Send {}
+
+struct MailboxTeardown<M> {
+    changed: Signal,
+    queue: Option<VecDeque<Envelope<M>>>,
+    latest: Option<Envelope<M>>,
+    termination: Option<Termination<M>>,
+}
+
+impl<M> Drop for MailboxTeardown<M> {
+    fn drop(&mut self) {
+        self.changed.pulse();
+        drop(self.queue.take());
+        drop(self.latest.take());
+        if let Some(termination) = self.termination.take() {
+            termination.finish();
+        }
+    }
+}
+
+impl<M: Send> MailboxTermination for MailboxTeardown<M> {}
+
 /// Type-erased control used by the supervision driver.
 pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
     fn configure(&self, mailbox: Mailbox);
     fn bind(&self, incarnation: Incarnation);
     fn freeze(&self, incarnation: Incarnation);
     fn close(&self, incarnation: Incarnation);
-    fn terminate(&self);
+    fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>>;
     fn stats(&self) -> MailboxStats;
 }
 
@@ -943,10 +965,10 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         drop(latest);
     }
 
-    fn terminate(&self) {
+    fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         if matches!(state.status, BindingStatus::Terminal(_)) {
-            return;
+            return None;
         }
         let final_incarnation = state.last_bound;
         state.status = BindingStatus::Terminal(final_incarnation);
@@ -958,10 +980,12 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             final_incarnation,
         };
         drop(state);
-        self.changed.pulse();
-        drop(queue);
-        drop(latest);
-        termination.finish();
+        Some(Box::new(MailboxTeardown {
+            changed: self.changed.clone(),
+            queue: Some(queue),
+            latest,
+            termination: Some(termination),
+        }))
     }
 
     fn stats(&self) -> MailboxStats {
@@ -1683,7 +1707,7 @@ mod tests {
 
         assert!(
             catch_unwind(AssertUnwindSafe(|| {
-                MailboxControl::terminate(&*mailbox);
+                drop(MailboxControl::prepare_termination(&*mailbox));
             }))
             .is_err()
         );

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -1,16 +1,14 @@
 //! Restart-stable scope snapshots and lifecycle streams.
 
 use std::{
-    collections::VecDeque,
     fmt,
-    sync::{Arc, Mutex, Weak},
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
 use crate::{
     ChildId, Exit, Incarnation, Intensity, Membership, RestartPolicy, Retention, StopReason,
-    Strategy,
-    driver::{Signal, SignalWatcher},
+    Strategy, driver, runtime,
 };
 
 /// Number of lifecycle events retained independently for each subscriber.
@@ -295,68 +293,25 @@ impl ScopeSnapshot {
 #[error("scope snapshot watch is closed")]
 pub struct SnapshotClosed;
 
-#[derive(Debug)]
-struct SnapshotSubscriber {
-    state: Mutex<SnapshotSubscriberState>,
-    signal: Signal,
-}
-
-#[derive(Debug)]
-struct SnapshotSubscriberState {
-    latest: Arc<ScopeSnapshot>,
-    version: u64,
-    closed: bool,
-}
-
 /// Conflating receiver for recursive scope snapshots.
+#[derive(Clone)]
 pub struct SnapshotReceiver {
-    subscriber: Arc<SnapshotSubscriber>,
-    watcher: SignalWatcher,
-    seen: u64,
+    inner: runtime::WatchReceiver<Arc<ScopeSnapshot>>,
 }
 
 impl SnapshotReceiver {
     /// Borrows the newest snapshot without marking it observed.
     #[must_use]
     pub fn borrow_latest(&self) -> Arc<ScopeSnapshot> {
-        Arc::clone(
-            &self
-                .subscriber
-                .state
-                .lock()
-                .expect("snapshot subscriber mutex poisoned")
-                .latest,
-        )
+        self.inner.borrow_cloned()
     }
 
     /// Waits for and returns a newer snapshot.
     pub async fn changed(&mut self) -> Result<Arc<ScopeSnapshot>, SnapshotClosed> {
-        loop {
-            {
-                let state = self
-                    .subscriber
-                    .state
-                    .lock()
-                    .expect("snapshot subscriber mutex poisoned");
-                if state.version != self.seen {
-                    self.seen = state.version;
-                    return Ok(Arc::clone(&state.latest));
-                }
-                if state.closed {
-                    return Err(SnapshotClosed);
-                }
-            }
-            self.watcher.changed().await;
-        }
-    }
-}
-
-impl Clone for SnapshotReceiver {
-    fn clone(&self) -> Self {
-        Self {
-            subscriber: Arc::clone(&self.subscriber),
-            watcher: self.subscriber.signal.watcher(),
-            seen: self.seen,
+        if self.inner.changed_or_closed().await {
+            Ok(self.inner.borrow_and_update_cloned())
+        } else {
+            Err(SnapshotClosed)
         }
     }
 }
@@ -365,94 +320,76 @@ impl fmt::Debug for SnapshotReceiver {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("SnapshotReceiver")
-            .field("seen", &self.seen)
+            .field("inner", &self.inner)
             .finish_non_exhaustive()
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub(crate) struct SnapshotHub {
-    subscribers: Mutex<Vec<Weak<SnapshotSubscriber>>>,
+    state: Mutex<SnapshotHubState>,
+}
+
+#[derive(Default)]
+struct SnapshotHubState {
+    sender: Option<runtime::WatchSender<Arc<ScopeSnapshot>>>,
+    closed: bool,
 }
 
 impl SnapshotHub {
     pub(crate) fn subscribe(&self, initial: Arc<ScopeSnapshot>) -> SnapshotReceiver {
-        let subscriber = Arc::new(SnapshotSubscriber {
-            state: Mutex::new(SnapshotSubscriberState {
-                latest: initial,
-                version: 0,
-                closed: false,
-            }),
-            signal: Signal::default(),
-        });
-        self.subscribers
-            .lock()
-            .expect("snapshot hub mutex poisoned")
-            .push(Arc::downgrade(&subscriber));
-        SnapshotReceiver {
-            watcher: subscriber.signal.watcher(),
-            subscriber,
-            seen: 0,
+        let mut state = self.state.lock().expect("snapshot hub mutex poisoned");
+        if state.closed {
+            let (sender, inner) = runtime::watch(initial);
+            drop(sender);
+            return SnapshotReceiver { inner };
         }
+        if let Some(sender) = &state.sender
+            && sender.receiver_count() > 0
+        {
+            return SnapshotReceiver {
+                inner: sender.watcher(),
+            };
+        }
+        let (sender, inner) = runtime::watch(initial);
+        state.sender = Some(sender);
+        SnapshotReceiver { inner }
     }
 
     pub(crate) fn publish(&self, snapshot: impl FnOnce() -> Arc<ScopeSnapshot>) {
-        let mut subscribers = self
-            .subscribers
-            .lock()
-            .expect("snapshot hub mutex poisoned");
-        subscribers.retain(|subscriber| subscriber.strong_count() > 0);
-        if subscribers.is_empty() {
+        let mut state = self.state.lock().expect("snapshot hub mutex poisoned");
+        let Some(sender) = &state.sender else {
+            return;
+        };
+        if sender.receiver_count() == 0 {
+            state.sender = None;
             return;
         }
-        let snapshot = snapshot();
-        subscribers.retain(|subscriber| {
-            let Some(subscriber) = subscriber.upgrade() else {
-                return false;
-            };
-            let mut state = subscriber
-                .state
-                .lock()
-                .expect("snapshot subscriber mutex poisoned");
-            state.latest = Arc::clone(&snapshot);
-            state.version = state.version.saturating_add(1);
-            drop(state);
-            subscriber.signal.pulse();
-            true
-        });
+        sender.replace(snapshot());
     }
 
     pub(crate) fn close(&self) {
-        let mut subscribers = self
-            .subscribers
-            .lock()
-            .expect("snapshot hub mutex poisoned");
-        subscribers.retain(|subscriber| {
-            let Some(subscriber) = subscriber.upgrade() else {
-                return false;
-            };
-            subscriber
-                .state
-                .lock()
-                .expect("snapshot subscriber mutex poisoned")
-                .closed = true;
-            subscriber.signal.pulse();
-            true
-        });
+        let mut state = self.state.lock().expect("snapshot hub mutex poisoned");
+        state.closed = true;
+        state.sender = None;
     }
 }
 
-#[derive(Debug)]
-struct LifecycleQueue {
-    state: Mutex<LifecycleQueueState>,
-    signal: Signal,
-}
-
-#[derive(Debug, Default)]
-struct LifecycleQueueState {
-    events: VecDeque<LifecycleEvent>,
-    lagged: Option<u64>,
-    closed: bool,
+impl fmt::Debug for SnapshotHub {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = self.state.lock().expect("snapshot hub mutex poisoned");
+        formatter
+            .debug_struct("SnapshotHub")
+            .field(
+                "receivers",
+                &state
+                    .sender
+                    .as_ref()
+                    .map_or(0, |sender| sender.receiver_count()),
+            )
+            .field("closed", &state.closed)
+            .finish()
+    }
 }
 
 /// Error from a non-blocking lifecycle receive.
@@ -469,8 +406,11 @@ pub enum LifecycleTryRecvError {
 
 /// One membership-owned lifecycle subscription.
 pub struct LifecycleEvents {
-    queue: Arc<LifecycleQueue>,
-    watcher: SignalWatcher,
+    events: runtime::BroadcastReceiver<LifecycleEvent>,
+    explicit_lag: runtime::WatchReceiver<u64>,
+    seen_explicit_lag: u64,
+    pending_event: Option<LifecycleEvent>,
+    pending_lag: u64,
 }
 
 impl LifecycleEvents {
@@ -480,69 +420,119 @@ impl LifecycleEvents {
             match self.try_recv() {
                 Ok(item) => return Some(item),
                 Err(LifecycleTryRecvError::Closed) => return None,
-                Err(LifecycleTryRecvError::Empty) => self.watcher.changed().await,
+                Err(LifecycleTryRecvError::Empty) => {}
+            }
+            let events = &mut self.events;
+            let explicit_lag = &mut self.explicit_lag;
+            match driver::select(events.receive(), explicit_lag.changed_or_closed()).await {
+                driver::Selected::First(runtime::BroadcastReceive::Item(event)) => {
+                    self.pending_event = Some(event);
+                }
+                driver::Selected::First(runtime::BroadcastReceive::Lagged(dropped)) => {
+                    self.pending_lag = self.pending_lag.saturating_add(dropped);
+                }
+                driver::Selected::First(
+                    runtime::BroadcastReceive::Empty | runtime::BroadcastReceive::Closed,
+                )
+                | driver::Selected::Second(_) => {}
             }
         }
     }
 
     /// Attempts to receive without waiting.
     pub fn try_recv(&mut self) -> Result<LifecycleItem, LifecycleTryRecvError> {
-        let mut state = self
-            .queue
-            .state
-            .lock()
-            .expect("lifecycle queue mutex poisoned");
         // The marker leads the overflow episode deliberately. A consumer
         // snapshots here, then discards retained events at or below that
         // watermark before applying the newer suffix.
-        if let Some(dropped) = state.lagged.take() {
+        let current_explicit_lag = self.explicit_lag.borrow_cloned();
+        if current_explicit_lag != self.seen_explicit_lag {
+            let mut dropped = current_explicit_lag.saturating_sub(self.seen_explicit_lag);
+            self.seen_explicit_lag = current_explicit_lag;
+            dropped = dropped.saturating_add(std::mem::take(&mut self.pending_lag));
+            if self.pending_event.is_none() {
+                match self.events.try_receive() {
+                    runtime::BroadcastReceive::Item(event) => self.pending_event = Some(event),
+                    runtime::BroadcastReceive::Lagged(overflow) => {
+                        dropped = dropped.saturating_add(overflow);
+                    }
+                    runtime::BroadcastReceive::Empty | runtime::BroadcastReceive::Closed => {}
+                }
+            }
             return Ok(LifecycleItem::Lagged { dropped });
         }
-        if let Some(event) = state.events.pop_front() {
+        if self.pending_lag > 0 {
+            return Ok(LifecycleItem::Lagged {
+                dropped: std::mem::take(&mut self.pending_lag),
+            });
+        }
+        if let Some(event) = self.pending_event.take() {
             return Ok(LifecycleItem::Event(event));
         }
-        if state.closed {
-            Err(LifecycleTryRecvError::Closed)
-        } else {
-            Err(LifecycleTryRecvError::Empty)
+        match self.events.try_receive() {
+            runtime::BroadcastReceive::Item(event) => Ok(LifecycleItem::Event(event)),
+            runtime::BroadcastReceive::Lagged(dropped) => Ok(LifecycleItem::Lagged { dropped }),
+            runtime::BroadcastReceive::Empty => Err(LifecycleTryRecvError::Empty),
+            runtime::BroadcastReceive::Closed => Err(LifecycleTryRecvError::Closed),
         }
     }
 }
 
 impl fmt::Debug for LifecycleEvents {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let state = self
-            .queue
-            .state
-            .lock()
-            .expect("lifecycle queue mutex poisoned");
         formatter
             .debug_struct("LifecycleEvents")
-            .field("queued", &state.events.len())
-            .field("lagged", &state.lagged)
-            .field("closed", &state.closed)
-            .finish()
+            .field("queued", &self.events.len())
+            .field("pending_lag", &self.pending_lag)
+            .finish_non_exhaustive()
     }
 }
 
-#[derive(Debug, Default)]
 pub(crate) struct LifecycleHub {
-    subscribers: Mutex<Vec<Weak<LifecycleQueue>>>,
+    channels: Mutex<Option<LifecycleChannels>>,
+}
+
+struct LifecycleChannels {
+    events: runtime::BroadcastSender<LifecycleEvent>,
+    explicit_lag: runtime::WatchSender<u64>,
+}
+
+impl Default for LifecycleHub {
+    fn default() -> Self {
+        let (events, _) = runtime::broadcast(LIFECYCLE_EVENT_CAPACITY);
+        let (explicit_lag, _) = runtime::watch(0);
+        Self {
+            channels: Mutex::new(Some(LifecycleChannels {
+                events,
+                explicit_lag,
+            })),
+        }
+    }
 }
 
 impl LifecycleHub {
     pub(crate) fn subscribe(&self) -> LifecycleEvents {
-        let queue = Arc::new(LifecycleQueue {
-            state: Mutex::new(LifecycleQueueState::default()),
-            signal: Signal::default(),
-        });
-        self.subscribers
-            .lock()
-            .expect("lifecycle hub mutex poisoned")
-            .push(Arc::downgrade(&queue));
+        let channels = self.channels.lock().expect("lifecycle hub mutex poisoned");
+        if let Some(channels) = channels.as_ref() {
+            let explicit_lag = channels.explicit_lag.watcher();
+            let seen_explicit_lag = explicit_lag.borrow_cloned();
+            return LifecycleEvents {
+                events: channels.events.subscribe(),
+                explicit_lag,
+                seen_explicit_lag,
+                pending_event: None,
+                pending_lag: 0,
+            };
+        }
+        let (events_sender, events) = runtime::broadcast(LIFECYCLE_EVENT_CAPACITY);
+        let (lag_sender, explicit_lag) = runtime::watch(0);
+        drop(events_sender);
+        drop(lag_sender);
         LifecycleEvents {
-            watcher: queue.signal.watcher(),
-            queue,
+            events,
+            explicit_lag,
+            seen_explicit_lag: 0,
+            pending_event: None,
+            pending_lag: 0,
         }
     }
 
@@ -554,67 +544,50 @@ impl LifecycleHub {
             kind = ?event.kind,
             "scope lifecycle event"
         );
-        let mut subscribers = self
-            .subscribers
+        if let Some(channels) = self
+            .channels
             .lock()
-            .expect("lifecycle hub mutex poisoned");
-        subscribers.retain(|subscriber| {
-            let Some(subscriber) = subscriber.upgrade() else {
-                return false;
-            };
-            let mut state = subscriber
-                .state
-                .lock()
-                .expect("lifecycle queue mutex poisoned");
-            if state.events.len() == LIFECYCLE_EVENT_CAPACITY {
-                let dropped = state.events.pop_front();
-                debug_assert!(dropped.is_some());
-                state.lagged = Some(state.lagged.unwrap_or(0).saturating_add(1));
-            }
-            state.events.push_back(event.clone());
-            drop(state);
-            subscriber.signal.pulse();
-            true
-        });
+            .expect("lifecycle hub mutex poisoned")
+            .as_ref()
+        {
+            let _ = channels.events.send(event);
+        }
     }
 
     pub(crate) fn publish_lagged(&self, dropped: u64) {
-        let mut subscribers = self
-            .subscribers
+        if let Some(channels) = self
+            .channels
             .lock()
-            .expect("lifecycle hub mutex poisoned");
-        subscribers.retain(|subscriber| {
-            let Some(subscriber) = subscriber.upgrade() else {
-                return false;
-            };
-            let mut state = subscriber
-                .state
-                .lock()
-                .expect("lifecycle queue mutex poisoned");
-            state.lagged = Some(state.lagged.unwrap_or(0).saturating_add(dropped));
-            drop(state);
-            subscriber.signal.pulse();
-            true
-        });
+            .expect("lifecycle hub mutex poisoned")
+            .as_ref()
+        {
+            channels
+                .explicit_lag
+                .send_modify(|total| *total = total.saturating_add(dropped));
+        }
     }
 
     pub(crate) fn close(&self) {
-        let mut subscribers = self
-            .subscribers
+        self.channels
             .lock()
-            .expect("lifecycle hub mutex poisoned");
-        subscribers.retain(|subscriber| {
-            let Some(subscriber) = subscriber.upgrade() else {
-                return false;
-            };
-            subscriber
-                .state
-                .lock()
-                .expect("lifecycle queue mutex poisoned")
-                .closed = true;
-            subscriber.signal.pulse();
-            true
-        });
+            .expect("lifecycle hub mutex poisoned")
+            .take();
+    }
+}
+
+impl fmt::Debug for LifecycleHub {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let channels = self.channels.lock().expect("lifecycle hub mutex poisoned");
+        formatter
+            .debug_struct("LifecycleHub")
+            .field(
+                "receivers",
+                &channels
+                    .as_ref()
+                    .map_or(0, |channels| channels.events.receiver_count()),
+            )
+            .field("closed", &channels.is_none())
+            .finish()
     }
 }
 

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{
     ChildId, Exit, Incarnation, Intensity, Membership, RestartPolicy, Retention, StopReason,
-    Strategy, driver, runtime,
+    Strategy, runtime,
 };
 
 /// Number of lifecycle events retained independently for each subscriber.
@@ -409,8 +409,6 @@ pub struct LifecycleEvents {
     events: runtime::BroadcastReceiver<LifecycleEvent>,
     explicit_lag: runtime::WatchReceiver<u64>,
     seen_explicit_lag: u64,
-    pending_event: Option<LifecycleEvent>,
-    pending_lag: u64,
 }
 
 impl LifecycleEvents {
@@ -422,20 +420,7 @@ impl LifecycleEvents {
                 Err(LifecycleTryRecvError::Closed) => return None,
                 Err(LifecycleTryRecvError::Empty) => {}
             }
-            let events = &mut self.events;
-            let explicit_lag = &mut self.explicit_lag;
-            match driver::select(events.receive(), explicit_lag.changed_or_closed()).await {
-                driver::Selected::First(runtime::BroadcastReceive::Item(event)) => {
-                    self.pending_event = Some(event);
-                }
-                driver::Selected::First(runtime::BroadcastReceive::Lagged(dropped)) => {
-                    self.pending_lag = self.pending_lag.saturating_add(dropped);
-                }
-                driver::Selected::First(
-                    runtime::BroadcastReceive::Empty | runtime::BroadcastReceive::Closed,
-                )
-                | driver::Selected::Second(_) => {}
-            }
+            let _ = self.explicit_lag.changed_or_closed().await;
         }
     }
 
@@ -448,25 +433,24 @@ impl LifecycleEvents {
         if current_explicit_lag != self.seen_explicit_lag {
             let mut dropped = current_explicit_lag.saturating_sub(self.seen_explicit_lag);
             self.seen_explicit_lag = current_explicit_lag;
-            dropped = dropped.saturating_add(std::mem::take(&mut self.pending_lag));
-            if self.pending_event.is_none() {
+            // Do not pull a retained event forward across this marker. It
+            // must remain in the bounded ring so a later overflow can still
+            // evict the oldest unread event. Tokio guarantees the next read
+            // reports lag when `len` exceeds the effective capacity; 128 is
+            // already a power of two, so the effective capacity is exact.
+            if self.events.len() > LIFECYCLE_EVENT_CAPACITY {
                 match self.events.try_receive() {
-                    runtime::BroadcastReceive::Item(event) => self.pending_event = Some(event),
                     runtime::BroadcastReceive::Lagged(overflow) => {
                         dropped = dropped.saturating_add(overflow);
                     }
-                    runtime::BroadcastReceive::Empty | runtime::BroadcastReceive::Closed => {}
+                    runtime::BroadcastReceive::Item(_)
+                    | runtime::BroadcastReceive::Empty
+                    | runtime::BroadcastReceive::Closed => {
+                        unreachable!("a lagging broadcast receiver reports its dropped prefix")
+                    }
                 }
             }
             return Ok(LifecycleItem::Lagged { dropped });
-        }
-        if self.pending_lag > 0 {
-            return Ok(LifecycleItem::Lagged {
-                dropped: std::mem::take(&mut self.pending_lag),
-            });
-        }
-        if let Some(event) = self.pending_event.take() {
-            return Ok(LifecycleItem::Event(event));
         }
         match self.events.try_receive() {
             runtime::BroadcastReceive::Item(event) => Ok(LifecycleItem::Event(event)),
@@ -482,7 +466,6 @@ impl fmt::Debug for LifecycleEvents {
         formatter
             .debug_struct("LifecycleEvents")
             .field("queued", &self.events.len())
-            .field("pending_lag", &self.pending_lag)
             .finish_non_exhaustive()
     }
 }
@@ -519,8 +502,6 @@ impl LifecycleHub {
                 events: channels.events.subscribe(),
                 explicit_lag,
                 seen_explicit_lag,
-                pending_event: None,
-                pending_lag: 0,
             };
         }
         let (events_sender, events) = runtime::broadcast(LIFECYCLE_EVENT_CAPACITY);
@@ -531,8 +512,6 @@ impl LifecycleHub {
             events,
             explicit_lag,
             seen_explicit_lag: 0,
-            pending_event: None,
-            pending_lag: 0,
         }
     }
 
@@ -551,6 +530,9 @@ impl LifecycleHub {
             .as_ref()
         {
             let _ = channels.events.send(event);
+            // The watch version is also the no-loss activity notification for
+            // async receivers. Its value changes only for explicit lag.
+            channels.explicit_lag.pulse();
         }
     }
 
@@ -608,11 +590,52 @@ pub enum WaitError {
 
 #[cfg(test)]
 mod tests {
-    use super::SnapshotHub;
+    use crate::{
+        ScopeState,
+        identity::ScopeIdentity,
+        observe::{LifecycleEvent, LifecycleEventKind, LifecycleItem},
+    };
+
+    use super::{LIFECYCLE_EVENT_CAPACITY, LifecycleHub, SnapshotHub};
 
     #[test]
     fn snapshot_projection_is_skipped_without_subscribers() {
         let hub = SnapshotHub::default();
         hub.publish(|| panic!("projection must be lazy when no receiver exists"));
+    }
+
+    #[test]
+    fn a_retained_event_after_explicit_lag_remains_subject_to_later_overflow() {
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let membership = identity.mint_membership().expect("membership available");
+        let event = |seq| LifecycleEvent {
+            scope_path: Vec::new(),
+            scope: membership,
+            seq,
+            kind: LifecycleEventKind::ScopeState {
+                state: ScopeState::Running,
+            },
+        };
+        let hub = LifecycleHub::default();
+        let mut events = hub.subscribe();
+
+        hub.publish_lagged(1);
+        hub.publish(event(1));
+        assert_eq!(events.try_recv(), Ok(LifecycleItem::Lagged { dropped: 1 }));
+
+        for seq in 2..=(LIFECYCLE_EVENT_CAPACITY as u64 + 2) {
+            hub.publish(event(seq));
+        }
+        assert_eq!(
+            events.try_recv(),
+            Ok(LifecycleItem::Lagged { dropped: 2 }),
+            "the prior retained event and the next oldest event are both evicted"
+        );
+        let LifecycleItem::Event(first_retained) =
+            events.try_recv().expect("the retained suffix follows lag")
+        else {
+            panic!("expected the retained suffix");
+        };
+        assert_eq!(first_retained.seq, 3);
     }
 }

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -143,8 +143,17 @@ impl<T> WatchSender<T> {
         self.0.send_modify(update);
     }
 
-    pub(crate) fn send_if_modified(&self, update: impl FnOnce(&mut T) -> bool) -> bool {
-        self.0.send_if_modified(update)
+    /// Mutates the retained value without advancing the watch version.
+    ///
+    /// This is only for compound publication that must finish another
+    /// synchronous state transition before receivers are notified. The caller
+    /// must follow a successful logical mutation with [`Self::pulse`].
+    pub(crate) fn modify_silently(&self, update: impl FnOnce(&mut T)) {
+        let notified = self.0.send_if_modified(|value| {
+            update(value);
+            false
+        });
+        debug_assert!(!notified);
     }
 
     pub(crate) fn replace(&self, value: T) {
@@ -237,14 +246,6 @@ impl<T: Clone> BroadcastSender<T> {
 }
 
 impl<T: Clone> BroadcastReceiver<T> {
-    pub(crate) async fn receive(&mut self) -> BroadcastReceive<T> {
-        match self.0.recv().await {
-            Ok(value) => BroadcastReceive::Item(value),
-            Err(broadcast::error::RecvError::Closed) => BroadcastReceive::Closed,
-            Err(broadcast::error::RecvError::Lagged(dropped)) => BroadcastReceive::Lagged(dropped),
-        }
-    }
-
     pub(crate) fn try_receive(&mut self) -> BroadcastReceive<T> {
         match self.0.try_recv() {
             Ok(value) => BroadcastReceive::Item(value),

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -1,6 +1,7 @@
 //! The only boundary between the library and its async runtime.
 
 use std::{
+    fmt,
     future::Future,
     ops::RangeBounds,
     sync::{
@@ -11,7 +12,7 @@ use std::{
 };
 
 use tokio::{
-    sync::{Notify, mpsc, oneshot},
+    sync::{Notify, broadcast, mpsc, oneshot, watch},
     task, time,
 };
 
@@ -111,6 +112,170 @@ impl<T> OneShotReceiver<T> {
     #[cfg(test)]
     pub(crate) fn try_receive(&mut self) -> Option<T> {
         self.0.try_recv().ok()
+    }
+}
+
+/// Publishing half of a runtime-backed conflating state channel.
+pub(crate) struct WatchSender<T>(watch::Sender<T>);
+
+/// Observing half of a runtime-backed conflating state channel.
+pub(crate) struct WatchReceiver<T>(watch::Receiver<T>);
+
+pub(crate) fn watch<T>(initial: T) -> (WatchSender<T>, WatchReceiver<T>) {
+    let (sender, receiver) = watch::channel(initial);
+    (WatchSender(sender), WatchReceiver(receiver))
+}
+
+impl<T> WatchSender<T> {
+    pub(crate) fn watcher(&self) -> WatchReceiver<T> {
+        WatchReceiver(self.0.subscribe())
+    }
+
+    pub(crate) fn receiver_count(&self) -> usize {
+        self.0.receiver_count()
+    }
+
+    pub(crate) fn pulse(&self) {
+        self.0.send_modify(|_| {});
+    }
+
+    pub(crate) fn send_modify(&self, update: impl FnOnce(&mut T)) {
+        self.0.send_modify(update);
+    }
+
+    pub(crate) fn send_if_modified(&self, update: impl FnOnce(&mut T) -> bool) -> bool {
+        self.0.send_if_modified(update)
+    }
+
+    pub(crate) fn replace(&self, value: T) {
+        self.0.send_replace(value);
+    }
+}
+
+impl<T: Clone> WatchSender<T> {
+    pub(crate) fn read_cloned(&self) -> T {
+        self.0.borrow().clone()
+    }
+}
+
+impl<T> Clone for WatchReceiver<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> WatchReceiver<T> {
+    pub(crate) async fn changed(&mut self) {
+        let _ = self.0.changed().await;
+    }
+
+    pub(crate) async fn changed_or_closed(&mut self) -> bool {
+        self.0.changed().await.is_ok()
+    }
+}
+
+impl<T: Clone> WatchReceiver<T> {
+    pub(crate) fn borrow_cloned(&self) -> T {
+        self.0.borrow().clone()
+    }
+
+    pub(crate) fn borrow_and_update_cloned(&mut self) -> T {
+        self.0.borrow_and_update().clone()
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for WatchSender<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WatchSender")
+            .field("value", &*self.0.borrow())
+            .field("receivers", &self.0.receiver_count())
+            .finish()
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for WatchReceiver<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WatchReceiver")
+            .field("value", &*self.0.borrow())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Result of receiving from a runtime-backed broadcast channel.
+pub(crate) enum BroadcastReceive<T> {
+    Item(T),
+    Empty,
+    Closed,
+    Lagged(u64),
+}
+
+/// Publishing half of a bounded runtime-backed broadcast channel.
+pub(crate) struct BroadcastSender<T>(broadcast::Sender<T>);
+
+/// Per-subscriber receiving half of a bounded runtime-backed broadcast channel.
+pub(crate) struct BroadcastReceiver<T>(broadcast::Receiver<T>);
+
+pub(crate) fn broadcast<T: Clone>(capacity: usize) -> (BroadcastSender<T>, BroadcastReceiver<T>) {
+    let (sender, receiver) = broadcast::channel(capacity);
+    (BroadcastSender(sender), BroadcastReceiver(receiver))
+}
+
+impl<T: Clone> BroadcastSender<T> {
+    pub(crate) fn subscribe(&self) -> BroadcastReceiver<T> {
+        BroadcastReceiver(self.0.subscribe())
+    }
+
+    pub(crate) fn send(&self, value: T) -> Result<usize, T> {
+        self.0.send(value).map_err(|error| error.0)
+    }
+
+    pub(crate) fn receiver_count(&self) -> usize {
+        self.0.receiver_count()
+    }
+}
+
+impl<T: Clone> BroadcastReceiver<T> {
+    pub(crate) async fn receive(&mut self) -> BroadcastReceive<T> {
+        match self.0.recv().await {
+            Ok(value) => BroadcastReceive::Item(value),
+            Err(broadcast::error::RecvError::Closed) => BroadcastReceive::Closed,
+            Err(broadcast::error::RecvError::Lagged(dropped)) => BroadcastReceive::Lagged(dropped),
+        }
+    }
+
+    pub(crate) fn try_receive(&mut self) -> BroadcastReceive<T> {
+        match self.0.try_recv() {
+            Ok(value) => BroadcastReceive::Item(value),
+            Err(broadcast::error::TryRecvError::Empty) => BroadcastReceive::Empty,
+            Err(broadcast::error::TryRecvError::Closed) => BroadcastReceive::Closed,
+            Err(broadcast::error::TryRecvError::Lagged(dropped)) => {
+                BroadcastReceive::Lagged(dropped)
+            }
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl<T> fmt::Debug for BroadcastSender<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BroadcastSender")
+            .field("receivers", &self.0.receiver_count())
+            .finish()
+    }
+}
+
+impl<T> fmt::Debug for BroadcastReceiver<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BroadcastReceiver")
+            .field("queued", &self.0.len())
+            .finish()
     }
 }
 


### PR DESCRIPTION
## Summary

- add runtime-boundary wrappers for `tokio::sync::watch` and `tokio::sync::broadcast`
- replace `MemberCell`'s `Mutex<MemberRecord> + Signal` with a watch-backed record
- replace per-subscriber snapshot state, versioning, closure, and waiter lists with one watch channel
- replace per-subscriber lifecycle queues and waiter lists with a bounded broadcast channel

## Semantic mapping

`MemberCell` and recursive snapshots are conflated state: writers retain the newest value, readers borrow synchronously, and async consumers wait for a newer version. Tokio `watch` provides that state/version/waker model. Member terminalization first closes the mailbox state without callbacks, silently publishes the terminal record, runs deferred mailbox teardown, and only then pulses the watch. Mailbox-derived wakes therefore observe the terminal record, record-derived wakes observe the closed mailbox, and no user waker runs while the watch value lock is held. The same ownership protocol covers concurrent terminalizers and attachment during terminal publication.

Lifecycle subscriptions are bounded sequenced streams with independent cursors and exact lag reporting. Tokio `broadcast` provides the retained ring, per-receiver cursor, cancellation cleanup, and overflow count. A watch-backed monotonic counter carries explicit lifecycle-sequence exhaustion markers and also serves as the no-loss activity wake. Broadcast consumption remains exclusively in `try_recv`, so retained events stay subject to later eviction and every lag marker leads its overflow episode. Explicit and simultaneous broadcast lag are coalesced.

Snapshot publication remains lazy when there are no receivers, closure still drains the last unseen value before reporting `SnapshotClosed`, lifecycle closure drains retained events, and new post-close subscriptions are immediately closed.

The mailbox queue remains bespoke: its accepted-prefix, reply-state, withdrawal, conflation, and backpressure semantics are not a watch/broadcast mapping. Other composite actor/scope wake signals remain outside this cluster.

All Tokio types remain confined to `runtime.rs`.

## Validation

- `./scripts/dev just ci`
- 204 tests passed
- exact two-episode lifecycle lag accounting passes (22 dropped per 150 events at capacity 128)
- sequence-exhaustion lag ordering and retained-event eviction across lag episodes pass
- snapshot closure/lazy projection and both directions of terminal mailbox wake ordering pass
- concurrent/reentrant terminalization and attach-during-publication ordering pass
- public API runtime reachability: clean
- runtime module path restriction: clean
- exit-path downcast restriction: clean

Stacked on #41.

Part of #37 (Cluster 3).
