### PR TITLE
Isolate user-owned supervisor disposal

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -3617,14 +3617,20 @@ async fn run_nested_tree(
     let plan = match tree.lower(inherited, Some(Arc::clone(&scope))) {
         Ok(plan) => plan,
         Err(error) => {
-            let failure = StartupFailure {
-                cause: match error {
-                    LowerError::Undefined(undefined) => StartupFailureCause::Lowering { undefined },
-                    LowerError::IdentityExhausted(id) => {
-                        StartupFailureCause::IdentityExhausted { id }
-                    }
-                },
+            let (cause, disposal) = match error {
+                LowerError::Undefined { paths, disposal } => {
+                    (StartupFailureCause::Lowering { undefined: paths }, disposal)
+                }
+                LowerError::IdentityExhausted { id, disposal } => {
+                    (StartupFailureCause::IdentityExhausted { id }, disposal)
+                }
             };
+            // Lowering never created a nested driver to own teardown. Keep
+            // its isolated definitions attached to this incarnation until
+            // they finish; hard-aborting the incarnation still detaches the
+            // cancellation-safe disposal jobs.
+            disposal.fired().await;
+            let failure = StartupFailure { cause };
             scope.set_startup(Err(StartupError::StartupFailed(failure.clone())));
             scope.finish_incarnation(epoch, StopReason::StartupFailed(failure.clone()));
             return Err(crate::ExitError::from_startup_failure(failure));

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -5,6 +5,7 @@ use std::{
     fmt,
     future::Future,
     ops::{Index, IndexMut},
+    panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     pin::Pin,
     sync::{
         Arc, Mutex, Weak,
@@ -31,7 +32,7 @@ use crate::{
         LifecycleHub, MembershipStatus, ScopeKind, ScopeSnapshot, SnapshotHub, SnapshotReceiver,
     },
     policy::{DefaultsInheritance, ResolvedDefaults},
-    raw::{RawRunContext, RawSpawn},
+    raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
     runtime::{self, Latch},
     task::{OnceTaskBody, TaskContext, TaskFactory},
     tree::{
@@ -429,7 +430,11 @@ impl MemberCell {
             .expect("member mailbox mutex poisoned")
             .teardown
             .take();
-        drop(teardown);
+        if let Some(teardown) = teardown
+            && let Some(payload) = teardown.finish()
+        {
+            runtime::dispose_detached(payload);
+        }
         if published {
             self.record.pulse();
         }
@@ -1487,7 +1492,13 @@ pub(crate) fn start_admission(
     response
 }
 
-pub(crate) fn cancel_dynamic_reservation(control: &Arc<DynamicControl>, slot: &Arc<SlotCell>) {
+fn cancel_dynamic_reservation_parts(
+    control: &Arc<DynamicControl>,
+    slot: &Arc<SlotCell>,
+) -> (
+    Option<runtime::Isolated<ChildConstruction>>,
+    Option<DynamicEntry>,
+) {
     let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
     let id = slot.member.id().clone();
     let cancelled = state.entries.get(&id).is_some_and(|entry| {
@@ -1495,16 +1506,24 @@ pub(crate) fn cancel_dynamic_reservation(control: &Arc<DynamicControl>, slot: &A
     });
     let removed = cancelled.then(|| state.entries.remove(&id)).flatten();
     drop(state);
-    if cancelled {
-        drop(slot.take_defined());
+    let definition = if cancelled {
+        let definition = slot.take_defined();
         slot.member.terminalize(Exit::never_started());
         if let Some(scope) = &slot.scope {
             scope.terminalize_never_started();
         }
-    }
+        definition
+    } else {
+        None
+    };
+    (definition, removed)
+}
+
+pub(crate) fn cancel_dynamic_reservation(control: &Arc<DynamicControl>, slot: &Arc<SlotCell>) {
+    let (definition, removed) = cancel_dynamic_reservation_parts(control, slot);
     // The entry's drop completes its removal response; it must follow the
-    // member's terminal publication.
-    drop(removed);
+    // member's terminal publication and isolated definition disposal.
+    dispose_definition_then(definition, move || drop(removed));
 }
 
 pub(crate) fn signal_fused_cancel(control: &Arc<DynamicControl>, latch: &Latch) {
@@ -1539,11 +1558,12 @@ pub(crate) fn remove_dynamic(
     if !entry.admitted {
         let entry = state.entries.remove(id).expect("entry was just resolved");
         drop(state);
-        drop(entry.slot.take_defined());
+        let definition = entry.slot.take_defined();
         entry.slot.member.terminalize(Exit::never_started());
         if let Some(scope) = &entry.slot.scope {
             scope.terminalize_never_started();
         }
+        dispose_definition_then(definition, move || drop(entry));
         return response;
     }
     // Terminal residents still have a driver registration. Route them
@@ -1570,6 +1590,37 @@ impl AdmissionRequest {
             let _ = sender.send(result);
         });
     }
+}
+
+fn reject_admission_after_disposal(
+    mut request: AdmissionRequest,
+    definition: Option<runtime::Isolated<ChildConstruction>>,
+    removed: Option<DynamicEntry>,
+    error: ReserveError,
+) {
+    dispose_definition_then(definition, move || {
+        drop(removed);
+        request.complete(Err(error));
+    });
+}
+
+fn dispose_definition_then(
+    mut definition: Option<runtime::Isolated<ChildConstruction>>,
+    completion: impl FnOnce() + Send + 'static,
+) {
+    let construction = definition.as_mut().and_then(runtime::Isolated::take);
+    let Some(construction) = construction else {
+        completion();
+        return;
+    };
+    let disposal = runtime::spawn_blocking((), move || drop(construction));
+    runtime::spawn((), async move {
+        // A never-admitted definition has no incarnation verdict to publish,
+        // but its destructor must still be isolated and complete before any
+        // response releases ownership back to the caller.
+        let _ = runtime::join(disposal).await;
+        completion();
+    });
 }
 
 enum DriverEvent {
@@ -1738,6 +1789,10 @@ enum ChildEvent {
         join: JoinVerdict,
         cancelled: bool,
     },
+    ConstructionDisposed {
+        child: ChildKey,
+        panic: Option<Option<String>>,
+    },
 }
 
 enum DeadlineKind {
@@ -1804,7 +1859,8 @@ fn discharge_child_terminality(completion: ChildTerminality) {
 struct ChildRuntime {
     slot: Arc<crate::tree::SlotCell>,
     terminality: Obligation<ChildTerminality>,
-    construction: Option<ChildConstruction>,
+    construction: runtime::Isolated<ChildConstruction>,
+    pending_terminal: Option<PendingTerminal>,
     options: crate::policy::ResolvedCommonOptions,
     incarnations: FenceCounter,
     restarts: RestartState,
@@ -1813,6 +1869,12 @@ struct ChildRuntime {
     initial_ready: bool,
     initial: bool,
     spawned_once: bool,
+}
+
+struct PendingTerminal {
+    exit: Exit,
+    exited_incarnation: Option<Incarnation>,
+    startup_aborted: bool,
 }
 
 impl ChildRuntime {
@@ -1843,7 +1905,8 @@ impl ChildRuntime {
         Self {
             terminality,
             slot,
-            construction: Some(construction),
+            construction,
+            pending_terminal: None,
             options,
             incarnations,
             restarts: RestartState::new(),
@@ -1853,6 +1916,10 @@ impl ChildRuntime {
             initial: true,
             spawned_once: false,
         }
+    }
+
+    fn is_disposing(&self) -> bool {
+        self.pending_terminal.is_some()
     }
 
     fn is_terminal(&self) -> bool {
@@ -2128,7 +2195,9 @@ impl Drop for ScopeRuntime {
             if let Some(active) = child.active.take() {
                 if let Some(mailbox) = child.slot.member.mailbox() {
                     mailbox.freeze(active.incarnation);
-                    mailbox.close(active.incarnation);
+                    if let Some(teardown) = mailbox.close(active.incarnation) {
+                        runtime::dispose_detached(teardown);
+                    }
                 }
                 active.shutdown.fire();
                 active.abort.fire();
@@ -2181,6 +2250,29 @@ enum SpawnBody {
     },
 }
 
+struct FactoryGuard(Option<Box<dyn Send + 'static>>);
+
+impl FactoryGuard {
+    fn new(factory: Option<Box<dyn Send + 'static>>) -> Self {
+        Self(factory)
+    }
+
+    fn finish(&mut self) -> Option<Box<dyn std::any::Any + Send + 'static>> {
+        let factory = self.0.take();
+        catch_unwind(AssertUnwindSafe(|| drop(factory))).err()
+    }
+}
+
+impl Drop for FactoryGuard {
+    fn drop(&mut self) {
+        let already_panicking = std::thread::panicking();
+        let panic = self.finish();
+        if !already_panicking && let Some(payload) = panic {
+            resume_unwind(payload);
+        }
+    }
+}
+
 impl ScopeRuntime {
     #[cfg(test)]
     fn record_storage(&self) {
@@ -2200,7 +2292,7 @@ impl ScopeRuntime {
         let Some(child) = self.children.get(key) else {
             return;
         };
-        if self.phase.is_draining() || child.is_terminal() {
+        if self.phase.is_draining() || child.is_terminal() || child.is_disposing() {
             return;
         }
         let child = &mut self.children[key];
@@ -2217,7 +2309,9 @@ impl ScopeRuntime {
             if child.options.retention == crate::Retention::Remove {
                 self.root.prune_child(&child.slot.member);
             }
-            child.construction.take();
+            if let Some(construction) = child.construction.take() {
+                runtime::dispose_detached(construction);
+            }
             let exit = match child.slot.member.record().stage {
                 MemberStage::Terminal(exit) => exit,
                 _ => Exit::never_started(),
@@ -2254,41 +2348,49 @@ impl ScopeRuntime {
             abort.clone(),
             ready.clone(),
         );
-        let construction = child
-            .construction
-            .as_mut()
-            .expect("a live child retains its construction");
+        let construction = child.construction.get_mut();
         let scope_child = matches!(construction, ChildConstruction::Scope(_));
-        let (body, declared_readiness) = match construction {
-            ChildConstruction::Raw(definition) => (
-                SpawnBody::Raw {
-                    spawn: definition.take_spawn(),
-                    context: RawRunContext {
-                        id,
-                        incarnation,
-                        member: Arc::clone(&child.slot.member),
-                        scope: crate::ScopeRef {
-                            cell: Arc::clone(&self.root),
+        let (body, factory_guard, declared_readiness) = match construction {
+            ChildConstruction::Raw(definition) => {
+                let spawn = definition.take_spawn();
+                let factory_guard = spawn.factory_guard();
+                (
+                    SpawnBody::Raw {
+                        spawn,
+                        context: RawRunContext {
+                            id,
+                            incarnation,
+                            member: Arc::clone(&child.slot.member),
+                            scope: crate::ScopeRef {
+                                cell: Arc::clone(&self.root),
+                            },
+                            shutdown: shutdown.clone(),
+                            abort: abort.clone(),
+                            ready: ready.clone(),
+                            local_stop: local_stop.clone(),
+                            mailbox_shutdown: child.options.mailbox_shutdown,
                         },
-                        shutdown: shutdown.clone(),
-                        abort: abort.clone(),
-                        ready: ready.clone(),
-                        local_stop: local_stop.clone(),
-                        mailbox_shutdown: child.options.mailbox_shutdown,
                     },
-                },
-                None,
-            ),
-            ChildConstruction::Task(definition) => (
-                SpawnBody::TaskRestartable(Arc::clone(&definition.factory)),
-                Some(child.options.readiness),
-            ),
+                    factory_guard,
+                    None,
+                )
+            }
+            ChildConstruction::Task(definition) => {
+                let factory = Arc::clone(&definition.factory);
+                (
+                    SpawnBody::TaskRestartable(Arc::clone(&factory)),
+                    Some(Box::new(factory) as Box<dyn Send + 'static>),
+                    Some(child.options.readiness),
+                )
+            }
             ChildConstruction::TaskOnce(definition) => {
                 let body = std::mem::replace(&mut definition.body, OnceTaskBody::Spent);
                 match body {
-                    OnceTaskBody::Available(body) => {
-                        (SpawnBody::TaskOnce(body), Some(child.options.readiness))
-                    }
+                    OnceTaskBody::Available(body) => (
+                        SpawnBody::TaskOnce(body),
+                        None,
+                        Some(child.options.readiness),
+                    ),
                     OnceTaskBody::Spent => {
                         panic!("one-shot task construction invoked more than once")
                     }
@@ -2312,6 +2414,7 @@ impl ScopeRuntime {
                             ),
                             inherited,
                         },
+                        Some(Box::new(Arc::clone(factory)) as Box<dyn Send + 'static>),
                         Some(Readiness::Manual),
                     ),
                     ScopeSource::OneShot(_) => {
@@ -2331,6 +2434,7 @@ impl ScopeRuntime {
                                 ),
                                 inherited,
                             },
+                            None,
                             Some(Readiness::Manual),
                         )
                     }
@@ -2409,63 +2513,90 @@ impl ScopeRuntime {
         let constructed_sender = self.events.clone();
         let run_release = construction_release.clone();
         let child_readiness_override = child.options.readiness_override;
+        if child.options.restart.is_never() {
+            // `body` and `factory_guard` now own every live user value needed
+            // by this sole incarnation. Releasing the framework definition
+            // while those owners are still local makes its drop metadata-only;
+            // the final user destructor runs inside the task boundary below.
+            drop(child.construction.take());
+        }
         let handle = runtime::spawn(incarnation, async move {
-            let result = match body {
-                SpawnBody::Raw { spawn, context } => {
-                    let instance = spawn.construct();
-                    let readiness = match child_readiness_override {
-                        Some(readiness) => readiness,
-                        None => instance.readiness(),
-                    };
-                    let _ = runtime::mpsc_send(
-                        &constructed_sender,
-                        DriverEvent::Child(ChildEvent::Constructed {
-                            child: key,
-                            incarnation,
-                            readiness,
-                        }),
-                    )
-                    .await;
-                    run_release.fired().await;
-                    instance.run(context, readiness).await
-                }
-                SpawnBody::TaskRestartable(factory) => {
-                    let future = factory(task_context);
-                    future.await
-                }
-                SpawnBody::TaskOnce(body) => body(task_context).await,
-                SpawnBody::ScopeRestartable {
-                    factory,
-                    scope,
-                    inherited,
-                } => {
-                    let tree = factory();
-                    run_nested_tree(
+            let mut factory_guard = FactoryGuard::new(factory_guard);
+            let body = async move {
+                match body {
+                    SpawnBody::Raw { spawn, context } => {
+                        let instance = spawn.construct();
+                        let readiness = match child_readiness_override {
+                            Some(readiness) => readiness,
+                            None => instance.readiness(),
+                        };
+                        let _ = runtime::mpsc_send(
+                            &constructed_sender,
+                            DriverEvent::Child(ChildEvent::Constructed {
+                                child: key,
+                                incarnation,
+                                readiness,
+                            }),
+                        )
+                        .await;
+                        run_release.fired().await;
+                        instance.run(context, readiness).await
+                    }
+                    SpawnBody::TaskRestartable(factory) => {
+                        let future = factory(task_context);
+                        future.await
+                    }
+                    SpawnBody::TaskOnce(body) => body(task_context).await,
+                    SpawnBody::ScopeRestartable {
+                        factory,
+                        scope,
+                        inherited,
+                    } => {
+                        let tree = factory();
+                        run_nested_tree(
+                            tree,
+                            scope,
+                            inherited,
+                            nested_ready,
+                            nested_cancel,
+                            nested_abort,
+                            nested_abort_ack,
+                        )
+                        .await
+                    }
+                    SpawnBody::ScopeOnce {
                         tree,
                         scope,
                         inherited,
-                        nested_ready,
-                        nested_cancel,
-                        nested_abort,
-                        nested_abort_ack,
-                    )
-                    .await
+                    } => {
+                        run_nested_tree(
+                            *tree,
+                            scope,
+                            inherited,
+                            nested_ready,
+                            nested_cancel,
+                            nested_abort,
+                            nested_abort_ack,
+                        )
+                        .await
+                    }
                 }
-                SpawnBody::ScopeOnce {
-                    tree,
-                    scope,
-                    inherited,
-                } => {
-                    run_nested_tree(
-                        *tree,
-                        scope,
-                        inherited,
-                        nested_ready,
-                        nested_cancel,
-                        nested_abort,
-                        nested_abort_ack,
-                    )
-                    .await
+            };
+            let outcome = CatchUnwindFuture::new(body).await;
+            let factory_panic = factory_guard.finish();
+            let result = match outcome {
+                Ok(result) => {
+                    if let Some(payload) = factory_panic {
+                        resume_unwind(payload);
+                    }
+                    result
+                }
+                Err(payload) => {
+                    // The execution panic is primary over a later factory
+                    // capture destructor panic, matching incarnation-owned
+                    // state and offload precedence.
+                    drop(factory_panic);
+                    resume_unwind(payload)
                 }
             };
             report.record(RecordedOutcome::Returned(result));
@@ -2608,7 +2739,7 @@ impl ScopeRuntime {
         let Some(child) = self.children.get_mut(key) else {
             return;
         };
-        if child.is_terminal() {
+        if child.is_terminal() || child.is_disposing() {
             return;
         }
         if let Some(active) = &mut child.active {
@@ -2617,6 +2748,15 @@ impl ScopeRuntime {
                     active.forced_outcome = forced;
                 }
                 return;
+            }
+            // Scope drain and planned removal suppress restart. Every
+            // restartable spawn retains a matching factory guard in the
+            // incarnation task, so releasing the driver's Arc in those modes
+            // can only make that panic boundary the final capture owner.
+            let restart_suppressed =
+                self.phase.is_draining() || child.slot.member.record().removing;
+            if restart_suppressed && let Some(construction) = child.construction.take() {
+                drop(construction);
             }
             self.root.transition_child(
                 &child.slot.member,
@@ -2641,15 +2781,27 @@ impl ScopeRuntime {
             }
             let record = child.slot.member.record();
             let exit = record.last_exit.unwrap_or_else(Exit::never_started);
-            if record.last_incarnation.is_none()
-                && let Some(scope) = &child.slot.scope
-            {
-                scope.terminalize_never_started();
+            if record.last_incarnation.is_none() {
+                if let Some(scope) = &child.slot.scope {
+                    scope.terminalize_never_started();
+                }
+                // A never-ran terminal is the plain `Stopped { NeverStarted }`
+                // state (B.6), not a §6 startup abort. Its definition still
+                // owns the only user resource, so join disposal before
+                // completing the scope, while publishing the never-started
+                // member state synchronously for startup observation.
+                self.begin_terminal_disposal(key, exit, None, false);
+                self.children[key].terminalize(&self.root, Exit::never_started(), None, false);
+            } else {
+                // Between incarnations, the recorded exit already owns the
+                // child verdict. Do not turn detached factory cleanup into a
+                // shutdown straggler solely because there is no incarnation
+                // left to host that cleanup.
+                child.terminalize(&self.root, exit, None, false);
+                if let Some(construction) = child.construction.take() {
+                    runtime::dispose_detached(construction);
+                }
             }
-            // A never-ran terminal is the plain `Stopped { NeverStarted }`
-            // state (B.6), not a §6 startup abort.
-            child.terminalize(&self.root, exit, None, false);
-            child.construction.take();
         }
     }
 
@@ -2749,7 +2901,9 @@ impl ScopeRuntime {
                 return;
             };
             self.begin_stop_child(key, None);
-            if self.children[key].active.is_some() {
+            if self.children[key].active.is_some()
+                || (self.children[key].is_disposing() && !self.children[key].is_terminal())
+            {
                 return;
             }
         }
@@ -2917,8 +3071,10 @@ impl ScopeRuntime {
         if let Some(deadline) = active.stop_deadline.take() {
             self.deadlines.cancel(deadline);
         }
-        if let Some(mailbox) = child.slot.member.mailbox() {
-            mailbox.close(incarnation);
+        if let Some(mailbox) = child.slot.member.mailbox()
+            && let Some(teardown) = mailbox.close(incarnation)
+        {
+            runtime::dispose_detached(teardown);
         }
         active.readiness.step(ReadinessEvent::Exit);
         if let (JoinVerdict::Cancelled { .. }, Some(after_grace)) =
@@ -2951,24 +3107,7 @@ impl ScopeRuntime {
                 // does not rewind it.
                 let pre_ready =
                     child.initial && !self.phase.startup_complete() && !child.initial_ready;
-                child.terminalize(&self.root, exit.clone(), Some(incarnation), pre_ready);
-                child.construction.take();
-                let removing = child.slot.member.record().removing;
-                if removing {
-                    self.finalize_removal(key);
-                } else if pre_ready && !self.phase.is_draining() {
-                    self.fail_startup(key, exit);
-                    if self.children[key].options.retention == crate::Retention::Remove {
-                        self.prune_terminal(key);
-                    }
-                } else {
-                    if child.options.retention == crate::Retention::Remove {
-                        self.prune_terminal(key);
-                    }
-                    if self.phase.is_draining() {
-                        self.stop_next_ordered();
-                    }
-                }
+                self.begin_terminal_disposal(key, exit, Some(incarnation), pre_ready);
             }
             ExitDispatch::ScheduleRestart => {
                 if !self.phase.startup_complete() {
@@ -3033,6 +3172,91 @@ impl ScopeRuntime {
         }
     }
 
+    fn begin_terminal_disposal(
+        &mut self,
+        key: ChildKey,
+        exit: Exit,
+        exited_incarnation: Option<Incarnation>,
+        startup_aborted: bool,
+    ) {
+        let construction = {
+            let Some(child) = self.children.get_mut(key) else {
+                return;
+            };
+            if child.pending_terminal.is_some() {
+                return;
+            }
+            child.pending_terminal = Some(PendingTerminal {
+                exit,
+                exited_incarnation,
+                startup_aborted,
+            });
+            child.construction.take()
+        };
+        let Some(construction) = construction else {
+            self.handle_construction_disposed(key, None);
+            return;
+        };
+
+        // The retained factory is user-owned. Destroy it on the blocking
+        // pool and join only its verdict; the scope driver remains free to
+        // advance unrelated children while the destructor runs.
+        let disposal = runtime::spawn_blocking((), move || drop(construction));
+        let sender = self.events.clone();
+        runtime::spawn((), async move {
+            let panic = match runtime::join(disposal).await {
+                runtime::JoinOutcome::Ok { .. } => None,
+                runtime::JoinOutcome::Panic { message } => Some(message),
+                runtime::JoinOutcome::Cancelled => Some(Some(
+                    "factory disposal task was cancelled before completion".to_owned(),
+                )),
+            };
+            let _ = runtime::mpsc_send(
+                &sender,
+                DriverEvent::Child(ChildEvent::ConstructionDisposed { child: key, panic }),
+            )
+            .await;
+        });
+    }
+
+    fn handle_construction_disposed(&mut self, key: ChildKey, panic: Option<Option<String>>) {
+        let Some(child) = self.children.get_mut(key) else {
+            return;
+        };
+        let Some(mut terminal) = child.pending_terminal.take() else {
+            return;
+        };
+        if let Some(message) = panic
+            && !matches!(terminal.exit.kind(), ExitKind::Panicked { .. })
+        {
+            terminal.exit = Exit::new(ExitKind::Panicked { message }, terminal.exit.cancelled());
+        }
+
+        let exit = terminal.exit;
+        self.children[key].terminalize(
+            &self.root,
+            exit.clone(),
+            terminal.exited_incarnation,
+            terminal.startup_aborted,
+        );
+        let removing = self.children[key].slot.member.record().removing;
+        if removing {
+            self.finalize_removal(key);
+        } else if terminal.startup_aborted && !self.phase.is_draining() {
+            self.fail_startup(key, exit);
+            if self.children[key].options.retention == crate::Retention::Remove {
+                self.prune_terminal(key);
+            }
+        } else {
+            if self.children[key].options.retention == crate::Retention::Remove {
+                self.prune_terminal(key);
+            }
+            if self.phase.is_draining() {
+                self.stop_next_ordered();
+            }
+        }
+    }
+
     fn fail_startup(&mut self, key: ChildKey, exit: Exit) {
         let child = &self.children[key];
         let failure = StartupFailure {
@@ -3051,20 +3275,20 @@ impl ScopeRuntime {
                     .children
                     .key_at(later_index)
                     .expect("ordered children are never reclaimed during startup");
-                if !self.children[later].spawned_once {
+                if !self.children[later].spawned_once
+                    && !self.children[later].is_disposing()
+                    && !self.children[later].is_terminal()
+                {
                     if let Some(scope) = &self.children[later].slot.scope {
                         scope.terminalize_never_started();
                     }
+                    self.begin_terminal_disposal(later, Exit::never_started(), None, false);
                     self.children[later].terminalize(
                         &self.root,
                         Exit::never_started(),
                         None,
                         false,
                     );
-                    if self.children[later].options.retention == crate::Retention::Remove {
-                        self.prune_terminal(later);
-                    }
-                    self.children[later].construction.take();
                 }
             }
         }
@@ -3125,7 +3349,11 @@ impl ScopeRuntime {
 
     fn finish_if_ready(&mut self) -> Option<StopReason> {
         if let Some(reason) = self.phase.draining_reason() {
-            if self.children.values().all(ChildRuntime::is_terminal) {
+            if self
+                .children
+                .values()
+                .all(|child| child.is_terminal() && !child.is_disposing())
+            {
                 return Some(reason.clone());
             }
             return None;
@@ -3133,7 +3361,10 @@ impl ScopeRuntime {
         if !self.phase.startup_failed()
             && self.flavor == ScopeFlavor::Ordered
             && !self.children.is_empty()
-            && self.children.values().all(ChildRuntime::is_terminal)
+            && self
+                .children
+                .values()
+                .all(|child| child.is_terminal() && !child.is_disposing())
         {
             return Some(StopReason::Finished);
         }
@@ -3152,7 +3383,6 @@ impl ScopeRuntime {
             || self.phase.is_draining()
             || self.phase.startup_failed()
         {
-            cancel_dynamic_reservation(&control, &request.slot);
             let cause = if self.phase.is_draining() {
                 NotAdmittingCause::Draining
             } else if self.phase.startup_failed() {
@@ -3160,25 +3390,37 @@ impl ScopeRuntime {
             } else {
                 NotAdmittingCause::NoLiveIncarnation
             };
-            request.complete(Err(ReserveError::NotAdmitting(cause)));
+            let (definition, removed) = cancel_dynamic_reservation_parts(&control, &request.slot);
+            reject_admission_after_disposal(
+                request,
+                definition,
+                removed,
+                ReserveError::NotAdmitting(cause),
+            );
             return;
         }
         if request.fused_cancel.as_ref().is_some_and(Latch::is_fired) {
-            cancel_dynamic_reservation(&control, &request.slot);
-            request.complete(Err(ReserveError::NotAdmitting(
-                NotAdmittingCause::ReservationEnded,
-            )));
+            let (definition, removed) = cancel_dynamic_reservation_parts(&control, &request.slot);
+            reject_admission_after_disposal(
+                request,
+                definition,
+                removed,
+                ReserveError::NotAdmitting(NotAdmittingCause::ReservationEnded),
+            );
             return;
         }
 
         let Some(definition) = request.slot.take_defined() else {
-            cancel_dynamic_reservation(&control, &request.slot);
-            request.complete(Err(ReserveError::NotAdmitting(
-                NotAdmittingCause::ReservationEnded,
-            )));
+            let (_, removed) = cancel_dynamic_reservation_parts(&control, &request.slot);
+            reject_admission_after_disposal(
+                request,
+                None,
+                removed,
+                ReserveError::NotAdmitting(NotAdmittingCause::ReservationEnded),
+            );
             return;
         };
-        let (options, one_shot) = match &definition {
+        let (options, one_shot) = match definition.get() {
             ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
             ChildConstruction::Task(definition) => (&definition.options, false),
             ChildConstruction::TaskOnce(definition) => (&definition.options, true),
@@ -3210,11 +3452,15 @@ impl ScopeRuntime {
                 }
                 // The entry's drop completes its removal response; preserve
                 // the same terminality-before-completion ordering as every
-                // other reservation-cancellation path.
-                drop(removed);
-                request.complete(Err(ReserveError::NotAdmitting(
-                    NotAdmittingCause::ReservationEnded,
-                )));
+                // other reservation-cancellation path. Definition disposal
+                // is also complete before either waiter regains ownership.
+                let ChildPlan { construction, .. } = plan;
+                reject_admission_after_disposal(
+                    request,
+                    Some(construction),
+                    removed,
+                    ReserveError::NotAdmitting(NotAdmittingCause::ReservationEnded),
+                );
                 return;
             }
             let entry = state
@@ -3548,7 +3794,9 @@ async fn run_scope_incarnation(
                 }
                 DriverEvent::Child(ChildEvent::Constructed { .. })
                 | DriverEvent::Child(ChildEvent::Ready { .. }) => ArbitrationClass::ReadinessSignal,
-                DriverEvent::Child(ChildEvent::Exited { .. }) => ArbitrationClass::ChildExit,
+                DriverEvent::Child(
+                    ChildEvent::Exited { .. } | ChildEvent::ConstructionDisposed { .. },
+                ) => ArbitrationClass::ChildExit,
                 DriverEvent::Admission(_) => ArbitrationClass::Admission,
             };
             pending.push((class, Pending::Driver(event)));
@@ -3613,9 +3861,9 @@ async fn run_scope_incarnation(
                         | DriverEvent::Child(ChildEvent::Ready { .. }) => {
                             ArbitrationClass::ReadinessSignal
                         }
-                        DriverEvent::Child(ChildEvent::Exited { .. }) => {
-                            ArbitrationClass::ChildExit
-                        }
+                        DriverEvent::Child(
+                            ChildEvent::Exited { .. } | ChildEvent::ConstructionDisposed { .. },
+                        ) => ArbitrationClass::ChildExit,
                         DriverEvent::Admission(_) => ArbitrationClass::Admission,
                     };
                     pending.push((class, Pending::Driver(event)));
@@ -3673,6 +3921,10 @@ async fn run_scope_incarnation(
                     join,
                     cancelled,
                 })) => scope.handle_exit(child, incarnation, recorded, join, cancelled),
+                Pending::Driver(DriverEvent::Child(ChildEvent::ConstructionDisposed {
+                    child,
+                    panic,
+                })) => scope.handle_construction_disposed(child, panic),
                 Pending::Deadline(deadline) => scope.handle_deadline(deadline),
             }
         }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -260,6 +260,7 @@ pub(crate) struct MemberCell {
     id: ChildId,
     membership: Mutex<Membership>,
     record: runtime::WatchSender<MemberRecord>,
+    terminal_disposal_pending: AtomicBool,
     mailbox: Mutex<MemberMailbox>,
     options: Mutex<Option<crate::policy::ResolvedCommonOptions>>,
     pub(crate) removal: Latch,
@@ -299,6 +300,7 @@ impl MemberCell {
             id,
             membership: Mutex::new(membership),
             record,
+            terminal_disposal_pending: AtomicBool::new(false),
             mailbox: Mutex::new(MemberMailbox::default()),
             options: Mutex::new(None),
             removal: Latch::default(),
@@ -332,6 +334,15 @@ impl MemberCell {
 
     pub(crate) fn record(&self) -> MemberRecord {
         self.record.read_cloned()
+    }
+
+    fn terminal_disposal_pending(&self) -> bool {
+        self.terminal_disposal_pending.load(Ordering::Acquire)
+    }
+
+    fn set_terminal_disposal_pending(&self, pending: bool) {
+        self.terminal_disposal_pending
+            .store(pending, Ordering::Release);
     }
 
     pub(crate) fn update(&self, update: impl FnOnce(&mut MemberRecord)) {
@@ -1679,7 +1690,9 @@ fn collect_stragglers(scope: &ScopeCell, prefix: &[ChildId], out: &mut Vec<Shutd
             .collect::<Vec<_>>()
     });
     for child in children {
-        if matches!(child.member.record().stage, MemberStage::Terminal(_)) {
+        if matches!(child.member.record().stage, MemberStage::Terminal(_))
+            || child.member.terminal_disposal_pending()
+        {
             continue;
         }
         let mut path = prefix.to_vec();
@@ -1737,7 +1750,11 @@ pub(crate) async fn shutdown_scope(
             collect_stragglers(&scope, &[], &mut stragglers);
             scope.force_shutdown(epoch);
             wait_for_incarnation(&scope, epoch).await;
-            Err(ShutdownTimeout { stragglers })
+            if stragglers.is_empty() {
+                Ok(())
+            } else {
+                Err(ShutdownTimeout { stragglers })
+            }
         }
     }
 }
@@ -2329,8 +2346,9 @@ impl ScopeRuntime {
         );
         let construction = child.construction.get_mut();
         let scope_child = matches!(construction, ChildConstruction::Scope(_));
-        let (body, declared_readiness) = match construction {
+        let (body, declared_readiness, construction_spent) = match construction {
             ChildConstruction::Raw(definition) => {
+                let one_shot = definition.one_shot();
                 let spawn = definition.take_spawn();
                 (
                     SpawnBody::Raw {
@@ -2350,6 +2368,7 @@ impl ScopeRuntime {
                         },
                     },
                     None,
+                    one_shot,
                 )
             }
             ChildConstruction::Task(definition) => {
@@ -2357,14 +2376,17 @@ impl ScopeRuntime {
                 (
                     SpawnBody::TaskRestartable(factory),
                     Some(child.options.readiness),
+                    false,
                 )
             }
             ChildConstruction::TaskOnce(definition) => {
                 let body = std::mem::replace(&mut definition.body, OnceTaskBody::Spent);
                 match body {
-                    OnceTaskBody::Available(body) => {
-                        (SpawnBody::TaskOnce(body), Some(child.options.readiness))
-                    }
+                    OnceTaskBody::Available(body) => (
+                        SpawnBody::TaskOnce(body),
+                        Some(child.options.readiness),
+                        true,
+                    ),
                     OnceTaskBody::Spent => {
                         panic!("one-shot task construction invoked more than once")
                     }
@@ -2389,6 +2411,7 @@ impl ScopeRuntime {
                             inherited,
                         },
                         Some(Readiness::Manual),
+                        false,
                     ),
                     ScopeSource::OneShot(_) => {
                         let source = std::mem::replace(&mut definition.source, ScopeSource::Spent);
@@ -2408,6 +2431,7 @@ impl ScopeRuntime {
                                 inherited,
                             },
                             Some(Readiness::Manual),
+                            true,
                         )
                     }
                     ScopeSource::Spent => {
@@ -2485,6 +2509,13 @@ impl ScopeRuntime {
         let constructed_sender = self.events.clone();
         let run_release = construction_release.clone();
         let child_readiness_override = child.options.readiness_override;
+        if construction_spent {
+            // One-shot actor/task/subtree state has moved into `body`; the
+            // retained construction is now framework-only spent metadata.
+            // Release it without adding a blocking-pool scheduling edge to
+            // terminal publication or restart-window arbitration.
+            drop(child.construction.take());
+        }
         let handle = runtime::spawn(incarnation, async move {
             let body = async move {
                 match body {
@@ -2736,11 +2767,15 @@ impl ScopeRuntime {
                 self.begin_terminal_disposal(key, exit, None, false);
                 self.children[key].terminalize(&self.root, Exit::never_started(), None, false);
             } else {
-                // Between incarnations the retained factory is still member
-                // ownership. Classify its final destructor before publishing
-                // terminality, unless hard escalation has already made all
-                // remaining cleanup detached.
-                self.begin_terminal_disposal(key, exit, None, false);
+                // Between incarnations, the recorded exit already owns the
+                // child verdict. There is no incarnation left to classify a
+                // later factory destructor, so publish synchronously and
+                // isolate cleanup without turning it into a shutdown
+                // straggler (including for a zero shutdown budget).
+                child.terminalize(&self.root, exit, None, false);
+                if let Some(construction) = child.construction.take() {
+                    runtime::dispose_detached(construction);
+                }
             }
         }
     }
@@ -2875,11 +2910,9 @@ impl ScopeRuntime {
             .filter(|key| self.children[*key].pending_terminal.is_some())
             .collect::<Vec<_>>();
         for key in disposing {
-            if let Some(terminal) = self.children[key].pending_terminal.as_mut()
-                && !matches!(terminal.exit.kind(), ExitKind::Panicked { .. })
-            {
-                terminal.exit = Exit::new(ExitKind::Aborted { after_grace: true }, true);
-            }
+            // The incarnation has already exited; only its retained factory
+            // remains. Hard escalation detaches that cleanup, but must not
+            // rewrite the actor's recorded verdict.
             self.handle_construction_disposed(key, None);
         }
     }
@@ -3145,6 +3178,7 @@ impl ScopeRuntime {
                 exited_incarnation,
                 startup_aborted,
             });
+            child.slot.member.set_terminal_disposal_pending(true);
             child.construction.take()
         };
         let Some(construction) = construction else {
@@ -3177,6 +3211,7 @@ impl ScopeRuntime {
         let Some(mut terminal) = child.pending_terminal.take() else {
             return;
         };
+        child.slot.member.set_terminal_disposal_pending(false);
         if let Some(message) = panic
             && !matches!(terminal.exit.kind(), ExitKind::Panicked { .. })
         {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -5,7 +5,6 @@ use std::{
     fmt,
     future::Future,
     ops::{Index, IndexMut},
-    panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     pin::Pin,
     sync::{
         Arc, Mutex, Weak,
@@ -1388,19 +1387,23 @@ impl DynamicControl {
         state.accepting = false;
         let entries = std::mem::take(&mut state.entries);
         drop(state);
-        for entry in entries.values() {
+        let mut retained = HashMap::new();
+        for (id, entry) in entries {
             if !entry.admitted {
-                drop(entry.slot.take_defined());
+                let definition = entry.slot.take_defined();
                 entry.slot.member.terminalize(Exit::never_started());
                 if let Some(scope) = &entry.slot.scope {
                     scope.terminalize_never_started();
                 }
+                dispose_definition_then(definition, move || drop(entry));
+            } else {
+                retained.insert(id, entry);
             }
         }
         // The caller holds admitted entries across member terminality and
         // residency removal. Dropping them then completes every in-flight
         // removal without waking a remover before those observation edges.
-        entries
+        retained
     }
 }
 
@@ -1613,12 +1616,10 @@ fn dispose_definition_then(
         completion();
         return;
     };
-    let disposal = runtime::spawn_blocking((), move || drop(construction));
-    runtime::spawn((), async move {
+    runtime::dispose_then(construction, move |_| {
         // A never-admitted definition has no incarnation verdict to publish,
         // but its destructor must still be isolated and complete before any
         // response releases ownership back to the caller.
-        let _ = runtime::join(disposal).await;
         completion();
     });
 }
@@ -2174,6 +2175,7 @@ struct ScopeRuntime {
     ancestor_abort: Option<Latch>,
     ancestor_abort_ack: Option<Latch>,
     ancestor_abort_seen: bool,
+    hard_forced: bool,
     completion: Option<ScopeCompletion>,
 }
 
@@ -2248,29 +2250,6 @@ enum SpawnBody {
         scope: Arc<ScopeCell>,
         inherited: ResolvedDefaults,
     },
-}
-
-struct FactoryGuard(Option<Box<dyn Send + 'static>>);
-
-impl FactoryGuard {
-    fn new(factory: Option<Box<dyn Send + 'static>>) -> Self {
-        Self(factory)
-    }
-
-    fn finish(&mut self) -> Option<Box<dyn std::any::Any + Send + 'static>> {
-        let factory = self.0.take();
-        catch_unwind(AssertUnwindSafe(|| drop(factory))).err()
-    }
-}
-
-impl Drop for FactoryGuard {
-    fn drop(&mut self) {
-        let already_panicking = std::thread::panicking();
-        let panic = self.finish();
-        if !already_panicking && let Some(payload) = panic {
-            resume_unwind(payload);
-        }
-    }
 }
 
 impl ScopeRuntime {
@@ -2350,10 +2329,9 @@ impl ScopeRuntime {
         );
         let construction = child.construction.get_mut();
         let scope_child = matches!(construction, ChildConstruction::Scope(_));
-        let (body, factory_guard, declared_readiness) = match construction {
+        let (body, declared_readiness) = match construction {
             ChildConstruction::Raw(definition) => {
                 let spawn = definition.take_spawn();
-                let factory_guard = spawn.factory_guard();
                 (
                     SpawnBody::Raw {
                         spawn,
@@ -2371,26 +2349,22 @@ impl ScopeRuntime {
                             mailbox_shutdown: child.options.mailbox_shutdown,
                         },
                     },
-                    factory_guard,
                     None,
                 )
             }
             ChildConstruction::Task(definition) => {
                 let factory = Arc::clone(&definition.factory);
                 (
-                    SpawnBody::TaskRestartable(Arc::clone(&factory)),
-                    Some(Box::new(factory) as Box<dyn Send + 'static>),
+                    SpawnBody::TaskRestartable(factory),
                     Some(child.options.readiness),
                 )
             }
             ChildConstruction::TaskOnce(definition) => {
                 let body = std::mem::replace(&mut definition.body, OnceTaskBody::Spent);
                 match body {
-                    OnceTaskBody::Available(body) => (
-                        SpawnBody::TaskOnce(body),
-                        None,
-                        Some(child.options.readiness),
-                    ),
+                    OnceTaskBody::Available(body) => {
+                        (SpawnBody::TaskOnce(body), Some(child.options.readiness))
+                    }
                     OnceTaskBody::Spent => {
                         panic!("one-shot task construction invoked more than once")
                     }
@@ -2414,7 +2388,6 @@ impl ScopeRuntime {
                             ),
                             inherited,
                         },
-                        Some(Box::new(Arc::clone(factory)) as Box<dyn Send + 'static>),
                         Some(Readiness::Manual),
                     ),
                     ScopeSource::OneShot(_) => {
@@ -2434,7 +2407,6 @@ impl ScopeRuntime {
                                 ),
                                 inherited,
                             },
-                            None,
                             Some(Readiness::Manual),
                         )
                     }
@@ -2513,15 +2485,7 @@ impl ScopeRuntime {
         let constructed_sender = self.events.clone();
         let run_release = construction_release.clone();
         let child_readiness_override = child.options.readiness_override;
-        if child.options.restart.is_never() {
-            // `body` and `factory_guard` now own every live user value needed
-            // by this sole incarnation. Releasing the framework definition
-            // while those owners are still local makes its drop metadata-only;
-            // the final user destructor runs inside the task boundary below.
-            drop(child.construction.take());
-        }
         let handle = runtime::spawn(incarnation, async move {
-            let mut factory_guard = FactoryGuard::new(factory_guard);
             let body = async move {
                 match body {
                     SpawnBody::Raw { spawn, context } => {
@@ -2583,21 +2547,9 @@ impl ScopeRuntime {
                 }
             };
             let outcome = CatchUnwindFuture::new(body).await;
-            let factory_panic = factory_guard.finish();
             let result = match outcome {
-                Ok(result) => {
-                    if let Some(payload) = factory_panic {
-                        resume_unwind(payload);
-                    }
-                    result
-                }
-                Err(payload) => {
-                    // The execution panic is primary over a later factory
-                    // capture destructor panic, matching incarnation-owned
-                    // state and offload precedence.
-                    drop(factory_panic);
-                    resume_unwind(payload)
-                }
+                Ok(result) => result,
+                Err(payload) => std::panic::resume_unwind(payload),
             };
             report.record(RecordedOutcome::Returned(result));
         });
@@ -2749,15 +2701,6 @@ impl ScopeRuntime {
                 }
                 return;
             }
-            // Scope drain and planned removal suppress restart. Every
-            // restartable spawn retains a matching factory guard in the
-            // incarnation task, so releasing the driver's Arc in those modes
-            // can only make that panic boundary the final capture owner.
-            let restart_suppressed =
-                self.phase.is_draining() || child.slot.member.record().removing;
-            if restart_suppressed && let Some(construction) = child.construction.take() {
-                drop(construction);
-            }
             self.root.transition_child(
                 &child.slot.member,
                 |record| record.stage = MemberStage::Stopping,
@@ -2793,14 +2736,11 @@ impl ScopeRuntime {
                 self.begin_terminal_disposal(key, exit, None, false);
                 self.children[key].terminalize(&self.root, Exit::never_started(), None, false);
             } else {
-                // Between incarnations, the recorded exit already owns the
-                // child verdict. Do not turn detached factory cleanup into a
-                // shutdown straggler solely because there is no incarnation
-                // left to host that cleanup.
-                child.terminalize(&self.root, exit, None, false);
-                if let Some(construction) = child.construction.take() {
-                    runtime::dispose_detached(construction);
-                }
+                // Between incarnations the retained factory is still member
+                // ownership. Classify its final destructor before publishing
+                // terminality, unless hard escalation has already made all
+                // remaining cleanup detached.
+                self.begin_terminal_disposal(key, exit, None, false);
             }
         }
     }
@@ -2910,6 +2850,7 @@ impl ScopeRuntime {
     }
 
     fn force_all(&mut self) {
+        self.hard_forced = true;
         if !self.phase.is_draining() {
             self.begin_drain(StopReason::ShutdownRequested);
         }
@@ -2927,6 +2868,19 @@ impl ScopeRuntime {
             active.abort.fire();
             active.ladder = Some(ladder);
             self.advance_ladder(key, now);
+        }
+        let disposing = self
+            .children
+            .keys()
+            .filter(|key| self.children[*key].pending_terminal.is_some())
+            .collect::<Vec<_>>();
+        for key in disposing {
+            if let Some(terminal) = self.children[key].pending_terminal.as_mut()
+                && !matches!(terminal.exit.kind(), ExitKind::Panicked { .. })
+            {
+                terminal.exit = Exit::new(ExitKind::Aborted { after_grace: true }, true);
+            }
+            self.handle_construction_disposed(key, None);
         }
     }
 
@@ -3198,24 +3152,21 @@ impl ScopeRuntime {
             return;
         };
 
+        if self.hard_forced {
+            runtime::dispose_detached(construction);
+            self.handle_construction_disposed(key, None);
+            return;
+        }
+
         // The retained factory is user-owned. Destroy it on the blocking
-        // pool and join only its verdict; the scope driver remains free to
-        // advance unrelated children while the destructor runs.
-        let disposal = runtime::spawn_blocking((), move || drop(construction));
+        // pool. The disposal job itself owns completion, so cancellation or
+        // failure to spawn an auxiliary async joiner cannot strand the child.
         let sender = self.events.clone();
-        runtime::spawn((), async move {
-            let panic = match runtime::join(disposal).await {
-                runtime::JoinOutcome::Ok { .. } => None,
-                runtime::JoinOutcome::Panic { message } => Some(message),
-                runtime::JoinOutcome::Cancelled => Some(Some(
-                    "factory disposal task was cancelled before completion".to_owned(),
-                )),
-            };
-            let _ = runtime::mpsc_send(
-                &sender,
-                DriverEvent::Child(ChildEvent::ConstructionDisposed { child: key, panic }),
-            )
-            .await;
+        runtime::dispose_then(construction, move |panic| {
+            let _ = sender.blocking_send(DriverEvent::Child(ChildEvent::ConstructionDisposed {
+                child: key,
+                panic,
+            }));
         });
     }
 
@@ -3740,6 +3691,7 @@ async fn run_scope_incarnation(
         ancestor_abort: incarnation_abort,
         ancestor_abort_ack: incarnation_abort_ack,
         ancestor_abort_seen: false,
+        hard_forced: false,
         completion: None,
     };
     #[cfg(test)]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2867,18 +2867,13 @@ impl ScopeRuntime {
             return;
         }
         loop {
-            let Some(key) = self
-                .children
-                .keys()
-                .rev()
-                .find(|key| !self.children[*key].is_terminal())
-            else {
+            let Some(key) = self.children.keys().rev().find(|key| {
+                !self.children[*key].is_terminal() || self.children[*key].is_disposing()
+            }) else {
                 return;
             };
             self.begin_stop_child(key, None);
-            if self.children[key].active.is_some()
-                || (self.children[key].is_disposing() && !self.children[key].is_terminal())
-            {
+            if self.children[key].active.is_some() || self.children[key].is_disposing() {
                 return;
             }
         }

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1062,7 +1062,7 @@ impl<M: Send + 'static> MailboxCell<M> {
         if message.is_some() {
             self.changed.pulse();
         }
-        promotion.finish_isolated();
+        promotion.finish();
         message
     }
 
@@ -1186,7 +1186,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         let promotion = promote_waiters(&mut state);
         drop(state);
         self.changed.pulse();
-        promotion.finish();
+        promotion.finish_isolated();
     }
 
     fn freeze(&self, incarnation: Incarnation) {

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -648,12 +648,12 @@ pub(crate) struct MailboxStats {
     pub(crate) capacity: usize,
 }
 
-struct Promotion<M> {
+struct Promotion<M: Send + 'static> {
     displaced: Vec<Envelope<M>>,
     wakers: Vec<Waker>,
 }
 
-impl<M> Default for Promotion<M> {
+impl<M: Send + 'static> Default for Promotion<M> {
     fn default() -> Self {
         Self {
             displaced: Vec::new(),
@@ -662,16 +662,35 @@ impl<M> Default for Promotion<M> {
     }
 }
 
-impl<M> Promotion<M> {
+impl<M: Send + 'static> Promotion<M> {
     fn finish(self) {}
+
+    fn finish_isolated(mut self) {
+        let displaced = std::mem::take(&mut self.displaced);
+        if !displaced.is_empty() {
+            crate::runtime::dispose_detached(MailboxPayload {
+                queue: Some(displaced.into()),
+                latest: None,
+                retired: Vec::new(),
+            });
+        }
+        self.finish();
+    }
 }
 
-impl<M> Drop for Promotion<M> {
+impl<M: Send + 'static> Drop for Promotion<M> {
     fn drop(&mut self) {
         let already_panicking = std::thread::panicking();
         let mut first_panic = None;
         for waker in self.wakers.drain(..) {
             if let Err(payload) = catch_unwind(AssertUnwindSafe(|| waker.wake()))
+                && first_panic.is_none()
+            {
+                first_panic = Some(payload);
+            }
+        }
+        for displaced in self.displaced.drain(..) {
+            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| drop(displaced)))
                 && first_panic.is_none()
             {
                 first_panic = Some(payload);
@@ -1043,7 +1062,7 @@ impl<M: Send + 'static> MailboxCell<M> {
         if message.is_some() {
             self.changed.pulse();
         }
-        promotion.finish();
+        promotion.finish_isolated();
         message
     }
 
@@ -1231,7 +1250,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
     }
 }
 
-fn promote_waiters<M>(state: &mut MailboxState<M>) -> Promotion<M> {
+fn promote_waiters<M: Send + 'static>(state: &mut MailboxState<M>) -> Promotion<M> {
     let mut promotion = Promotion::default();
     let Some(kind) = state.kind else {
         return promotion;

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -689,16 +689,58 @@ struct Termination<M> {
 }
 
 impl<M> Termination<M> {
-    fn finish(self) {}
-
-    fn drain(&mut self) {
-        let already_panicking = std::thread::panicking();
+    fn finish(
+        &mut self,
+        retired: &mut Vec<Arc<SendOperation<M>>>,
+    ) -> Option<Box<dyn std::any::Any + Send + 'static>> {
         let mut first_panic = None;
+        let final_incarnation = self.final_incarnation;
         while let Some((registration, waiter)) = self.waiters.pop_front() {
             waiter.clear_registration(registration);
             if let Err(payload) = catch_unwind(AssertUnwindSafe(|| {
-                waiter.terminate(self.final_incarnation);
+                waiter.terminate(final_incarnation);
             })) && first_panic.is_none()
+            {
+                first_panic = Some(payload);
+            }
+            // A withdrawn sender may leave this as the final operation owner,
+            // so retain it for the same isolated path as unread messages.
+            retired.push(waiter);
+        }
+        first_panic
+    }
+}
+
+pub(crate) trait MailboxDisposal: Send {}
+
+struct MailboxPayload<M> {
+    queue: Option<VecDeque<Envelope<M>>>,
+    latest: Option<Envelope<M>>,
+    retired: Vec<Arc<SendOperation<M>>>,
+}
+
+impl<M> Drop for MailboxPayload<M> {
+    fn drop(&mut self) {
+        let already_panicking = std::thread::panicking();
+        let mut first_panic = None;
+        if let Some(mut queue) = self.queue.take() {
+            while let Some(envelope) = queue.pop_front() {
+                if let Err(payload) = catch_unwind(AssertUnwindSafe(|| drop(envelope)))
+                    && first_panic.is_none()
+                {
+                    first_panic = Some(payload);
+                }
+            }
+        }
+        if let Some(latest) = self.latest.take()
+            && let Err(payload) = catch_unwind(AssertUnwindSafe(|| drop(latest)))
+            && first_panic.is_none()
+        {
+            first_panic = Some(payload);
+        }
+        for waiter in self.retired.drain(..) {
+            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| drop(waiter)))
+                && first_panic.is_none()
             {
                 first_panic = Some(payload);
             }
@@ -709,40 +751,72 @@ impl<M> Termination<M> {
     }
 }
 
-impl<M> Drop for Termination<M> {
-    fn drop(&mut self) {
-        self.drain();
-    }
+impl<M: Send> MailboxDisposal for MailboxPayload<M> {}
+
+pub(crate) trait MailboxTermination: Send {
+    fn finish(self: Box<Self>) -> Option<Box<dyn MailboxDisposal>>;
 }
 
-pub(crate) trait MailboxTermination: Send {}
-
-struct MailboxTeardown<M> {
-    changed: Signal,
-    queue: Option<VecDeque<Envelope<M>>>,
-    latest: Option<Envelope<M>>,
+struct MailboxTeardown<M: Send + 'static> {
+    changed: Option<Signal>,
+    payload: crate::runtime::Isolated<MailboxPayload<M>>,
     termination: Option<Termination<M>>,
 }
 
-impl<M> Drop for MailboxTeardown<M> {
-    fn drop(&mut self) {
-        self.changed.pulse();
-        drop(self.queue.take());
-        drop(self.latest.take());
-        if let Some(termination) = self.termination.take() {
-            termination.finish();
+impl<M: Send + 'static> MailboxTeardown<M> {
+    fn finish_framework(&mut self) -> Option<Box<dyn std::any::Any + Send + 'static>> {
+        let mut first_panic = None;
+        if let Some(changed) = self.changed.take()
+            && let Err(payload) = catch_unwind(AssertUnwindSafe(|| changed.pulse()))
+        {
+            first_panic = Some(payload);
         }
+        if let Some(mut termination) = self.termination.take() {
+            let panic = termination.finish(&mut self.payload.get_mut().retired);
+            if first_panic.is_none() {
+                first_panic = panic;
+            }
+        }
+        first_panic
     }
 }
 
-impl<M: Send> MailboxTermination for MailboxTeardown<M> {}
+impl<M: Send + 'static> MailboxTermination for MailboxTeardown<M> {
+    fn finish(mut self: Box<Self>) -> Option<Box<dyn MailboxDisposal>> {
+        let panic = self.finish_framework();
+        let payload = self
+            .payload
+            .take()
+            .map(|payload| Box::new(payload) as Box<dyn MailboxDisposal>);
+        if let Some(panic) = panic {
+            if let Some(payload) = payload {
+                crate::runtime::dispose_detached(payload);
+            }
+            resume_unwind(panic);
+        }
+        payload
+    }
+}
+
+impl<M: Send + 'static> Drop for MailboxTeardown<M> {
+    fn drop(&mut self) {
+        let already_panicking = std::thread::panicking();
+        let panic = self.finish_framework();
+        if let Some(payload) = self.payload.take() {
+            crate::runtime::dispose_detached(payload);
+        }
+        if !already_panicking && let Some(panic) = panic {
+            resume_unwind(panic);
+        }
+    }
+}
 
 /// Type-erased control used by the supervision driver.
 pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
     fn configure(&self, mailbox: Mailbox);
     fn bind(&self, incarnation: Incarnation);
     fn freeze(&self, incarnation: Incarnation);
-    fn close(&self, incarnation: Incarnation);
+    fn close(&self, incarnation: Incarnation) -> Option<Box<dyn MailboxDisposal>>;
     fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>>;
     fn stats(&self) -> MailboxStats;
 }
@@ -1105,22 +1179,25 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         }
     }
 
-    fn close(&self, incarnation: Incarnation) {
+    fn close(&self, incarnation: Incarnation) -> Option<Box<dyn MailboxDisposal>> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         if !matches!(
             state.status,
             BindingStatus::Bound(current) | BindingStatus::Frozen(current)
                 if current == incarnation
         ) {
-            return;
+            return None;
         }
         state.status = BindingStatus::Unbound;
         let queue = std::mem::take(&mut state.queue);
         let latest = state.latest.take();
         drop(state);
         self.changed.pulse();
-        drop(queue);
-        drop(latest);
+        Some(Box::new(MailboxPayload {
+            queue: Some(queue),
+            latest,
+            retired: Vec::new(),
+        }))
     }
 
     fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>> {
@@ -1139,9 +1216,12 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         };
         drop(state);
         Some(Box::new(MailboxTeardown {
-            changed: self.changed.clone(),
-            queue: Some(queue),
-            latest,
+            changed: Some(self.changed.clone()),
+            payload: crate::runtime::Isolated::new(MailboxPayload {
+                queue: Some(queue),
+                latest,
+                retired: Vec::new(),
+            }),
             termination: Some(termination),
         }))
     }

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -226,6 +226,17 @@ impl<F: Future> Future for CatchUnwindFuture<F> {
     }
 }
 
+impl<F> Drop for CatchUnwindFuture<F> {
+    fn drop(&mut self) {
+        let already_panicking = std::thread::panicking();
+        let future = self.future.take();
+        let panic = catch_unwind(AssertUnwindSafe(|| drop(future))).err();
+        if !already_panicking && let Some(payload) = panic {
+            resume_unwind(payload);
+        }
+    }
+}
+
 enum QueuedEvent<M> {
     Deliver {
         cancellation: Latch,
@@ -1708,6 +1719,13 @@ pub(crate) enum RawSpawn {
 }
 
 impl RawSpawn {
+    pub(crate) fn factory_guard(&self) -> Option<Box<dyn Send + 'static>> {
+        match self {
+            Self::Restartable(factory) => Some(Box::new(Arc::clone(factory))),
+            Self::OneShot(_) => None,
+        }
+    }
+
     pub(crate) fn construct(self) -> Box<dyn ErasedRawInstance> {
         match self {
             Self::Restartable(factory) => factory(),

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -1719,13 +1719,6 @@ pub(crate) enum RawSpawn {
 }
 
 impl RawSpawn {
-    pub(crate) fn factory_guard(&self) -> Option<Box<dyn Send + 'static>> {
-        match self {
-            Self::Restartable(factory) => Some(Box::new(Arc::clone(factory))),
-            Self::OneShot(_) => None,
-        }
-    }
-
     pub(crate) fn construct(self) -> Box<dyn ErasedRawInstance> {
         match self {
             Self::Restartable(factory) => factory(),

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -7,7 +7,7 @@ use std::{
     panic::{AssertUnwindSafe, catch_unwind},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -160,6 +160,30 @@ where
 /// fails and drops the closure on the submitting thread.
 pub(crate) fn dispose_detached<T: Send + 'static>(value: T) {
     dispose_then(value, |_| {});
+}
+
+/// Starts isolated disposal for every value and fires once all jobs finish.
+///
+/// Each value gets its own unwind boundary, so one destructor panic cannot
+/// prevent the remaining values or the aggregate completion from running.
+pub(crate) fn dispose_all<T: Send + 'static>(values: Vec<T>) -> Latch {
+    let completion = Latch::default();
+    if values.is_empty() {
+        completion.fire();
+        return completion;
+    }
+
+    let remaining = Arc::new(AtomicUsize::new(values.len()));
+    for value in values {
+        let remaining = Arc::clone(&remaining);
+        let value_completion = completion.clone();
+        dispose_then(value, move |_| {
+            if remaining.fetch_sub(1, Ordering::AcqRel) == 1 {
+                value_completion.fire();
+            }
+        });
+    }
+    completion
 }
 
 /// A one-shot, multi-waiter signal backed by Tokio's waiter queue.

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -637,14 +637,44 @@ mod tests {
     use std::{
         future::Future,
         sync::{
-            Arc,
+            Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
         },
         task::Poll,
         time::Duration,
     };
 
-    use super::{JoinOutcome, Latch, Timeout, join, spawn, timeout, yield_now};
+    use super::{DisposalJob, JoinOutcome, Latch, Timeout, join, spawn, timeout, yield_now};
+
+    struct PanickingDrop(Arc<AtomicUsize>);
+
+    impl Drop for PanickingDrop {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            panic!("cancelled disposal job payload");
+        }
+    }
+
+    #[test]
+    fn dropping_an_unstarted_disposal_job_contains_panic_and_completes_once() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let diagnostic = Arc::new(Mutex::new(None));
+        let completion_diagnostic = Arc::clone(&diagnostic);
+        let job = DisposalJob::new(PanickingDrop(Arc::clone(&drops)), move |panic| {
+            *completion_diagnostic
+                .lock()
+                .expect("diagnostic mutex poisoned") = Some(panic);
+        });
+
+        drop(job);
+
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        let diagnostic = diagnostic.lock().expect("diagnostic mutex poisoned");
+        assert!(matches!(
+            diagnostic.as_ref(),
+            Some(Some(Some(message))) if message == "cancelled disposal job payload"
+        ));
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn exactly_one_concurrent_fire_performs_the_transition() {

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -4,6 +4,7 @@ use std::{
     fmt,
     future::Future,
     ops::RangeBounds,
+    panic::{AssertUnwindSafe, catch_unwind},
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -25,6 +26,70 @@ pub(crate) fn now() -> std::time::Instant {
 
 pub(crate) fn is_available() -> bool {
     tokio::runtime::Handle::try_current().is_ok()
+}
+
+/// Ownership wrapper for user values retained by framework state.
+///
+/// Dropping the wrapper transfers the value to an isolated blocking task, so
+/// framework futures never run user destruction as part of their own drop
+/// glue. Callers that need to classify destruction can take the value and
+/// join a dedicated blocking task explicitly.
+pub(crate) struct Isolated<T: Send + 'static> {
+    value: Option<T>,
+}
+
+impl<T: Send + 'static> Isolated<T> {
+    pub(crate) const fn new(value: T) -> Self {
+        Self { value: Some(value) }
+    }
+
+    pub(crate) fn get(&self) -> &T {
+        self.value
+            .as_ref()
+            .expect("isolated user value was already taken")
+    }
+
+    pub(crate) fn get_mut(&mut self) -> &mut T {
+        self.value
+            .as_mut()
+            .expect("isolated user value was already taken")
+    }
+
+    pub(crate) fn take(&mut self) -> Option<T> {
+        self.value.take()
+    }
+}
+
+impl<T: Send + 'static> Drop for Isolated<T> {
+    fn drop(&mut self) {
+        if let Some(value) = self.value.take() {
+            dispose_detached(value);
+        }
+    }
+}
+
+struct PanicSafeDrop<T>(Option<T>);
+
+impl<T> Drop for PanicSafeDrop<T> {
+    fn drop(&mut self) {
+        if let Some(value) = self.0.take() {
+            let _ = catch_unwind(AssertUnwindSafe(|| drop(value)));
+        }
+    }
+}
+
+/// Detaches potentially blocking or panicking user destruction from the
+/// caller. The guard also contains a panic if task/thread creation itself
+/// fails and drops the closure on the submitting thread.
+pub(crate) fn dispose_detached<T: Send + 'static>(value: T) {
+    let guarded = PanicSafeDrop(Some(value));
+    if is_available() {
+        drop(task::spawn_blocking(move || drop(guarded)));
+    } else {
+        let _ = std::thread::Builder::new()
+            .name("shelterwood-disposal".to_owned())
+            .spawn(move || drop(guarded));
+    }
 }
 
 /// A one-shot, multi-waiter signal backed by Tokio's waiter queue.

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -6,7 +6,7 @@ use std::{
     ops::RangeBounds,
     panic::{AssertUnwindSafe, catch_unwind},
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicBool, Ordering},
     },
     time::Duration,
@@ -68,28 +68,98 @@ impl<T: Send + 'static> Drop for Isolated<T> {
     }
 }
 
-struct PanicSafeDrop<T>(Option<T>);
+struct DisposalJob<T, C>
+where
+    T: Send + 'static,
+    C: FnOnce(Option<Option<String>>) + Send + 'static,
+{
+    state: Mutex<Option<(T, C)>>,
+}
 
-impl<T> Drop for PanicSafeDrop<T> {
+impl<T, C> DisposalJob<T, C>
+where
+    T: Send + 'static,
+    C: FnOnce(Option<Option<String>>) + Send + 'static,
+{
+    fn new(value: T, completion: C) -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(Some((value, completion))),
+        })
+    }
+
+    fn finish(&self) {
+        let Some((value, completion)) = self
+            .state
+            .lock()
+            .expect("disposal job mutex poisoned")
+            .take()
+        else {
+            return;
+        };
+        let panic = catch_unwind(AssertUnwindSafe(|| drop(value)))
+            .err()
+            .map(panic_message);
+        // Completion is framework bookkeeping. Contain it as well so a
+        // hostile waker or a runtime teardown race cannot unwind a blocking
+        // worker or double-panic while the job is being dropped.
+        let _ = catch_unwind(AssertUnwindSafe(|| completion(panic)));
+    }
+}
+
+impl<T, C> Drop for DisposalJob<T, C>
+where
+    T: Send + 'static,
+    C: FnOnce(Option<Option<String>>) + Send + 'static,
+{
     fn drop(&mut self) {
-        if let Some(value) = self.0.take() {
-            let _ = catch_unwind(AssertUnwindSafe(|| drop(value)));
+        self.finish();
+    }
+}
+
+fn dispatch_disposal<T, C>(job: Arc<DisposalJob<T, C>>)
+where
+    T: Send + 'static,
+    C: FnOnce(Option<Option<String>>) + Send + 'static,
+{
+    if is_available() {
+        let worker = Arc::clone(&job);
+        if let Ok(handle) = catch_unwind(AssertUnwindSafe(|| {
+            task::spawn_blocking(move || worker.finish())
+        })) {
+            drop(handle);
+            return;
         }
     }
+
+    let worker = Arc::clone(&job);
+    if std::thread::Builder::new()
+        .name("shelterwood-disposal".to_owned())
+        .spawn(move || worker.finish())
+        .is_ok()
+    {
+        return;
+    }
+
+    // Exhausted task and thread creation must not strand completion or expose
+    // a destructor panic. Blocking here is the only remaining safe fallback.
+    job.finish();
+}
+
+/// Runs potentially blocking user destruction away from the caller and then
+/// invokes framework completion with the contained panic diagnostic.
+pub(crate) fn dispose_then<T, C>(value: T, completion: C)
+where
+    T: Send + 'static,
+    C: FnOnce(Option<Option<String>>) + Send + 'static,
+{
+    dispatch_disposal(DisposalJob::new(value, completion));
 }
 
 /// Detaches potentially blocking or panicking user destruction from the
 /// caller. The guard also contains a panic if task/thread creation itself
 /// fails and drops the closure on the submitting thread.
 pub(crate) fn dispose_detached<T: Send + 'static>(value: T) {
-    let guarded = PanicSafeDrop(Some(value));
-    if is_available() {
-        drop(task::spawn_blocking(move || drop(guarded)));
-    } else {
-        let _ = std::thread::Builder::new()
-            .name("shelterwood-disposal".to_owned())
-            .spawn(move || drop(guarded));
-    }
+    dispose_then(value, |_| {});
 }
 
 /// A one-shot, multi-waiter signal backed by Tokio's waiter queue.

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -98,7 +98,7 @@ where
         };
         let panic = catch_unwind(AssertUnwindSafe(|| drop(value)))
             .err()
-            .map(panic_message);
+            .map(contain_panic_payload);
         // Completion is framework bookkeeping. Contain it as well so a
         // hostile waker or a runtime teardown race cannot unwind a blocking
         // worker or double-panic while the job is being dropped.
@@ -537,7 +537,7 @@ pub(crate) async fn join<I, T>(handle: JoinHandle<I, T>) -> JoinOutcome<T> {
     match inner.await {
         Ok(value) => JoinOutcome::Ok { value },
         Err(error) if error.is_panic() => JoinOutcome::Panic {
-            message: panic_message(error.into_panic()),
+            message: contain_panic_payload(error.into_panic()),
         },
         Err(error) => {
             debug_assert!(error.is_cancelled());
@@ -558,7 +558,17 @@ pub(crate) async fn join_resuming<I, T>(handle: JoinHandle<I, T>) -> (I, T) {
     }
 }
 
-fn panic_message(payload: Box<dyn std::any::Any + Send + 'static>) -> Option<String> {
+fn contain_panic_payload(payload: Box<dyn std::any::Any + Send + 'static>) -> Option<String> {
+    let message = catch_unwind(AssertUnwindSafe(|| panic_message(payload.as_ref())))
+        .ok()
+        .flatten();
+    // A custom panic payload is user-owned too. Its destructor may panic, so
+    // discard it under a fresh unwind boundary before publishing completion.
+    let _ = catch_unwind(AssertUnwindSafe(|| drop(payload)));
+    message
+}
+
+fn panic_message(payload: &(dyn std::any::Any + Send + 'static)) -> Option<String> {
     if let Some(message) = payload.downcast_ref::<&str>() {
         Some((*message).to_owned())
     } else {

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -157,7 +157,7 @@ pub(crate) enum ChildConstruction {
 
 enum DefinitionState {
     Undefined,
-    Defined(ChildConstruction),
+    Defined(crate::runtime::Isolated<ChildConstruction>),
     Lowered,
 }
 
@@ -179,7 +179,9 @@ impl SlotCell {
     pub(crate) fn define(&self, definition: ChildConstruction) {
         let mut state = self.definition.lock().expect("definition mutex poisoned");
         match *state {
-            DefinitionState::Undefined => *state = DefinitionState::Defined(definition),
+            DefinitionState::Undefined => {
+                *state = DefinitionState::Defined(crate::runtime::Isolated::new(definition));
+            }
             DefinitionState::Defined(_) | DefinitionState::Lowered => {
                 panic!("a child slot was defined more than once")
             }
@@ -193,7 +195,7 @@ impl SlotCell {
         )
     }
 
-    pub(crate) fn take_definition(&self) -> Option<ChildConstruction> {
+    pub(crate) fn take_definition(&self) -> Option<crate::runtime::Isolated<ChildConstruction>> {
         let mut state = self.definition.lock().expect("definition mutex poisoned");
         match std::mem::replace(&mut *state, DefinitionState::Lowered) {
             DefinitionState::Defined(definition) => Some(definition),
@@ -205,7 +207,7 @@ impl SlotCell {
         }
     }
 
-    pub(crate) fn take_defined(&self) -> Option<ChildConstruction> {
+    pub(crate) fn take_defined(&self) -> Option<crate::runtime::Isolated<ChildConstruction>> {
         let mut state = self.definition.lock().expect("definition mutex poisoned");
         match std::mem::replace(&mut *state, DefinitionState::Lowered) {
             DefinitionState::Defined(definition) => Some(definition),
@@ -311,7 +313,7 @@ impl BuilderCore {
             let definition = slot
                 .take_definition()
                 .expect("validated slot must have a definition");
-            let (options, one_shot) = match &definition {
+            let (options, one_shot) = match definition.get() {
                 ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
                 ChildConstruction::Task(definition) => (&definition.options, false),
                 ChildConstruction::TaskOnce(definition) => (&definition.options, true),
@@ -388,7 +390,7 @@ impl Drop for ScopePlan {
 
 pub(crate) struct ChildPlan {
     pub(crate) slot: Arc<SlotCell>,
-    pub(crate) construction: ChildConstruction,
+    pub(crate) construction: crate::runtime::Isolated<ChildConstruction>,
     pub(crate) options: ResolvedCommonOptions,
 }
 

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -128,8 +128,14 @@ pub enum BuildError {
 
 #[derive(Debug)]
 pub(crate) enum LowerError {
-    Undefined(Vec<Vec<ChildId>>),
-    IdentityExhausted(ChildId),
+    Undefined {
+        paths: Vec<Vec<ChildId>>,
+        disposal: crate::runtime::Latch,
+    },
+    IdentityExhausted {
+        id: ChildId,
+        disposal: crate::runtime::Latch,
+    },
 }
 
 /// Outcome of an idempotent dynamic removal.
@@ -230,6 +236,16 @@ pub(crate) struct BuilderCore {
 }
 
 impl BuilderCore {
+    fn begin_failed_disposal(&self) -> crate::runtime::Latch {
+        let definitions = self
+            .slots
+            .iter()
+            .filter_map(|slot| slot.take_defined())
+            .filter_map(|mut definition| definition.take())
+            .collect();
+        crate::runtime::dispose_all(definitions)
+    }
+
     fn new(flavor: ScopeFlavor) -> Self {
         let root_id = ChildId::from("$root");
         let mut root_identity =
@@ -290,7 +306,11 @@ impl BuilderCore {
             .map(|slot| vec![slot.member.id().clone()])
             .collect();
         if !undefined.is_empty() {
-            return Err(LowerError::Undefined(undefined));
+            let disposal = self.begin_failed_disposal();
+            return Err(LowerError::Undefined {
+                paths: undefined,
+                disposal,
+            });
         }
         if !Arc::ptr_eq(&root, &self.root) {
             let mut identity = root
@@ -298,9 +318,14 @@ impl BuilderCore {
                 .lock()
                 .expect("scope identity mutex poisoned");
             for slot in &self.slots {
-                let membership = identity
-                    .adopt_or_mint_membership(slot.member.id(), slot.member.membership())
-                    .ok_or_else(|| LowerError::IdentityExhausted(slot.member.id().clone()))?;
+                let Some(membership) =
+                    identity.adopt_or_mint_membership(slot.member.id(), slot.member.membership())
+                else {
+                    let id = slot.member.id().clone();
+                    drop(identity);
+                    let disposal = self.begin_failed_disposal();
+                    return Err(LowerError::IdentityExhausted { id, disposal });
+                };
                 if membership != slot.member.membership() {
                     slot.member.rebase_membership(membership);
                 }
@@ -728,8 +753,8 @@ fn spawn_builder<R>(
     let plan = core
         .lower(ResolvedDefaults::default(), None)
         .map_err(|error| match error {
-            LowerError::Undefined(paths) => BuildError::UnfilledReservations { paths },
-            LowerError::IdentityExhausted(_) => {
+            LowerError::Undefined { paths, .. } => BuildError::UnfilledReservations { paths },
+            LowerError::IdentityExhausted { .. } => {
                 unreachable!("root lowering does not mint memberships")
             }
         })?;

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -15,8 +15,8 @@ use crate::common::{
 };
 use shelterwood::{
     Backoff, ChildState, DynamicTree, ExitError, ExitKind, ExitResult, Jitter, LifecycleEventKind,
-    LifecycleItem, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Readiness, RemoveOutcome,
-    RestartCondition, RestartPolicy, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
+    LifecycleItem, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline,
+    RemoveOutcome, RestartCondition, RestartPolicy, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
 };
 
 struct DropProbe {
@@ -69,6 +69,50 @@ impl BlockingDropProbe {
 impl Drop for BlockingDropProbe {
     fn drop(&mut self) {
         let _ = self.dropped.send(thread::current().id());
+    }
+}
+
+struct OrderedBlockingDropProbe {
+    order: Arc<std::sync::Mutex<Vec<&'static str>>>,
+    blocker: Option<DestructorBlocker>,
+}
+
+impl OrderedBlockingDropProbe {
+    fn new(gate: &DestructorGate, order: Arc<std::sync::Mutex<Vec<&'static str>>>) -> Self {
+        Self {
+            order,
+            blocker: Some(gate.blocker()),
+        }
+    }
+}
+
+impl Drop for OrderedBlockingDropProbe {
+    fn drop(&mut self) {
+        self.order
+            .lock()
+            .expect("order mutex is available")
+            .push("later-dispose-start");
+        drop(self.blocker.take());
+        self.order
+            .lock()
+            .expect("order mutex is available")
+            .push("later-dispose-end");
+    }
+}
+
+struct PanickingPanicPayload;
+
+impl Drop for PanickingPanicPayload {
+    fn drop(&mut self) {
+        panic!("panic payload destructor");
+    }
+}
+
+struct PanicAnyOnDrop;
+
+impl Drop for PanicAnyOnDrop {
+    fn drop(&mut self) {
+        std::panic::panic_any(PanickingPanicPayload);
     }
 }
 
@@ -454,6 +498,105 @@ async fn unadmitted_removal_completes_after_blocking_definition_disposal() {
         .shutdown(Duration::from_secs(1))
         .await
         .expect("dynamic root shuts down");
+}
+
+#[tokio::test]
+async fn unadmitted_removal_completes_when_the_panic_payload_destructor_panics() {
+    let tree = DynamicTree::new();
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+    let slot = scope.reserve_task("pending").expect("task reservation");
+    let task = slot.task_ref();
+    let admission = slot.define(TaskDef::new({
+        let capture = PanicAnyOnDrop;
+        move |_| {
+            let _ = &capture;
+            async { Ok(()) }
+        }
+    }));
+
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), scope.remove_task(&task))
+            .await
+            .expect("panic payload disposal publishes removal completion"),
+        RemoveOutcome::Removed
+    );
+    assert!(matches!(task.wait().await.kind(), ExitKind::NeverStarted));
+    drop(admission);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root shuts down");
+}
+
+#[tokio::test]
+async fn ordered_shutdown_waits_for_later_unstarted_definition_disposal() {
+    let gate = DestructorGate::default();
+    let order = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let (started, mut starts) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    tree.add_task(
+        "earlier",
+        TaskDef::new({
+            let order = Arc::clone(&order);
+            move |context| {
+                let shutdown = context.shutdown_token();
+                started
+                    .send(shutdown.clone())
+                    .expect("test observes task startup");
+                let order = Arc::clone(&order);
+                async move {
+                    shutdown.cancelled().await;
+                    order
+                        .lock()
+                        .expect("order mutex is available")
+                        .push("earlier-stop");
+                    Ok(())
+                }
+            }
+        })
+        .readiness(Readiness::Manual)
+        .expect("manual readiness")
+        .readiness_deadline(ReadinessDeadline::Unbounded),
+    )
+    .expect("valid earlier task");
+    let (_later, _completion) = tree
+        .add_task_once(
+            "later",
+            TaskOnceDef::new({
+                let capture = OrderedBlockingDropProbe::new(&gate, Arc::clone(&order));
+                move |_| {
+                    let _ = &capture;
+                    async { Ok::<_, ExitError>(()) }
+                }
+            }),
+        )
+        .expect("valid later task");
+
+    let system = tree.spawn().expect("runtime is available");
+    let shutdown_token = starts.recv().await.expect("earlier task starts");
+    let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(1)));
+    wait_for_destructor(&gate).await;
+    assert!(
+        !shutdown_token.is_cancelled(),
+        "earlier child must remain live while later definition disposal is pending"
+    );
+    assert_eq!(
+        *order.lock().expect("order mutex is available"),
+        ["later-dispose-start"]
+    );
+
+    gate.release();
+    shutdown_token.cancelled().await;
+    shutdown
+        .await
+        .expect("shutdown task joins")
+        .expect("ordered root shuts down");
+    assert_eq!(
+        *order.lock().expect("order mutex is available"),
+        ["later-dispose-start", "later-dispose-end", "earlier-stop"]
+    );
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -1,0 +1,251 @@
+use std::{
+    marker::PhantomData,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use crate::common::{DestructorBlocker, DestructorGate, PanicOnDrop, policy::never, poll_until};
+use shelterwood::{
+    ExitKind, ExitResult, LifecycleEventKind, LifecycleItem, RawActor, RawContext, RawOnceDef,
+    TaskDef, Tree,
+};
+
+struct Unread<M>(PhantomData<M>);
+
+impl<M> Default for Unread<M> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<M: Send + 'static> RawActor for Unread<M> {
+    type Msg = M;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        context.shutdown_token().cancelled().await;
+        Ok(())
+    }
+}
+
+async fn wait_for_destructor(gate: &DestructorGate) {
+    let gate = gate.clone();
+    tokio::task::spawn_blocking(move || gate.wait_entered())
+        .await
+        .expect("destructor waiter joins");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn blocking_unread_message_does_not_hold_bounded_shutdown() {
+    let gate = DestructorGate::default();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "unread",
+            RawOnceDef::new(Unread::<DestructorBlocker>::default()),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    actor
+        .send(gate.blocker())
+        .await
+        .expect("message is accepted without being read");
+
+    let mut shutdown = tokio::spawn(system.shutdown(Duration::from_secs(1)));
+    wait_for_destructor(&gate).await;
+    let bounded = tokio::time::timeout(Duration::from_secs(1), &mut shutdown).await;
+    gate.release();
+    let result = match bounded {
+        Ok(joined) => joined.expect("shutdown task joins"),
+        Err(_) => {
+            let _ = shutdown.await;
+            panic!("an unread-message destructor held the scope driver")
+        }
+    };
+    result.expect("scope shuts down while message destruction is blocked");
+}
+
+struct CountedPanic {
+    drops: Arc<AtomicUsize>,
+    message: &'static str,
+}
+
+impl CountedPanic {
+    fn new(drops: &Arc<AtomicUsize>, message: &'static str) -> Self {
+        Self {
+            drops: Arc::clone(drops),
+            message,
+        }
+    }
+}
+
+impl Drop for CountedPanic {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+        panic!("{}", self.message);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn panicking_unread_messages_are_all_disposed_without_reclassifying_the_actor() {
+    let drops = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once("unread", RawOnceDef::new(Unread::<CountedPanic>::default()))
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    let scope = system.scope();
+    system.wait_started().await.expect("actor starts");
+    let mut lifecycle = scope.subscribe_lifecycle();
+    actor
+        .send(CountedPanic::new(&drops, "first payload destructor"))
+        .await
+        .expect("first message is accepted");
+    actor
+        .send(CountedPanic::new(&drops, "second payload destructor"))
+        .await
+        .expect("second message is accepted");
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("payload panics do not unwind the scope driver");
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            drops.load(Ordering::SeqCst) == 2
+        })
+        .await,
+        "one payload panic must not strand the remaining unread messages"
+    );
+    let exit = loop {
+        let Some(item) = lifecycle.recv().await else {
+            panic!("actor exit was not published")
+        };
+        if let LifecycleItem::Event(event) = item
+            && let LifecycleEventKind::Exited { id, exit, .. } = event.kind
+            && id.as_str() == "unread"
+        {
+            break exit;
+        }
+    };
+    assert!(matches!(exit.kind(), ExitKind::Completed));
+    assert!(exit.cancelled());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn factory_capture_destructor_panics_are_isolated_classified_and_independent() {
+    let drops = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let first = tree
+        .add_task(
+            "first",
+            TaskDef::new({
+                let capture = CountedPanic::new(&drops, "first factory destructor");
+                move |_| {
+                    let _ = &capture;
+                    async { Ok(()) }
+                }
+            })
+            .restart(never()),
+        )
+        .expect("valid first task");
+    let second = tree
+        .add_task(
+            "second",
+            TaskDef::new({
+                let capture = CountedPanic::new(&drops, "second factory destructor");
+                move |_| {
+                    let _ = &capture;
+                    async { Ok(()) }
+                }
+            })
+            .restart(never()),
+        )
+        .expect("valid second task");
+
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("tasks start");
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert_eq!(drops.load(Ordering::SeqCst), 2);
+
+    let first_exit = first.wait().await;
+    assert!(matches!(
+        first_exit.kind(),
+        ExitKind::Panicked { message } if message.as_deref() == Some("first factory destructor")
+    ));
+    let second_exit = second.wait().await;
+    assert!(matches!(
+        second_exit.kind(),
+        ExitKind::Panicked { message } if message.as_deref() == Some("second factory destructor")
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn factory_capture_destructor_panic_is_classified_during_shutdown() {
+    let drops = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let task = tree
+        .add_task(
+            "shutdown",
+            TaskDef::new({
+                let capture = CountedPanic::new(&drops, "shutdown factory destructor");
+                move |context| {
+                    let _ = &capture;
+                    async move {
+                        context.shutdown_token().cancelled().await;
+                        Ok(())
+                    }
+                }
+            })
+            .restart(never()),
+        )
+        .expect("valid task");
+
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("task starts");
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("factory destruction stays off the scope driver");
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    let exit = task.wait().await;
+    assert!(matches!(
+        exit.kind(),
+        ExitKind::Panicked { message }
+            if message.as_deref() == Some("shutdown factory destructor")
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn incarnation_panic_remains_primary_over_factory_destructor_panic() {
+    let mut tree = Tree::new();
+    let task = tree
+        .add_task(
+            "precedence",
+            TaskDef::new({
+                let capture = PanicOnDrop::new("secondary factory destructor");
+                move |_| {
+                    let _ = &capture;
+                    async move {
+                        let _incarnation = PanicOnDrop::new("primary incarnation destructor");
+                        Ok(())
+                    }
+                }
+            })
+            .restart(never()),
+        )
+        .expect("valid task");
+
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("task starts");
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    let exit = task.wait().await;
+    assert!(matches!(
+        exit.kind(),
+        ExitKind::Panicked { message }
+            if message.as_deref() == Some("primary incarnation destructor")
+    ));
+}

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -16,7 +16,7 @@ use crate::common::{
 use shelterwood::{
     Backoff, ChildState, DynamicTree, ExitError, ExitKind, ExitResult, Jitter, LifecycleEventKind,
     LifecycleItem, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Readiness, RemoveOutcome,
-    RestartCondition, RestartPolicy, TaskDef, TaskOnceDef, Tree,
+    RestartCondition, RestartPolicy, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
 };
 
 struct DropProbe {
@@ -549,6 +549,46 @@ async fn startup_rollback_detaches_never_started_one_shot_state_after_escalation
             .kind(),
         ExitKind::NeverStarted
     ));
+}
+
+#[tokio::test]
+async fn hard_shutdown_detaches_failed_nested_lowering_disposal() {
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut nested = Tree::new();
+    let _undefined = nested.reserve_task("undefined").expect("task reservation");
+    let (_task, _completion) = nested
+        .add_task_once(
+            "blocked-definition",
+            TaskOnceDef::new({
+                let state = BlockingDropProbe::new(&gate, dropped);
+                move |_| {
+                    let _ = &state;
+                    async { Ok::<_, ExitError>(()) }
+                }
+            }),
+        )
+        .expect("valid one-shot definition");
+    let mut tree = Tree::new();
+    tree.add_subtree_once("nested", SubtreeOnceDef::new(nested))
+        .expect("valid one-shot subtree");
+
+    let system = tree.spawn().expect("runtime is available");
+    wait_for_destructor(&gate).await;
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("failed definition disposal reports its thread"),
+        thread::current().id()
+    );
+    let mut shutdown = tokio::spawn(system.shutdown(Duration::ZERO));
+    let bounded = tokio::time::timeout(Duration::from_secs(1), &mut shutdown).await;
+    gate.release();
+    let result = bounded
+        .expect("hard shutdown is not held by failed lowering disposal")
+        .expect("shutdown task joins");
+    assert!(result.is_err(), "the still-live subtree is a straggler");
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -1,17 +1,76 @@
 use std::{
+    future::{Future, poll_fn},
     marker::PhantomData,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
+    task::Poll,
+    thread::{self, ThreadId},
     time::Duration,
 };
 
-use crate::common::{DestructorBlocker, DestructorGate, PanicOnDrop, policy::never, poll_until};
-use shelterwood::{
-    ExitKind, ExitResult, LifecycleEventKind, LifecycleItem, RawActor, RawContext, RawOnceDef,
-    TaskDef, Tree,
+use crate::common::{
+    DestructorBlocker, DestructorGate, PanicOnDrop, ReleaseGate, policy::never, poll_until,
 };
+use shelterwood::{
+    Backoff, ChildState, DynamicTree, ExitError, ExitKind, ExitResult, Jitter, LifecycleEventKind,
+    LifecycleItem, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Readiness, RemoveOutcome,
+    RestartCondition, RestartPolicy, TaskDef, TaskOnceDef, Tree,
+};
+
+struct DropProbe {
+    dropped: tokio::sync::mpsc::UnboundedSender<ThreadId>,
+    panic: Option<&'static str>,
+}
+
+impl DropProbe {
+    fn reporting(dropped: tokio::sync::mpsc::UnboundedSender<ThreadId>) -> Self {
+        Self {
+            dropped,
+            panic: None,
+        }
+    }
+
+    fn panicking(
+        dropped: tokio::sync::mpsc::UnboundedSender<ThreadId>,
+        message: &'static str,
+    ) -> Self {
+        Self {
+            dropped,
+            panic: Some(message),
+        }
+    }
+}
+
+impl Drop for DropProbe {
+    fn drop(&mut self) {
+        let _ = self.dropped.send(thread::current().id());
+        if let Some(message) = self.panic {
+            panic!("{message}");
+        }
+    }
+}
+
+struct BlockingDropProbe {
+    dropped: tokio::sync::mpsc::UnboundedSender<ThreadId>,
+    _blocker: DestructorBlocker,
+}
+
+impl BlockingDropProbe {
+    fn new(gate: &DestructorGate, dropped: tokio::sync::mpsc::UnboundedSender<ThreadId>) -> Self {
+        Self {
+            dropped,
+            _blocker: gate.blocker(),
+        }
+    }
+}
+
+impl Drop for BlockingDropProbe {
+    fn drop(&mut self) {
+        let _ = self.dropped.send(thread::current().id());
+    }
+}
 
 struct Unread<M>(PhantomData<M>);
 
@@ -35,6 +94,14 @@ async fn wait_for_destructor(gate: &DestructorGate) {
     tokio::task::spawn_blocking(move || gate.wait_entered())
         .await
         .expect("destructor waiter joins");
+}
+
+async fn poll_pending<F: Future>(future: &mut std::pin::Pin<Box<F>>) {
+    poll_fn(|context| match future.as_mut().poll(context) {
+        Poll::Pending => Poll::Ready(()),
+        Poll::Ready(_) => panic!("operation completed before its owned disposal"),
+    })
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -247,5 +314,347 @@ async fn incarnation_panic_remains_primary_over_factory_destructor_panic() {
         exit.kind(),
         ExitKind::Panicked { message }
             if message.as_deref() == Some("primary incarnation destructor")
+    ));
+}
+
+#[test]
+fn final_factory_capture_is_destroyed_outside_the_current_thread_driver() {
+    let driver_thread = thread::current().id();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .expect("test runtime");
+    let dropped = runtime.block_on(async {
+        let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+        let mut tree = Tree::new();
+        tree.add_task(
+            "factory",
+            TaskDef::new({
+                let capture = DropProbe::reporting(dropped);
+                move |_| {
+                    let _ = &capture;
+                    async { Ok(()) }
+                }
+            })
+            .restart(never()),
+        )
+        .expect("valid task");
+        let system = tree.spawn().expect("runtime is available");
+        assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+        drops.recv().await.expect("factory capture was destroyed")
+    });
+    assert_ne!(dropped, driver_thread);
+}
+
+#[test]
+fn latest_prebind_conflation_is_destroyed_outside_the_current_thread_driver() {
+    let driver_thread = thread::current().id();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .expect("test runtime");
+    let displaced_thread = runtime.block_on(async {
+        let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+        let mut tree = Tree::new();
+        let actor = tree
+            .add_raw_once(
+                "latest",
+                RawOnceDef::new(Unread::<DropProbe>::default()).mailbox(Mailbox::Latest),
+            )
+            .expect("valid actor");
+
+        let mut first = Box::pin(actor.send(DropProbe::reporting(dropped.clone())));
+        let mut second = Box::pin(actor.send(DropProbe::reporting(dropped)));
+        poll_pending(&mut first).await;
+        poll_pending(&mut second).await;
+
+        let system = tree.spawn().expect("runtime is available");
+        system.wait_started().await.expect("actor starts");
+        let displaced_thread = drops
+            .recv()
+            .await
+            .expect("first latest value was displaced");
+        assert!(first.await.is_ok());
+        assert!(second.await.is_ok());
+        system
+            .shutdown(Duration::from_secs(1))
+            .await
+            .expect("latest actor shuts down");
+        displaced_thread
+    });
+    assert_ne!(displaced_thread, driver_thread);
+}
+
+#[tokio::test]
+async fn non_runtime_reservation_cancellation_contains_destructor_panic() {
+    let tree = DynamicTree::new();
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let slot = scope.reserve_task("cancelled").expect("task reservation");
+    let task = slot.task_ref();
+    let admission = slot.define(TaskDef::new({
+        let capture = DropProbe::panicking(dropped, "cancelled definition destructor");
+        move |_| {
+            let _ = &capture;
+            async { Ok(()) }
+        }
+    }));
+
+    let cancellation = thread::spawn(move || {
+        let cancellation_thread = thread::current().id();
+        drop(admission);
+        cancellation_thread
+    });
+    let cancellation_thread = cancellation
+        .join()
+        .expect("cancellation outside a Tokio runtime must not panic");
+    let disposal_thread = drops.recv().await.expect("definition was disposed");
+    assert_ne!(disposal_thread, cancellation_thread);
+    assert!(matches!(task.wait().await.kind(), ExitKind::NeverStarted));
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root shuts down");
+}
+
+#[tokio::test]
+async fn unadmitted_removal_completes_after_blocking_definition_disposal() {
+    let tree = DynamicTree::new();
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let slot = scope.reserve_task("pending").expect("task reservation");
+    let task = slot.task_ref();
+    let admission = slot.define(TaskDef::new({
+        let capture = BlockingDropProbe::new(&gate, dropped);
+        move |_| {
+            let _ = &capture;
+            async { Ok(()) }
+        }
+    }));
+    let mut removal = Box::pin(scope.remove_task(&task));
+    wait_for_destructor(&gate).await;
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("definition disposal reports its thread"),
+        thread::current().id()
+    );
+    assert!(matches!(task.wait().await.kind(), ExitKind::NeverStarted));
+    poll_pending(&mut removal).await;
+    gate.release();
+    assert_eq!(removal.await, RemoveOutcome::Removed);
+    drop(admission);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root shuts down");
+}
+
+#[tokio::test]
+async fn hard_shutdown_detaches_a_blocking_factory_disposal() {
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let task = tree
+        .add_task(
+            "blocked-factory",
+            TaskDef::new({
+                let capture = BlockingDropProbe::new(&gate, dropped);
+                move |context| {
+                    let _ = &capture;
+                    async move {
+                        context.shutdown_token().cancelled().await;
+                        Ok(())
+                    }
+                }
+            }),
+        )
+        .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("task starts");
+
+    let mut shutdown = tokio::spawn(system.shutdown(Duration::ZERO));
+    wait_for_destructor(&gate).await;
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("factory disposal reports its thread"),
+        thread::current().id()
+    );
+    let bounded = tokio::time::timeout(Duration::from_secs(1), &mut shutdown).await;
+    gate.release();
+    let result = bounded
+        .expect("hard escalation is not held by factory disposal")
+        .expect("shutdown task joins");
+    result.expect("post-exit disposal is not an actor straggler");
+    let exit = task.wait().await;
+    assert!(matches!(exit.kind(), ExitKind::Completed));
+    assert!(exit.cancelled());
+}
+
+#[tokio::test]
+async fn startup_rollback_detaches_never_started_one_shot_state_after_escalation() {
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    tree.add_task(
+        "fails",
+        TaskDef::new(|_| async { Err(ExitError::message("startup failure")) })
+            .restart(never())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness"),
+    )
+    .expect("valid failing task");
+    let (_never_started, completion) = tree
+        .add_task_once(
+            "never-started",
+            TaskOnceDef::new({
+                let state = BlockingDropProbe::new(&gate, dropped);
+                move |_| {
+                    let _ = &state;
+                    async { Ok::<_, ExitError>(()) }
+                }
+            }),
+        )
+        .expect("valid one-shot suffix");
+
+    let system = tree.spawn().expect("runtime is available");
+    let mut rollback = tokio::spawn(system.start_or_shutdown(Duration::ZERO));
+    wait_for_destructor(&gate).await;
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("one-shot state reports its thread"),
+        thread::current().id()
+    );
+    let bounded = tokio::time::timeout(Duration::from_secs(1), &mut rollback).await;
+    gate.release();
+    let result = bounded
+        .expect("rollback escalation is not held by one-shot state")
+        .expect("rollback task joins");
+    assert!(result.is_err(), "startup failure is preserved");
+    assert!(matches!(
+        completion
+            .wait()
+            .await
+            .expect_err("the ordered suffix never ran")
+            .kind(),
+        ExitKind::NeverStarted
+    ));
+}
+
+#[tokio::test]
+async fn restart_window_cleanup_is_isolated_without_reclassifying_the_recorded_exit() {
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let task = tree
+        .add_task(
+            "restarting",
+            TaskDef::new({
+                let capture = DropProbe::panicking(dropped, "restart-window factory destructor");
+                move |_| {
+                    let _ = &capture;
+                    async { Err(ExitError::message("restart me")) }
+                }
+            })
+            .restart(RestartPolicy::new(
+                RestartCondition::OnFailure,
+                Backoff::fixed(Duration::from_secs(60), Jitter::None).expect("fixed backoff"),
+            )),
+        )
+        .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+    let scope = system.scope();
+    system
+        .wait_started()
+        .await
+        .expect("first incarnation starts");
+    scope
+        .wait_for_child(
+            "restarting",
+            |child| matches!(child.state, ChildState::Restarting),
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("task enters restart backoff");
+    system
+        .shutdown(Duration::ZERO)
+        .await
+        .expect("restart-window cleanup does not become a shutdown straggler");
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("restart-window factory was disposed"),
+        thread::current().id()
+    );
+    assert!(matches!(
+        task.wait().await.kind(),
+        ExitKind::Failed(error) if error.to_string() == "restart me"
+    ));
+}
+
+struct OffloadPanic {
+    run: ReleaseGate,
+}
+
+impl RawActor for OffloadPanic {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        self.run.wait().await;
+        let _: () = context
+            .run_blocking(|_| -> () { panic!("primary blocking offload panic") })
+            .await;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn blocking_offload_panic_remains_primary_over_factory_destructor_panic() {
+    let run = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.add_raw(
+        "offload-precedence",
+        RawDef::factory({
+            let capture = PanicOnDrop::new("secondary raw factory destructor");
+            let run = run.clone();
+            move || {
+                let _ = &capture;
+                OffloadPanic { run: run.clone() }
+            }
+        })
+        .restart(never()),
+    )
+    .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    let mut lifecycle = system.scope().subscribe_lifecycle();
+    run.release();
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+
+    let exit = loop {
+        let Some(item) = lifecycle.recv().await else {
+            panic!("actor exit was not published")
+        };
+        if let LifecycleItem::Event(event) = item
+            && let LifecycleEventKind::Exited { id, exit, .. } = event.kind
+            && id.as_str() == "offload-precedence"
+        {
+            break exit;
+        }
+    };
+    assert!(matches!(
+        exit.kind(),
+        ExitKind::Panicked { message }
+            if message.as_deref() == Some("primary blocking offload panic")
     ));
 }

--- a/crates/shelterwood/tests/mod.rs
+++ b/crates/shelterwood/tests/mod.rs
@@ -6,6 +6,7 @@ mod api_trait_conformance;
 mod common;
 mod deadlines;
 mod delivery;
+mod disposal;
 mod drain;
 mod dynamic;
 mod events;


### PR DESCRIPTION
## Summary

- move unread mailbox payload destruction onto isolated blocking disposal boundaries while retaining synchronous terminal mailbox state and waiter wake ordering
- keep restartable factory captures owned by incarnation/drop boundaries, preserving primary execution-panic precedence and classifying terminal capture destructor panics as child panics
- isolate definitions that never become incarnations, and delay admission/removal completion where resource-ownership ordering requires joined disposal
- add deterministic regression coverage for blocking unread-message destructors, independent payload panics, multiple factory-capture panics, shutdown classification, and double-panic precedence

## Why

The supervisor driver retained application messages and factory captures in its own state. Their destructors could therefore block or panic while the driver was advancing lifecycle state, potentially stalling bounded shutdown, unwinding the driver, or suppressing later cleanup. Framework state now retains only isolated ownership wrappers or metadata; user destruction runs at a detached blocking boundary or the relevant incarnation boundary.

## Validation

- `./scripts/dev just ci`
- `./scripts/dev just ci-nix`
- focused disposal and ownership/race regression tests

Part of #35 (item 7)