### PR TITLE
Close conformance and fault-path test gaps

### DIFF
--- a/crates/shelterwood/doctests/README.md
+++ b/crates/shelterwood/doctests/README.md
@@ -1,0 +1,92 @@
+# shelterwood
+
+Shelterwood is a structured-supervision and actor runtime for asynchronous
+Rust. A system is declared as a tree of actors, plain tasks, and nested scopes;
+the tree owns startup order, readiness, restart policy, bounded mailboxes,
+shutdown, and observation. Stable membership and incarnation identities make
+failure recovery explicit without a global registry.
+
+The current `0.1` surface is the core described by [SPEC.md](SPEC.md): ordered
+and dynamic scopes, `OneForOne` supervision, handler and raw actors, supervised
+tasks, queue and latest-value mailboxes, lifecycle events, and recursive
+snapshots. Part II features in the specification are intentionally not part of
+the core API yet.
+
+## Getting started
+
+The repository toolchain comes from Nix. `scripts/dev` enters the dev shell for
+the current checkout, including when invoked from a worktree:
+
+```sh
+./scripts/dev just test
+./scripts/dev just ci
+./scripts/dev just ci-nix
+```
+
+A task-first application needs no actor merely to obtain supervision:
+
+```rust
+use std::time::Duration;
+
+use shelterwood::{ExitError, TaskOnceDef, Tree};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tree = Tree::new();
+    let (_worker, _completion) = tree.add_task_once(
+        "worker",
+        TaskOnceDef::new(|context| async move {
+            context.shutdown_token().cancelled().await;
+            Ok::<_, ExitError>(())
+        }),
+    )?;
+
+    let system = tree.spawn()?;
+    system.wait_started().await?;
+
+    // The owner drives bounded teardown and waits for every child to join.
+    system.shutdown(Duration::from_secs(5)).await?;
+    Ok(())
+}
+```
+
+Use `Tree` when declaration order should also be startup order and reverse
+shutdown order. Use `DynamicTree` for concurrently started membership that can
+be added and removed at runtime. Actors and tasks are peers in either kind of
+scope, and subtrees compose both recursively.
+
+## Operational guides
+
+- [Calls, retries, and message ordering](docs/retry-and-ordering.md)
+- [Shutdown and resource ownership](docs/shutdown-and-resources.md)
+- [Snapshots and lifecycle events](docs/observation.md)
+- [Embedding Shelterwood in a host process](docs/embedding.md)
+
+The executable application-scale examples live in the M5 acceptance tests:
+[shard store](crates/shelterwood/tests/acceptance/shard_store.rs),
+[sidecar](crates/shelterwood/tests/acceptance/sidecar.rs), and
+[assistant control plane](crates/shelterwood/tests/acceptance/assistant.rs).
+
+## Operational preconditions
+
+Shelterwood supervision classifies panics only when the process uses
+`panic = "unwind"`; `panic = "abort"` ends the process before a supervisor can
+observe the panic. Rust's ordinary double-panic rule still applies: if a
+destructor panics while the same user future is already unwinding, the process
+aborts before supervision can publish an exit. Spawn systems inside a Tokio
+runtime with time enabled, and resolve `System::shutdown` (or allow the dropped
+owner to finish teardown) before destroying that runtime. Destroying the
+runtime around a live system is outside the contract.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE))
+- MIT license ([LICENSE-MIT](LICENSE-MIT))
+
+at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this project by you shall be dual licensed as above, without
+any additional terms or conditions.

--- a/crates/shelterwood/doctests/docs/embedding.md
+++ b/crates/shelterwood/doctests/docs/embedding.md
@@ -1,0 +1,70 @@
+# Embedding Shelterwood in a host process
+
+Shelterwood does not need to own `main` or the Tokio runtime. A host can open
+process-lifetime resources, build and spawn a tree, await readiness, operate it,
+then consume the `System` with bounded shutdown. A fresh tree can repeat that
+cycle in the same process; the sidecar acceptance test runs two complete
+embed/start/stop cycles over shared host-owned state.
+
+Plain `TaskDef` and `TaskOnceDef` children are first-class siblings of actors
+and subtrees. A task-first service can therefore supervise config loading,
+telemetry, serving, and cleanup directly, adding an actor subtree only where a
+mailbox protocol is useful.
+
+## Startup ownership
+
+An ordered `Tree` starts children in declaration order and gates each following
+child on readiness. Manual readiness lets a task or actor publish that its
+external resource is usable rather than merely that its future was spawned.
+
+At the root, `wait_started()` reports a startup failure but deliberately leaves
+the successfully started prefix supervised. This permits a host-specific
+decision, but most embeddings want rollback:
+
+```rust,no_run
+# use std::time::Duration;
+# use shelterwood::{System, Tree};
+# async fn start(tree: Tree) -> Result<System, Box<dyn std::error::Error>> {
+let system = tree.spawn()?;
+let system = system
+    .start_or_shutdown(Duration::from_secs(5))
+    .await?;
+# Ok(system)
+# }
+```
+
+`start_or_shutdown` returns the owner on success. On failure it drives full
+shutdown of the started prefix and returns both the original startup error and
+any rollback timeout report; rollback never masks the cause.
+
+## One-shot means one incarnation
+
+The `_once` declaration family consumes owned construction input and can create
+exactly one incarnation. It does not mean “one loop iteration.” A cleanly
+returning restartable child under `RestartCondition::OnFailure` also runs only
+once; use `_once` when the arguments or future cannot be minted again, or when
+the type should make restart impossible.
+
+Restartable definitions take cloneable arguments or a factory that creates
+fresh input for every incarnation. Put reconnectable incarnation state there.
+Keep process-lifetime durable state in the host and pass cloneable handles into
+each fresh tree or actor incarnation.
+
+## A complete host cycle
+
+1. Open host-owned resources and construct a fresh `Tree` or `DynamicTree`.
+2. Spawn inside a Tokio runtime with time enabled.
+3. Use `start_or_shutdown` to either receive a ready owner or roll back.
+4. Keep the `System` owner alive while the service runs. Non-owning scope and
+   actor handles may be cloned freely.
+5. Call `system.shutdown(timeout).await` before closing host resources or
+   destroying the runtime.
+6. Inspect a structured timeout report if cooperative teardown exceeded its
+   budget; all actor futures are nevertheless joined when the call returns.
+7. Build a new tree for another cycle. Builders and `System` are single-use by
+   design; durable host state is what crosses cycles.
+
+Dropping `System` also requests graceful shutdown, but awaiting explicit
+shutdown is the only way for the host to know teardown has joined and to receive
+straggler evidence. See [shutdown and resource ownership](shutdown-and-resources.md)
+for grace, blocking-work, and teardown-notification rules.

--- a/crates/shelterwood/doctests/docs/observation.md
+++ b/crates/shelterwood/doctests/docs/observation.md
@@ -1,0 +1,100 @@
+# Snapshots and lifecycle events
+
+Shelterwood provides two restart-stable observation surfaces. `snapshot()` is
+authoritative recursive current state and snapshot subscriptions conflate to
+the latest value. Lifecycle subscriptions are bounded ordered histories for the
+subscribed scope and all descendants. Both are owned by the scope membership,
+so they remain valid across scope incarnations.
+
+## Subscribe, then snapshot
+
+Subscriptions begin “now”; they do not replay history. Use this catch-up
+protocol both at initial attachment and after `LifecycleItem::Lagged`:
+
+1. Subscribe to lifecycle events.
+2. Read `snapshot()` after subscribing and treat it as ground truth.
+3. Discard queued events already reflected by the snapshot.
+4. Apply later events as deltas. On `Lagged`, restart from a fresh snapshot.
+
+Every emitting scope has a membership token and sequence. A recursive
+`ScopeSnapshot` carries `lifecycle_seq` for itself; a scope child also carries
+`scope_seq`, including during a restart window when its nested snapshot is
+temporarily absent. For an event emitted by the subscribed scope itself, compare
+`event.scope` with the scope handle's `membership()` and use
+`snapshot.lifecycle_seq`. For a descendant event,
+`snapshot.watermark(event.scope)` finds the matching watermark. An event is
+already reflected when `event.seq <= watermark`.
+
+A child in `Restarting` normally exposes its absolute backoff deadline through
+`restart_at`. If the requested delay is too large for the platform clock to
+represent, `restart_at` is `None`; the child remains in `Restarting` until
+removal or shutdown rather than restarting immediately.
+
+If the event's scope token is absent from the snapshot, use causal introduction:
+
+- if you applied a later `Added` whose membership is that scope token, the new
+  scope has no prior watermark; apply its causally following events;
+- otherwise it is a stale membership whose removal the snapshot already
+  reflects; discard it.
+
+`Lagged { dropped }` is a subscription item, not a lifecycle event. It has no
+scope path or sequence because the dropped events may have come from several
+descendant scopes. Each subscriber has its own buffer, so a slow observer
+cannot cause another observer to lose events.
+
+## Identity and paths
+
+`scope_path` is a human-readable child-id path relative to the subscribed
+scope. Child ids are reusable, so the path is not a fence. Use the event's
+`scope` membership and each `Added`/`Removed` membership to distinguish a
+replacement from stale traffic.
+
+An `ActorRef` follows all incarnations of one membership but never follows a
+same-id replacement membership. Compare incarnations with `supersedes`, not an
+expected generation number. Several restarts may occur between observations.
+
+## Waits must accept at-or-past state
+
+Snapshot watches conflate intermediate states. A `wait_for_child` predicate
+must accept every state at or beyond the desired edge, not only the single
+transition it hopes to catch. For example, a readiness wait should accept a
+running or terminal state according to the application's protocol, and a
+restart wait should accept any incarnation that `supersedes` the saved one.
+Pin the returned `membership` when a same-id replacement would not satisfy the
+logical wait.
+
+Use a finite deadline for operational waits. `Duration::ZERO` still examines
+the current snapshot once, so an already-satisfied predicate succeeds. A
+duration too large for the platform clock to represent (including
+`Duration::MAX`) behaves as an unbounded wait rather than an immediate timeout.
+A missing child does not match yet because a future `Added` under that label may
+satisfy the wait. If the containing scope terminalizes first, `wait_for_child`
+returns its terminal scope state.
+
+## Terminal state is not pruning
+
+Terminalization records the final child state and emits its terminal lifecycle
+edge. Pruning removes that membership from scope residency. With
+`Retention::Retain`, a terminal child remains as an observable tombstone and
+continues to make the id a duplicate until explicit removal or scope teardown.
+It does not remain live and cannot restart.
+
+With `Retention::Remove`, pruning follows terminalization. Explicit removal,
+successful exact-handle retirement, and containing-scope teardown also prune.
+The lifecycle `Removed` event describes that pruning edge; do not infer that a
+terminal snapshot must immediately disappear.
+
+For planned replacement, retain the admission receipt or exact handle, remove
+that membership, await `RemoveOutcome::Removed`, then add the replacement. An
+add racing an in-progress same-id removal fails with `RemovalInProgress`; await
+the removal and retry. The replacement's membership is distinct rather than a
+new incarnation of the old one, and it supersedes the removed same-id
+membership. Different ids and different owning scopes remain incomparable.
+
+## Pre-spawn observation
+
+Scope handles, snapshots, and subscriptions exist before spawn. Their initial
+scope state is `Unstarted`. Dropping an unspawned tree terminalizes declared
+members as never started, publishes the final state/event, and closes streams;
+pre-spawn observation and shutdown waits therefore resolve structurally instead
+of hanging.

--- a/crates/shelterwood/doctests/docs/retry-and-ordering.md
+++ b/crates/shelterwood/doctests/docs/retry-and-ordering.md
@@ -1,0 +1,98 @@
+# Calls, retries, and message ordering
+
+`ActorRef::call` uses one deadline for message construction, mailbox acceptance,
+and the reply. The budget starts when the call future is first polled, before
+the user-supplied message constructor runs, so slow construction consumes the
+same budget. Its result always carries identity evidence: `Replied<T>`
+identifies the incarnation that accepted a successful request, while
+`CallError` records the accepting or observed incarnation when one exists.
+Treat these tokens as part of the protocol, not merely diagnostic metadata.
+
+## The retry decision
+
+| Result | What is known | Required action |
+| --- | --- | --- |
+| `AcceptanceTimedOut` | The request was withdrawn and was not accepted. | Retrying is safe. Keep it within the logical operation's overall deadline. |
+| `ResponseTimedOut` | The request was accepted; its effect and reply are unknown. | Do not resend blindly. Reconcile against durable application state. |
+| `ReplyDropped` | The request was accepted, but its `Reply` was dropped unanswered. | Retry only an idempotent operation, only under one overall deadline, and only after a newer incarnation is running. |
+| `Terminated` | The target membership ended before acceptance. | That handle can never follow a same-id replacement. Obtain the replacement's new handle deliberately. |
+
+For a safe `ReplyDropped` retry in the core API:
+
+1. Give the logical operation a durable id and make duplicate processing
+   idempotent.
+2. Save `CallError::incarnation_observed`; it identifies the incarnation that
+   accepted and then lost the reply.
+3. Observe snapshots or lifecycle events until the live incarnation
+   `supersedes` the saved one. Do not assume the next generation is exactly
+   `old + 1`: several restarts may happen between observations.
+4. Resend the same operation id using only the time left in one overall
+   deadline.
+5. Bound the retry horizon and garbage-collect the application's idempotency
+   ledger only after a retry is no longer possible.
+
+`ResponseTimedOut` deliberately has no equivalent retry recipe. Acceptance
+happened, so only application ground truth can distinguish “not applied,”
+“applied without a reply,” and “still running.” Reconcile first. The shard-store
+acceptance test demonstrates both the post-commit reconciliation case and the
+idempotent `ReplyDropped` loop.
+
+Membership and incarnation answer different questions. An `ActorRef` follows
+restarts of one membership. After remove and re-add under the same child id,
+the replacement has a new `Membership` that supersedes the removed membership,
+while the old handle remains pinned to the removed one and never retargets.
+Membership ordering is narrow: only replacements of the same child id in the
+same stable scope compare. Different child ids and memberships owned by
+different scopes remain incomparable.
+
+The stable scope identity also spans declaration and runtime boundaries.
+Replacing an initially declared child dynamically therefore supersedes that
+declared membership, and a corresponding descendant produced after a nested
+scope restart supersedes its predecessor. A rebuilt declaration's handle
+observes that rebased membership, but the handle's own `Eq`/`Hash` identity
+is the slot itself: a handle stashed in a map before lowering remains
+addressable afterward. Read `membership()` when the exact token matters.
+Within one membership, `Incarnation::supersedes` remains the correct restart
+ordering test.
+
+## Latest-value mailboxes and calls
+
+`Mailbox::latest()` stores only the newest accepted message. Replacing a call
+message drops its embedded `Reply`, so that caller receives `ReplyDropped`.
+Calls are allowed on a latest-value mailbox, but this behavior makes them a
+correctness trap unless conflation is an intentional, idempotent part of the
+protocol. Prefer a queue mailbox for commands and calls; reserve `latest()` for
+state-like updates where only the newest value matters.
+
+`Reply::send` consumes the capability and is infallible. If the caller has
+cancelled or timed out, the value is discarded. Actor code should not branch on
+caller liveness.
+
+## Ordering is intentionally narrow
+
+A queue mailbox guarantees FIFO only for messages sent by the same sender task,
+accepted by the same actor incarnation. There is no order guarantee across
+sender tasks, across incarnations, or between mailbox messages and offload
+completions. A latest-value mailbox orders by replacement: only its newest
+accepted survivor is delivered.
+
+Actor-local `continue_with` messages run ahead of external input, with a
+fairness turn between consecutive continuations. Use this when a handler needs
+to split work into protocol steps without awaiting itself.
+
+## Never call and await `myself()` in a handler
+
+Awaiting `context.myself().call(...)` from `handle` deadlocks: the reply can be
+produced only by the actor loop that the current handler is blocking. Use one
+of these shapes instead:
+
+- `continue_with` for a later step on the same actor;
+- call another actor through an incarnation-owned `offload`, returning the
+  result as a continuation message; or
+- split `Reply::channel()`, `try_send` the request from the handler (handling
+  `Full`/`NotRunning` — a plain `send` future is lazy, so constructing it
+  without awaiting it sends nothing), and await the receiver from an offload.
+
+Offloads use one deadline and their completion returns through the actor loop.
+Cancellation suppresses the continuation, so no offload extends the actor
+incarnation that created it.

--- a/crates/shelterwood/doctests/docs/shutdown-and-resources.md
+++ b/crates/shelterwood/doctests/docs/shutdown-and-resources.md
@@ -1,0 +1,115 @@
+# Shutdown and resource ownership
+
+Shelterwood uses one escalation ladder everywhere:
+
+```text
+cooperative cancellation -> grace expiry -> tidy-abort beat -> hard abort
+```
+
+`Shutdown::Abort` is the zero-grace point on that ladder. The shutdown token
+still fires strictly before the abort token, and the tidy beat still occurs.
+`ExitKind::Aborted { after_grace }` distinguishes hard abort after an expired
+grace (`true`) from the immediate policy (`false`). These token transitions are
+observable inside a child; lifecycle events report the eventual exit, not
+separate ladder steps.
+
+## Grace is an upper bound
+
+A graceful child does not receive a guaranteed amount of CPU time after its
+shutdown token fires. Its grace is a supervisor-side upper bound. Scheduler
+latency and competing work can reduce the time user code observes.
+
+For handler actors, one grace budget covers both delivery of the frozen mailbox
+prefix and `on_stop`. With `MailboxShutdown::Drain`, the loop freezes intake,
+drains accepted messages, then invokes `on_stop`. With `Discard`, it drops the
+prefix and proceeds to `on_stop`. A handler error, panic, or hard abort can
+truncate or skip cleanup.
+
+Consequently, `on_stop` is best-effort resource return, not a durability
+boundary. Durable correctness must already survive a crash. Size a resource
+owner's grace for drain plus close, or choose `Discard` when draining is less
+important than allowing the close its full budget.
+
+## Teardown communication uses `try_send`
+
+Ordinary `send` waits through rebind windows. During teardown, that can park
+forever against a sibling whose current incarnation has already frozen intake.
+Use `try_send` for best-effort shutdown notifications and handle
+`NotRunning`, `Full`, and `Terminated` explicitly. Correct teardown must not
+depend on such a notification arriving; scope order and cancellation tokens
+are the reliable control plane.
+
+Ordered scopes stop children in reverse declaration order, one fully joined
+child at a time. Put a slow resource owner earlier in declaration order so its
+dependents stop first and its close runs quiescent. Per-child graces therefore
+sum in an ordered scope. Dynamic scopes start all stop ladders together and
+drain concurrently.
+
+## Raw actors must implement the drain policy
+
+The framework always freezes raw-actor intake, but the raw loop owns delivery.
+It must consult `RawContext::mailbox_shutdown` and use `try_recv` to drain the
+frozen prefix when requested:
+
+```rust,no_run
+# use shelterwood::{ExitError, ExitResult, MailboxShutdown, RawContext};
+# fn handle<T>(_message: T) -> Result<(), ExitError> { Ok(()) }
+# async fn drain<M: Send + 'static>(context: &mut RawContext<M>) -> ExitResult {
+while let Some(message) = context.recv().await {
+    handle(message)?;
+}
+
+if context.mailbox_shutdown() == MailboxShutdown::Drain {
+    while let Some(message) = context.try_recv() {
+        handle(message)?;
+    }
+}
+# Ok(())
+# }
+```
+
+For a queue mailbox, that prefix is every accepted but undelivered message in
+acceptance order. For `latest()`, it is at most the one surviving value.
+Draining still shares the child's grace and may be truncated by failure or hard
+abort. The high-level `Actor` handler loop performs this protocol itself.
+
+## Choose the resource owner deliberately
+
+An incarnation-owned resource is created by `init` and dropped on restart;
+use this when restart should reconnect or repair it. A resource that must
+survive restarts belongs outside the incarnation: open it in the host, pass a
+cloneable handle through `Args`, resolve system shutdown, then close it in host
+code. Host-owned closes run outside child grace budgets.
+
+`run_blocking` is available from normal and stop contexts for blocking work.
+The closure receives a cooperative cancellation token. Dropping its returned
+future cancels that token, but cannot forcibly stop a thread. After hard abort,
+the blocking thread is detached and may continue; Shelterwood never joins it.
+A late return value or panic is discarded if its future was dropped. Therefore
+blocking operations must be safe to outlive the actor and must not retain
+exclusive process resources indefinitely.
+
+Async offloads are different: they are incarnation-owned, are cancelled at the
+stop freeze, and never outlive the incarnation. They are intentionally absent
+from `StopContext`.
+
+## Owner and runtime lifetime
+
+`System::shutdown(timeout)` consumes the owner, requests teardown, and joins
+every descendant before returning. The timeout bounds the cooperative phase;
+after it expires Shelterwood escalates and joins stragglers, so destruction of
+user futures can make the final return take longer. A zero timeout skips the
+cooperative wait but still follows token ordering and the tidy beat.
+
+Dropping `System` requests graceful shutdown, but an embedding host should
+normally await `shutdown` before tearing down the Tokio runtime. The ambient
+runtime must have time enabled. Supervised panic classification additionally
+requires `panic = "unwind"`. The standard double-panic exclusion remains: a
+destructor that panics while its user future is already unwinding aborts the
+process before the supervisor can publish an exit.
+
+A shutdown request through a pre-spawn scope handle is retained as a pending
+stop. The first incarnation starts and immediately enters teardown; the timeout
+for `shutdown_and_wait` begins when that incarnation starts, because there is
+nothing to escalate beforehand. If the membership is terminalized without ever
+spawning, the wait resolves as already stopped rather than hanging.

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -46,3 +46,23 @@ pub use tree::{
     ReserveError, ScopeRef, StartOrShutdownError, StartupError, StopReason, Subtree, SubtreeDef,
     SubtreeOnceDef, SubtreeSlot, System, TaskSlot, Tree,
 };
+
+// Keep the repository-facing examples in the same rustdoc compilation lane as
+// the crate API without adding documentation-only modules to the public surface.
+#[cfg(doctest)]
+mod repository_docs {
+    #[doc = include_str!("../../../README.md")]
+    mod readme {}
+
+    #[doc = include_str!("../../../docs/embedding.md")]
+    mod embedding {}
+
+    #[doc = include_str!("../../../docs/observation.md")]
+    mod observation {}
+
+    #[doc = include_str!("../../../docs/retry-and-ordering.md")]
+    mod retry_and_ordering {}
+
+    #[doc = include_str!("../../../docs/shutdown-and-resources.md")]
+    mod shutdown_and_resources {}
+}

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -49,20 +49,22 @@ pub use tree::{
 
 // Keep the repository-facing examples in the same rustdoc compilation lane as
 // the crate API without adding documentation-only modules to the public surface.
+// These synchronized copies live inside the crate so packaged doctests use the
+// same sources as repository doctests.
 #[cfg(doctest)]
 mod repository_docs {
-    #[doc = include_str!("../../../README.md")]
+    #[doc = include_str!("../doctests/README.md")]
     mod readme {}
 
-    #[doc = include_str!("../../../docs/embedding.md")]
+    #[doc = include_str!("../doctests/docs/embedding.md")]
     mod embedding {}
 
-    #[doc = include_str!("../../../docs/observation.md")]
+    #[doc = include_str!("../doctests/docs/observation.md")]
     mod observation {}
 
-    #[doc = include_str!("../../../docs/retry-and-ordering.md")]
+    #[doc = include_str!("../doctests/docs/retry-and-ordering.md")]
     mod retry_and_ordering {}
 
-    #[doc = include_str!("../../../docs/shutdown-and-resources.md")]
+    #[doc = include_str!("../doctests/docs/shutdown-and-resources.md")]
     mod shutdown_and_resources {}
 }

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, poll_until};
+use crate::common::{ReleaseGate, assert_quiet, poll_until};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DynamicTree, ExitError, ExitResult, Handler, RawActor,
     RawContext, RawOnceDef, Readiness, StopContext, TaskDef, Tree,
@@ -160,9 +160,10 @@ struct ManualActor;
 
 impl Actor for ManualActor {
     type Msg = ();
-    type Args = ();
+    type Args = ReleaseGate;
 
-    async fn init(_: (), _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+    async fn init(entered: ReleaseGate, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        entered.release();
         Ok(Self)
     }
 
@@ -172,14 +173,15 @@ impl Actor for ManualActor {
     }
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn manual_handler_readiness_is_not_released_automatically_after_init() {
+    let init_entered = ReleaseGate::default();
     let sibling_started = Arc::new(AtomicBool::new(false));
     let mut tree = Tree::new();
     let actor = tree
         .add_actor_once(
             "actor",
-            ActorOnceDef::<ManualActor>::new(()).readiness(Readiness::Manual),
+            ActorOnceDef::<ManualActor>::new(init_entered.clone()).readiness(Readiness::Manual),
         )
         .expect("valid actor");
     let observed = Arc::clone(&sibling_started);
@@ -193,8 +195,11 @@ async fn manual_handler_readiness_is_not_released_automatically_after_init() {
         )
         .expect("valid sibling");
     let system = tree.spawn().expect("runtime is available");
-    tokio::task::yield_now().await;
-    assert!(!sibling_started.load(Ordering::SeqCst));
+    init_entered.wait().await;
+    assert_quiet(Duration::from_millis(20), || {
+        sibling_started.load(Ordering::SeqCst)
+    })
+    .await;
     actor
         .send(())
         .await
@@ -225,6 +230,8 @@ impl Actor for GatedActor {
 
 struct AwaitingDecorator<R> {
     inner: R,
+    entered: ReleaseGate,
+    release: ReleaseGate,
 }
 
 impl<R: RawActor> RawActor for AwaitingDecorator<R> {
@@ -235,20 +242,25 @@ impl<R: RawActor> RawActor for AwaitingDecorator<R> {
     }
 
     async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
-        tokio::task::yield_now().await;
+        self.entered.release();
+        self.release.wait().await;
         self.inner.run(context).await
     }
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn raw_decorator_await_before_handler_delegate_preserves_declared_readiness() {
-    let gate = ReleaseGate::default();
+    let decorator_entered = ReleaseGate::default();
+    let release_decorator = ReleaseGate::default();
+    let release_init = ReleaseGate::default();
     let sibling_started = Arc::new(AtomicBool::new(false));
     let mut tree = Tree::new();
     tree.add_raw_once(
         "actor",
         RawOnceDef::new(AwaitingDecorator {
-            inner: Handler::<GatedActor>::new(gate.clone()),
+            inner: Handler::<GatedActor>::new(release_init.clone()),
+            entered: decorator_entered.clone(),
+            release: release_decorator.clone(),
         }),
     )
     .expect("valid decorated actor");
@@ -266,9 +278,13 @@ async fn raw_decorator_await_before_handler_delegate_preserves_declared_readines
     )
     .expect("valid sibling");
     let system = tree.spawn().expect("runtime is available");
-    tokio::task::yield_now().await;
-    assert!(!sibling_started.load(Ordering::SeqCst));
-    gate.release();
+    decorator_entered.wait().await;
+    assert_quiet(Duration::from_millis(20), || {
+        sibling_started.load(Ordering::SeqCst)
+    })
+    .await;
+    release_decorator.release();
+    release_init.release();
     system
         .wait_started()
         .await
@@ -336,9 +352,10 @@ struct InertActor;
 
 impl Actor for InertActor {
     type Msg = ();
-    type Args = ();
+    type Args = ReleaseGate;
 
-    async fn init(_: (), _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+    async fn init(entered: ReleaseGate, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        entered.release();
         Ok(Self)
     }
 
@@ -348,26 +365,28 @@ impl Actor for InertActor {
     }
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn manual_readiness_override_on_a_wrapped_handler_stays_gated() {
+    let init_entered = ReleaseGate::default();
     let mut tree = Tree::new();
     let actor = tree
         .add_raw_once(
             "gated",
-            RawOnceDef::new(Handler::<InertActor>::new(()))
+            RawOnceDef::new(Handler::<InertActor>::new(init_entered.clone()))
                 .readiness(Readiness::Manual)
                 .expect("manual readiness override"),
         )
         .expect("valid raw actor");
     let system = tree.spawn().expect("runtime is available");
+    init_entered.wait().await;
     // The engine gates on the Manual override; the blanket handler loop must
     // consult the same resolved mode instead of auto-firing after init.
-    assert!(
-        tokio::time::timeout(Duration::from_millis(50), system.wait_started())
-            .await
-            .is_err(),
-        "a Manual override must not be released by the handler's post-init mark_ready"
-    );
+    let mut started = Box::pin(system.wait_started());
+    assert_quiet(Duration::from_millis(50), || {
+        crate::common::poll_once(started.as_mut()).is_ready()
+    })
+    .await;
+    drop(started);
     actor.send(()).await.expect("gated actor accepts messages");
     system
         .wait_started()

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -3,11 +3,11 @@ use std::{cell::Cell, error::Error, hash::Hash, time::Duration};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, ActorSlot, Admission, Blocking, CallError, CallFuture,
     CancellationToken, Context, DeadlineElapsed, DynamicActorSlot, DynamicScopeRef,
-    DynamicSubtreeSlot, DynamicTaskSlot, ExitError, ExitResult, Guard, Handler, Incarnation,
-    LifecycleEvents, LifecycleTryRecvError, Membership, OneShotTaskRef, RawActor, RawContext,
-    RawDef, RawOnceDef, Removal, Reply, ReplyReceive, ReplyReceiver, ScopeRef, SendError,
-    SendFuture, SendTimeout, SnapshotClosed, SnapshotReceiver, SubtreeDef, SubtreeOnceDef,
-    SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, Tree, WaitError,
+    DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, ExitError, ExitResult, Guard, Handler,
+    Incarnation, LifecycleEvents, LifecycleTryRecvError, Membership, OneShotTaskRef, RawActor,
+    RawContext, RawDef, RawOnceDef, Removal, Reply, ReplyReceive, ReplyReceiver, ScopeRef,
+    SendError, SendFuture, SendTimeout, SnapshotClosed, SnapshotReceiver, SubtreeDef,
+    SubtreeOnceDef, SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, Tree, WaitError,
 };
 
 fn assert_error<T: Error>() {}
@@ -35,12 +35,15 @@ fn documented_identity_handle_token_and_owned_value_bounds_compile() {
     // These owned, at-most-once values promise Send. Deliberately do not
     // turn their current implementation's incidental Sync-ness into API.
     assert_send_type::<System<ScopeRef>>();
+    assert_send_type::<System<DynamicScopeRef>>();
     assert_send_type::<ActorSlot<Cell<()>>>();
     assert_send_type::<DynamicActorSlot<Cell<()>>>();
     assert_send_type::<TaskSlot>();
     assert_send_type::<DynamicTaskSlot>();
     assert_send_type::<SubtreeSlot<Tree>>();
+    assert_send_type::<SubtreeSlot<DynamicTree>>();
     assert_send_type::<DynamicSubtreeSlot<Tree>>();
+    assert_send_type::<DynamicSubtreeSlot<DynamicTree>>();
     assert_send_type::<OneShotTaskRef<Cell<()>>>();
     assert_send_type::<Reply<Cell<()>>>();
     assert_send_type::<ReplyReceiver<Cell<()>>>();
@@ -177,7 +180,14 @@ fn raw_types_obey_error_and_future_trait_contracts() {
         .expect("valid actor");
     assert_send(actor.send(Cell::new(())));
     assert_send(actor.send_timeout(Cell::new(()), Duration::from_secs(1)));
-    assert_send(actor.call(|_reply: Reply<()>| Cell::new(()), Duration::from_secs(1)));
+    let call_state = Cell::new(());
+    assert_send(actor.call(
+        move |_reply: Reply<()>| {
+            call_state.set(());
+            Cell::new(())
+        },
+        Duration::from_secs(1),
+    ));
     let (reply, receiver) = Reply::<Cell<()>>::channel();
     assert_send(reply);
     assert_send(receiver);

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -1,16 +1,84 @@
-use std::{cell::Cell, error::Error, time::Duration};
+use std::{cell::Cell, error::Error, hash::Hash, time::Duration};
 
 use shelterwood::{
-    Actor, ActorDef, ActorOnceDef, ActorRef, Blocking, CallError, Context, DeadlineElapsed,
-    ExitError, ExitResult, Guard, Handler, LifecycleEvents, LifecycleTryRecvError, RawActor,
-    RawContext, RawOnceDef, Reply, SendError, SnapshotClosed, SnapshotReceiver, Tree, WaitError,
+    Actor, ActorDef, ActorOnceDef, ActorRef, ActorSlot, Admission, Blocking, CallError, CallFuture,
+    CancellationToken, Context, DeadlineElapsed, DynamicActorSlot, DynamicScopeRef,
+    DynamicSubtreeSlot, DynamicTaskSlot, ExitError, ExitResult, Guard, Handler, Incarnation,
+    LifecycleEvents, LifecycleTryRecvError, Membership, OneShotTaskRef, RawActor, RawContext,
+    RawDef, RawOnceDef, Removal, Reply, ReplyReceive, ReplyReceiver, ScopeRef, SendError,
+    SendFuture, SendTimeout, SnapshotClosed, SnapshotReceiver, SubtreeDef, SubtreeOnceDef,
+    SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, Tree, WaitError,
 };
 
 fn assert_error<T: Error>() {}
 fn assert_send<T: Send>(_: T) {}
 fn assert_send_type<T: Send>() {}
 fn assert_send_sync<T: Send + Sync>() {}
+fn assert_copy_eq_hash_send_sync<T: Copy + Eq + Hash + Send + Sync>() {}
+fn assert_clone_eq_hash_send_sync<T: Clone + Eq + Hash + Send + Sync>() {}
 fn assert_static<T: 'static>() {}
+
+#[test]
+fn documented_identity_handle_token_and_owned_value_bounds_compile() {
+    assert_copy_eq_hash_send_sync::<Membership>();
+    assert_copy_eq_hash_send_sync::<Incarnation>();
+
+    assert_clone_eq_hash_send_sync::<ActorRef<Cell<()>>>();
+    assert_clone_eq_hash_send_sync::<TaskRef>();
+    assert_clone_eq_hash_send_sync::<ScopeRef>();
+    assert_clone_eq_hash_send_sync::<DynamicScopeRef>();
+    assert_send_sync::<SnapshotReceiver>();
+    assert_send_sync::<LifecycleEvents>();
+    assert_send_sync::<CancellationToken>();
+    assert_clone::<CancellationToken>();
+
+    // These owned, at-most-once values promise Send. Deliberately do not
+    // turn their current implementation's incidental Sync-ness into API.
+    assert_send_type::<System<ScopeRef>>();
+    assert_send_type::<ActorSlot<Cell<()>>>();
+    assert_send_type::<DynamicActorSlot<Cell<()>>>();
+    assert_send_type::<TaskSlot>();
+    assert_send_type::<DynamicTaskSlot>();
+    assert_send_type::<SubtreeSlot<Tree>>();
+    assert_send_type::<DynamicSubtreeSlot<Tree>>();
+    assert_send_type::<OneShotTaskRef<Cell<()>>>();
+    assert_send_type::<Reply<Cell<()>>>();
+    assert_send_type::<ReplyReceiver<Cell<()>>>();
+    assert_send_type::<Guard>();
+
+    assert_send_type::<Admission<TaskRef>>();
+    assert_send_type::<Removal>();
+    assert_send_type::<SendFuture<Cell<()>>>();
+    assert_send_type::<SendTimeout<Cell<()>>>();
+    assert_send_type::<CallFuture<Cell<()>, Cell<()>>>();
+    assert_send_type::<ReplyReceive<Cell<()>>>();
+
+    let _assert_token_future = |token: &CancellationToken| assert_send(token.cancelled());
+    let _assert_guard_future = |guard: &Guard| assert_send(guard.finished());
+    let _assert_task_future = |task: &TaskRef| assert_send(task.wait());
+    let _assert_one_shot_future = |task: OneShotTaskRef<Cell<()>>| assert_send(task.wait());
+    let _assert_snapshot_future = |receiver: &mut SnapshotReceiver| assert_send(receiver.changed());
+    let _assert_lifecycle_future = |events: &mut LifecycleEvents| assert_send(events.recv());
+    let _assert_scope_futures = |scope: &ScopeRef| {
+        assert_send(scope.wait_stopped());
+        assert_send(scope.shutdown_and_wait(Duration::ZERO));
+        assert_send(scope.wait_for_child("child", |_| true, Duration::ZERO));
+    };
+    let _assert_dynamic_scope_futures = |scope: &DynamicScopeRef| {
+        assert_send(scope.wait_stopped());
+        assert_send(scope.shutdown_and_wait(Duration::ZERO));
+        assert_send(scope.wait_for_child("child", |_| true, Duration::ZERO));
+    };
+    let _assert_start_future = |system: System<ScopeRef>| {
+        assert_send(system.start_or_shutdown(Duration::ZERO));
+    };
+    let _assert_shutdown_future = |system: System<ScopeRef>| {
+        assert_send(system.shutdown(Duration::ZERO));
+    };
+    let _assert_wait_future = |system: System<ScopeRef>| assert_send(system.wait());
+}
+
+fn assert_clone<T: Clone>() {}
 
 struct OpaqueActor {
     _not_sync: Cell<()>,
@@ -54,13 +122,26 @@ fn actor_types_obey_resource_and_payload_trait_contracts() {
     assert_raw::<Handler<OpaqueActor>>();
     assert_send_type::<Blocking<Cell<()>>>();
     assert_static::<Blocking<Cell<()>>>();
-    assert_send_sync::<Guard>();
+    assert_send_type::<Guard>();
 
     // The repeatable factory itself is Send + Sync after #37, but its
     // per-incarnation result and the one-shot path remain Send-only.
     let _ = ActorDef::<OpaqueActor>::factory(|| Cell::new(()));
     let _ = ActorDef::<ClonedActor>::cloned(());
     let _ = ActorOnceDef::<OpaqueActor>::new(Cell::new(()));
+    let _ = TaskDef::new(|context| async move {
+        let send_only_state = Cell::new(());
+        context.shutdown_token().cancelled().await;
+        send_only_state.set(());
+        Ok(())
+    });
+    let captured = Cell::new(());
+    let _ = TaskOnceDef::new(move |_| async move {
+        captured.set(());
+        Ok::<_, ExitError>(captured)
+    });
+    let _ = SubtreeDef::factory(Tree::new);
+    let _ = SubtreeOnceDef::new(Tree::new());
 }
 
 struct OpaqueRaw {
@@ -80,6 +161,10 @@ fn raw_types_obey_error_and_future_trait_contracts() {
     assert_error::<SendError<Cell<()>>>();
     assert_error::<CallError>();
     assert_send_sync::<ActorRef<Cell<()>>>();
+
+    let _ = RawDef::<OpaqueRaw>::factory(|| OpaqueRaw {
+        _not_sync: Cell::new(()),
+    });
 
     let mut tree = Tree::new();
     let actor = tree

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, time::Duration};
+use std::{cell::Cell, error::Error, time::Duration};
 
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, Blocking, CallError, Context, DeadlineElapsed,
@@ -12,16 +12,32 @@ fn assert_send_type<T: Send>() {}
 fn assert_send_sync<T: Send + Sync>() {}
 fn assert_static<T: 'static>() {}
 
-#[derive(Clone)]
-struct OpaqueArgs;
-
-struct OpaqueMessage;
-
-struct OpaqueActor;
+struct OpaqueActor {
+    _not_sync: Cell<()>,
+}
 
 impl Actor for OpaqueActor {
-    type Msg = OpaqueMessage;
-    type Args = OpaqueArgs;
+    type Msg = Cell<()>;
+    type Args = Cell<()>;
+
+    async fn init(_: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self {
+            _not_sync: Cell::new(()),
+        })
+    }
+
+    async fn handle(&mut self, _: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+}
+
+fn assert_raw<T: RawActor<Msg = Cell<()>>>() {}
+
+struct ClonedActor;
+
+impl Actor for ClonedActor {
+    type Msg = ();
+    type Args = ();
 
     async fn init(_: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
         Ok(Self)
@@ -32,26 +48,27 @@ impl Actor for OpaqueActor {
     }
 }
 
-fn assert_raw<T: RawActor<Msg = OpaqueMessage>>() {}
-
 #[test]
 fn actor_types_obey_resource_and_payload_trait_contracts() {
     assert_error::<DeadlineElapsed>();
     assert_raw::<Handler<OpaqueActor>>();
-    assert_send_type::<Blocking<OpaqueMessage>>();
-    assert_static::<Blocking<OpaqueMessage>>();
+    assert_send_type::<Blocking<Cell<()>>>();
+    assert_static::<Blocking<Cell<()>>>();
     assert_send_sync::<Guard>();
 
-    let _ = ActorDef::<OpaqueActor>::cloned(OpaqueArgs);
-    let _ = ActorOnceDef::<OpaqueActor>::new(OpaqueArgs);
+    // The repeatable factory itself is Send + Sync after #37, but its
+    // per-incarnation result and the one-shot path remain Send-only.
+    let _ = ActorDef::<OpaqueActor>::factory(|| Cell::new(()));
+    let _ = ActorDef::<ClonedActor>::cloned(());
+    let _ = ActorOnceDef::<OpaqueActor>::new(Cell::new(()));
 }
 
-struct Message;
-
-struct OpaqueRaw;
+struct OpaqueRaw {
+    _not_sync: Cell<()>,
+}
 
 impl RawActor for OpaqueRaw {
-    type Msg = Message;
+    type Msg = Cell<()>;
 
     async fn run(&mut self, _context: &mut RawContext<Self::Msg>) -> ExitResult {
         Ok(())
@@ -60,18 +77,23 @@ impl RawActor for OpaqueRaw {
 
 #[test]
 fn raw_types_obey_error_and_future_trait_contracts() {
-    assert_error::<SendError<Message>>();
+    assert_error::<SendError<Cell<()>>>();
     assert_error::<CallError>();
-    assert_send_sync::<ActorRef<Message>>();
+    assert_send_sync::<ActorRef<Cell<()>>>();
 
     let mut tree = Tree::new();
     let actor = tree
-        .add_raw_once("traits", RawOnceDef::new(OpaqueRaw))
+        .add_raw_once(
+            "traits",
+            RawOnceDef::new(OpaqueRaw {
+                _not_sync: Cell::new(()),
+            }),
+        )
         .expect("valid actor");
-    assert_send(actor.send(Message));
-    assert_send(actor.send_timeout(Message, Duration::from_secs(1)));
-    assert_send(actor.call(|_reply: Reply<()>| Message, Duration::from_secs(1)));
-    let (reply, receiver) = Reply::<Message>::channel();
+    assert_send(actor.send(Cell::new(())));
+    assert_send(actor.send_timeout(Cell::new(()), Duration::from_secs(1)));
+    assert_send(actor.call(|_reply: Reply<()>| Cell::new(()), Duration::from_secs(1)));
+    let (reply, receiver) = Reply::<Cell<()>>::channel();
     assert_send(reply);
     assert_send(receiver);
 }

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -391,14 +391,7 @@ async fn message_construction_consumes_the_call_budget() {
     let error = result.expect_err("the over-budget call times out");
     assert_eq!(error.kind, CallErrorKind::AcceptanceTimedOut);
     assert_eq!(calls.load(Ordering::SeqCst), 0);
-    for _ in 0..8 {
-        tokio::task::yield_now().await;
-    }
-    assert_eq!(
-        calls.load(Ordering::SeqCst),
-        0,
-        "an available mailbox must not accept work after construction exhausts the budget"
-    );
+    assert_quiet(Duration::from_secs(1), || calls.load(Ordering::SeqCst) != 0).await;
 
     system
         .shutdown(Duration::from_secs(1))
@@ -408,12 +401,20 @@ async fn message_construction_consumes_the_call_budget() {
 
 #[tokio::test(start_paused = true)]
 async fn overflowing_readiness_deadline_remains_pending() {
+    let task_started = ReleaseGate::default();
     let mut tree = Tree::new();
     tree.add_task(
         "manual",
-        TaskDef::new(|context| async move {
-            context.shutdown_token().cancelled().await;
-            Ok(())
+        TaskDef::new({
+            let task_started = task_started.clone();
+            move |context| {
+                let task_started = task_started.clone();
+                async move {
+                    task_started.release();
+                    context.shutdown_token().cancelled().await;
+                    Ok(())
+                }
+            }
         })
         .readiness(Readiness::Manual)
         .expect("manual readiness")
@@ -422,9 +423,7 @@ async fn overflowing_readiness_deadline_remains_pending() {
     .expect("valid task");
     let system = tree.spawn().expect("runtime is available");
 
-    for _ in 0..16 {
-        tokio::task::yield_now().await;
-    }
+    task_started.wait().await;
     let mut startup = Box::pin(system.wait_started());
     assert!(poll_once(startup.as_mut()).is_pending());
     assert!(matches!(
@@ -446,16 +445,20 @@ async fn overflowing_readiness_deadline_remains_pending() {
 #[tokio::test(start_paused = true)]
 async fn overflowing_shutdown_grace_does_not_escalate() {
     let dropped = Arc::new(AtomicBool::new(false));
+    let shutdown_seen = ReleaseGate::default();
     let mut tree = Tree::new();
     tree.add_task(
         "stubborn",
         TaskDef::new({
             let dropped = Arc::clone(&dropped);
+            let shutdown_seen = shutdown_seen.clone();
             move |context| {
                 let dropped = Arc::clone(&dropped);
+                let shutdown_seen = shutdown_seen.clone();
                 async move {
                     let _drop = DropFlag(dropped);
                     context.shutdown_token().cancelled().await;
+                    shutdown_seen.release();
                     std::future::pending::<ExitResult>().await
                 }
             }
@@ -469,13 +472,8 @@ async fn overflowing_shutdown_grace_does_not_escalate() {
     system.wait_started().await.expect("task starts");
 
     system.scope().request_shutdown();
-    for _ in 0..16 {
-        tokio::task::yield_now().await;
-    }
-    assert!(
-        !dropped.load(Ordering::SeqCst),
-        "an overflowing grace must not trigger immediate escalation"
-    );
+    shutdown_seen.wait().await;
+    assert_quiet(Duration::from_secs(1), || dropped.load(Ordering::SeqCst)).await;
 
     let shutdown = system.shutdown(Duration::ZERO).await;
     assert!(shutdown.is_err(), "forced cleanup reports the straggler");
@@ -526,10 +524,10 @@ async fn overflowing_restart_delay_never_restarts_immediately() {
         })
         .await
     );
-    for _ in 0..16 {
-        tokio::task::yield_now().await;
-    }
-    assert_eq!(starts.load(Ordering::SeqCst), 1);
+    assert_quiet(Duration::from_secs(1), || {
+        starts.load(Ordering::SeqCst) != 1
+    })
+    .await;
 
     system
         .shutdown(Duration::from_secs(1))

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -22,6 +22,7 @@ enum Message {
 
 struct BoundaryActor {
     gate: Option<ReleaseGate>,
+    call_seen: Option<ReleaseGate>,
     values: Arc<Mutex<Vec<usize>>>,
     calls: Arc<AtomicUsize>,
     hold_reply: bool,
@@ -52,6 +53,9 @@ impl RawActor for BoundaryActor {
                     .push(value),
                 Message::Ask(reply) => {
                     self.calls.fetch_add(1, Ordering::SeqCst);
+                    if let Some(call_seen) = &self.call_seen {
+                        call_seen.release();
+                    }
                     if self.hold_reply {
                         self.held = Some(reply);
                     } else {
@@ -72,6 +76,7 @@ fn boundary_actor(
 ) -> BoundaryActor {
     BoundaryActor {
         gate,
+        call_seen: None,
         values: Arc::clone(values),
         calls: Arc::clone(calls),
         hold_reply,
@@ -315,14 +320,16 @@ async fn preacceptance_expiry_and_terminality_follow_the_identity_table() {
 #[tokio::test(start_paused = true)]
 async fn call_uses_one_budget_across_acceptance_and_response() {
     let gate = ReleaseGate::default();
+    let call_seen = ReleaseGate::default();
     let values = Arc::new(Mutex::new(Vec::new()));
     let calls = Arc::new(AtomicUsize::new(0));
     let mut tree = Tree::new();
+    let mut definition = boundary_actor(Some(gate.clone()), &values, &calls, true);
+    definition.call_seen = Some(call_seen.clone());
     let actor = tree
         .add_raw_once(
             "one-budget",
-            RawOnceDef::new(boundary_actor(Some(gate.clone()), &values, &calls, true))
-                .mailbox(Mailbox::queue(1).expect("non-zero capacity")),
+            RawOnceDef::new(definition).mailbox(Mailbox::queue(1).expect("non-zero capacity")),
         )
         .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
@@ -334,12 +341,7 @@ async fn call_uses_one_budget_across_acceptance_and_response() {
 
     advance_time(Duration::from_secs(6)).await;
     gate.release();
-    for _ in 0..32 {
-        if calls.load(Ordering::SeqCst) == 1 {
-            break;
-        }
-        tokio::task::yield_now().await;
-    }
+    call_seen.wait().await;
     assert_eq!(calls.load(Ordering::SeqCst), 1);
     assert_quiet(Duration::from_secs(3), || {
         poll_once(call.as_mut()).is_ready()

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -283,26 +283,17 @@ async fn preacceptance_expiry_and_terminality_follow_the_identity_table() {
         .expect("valid actor");
     let width = Duration::from_secs(10);
 
-    let timed_actor = actor.clone();
-    let timed =
-        tokio::spawn(async move { timed_actor.send_timeout(Message::Value(1), width).await });
-    tokio::task::yield_now().await;
+    let mut timed = Box::pin(actor.send_timeout(Message::Value(1), width));
+    assert!(poll_once(timed.as_mut()).is_pending());
     advance_time(width).await;
-    let timed = timed
-        .await
-        .expect("timed send joins")
-        .expect_err("unbound send expires");
+    let timed = timed.await.expect_err("unbound send expires");
     assert_eq!(timed.kind, SendErrorKind::TimedOut);
     assert_eq!(timed.incarnation_observed, None);
 
-    let call_actor = actor.clone();
-    let call = tokio::spawn(async move { call_actor.call(Message::Ask, width).await });
-    tokio::task::yield_now().await;
+    let mut call = Box::pin(actor.call(Message::Ask, width));
+    assert!(poll_once(call.as_mut()).is_pending());
     advance_time(width).await;
-    let call = call
-        .await
-        .expect("call task joins")
-        .expect_err("unbound call expires");
+    let call = call.await.expect_err("unbound call expires");
     assert_eq!(call.kind, CallErrorKind::AcceptanceTimedOut);
     assert_eq!(call.incarnation_observed, None);
 
@@ -338,9 +329,8 @@ async fn call_uses_one_budget_across_acceptance_and_response() {
     system.wait_started().await.expect("actor starts");
     let accepting = actor.try_send(Message::Value(1)).expect("queue fills");
     let budget = Duration::from_secs(10);
-    let call_actor = actor.clone();
-    let call = tokio::spawn(async move { call_actor.call(Message::Ask, budget).await });
-    tokio::task::yield_now().await;
+    let mut call = Box::pin(actor.call(Message::Ask, budget));
+    assert!(poll_once(call.as_mut()).is_pending());
 
     advance_time(Duration::from_secs(6)).await;
     gate.release();
@@ -351,15 +341,12 @@ async fn call_uses_one_budget_across_acceptance_and_response() {
         tokio::task::yield_now().await;
     }
     assert_eq!(calls.load(Ordering::SeqCst), 1);
-    assert!(
-        !call.is_finished(),
-        "response still has the remaining budget"
-    );
-    advance_time(Duration::from_secs(4)).await;
-    let error = call
-        .await
-        .expect("call task joins")
-        .expect_err("one overall budget expires");
+    assert_quiet(Duration::from_secs(3), || {
+        poll_once(call.as_mut()).is_ready()
+    })
+    .await;
+    advance_time(Duration::from_secs(1)).await;
+    let error = call.await.expect_err("one overall budget expires");
     assert_eq!(error.kind, CallErrorKind::ResponseTimedOut);
     assert_eq!(error.incarnation_observed, Some(accepting));
     system

--- a/crates/shelterwood/tests/delivery.rs
+++ b/crates/shelterwood/tests/delivery.rs
@@ -142,18 +142,13 @@ async fn accepted_then_killed_call_reports_reply_dropped_with_accepting_identity
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("actor starts");
     let accepting = actor.try_send(CallMessage::Marker).expect("marker accepts");
-    let call_actor = actor.clone();
-    let call = tokio::spawn(async move {
-        call_actor
-            .call(CallMessage::Ask, Duration::from_secs(1))
-            .await
-    });
-    tokio::task::yield_now().await;
+    let mut call = Box::pin(actor.call(CallMessage::Ask, Duration::from_secs(1)));
+    assert!(
+        poll_once(call.as_mut()).is_pending(),
+        "the call is registered behind the marker before the actor is released"
+    );
     gate.release();
-    let error = call
-        .await
-        .expect("call task joins")
-        .expect_err("killed call loses its reply");
+    let error = call.await.expect_err("killed call loses its reply");
     assert_eq!(error.kind, CallErrorKind::ReplyDropped);
     assert_eq!(error.incarnation_observed, Some(accepting));
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
@@ -475,17 +470,14 @@ async fn undelivered_call_killed_at_incarnation_close_reports_reply_dropped() {
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("actor starts");
     let accepting = actor.try_send(CallMessage::Marker).expect("marker accepts");
-    let call_actor = actor.clone();
-    let call = tokio::spawn(async move {
-        call_actor
-            .call(CallMessage::Ask, Duration::from_secs(1))
-            .await
-    });
-    tokio::task::yield_now().await;
+    let mut call = Box::pin(actor.call(CallMessage::Ask, Duration::from_secs(1)));
+    assert!(
+        poll_once(call.as_mut()).is_pending(),
+        "the accepted call is queued before the marker terminates the incarnation"
+    );
     gate.release();
     let error = call
         .await
-        .expect("call task joins")
         .expect_err("the undelivered call loses its reply at close");
     assert_eq!(error.kind, CallErrorKind::ReplyDropped);
     assert_eq!(error.incarnation_observed, Some(accepting));

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -1,14 +1,16 @@
 use std::{
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, poll_until};
+use crate::common::{ReleaseGate, assert_quiet, poll_until};
 use shelterwood::{
-    Actor, ActorOnceDef, Context, ExitError, ExitResult, Mailbox, SendErrorKind, Tree,
+    Actor, ActorOnceDef, Context, Exit, ExitError, ExitKind, ExitResult, LifecycleEventKind,
+    LifecycleEvents, LifecycleItem, Mailbox, MailboxShutdown, SendErrorKind, Shutdown, StopContext,
+    Tree,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -140,12 +142,16 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
     assert!(rejection.incarnation_observed.is_some());
 
     let parked_actor = actor.clone();
-    let parked = tokio::spawn(async move { parked_actor.send(Message::Value(4)).await });
-    tokio::task::yield_now().await;
-    assert!(
-        !parked.is_finished(),
-        "ordinary send parks at frozen intake"
-    );
+    let parked_started = ReleaseGate::default();
+    let parked = tokio::spawn({
+        let parked_started = parked_started.clone();
+        async move {
+            parked_started.release();
+            parked_actor.send(Message::Value(4)).await
+        }
+    });
+    parked_started.wait().await;
+    assert_quiet(Duration::from_millis(20), || parked.is_finished()).await;
 
     allow_drain.release();
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
@@ -158,12 +164,289 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
     assert!(!deferred_ran.load(Ordering::SeqCst));
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn queue_drain_is_the_exact_frozen_accepted_prefix_and_rejects_deferred_work() {
     assert_drain_fixture(Mailbox::queue(8).expect("valid capacity"), &[0, 1, 2]).await;
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn latest_drain_is_the_post_conflation_survivor_and_rejects_deferred_work() {
     assert_drain_fixture(Mailbox::latest(), &[0, 2]).await;
+}
+
+#[derive(Clone, Copy, Debug)]
+enum FaultMode {
+    Discard,
+    DrainError,
+    DrainPanic,
+    StopPanic,
+    SharedGrace,
+    StopBlocking,
+}
+
+#[derive(Clone, Copy)]
+enum FaultMessage {
+    Hold,
+    Fault,
+}
+
+struct FaultArgs {
+    mode: FaultMode,
+    hold_entered: ReleaseGate,
+    hold_release: ReleaseGate,
+    shutdown_seen: ReleaseGate,
+    drain_entered: ReleaseGate,
+    stop_entered: Arc<AtomicBool>,
+    drained: Arc<AtomicUsize>,
+    blocking_result: Arc<AtomicUsize>,
+}
+
+struct FaultActor(FaultArgs);
+
+impl Actor for FaultActor {
+    type Msg = FaultMessage;
+    type Args = FaultArgs;
+
+    async fn init(args: Self::Args, context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        let shutdown = context.shutdown_token();
+        let shutdown_seen = args.shutdown_seen.clone();
+        tokio::spawn(async move {
+            shutdown.cancelled().await;
+            shutdown_seen.release();
+        });
+        Ok(Self(args))
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            FaultMessage::Hold => {
+                assert!(!context.is_draining());
+                self.0.hold_entered.release();
+                self.0.hold_release.wait().await;
+                Ok(())
+            }
+            FaultMessage::Fault => {
+                assert!(context.is_draining());
+                self.0.drained.fetch_add(1, Ordering::SeqCst);
+                self.0.drain_entered.release();
+                match self.0.mode {
+                    FaultMode::DrainError => Err(ExitError::message("drain error")),
+                    FaultMode::DrainPanic => panic!("drain panic"),
+                    FaultMode::SharedGrace => {
+                        tokio::time::sleep(Duration::from_secs(8)).await;
+                        Ok(())
+                    }
+                    FaultMode::Discard | FaultMode::StopPanic | FaultMode::StopBlocking => Ok(()),
+                }
+            }
+        }
+    }
+
+    async fn on_stop(&mut self, context: &mut StopContext<'_, Self>) {
+        self.0.stop_entered.store(true, Ordering::SeqCst);
+        match self.0.mode {
+            FaultMode::StopPanic => panic!("on_stop panic"),
+            FaultMode::SharedGrace => tokio::time::sleep(Duration::from_secs(8)).await,
+            FaultMode::StopBlocking => {
+                let value = context
+                    .run_blocking(|shutdown| {
+                        assert!(shutdown.is_cancelled());
+                        73usize
+                    })
+                    .await;
+                self.0.blocking_result.store(value, Ordering::SeqCst);
+            }
+            FaultMode::Discard | FaultMode::DrainError | FaultMode::DrainPanic => {}
+        }
+    }
+}
+
+struct FaultOutcome {
+    exit: Exit,
+    elapsed: Duration,
+    stop_entered: bool,
+    drained: usize,
+    blocking_result: usize,
+}
+
+async fn exited_actor(events: &mut LifecycleEvents) -> Exit {
+    while let Some(item) = events.recv().await {
+        if let LifecycleItem::Event(event) = item
+            && let LifecycleEventKind::Exited { id, exit, .. } = event.kind
+            && id.as_str() == "actor"
+        {
+            return exit;
+        }
+    }
+    panic!("actor exit must precede lifecycle closure");
+}
+
+async fn run_fault_fixture(
+    mode: FaultMode,
+    mailbox_shutdown: MailboxShutdown,
+    grace: Duration,
+    queue_fault: bool,
+) -> FaultOutcome {
+    let hold_entered = ReleaseGate::default();
+    let hold_release = ReleaseGate::default();
+    let shutdown_seen = ReleaseGate::default();
+    let drain_entered = ReleaseGate::default();
+    let stop_entered = Arc::new(AtomicBool::new(false));
+    let drained = Arc::new(AtomicUsize::new(0));
+    let blocking_result = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "actor",
+            ActorOnceDef::<FaultActor>::new(FaultArgs {
+                mode,
+                hold_entered: hold_entered.clone(),
+                hold_release: hold_release.clone(),
+                shutdown_seen: shutdown_seen.clone(),
+                drain_entered: drain_entered.clone(),
+                stop_entered: Arc::clone(&stop_entered),
+                drained: Arc::clone(&drained),
+                blocking_result: Arc::clone(&blocking_result),
+            })
+            .mailbox_shutdown(mailbox_shutdown)
+            .shutdown(Shutdown::Graceful { grace }),
+        )
+        .expect("valid fault actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    let mut events = system.scope().subscribe_lifecycle();
+    actor
+        .send(FaultMessage::Hold)
+        .await
+        .expect("hold message is accepted");
+    hold_entered.wait().await;
+    if queue_fault {
+        actor
+            .send(FaultMessage::Fault)
+            .await
+            .expect("fault message joins the accepted prefix");
+    }
+
+    let started_at = tokio::time::Instant::now();
+    let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(30)));
+    shutdown_seen.wait().await;
+    hold_release.release();
+    if matches!(mode, FaultMode::SharedGrace) {
+        drain_entered.wait().await;
+        assert!(
+            poll_until(Duration::from_secs(9), Duration::from_secs(1), || {
+                stop_entered.load(Ordering::SeqCst)
+            })
+            .await,
+            "draining leaves part of the shared grace for on_stop"
+        );
+    }
+    shutdown
+        .await
+        .expect("shutdown task joins")
+        .expect("the child policy bounds shutdown");
+    let elapsed = tokio::time::Instant::now() - started_at;
+    let exit = exited_actor(&mut events).await;
+    FaultOutcome {
+        exit,
+        elapsed,
+        stop_entered: stop_entered.load(Ordering::SeqCst),
+        drained: drained.load(Ordering::SeqCst),
+        blocking_result: blocking_result.load(Ordering::SeqCst),
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn handler_discard_skips_the_prefix_and_still_runs_on_stop() {
+    let outcome = run_fault_fixture(
+        FaultMode::Discard,
+        MailboxShutdown::Discard,
+        Duration::from_secs(10),
+        true,
+    )
+    .await;
+    assert_eq!(outcome.drained, 0);
+    assert!(outcome.stop_entered);
+    assert!(matches!(outcome.exit.kind(), ExitKind::Completed));
+    assert!(outcome.exit.cancelled());
+}
+
+#[tokio::test(start_paused = true)]
+async fn handler_drain_errors_and_panics_keep_their_authoritative_exit() {
+    let error = run_fault_fixture(
+        FaultMode::DrainError,
+        MailboxShutdown::Drain,
+        Duration::from_secs(10),
+        true,
+    )
+    .await;
+    assert!(matches!(
+        error.exit.kind(),
+        ExitKind::Failed(cause) if cause.to_string() == "drain error"
+    ));
+    assert!(!error.stop_entered);
+
+    let panic = run_fault_fixture(
+        FaultMode::DrainPanic,
+        MailboxShutdown::Drain,
+        Duration::from_secs(10),
+        true,
+    )
+    .await;
+    assert!(matches!(
+        panic.exit.kind(),
+        ExitKind::Panicked { message } if message.as_deref() == Some("drain panic")
+    ));
+    assert!(!panic.stop_entered);
+}
+
+#[tokio::test(start_paused = true)]
+async fn handler_on_stop_panic_is_contained_and_classified() {
+    let outcome = run_fault_fixture(
+        FaultMode::StopPanic,
+        MailboxShutdown::Drain,
+        Duration::from_secs(10),
+        false,
+    )
+    .await;
+    assert!(matches!(
+        outcome.exit.kind(),
+        ExitKind::Panicked { message } if message.as_deref() == Some("on_stop panic")
+    ));
+}
+
+#[tokio::test(start_paused = true)]
+async fn handler_drain_and_on_stop_share_one_grace_budget() {
+    let outcome = run_fault_fixture(
+        FaultMode::SharedGrace,
+        MailboxShutdown::Drain,
+        Duration::from_secs(10),
+        true,
+    )
+    .await;
+    assert_eq!(outcome.drained, 1);
+    assert!(outcome.stop_entered);
+    assert!(matches!(
+        outcome.exit.kind(),
+        ExitKind::Aborted { after_grace: true }
+    ));
+    assert!(outcome.elapsed >= Duration::from_secs(10));
+    assert!(
+        outcome.elapsed < Duration::from_secs(16),
+        "drain and on_stop must not receive separate eight-second budgets"
+    );
+}
+
+#[tokio::test]
+async fn stop_context_run_blocking_returns_inside_cooperative_grace() {
+    let outcome = run_fault_fixture(
+        FaultMode::StopBlocking,
+        MailboxShutdown::Drain,
+        Duration::from_secs(1),
+        false,
+    )
+    .await;
+    assert_eq!(outcome.blocking_result, 73);
+    assert!(outcome.stop_entered);
+    assert!(matches!(outcome.exit.kind(), ExitKind::Completed));
 }

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -13,10 +13,10 @@ use crate::common::{
     waiting::{task as waiting_task, tree as waiting_tree},
 };
 use shelterwood::{
-    Actor, ActorOnceDef, Backoff, Context as ActorContext, DynamicTree, ExitError, ExitKind,
-    ExitResult, NotAdmittingCause, Readiness, RemoveOutcome, ReserveError, RestartCondition,
-    RestartPolicy, Retention, SendErrorKind, Shutdown, StopReason, SubtreeDef, SubtreeOnceDef,
-    TaskDef, TaskOnceDef, Tree,
+    Actor, ActorOnceDef, Backoff, ChildState, Context as ActorContext, DynamicTree, ExitError,
+    ExitKind, ExitResult, NotAdmittingCause, RawActor, RawContext, RawDef, Readiness,
+    RemoveOutcome, ReserveError, RestartCondition, RestartPolicy, Retention, SendErrorKind,
+    Shutdown, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
 };
 
 struct DropProbe(Arc<AtomicBool>);
@@ -56,6 +56,48 @@ impl Actor for EvidenceActor {
     async fn handle(&mut self, (): (), _: &mut ActorContext<'_, Self>) -> ExitResult {
         Ok(())
     }
+}
+
+struct WaitingRaw;
+
+impl RawActor for WaitingRaw {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        context.shutdown_token().cancelled().await;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn restartable_dynamic_surfaces_are_parallel_across_all_three_child_kinds() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+
+    let task_receipt = scope
+        .add_task("task", waiting_task())
+        .await
+        .expect("restartable task is admitted");
+    let task = task_receipt.into_handles();
+    let raw_receipt = scope
+        .add_raw("raw", RawDef::factory(|| WaitingRaw))
+        .await
+        .expect("restartable raw actor is admitted");
+    let raw = raw_receipt.into_handles();
+    let subtree_receipt = scope
+        .add_subtree("subtree", SubtreeDef::factory(waiting_tree))
+        .await
+        .expect("restartable subtree is admitted");
+    let subtree = subtree_receipt.into_handles();
+
+    assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
+    assert_eq!(scope.remove_actor(&raw).await, RemoveOutcome::Removed);
+    assert_eq!(scope.remove_scope(&subtree).await, RemoveOutcome::Removed);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
 }
 
 #[tokio::test]
@@ -786,10 +828,15 @@ async fn dynamic_scope_rejects_reservations_between_incarnations() {
         })
         .await
     );
-    advance_time(Duration::from_secs(1)).await;
-    for _ in 0..8 {
-        tokio::task::yield_now().await;
-    }
+    system
+        .scope()
+        .wait_for_child(
+            "dynamic",
+            |child| matches!(child.state, ChildState::Restarting),
+            Duration::MAX,
+        )
+        .await
+        .expect("the failed incarnation enters its explicit restart window");
     assert_eq!(factories.load(Ordering::SeqCst), 1);
     assert!(matches!(
         scope.reserve_task("too-early"),
@@ -880,18 +927,27 @@ async fn pending_restart_window_stop_targets_the_next_incarnation_once() {
         })
         .await
     );
-    for _ in 0..8 {
-        tokio::task::yield_now().await;
-    }
+    system
+        .scope()
+        .wait_for_child(
+            "nested",
+            |child| matches!(child.state, ChildState::Restarting),
+            Duration::MAX,
+        )
+        .await
+        .expect("the first incarnation enters its explicit restart window");
 
     let nested_wait = nested.clone();
-    let stop =
-        tokio::spawn(async move { nested_wait.shutdown_and_wait(Duration::from_secs(1)).await });
-    tokio::task::yield_now().await;
-    assert!(
-        !stop.is_finished(),
-        "restart-window request waits for the next incarnation"
-    );
+    let stop_started = ReleaseGate::default();
+    let stop = tokio::spawn({
+        let stop_started = stop_started.clone();
+        async move {
+            stop_started.release();
+            nested_wait.shutdown_and_wait(Duration::from_secs(1)).await
+        }
+    });
+    stop_started.wait().await;
+    assert_quiet(Duration::from_secs(1), || stop.is_finished()).await;
     advance_time(width).await;
     stop.await
         .expect("stop waiter joins")
@@ -996,4 +1052,88 @@ async fn removal_of_a_polled_split_definition_keeps_the_scope_admitting() {
         .shutdown(Duration::from_secs(1))
         .await
         .expect("root stops");
+}
+
+#[tokio::test(start_paused = true)]
+async fn ancestor_hard_abort_disposes_a_queued_admission_and_midflight_removal() {
+    let worker_started = ReleaseGate::default();
+    let worker_cancelled = ReleaseGate::default();
+    let mut nested = DynamicTree::new();
+    let worker = nested
+        .add_task(
+            "worker",
+            TaskDef::new({
+                let worker_started = worker_started.clone();
+                let worker_cancelled = worker_cancelled.clone();
+                move |context| {
+                    let worker_started = worker_started.clone();
+                    let worker_cancelled = worker_cancelled.clone();
+                    async move {
+                        worker_started.release();
+                        context.shutdown_token().cancelled().await;
+                        worker_cancelled.release();
+                        std::future::pending::<ExitResult>().await
+                    }
+                }
+            })
+            .shutdown(Shutdown::Graceful {
+                grace: Duration::from_secs(60),
+            }),
+        )
+        .expect("valid worker");
+    let mut root = Tree::new();
+    let nested = root
+        .add_subtree_once(
+            "nested",
+            SubtreeOnceDef::new(nested).shutdown(Shutdown::Abort),
+        )
+        .expect("valid dynamic subtree");
+    let system = root.spawn().expect("runtime is available");
+    system.wait_started().await.expect("nested scope starts");
+    worker_started.wait().await;
+
+    let mut removal = Box::pin(nested.remove_task(&worker));
+    worker_cancelled.wait().await;
+    assert!(
+        poll_once(removal.as_mut()).is_pending(),
+        "the worker keeps exact removal in flight"
+    );
+
+    let slot = nested.reserve_task("queued").expect("reservation succeeds");
+    let queued = slot.task_ref();
+    let mut admission =
+        Box::pin(slot.define(
+            TaskDef::new(|_| std::future::pending::<ExitResult>()).shutdown(Shutdown::Abort),
+        ));
+    assert!(
+        poll_once(admission.as_mut()).is_pending(),
+        "first poll owns a queued admission request before yielding"
+    );
+
+    let mut shutdown = Box::pin(system.shutdown(Duration::from_secs(1)));
+    assert!(
+        poll_once(shutdown.as_mut()).is_pending(),
+        "ancestor shutdown is armed before queued work gets a scheduler turn"
+    );
+
+    match admission.await {
+        Ok(receipt) => {
+            assert_eq!(receipt.membership(), queued.membership());
+            drop(receipt);
+        }
+        Err(ReserveError::NotAdmitting(_)) => {}
+        Err(error) => panic!("unexpected queued-admission result: {error:?}"),
+    }
+    shutdown
+        .await
+        .expect("the aborting subtree recursively joins its descendants");
+    assert_eq!(removal.await, RemoveOutcome::Removed);
+    assert!(matches!(
+        worker.wait().await.kind(),
+        ExitKind::Aborted { .. }
+    ));
+    assert!(matches!(
+        queued.wait().await.kind(),
+        ExitKind::Aborted { .. } | ExitKind::NeverStarted
+    ));
 }

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -701,7 +701,7 @@ async fn removing_a_member_releases_its_factory_before_scope_shutdown() {
         .expect("root stops");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn pre_spawn_shutdown_waits_for_teardown_to_exist() {
     let gate = ReleaseGate::default();
     let mut nested = Tree::new();
@@ -724,23 +724,18 @@ async fn pre_spawn_shutdown_waits_for_teardown_to_exist() {
     let mut root = Tree::new();
     let slot = root.reserve_subtree::<Tree>("nested").expect("reservation");
     let scope = slot.scope_ref();
-    let scope_for_wait = scope.clone();
-    let waiter = tokio::spawn(async move {
-        scope_for_wait
-            .shutdown_and_wait(Duration::from_millis(10))
-            .await
-    });
-    tokio::time::sleep(Duration::from_millis(25)).await;
+    let mut waiter = Box::pin(scope.shutdown_and_wait(Duration::from_millis(10)));
     assert!(
-        !waiter.is_finished(),
-        "timeout must not arm before an incarnation starts"
+        poll_once(waiter.as_mut()).is_pending(),
+        "the pre-spawn shutdown request registers without completing"
     );
+    assert_quiet(Duration::from_millis(25), || {
+        poll_once(waiter.as_mut()).is_ready()
+    })
+    .await;
     let _nested_handle = slot.define_once(SubtreeOnceDef::new(nested));
     let system = root.spawn().expect("runtime is available");
-    let timeout = waiter
-        .await
-        .expect("waiter joins")
-        .expect_err("live teardown exceeds its bound");
+    let timeout = waiter.await.expect_err("live teardown exceeds its bound");
     assert_eq!(timeout.stragglers.len(), 1);
     assert_eq!(timeout.stragglers[0].path[0].as_str(), "worker");
     gate.release();

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -14,7 +14,7 @@ use crate::common::{
 };
 use shelterwood::{
     Actor, ActorOnceDef, Backoff, ChildState, Context as ActorContext, DynamicTree, ExitError,
-    ExitKind, ExitResult, NotAdmittingCause, RawActor, RawContext, RawDef, Readiness,
+    ExitKind, ExitResult, NotAdmittingCause, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
     RemoveOutcome, ReserveError, RestartCondition, RestartPolicy, Retention, SendErrorKind,
     Shutdown, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
 };
@@ -89,6 +89,44 @@ async fn restartable_dynamic_surfaces_are_parallel_across_all_three_child_kinds(
         .add_subtree("subtree", SubtreeDef::factory(waiting_tree))
         .await
         .expect("restartable subtree is admitted");
+    let subtree = subtree_receipt.into_handles();
+
+    assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
+    assert_eq!(scope.remove_actor(&raw).await, RemoveOutcome::Removed);
+    assert_eq!(scope.remove_scope(&subtree).await, RemoveOutcome::Removed);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[tokio::test]
+async fn consuming_dynamic_surfaces_are_parallel_across_all_three_child_kinds() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+
+    let task_receipt = scope
+        .add_task_once(
+            "task-once",
+            TaskOnceDef::new(|context| async move {
+                context.shutdown_token().cancelled().await;
+                Ok::<_, ExitError>(())
+            }),
+        )
+        .await
+        .expect("one-shot task is admitted");
+    let (task, completion) = task_receipt.into_handles();
+    drop(completion);
+    let raw_receipt = scope
+        .add_raw_once("raw-once", RawOnceDef::new(WaitingRaw))
+        .await
+        .expect("one-shot raw actor is admitted");
+    let raw = raw_receipt.into_handles();
+    let subtree_receipt = scope
+        .add_subtree_once("subtree-once", SubtreeOnceDef::new(waiting_tree()))
+        .await
+        .expect("one-shot subtree is admitted");
     let subtree = subtree_receipt.into_handles();
 
     assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -27,6 +27,14 @@ impl Drop for DropProbe {
     }
 }
 
+struct DropSignal(ReleaseGate);
+
+impl Drop for DropSignal {
+    fn drop(&mut self) {
+        self.0.release();
+    }
+}
+
 struct GatedDynamicActor;
 
 impl Actor for GatedDynamicActor {
@@ -1096,6 +1104,7 @@ async fn removal_of_a_polled_split_definition_keeps_the_scope_admitting() {
 async fn ancestor_hard_abort_disposes_a_queued_admission_and_midflight_removal() {
     let worker_started = ReleaseGate::default();
     let worker_cancelled = ReleaseGate::default();
+    let queued_disposed = ReleaseGate::default();
     let mut nested = DynamicTree::new();
     let worker = nested
         .add_task(
@@ -1139,10 +1148,18 @@ async fn ancestor_hard_abort_disposes_a_queued_admission_and_midflight_removal()
 
     let slot = nested.reserve_task("queued").expect("reservation succeeds");
     let queued = slot.task_ref();
-    let mut admission =
-        Box::pin(slot.define(
-            TaskDef::new(|_| std::future::pending::<ExitResult>()).shutdown(Shutdown::Abort),
-        ));
+    let mut admission = Box::pin(
+        slot.define(
+            TaskDef::new({
+                let drop_signal = DropSignal(queued_disposed.clone());
+                move |_| {
+                    let _ = &drop_signal;
+                    std::future::pending::<ExitResult>()
+                }
+            })
+            .shutdown(Shutdown::Abort),
+        ),
+    );
     assert!(
         poll_once(admission.as_mut()).is_pending(),
         "first poll owns a queued admission request before yielding"
@@ -1165,6 +1182,7 @@ async fn ancestor_hard_abort_disposes_a_queued_admission_and_midflight_removal()
     shutdown
         .await
         .expect("the aborting subtree recursively joins its descendants");
+    queued_disposed.wait().await;
     assert_eq!(removal.await, RemoveOutcome::Removed);
     assert!(matches!(
         worker.wait().await.kind(),

--- a/crates/shelterwood/tests/events.rs
+++ b/crates/shelterwood/tests/events.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::ReleaseGate;
+use crate::common::{ReleaseGate, assert_quiet};
 use shelterwood::{Actor, ActorOnceDef, Context, ExitError, ExitResult, Tree};
 
 #[derive(Clone, Copy, Debug)]
@@ -300,23 +300,34 @@ enum IntervalMessage {
 
 struct IntervalActor {
     ticks: Arc<AtomicUsize>,
+    armed: ReleaseGate,
+    ticked: ReleaseGate,
 }
 
 impl Actor for IntervalActor {
     type Msg = IntervalMessage;
-    type Args = Arc<AtomicUsize>;
+    type Args = (Arc<AtomicUsize>, ReleaseGate, ReleaseGate);
 
     async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
-        Ok(Self { ticks: args })
+        Ok(Self {
+            ticks: args.0,
+            armed: args.1,
+            ticked: args.2,
+        })
     }
 
     async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
         match message {
-            IntervalMessage::Arm => context
-                .set_interval("interval", IntervalMessage::Tick, Duration::from_secs(10))
-                .expect("interval accepted"),
+            IntervalMessage::Arm => {
+                context
+                    .set_interval("interval", IntervalMessage::Tick, Duration::from_secs(10))
+                    .expect("interval accepted");
+                self.armed.release();
+            }
             IntervalMessage::Tick => {
-                if self.ticks.fetch_add(1, Ordering::SeqCst) == 1 {
+                let prior = self.ticks.fetch_add(1, Ordering::SeqCst);
+                self.ticked.release();
+                if prior == 1 {
                     assert_eq!(context.clear_timer(&"interval"), Ok(true));
                     context.stop();
                 }
@@ -329,24 +340,24 @@ impl Actor for IntervalActor {
 #[tokio::test(start_paused = true)]
 async fn intervals_start_after_one_period_and_skip_missed_ticks() {
     let ticks = Arc::new(AtomicUsize::new(0));
+    let armed = ReleaseGate::default();
+    let ticked = ReleaseGate::default();
     let mut tree = Tree::new();
     let actor = tree
         .add_actor_once(
             "interval",
-            ActorOnceDef::<IntervalActor>::new(Arc::clone(&ticks)),
+            ActorOnceDef::<IntervalActor>::new((Arc::clone(&ticks), armed.clone(), ticked.clone())),
         )
         .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("actor starts");
     actor.send(IntervalMessage::Arm).await.expect("actor live");
-    tokio::task::yield_now().await;
+    armed.wait().await;
 
     tokio::time::advance(Duration::from_secs(35)).await;
-    tokio::task::yield_now().await;
+    ticked.wait().await;
     assert_eq!(ticks.load(Ordering::SeqCst), 1);
-    tokio::time::advance(Duration::from_secs(9)).await;
-    tokio::task::yield_now().await;
-    assert_eq!(ticks.load(Ordering::SeqCst), 1);
+    assert_quiet(Duration::from_secs(9), || ticks.load(Ordering::SeqCst) != 1).await;
     tokio::time::advance(Duration::from_secs(1)).await;
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert_eq!(ticks.load(Ordering::SeqCst), 2);
@@ -405,13 +416,7 @@ async fn overflowing_timer_deadlines_never_fire() {
         .expect("valid actor");
         let system = tree.spawn().expect("runtime is available");
         system.wait_started().await.expect("actor starts");
-        tokio::time::advance(Duration::from_secs(1)).await;
-        tokio::task::yield_now().await;
-        assert_eq!(
-            fired.load(Ordering::SeqCst),
-            0,
-            "an overflowed deadline (interval: {interval}) must never fire"
-        );
+        assert_quiet(Duration::from_secs(1), || fired.load(Ordering::SeqCst) != 0).await;
         system
             .shutdown(Duration::from_secs(1))
             .await

--- a/crates/shelterwood/tests/mailbox.rs
+++ b/crates/shelterwood/tests/mailbox.rs
@@ -87,7 +87,7 @@ fn recorder(
     }
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn queue_backpressure_and_send_error_identity_are_exact() {
     let gate = ReleaseGate::default();
     let values = Arc::new(Mutex::new(Vec::new()));
@@ -124,11 +124,16 @@ async fn queue_backpressure_and_send_error_identity_are_exact() {
     assert_eq!(full.incarnation_observed, Some(accepting));
 
     let waiting_actor = actor.clone();
-    let waiting = tokio::spawn(async move { waiting_actor.send(full.message).await });
-    for _ in 0..4 {
-        tokio::task::yield_now().await;
-    }
-    assert!(!waiting.is_finished(), "send applies real backpressure");
+    let waiting_started = ReleaseGate::default();
+    let waiting = tokio::spawn({
+        let waiting_started = waiting_started.clone();
+        async move {
+            waiting_started.release();
+            waiting_actor.send(full.message).await
+        }
+    });
+    waiting_started.wait().await;
+    assert_quiet(Duration::from_millis(20), || waiting.is_finished()).await;
     gate.release();
     assert_eq!(
         waiting
@@ -322,13 +327,10 @@ async fn call_distinguishes_success_drop_and_response_timeout() {
 async fn reply_receiver_is_consuming_and_late_replies_are_discarded() {
     let width = Duration::from_secs(10);
     let (reply, receiver) = Reply::channel();
-    let waiter = tokio::spawn(async move { receiver.recv(width).await });
-    tokio::task::yield_now().await;
+    let mut waiter = Box::pin(receiver.recv(width));
+    assert!(poll_once(waiter.as_mut()).is_pending());
     advance_time(width).await;
-    assert_eq!(
-        waiter.await.expect("receiver task joins"),
-        Err(ReplyError::Timeout)
-    );
+    assert_eq!(waiter.await, Err(ReplyError::Timeout));
     reply.send(1);
 
     let (reply, receiver) = Reply::<usize>::channel();

--- a/crates/shelterwood/tests/mailbox.rs
+++ b/crates/shelterwood/tests/mailbox.rs
@@ -225,15 +225,10 @@ async fn timed_send_withdraws_and_recovers_the_message() {
     let accepting = actor.try_send(Message::Value(1)).expect("queue fills");
 
     let width = Duration::from_secs(10);
-    let timed_actor = actor.clone();
-    let timed =
-        tokio::spawn(async move { timed_actor.send_timeout(Message::Value(2), width).await });
-    tokio::task::yield_now().await;
+    let mut timed = Box::pin(actor.send_timeout(Message::Value(2), width));
+    assert!(poll_once(timed.as_mut()).is_pending());
     advance_time(width).await;
-    let error = timed
-        .await
-        .expect("timed send task joins")
-        .expect_err("send withdraws");
+    let error = timed.await.expect_err("send withdraws");
     assert_eq!(error.kind, SendErrorKind::TimedOut);
     assert_eq!(error.incarnation_observed, Some(accepting));
 

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -1083,26 +1083,18 @@ async fn wait_for_child_with_a_far_future_deadline_stays_pending() {
     .expect("valid task");
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
-    let waiter = tokio::spawn({
-        let scope = scope.clone();
-        async move {
-            scope
-                .wait_for_child(
-                    "gated",
-                    |child| matches!(child.state, ChildState::Running),
-                    Duration::MAX,
-                )
-                .await
-        }
-    });
-    for _ in 0..8 {
-        tokio::task::yield_now().await;
-    }
-    assert!(!waiter.is_finished(), "the overflowing wait remains armed");
+    let mut waiter = Box::pin(scope.wait_for_child(
+        "gated",
+        |child| matches!(child.state, ChildState::Running),
+        Duration::MAX,
+    ));
+    assert!(
+        poll_once(waiter.as_mut()).is_pending(),
+        "an unsatisfied far-future wait is registered rather than timing out"
+    );
     gate.release();
     waiter
         .await
-        .expect("waiter joins")
         .expect("a far-future deadline waits for the condition instead of expiring");
     system
         .shutdown(Duration::from_secs(1))

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::common::{
-    ReleaseGate, poll_until,
+    ReleaseGate, assert_quiet, poll_once, poll_until,
     waiting::{task as waiting_task, tree as waiting_tree},
 };
 use shelterwood::{
@@ -1108,4 +1108,87 @@ async fn wait_for_child_with_a_far_future_deadline_stays_pending() {
         .shutdown(Duration::from_secs(1))
         .await
         .expect("tree shuts down");
+}
+
+#[tokio::test(start_paused = true)]
+async fn snapshot_subscriptions_conflate_unobserved_transitions_to_the_latest_value() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+    let mut snapshots = scope.subscribe_snapshots();
+
+    let task = scope
+        .add_task(
+            "ephemeral",
+            TaskDef::new(|_| async { Ok(()) })
+                .restart(RestartPolicy::new(
+                    RestartCondition::Never,
+                    Backoff::Immediate,
+                ))
+                .retention(Retention::Remove),
+        )
+        .await
+        .expect("ephemeral task is admitted")
+        .into_handles();
+    task.wait().await;
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            scope.child("ephemeral").is_none()
+        })
+        .await,
+        "terminal removal reaches the latest snapshot"
+    );
+
+    let latest = snapshots
+        .changed()
+        .await
+        .expect("one notification exposes the newest conflated snapshot");
+    assert!(latest.child("ephemeral").is_none());
+    let mut next = Box::pin(snapshots.changed());
+    assert_quiet(Duration::from_secs(1), || {
+        poll_once(next.as_mut()).is_ready()
+    })
+    .await;
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[tokio::test(start_paused = true)]
+async fn lifecycle_subscriptions_start_now_without_replaying_prior_history() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+    let old = scope
+        .add_task("old", waiting_task())
+        .await
+        .expect("old membership is admitted")
+        .into_handles();
+    assert_eq!(scope.remove_task(&old).await, RemoveOutcome::Removed);
+
+    let mut events = scope.subscribe_lifecycle();
+    assert_quiet(Duration::from_secs(1), || {
+        !matches!(events.try_recv(), Err(LifecycleTryRecvError::Empty))
+    })
+    .await;
+
+    let new = scope
+        .add_task("new", waiting_task())
+        .await
+        .expect("new membership is admitted")
+        .into_handles();
+    let event = next_event(&mut events).await;
+    assert!(matches!(
+        event.kind,
+        LifecycleEventKind::Added { ref id, membership }
+            if id.as_str() == "new" && membership == new.membership()
+    ));
+
+    assert_eq!(scope.remove_task(&new).await, RemoveOutcome::Removed);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
 }

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::poll_until;
+use crate::common::{assert_quiet, poll_until};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
     LifecycleEventKind, LifecycleItem, Readiness, Shutdown, StartupError, StartupFailureCause,
@@ -158,6 +158,7 @@ enum DeadlineMessage {
 
 struct ExactDeadlineActor {
     armed: Arc<AtomicBool>,
+    offload_started: Arc<AtomicBool>,
     result: Arc<Mutex<Option<Result<usize, DeadlineElapsed>>>>,
 }
 
@@ -165,22 +166,26 @@ impl Actor for ExactDeadlineActor {
     type Msg = DeadlineMessage;
     type Args = (
         Arc<AtomicBool>,
+        Arc<AtomicBool>,
         Arc<Mutex<Option<Result<usize, DeadlineElapsed>>>>,
     );
 
     async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
         Ok(Self {
             armed: args.0,
-            result: args.1,
+            offload_started: args.1,
+            result: args.2,
         })
     }
 
     async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
         match message {
             DeadlineMessage::Start => {
+                let offload_started = Arc::clone(&self.offload_started);
                 context
                     .offload(
-                        async {
+                        async move {
+                            offload_started.store(true, Ordering::SeqCst);
                             tokio::time::sleep(Duration::from_secs(10)).await;
                             42usize
                         },
@@ -202,12 +207,17 @@ impl Actor for ExactDeadlineActor {
 #[tokio::test(start_paused = true)]
 async fn offload_completion_wins_at_the_exact_deadline() {
     let armed = Arc::new(AtomicBool::new(false));
+    let offload_started = Arc::new(AtomicBool::new(false));
     let result = Arc::new(Mutex::new(None));
     let mut tree = Tree::new();
     let actor = tree
         .add_actor_once(
             "deadline",
-            ActorOnceDef::<ExactDeadlineActor>::new((Arc::clone(&armed), Arc::clone(&result))),
+            ActorOnceDef::<ExactDeadlineActor>::new((
+                Arc::clone(&armed),
+                Arc::clone(&offload_started),
+                Arc::clone(&result),
+            )),
         )
         .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
@@ -216,10 +226,13 @@ async fn offload_completion_wins_at_the_exact_deadline() {
         .send(DeadlineMessage::Start)
         .await
         .expect("actor live");
-    while !armed.load(Ordering::SeqCst) {
-        tokio::task::yield_now().await;
-    }
-    tokio::task::yield_now().await;
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            armed.load(Ordering::SeqCst) && offload_started.load(Ordering::SeqCst)
+        })
+        .await,
+        "the offload is polled and its deadline is registered before time moves"
+    );
     tokio::time::advance(Duration::from_secs(10)).await;
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert_eq!(*result.lock().expect("result mutex poisoned"), Some(Ok(42)));
@@ -233,14 +246,18 @@ enum GuardMessage {
 
 struct GuardedActor {
     deliveries: Arc<AtomicUsize>,
+    guard_dropped: Arc<AtomicBool>,
 }
 
 impl Actor for GuardedActor {
     type Msg = GuardMessage;
-    type Args = Arc<AtomicUsize>;
+    type Args = (Arc<AtomicUsize>, Arc<AtomicBool>);
 
     async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
-        Ok(Self { deliveries: args })
+        Ok(Self {
+            deliveries: args.0,
+            guard_dropped: args.1,
+        })
     }
 
     async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
@@ -254,6 +271,7 @@ impl Actor for GuardedActor {
                     )
                     .expect("guarded offload accepted");
                 drop(guard);
+                self.guard_dropped.store(true, Ordering::SeqCst);
             }
             GuardMessage::Unexpected => {
                 self.deliveries.fetch_add(1, Ordering::SeqCst);
@@ -264,22 +282,34 @@ impl Actor for GuardedActor {
     }
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn dropping_scoped_guard_suppresses_the_continuation() {
     let deliveries = Arc::new(AtomicUsize::new(0));
+    let guard_dropped = Arc::new(AtomicBool::new(false));
     let mut tree = Tree::new();
     let actor = tree
         .add_actor_once(
             "guarded",
-            ActorOnceDef::<GuardedActor>::new(Arc::clone(&deliveries)),
+            ActorOnceDef::<GuardedActor>::new((
+                Arc::clone(&deliveries),
+                Arc::clone(&guard_dropped),
+            )),
         )
         .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("actor starts");
     actor.send(GuardMessage::Start).await.expect("actor live");
-    for _ in 0..8 {
-        tokio::task::yield_now().await;
-    }
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            guard_dropped.load(Ordering::SeqCst)
+        })
+        .await,
+        "the actor drops the guard before the negative window begins"
+    );
+    assert_quiet(Duration::from_secs(1), || {
+        deliveries.load(Ordering::SeqCst) != 0
+    })
+    .await;
     actor.send(GuardMessage::Stop).await.expect("actor live");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert_eq!(deliveries.load(Ordering::SeqCst), 0);

--- a/crates/shelterwood/tests/one_shot_resource_ownership.rs
+++ b/crates/shelterwood/tests/one_shot_resource_ownership.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::common::{ConsumeCount, ConsumeGuard, policy::never};
+use crate::common::{ConsumeCount, ConsumeGuard, ReleaseGate, policy::never};
 use shelterwood::{
     Actor, ActorOnceDef, Context, ExitError, ExitResult, RawActor, RawContext, RawOnceDef,
     Readiness, ReadinessDeadline, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
@@ -220,12 +220,20 @@ async fn one_shot_actor_args_drop_once_on_init_panic_and_startup_failure() {
 #[tokio::test]
 async fn one_shot_actor_args_drop_once_when_shutdown_prevents_start() {
     let count = ConsumeCount::default();
+    let gate_started = ReleaseGate::default();
     let mut tree = Tree::new();
     tree.add_task(
         "gate",
-        TaskDef::new(|context| async move {
-            context.shutdown_token().cancelled().await;
-            Ok(())
+        TaskDef::new({
+            let gate_started = gate_started.clone();
+            move |context| {
+                let gate_started = gate_started.clone();
+                async move {
+                    gate_started.release();
+                    context.shutdown_token().cancelled().await;
+                    Ok(())
+                }
+            }
         })
         .readiness(Readiness::Manual)
         .expect("manual task readiness is valid"),
@@ -240,7 +248,7 @@ async fn one_shot_actor_args_drop_once_when_shutdown_prevents_start() {
     )
     .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
-    tokio::task::yield_now().await;
+    gate_started.wait().await;
     system
         .shutdown(Duration::from_secs(1))
         .await

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, poll_until};
+use crate::common::{ReleaseGate, assert_quiet, poll_until};
 use shelterwood::{
     DynamicTree, ExitError, ExitResult, Mailbox, MailboxShutdown, PolicyError, RawActor,
     RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline, RemoveOutcome, ScopeDefaults,
@@ -230,7 +230,7 @@ impl RawActor for ManualActor {
     }
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn raw_manual_readiness_gates_ordered_startup_but_not_mailbox_acceptance() {
     let release_ready = ReleaseGate::default();
     let entered = Arc::new(AtomicBool::new(false));
@@ -267,7 +267,10 @@ async fn raw_manual_readiness_gates_ordered_startup_but_not_mailbox_acceptance()
         })
         .await
     );
-    assert!(!sibling_started.load(Ordering::SeqCst));
+    assert_quiet(Duration::from_millis(20), || {
+        sibling_started.load(Ordering::SeqCst)
+    })
+    .await;
     actor
         .send(7)
         .await

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -122,18 +122,22 @@ async fn readiness_deadline_is_typed_and_absolute() {
 async fn ready_at_deadline_wins_and_shutdown_disarms_the_gate() {
     let width = Duration::from_secs(10);
     let ready_started = Arc::new(AtomicBool::new(false));
+    let ready_marked = ReleaseGate::default();
     let mut ready_tree = Tree::new();
     let ready_task = ready_tree
         .add_task(
             "edge",
             TaskDef::new({
                 let ready_started = Arc::clone(&ready_started);
+                let ready_marked = ready_marked.clone();
                 move |context| {
                     let ready_started = Arc::clone(&ready_started);
+                    let ready_marked = ready_marked.clone();
                     async move {
                         ready_started.store(true, Ordering::SeqCst);
                         tokio::time::sleep(width).await;
                         context.mark_ready();
+                        ready_marked.release();
                         context.shutdown_token().cancelled().await;
                         Ok(())
                     }
@@ -152,7 +156,7 @@ async fn ready_at_deadline_wins_and_shutdown_disarms_the_gate() {
         .await
     );
     advance_time(width).await;
-    tokio::task::yield_now().await;
+    ready_marked.wait().await;
     ready_system
         .wait_started()
         .await

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -8,8 +8,8 @@ use std::{
 
 use crate::common::{ReleaseGate, advance_time, assert_quiet, policy::never, poll_until};
 use shelterwood::{
-    DynamicTree, ExitError, ExitKind, Readiness, ReadinessDeadline, Shutdown, StartupError,
-    StartupFailureCause, SubtreeOnceDef, TaskDef, Tree,
+    ChildState, DynamicTree, ExitError, ExitKind, Readiness, ReadinessDeadline, ScopeState,
+    Shutdown, StartupError, StartupFailureCause, SubtreeOnceDef, TaskDef, Tree,
 };
 
 #[tokio::test]
@@ -573,4 +573,195 @@ async fn start_or_shutdown_preserves_startup_error_and_rolls_back_the_prefix() {
     assert!(matches!(error.startup, StartupError::StartupFailed(_)));
     assert!(error.rollback_timeout.is_none());
     assert!(prefix_cancelled.load(Ordering::SeqCst));
+}
+
+#[tokio::test(start_paused = true)]
+async fn start_or_shutdown_rollback_timeout_preserves_the_startup_cause_and_stragglers() {
+    let mut tree = Tree::new();
+    let prefix = tree
+        .add_task(
+            "prefix",
+            TaskDef::new(|_| std::future::pending::<shelterwood::ExitResult>()).shutdown(
+                Shutdown::Graceful {
+                    grace: Duration::from_secs(60),
+                },
+            ),
+        )
+        .expect("valid prefix");
+    tree.add_task(
+        "failure",
+        TaskDef::new(|_| async { Err(ExitError::message("original startup cause")) })
+            .restart(never())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness"),
+    )
+    .expect("valid failure");
+
+    let error = tree
+        .spawn()
+        .expect("runtime is available")
+        .start_or_shutdown(Duration::ZERO)
+        .await
+        .expect_err("startup fails and zero-budget rollback reports its live prefix");
+
+    let StartupError::StartupFailed(failure) = error.startup else {
+        panic!("expected the original structured startup failure");
+    };
+    assert!(matches!(
+        failure.cause,
+        StartupFailureCause::Child { ref id, ref exit, .. }
+            if id.as_str() == "failure"
+                && matches!(exit.kind(), ExitKind::Failed(cause) if cause.to_string() == "original startup cause")
+    ));
+    let rollback = error
+        .rollback_timeout
+        .expect("the still-live prefix is retained as rollback evidence");
+    assert_eq!(rollback.stragglers.len(), 1);
+    assert_eq!(rollback.stragglers[0].path[0].as_str(), "prefix");
+    assert_eq!(rollback.stragglers[0].membership, prefix.membership());
+    assert!(matches!(
+        prefix.wait().await.kind(),
+        ExitKind::Aborted { .. }
+    ));
+}
+
+#[tokio::test(start_paused = true)]
+async fn aggregate_readiness_stays_monotonic_after_a_ready_child_restarts() {
+    let incarnation = Arc::new(AtomicUsize::new(0));
+    let fail_first = ReleaseGate::default();
+    let second_started = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.add_task(
+        "worker",
+        TaskDef::new({
+            let incarnation = Arc::clone(&incarnation);
+            let fail_first = fail_first.clone();
+            let second_started = second_started.clone();
+            move |context| {
+                let current = incarnation.fetch_add(1, Ordering::SeqCst) + 1;
+                let fail_first = fail_first.clone();
+                let second_started = second_started.clone();
+                async move {
+                    if current == 1 {
+                        context.mark_ready();
+                        fail_first.wait().await;
+                        return Err(ExitError::message("restart after aggregate readiness"));
+                    }
+                    second_started.release();
+                    context.shutdown_token().cancelled().await;
+                    Ok(())
+                }
+            }
+        })
+        .readiness(Readiness::Manual)
+        .expect("manual readiness")
+        .readiness_deadline(ReadinessDeadline::Unbounded)
+        .shutdown(Shutdown::Abort),
+    )
+    .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("the first incarnation releases aggregate readiness");
+
+    fail_first.release();
+    second_started.wait().await;
+    let snapshot = system.scope().snapshot();
+    assert_eq!(snapshot.state, ScopeState::Running);
+    assert!(matches!(
+        snapshot
+            .child("worker")
+            .expect("worker remains resident")
+            .state,
+        ChildState::Starting
+    ));
+    system
+        .wait_started()
+        .await
+        .expect("published aggregate readiness never regresses");
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[tokio::test]
+async fn nested_startup_rollback_includes_runtime_added_members() {
+    let failure_entered = ReleaseGate::default();
+    let fail = ReleaseGate::default();
+    let runtime_started = ReleaseGate::default();
+    let runtime_cancelled = ReleaseGate::default();
+    let mut nested = DynamicTree::new();
+    nested
+        .add_task(
+            "failure",
+            TaskDef::new({
+                let failure_entered = failure_entered.clone();
+                let fail = fail.clone();
+                move |_| {
+                    let failure_entered = failure_entered.clone();
+                    let fail = fail.clone();
+                    async move {
+                        failure_entered.release();
+                        fail.wait().await;
+                        Err(ExitError::message("nested startup failure"))
+                    }
+                }
+            })
+            .restart(never())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness")
+            .readiness_deadline(ReadinessDeadline::Unbounded),
+        )
+        .expect("valid failure");
+    let mut root = Tree::new();
+    let nested = root
+        .add_subtree_once("nested", SubtreeOnceDef::new(nested))
+        .expect("valid nested scope");
+    let system = root.spawn().expect("runtime is available");
+    failure_entered.wait().await;
+
+    let runtime = nested
+        .add_task(
+            "runtime",
+            TaskDef::new({
+                let runtime_started = runtime_started.clone();
+                let runtime_cancelled = runtime_cancelled.clone();
+                move |context| {
+                    let runtime_started = runtime_started.clone();
+                    let runtime_cancelled = runtime_cancelled.clone();
+                    async move {
+                        runtime_started.release();
+                        context.shutdown_token().cancelled().await;
+                        runtime_cancelled.release();
+                        Ok(())
+                    }
+                }
+            }),
+        )
+        .await
+        .expect("runtime member is admitted during nested startup")
+        .into_handles();
+    runtime_started.wait().await;
+
+    fail.release();
+    assert!(matches!(
+        system.wait_started().await,
+        Err(StartupError::StartupFailed(_))
+    ));
+    runtime_cancelled.wait().await;
+    let runtime_exit = runtime.wait().await;
+    assert!(matches!(runtime_exit.kind(), ExitKind::Completed));
+    assert!(runtime_exit.cancelled());
+    assert!(matches!(
+        nested.wait_stopped().await,
+        shelterwood::StopReason::StartupFailed(_)
+    ));
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed root rolls back");
 }

--- a/crates/shelterwood/tests/rebind.rs
+++ b/crates/shelterwood/tests/rebind.rs
@@ -309,9 +309,8 @@ async fn timed_send_withdraws_while_replacement_is_in_backoff() {
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("actor starts");
     let first = actor.try_send(1).expect("first incarnation accepts");
-    let timed_actor = actor.clone();
-    let timed = tokio::spawn(async move { timed_actor.send_timeout(42, timeout).await });
-    tokio::task::yield_now().await;
+    let mut timed = Box::pin(actor.send_timeout(42, timeout));
+    assert!(poll_once(timed.as_mut()).is_pending());
     fail_first.release();
     let mut observed_rebind = None;
     assert!(
@@ -328,10 +327,7 @@ async fn timed_send_withdraws_while_replacement_is_in_backoff() {
     );
     assert_eq!(observed_rebind, Some(None));
     tokio::time::advance(timeout).await;
-    let error = timed
-        .await
-        .expect("timed send task joins")
-        .expect_err("backoff outlives timeout");
+    let error = timed.await.expect_err("backoff outlives timeout");
     assert_eq!(error.kind, SendErrorKind::TimedOut);
     assert_eq!(error.incarnation_observed, Some(first));
     assert_eq!(error.message, 42);

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -9,9 +9,11 @@ use std::{
 
 use crate::common::{ReleaseGate, advance_time, poll_until};
 use shelterwood::{
-    Backoff, DynamicTree, ExitError, ExitKind, Intensity, Readiness, RestartCondition,
-    RestartPolicy, Shutdown, StartupError, StartupFailureCause, StopReason, SubtreeDef,
-    SubtreeOnceDef, TaskDef, TaskOnceDef, TaskRef, Tree,
+    Actor, ActorOnceDef, Backoff, Context, DefaultsInheritance, DynamicTree, ExitError, ExitKind,
+    ExitResult, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Mailbox,
+    Readiness, ReadinessDeadline, RestartCondition, RestartPolicy, ScopeDefaults, SendErrorKind,
+    Shutdown, StartupError, StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef,
+    TaskOnceDef, TaskRef, Tree,
 };
 
 #[tokio::test]
@@ -663,4 +665,184 @@ async fn locally_requested_subtree_shutdown_reads_cancelled() {
         exit.cancelled(),
         "a locally requested shutdown is still a stop request: {exit:?}"
     );
+}
+
+#[tokio::test(start_paused = true)]
+async fn restart_attempt_resets_after_a_ready_incarnation_settles() {
+    let starts = Arc::new(AtomicUsize::new(0));
+    let replacement_started = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.intensity(Intensity::new(100, Duration::from_secs(10)).expect("valid intensity"));
+    tree.add_task(
+        "worker",
+        TaskDef::new({
+            let starts = Arc::clone(&starts);
+            let replacement_started = replacement_started.clone();
+            move |context| {
+                let generation = starts.fetch_add(1, Ordering::SeqCst) + 1;
+                let replacement_started = replacement_started.clone();
+                async move {
+                    match generation {
+                        1 => Err(ExitError::message("pre-ready failure")),
+                        2 => {
+                            context.mark_ready();
+                            tokio::time::sleep(Duration::from_secs(11)).await;
+                            Err(ExitError::message("post-ready failure"))
+                        }
+                        _ => {
+                            replacement_started.release();
+                            context.mark_ready();
+                            context.shutdown_token().cancelled().await;
+                            Ok(())
+                        }
+                    }
+                }
+            }
+        })
+        .readiness(Readiness::Manual)
+        .expect("manual readiness")
+        .readiness_deadline(ReadinessDeadline::Unbounded)
+        .shutdown(Shutdown::Abort),
+    )
+    .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+    let mut events = system.scope().subscribe_lifecycle();
+    system
+        .wait_started()
+        .await
+        .expect("the second incarnation settles aggregate readiness");
+
+    advance_time(Duration::from_secs(11)).await;
+    replacement_started.wait().await;
+
+    let mut attempts = Vec::new();
+    loop {
+        match events.try_recv() {
+            Ok(LifecycleItem::Event(event)) => {
+                if let LifecycleEventKind::RestartScheduled { attempt, .. } = event.kind {
+                    attempts.push(attempt);
+                }
+            }
+            Ok(LifecycleItem::Lagged { dropped }) => {
+                panic!("short restart trace unexpectedly lagged by {dropped}")
+            }
+            Err(LifecycleTryRecvError::Empty) => break,
+            Err(LifecycleTryRecvError::Closed) => panic!("live root stream closed"),
+            Ok(_) | Err(_) => panic!("unexpected future lifecycle variant"),
+        }
+    }
+    assert_eq!(attempts, [1, 1]);
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[derive(Clone, Copy)]
+enum CapacityMessage {
+    Hold,
+    Queued,
+}
+
+struct CapacityActor {
+    entered: ReleaseGate,
+    release: ReleaseGate,
+}
+
+impl Actor for CapacityActor {
+    type Msg = CapacityMessage;
+    type Args = (ReleaseGate, ReleaseGate);
+
+    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self {
+            entered: args.0,
+            release: args.1,
+        })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+        if matches!(message, CapacityMessage::Hold) {
+            self.entered.release();
+            self.release.wait().await;
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn subtree_defaults_inherit_or_reset_end_to_end() {
+    let inherited_entered = ReleaseGate::default();
+    let inherited_release = ReleaseGate::default();
+    let reset_entered = ReleaseGate::default();
+    let reset_release = ReleaseGate::default();
+
+    let mut inherited_tree = Tree::new();
+    let inherited_actor = inherited_tree
+        .add_actor_once(
+            "actor",
+            ActorOnceDef::<CapacityActor>::new((
+                inherited_entered.clone(),
+                inherited_release.clone(),
+            )),
+        )
+        .expect("valid inherited actor");
+    let mut reset_tree = Tree::new();
+    let reset_actor = reset_tree
+        .add_actor_once(
+            "actor",
+            ActorOnceDef::<CapacityActor>::new((reset_entered.clone(), reset_release.clone())),
+        )
+        .expect("valid reset actor");
+
+    let mut root = Tree::new();
+    root.defaults(ScopeDefaults {
+        mailbox: Some(Mailbox::queue(1).expect("valid inherited capacity")),
+        ..ScopeDefaults::default()
+    });
+    root.add_subtree_once(
+        "inherited",
+        SubtreeOnceDef::new(inherited_tree).defaults(DefaultsInheritance::Inherit),
+    )
+    .expect("valid inherited subtree");
+    root.add_subtree_once(
+        "reset",
+        SubtreeOnceDef::new(reset_tree).defaults(DefaultsInheritance::Reset),
+    )
+    .expect("valid reset subtree");
+    let system = root.spawn().expect("runtime is available");
+    system.wait_started().await.expect("both subtrees start");
+
+    inherited_actor
+        .send(CapacityMessage::Hold)
+        .await
+        .expect("inherited actor accepts hold");
+    reset_actor
+        .send(CapacityMessage::Hold)
+        .await
+        .expect("reset actor accepts hold");
+    inherited_entered.wait().await;
+    reset_entered.wait().await;
+
+    inherited_actor
+        .try_send(CapacityMessage::Queued)
+        .expect("the inherited one-slot queue accepts one pending message");
+    let inherited_full = inherited_actor
+        .try_send(CapacityMessage::Queued)
+        .expect_err("the second pending message observes the inherited capacity");
+    assert_eq!(inherited_full.kind, SendErrorKind::Full);
+
+    reset_actor
+        .try_send(CapacityMessage::Queued)
+        .expect("reset uses the library queue capacity");
+    reset_actor
+        .try_send(CapacityMessage::Queued)
+        .expect("reset does not inherit the parent's one-slot capacity");
+
+    inherited_release.release();
+    reset_release.release();
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
 }

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -7,13 +7,13 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, advance_time, poll_until};
+use crate::common::{ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
 use shelterwood::{
-    Actor, ActorOnceDef, Backoff, Context, DefaultsInheritance, DynamicTree, ExitError, ExitKind,
-    ExitResult, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Mailbox,
-    Readiness, ReadinessDeadline, RestartCondition, RestartPolicy, ScopeDefaults, SendErrorKind,
-    Shutdown, StartupError, StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef,
-    TaskOnceDef, TaskRef, Tree,
+    Actor, ActorOnceDef, Backoff, ChildState, Context, DefaultsInheritance, DynamicTree, ExitError,
+    ExitKind, ExitResult, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError,
+    Mailbox, MailboxShutdown, Readiness, ReadinessDeadline, RestartCondition, RestartPolicy,
+    ScopeDefaults, SendErrorKind, Shutdown, StartupError, StartupFailureCause, StopReason,
+    SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef, TaskRef, Tree,
 };
 
 #[tokio::test]
@@ -365,7 +365,7 @@ async fn ordered_graces_sum_while_dynamic_graces_overlap() {
     assert!(dynamic_elapsed < Duration::from_secs(15));
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn dynamic_and_always_members_do_not_finish_naturally() {
     let mut dynamic = DynamicTree::new();
     let (_task, _completion) = dynamic
@@ -376,11 +376,13 @@ async fn dynamic_and_always_members_do_not_finish_naturally() {
         .expect("valid task");
     let dynamic = dynamic.spawn().expect("runtime is available");
     dynamic.wait_started().await.expect("dynamic starts");
-    assert!(
-        tokio::time::timeout(Duration::from_millis(20), dynamic.scope().wait_stopped())
-            .await
-            .is_err()
-    );
+    let dynamic_scope = dynamic.scope();
+    let mut dynamic_stopped = Box::pin(dynamic_scope.wait_stopped());
+    assert_quiet(Duration::from_millis(20), || {
+        poll_once(dynamic_stopped.as_mut()).is_ready()
+    })
+    .await;
+    drop(dynamic_stopped);
     dynamic
         .shutdown(Duration::from_secs(1))
         .await
@@ -420,11 +422,13 @@ async fn dynamic_and_always_members_do_not_finish_naturally() {
         })
         .await
     );
-    assert!(
-        tokio::time::timeout(Duration::from_millis(20), ordered.scope().wait_stopped())
-            .await
-            .is_err()
-    );
+    let ordered_scope = ordered.scope();
+    let mut ordered_stopped = Box::pin(ordered_scope.wait_stopped());
+    assert_quiet(Duration::from_millis(20), || {
+        poll_once(ordered_stopped.as_mut()).is_ready()
+    })
+    .await;
+    drop(ordered_stopped);
     ordered
         .shutdown(Duration::from_secs(1))
         .await
@@ -519,8 +523,7 @@ async fn owning_shutdown_joins_recursively_aborted_scope_drivers() {
         "leaf starts polling"
     );
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(5)));
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    let returned_before_leaf_dropped = shutdown.is_finished();
+    assert_quiet(Duration::from_millis(50), || shutdown.is_finished()).await;
     {
         let (released, wake) = &*release;
         *released.lock().expect("release mutex poisoned") = true;
@@ -534,10 +537,6 @@ async fn owning_shutdown_joins_recursively_aborted_scope_drivers() {
     assert!(
         weak.upgrade().is_none(),
         "shutdown returns only after every nested driver and construction drops"
-    );
-    assert!(
-        !returned_before_leaf_dropped,
-        "shutdown must not return while a recursively aborted child future is still polling"
     );
 }
 
@@ -594,18 +593,24 @@ async fn shutdown_and_wait_wakes_when_a_parent_drain_terminalizes_a_restarting_s
     // schedules the subtree restart far in the future, so the membership
     // sits in its restart window with no live incarnation.
     assert!(matches!(inner.wait().await.kind(), ExitKind::Failed(_)));
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    let waiter = tokio::spawn({
-        let sub = sub.clone();
-        async move { sub.shutdown_and_wait(Duration::from_secs(1)).await }
-    });
-    // Give the waiter time to park on the scope signal before draining.
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    system
+        .scope()
+        .wait_for_child(
+            "nested",
+            |child| matches!(child.state, ChildState::Restarting),
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("the parent publishes the subtree restart window");
+    let mut waiter = Box::pin(sub.shutdown_and_wait(Duration::from_secs(1)));
+    assert!(
+        poll_once(waiter.as_mut()).is_pending(),
+        "the restart-window stop request is registered before parent teardown"
+    );
     drop(system);
     tokio::time::timeout(Duration::from_secs(3), waiter)
         .await
         .expect("parent drain terminalizes the restarting subtree and wakes waiters")
-        .expect("waiter joins")
         .expect("teardown completes in bound");
 }
 
@@ -841,6 +846,380 @@ async fn subtree_defaults_inherit_or_reset_end_to_end() {
 
     inherited_release.release();
     reset_release.release();
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[tokio::test]
+async fn subtree_restart_defaults_inherit_or_reset_end_to_end() {
+    let inherited_starts = Arc::new(AtomicUsize::new(0));
+    let inherited_fail = ReleaseGate::default();
+    let reset_starts = Arc::new(AtomicUsize::new(0));
+    let reset_fail = ReleaseGate::default();
+    let reset_restarted = ReleaseGate::default();
+
+    let mut inherited_tree = Tree::new();
+    let inherited_task = inherited_tree
+        .add_task(
+            "worker",
+            TaskDef::new({
+                let starts = Arc::clone(&inherited_starts);
+                let fail = inherited_fail.clone();
+                move |context| {
+                    let starts = Arc::clone(&starts);
+                    let fail = fail.clone();
+                    async move {
+                        starts.fetch_add(1, Ordering::SeqCst);
+                        context.mark_ready();
+                        fail.wait().await;
+                        Err(ExitError::message("inherited restart default"))
+                    }
+                }
+            })
+            .readiness(Readiness::Manual)
+            .expect("manual readiness"),
+        )
+        .expect("valid inherited worker");
+
+    let mut reset_tree = Tree::new();
+    let reset_task = reset_tree
+        .add_task(
+            "worker",
+            TaskDef::new({
+                let starts = Arc::clone(&reset_starts);
+                let fail = reset_fail.clone();
+                let restarted = reset_restarted.clone();
+                move |context| {
+                    let starts = Arc::clone(&starts);
+                    let fail = fail.clone();
+                    let restarted = restarted.clone();
+                    async move {
+                        let attempt = starts.fetch_add(1, Ordering::SeqCst);
+                        context.mark_ready();
+                        if attempt == 0 {
+                            fail.wait().await;
+                            Err(ExitError::message("reset restart default"))
+                        } else {
+                            restarted.release();
+                            context.shutdown_token().cancelled().await;
+                            Ok(())
+                        }
+                    }
+                }
+            })
+            .readiness(Readiness::Manual)
+            .expect("manual readiness"),
+        )
+        .expect("valid reset worker");
+
+    let mut root = Tree::new();
+    root.defaults(ScopeDefaults {
+        child_restart: Some(RestartPolicy::new(
+            RestartCondition::Never,
+            Backoff::Immediate,
+        )),
+        ..ScopeDefaults::default()
+    });
+    root.add_subtree_once(
+        "inherited",
+        SubtreeOnceDef::new(inherited_tree).defaults(DefaultsInheritance::Inherit),
+    )
+    .expect("valid inherited subtree");
+    root.add_subtree_once(
+        "reset",
+        SubtreeOnceDef::new(reset_tree).defaults(DefaultsInheritance::Reset),
+    )
+    .expect("valid reset subtree");
+    let system = root.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("both workers become ready");
+
+    inherited_fail.release();
+    reset_fail.release();
+    assert!(matches!(
+        inherited_task.wait().await.kind(),
+        ExitKind::Failed(cause) if cause.to_string() == "inherited restart default"
+    ));
+    reset_restarted.wait().await;
+    assert_eq!(inherited_starts.load(Ordering::SeqCst), 1);
+    assert_eq!(reset_starts.load(Ordering::SeqCst), 2);
+    let mut reset_wait = Box::pin(reset_task.wait());
+    assert!(poll_once(reset_wait.as_mut()).is_pending());
+    drop(reset_wait);
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[tokio::test(start_paused = true)]
+async fn subtree_shutdown_defaults_inherit_or_reset_end_to_end() {
+    fn stubborn_tree(started: ReleaseGate) -> (Tree, TaskRef) {
+        let mut tree = Tree::new();
+        let task = tree
+            .add_task(
+                "worker",
+                TaskDef::new(move |context| {
+                    let started = started.clone();
+                    async move {
+                        started.release();
+                        context.shutdown_token().cancelled().await;
+                        std::future::pending::<ExitResult>().await
+                    }
+                }),
+            )
+            .expect("valid stubborn worker");
+        (tree, task)
+    }
+
+    let inherited_started = ReleaseGate::default();
+    let reset_started = ReleaseGate::default();
+    let (inherited_tree, inherited_task) = stubborn_tree(inherited_started.clone());
+    let (reset_tree, reset_task) = stubborn_tree(reset_started.clone());
+    let mut root = Tree::new();
+    root.defaults(ScopeDefaults {
+        child_shutdown: Some(Shutdown::Abort),
+        ..ScopeDefaults::default()
+    });
+    let inherited_scope = root
+        .add_subtree_once(
+            "inherited",
+            SubtreeOnceDef::new(inherited_tree).defaults(DefaultsInheritance::Inherit),
+        )
+        .expect("valid inherited subtree");
+    let reset_scope = root
+        .add_subtree_once(
+            "reset",
+            SubtreeOnceDef::new(reset_tree).defaults(DefaultsInheritance::Reset),
+        )
+        .expect("valid reset subtree");
+    let system = root.spawn().expect("runtime is available");
+    system.wait_started().await.expect("both workers start");
+    inherited_started.wait().await;
+    reset_started.wait().await;
+
+    inherited_scope
+        .shutdown_and_wait(Duration::from_secs(30))
+        .await
+        .expect("inherited abort policy stops immediately");
+    reset_scope
+        .shutdown_and_wait(Duration::from_secs(30))
+        .await
+        .expect("reset library grace eventually escalates");
+    assert!(matches!(
+        inherited_task.wait().await.kind(),
+        ExitKind::Aborted { after_grace: false }
+    ));
+    assert!(matches!(
+        reset_task.wait().await.kind(),
+        ExitKind::Aborted { after_grace: true }
+    ));
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+struct DefaultMailboxActor {
+    entered: ReleaseGate,
+    release: ReleaseGate,
+    handled: Arc<AtomicUsize>,
+}
+
+impl Actor for DefaultMailboxActor {
+    type Msg = CapacityMessage;
+    type Args = (ReleaseGate, ReleaseGate, ReleaseGate, Arc<AtomicUsize>);
+
+    async fn init(args: Self::Args, context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        let shutdown = context.shutdown_token();
+        let shutdown_seen = args.2.clone();
+        tokio::spawn(async move {
+            shutdown.cancelled().await;
+            shutdown_seen.release();
+        });
+        Ok(Self {
+            entered: args.0,
+            release: args.1,
+            handled: args.3,
+        })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            CapacityMessage::Hold => {
+                self.entered.release();
+                self.release.wait().await;
+            }
+            CapacityMessage::Queued => {
+                self.handled.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn subtree_mailbox_shutdown_defaults_inherit_or_reset_end_to_end() {
+    let inherited_entered = ReleaseGate::default();
+    let inherited_release = ReleaseGate::default();
+    let inherited_shutdown = ReleaseGate::default();
+    let inherited_handled = Arc::new(AtomicUsize::new(0));
+    let reset_entered = ReleaseGate::default();
+    let reset_release = ReleaseGate::default();
+    let reset_shutdown = ReleaseGate::default();
+    let reset_handled = Arc::new(AtomicUsize::new(0));
+
+    let mut inherited_tree = Tree::new();
+    let inherited_actor = inherited_tree
+        .add_actor_once(
+            "actor",
+            ActorOnceDef::<DefaultMailboxActor>::new((
+                inherited_entered.clone(),
+                inherited_release.clone(),
+                inherited_shutdown.clone(),
+                Arc::clone(&inherited_handled),
+            )),
+        )
+        .expect("valid inherited actor");
+    let mut reset_tree = Tree::new();
+    let reset_actor = reset_tree
+        .add_actor_once(
+            "actor",
+            ActorOnceDef::<DefaultMailboxActor>::new((
+                reset_entered.clone(),
+                reset_release.clone(),
+                reset_shutdown.clone(),
+                Arc::clone(&reset_handled),
+            )),
+        )
+        .expect("valid reset actor");
+
+    let mut root = Tree::new();
+    root.defaults(ScopeDefaults {
+        mailbox_shutdown: Some(MailboxShutdown::Discard),
+        ..ScopeDefaults::default()
+    });
+    let inherited_scope = root
+        .add_subtree_once(
+            "inherited",
+            SubtreeOnceDef::new(inherited_tree).defaults(DefaultsInheritance::Inherit),
+        )
+        .expect("valid inherited subtree");
+    let reset_scope = root
+        .add_subtree_once(
+            "reset",
+            SubtreeOnceDef::new(reset_tree).defaults(DefaultsInheritance::Reset),
+        )
+        .expect("valid reset subtree");
+    let system = root.spawn().expect("runtime is available");
+    system.wait_started().await.expect("both actors start");
+    inherited_actor
+        .send(CapacityMessage::Hold)
+        .await
+        .expect("inherited hold is accepted");
+    reset_actor
+        .send(CapacityMessage::Hold)
+        .await
+        .expect("reset hold is accepted");
+    inherited_entered.wait().await;
+    reset_entered.wait().await;
+    inherited_actor
+        .send(CapacityMessage::Queued)
+        .await
+        .expect("inherited prefix is accepted");
+    reset_actor
+        .send(CapacityMessage::Queued)
+        .await
+        .expect("reset prefix is accepted");
+
+    inherited_scope.request_shutdown();
+    reset_scope.request_shutdown();
+    inherited_shutdown.wait().await;
+    reset_shutdown.wait().await;
+    inherited_release.release();
+    reset_release.release();
+    inherited_scope.wait_stopped().await;
+    reset_scope.wait_stopped().await;
+    assert_eq!(inherited_handled.load(Ordering::SeqCst), 0);
+    assert_eq!(reset_handled.load(Ordering::SeqCst), 1);
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[tokio::test(start_paused = true)]
+async fn subtree_readiness_deadline_defaults_inherit_or_reset_end_to_end() {
+    fn manual_tree(started: ReleaseGate) -> (Tree, TaskRef) {
+        let mut tree = Tree::new();
+        let task = tree
+            .add_task(
+                "manual",
+                TaskDef::new(move |context| {
+                    let started = started.clone();
+                    async move {
+                        started.release();
+                        context.shutdown_token().cancelled().await;
+                        Ok(())
+                    }
+                })
+                .restart(RestartPolicy::new(
+                    RestartCondition::Never,
+                    Backoff::Immediate,
+                ))
+                .readiness(Readiness::Manual)
+                .expect("manual readiness"),
+            )
+            .expect("valid manual worker");
+        (tree, task)
+    }
+
+    let inherited_started = ReleaseGate::default();
+    let reset_started = ReleaseGate::default();
+    let (inherited_tree, inherited_task) = manual_tree(inherited_started.clone());
+    let (reset_tree, reset_task) = manual_tree(reset_started.clone());
+    let mut root = DynamicTree::new();
+    root.defaults(ScopeDefaults {
+        readiness_deadline: Some(ReadinessDeadline::Unbounded),
+        ..ScopeDefaults::default()
+    });
+    let inherited_scope = root
+        .add_subtree_once(
+            "inherited",
+            SubtreeOnceDef::new(inherited_tree).defaults(DefaultsInheritance::Inherit),
+        )
+        .expect("valid inherited subtree");
+    root.add_subtree_once(
+        "reset",
+        SubtreeOnceDef::new(reset_tree).defaults(DefaultsInheritance::Reset),
+    )
+    .expect("valid reset subtree");
+    let system = root.spawn().expect("runtime is available");
+    inherited_started.wait().await;
+    reset_started.wait().await;
+
+    assert!(matches!(
+        reset_task.wait().await.kind(),
+        ExitKind::ReadinessTimedOut { .. }
+    ));
+    assert!(matches!(
+        inherited_scope
+            .child("manual")
+            .expect("inherited manual worker remains resident")
+            .state,
+        ChildState::Starting
+    ));
+    let mut inherited_wait = Box::pin(inherited_task.wait());
+    assert!(poll_once(inherited_wait.as_mut()).is_pending());
+    drop(inherited_wait);
+
     system
         .shutdown(Duration::from_secs(1))
         .await

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -21,11 +21,16 @@ At the root, `wait_started()` reports a startup failure but deliberately leaves
 the successfully started prefix supervised. This permits a host-specific
 decision, but most embeddings want rollback:
 
-```rust,ignore
+```rust,no_run
+# use std::time::Duration;
+# use shelterwood::{System, Tree};
+# async fn start(tree: Tree) -> Result<System, Box<dyn std::error::Error>> {
 let system = tree.spawn()?;
 let system = system
     .start_or_shutdown(Duration::from_secs(5))
     .await?;
+# Ok(system)
+# }
 ```
 
 `start_or_shutdown` returns the owner on success. On failure it drives full

--- a/docs/shutdown-and-resources.md
+++ b/docs/shutdown-and-resources.md
@@ -51,7 +51,10 @@ The framework always freezes raw-actor intake, but the raw loop owns delivery.
 It must consult `RawContext::mailbox_shutdown` and use `try_recv` to drain the
 frozen prefix when requested:
 
-```rust,ignore
+```rust,no_run
+# use shelterwood::{ExitError, ExitResult, MailboxShutdown, RawContext};
+# fn handle<T>(_message: T) -> Result<(), ExitError> { Ok(()) }
+# async fn drain<M: Send + 'static>(context: &mut RawContext<M>) -> ExitResult {
 while let Some(message) = context.recv().await {
     handle(message)?;
 }
@@ -61,6 +64,8 @@ if context.mailbox_shutdown() == MailboxShutdown::Drain {
         handle(message)?;
     }
 }
+# Ok(())
+# }
 ```
 
 For a queue mailbox, that prefix is every accepted but undelivered message in

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,10 @@
     }:
     rust-env.lib.mkRustProject {
       src = ./.;
+      # Repository docs are compiled as crate doctests, so keep Markdown
+      # alongside Cargo sources in the clean build sandbox.
+      extraSourceFilter =
+        path: type: type == "regular" && builtins.match ".*\\.md" (toString path) != null;
       extraChecks =
         pkgs:
         let

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,8 @@
     }:
     rust-env.lib.mkRustProject {
       src = ./.;
-      # Repository docs are compiled as crate doctests, so keep Markdown
-      # alongside Cargo sources in the clean build sandbox.
+      # Repository docs and their packaged doctest copies are compared in the
+      # clean build sandbox, so keep Markdown alongside Cargo sources.
       extraSourceFilter =
         path: type: type == "regular" && builtins.match ".*\\.md" (toString path) != null;
       extraChecks =
@@ -37,7 +37,8 @@
               path: type:
               type == "directory"
               || craneLib.filterCargoSources path type
-              || pkgs.lib.hasSuffix ".sh" (toString path);
+              || pkgs.lib.hasSuffix ".sh" (toString path)
+              || pkgs.lib.hasSuffix ".md" (toString path);
           };
           commonArgs = {
             pname = "shelterwood-part0-enforcement";
@@ -61,6 +62,8 @@
                   target/doc/shelterwood.json
                 ${pkgs.bash}/bin/bash ./tools/check-runtime-paths.sh
                 ${pkgs.bash}/bin/bash ./tools/check-exit-paths.sh
+                ${pkgs.bash}/bin/bash ./tools/sync-packaged-docs.sh --check
+                ${pkgs.bash}/bin/bash ./tools/check-packaged-crate.sh
               '';
               doInstallCargoArtifacts = false;
             }

--- a/justfile
+++ b/justfile
@@ -34,12 +34,21 @@ runtime-path-check:
 exit-path-check:
     ./tools/check-exit-paths.sh
 
+packaged-docs-sync:
+    ./tools/sync-packaged-docs.sh --write
+
+packaged-docs-check:
+    ./tools/sync-packaged-docs.sh --check
+
+package-check:
+    ./tools/check-packaged-crate.sh
+
 nixfmt-check:
     git ls-files -z '*.nix' | xargs -0 nixfmt --check
 
 # Fast local CI mirror — reuses the local cargo cache and incremental builds.
 # The clean Nix lane retains the explicit all-target build for non-test codegen coverage.
-ci: fmt lint test doc-check runtime-api-check runtime-path-check exit-path-check nixfmt-check
+ci: fmt lint test doc-check runtime-api-check runtime-path-check exit-path-check packaged-docs-check package-check nixfmt-check
 
 # Full clean Nix CI lane; use before pushing or when touching Nix files.
 ci-nix:

--- a/tools/check-packaged-crate.sh
+++ b/tools/check-packaged-crate.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+manifest="$repo_root/crates/shelterwood/Cargo.toml"
+
+cd "$repo_root"
+package_id="$(cargo pkgid --manifest-path "$manifest")"
+version="${package_id##*#}"
+target_dir="${CARGO_TARGET_DIR:-target}"
+if [[ "$target_dir" != /* ]]; then
+  target_dir="$repo_root/$target_dir"
+fi
+archive="$target_dir/package/shelterwood-$version.crate"
+
+cargo package \
+  --manifest-path "$manifest" \
+  --locked \
+  --allow-dirty \
+  --offline
+
+if [[ ! -f "$archive" ]]; then
+  echo "cargo package did not produce $archive" >&2
+  exit 1
+fi
+
+unpack_root="$(mktemp -d "${TMPDIR:-/tmp}/shelterwood-package-check.XXXXXX")"
+cleanup() {
+  rm -rf -- "$unpack_root"
+}
+trap cleanup EXIT
+
+tar -xzf "$archive" -C "$unpack_root"
+unpacked="$unpack_root/shelterwood-$version"
+if [[ ! -d "$unpacked" ]]; then
+  echo "crate archive did not contain shelterwood-$version" >&2
+  exit 1
+fi
+
+(
+  cd "$unpacked"
+  cargo test --locked --offline --doc --all-features
+)

--- a/tools/sync-packaged-docs.sh
+++ b/tools/sync-packaged-docs.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+sources=(
+  "README.md"
+  "docs/embedding.md"
+  "docs/observation.md"
+  "docs/retry-and-ordering.md"
+  "docs/shutdown-and-resources.md"
+)
+
+case "${1:-}" in
+  --check | --write)
+    mode="$1"
+    ;;
+  *)
+    echo "usage: $0 --check|--write" >&2
+    exit 2
+    ;;
+esac
+
+status=0
+for source in "${sources[@]}"; do
+  packaged="crates/shelterwood/doctests/$source"
+  if [[ "$mode" == "--write" ]]; then
+    mkdir -p "$repo_root/$(dirname "$packaged")"
+    cp "$repo_root/$source" "$repo_root/$packaged"
+  elif ! cmp -s "$repo_root/$source" "$repo_root/$packaged"; then
+    echo "$packaged is not synchronized with $source" >&2
+    status=1
+  fi
+done
+
+if [[ "$status" -ne 0 ]]; then
+  echo "run 'just packaged-docs-sync' and commit the synchronized copies" >&2
+fi
+
+exit "$status"


### PR DESCRIPTION
Part of #35 (item 10)

## What changed

Closes the post-review conformance and fault-path coverage gaps with deterministic integration tests, compile-time API probes, and repository-document doctests. This remains test/documentation/build-infrastructure only; it does not change runtime behavior or the public API.

This pass is rebased directly onto PR #54's final head, so the evidence exercises isolated user-owned disposal together with the merged runtime-reclamation, hot-path, and authoritative-verdict work. In particular, the ancestor hard-abort race now proves the queued restartable definition is actually disposed, not merely that its admission future resolves.

## Row-by-row evidence

1. **Ancestor hard abort with queued admission and mid-flight removal** — `dynamic::ancestor_hard_abort_disposes_a_queued_admission_and_midflight_removal` gates a live removal, first-polls an admission, recursively aborts the ancestor, and verifies both obligations, memberships, and queued-definition disposal terminate.
2. **Rollback timeout retains startup cause and stragglers** — `readiness::start_or_shutdown_rollback_timeout_preserves_the_startup_cause_and_stragglers` checks the structured child failure, exact path/membership, and post-timeout abort.
3. **Handler stop/fault paths** — the `drain` fault fixtures cover Discard, drain error/panic, on_stop panic, one shared budget, and StopContext blocking work.
4. **Subtree Inherit and Reset** — end-to-end subtree tests now distinguish Inherit from Reset for all five `ScopeDefaults` fields: child restart, child shutdown, mailbox capacity, mailbox shutdown, and readiness deadline.
5. **Aggregate readiness and nested rollback** — readiness tests cover monotonic root readiness and cancellation/join of runtime-added nested members.
6. **Dynamic task/raw/subtree parity** — `dynamic::{restartable_dynamic_surfaces_are_parallel_across_all_three_child_kinds,consuming_dynamic_surfaces_are_parallel_across_all_three_child_kinds}` exercise admission and exact removal for both modes of all three kinds.
7. **Restart-attempt reset** — `subtrees::restart_attempt_resets_after_a_ready_incarnation_settles` observes attempts `[1, 1]` around a settled incarnation under paused time.
8. **Public trait contracts** — `api_trait_conformance` compile-checks identity, handle, token, ordered/dynamic system and slot, owned-value, returned-future, error, and observation promises. Send-only `Cell` probes cover actor values, messages, one-shot inputs, call constructors, and owned values without promoting incidental Sync behavior to API.
9. **Snapshot conflation and lifecycle no replay** — observation tests target the final watch/broadcast implementation.
10. **Compile-checked README and guides** — a private rustdoc-only module includes synchronized packaged copies of the README and four guides. The package check compiles those doctests from the actual crate archive, and the Nix source filter carries Markdown into the clean sandbox.
11. **Deterministic negative assertions** — timer, offload, call-delivery, pre-spawn shutdown, restart-window, recursive-join, readiness, mailbox, deadline, rebind, one-shot-start, and far-future tests use owned signals, direct first-poll registration, published child states, paused time, and quiet windows rather than fixed scheduler yields or wall-clock sleeps.

No exclusions were necessary.

## Validation

- focused changed-module suite — 88/88 passed
- PR #54 disposal suite — 16/16 passed
- `./scripts/dev just ci` — formatting, clippy with warnings denied, 304 tests, 3 repository/package doctests, rustdoc, API reachability, runtime/exit path guards, package verification, sync checks, and nixfmt all pass.
- `./scripts/dev just ci-nix` — authoritative clean Nix lane passes.
- GitHub Actions run [31224363106](https://github.com/ralexstokes/shelterwood/actions/runs/31224363106) passes.