### PR TITLE
Fix recursive shutdown test ownership

### DIFF
--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -472,27 +472,25 @@ async fn owning_shutdown_joins_recursively_aborted_scope_drivers() {
     let started = Arc::new(AtomicBool::new(false));
     let release = Arc::new((Mutex::new(false), Condvar::new()));
     let mut inner = Tree::new();
-    inner
-        .add_task(
+    // Keep the probe exclusively in the live future. Restartable factories
+    // are retained definitions whose cleanup is intentionally detached after
+    // hard escalation, so they cannot witness the recursive driver join.
+    let (_leaf, _completion) = inner
+        .add_task_once(
             "leaf",
-            TaskDef::new({
+            TaskOnceDef::new({
                 let held = Arc::clone(&held);
                 let started = Arc::clone(&started);
                 let release = Arc::clone(&release);
-                move |_| {
-                    let held = Arc::clone(&held);
-                    let started = Arc::clone(&started);
-                    let release = Arc::clone(&release);
-                    async move {
-                        let _held = held;
-                        started.store(true, Ordering::Release);
-                        let (released, wake) = &*release;
-                        let mut released = released.lock().expect("release mutex poisoned");
-                        while !*released {
-                            released = wake.wait(released).expect("release mutex poisoned");
-                        }
-                        Ok(())
+                move |_| async move {
+                    let _held = held;
+                    started.store(true, Ordering::Release);
+                    let (released, wake) = &*release;
+                    let mut released = released.lock().expect("release mutex poisoned");
+                    while !*released {
+                        released = wake.wait(released).expect("release mutex poisoned");
                     }
+                    Ok(())
                 }
             })
             .shutdown(Shutdown::Graceful {
@@ -536,7 +534,7 @@ async fn owning_shutdown_joins_recursively_aborted_scope_drivers() {
 
     assert!(
         weak.upgrade().is_none(),
-        "shutdown returns only after every nested driver and construction drops"
+        "shutdown returns only after every nested driver and active future drops"
     );
 }
 

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -521,16 +521,23 @@ async fn owning_shutdown_joins_recursively_aborted_scope_drivers() {
         "leaf starts polling"
     );
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(5)));
-    assert_quiet(Duration::from_millis(50), || shutdown.is_finished()).await;
+    let returned_before_leaf_released =
+        poll_until(Duration::from_millis(50), Duration::from_millis(1), || {
+            shutdown.is_finished()
+        })
+        .await;
     {
         let (released, wake) = &*release;
         *released.lock().expect("release mutex poisoned") = true;
         wake.notify_all();
     }
-    shutdown
-        .await
-        .expect("shutdown task does not panic")
-        .expect("root shuts down");
+    let shutdown_result = shutdown.await.expect("shutdown task does not panic");
+
+    assert!(
+        !returned_before_leaf_released,
+        "shutdown must not return while a recursively aborted child future is still polling"
+    );
+    shutdown_result.expect("root shuts down");
 
     assert!(
         weak.upgrade().is_none(),


### PR DESCRIPTION
## Summary

- make the recursive shutdown join regression use a one-shot task
- keep the lifetime probe exclusively in the active task future
- ensure an early-return regression releases and joins the blocking fixture before asserting
- clarify that the ownership assertion covers nested drivers and active futures

## Root cause

Main CI's cache-seeding `just ci` rerun failed in `owning_shutdown_joins_recursively_aborted_scope_drivers`. The test used a restartable task factory, so the probed `Arc` was retained both by the active future and by the factory definition. Hard escalation intentionally detaches retained-factory disposal, allowing shutdown to complete before that unrelated factory reference is dropped. The final `Weak` assertion therefore raced detached cleanup instead of measuring recursive driver joining.

Using a one-shot task removes the retained restartable factory from the ownership probe while preserving the blocked active future and recursive hard-abort path that the test is intended to verify. Production shutdown semantics are unchanged.

The early-return observation is recorded before the blocking leaf is released, but asserted only after release and shutdown-task join. This keeps the regression failure prompt and prevents the test runtime from hanging on the intentionally blocked worker.

Failing run: https://github.com/ralexstokes/shelterwood/actions/runs/31271979857

## Validation

- `./scripts/dev cargo nextest run --locked -p shelterwood --all-features --test integration owning_shutdown_joins_recursively_aborted_scope_drivers --stress-count 500 --no-fail-fast`
- mutation check restoring the pre-fix ancestor-abort return: the revised test failed promptly at the early-return assertion
- `./scripts/dev just ci` (304 tests and all lint, doctest, docs, API/path, packaging, and formatting checks passed)