### PR TITLE
Use Tokio watch for projected scope state

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -583,16 +583,30 @@ pub(crate) struct ScopeRecord {
     pub(crate) total_restarts: u64,
 }
 
+/// Shared scope state follows two distinct synchronization regimes.
+///
+/// `OBSERVATION_GATE` serializes compound, observation-visible transitions
+/// across `config`, `record`, `current_children`, and `parent`, including
+/// recursive snapshot projection and lifecycle-event staging. Their watch
+/// channels retain the latest independently readable value; they do not make
+/// that compound transition atomic, so every multi-field observation path must
+/// continue to hold the gate.
+///
+/// The remaining mutexes are deliberately not collapsed into one state lock.
+/// `control` is an epoch-tagged request plane with concurrent callers,
+/// `child_identity` and `lifecycle_sequence` mint monotonic identities, and
+/// `current_dynamic` owns the independently published dynamic request route.
+/// Scope state therefore has multiple writers and no single-writer invariant.
 pub(crate) struct ScopeCell {
     pub(crate) member: Arc<MemberCell>,
     pub(crate) flavor: ScopeFlavor,
     pub(crate) child_identity: Mutex<ScopeIdentity>,
-    config: Mutex<crate::tree::ScopeConfig>,
-    record: Mutex<ScopeRecord>,
+    config: runtime::WatchSender<crate::tree::ScopeConfig>,
+    record: runtime::WatchSender<ScopeRecord>,
     control: Mutex<ScopeControl>,
     current_dynamic: Mutex<Option<Arc<DynamicControl>>>,
-    current_children: Mutex<Vec<ResidentChild>>,
-    parent: Mutex<Option<Weak<ScopeCell>>>,
+    current_children: runtime::WatchSender<Vec<ResidentChild>>,
+    parent: runtime::WatchSender<Option<Weak<ScopeCell>>>,
     lifecycle_sequence: Mutex<FenceCounter>,
     lifecycle_seq: AtomicU64,
     lifecycle: LifecycleHub,
@@ -621,20 +635,24 @@ impl ScopeCell {
         flavor: ScopeFlavor,
         child_identity: ScopeIdentity,
     ) -> Arc<Self> {
+        let (config, _) = runtime::watch(crate::tree::ScopeConfig::default());
+        let (record, _) = runtime::watch(ScopeRecord {
+            state: ScopeState::Unstarted,
+            startup: None,
+            total_restarts: 0,
+        });
+        let (current_children, _) = runtime::watch(Vec::new());
+        let (parent, _) = runtime::watch(None);
         Arc::new(Self {
             member,
             flavor,
             child_identity: Mutex::new(child_identity),
-            config: Mutex::new(crate::tree::ScopeConfig::default()),
-            record: Mutex::new(ScopeRecord {
-                state: ScopeState::Unstarted,
-                startup: None,
-                total_restarts: 0,
-            }),
+            config,
+            record,
             control: Mutex::new(ScopeControl::default()),
             current_dynamic: Mutex::new(None),
-            current_children: Mutex::new(Vec::new()),
-            parent: Mutex::new(None),
+            current_children,
+            parent,
             lifecycle_sequence: Mutex::new(FenceCounter::new(0)),
             lifecycle_seq: AtomicU64::new(0),
             lifecycle: LifecycleHub::default(),
@@ -644,19 +662,19 @@ impl ScopeCell {
     }
 
     pub(crate) fn record(&self) -> ScopeRecord {
-        self.record.lock().expect("scope mutex poisoned").clone()
+        self.record.read_cloned()
     }
 
     pub(crate) fn set_state(&self, state: ScopeState) {
         let _gate = OBSERVATION_GATE
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let mut record = self.record.lock().expect("scope mutex poisoned");
-        if state == ScopeState::Starting {
-            record.total_restarts = 0;
-        }
-        record.state = state.clone();
-        drop(record);
+        self.record.send_modify(|record| {
+            if state == ScopeState::Starting {
+                record.total_restarts = 0;
+            }
+            record.state = state.clone();
+        });
         self.member.record.pulse();
         self.emit_locked(LifecycleEventKind::ScopeState { state });
     }
@@ -665,7 +683,7 @@ impl ScopeCell {
         let _gate = OBSERVATION_GATE
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        *self.config.lock().expect("scope config mutex poisoned") = config;
+        self.config.replace(config);
         self.publish_snapshot_chain_locked();
     }
 
@@ -704,9 +722,9 @@ impl ScopeCell {
         let _gate = OBSERVATION_GATE
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let mut scope = self.record.lock().expect("scope mutex poisoned");
-        scope.total_restarts = scope.total_restarts.saturating_add(1);
-        drop(scope);
+        self.record.send_modify(|scope| {
+            scope.total_restarts = scope.total_restarts.saturating_add(1);
+        });
         member.update_locked(update);
         self.emit_locked(exited);
         self.emit_locked(scheduled);
@@ -735,14 +753,14 @@ impl ScopeCell {
                 exit: exit.clone(),
             });
         }
-        if let Some(scope) = self
-            .current_children
-            .lock()
-            .expect("scope children mutex poisoned")
-            .iter()
-            .find(|resident| resident.slot.member.membership() == member.membership())
-            .and_then(|resident| resident.slot.scope.as_ref())
-        {
+        let nested = self.current_children.read_with(|children| {
+            children
+                .iter()
+                .find(|resident| resident.slot.member.membership() == member.membership())
+                .and_then(|resident| resident.slot.scope.as_ref())
+                .cloned()
+        });
+        if let Some(scope) = nested {
             scope.close_observation_locked();
         }
         true
@@ -753,19 +771,21 @@ impl ScopeCell {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let membership = member.membership();
-        let resident = {
-            let mut children = self
-                .current_children
-                .lock()
-                .expect("scope children mutex poisoned");
+        let mut resident = None;
+        let removed = self.current_children.send_if_modified(|children| {
             let Some(index) = children
                 .iter()
                 .position(|child| child.slot.member.membership() == membership)
             else {
                 return false;
             };
-            children.remove(index)
-        };
+            resident = Some(children.remove(index));
+            true
+        });
+        if !removed {
+            return false;
+        }
+        let resident = resident.expect("a reported removal owns its resident entry");
         debug_assert_eq!(resident.slot.member.membership(), membership);
         // Dropping residency while the observation gate is held emits the
         // matching Removed edge through its owned completion.
@@ -804,18 +824,15 @@ impl ScopeCell {
 
     fn snapshot_locked(&self) -> Arc<ScopeSnapshot> {
         let record = self.record();
-        let config = self
-            .config
-            .lock()
-            .expect("scope config mutex poisoned")
-            .clone();
+        let config = self.config.read_cloned();
         let children = self
             .current_children
-            .lock()
-            .expect("scope children mutex poisoned")
-            .iter()
-            .map(|resident| Arc::clone(&resident.slot))
-            .collect::<Vec<_>>()
+            .read_with(|children| {
+                children
+                    .iter()
+                    .map(|resident| Arc::clone(&resident.slot))
+                    .collect::<Vec<_>>()
+            })
             .into_iter()
             .map(|slot| self.child_snapshot_locked(&slot))
             .collect::<Vec<_>>();
@@ -875,19 +892,9 @@ impl ScopeCell {
 
     fn ancestors_locked(&self) -> Vec<Arc<ScopeCell>> {
         let mut ancestors = Vec::new();
-        let mut current = self
-            .parent
-            .lock()
-            .expect("scope parent mutex poisoned")
-            .as_ref()
-            .and_then(Weak::upgrade);
+        let mut current = self.parent.read_cloned().as_ref().and_then(Weak::upgrade);
         while let Some(scope) = current {
-            current = scope
-                .parent
-                .lock()
-                .expect("scope parent mutex poisoned")
-                .as_ref()
-                .and_then(Weak::upgrade);
+            current = scope.parent.read_cloned().as_ref().and_then(Weak::upgrade);
             ancestors.push(scope);
         }
         ancestors
@@ -943,10 +950,13 @@ impl ScopeCell {
     }
 
     pub(crate) fn set_startup(&self, startup: Result<(), StartupError>) {
-        let mut record = self.record.lock().expect("scope mutex poisoned");
-        if record.startup.is_none() {
+        if self.record.send_if_modified(|record| {
+            if record.startup.is_some() {
+                return false;
+            }
             record.startup = Some(startup);
-            drop(record);
+            true
+        }) {
             self.member.record.pulse();
         }
     }
@@ -981,13 +991,12 @@ impl ScopeCell {
         let state = ScopeState::Stopped {
             reason: reason.clone(),
         };
-        {
-            let mut record = self.record.lock().expect("scope mutex poisoned");
+        self.record.send_modify(|record| {
             if record.startup.is_none() {
                 record.startup = Some(Err(StartupError::ShutdownRequested));
             }
             record.state = state.clone();
-        }
+        });
         let terminal = terminal_exit.is_some();
         if let Some(exit) = terminal_exit {
             self.member.terminalize(exit);
@@ -1026,13 +1035,12 @@ impl ScopeCell {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             let state = ScopeState::Stopped { reason };
-            {
-                let mut record = self.record.lock().expect("scope mutex poisoned");
+            self.record.send_modify(|record| {
                 if record.startup.is_none() {
                     record.startup = Some(Err(StartupError::ShutdownRequested));
                 }
                 record.state = state.clone();
-            }
+            });
             self.member.terminalize(exit);
             self.member.record.pulse();
             self.emit_locked(LifecycleEventKind::ScopeState { state });
@@ -1107,16 +1115,14 @@ impl ScopeCell {
         self.clear_residents_locked();
         for child in children {
             if let Some(scope) = &child.scope {
-                *scope.parent.lock().expect("scope parent mutex poisoned") =
-                    Some(Arc::downgrade(self));
+                scope.parent.replace(Some(Arc::downgrade(self)));
             }
             child
                 .member
                 .update_locked(|record| record.stage = MemberStage::Admitted);
-            self.current_children
-                .lock()
-                .expect("scope children mutex poisoned")
-                .push(ResidentChild::new(self, Arc::clone(&child)));
+            self.current_children.send_modify(|children| {
+                children.push(ResidentChild::new(self, Arc::clone(&child)))
+            });
             self.emit_locked(LifecycleEventKind::Added {
                 id: child.member.id().clone(),
                 membership: child.member.membership(),
@@ -1129,12 +1135,10 @@ impl ScopeCell {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if let Some(scope) = &child.scope {
-            *scope.parent.lock().expect("scope parent mutex poisoned") = Some(Arc::downgrade(self));
+            scope.parent.replace(Some(Arc::downgrade(self)));
         }
         self.current_children
-            .lock()
-            .expect("scope children mutex poisoned")
-            .push(ResidentChild::new(self, Arc::clone(child)));
+            .send_modify(|children| children.push(ResidentChild::new(self, Arc::clone(child))));
         child
             .member
             .update_locked(|record| record.stage = MemberStage::Admitted);
@@ -1152,12 +1156,7 @@ impl ScopeCell {
     }
 
     fn clear_residents_locked(&self) {
-        let residents = std::mem::take(
-            &mut *self
-                .current_children
-                .lock()
-                .expect("scope children mutex poisoned"),
-        );
+        let residents = self.current_children.take();
         // Each entry's owned completion emits Removed. Drop the vector only
         // after releasing the child-set mutex so snapshot publication can
         // project the now-empty set while this observation gate stays held.
@@ -1184,9 +1183,9 @@ impl ScopeCell {
     }
 
     pub(crate) async fn wait_started(&self) -> Result<(), StartupError> {
-        let mut watcher = self.member.record.watcher();
+        let mut watcher = self.record.watcher();
         loop {
-            if let Some(result) = self.record().startup {
+            if let Some(result) = watcher.borrow_and_update_cloned().startup {
                 return result;
             }
             watcher.changed().await;
@@ -1213,15 +1212,14 @@ impl ScopeCell {
             return;
         }
         self.member.terminalize(Exit::never_started());
-        {
-            let mut record = self.record.lock().expect("scope mutex poisoned");
+        self.record.send_modify(|record| {
             if record.startup.is_none() {
                 record.startup = Some(Err(StartupError::ShutdownRequested));
             }
             record.state = ScopeState::Stopped {
                 reason: StopReason::NeverStarted,
             };
-        }
+        });
         self.member.record.pulse();
         self.emit_locked(LifecycleEventKind::ScopeState {
             state: ScopeState::Stopped {
@@ -1548,13 +1546,12 @@ pub(crate) fn runtime_available() -> bool {
 }
 
 fn collect_stragglers(scope: &ScopeCell, prefix: &[ChildId], out: &mut Vec<ShutdownStraggler>) {
-    let children = scope
-        .current_children
-        .lock()
-        .expect("scope children mutex poisoned")
-        .iter()
-        .map(|resident| Arc::clone(&resident.slot))
-        .collect::<Vec<_>>();
+    let children = scope.current_children.read_with(|children| {
+        children
+            .iter()
+            .map(|resident| Arc::clone(&resident.slot))
+            .collect::<Vec<_>>()
+    });
     for child in children {
         if matches!(child.member.record().stage, MemberStage::Terminal(_)) {
             continue;

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -950,14 +950,19 @@ impl ScopeCell {
     }
 
     pub(crate) fn set_startup(&self, startup: Result<(), StartupError>) {
-        if self.record.send_if_modified(|record| {
-            if record.startup.is_some() {
-                return false;
+        let mut published = false;
+        self.record.modify_silently(|record| {
+            if record.startup.is_none() {
+                record.startup = Some(startup);
+                published = true;
             }
-            record.startup = Some(startup);
-            true
-        }) {
+        });
+        if published {
+            // Before the record became watch-backed, startup waiters shared
+            // the member signal. Preserve that ordering boundary: publish the
+            // member-plane wake before releasing the startup result itself.
             self.member.record.pulse();
+            self.record.pulse();
         }
     }
 
@@ -991,7 +996,7 @@ impl ScopeCell {
         let state = ScopeState::Stopped {
             reason: reason.clone(),
         };
-        self.record.send_modify(|record| {
+        self.record.modify_silently(|record| {
             if record.startup.is_none() {
                 record.startup = Some(Err(StartupError::ShutdownRequested));
             }
@@ -1017,6 +1022,9 @@ impl ScopeCell {
         }
         drop(control);
         self.member.record.pulse();
+        // `wait_started` must not observe terminal startup until the member
+        // and incarnation-control planes above are consistent.
+        self.record.pulse();
         self.emit_locked(LifecycleEventKind::ScopeState { state });
         if terminal {
             self.close_observation_locked();
@@ -1035,7 +1043,7 @@ impl ScopeCell {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             let state = ScopeState::Stopped { reason };
-            self.record.send_modify(|record| {
+            self.record.modify_silently(|record| {
                 if record.startup.is_none() {
                     record.startup = Some(Err(StartupError::ShutdownRequested));
                 }
@@ -1043,6 +1051,7 @@ impl ScopeCell {
             });
             self.member.terminalize(exit);
             self.member.record.pulse();
+            self.record.pulse();
             self.emit_locked(LifecycleEventKind::ScopeState { state });
             self.close_observation_locked();
         }
@@ -1158,7 +1167,7 @@ impl ScopeCell {
     fn clear_residents_locked(&self) {
         let residents = self.current_children.take();
         // Each entry's owned completion emits Removed. Drop the vector only
-        // after releasing the child-set mutex so snapshot publication can
+        // after releasing the child-set watch value guard so snapshot publication can
         // project the now-empty set while this observation gate stays held.
         drop(residents);
     }
@@ -1212,7 +1221,7 @@ impl ScopeCell {
             return;
         }
         self.member.terminalize(Exit::never_started());
-        self.record.send_modify(|record| {
+        self.record.modify_silently(|record| {
             if record.startup.is_none() {
                 record.startup = Some(Err(StartupError::ShutdownRequested));
             }
@@ -1221,6 +1230,7 @@ impl ScopeCell {
             };
         });
         self.member.record.pulse();
+        self.record.pulse();
         self.emit_locked(LifecycleEventKind::ScopeState {
             state: ScopeState::Stopped {
                 reason: StopReason::NeverStarted,
@@ -3628,6 +3638,33 @@ mod tests {
         }
     }
 
+    struct ObserveScopeOnStartupWake {
+        scope: Arc<ScopeCell>,
+        epoch: Option<u64>,
+        observed: Mutex<Option<(MemberStage, Option<bool>)>>,
+    }
+
+    impl ObserveScopeOnStartupWake {
+        fn observe(&self) {
+            let member = self.scope.member.record().stage;
+            let incarnation_finished = self
+                .epoch
+                .map(|epoch| self.scope.incarnation_finished(epoch));
+            *self.observed.lock().expect("observation mutex poisoned") =
+                Some((member, incarnation_finished));
+        }
+    }
+
+    impl Wake for ObserveScopeOnStartupWake {
+        fn wake(self: Arc<Self>) {
+            self.observe();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.observe();
+        }
+    }
+
     #[test]
     fn terminality_signal_follows_mailbox_termination() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
@@ -3772,6 +3809,97 @@ mod tests {
             panic!("one terminal record must be visible");
         };
         assert_eq!(record.last_exit, Some(exit));
+    }
+
+    #[test]
+    fn terminal_startup_wake_follows_member_and_incarnation_publication() {
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let member = MemberCell::new(
+            ChildId::from("root"),
+            identity.mint_membership().expect("membership available"),
+        );
+        let scope = ScopeCell::new(
+            member,
+            ScopeFlavor::Ordered,
+            ScopeIdentity::new().expect("child identity available"),
+        );
+        let epoch = scope.begin_incarnation();
+        let probe = Arc::new(ObserveScopeOnStartupWake {
+            scope: Arc::clone(&scope),
+            epoch: Some(epoch),
+            observed: Mutex::new(None),
+        });
+        let waker = Waker::from(Arc::clone(&probe));
+        let mut watcher = scope.record.watcher();
+        let mut changed = Box::pin(watcher.changed());
+        assert!(
+            changed
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending()
+        );
+
+        scope.finish_root_incarnation(epoch, StopReason::ShutdownRequested, Exit::never_started());
+
+        let observed = probe
+            .observed
+            .lock()
+            .expect("observation mutex poisoned")
+            .clone()
+            .expect("terminal startup wakes the scope watcher");
+        assert!(matches!(observed.0, MemberStage::Terminal(_)));
+        assert_eq!(observed.1, Some(true));
+        assert!(
+            changed
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_ready()
+        );
+    }
+
+    #[test]
+    fn no_live_root_startup_wake_follows_member_publication() {
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let member = MemberCell::new(
+            ChildId::from("root"),
+            identity.mint_membership().expect("membership available"),
+        );
+        let scope = ScopeCell::new(
+            member,
+            ScopeFlavor::Ordered,
+            ScopeIdentity::new().expect("child identity available"),
+        );
+        let probe = Arc::new(ObserveScopeOnStartupWake {
+            scope: Arc::clone(&scope),
+            epoch: None,
+            observed: Mutex::new(None),
+        });
+        let waker = Waker::from(Arc::clone(&probe));
+        let mut watcher = scope.record.watcher();
+        let mut changed = Box::pin(watcher.changed());
+        assert!(
+            changed
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending()
+        );
+
+        scope.finish_live_root_incarnation(StopReason::ShutdownRequested, Exit::never_started());
+
+        let observed = probe
+            .observed
+            .lock()
+            .expect("observation mutex poisoned")
+            .clone()
+            .expect("terminal startup wakes the scope watcher");
+        assert!(matches!(observed.0, MemberStage::Terminal(_)));
+        assert_eq!(observed.1, None);
+        assert!(
+            changed
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_ready()
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -135,12 +135,20 @@ impl<T> WatchSender<T> {
         self.0.receiver_count()
     }
 
+    pub(crate) fn read_with<R>(&self, read: impl FnOnce(&T) -> R) -> R {
+        read(&self.0.borrow())
+    }
+
     pub(crate) fn pulse(&self) {
         self.0.send_modify(|_| {});
     }
 
     pub(crate) fn send_modify(&self, update: impl FnOnce(&mut T)) {
         self.0.send_modify(update);
+    }
+
+    pub(crate) fn send_if_modified(&self, update: impl FnOnce(&mut T) -> bool) -> bool {
+        self.0.send_if_modified(update)
     }
 
     /// Mutates the retained value without advancing the watch version.
@@ -158,6 +166,12 @@ impl<T> WatchSender<T> {
 
     pub(crate) fn replace(&self, value: T) {
         self.0.send_replace(value);
+    }
+}
+
+impl<T: Default> WatchSender<T> {
+    pub(crate) fn take(&self) -> T {
+        self.0.send_replace(T::default())
     }
 }
 


### PR DESCRIPTION
Stack step 4/4 for #37. This PR is based on #46.

## Audit result

The pre-change audit rejected both a single-writer assumption and one consolidated ScopeCell state lock:

- `control` is an epoch-tagged request plane with concurrent callers.
- `child_identity` and `lifecycle_sequence` mint monotonic identities.
- `current_dynamic` publishes an independent dynamic request route.
- `OBSERVATION_GATE`, not any per-field lock, provides compound consistency for recursive snapshots and lifecycle-event staging.

Accordingly, those four mutexes remain separate and the invariant is now documented on `ScopeCell`.

## Semantic mapping

The four retained fields projected into observation are migrated through runtime-owned Tokio watch wrappers:

- `record` → latest `ScopeRecord`; `wait_started` subscribes directly to this state.
- `config` → latest resolved `ScopeConfig`.
- `current_children` → latest resident set; closure-based reads clone slot handles before recursion, and removals/take release the watch value guard before residency completion can emit `Removed`.
- `parent` → latest weak ancestor link used for recursive snapshot/event forwarding.

`OBSERVATION_GATE` still surrounds every compound observation-visible transition. The watch channels retain independently readable field values but are explicitly not treated as a multi-field transaction.

Tokio implementation types remain confined to `runtime.rs`, and no watch guard crosses an `await`.

## Adversarial review

A fresh reviewer found that direct scope-watch notification could wake `wait_started` before member terminal publication and, for a live incarnation, before `last_stopped_epoch` advanced. Commit `5a4b37f` stages those record updates silently and pulses the scope watch beside the original member/control publication boundary. Deterministic custom-waker tests cover both the live-epoch and no-live-root paths.

## Validation

- `./scripts/dev just ci`
- 206/206 tests passed
- formatting, Clippy with warnings denied, docs, API reachability, runtime-path, exit-path, and Nix formatting gates passed