### PR TITLE
Remove global and quadratic runtime hot paths

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -698,10 +698,65 @@ impl ScopeCell {
     }
 
     fn adopt_observation_gate(&self, gate: &Arc<Mutex<()>>) {
-        *self
-            .observation_gate
-            .lock()
-            .expect("observation gate handoff mutex poisoned") = Arc::clone(gate);
+        loop {
+            let current = self.observation_gate();
+            if Arc::ptr_eq(&current, gate) {
+                return;
+            }
+
+            // An operation that passed `with_observation_gate`'s pointer
+            // check is allowed to finish its complete observation edge before
+            // the handoff. Conversely, an operation that only captured this
+            // gate will see the replacement after acquiring it and retry.
+            let current_guard = current
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut installed = self
+                .observation_gate
+                .lock()
+                .expect("observation gate handoff mutex poisoned");
+            if Arc::ptr_eq(&current, &installed) {
+                *installed = Arc::clone(gate);
+                drop(installed);
+                self.adopt_descendant_observation_gates_locked(&current, gate);
+                drop(current_guard);
+                return;
+            }
+            drop(installed);
+            drop(current_guard);
+        }
+    }
+
+    /// Re-homes a resident subtree while its former tree gate is held. The
+    /// caller also holds the destination gate, so observers cannot enter
+    /// either half of the tree while the handoff is being installed.
+    fn adopt_descendant_observation_gates_locked(
+        &self,
+        previous: &Arc<Mutex<()>>,
+        gate: &Arc<Mutex<()>>,
+    ) {
+        let descendants = self.current_children.read_with(|children| {
+            children
+                .iter()
+                .filter_map(|resident| resident.slot.scope.as_ref().cloned())
+                .collect::<Vec<_>>()
+        });
+        for descendant in descendants {
+            let mut installed = descendant
+                .observation_gate
+                .lock()
+                .expect("observation gate handoff mutex poisoned");
+            if Arc::ptr_eq(&installed, previous) {
+                *installed = Arc::clone(gate);
+            } else {
+                assert!(
+                    Arc::ptr_eq(&installed, gate),
+                    "one resident tree must share one observation gate"
+                );
+            }
+            drop(installed);
+            descendant.adopt_descendant_observation_gates_locked(previous, gate);
+        }
     }
 
     /// Runs against the cell's current tree gate. Adoption can race an early
@@ -1164,8 +1219,8 @@ impl ScopeCell {
     }
 
     fn set_admitted_children(self: &Arc<Self>, children: Vec<Arc<SlotCell>>) {
-        let gate = self.observation_gate();
         self.with_observation_gate(|| {
+            let gate = self.observation_gate();
             self.clear_residents_locked();
             for child in children {
                 if let Some(scope) = &child.scope {
@@ -1187,8 +1242,8 @@ impl ScopeCell {
     }
 
     fn admit_child(self: &Arc<Self>, child: &Arc<SlotCell>) {
-        let gate = self.observation_gate();
         self.with_observation_gate(|| {
+            let gate = self.observation_gate();
             if let Some(scope) = &child.scope {
                 scope.adopt_observation_gate(&gate);
                 scope.parent.replace(Some(Arc::downgrade(self)));
@@ -3438,9 +3493,10 @@ mod tests {
 
     fn isolated_scope(id: &'static str, flavor: ScopeFlavor) -> Arc<ScopeCell> {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let id = ChildId::from(id);
         let member = MemberCell::new(
-            ChildId::from(id),
-            identity.mint_membership().expect("membership available"),
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
         );
         ScopeCell::new(
             member,
@@ -3490,6 +3546,26 @@ mod tests {
     }
 
     #[test]
+    fn admitted_subtree_rehomes_existing_descendants_to_one_gate() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
+        let leaf = isolated_scope("leaf", ScopeFlavor::Ordered);
+        let leaf_slot = SlotCell::new(Arc::clone(&leaf.member), Some(Arc::clone(&leaf)));
+        nested.set_admitted_children(vec![leaf_slot]);
+        assert!(Arc::ptr_eq(
+            &nested.observation_gate(),
+            &leaf.observation_gate()
+        ));
+
+        let nested_slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
+        root.set_admitted_children(vec![nested_slot]);
+
+        let root_gate = root.observation_gate();
+        assert!(Arc::ptr_eq(&root_gate, &nested.observation_gate()));
+        assert!(Arc::ptr_eq(&root_gate, &leaf.observation_gate()));
+    }
+
+    #[test]
     fn pre_admission_observer_retries_after_gate_handoff() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
         let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
@@ -3511,8 +3587,13 @@ mod tests {
             "observer must be waiting on the pre-admission gate"
         );
 
-        let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
-        root.set_admitted_children(vec![slot]);
+        // Model the instant at which adoption owns the old gate and publishes
+        // the replacement. The waiting observer must acquire the old gate,
+        // detect this handoff, and retry on the root gate.
+        *nested
+            .observation_gate
+            .lock()
+            .expect("observation gate handoff mutex remains healthy") = root.observation_gate();
         drop(held);
         worker.join().expect("observer follows the gate handoff");
 
@@ -3540,6 +3621,67 @@ mod tests {
             );
             assert!(!phase.begin_drain(StopReason::Finished));
         }
+    }
+
+    #[test]
+    fn gate_handoff_waits_for_an_in_flight_observation_edge() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
+        let prior_gate = nested.observation_gate();
+        let (entered, entered_receiver) = std::sync::mpsc::sync_channel(0);
+        let (release, release_receiver) = std::sync::mpsc::sync_channel(0);
+        let observer = Arc::clone(&nested);
+        let observation = std::thread::spawn(move || {
+            observer.with_observation_gate(|| {
+                entered.send(()).expect("test receiver remains available");
+                release_receiver
+                    .recv()
+                    .expect("test sender releases the observation edge");
+            });
+        });
+        entered_receiver
+            .recv()
+            .expect("observer enters the pre-admission edge");
+
+        let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
+        let adopting_root = Arc::clone(&root);
+        let (adopted, adopted_receiver) = std::sync::mpsc::sync_channel(0);
+        let adoption = std::thread::spawn(move || {
+            adopting_root.set_admitted_children(vec![slot]);
+            adopted.send(()).expect("test receiver remains available");
+        });
+
+        // The field, this test, and the active observation own three gate
+        // references. A fourth proves adoption reached the old gate and is
+        // blocked behind the complete observation edge rather than replacing
+        // it concurrently.
+        for _ in 0..100_000 {
+            if Arc::strong_count(&prior_gate) >= 4 {
+                break;
+            }
+            std::thread::yield_now();
+        }
+        assert!(
+            Arc::strong_count(&prior_gate) >= 4,
+            "adoption must synchronize through the prior observation gate"
+        );
+        assert!(matches!(
+            adopted_receiver.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ));
+
+        release
+            .send(())
+            .expect("active observation remains available");
+        observation.join().expect("observation edge completes");
+        adopted_receiver
+            .recv()
+            .expect("adoption reports completion after the edge");
+        adoption.join().expect("gate handoff completes");
+        assert!(Arc::ptr_eq(
+            &root.observation_gate(),
+            &nested.observation_gate()
+        ));
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -41,13 +41,6 @@ use crate::{
     },
 };
 
-/// Observation is one globally serialized projection/publication path.
-///
-/// The decision records remain independently locked and runtime-free. This
-/// gate makes a state mutation, recursive projection, and lifecycle staging
-/// one atomic observation edge, including cross-scope forwarding.
-static OBSERVATION_GATE: Mutex<()> = Mutex::new(());
-
 pub(crate) type DriverSleep = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 
 pub(crate) fn deadline(duration: Duration) -> Deadline {
@@ -613,12 +606,12 @@ pub(crate) struct ScopeRecord {
 
 /// Shared scope state follows two distinct synchronization regimes.
 ///
-/// `OBSERVATION_GATE` serializes compound, observation-visible transitions
-/// across `config`, `record`, `current_children`, and `parent`, including
-/// recursive snapshot projection and lifecycle-event staging. Their watch
-/// channels retain the latest independently readable value; they do not make
-/// that compound transition atomic, so every multi-field observation path must
-/// continue to hold the gate.
+/// One gate per running tree serializes compound, observation-visible
+/// transitions across `config`, `record`, `current_children`, and `parent`,
+/// including recursive snapshot projection and lifecycle-event staging. Their
+/// watch channels retain the latest independently readable value; they do not
+/// make that compound transition atomic, so every multi-field observation path
+/// must continue to hold the gate.
 ///
 /// The remaining mutexes are deliberately not collapsed into one state lock.
 /// `control` is an epoch-tagged request plane with concurrent callers,
@@ -635,6 +628,7 @@ pub(crate) struct ScopeCell {
     current_dynamic: Mutex<Option<Arc<DynamicControl>>>,
     current_children: runtime::WatchSender<Vec<ResidentChild>>,
     parent: runtime::WatchSender<Option<Weak<ScopeCell>>>,
+    observation_gate: Mutex<Arc<Mutex<()>>>,
     lifecycle_sequence: Mutex<FenceCounter>,
     lifecycle_seq: AtomicU64,
     lifecycle: LifecycleHub,
@@ -681,6 +675,7 @@ impl ScopeCell {
             current_dynamic: Mutex::new(None),
             current_children,
             parent,
+            observation_gate: Mutex::new(Arc::new(Mutex::new(()))),
             lifecycle_sequence: Mutex::new(FenceCounter::new(0)),
             lifecycle_seq: AtomicU64::new(0),
             lifecycle: LifecycleHub::default(),
@@ -693,26 +688,62 @@ impl ScopeCell {
         self.record.read_cloned()
     }
 
-    pub(crate) fn set_state(&self, state: ScopeState) {
-        let _gate = OBSERVATION_GATE
+    fn observation_gate(&self) -> Arc<Mutex<()>> {
+        Arc::clone(
+            &self
+                .observation_gate
+                .lock()
+                .expect("observation gate handoff mutex poisoned"),
+        )
+    }
+
+    fn adopt_observation_gate(&self, gate: &Arc<Mutex<()>>) {
+        *self
+            .observation_gate
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        self.record.send_modify(|record| {
-            if state == ScopeState::Starting {
-                record.total_restarts = 0;
+            .expect("observation gate handoff mutex poisoned") = Arc::clone(gate);
+    }
+
+    /// Runs against the cell's current tree gate. Adoption can race an early
+    /// pre-start observer, so a waiter that acquired an obsolete gate retries
+    /// before entering the observation critical section.
+    fn with_observation_gate<R>(&self, operation: impl FnOnce() -> R) -> R {
+        let mut operation = Some(operation);
+        loop {
+            let gate = self.observation_gate();
+            let guard = gate
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if Arc::ptr_eq(&gate, &self.observation_gate()) {
+                let operation = operation
+                    .take()
+                    .expect("observation operation runs exactly once");
+                let result = operation();
+                drop(guard);
+                return result;
             }
-            record.state = state.clone();
+            drop(guard);
+        }
+    }
+
+    pub(crate) fn set_state(&self, state: ScopeState) {
+        self.with_observation_gate(|| {
+            self.record.send_modify(|record| {
+                if state == ScopeState::Starting {
+                    record.total_restarts = 0;
+                }
+                record.state = state.clone();
+            });
+            self.member.record.pulse();
+            self.emit_locked(LifecycleEventKind::ScopeState { state });
         });
-        self.member.record.pulse();
-        self.emit_locked(LifecycleEventKind::ScopeState { state });
     }
 
     pub(crate) fn set_config(&self, config: crate::tree::ScopeConfig) {
-        let _gate = OBSERVATION_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        self.config.replace(config);
-        self.publish_snapshot_chain_locked();
+        self.with_observation_gate(|| {
+            self.config.replace(config);
+            self.publish_snapshot_chain_locked();
+        });
     }
 
     pub(crate) fn transition_child(
@@ -721,23 +752,19 @@ impl ScopeCell {
         update: impl FnOnce(&mut MemberRecord),
         event: Option<LifecycleEventKind>,
     ) {
-        let _gate = OBSERVATION_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        member.update_locked(update);
-        if let Some(event) = event {
-            self.emit_locked(event);
-        } else {
-            self.publish_snapshot_chain_locked();
-        }
+        self.with_observation_gate(|| {
+            member.update_locked(update);
+            if let Some(event) = event {
+                self.emit_locked(event);
+            } else {
+                self.publish_snapshot_chain_locked();
+            }
+        });
     }
 
     #[cfg(test)]
     pub(crate) fn emit(&self, event: LifecycleEventKind) {
-        let _gate = OBSERVATION_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        self.emit_locked(event);
+        self.with_observation_gate(|| self.emit_locked(event));
     }
 
     pub(crate) fn publish_child_restart(
@@ -748,15 +775,14 @@ impl ScopeCell {
         exited: LifecycleEventKind,
         scheduled: LifecycleEventKind,
     ) {
-        let _gate = OBSERVATION_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        self.record.send_modify(|scope| {
-            scope.total_restarts = total_restarts;
+        self.with_observation_gate(|| {
+            self.record.send_modify(|scope| {
+                scope.total_restarts = total_restarts;
+            });
+            member.update_locked(update);
+            self.emit_locked(exited);
+            self.emit_locked(scheduled);
         });
-        member.update_locked(update);
-        self.emit_locked(exited);
-        self.emit_locked(scheduled);
     }
 
     pub(crate) fn terminalize_child(
@@ -766,89 +792,82 @@ impl ScopeCell {
         exited_incarnation: Option<Incarnation>,
         startup_aborted: bool,
     ) -> bool {
-        let _gate = OBSERVATION_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if matches!(member.record().stage, MemberStage::Terminal(_)) {
-            return false;
-        }
-        member.update_locked(|record| record.startup_aborted = startup_aborted);
-        member.terminalize(exit.clone());
-        if let Some(incarnation) = exited_incarnation {
-            self.emit_locked(LifecycleEventKind::Exited {
-                id: member.id().clone(),
-                membership: member.membership(),
-                incarnation,
-                exit: exit.clone(),
+        self.with_observation_gate(|| {
+            if matches!(member.record().stage, MemberStage::Terminal(_)) {
+                return false;
+            }
+            member.update_locked(|record| record.startup_aborted = startup_aborted);
+            member.terminalize(exit.clone());
+            if let Some(incarnation) = exited_incarnation {
+                self.emit_locked(LifecycleEventKind::Exited {
+                    id: member.id().clone(),
+                    membership: member.membership(),
+                    incarnation,
+                    exit: exit.clone(),
+                });
+            }
+            let nested = self.current_children.read_with(|children| {
+                children
+                    .iter()
+                    .find(|resident| resident.slot.member.membership() == member.membership())
+                    .and_then(|resident| resident.slot.scope.as_ref())
+                    .cloned()
             });
-        }
-        let nested = self.current_children.read_with(|children| {
-            children
-                .iter()
-                .find(|resident| resident.slot.member.membership() == member.membership())
-                .and_then(|resident| resident.slot.scope.as_ref())
-                .cloned()
-        });
-        if let Some(scope) = nested {
-            scope.close_observation_locked();
-        }
-        true
+            if let Some(scope) = nested {
+                scope.close_observation_locked();
+            }
+            true
+        })
     }
 
     pub(crate) fn prune_child(&self, member: &MemberCell) -> bool {
-        let _gate = OBSERVATION_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let membership = member.membership();
-        let mut resident = None;
-        let removed = self.current_children.send_if_modified(|children| {
-            let Some(index) = children
-                .iter()
-                .position(|child| child.slot.member.membership() == membership)
-            else {
+        self.with_observation_gate(|| {
+            let membership = member.membership();
+            let mut resident = None;
+            let removed = self.current_children.send_if_modified(|children| {
+                let Some(index) = children
+                    .iter()
+                    .position(|child| child.slot.member.membership() == membership)
+                else {
+                    return false;
+                };
+                resident = Some(children.remove(index));
+                true
+            });
+            if !removed {
                 return false;
-            };
-            resident = Some(children.remove(index));
+            }
+            let resident = resident.expect("a reported removal owns its resident entry");
+            debug_assert_eq!(resident.slot.member.membership(), membership);
+            // Dropping residency while the observation gate is held emits the
+            // matching Removed edge through its owned completion.
+            drop(resident);
             true
-        });
-        if !removed {
-            return false;
-        }
-        let resident = resident.expect("a reported removal owns its resident entry");
-        debug_assert_eq!(resident.slot.member.membership(), membership);
-        // Dropping residency while the observation gate is held emits the
-        // matching Removed edge through its owned completion.
-        drop(resident);
-        true
+        })
     }
 
     pub(crate) fn snapshot(&self) -> Arc<ScopeSnapshot> {
-        let _gate = OBSERVATION_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        self.snapshot_locked()
+        self.with_observation_gate(|| self.snapshot_locked())
     }
 
     pub(crate) fn subscribe_snapshots(&self) -> SnapshotReceiver {
-        let _gate = OBSERVATION_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let receiver = self.snapshots.subscribe(self.snapshot_locked());
-        if self.observation_closed.load(Ordering::Acquire) {
-            self.snapshots.close();
-        }
-        receiver
+        self.with_observation_gate(|| {
+            let receiver = self.snapshots.subscribe(self.snapshot_locked());
+            if self.observation_closed.load(Ordering::Acquire) {
+                self.snapshots.close();
+            }
+            receiver
+        })
     }
 
     pub(crate) fn subscribe_lifecycle(&self) -> LifecycleEvents {
-        let _gate = OBSERVATION_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let events = self.lifecycle.subscribe();
-        if self.observation_closed.load(Ordering::Acquire) {
-            self.lifecycle.close();
-        }
-        events
+        self.with_observation_gate(|| {
+            let events = self.lifecycle.subscribe();
+            if self.observation_closed.load(Ordering::Acquire) {
+                self.lifecycle.close();
+            }
+            events
+        })
     }
 
     fn snapshot_locked(&self) -> Arc<ScopeSnapshot> {
@@ -1019,45 +1038,44 @@ impl ScopeCell {
         reason: StopReason,
         terminal_exit: Option<Exit>,
     ) {
-        let _gate = OBSERVATION_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let state = ScopeState::Stopped {
-            reason: reason.clone(),
-        };
-        self.record.modify_silently(|record| {
-            if record.startup.is_none() {
-                record.startup = Some(Err(StartupError::ShutdownRequested));
+        self.with_observation_gate(|| {
+            let state = ScopeState::Stopped {
+                reason: reason.clone(),
+            };
+            self.record.modify_silently(|record| {
+                if record.startup.is_none() {
+                    record.startup = Some(Err(StartupError::ShutdownRequested));
+                }
+                record.state = state.clone();
+            });
+            let terminal = terminal_exit.is_some();
+            if let Some(exit) = terminal_exit {
+                self.member.terminalize(exit);
             }
-            record.state = state.clone();
+            let mut control = self.control.lock().expect("scope control mutex poisoned");
+            if control.current_epoch == epoch {
+                control.live = false;
+                control.last_stopped_epoch = control.last_stopped_epoch.max(epoch);
+                if control
+                    .shutdown
+                    .is_some_and(|request| request.epoch <= epoch)
+                {
+                    control.shutdown = None;
+                }
+                if control.force.is_some_and(|request| request.epoch <= epoch) {
+                    control.force = None;
+                }
+            }
+            drop(control);
+            self.member.record.pulse();
+            // `wait_started` must not observe terminal startup until the member
+            // and incarnation-control planes above are consistent.
+            self.record.pulse();
+            self.emit_locked(LifecycleEventKind::ScopeState { state });
+            if terminal {
+                self.close_observation_locked();
+            }
         });
-        let terminal = terminal_exit.is_some();
-        if let Some(exit) = terminal_exit {
-            self.member.terminalize(exit);
-        }
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        if control.current_epoch == epoch {
-            control.live = false;
-            control.last_stopped_epoch = control.last_stopped_epoch.max(epoch);
-            if control
-                .shutdown
-                .is_some_and(|request| request.epoch <= epoch)
-            {
-                control.shutdown = None;
-            }
-            if control.force.is_some_and(|request| request.epoch <= epoch) {
-                control.force = None;
-            }
-        }
-        drop(control);
-        self.member.record.pulse();
-        // `wait_started` must not observe terminal startup until the member
-        // and incarnation-control planes above are consistent.
-        self.record.pulse();
-        self.emit_locked(LifecycleEventKind::ScopeState { state });
-        if terminal {
-            self.close_observation_locked();
-        }
     }
 
     fn finish_live_root_incarnation(&self, reason: StopReason, exit: Exit) {
@@ -1068,21 +1086,20 @@ impl ScopeCell {
         if let Some(epoch) = epoch {
             self.finish_root_incarnation(epoch, reason, exit);
         } else {
-            let _gate = OBSERVATION_GATE
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let state = ScopeState::Stopped { reason };
-            self.record.modify_silently(|record| {
-                if record.startup.is_none() {
-                    record.startup = Some(Err(StartupError::ShutdownRequested));
-                }
-                record.state = state.clone();
+            self.with_observation_gate(|| {
+                let state = ScopeState::Stopped { reason };
+                self.record.modify_silently(|record| {
+                    if record.startup.is_none() {
+                        record.startup = Some(Err(StartupError::ShutdownRequested));
+                    }
+                    record.state = state.clone();
+                });
+                self.member.terminalize(exit);
+                self.member.record.pulse();
+                self.record.pulse();
+                self.emit_locked(LifecycleEventKind::ScopeState { state });
+                self.close_observation_locked();
             });
-            self.member.terminalize(exit);
-            self.member.record.pulse();
-            self.record.pulse();
-            self.emit_locked(LifecycleEventKind::ScopeState { state });
-            self.close_observation_locked();
         }
     }
 
@@ -1147,50 +1164,49 @@ impl ScopeCell {
     }
 
     fn set_admitted_children(self: &Arc<Self>, children: Vec<Arc<SlotCell>>) {
-        let _gate = OBSERVATION_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        self.clear_residents_locked();
-        for child in children {
+        let gate = self.observation_gate();
+        self.with_observation_gate(|| {
+            self.clear_residents_locked();
+            for child in children {
+                if let Some(scope) = &child.scope {
+                    scope.adopt_observation_gate(&gate);
+                    scope.parent.replace(Some(Arc::downgrade(self)));
+                }
+                child
+                    .member
+                    .update_locked(|record| record.stage = MemberStage::Admitted);
+                self.current_children.send_modify(|children| {
+                    children.push(ResidentChild::new(self, Arc::clone(&child)))
+                });
+                self.emit_locked(LifecycleEventKind::Added {
+                    id: child.member.id().clone(),
+                    membership: child.member.membership(),
+                });
+            }
+        });
+    }
+
+    fn admit_child(self: &Arc<Self>, child: &Arc<SlotCell>) {
+        let gate = self.observation_gate();
+        self.with_observation_gate(|| {
             if let Some(scope) = &child.scope {
+                scope.adopt_observation_gate(&gate);
                 scope.parent.replace(Some(Arc::downgrade(self)));
             }
+            self.current_children
+                .send_modify(|children| children.push(ResidentChild::new(self, Arc::clone(child))));
             child
                 .member
                 .update_locked(|record| record.stage = MemberStage::Admitted);
-            self.current_children.send_modify(|children| {
-                children.push(ResidentChild::new(self, Arc::clone(&child)))
-            });
             self.emit_locked(LifecycleEventKind::Added {
                 id: child.member.id().clone(),
                 membership: child.member.membership(),
             });
-        }
-    }
-
-    fn admit_child(self: &Arc<Self>, child: &Arc<SlotCell>) {
-        let _gate = OBSERVATION_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if let Some(scope) = &child.scope {
-            scope.parent.replace(Some(Arc::downgrade(self)));
-        }
-        self.current_children
-            .send_modify(|children| children.push(ResidentChild::new(self, Arc::clone(child))));
-        child
-            .member
-            .update_locked(|record| record.stage = MemberStage::Admitted);
-        self.emit_locked(LifecycleEventKind::Added {
-            id: child.member.id().clone(),
-            membership: child.member.membership(),
         });
     }
 
     pub(crate) fn clear_residents(&self) {
-        let _gate = OBSERVATION_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        self.clear_residents_locked();
+        self.with_observation_gate(|| self.clear_residents_locked());
     }
 
     fn clear_residents_locked(&self) {
@@ -1243,29 +1259,28 @@ impl ScopeCell {
     }
 
     pub(crate) fn terminalize_never_started(&self) {
-        let _gate = OBSERVATION_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if self.observation_closed.load(Ordering::Acquire) {
-            return;
-        }
-        self.member.terminalize(Exit::never_started());
-        self.record.modify_silently(|record| {
-            if record.startup.is_none() {
-                record.startup = Some(Err(StartupError::ShutdownRequested));
+        self.with_observation_gate(|| {
+            if self.observation_closed.load(Ordering::Acquire) {
+                return;
             }
-            record.state = ScopeState::Stopped {
-                reason: StopReason::NeverStarted,
-            };
+            self.member.terminalize(Exit::never_started());
+            self.record.modify_silently(|record| {
+                if record.startup.is_none() {
+                    record.startup = Some(Err(StartupError::ShutdownRequested));
+                }
+                record.state = ScopeState::Stopped {
+                    reason: StopReason::NeverStarted,
+                };
+            });
+            self.member.record.pulse();
+            self.record.pulse();
+            self.emit_locked(LifecycleEventKind::ScopeState {
+                state: ScopeState::Stopped {
+                    reason: StopReason::NeverStarted,
+                },
+            });
+            self.close_observation_locked();
         });
-        self.member.record.pulse();
-        self.record.pulse();
-        self.emit_locked(LifecycleEventKind::ScopeState {
-            state: ScopeState::Stopped {
-                reason: StopReason::NeverStarted,
-            },
-        });
-        self.close_observation_locked();
     }
 }
 
@@ -3054,10 +3069,7 @@ fn mint_child_incarnation(slot: &Arc<SlotCell>, counter: &mut FenceCounter) -> O
             if record.last_incarnation.is_none() {
                 scope.terminalize_never_started();
             } else {
-                let _gate = OBSERVATION_GATE
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                scope.close_observation_locked();
+                scope.with_observation_gate(|| scope.close_observation_locked());
             }
         }
     }
@@ -3423,6 +3435,93 @@ mod tests {
         ScopeCell, ScopeFlavor, ScopePhase, StartupPhase, complete_removals,
         mint_child_incarnation, report_channel, run_nested_tree, run_scope_incarnation,
     };
+
+    fn isolated_scope(id: &'static str, flavor: ScopeFlavor) -> Arc<ScopeCell> {
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let member = MemberCell::new(
+            ChildId::from(id),
+            identity.mint_membership().expect("membership available"),
+        );
+        ScopeCell::new(
+            member,
+            flavor,
+            ScopeIdentity::new().expect("child identity available"),
+        )
+    }
+
+    #[test]
+    fn independent_systems_do_not_share_an_observation_critical_section() {
+        let first = isolated_scope("first", ScopeFlavor::Ordered);
+        let second = isolated_scope("second", ScopeFlavor::Ordered);
+        let first_gate = first.observation_gate();
+        let second_gate = second.observation_gate();
+        assert!(!Arc::ptr_eq(&first_gate, &second_gate));
+
+        let held = first_gate
+            .lock()
+            .expect("first observation gate starts healthy");
+        let (completed, receiver) = std::sync::mpsc::sync_channel(0);
+        let worker = std::thread::spawn(move || {
+            second.set_state(ScopeState::Starting);
+            completed.send(()).expect("test receiver remains available");
+        });
+        let result = receiver.recv_timeout(Duration::from_secs(2));
+        drop(held);
+        worker.join().expect("independent transition succeeds");
+        assert_eq!(
+            result,
+            Ok(()),
+            "holding one system's gate must not stall another system"
+        );
+    }
+
+    #[test]
+    fn admitted_subtrees_share_their_parent_observation_gate() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
+        let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
+
+        root.set_admitted_children(vec![slot]);
+
+        assert!(Arc::ptr_eq(
+            &root.observation_gate(),
+            &nested.observation_gate()
+        ));
+    }
+
+    #[test]
+    fn pre_admission_observer_retries_after_gate_handoff() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
+        let prior_gate = nested.observation_gate();
+        let held = prior_gate
+            .lock()
+            .expect("pre-admission observation gate starts healthy");
+        let observer = Arc::clone(&nested);
+        let worker = std::thread::spawn(move || observer.set_state(ScopeState::Starting));
+
+        for _ in 0..100_000 {
+            if Arc::strong_count(&prior_gate) >= 3 {
+                break;
+            }
+            std::thread::yield_now();
+        }
+        assert!(
+            Arc::strong_count(&prior_gate) >= 3,
+            "observer must be waiting on the pre-admission gate"
+        );
+
+        let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
+        root.set_admitted_children(vec![slot]);
+        drop(held);
+        worker.join().expect("observer follows the gate handoff");
+
+        assert_eq!(nested.record().state, ScopeState::Starting);
+        assert!(Arc::ptr_eq(
+            &root.observation_gate(),
+            &nested.observation_gate()
+        ));
+    }
 
     #[test]
     fn scope_phase_preserves_startup_status_while_draining() {

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1,7 +1,7 @@
 //! Membership-owned actor mailboxes and request/reply capabilities.
 
 use std::{
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     fmt,
     future::Future,
     hash::{Hash, Hasher},
@@ -427,6 +427,7 @@ enum OperationOutcome<M> {
 struct OperationState<M> {
     outcome: OperationOutcome<M>,
     waker: Option<Waker>,
+    registration: Option<WaiterId>,
 }
 
 struct SendOperation<M> {
@@ -442,8 +443,22 @@ impl<M> SendOperation<M> {
                     newest_observed: None,
                 },
                 waker: None,
+                registration: None,
             }),
         })
+    }
+
+    fn register(&self, registration: WaiterId) {
+        let mut state = self.state.lock().expect("send operation mutex poisoned");
+        debug_assert!(state.registration.is_none());
+        debug_assert!(matches!(state.outcome, OperationOutcome::Waiting { .. }));
+        state.registration = Some(registration);
+    }
+
+    fn clear_registration(&self, registration: WaiterId) {
+        let mut state = self.state.lock().expect("send operation mutex poisoned");
+        debug_assert_eq!(state.registration, Some(registration));
+        state.registration = None;
     }
 
     fn observe(&self, incarnation: Incarnation) {
@@ -494,11 +509,128 @@ struct MailboxState<M> {
     last_bound: Option<Incarnation>,
     queue: VecDeque<Envelope<M>>,
     latest: Option<Envelope<M>>,
-    waiters: VecDeque<Arc<SendOperation<M>>>,
+    waiters: WaiterQueue<M>,
     accepted: u64,
     delivered: u64,
     conflated: u64,
     sends_rejected: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct WaiterId(u64);
+
+struct WaiterEntry<M> {
+    operation: Arc<SendOperation<M>>,
+    previous: Option<WaiterId>,
+    next: Option<WaiterId>,
+}
+
+/// FIFO registrations with constant-time removal by a send operation.
+///
+/// The mailbox mutex serializes every mutation, so a compact intrusive list
+/// can use monotonic local ids without another synchronization layer. The ids
+/// are never reused, which also prevents a stale cancellation from unlinking
+/// a later operation.
+struct WaiterQueue<M> {
+    entries: HashMap<WaiterId, WaiterEntry<M>>,
+    head: Option<WaiterId>,
+    tail: Option<WaiterId>,
+    next_id: u64,
+    #[cfg(test)]
+    direct_removals: usize,
+}
+
+impl<M> Default for WaiterQueue<M> {
+    fn default() -> Self {
+        Self {
+            entries: HashMap::new(),
+            head: None,
+            tail: None,
+            next_id: 0,
+            #[cfg(test)]
+            direct_removals: 0,
+        }
+    }
+}
+
+impl<M> WaiterQueue<M> {
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn push_back(&mut self, operation: Arc<SendOperation<M>>) -> WaiterId {
+        let id = WaiterId(self.next_id);
+        self.next_id = self
+            .next_id
+            .checked_add(1)
+            .expect("mailbox waiter identity space exhausted");
+        let previous = self.tail;
+        let replaced = self.entries.insert(
+            id,
+            WaiterEntry {
+                operation,
+                previous,
+                next: None,
+            },
+        );
+        debug_assert!(replaced.is_none());
+        if let Some(previous) = previous {
+            self.entries
+                .get_mut(&previous)
+                .expect("tail registration must be live")
+                .next = Some(id);
+        } else {
+            self.head = Some(id);
+        }
+        self.tail = Some(id);
+        id
+    }
+
+    fn park(&mut self, operation: &Arc<SendOperation<M>>) {
+        let registration = self.push_back(Arc::clone(operation));
+        operation.register(registration);
+    }
+
+    fn observe_all(&self, incarnation: Incarnation) {
+        for entry in self.entries.values() {
+            entry.operation.observe(incarnation);
+        }
+    }
+
+    fn pop_front(&mut self) -> Option<(WaiterId, Arc<SendOperation<M>>)> {
+        let id = self.head?;
+        self.remove(id).map(|operation| (id, operation))
+    }
+
+    fn remove(&mut self, id: WaiterId) -> Option<Arc<SendOperation<M>>> {
+        let entry = self.entries.remove(&id)?;
+        #[cfg(test)]
+        {
+            self.direct_removals = self.direct_removals.saturating_add(1);
+        }
+        if let Some(previous) = entry.previous {
+            self.entries
+                .get_mut(&previous)
+                .expect("previous registration must be live")
+                .next = entry.next;
+        } else {
+            self.head = entry.next;
+        }
+        if let Some(next) = entry.next {
+            self.entries
+                .get_mut(&next)
+                .expect("next registration must be live")
+                .previous = entry.previous;
+        } else {
+            self.tail = entry.previous;
+        }
+        Some(entry.operation)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -547,7 +679,7 @@ impl<M> Drop for Promotion<M> {
 }
 
 struct Termination<M> {
-    waiters: VecDeque<Arc<SendOperation<M>>>,
+    waiters: WaiterQueue<M>,
     final_incarnation: Option<Incarnation>,
 }
 
@@ -557,7 +689,8 @@ impl<M> Termination<M> {
     fn drain(&mut self) {
         let already_panicking = std::thread::panicking();
         let mut first_panic = None;
-        while let Some(waiter) = self.waiters.pop_front() {
+        while let Some((registration, waiter)) = self.waiters.pop_front() {
+            waiter.clear_registration(registration);
             if let Err(payload) = catch_unwind(AssertUnwindSafe(|| {
                 waiter.terminate(self.final_incarnation);
             })) && first_panic.is_none()
@@ -634,7 +767,7 @@ impl<M: Send + 'static> MailboxCell<M> {
                 last_bound: None,
                 queue: VecDeque::new(),
                 latest: None,
-                waiters: VecDeque::new(),
+                waiters: WaiterQueue::default(),
                 accepted: 0,
                 delivered: 0,
                 conflated: 0,
@@ -693,14 +826,14 @@ impl<M: Send + 'static> MailboxCell<M> {
                     }
                     drop(displaced);
                 } else {
-                    state.waiters.push_back(Arc::clone(operation));
+                    state.waiters.park(operation);
                 }
             }
             BindingStatus::Frozen(incarnation) => {
                 operation.observe(incarnation);
-                state.waiters.push_back(Arc::clone(operation));
+                state.waiters.park(operation);
             }
-            BindingStatus::Unbound => state.waiters.push_back(Arc::clone(operation)),
+            BindingStatus::Unbound => state.waiters.park(operation),
         }
     }
 
@@ -869,7 +1002,7 @@ impl<M: Send + 'static> MailboxCell<M> {
 impl<M> MailboxCell<M> {
     fn withdraw(&self, operation: &Arc<SendOperation<M>>) -> Withdrawal<M> {
         let mut mailbox = self.state.lock().expect("mailbox mutex poisoned");
-        let result = {
+        let (result, registration) = {
             let mut state = operation
                 .state
                 .lock()
@@ -885,26 +1018,39 @@ impl<M> MailboxCell<M> {
                     let observed = *newest_observed;
                     state.outcome = OperationOutcome::Withdrawn;
                     state.waker = None;
-                    Withdrawal::Withdrawn { message, observed }
+                    (
+                        Withdrawal::Withdrawn { message, observed },
+                        state.registration.take(),
+                    )
                 }
-                OperationOutcome::Accepted(incarnation) => Withdrawal::Accepted(*incarnation),
+                OperationOutcome::Accepted(incarnation) => (
+                    Withdrawal::Accepted(*incarnation),
+                    state.registration.take(),
+                ),
                 OperationOutcome::Terminated {
                     message,
                     final_incarnation,
-                } => Withdrawal::Terminated {
-                    message: message
-                        .take()
-                        .expect("a terminal operation must retain its message"),
-                    observed: *final_incarnation,
-                },
+                } => (
+                    Withdrawal::Terminated {
+                        message: message
+                            .take()
+                            .expect("a terminal operation must retain its message"),
+                        observed: *final_incarnation,
+                    },
+                    state.registration.take(),
+                ),
                 OperationOutcome::Withdrawn => {
                     panic!("a send operation was withdrawn more than once")
                 }
             }
         };
-        mailbox
-            .waiters
-            .retain(|candidate| !Arc::ptr_eq(candidate, operation));
+        if let Some(registration) = registration {
+            let removed = mailbox
+                .waiters
+                .remove(registration)
+                .expect("a waiting operation's registration must be live");
+            debug_assert!(Arc::ptr_eq(&removed, operation));
+        }
         result
     }
 }
@@ -938,9 +1084,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         // into the current capacity. Withdrawal takes the mailbox lock before
         // the operation lock, so a concurrent timeout sees either the prior
         // evidence or this incarnation consistently with which edge won.
-        for operation in &state.waiters {
-            operation.observe(incarnation);
-        }
+        state.waiters.observe_all(incarnation);
         let promotion = promote_waiters(&mut state);
         drop(state);
         self.changed.pulse();
@@ -1016,9 +1160,10 @@ fn promote_waiters<M>(state: &mut MailboxState<M>) -> Promotion<M> {
     };
     let mut accepted = 0usize;
     while accepted < available {
-        let Some(operation) = state.waiters.pop_front() else {
+        let Some((registration, operation)) = state.waiters.pop_front() else {
             break;
         };
+        operation.clear_registration(registration);
         operation.observe(incarnation);
         let Some((message, wake)) = operation.accept(incarnation) else {
             continue;
@@ -1639,6 +1784,41 @@ mod tests {
     fn park_with(future: &mut std::pin::Pin<Box<super::SendFuture<u8>>>, waker: &Waker) {
         let mut context = Context::from_waker(waker);
         assert!(future.as_mut().poll(&mut context).is_pending());
+    }
+
+    #[test]
+    fn cancelling_many_parked_sends_unlinks_one_registration_each() {
+        const SENDS: usize = 16_384;
+
+        let (mailbox, actor) = actor();
+        let mut sends = Vec::with_capacity(SENDS);
+        for _ in 0..SENDS {
+            let mut send = Box::pin(actor.send(1));
+            park_with(&mut send, Waker::noop());
+            sends.push(send);
+        }
+        assert_eq!(
+            mailbox
+                .state
+                .lock()
+                .expect("mailbox mutex poisoned")
+                .waiters
+                .len(),
+            SENDS
+        );
+
+        // Reverse cancellation stresses head, tail, and interior unlinking
+        // without making the result depend on scheduler timing.
+        while let Some(send) = sends.pop() {
+            drop(send);
+        }
+
+        let state = mailbox.state.lock().expect("mailbox mutex poisoned");
+        assert!(state.waiters.is_empty());
+        assert_eq!(
+            state.waiters.direct_removals, SENDS,
+            "mass cancellation must do one direct unlink per parked send"
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -457,8 +457,13 @@ impl<M> SendOperation<M> {
 
     fn clear_registration(&self, registration: WaiterId) {
         let mut state = self.state.lock().expect("send operation mutex poisoned");
-        debug_assert_eq!(state.registration, Some(registration));
-        state.registration = None;
+        if state.registration == Some(registration) {
+            state.registration = None;
+        } else {
+            // A cancellation can win after terminal teardown detaches the
+            // queue but before it discharges this entry.
+            debug_assert!(state.registration.is_none());
+        }
     }
 
     fn observe(&self, incarnation: Incarnation) {
@@ -1045,11 +1050,11 @@ impl<M> MailboxCell<M> {
             }
         };
         if let Some(registration) = registration {
-            let removed = mailbox
-                .waiters
-                .remove(registration)
-                .expect("a waiting operation's registration must be live");
-            debug_assert!(Arc::ptr_eq(&removed, operation));
+            if let Some(removed) = mailbox.waiters.remove(registration) {
+                debug_assert!(Arc::ptr_eq(&removed, operation));
+            } else {
+                debug_assert!(matches!(mailbox.status, BindingStatus::Terminal(_)));
+            }
         }
         result
     }
@@ -1795,7 +1800,7 @@ mod tests {
         for _ in 0..SENDS {
             let mut send = Box::pin(actor.send(1));
             park_with(&mut send, Waker::noop());
-            sends.push(send);
+            sends.push(Some(send));
         }
         assert_eq!(
             mailbox
@@ -1807,9 +1812,18 @@ mod tests {
             SENDS
         );
 
-        // Reverse cancellation stresses head, tail, and interior unlinking
-        // without making the result depend on scheduler timing.
-        while let Some(send) = sends.pop() {
+        // Exercise one interior, the head, and the tail explicitly, then a
+        // deterministic odd/even permutation. The counter measures queue
+        // operations rather than elapsed time or scheduler behavior.
+        for index in [SENDS / 2, 0, SENDS - 1] {
+            drop(sends[index].take().expect("selected send remains live"));
+        }
+        for index in (1..SENDS - 1).step_by(2) {
+            if let Some(send) = sends[index].take() {
+                drop(send);
+            }
+        }
+        for send in sends.into_iter().flatten() {
             drop(send);
         }
 
@@ -1898,5 +1912,53 @@ mod tests {
             };
             assert_eq!(error.kind, SendErrorKind::Terminated);
         }
+    }
+
+    #[test]
+    fn cancellation_can_race_detached_terminal_teardown() {
+        let (mailbox, actor) = actor();
+        let mut send = Box::pin(actor.send(1));
+        park_with(&mut send, Waker::noop());
+
+        let teardown = MailboxControl::prepare_termination(&*mailbox)
+            .expect("live mailbox prepares terminal teardown");
+        // Teardown is deliberately retained: cancellation sees terminal state
+        // after the waiter queue was detached but before it was discharged.
+        drop(send);
+        drop(teardown);
+
+        assert!(
+            mailbox
+                .state
+                .lock()
+                .expect("mailbox mutex remains healthy")
+                .waiters
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn stale_waiter_id_cannot_unlink_a_later_registration() {
+        let mut waiters = super::WaiterQueue::default();
+        let first = super::SendOperation::new(1_u8);
+        let first_id = waiters.push_back(Arc::clone(&first));
+        first.register(first_id);
+        let removed = waiters.remove(first_id).expect("first waiter is live");
+        removed.clear_registration(first_id);
+
+        let second = super::SendOperation::new(2_u8);
+        let second_id = waiters.push_back(Arc::clone(&second));
+        second.register(second_id);
+        assert_ne!(first_id, second_id, "waiter identities are never reused");
+        assert!(
+            waiters.remove(first_id).is_none(),
+            "a stale cancellation cannot unlink a later waiter"
+        );
+        let removed = waiters
+            .remove(second_id)
+            .expect("second waiter remains live");
+        assert!(Arc::ptr_eq(&removed, &second));
+        removed.clear_registration(second_id);
+        assert!(waiters.is_empty());
     }
 }

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -501,10 +501,14 @@ impl<M> TimerStore<M> {
 
     fn entry_mut(&mut self, arming_order: u64) -> Option<&mut TimerEntry<M>> {
         let hash = *self.armings.get(&arming_order)?;
-        self.keyed
-            .get_mut(&hash)?
+        let entry = self
+            .keyed
+            .get_mut(&hash)
+            .expect("an arming index must reference a key bucket")
             .iter_mut()
             .find(|entry| entry.arming_order == arming_order)
+            .expect("an arming index must reference a timer");
+        Some(entry)
     }
 
     fn take_due(&mut self, now: Instant) -> VecDeque<u64> {
@@ -1299,33 +1303,27 @@ impl<M: Send + 'static> RawContext<M> {
     }
 
     fn deliver_timer(&mut self, arming: u64) -> Option<M> {
-        let interval = self.resources.timers.entry_mut(arming)?.period.is_some();
-        if !interval {
-            let entry = self.resources.timers.remove_arming(arming)?;
-            let TimerMessage::Once(message) = entry.message else {
-                unreachable!("a non-interval timer must own a one-shot message")
-            };
-            return message;
-        }
-
-        let (message, deadline) = {
-            let entry = self
-                .resources
-                .timers
-                .entry_mut(arming)
-                .expect("the interval timer remains registered");
-            let period = entry
-                .period
-                .expect("an interval timer must retain its period");
+        let entry = self.resources.timers.entry_mut(arming)?;
+        if let Some(period) = entry.period {
             let deadline = crate::deadline::Deadline::after(crate::driver::now(), period).instant();
             entry.deadline = deadline;
             let TimerMessage::Interval(make_message) = &entry.message else {
                 unreachable!("an interval timer must own a message factory")
             };
-            (make_message(), deadline)
+            let message = make_message();
+            self.resources.timers.arm_deadline(arming, deadline);
+            return Some(message);
+        }
+
+        let entry = self
+            .resources
+            .timers
+            .remove_arming(arming)
+            .expect("a due one-shot timer remains registered");
+        let TimerMessage::Once(message) = entry.message else {
+            unreachable!("a non-interval timer must own a one-shot message")
         };
-        self.resources.timers.arm_deadline(arming, deadline);
-        Some(message)
+        message
     }
 
     fn next_timer_deadline(&self) -> Option<Instant> {

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -2048,9 +2048,21 @@ mod tests {
 
 #[cfg(test)]
 mod timer_store_tests {
-    use std::time::{Duration, Instant};
+    use std::{
+        collections::HashSet,
+        time::{Duration, Instant},
+    };
 
     use super::{TimerMessage, TimerStore};
+
+    #[derive(Eq, PartialEq)]
+    struct CollidingKey(u8);
+
+    impl std::hash::Hash for CollidingKey {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            0_u8.hash(state);
+        }
+    }
 
     fn once(entry: super::TimerEntry<&'static str>) -> &'static str {
         let TimerMessage::Once(Some(message)) = entry.message else {
@@ -2103,21 +2115,76 @@ mod timer_store_tests {
     }
 
     #[test]
+    fn hash_collision_uses_exact_erased_key_equality() {
+        let mut timers = TimerStore::default();
+        timers.replace(
+            CollidingKey(1),
+            None,
+            1,
+            TimerMessage::Once(Some("first")),
+            None,
+        );
+        timers.replace(
+            CollidingKey(2),
+            None,
+            2,
+            TimerMessage::Once(Some("second")),
+            None,
+        );
+        timers.replace(
+            CollidingKey(1),
+            None,
+            3,
+            TimerMessage::Once(Some("replacement")),
+            None,
+        );
+
+        assert_eq!(
+            once(
+                timers
+                    .remove(&CollidingKey(2))
+                    .expect("colliding peer remains registered")
+            ),
+            "second"
+        );
+        assert_eq!(
+            once(
+                timers
+                    .remove(&CollidingKey(1))
+                    .expect("replacement remains registered")
+            ),
+            "replacement"
+        );
+        assert!(timers.is_empty());
+    }
+
+    #[test]
     fn keyed_timer_churn_has_one_lookup_probe_per_removal() {
         const TIMERS: usize = 16_384;
 
         let start = Instant::now();
         let mut timers = TimerStore::default();
-        for key in 0..TIMERS {
+        let mut hashes = HashSet::with_capacity(TIMERS);
+        let mut keys = Vec::with_capacity(TIMERS);
+        let mut candidate = 0_usize;
+        while keys.len() < TIMERS {
+            if hashes.insert(timers.hash_key(&candidate)) {
+                keys.push(candidate);
+            }
+            candidate = candidate
+                .checked_add(1)
+                .expect("test key space must contain enough distinct hashes");
+        }
+        for (index, key) in keys.iter().copied().enumerate() {
             timers.replace(
                 key,
-                Some(start + Duration::from_secs((TIMERS - key) as u64)),
-                key as u64,
+                Some(start + Duration::from_secs((TIMERS - index) as u64)),
+                index as u64,
                 TimerMessage::Once(Some(())),
                 None,
             );
         }
-        for key in (0..TIMERS).rev() {
+        for key in keys.into_iter().rev() {
             assert!(timers.remove(&key).is_some());
         }
 

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -1,11 +1,11 @@
 //! Minimal loop-owning raw actors and their incarnation context.
 
 use std::{
-    any::Any,
-    collections::VecDeque,
+    any::{Any, TypeId},
+    collections::{BTreeSet, HashMap, VecDeque, hash_map::RandomState},
     fmt,
     future::Future,
-    hash::Hash,
+    hash::{BuildHasher, Hash},
     panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     pin::Pin,
     sync::{Arc, Mutex},
@@ -374,6 +374,162 @@ struct TimerEntry<M> {
     period: Option<Duration>,
 }
 
+/// Type-aware keyed timer lookup paired with an independently ordered
+/// deadline index.
+///
+/// Type identity participates in the key hash, so equal values of different
+/// key types remain distinct. A hash bucket still verifies erased equality to
+/// preserve `Eq` semantics in the unlikely event of a collision.
+struct TimerStore<M> {
+    key_hasher: RandomState,
+    keyed: HashMap<u64, Vec<TimerEntry<M>>>,
+    armings: HashMap<u64, u64>,
+    deadlines: BTreeSet<(Instant, u64)>,
+    #[cfg(test)]
+    lookup_probes: usize,
+}
+
+impl<M> Default for TimerStore<M> {
+    fn default() -> Self {
+        Self {
+            key_hasher: RandomState::new(),
+            keyed: HashMap::new(),
+            armings: HashMap::new(),
+            deadlines: BTreeSet::new(),
+            #[cfg(test)]
+            lookup_probes: 0,
+        }
+    }
+}
+
+impl<M> TimerStore<M> {
+    fn hash_key<K: Hash + 'static>(&self, key: &K) -> u64 {
+        self.key_hasher.hash_one((TypeId::of::<K>(), key))
+    }
+
+    fn is_empty(&self) -> bool {
+        self.armings.is_empty()
+    }
+
+    fn clear(&mut self) {
+        self.keyed.clear();
+        self.armings.clear();
+        self.deadlines.clear();
+    }
+
+    fn replace<K>(
+        &mut self,
+        key: K,
+        deadline: Option<Instant>,
+        arming_order: u64,
+        message: TimerMessage<M>,
+        period: Option<Duration>,
+    ) where
+        K: Hash + Eq + Send + 'static,
+    {
+        let _ = self.remove(&key);
+        let hash = self.hash_key(&key);
+        self.keyed.entry(hash).or_default().push(TimerEntry {
+            key: Box::new(StoredTimerKey(key)),
+            deadline,
+            arming_order,
+            message,
+            period,
+        });
+        let previous = self.armings.insert(arming_order, hash);
+        debug_assert!(previous.is_none());
+        if let Some(deadline) = deadline {
+            self.deadlines.insert((deadline, arming_order));
+        }
+    }
+
+    fn remove<K>(&mut self, key: &K) -> Option<TimerEntry<M>>
+    where
+        K: Hash + Eq + 'static,
+    {
+        let hash = self.hash_key(key);
+        let (entry, empty) = {
+            let bucket = self.keyed.get_mut(&hash)?;
+            #[cfg(test)]
+            let mut probes = 0;
+            let index = bucket.iter().position(|entry| {
+                #[cfg(test)]
+                {
+                    probes += 1;
+                }
+                entry.key.as_any().downcast_ref::<K>() == Some(key)
+            })?;
+            #[cfg(test)]
+            {
+                self.lookup_probes = self.lookup_probes.saturating_add(probes);
+            }
+            let entry = bucket.swap_remove(index);
+            (entry, bucket.is_empty())
+        };
+        if empty {
+            self.keyed.remove(&hash);
+        }
+        self.armings.remove(&entry.arming_order);
+        if let Some(deadline) = entry.deadline {
+            self.deadlines.remove(&(deadline, entry.arming_order));
+        }
+        Some(entry)
+    }
+
+    fn remove_arming(&mut self, arming_order: u64) -> Option<TimerEntry<M>> {
+        let hash = self.armings.remove(&arming_order)?;
+        let (entry, empty) = {
+            let bucket = self
+                .keyed
+                .get_mut(&hash)
+                .expect("an arming index must reference a key bucket");
+            let index = bucket
+                .iter()
+                .position(|entry| entry.arming_order == arming_order)
+                .expect("an arming index must reference a timer");
+            let entry = bucket.swap_remove(index);
+            (entry, bucket.is_empty())
+        };
+        if empty {
+            self.keyed.remove(&hash);
+        }
+        if let Some(deadline) = entry.deadline {
+            self.deadlines.remove(&(deadline, arming_order));
+        }
+        Some(entry)
+    }
+
+    fn entry_mut(&mut self, arming_order: u64) -> Option<&mut TimerEntry<M>> {
+        let hash = *self.armings.get(&arming_order)?;
+        self.keyed
+            .get_mut(&hash)?
+            .iter_mut()
+            .find(|entry| entry.arming_order == arming_order)
+    }
+
+    fn take_due(&mut self, now: Instant) -> VecDeque<u64> {
+        let due = self
+            .deadlines
+            .range(..=(now, u64::MAX))
+            .copied()
+            .collect::<Vec<_>>();
+        for deadline in &due {
+            self.deadlines.remove(deadline);
+        }
+        due.into_iter().map(|(_, arming)| arming).collect()
+    }
+
+    fn arm_deadline(&mut self, arming_order: u64, deadline: Option<Instant>) {
+        if let Some(deadline) = deadline {
+            self.deadlines.insert((deadline, arming_order));
+        }
+    }
+
+    fn next_deadline(&self) -> Option<Instant> {
+        self.deadlines.first().map(|(deadline, _)| *deadline)
+    }
+}
+
 struct FiredTimerBatch {
     armings: VecDeque<u64>,
     continuations_remaining: usize,
@@ -523,7 +679,7 @@ struct RawResources<M> {
     accepting: bool,
     continuations: VecDeque<M>,
     continuation_needs_external: bool,
-    timers: Vec<TimerEntry<M>>,
+    timers: TimerStore<M>,
     next_timer_order: u64,
     fired_batch: Option<FiredTimerBatch>,
     events: Arc<EventQueue<M>>,
@@ -540,7 +696,7 @@ impl<M> Default for RawResources<M> {
             accepting: true,
             continuations: VecDeque::new(),
             continuation_needs_external: false,
-            timers: Vec::new(),
+            timers: TimerStore::default(),
             next_timer_order: 0,
             fired_batch: None,
             events,
@@ -820,16 +976,7 @@ impl<M: Send + 'static> RawContext<M> {
     where
         K: Hash + Eq + Send + 'static,
     {
-        let Some(index) = self
-            .resources
-            .timers
-            .iter()
-            .position(|entry| entry.key.as_any().downcast_ref::<K>() == Some(key))
-        else {
-            return false;
-        };
-        self.resources.timers.swap_remove(index);
-        true
+        self.resources.timers.remove(key).is_some()
     }
 
     /// Starts incarnation-owned async work with one total deadline budget.
@@ -921,24 +1068,16 @@ impl<M: Send + 'static> RawContext<M> {
     ) where
         K: Hash + Eq + Send + 'static,
     {
-        if let Some(index) = self
-            .resources
-            .timers
-            .iter()
-            .position(|entry| entry.key.as_any().downcast_ref::<K>() == Some(&key))
-        {
-            self.resources.timers.swap_remove(index);
-        }
         self.resources.next_timer_order = self.resources.next_timer_order.saturating_add(1);
         let now = crate::driver::now();
         let deadline = crate::deadline::Deadline::after(now, after).instant();
-        self.resources.timers.push(TimerEntry {
-            key: Box::new(StoredTimerKey(key)),
+        self.resources.timers.replace(
+            key,
             deadline,
-            arming_order: self.resources.next_timer_order,
+            self.resources.next_timer_order,
             message,
             period,
-        });
+        );
     }
 
     fn start_offload<F, T, C>(
@@ -1145,19 +1284,12 @@ impl<M: Send + 'static> RawContext<M> {
             return;
         }
         let now = crate::driver::now();
-        let mut elapsed: Vec<_> = self
-            .resources
-            .timers
-            .iter()
-            .filter(|timer| timer.deadline.is_some_and(|deadline| deadline <= now))
-            .map(|timer| (timer.deadline, timer.arming_order))
-            .collect();
-        if elapsed.is_empty() {
+        let armings = self.resources.timers.take_due(now);
+        if armings.is_empty() {
             return;
         }
-        elapsed.sort_unstable();
         self.resources.fired_batch = Some(FiredTimerBatch {
-            armings: elapsed.into_iter().map(|(_, arming)| arming).collect(),
+            armings,
             continuations_remaining: self.resources.continuations.len(),
             mailbox_through: self.receiver.accepted_sequence(),
             mailbox_complete: false,
@@ -1167,38 +1299,37 @@ impl<M: Send + 'static> RawContext<M> {
     }
 
     fn deliver_timer(&mut self, arming: u64) -> Option<M> {
-        let index = self
-            .resources
-            .timers
-            .iter()
-            .position(|timer| timer.arming_order == arming)?;
-        let TimerEntry {
-            deadline,
-            message,
-            period,
-            ..
-        } = &mut self.resources.timers[index];
-        match message {
-            TimerMessage::Once(message) => {
-                let message = message.take();
-                self.resources.timers.swap_remove(index);
-                message
-            }
-            TimerMessage::Interval(make_message) => {
-                let period = period.expect("an interval timer must retain its period");
-                let now = crate::driver::now();
-                *deadline = crate::deadline::Deadline::after(now, period).instant();
-                Some(make_message())
-            }
+        let interval = self.resources.timers.entry_mut(arming)?.period.is_some();
+        if !interval {
+            let entry = self.resources.timers.remove_arming(arming)?;
+            let TimerMessage::Once(message) = entry.message else {
+                unreachable!("a non-interval timer must own a one-shot message")
+            };
+            return message;
         }
+
+        let (message, deadline) = {
+            let entry = self
+                .resources
+                .timers
+                .entry_mut(arming)
+                .expect("the interval timer remains registered");
+            let period = entry
+                .period
+                .expect("an interval timer must retain its period");
+            let deadline = crate::deadline::Deadline::after(crate::driver::now(), period).instant();
+            entry.deadline = deadline;
+            let TimerMessage::Interval(make_message) = &entry.message else {
+                unreachable!("an interval timer must own a message factory")
+            };
+            (make_message(), deadline)
+        };
+        self.resources.timers.arm_deadline(arming, deadline);
+        Some(message)
     }
 
     fn next_timer_deadline(&self) -> Option<Instant> {
-        self.resources
-            .timers
-            .iter()
-            .filter_map(|timer| timer.deadline)
-            .min()
+        self.resources.timers.next_deadline()
     }
 
     async fn wait_for_event(&mut self) {
@@ -1911,6 +2042,90 @@ mod tests {
             drops.load(Ordering::SeqCst),
             2,
             "repeat cancellation is inert"
+        );
+    }
+}
+
+#[cfg(test)]
+mod timer_store_tests {
+    use std::time::{Duration, Instant};
+
+    use super::{TimerMessage, TimerStore};
+
+    fn once(entry: super::TimerEntry<&'static str>) -> &'static str {
+        let TimerMessage::Once(Some(message)) = entry.message else {
+            panic!("expected a live one-shot timer")
+        };
+        message
+    }
+
+    #[test]
+    fn heterogeneous_keys_keep_exact_identity_and_deadline_order() {
+        let start = Instant::now();
+        let mut timers = TimerStore::default();
+        timers.replace(
+            7_u8,
+            Some(start + Duration::from_secs(3)),
+            1,
+            TimerMessage::Once(Some("old-u8")),
+            None,
+        );
+        timers.replace(
+            7_u16,
+            Some(start + Duration::from_secs(1)),
+            2,
+            TimerMessage::Once(Some("u16")),
+            None,
+        );
+        timers.replace(
+            7_u8,
+            Some(start + Duration::from_secs(2)),
+            3,
+            TimerMessage::Once(Some("new-u8")),
+            None,
+        );
+
+        assert_eq!(timers.next_deadline(), Some(start + Duration::from_secs(1)));
+        assert_eq!(
+            timers.take_due(start + Duration::from_secs(3)),
+            [2, 3],
+            "different key types coexist and replacement takes a fresh order"
+        );
+        assert_eq!(
+            once(timers.remove_arming(2).expect("u16 timer remains")),
+            "u16"
+        );
+        assert_eq!(
+            once(timers.remove_arming(3).expect("replacement remains")),
+            "new-u8"
+        );
+        assert!(timers.is_empty());
+    }
+
+    #[test]
+    fn keyed_timer_churn_has_one_lookup_probe_per_removal() {
+        const TIMERS: usize = 16_384;
+
+        let start = Instant::now();
+        let mut timers = TimerStore::default();
+        for key in 0..TIMERS {
+            timers.replace(
+                key,
+                Some(start + Duration::from_secs((TIMERS - key) as u64)),
+                key as u64,
+                TimerMessage::Once(Some(())),
+                None,
+            );
+        }
+        for key in (0..TIMERS).rev() {
+            assert!(timers.remove(&key).is_some());
+        }
+
+        assert!(timers.is_empty());
+        assert!(timers.deadlines.is_empty());
+        assert_eq!(
+            timers.lookup_probes, TIMERS,
+            "distinct hashes need one exact-key check each, not a vector scan"
         );
     }
 }


### PR DESCRIPTION
Part of #35 (item 8). Closes #39.

## What changed

- Scope the observation publication gate to each running tree. Adopted subtrees inherit the parent gate, complete in-flight edges before handoff, and recursively re-home resident descendants without splitting parent/child projection.
- Replace raw actors' vector-scanned keyed timers with a type-aware hash index plus independently ordered deadline index. Replacement/removal use keyed lookup while equal deadlines retain arming order, heterogeneous key types remain distinct, and item 5's centralized overflow-safe deadline semantics remain authoritative.
- Replace parked mailbox sends' `VecDeque::retain` cancellation with monotonic, directly removable intrusive registrations. FIFO promotion, current incarnation evidence for every waiter from item 3, and the mailbox-lock-before-operation-lock race protocol are preserved.

## Why

Independent systems previously contended on one process-global observation mutex. Keyed timer replacement/removal and parked-send cancellation performed repeated linear scans, making churn and mass cancellation scale quadratically.

## Adversarial review fixes

- Serialize observation-gate adoption with an edge already executing under the former gate, and re-home a resident descendant tree as one atomic handoff.
- Permit cancellation after terminal teardown has detached the waiter queue without a stale-registration panic; monotonic IDs still cannot target later waiters.
- Cover exact-key equality under timer hash collisions and make the 16,384-key scaling assertion select distinct hashes before requiring one probe per removal.
- Exercise head, tail, and interior waiter unlinking in a deterministic operation-count test rather than relying on elapsed time.

## Correctness and regression coverage

- Verifies independent systems make observation progress while another system's gate is held.
- Verifies adopted subtrees and existing descendants share one gate; waiting and already-active pre-admission observers cross handoff safely.
- Verifies heterogeneous/colliding timer keys, replacement ordering, overflow-safe arming, stale-index retraction, and 16,384 keyed removals with one exact-key probe per removal.
- Verifies 16,384 parked sends cancel with one direct unlink each, stale IDs cannot unlink successors, and cancellation can race detached terminal teardown.
- Existing observation forwarding/atomic snapshot, timer retraction/interval/watermark, mailbox FIFO/latest/promotion/cancellation/rebind, item 3 evidence, and item 5 deadline suites remain green.

## Rebase

Rebased onto `c87d783` (merged PRs #42 and #45). The raw-timer conflict was resolved by composing the keyed indexes with `Deadline::after(...).instant()`, and mailbox binding adapts item 3's all-waiter evidence refresh through the intrusive queue.

## Validation

- Focused timer store, mailbox, events, deadlines, rebind, and observation-gate tests
- `./scripts/dev just ci` (231 tests; fmt, clippy `-D warnings`, nextest, docs, API/runtime-path checks)
- `./scripts/dev just ci-nix` (all clean Nix checks passed)

