### PR TITLE
Make readiness and completion verdicts authoritative

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2078,7 +2078,6 @@ impl ScopeRuntime {
                         abort: abort.clone(),
                         ready: ready.clone(),
                         local_stop: local_stop.clone(),
-                        readiness_override: child.options.readiness_override,
                         mailbox_shutdown: child.options.mailbox_shutdown,
                     },
                 },
@@ -2208,11 +2207,15 @@ impl ScopeRuntime {
         let nested_abort_ack = framework_abort_ack.clone();
         let constructed_sender = self.events.clone();
         let run_release = construction_release.clone();
+        let child_readiness_override = child.options.readiness_override;
         let handle = runtime::spawn(incarnation, async move {
             let result = match body {
                 SpawnBody::Raw { spawn, context } => {
                     let instance = spawn.construct();
-                    let readiness = instance.readiness();
+                    let readiness = match child_readiness_override {
+                        Some(readiness) => readiness,
+                        None => instance.readiness(),
+                    };
                     let _ = runtime::mpsc_send(
                         &constructed_sender,
                         DriverEvent::Child(ChildEvent::Constructed {
@@ -2223,7 +2226,7 @@ impl ScopeRuntime {
                     )
                     .await;
                     run_release.fired().await;
-                    instance.run(context).await
+                    instance.run(context, readiness).await
                 }
                 SpawnBody::TaskRestartable(factory) => {
                     let future = factory(task_context);
@@ -2542,7 +2545,7 @@ impl ScopeRuntime {
         }
     }
 
-    fn handle_constructed(&mut self, index: usize, incarnation: Incarnation, declared: Readiness) {
+    fn handle_constructed(&mut self, index: usize, incarnation: Incarnation, readiness: Readiness) {
         let mut became_ready = false;
         let mut deadline_to_arm = None;
         {
@@ -2557,7 +2560,6 @@ impl ScopeRuntime {
                 active.construction_release.fire();
                 return;
             }
-            let readiness = child.options.readiness_override.unwrap_or(declared);
             if readiness == Readiness::Immediate {
                 active.readiness = ReadinessGate::Immediate;
                 active.ready_signal.fire();

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -1426,7 +1426,7 @@ type RawFactory = Arc<dyn Fn() -> Box<dyn ErasedRawInstance> + Send + Sync + 'st
 
 pub(crate) trait ErasedRawInstance: Send {
     fn readiness(&self) -> Readiness;
-    fn run(self: Box<Self>, context: RawRunContext) -> RawFuture;
+    fn run(self: Box<Self>, context: RawRunContext, readiness: Readiness) -> RawFuture;
 }
 
 struct RawInstance<R: RawActor> {
@@ -1502,12 +1502,11 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
         self.actor.readiness()
     }
 
-    fn run(self: Box<Self>, context: RawRunContext) -> RawFuture {
+    fn run(self: Box<Self>, context: RawRunContext, readiness: Readiness) -> RawFuture {
         Box::pin(async move {
             let Self { actor, mailbox } = *self;
             let incarnation = context.incarnation;
             let myself = ActorRef::new(Arc::clone(&context.member), Arc::clone(&mailbox));
-            let readiness = context.readiness_override.unwrap_or(actor.readiness());
             let raw = RawContext::new(context, myself, Arc::clone(&mailbox), readiness);
             let mut owner = RawIncarnationOwner::new(raw, actor);
             let outcome = {
@@ -1603,7 +1602,6 @@ pub(crate) struct RawRunContext {
     pub(crate) abort: Latch,
     pub(crate) ready: Latch,
     pub(crate) local_stop: Latch,
-    pub(crate) readiness_override: Option<Readiness>,
     pub(crate) mailbox_shutdown: MailboxShutdown,
 }
 

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -354,14 +354,19 @@ impl<T> OneShotTaskRef<T> {
         Self { completion, task }
     }
 
-    /// Consumes the claim and waits for the typed value or terminal exit.
+    /// Consumes the claim and waits for the authoritative terminal verdict.
+    ///
+    /// The typed value is released only when terminal publication classifies
+    /// the membership as [`crate::ExitKind::Completed`]. Any competing
+    /// failure, panic, abort, readiness timeout, or never-started verdict wins
+    /// even if the task body produced a value first.
     pub async fn wait(self) -> Result<T, Exit> {
         let Self { completion, task } = self;
-        if let Some(value) = completion.receive().await {
-            Ok(value)
-        } else {
-            Err(task.wait().await)
+        let exit = task.wait().await;
+        if !matches!(exit.kind(), crate::ExitKind::Completed) {
+            return Err(exit);
         }
+        completion.receive().await.ok_or(exit)
     }
 }
 

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -372,11 +372,60 @@ impl<T> OneShotTaskRef<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{
+        future::Future,
+        task::{Context, Poll, Waker},
+        time::Duration,
+    };
 
-    use crate::runtime::{self, JoinOutcome, Latch, Timeout};
+    use crate::{
+        ChildId, Exit, ExitKind,
+        driver::MemberCell,
+        identity::ScopeIdentity,
+        runtime::{self, JoinOutcome, Latch, Timeout},
+    };
 
-    use super::CancellationToken;
+    use super::{CancellationToken, OneShotTaskRef, TaskRef};
+
+    fn one_shot_claim<T>() -> (
+        runtime::OneShotSender<T>,
+        OneShotTaskRef<T>,
+        std::sync::Arc<MemberCell>,
+    ) {
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let member = MemberCell::new(
+            ChildId::from("task"),
+            identity.mint_membership().expect("membership available"),
+        );
+        let (sender, receiver) = runtime::oneshot();
+        let claim = OneShotTaskRef::new(receiver, TaskRef::new(std::sync::Arc::clone(&member)));
+        (sender, claim, member)
+    }
+
+    #[crate::runtime::test]
+    async fn typed_value_waits_for_completed_terminal_publication() {
+        let (sender, claim, member) = one_shot_claim();
+        sender.send(42_u8).expect("claim remains open");
+        let mut waiting = Box::pin(claim.wait());
+        let mut context = Context::from_waker(Waker::noop());
+
+        assert!(matches!(waiting.as_mut().poll(&mut context), Poll::Pending));
+        member.terminalize(Exit::new(ExitKind::Completed, false));
+        assert_eq!(waiting.await, Ok(42));
+    }
+
+    #[crate::runtime::test]
+    async fn non_completed_terminal_publication_hides_a_queued_typed_value() {
+        let (sender, claim, member) = one_shot_claim();
+        sender.send(42_u8).expect("claim remains open");
+        let mut waiting = Box::pin(claim.wait());
+        let mut context = Context::from_waker(Waker::noop());
+        let exit = Exit::new(ExitKind::Aborted { after_grace: false }, true);
+
+        assert!(matches!(waiting.as_mut().poll(&mut context), Poll::Pending));
+        member.terminalize(exit.clone());
+        assert_eq!(waiting.await, Err(exit));
+    }
 
     #[crate::runtime::test]
     async fn local_cancellation_cancels_only_the_derived_token() {

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -393,10 +393,9 @@ mod tests {
         std::sync::Arc<MemberCell>,
     ) {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
-        let member = MemberCell::new(
-            ChildId::from("task"),
-            identity.mint_membership().expect("membership available"),
-        );
+        let id = ChildId::from("task");
+        let membership = identity.mint_membership(&id).expect("membership available");
+        let member = MemberCell::new(id, membership);
         let (sender, receiver) = runtime::oneshot();
         let claim = OneShotTaskRef::new(receiver, TaskRef::new(std::sync::Arc::clone(&member)));
         (sender, claim, member)

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -96,6 +96,65 @@ async fn raw_readiness_is_resolved_once_per_incarnation() {
     assert_eq!(calls.load(Ordering::SeqCst), 1);
 }
 
+struct RestartingReadiness {
+    generation: usize,
+    calls: Arc<AtomicUsize>,
+}
+
+impl RawActor for RestartingReadiness {
+    type Msg = ();
+
+    fn readiness(&self) -> Readiness {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if self.generation == 0 {
+            Readiness::Immediate
+        } else {
+            Readiness::Manual
+        }
+    }
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        let expected = if self.generation == 0 {
+            Readiness::Immediate
+        } else {
+            Readiness::Manual
+        };
+        assert_eq!(context.readiness(), expected);
+        if expected == Readiness::Manual {
+            context.mark_ready();
+        }
+        if self.generation == 0 {
+            Err(ExitError::message("restart once"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[tokio::test]
+async fn raw_readiness_is_resolved_once_for_each_restartable_incarnation() {
+    let generations = Arc::new(AtomicUsize::new(0));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    tree.add_raw(
+        "restartable-readiness",
+        RawDef::factory({
+            let generations = Arc::clone(&generations);
+            let calls = Arc::clone(&calls);
+            move || RestartingReadiness {
+                generation: generations.fetch_add(1, Ordering::SeqCst),
+                calls: Arc::clone(&calls),
+            }
+        }),
+    )
+    .expect("valid actor");
+
+    let system = tree.spawn().expect("runtime is available");
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert_eq!(generations.load(Ordering::SeqCst), 2);
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+}
+
 struct OverrideReadiness {
     calls: Arc<AtomicUsize>,
 }

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -1,7 +1,7 @@
 use std::{
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -56,6 +56,87 @@ fn raw_readiness_override_rejects_after_init_eagerly() {
         .readiness(Readiness::AfterInit)
         .expect_err("raw actors have no init phase");
     assert_eq!(error, PolicyError::UnsupportedReadiness);
+}
+
+struct StatefulReadiness {
+    calls: Arc<AtomicUsize>,
+}
+
+impl RawActor for StatefulReadiness {
+    type Msg = ();
+
+    fn readiness(&self) -> Readiness {
+        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            Readiness::Immediate
+        } else {
+            Readiness::Manual
+        }
+    }
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        assert_eq!(context.readiness(), Readiness::Immediate);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn raw_readiness_is_resolved_once_per_incarnation() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    tree.add_raw_once(
+        "stateful-readiness",
+        RawOnceDef::new(StatefulReadiness {
+            calls: Arc::clone(&calls),
+        }),
+    )
+    .expect("valid actor");
+
+    let system = tree.spawn().expect("runtime is available");
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+struct OverrideReadiness {
+    calls: Arc<AtomicUsize>,
+}
+
+impl RawActor for OverrideReadiness {
+    type Msg = ();
+
+    fn readiness(&self) -> Readiness {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        panic!("an effective definition override must bypass actor readiness")
+    }
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        assert_eq!(context.readiness(), Readiness::Manual);
+        context.mark_ready();
+        context.shutdown_token().cancelled().await;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn raw_readiness_override_does_not_evaluate_actor_readiness() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    tree.add_raw_once(
+        "overridden-readiness",
+        RawOnceDef::new(OverrideReadiness {
+            calls: Arc::clone(&calls),
+        })
+        .readiness(Readiness::Manual)
+        .expect("manual readiness override"),
+    )
+    .expect("valid actor");
+
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor becomes ready");
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("actor stops cooperatively");
 }
 
 struct ManualActor {

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -184,11 +184,13 @@ async fn one_shot_completion_reports_abort_verdict() {
 #[tokio::test(start_paused = true)]
 async fn one_shot_value_cannot_override_readiness_timeout_verdict() {
     let readiness_width = Duration::from_secs(10);
+    let (entered, entered_rx) = tokio::sync::oneshot::channel();
     let mut tree = Tree::new();
     let (_task, completion) = tree
         .add_task_once(
             "late-value",
-            TaskOnceDef::new(|context| async move {
+            TaskOnceDef::new(move |context| async move {
+                entered.send(()).expect("test still waits for task entry");
                 context.shutdown_token().cancelled().await;
                 Ok::<_, ExitError>(42_u8)
             })
@@ -202,6 +204,7 @@ async fn one_shot_value_cannot_override_readiness_timeout_verdict() {
         .expect("valid declaration");
     let system = tree.spawn().expect("runtime is available");
 
+    entered_rx.await.expect("task body entered");
     tokio::time::advance(readiness_width).await;
     assert!(matches!(
         completion

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -2,8 +2,8 @@ use std::time::Duration;
 
 use crate::common::LiveFlag;
 use shelterwood::{
-    BuildError, DynamicTree, ExitKind, Readiness, RemoveOutcome, StopReason, TaskDef, TaskOnceDef,
-    Tree,
+    BuildError, DynamicTree, ExitError, ExitKind, Readiness, ReadinessDeadline, RemoveOutcome,
+    Shutdown, StopReason, TaskDef, TaskOnceDef, Tree,
 };
 
 #[test]
@@ -114,6 +114,108 @@ async fn one_shot_completion_finishes_an_ordered_root() {
     assert_eq!(completion.wait().await.expect("task completed"), 42);
     assert!(matches!(task.wait().await.kind(), ExitKind::Completed));
     assert_eq!(system.wait().await, StopReason::Finished);
+}
+
+#[tokio::test]
+async fn one_shot_completion_reports_failure_and_panic_verdicts() {
+    let mut failed_tree = Tree::new();
+    let (_task, failed) = failed_tree
+        .add_task_once(
+            "failed",
+            TaskOnceDef::<u8>::new(|_| async { Err(ExitError::message("failed")) }),
+        )
+        .expect("valid declaration");
+    let failed_system = failed_tree.spawn().expect("runtime is available");
+    assert!(matches!(
+        failed
+            .wait()
+            .await
+            .expect_err("failure has no value")
+            .kind(),
+        ExitKind::Failed(_)
+    ));
+    assert_eq!(failed_system.wait().await, StopReason::Finished);
+
+    let mut panicked_tree = Tree::new();
+    let (_task, panicked) = panicked_tree
+        .add_task_once(
+            "panicked",
+            TaskOnceDef::<u8>::new(|_| async { panic!("one-shot panic") }),
+        )
+        .expect("valid declaration");
+    let panicked_system = panicked_tree.spawn().expect("runtime is available");
+    assert!(matches!(
+        panicked
+            .wait()
+            .await
+            .expect_err("panic has no value")
+            .kind(),
+        ExitKind::Panicked { .. }
+    ));
+    assert_eq!(panicked_system.wait().await, StopReason::Finished);
+}
+
+#[tokio::test(start_paused = true)]
+async fn one_shot_completion_reports_abort_verdict() {
+    let mut tree = Tree::new();
+    let (_task, completion) = tree
+        .add_task_once(
+            "aborted",
+            TaskOnceDef::<u8>::new(|_| std::future::pending()).shutdown(Shutdown::Abort),
+        )
+        .expect("valid declaration");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("task starts");
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("forced shutdown joins the task");
+
+    assert!(matches!(
+        completion
+            .wait()
+            .await
+            .expect_err("aborted task has no value")
+            .kind(),
+        ExitKind::Aborted { .. }
+    ));
+}
+
+#[tokio::test(start_paused = true)]
+async fn one_shot_value_cannot_override_readiness_timeout_verdict() {
+    let readiness_width = Duration::from_secs(10);
+    let mut tree = Tree::new();
+    let (_task, completion) = tree
+        .add_task_once(
+            "late-value",
+            TaskOnceDef::new(|context| async move {
+                context.shutdown_token().cancelled().await;
+                Ok::<_, ExitError>(42_u8)
+            })
+            .shutdown(Shutdown::Abort)
+            .readiness(Readiness::Manual)
+            .expect("manual readiness")
+            .readiness_deadline(
+                ReadinessDeadline::bounded(readiness_width).expect("non-zero deadline"),
+            ),
+        )
+        .expect("valid declaration");
+    let system = tree.spawn().expect("runtime is available");
+
+    tokio::time::advance(readiness_width).await;
+    assert!(matches!(
+        completion
+            .wait()
+            .await
+            .expect_err("the readiness verdict wins over the returned value")
+            .kind(),
+        ExitKind::ReadinessTimedOut { .. }
+    ));
+    assert!(system.wait_started().await.is_err());
+    system
+        .shutdown(Duration::ZERO)
+        .await
+        .expect("terminal task leaves no straggler");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Part of #35 (item 4)

## What changed

- wait for terminal membership publication before a one-shot task claim releases its typed value
- return every competing terminal `Exit` (failure, panic, abort, never-started, or readiness timeout) instead of an early `Ok(T)`
- resolve each raw incarnation's effective readiness once, bypassing `RawActor::readiness` entirely when the definition supplies an override
- pass that single readiness value to both the driver gate and `RawContext`

## Why

The typed value channel previously became observable before the driver had classified the final exit, so a value returned after a readiness deadline could incorrectly win over `ReadinessTimedOut`. Raw actor readiness was also evaluated independently by the driver and runner, allowing stateful implementations to disagree.

## Impact

One-shot completion now reflects the authoritative terminal verdict. Raw actors receive the exact readiness mode used by supervision, with one actor readiness evaluation per incarnation and no unnecessary evaluation under an override.

## Validation

- focused task and raw-readiness integration tests
- `./scripts/dev just ci` (212 tests plus formatting, Clippy, docs, and repository guards)
- `./scripts/dev just ci-nix` (all clean Nix checks passed)
