### PR TITLE
Fix restart-window shutdown and offload wakeups

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1143,6 +1143,7 @@ impl ScopeCell {
 
     pub(crate) fn request_shutdown(&self) -> u64 {
         let mut control = self.control.lock().expect("scope control mutex poisoned");
+        let pending_incarnation = !control.live;
         let target = if control.live {
             control.current_epoch
         } else {
@@ -1159,7 +1160,24 @@ impl ScopeCell {
         }
         drop(control);
         self.member.record.pulse();
+        // A nested scope has no live driver while its parent is retaining it
+        // in restart backoff. Wake that parent as well so it can start the
+        // pending incarnation immediately; that incarnation consumes the
+        // stop and begins the timeout-bounded teardown required by B.9.
+        if pending_incarnation
+            && let Some(parent) = self.parent.read_cloned().as_ref().and_then(Weak::upgrade)
+        {
+            parent.member.record.pulse();
+        }
         target
+    }
+
+    fn has_pending_incarnation_shutdown(&self) -> bool {
+        let control = self.control.lock().expect("scope control mutex poisoned");
+        !control.live
+            && control.shutdown.is_some_and(|request| {
+                !request.consumed && request.epoch > control.last_stopped_epoch
+            })
     }
 
     fn take_shutdown_request(&self, epoch: u64) -> bool {
@@ -2270,6 +2288,22 @@ enum SpawnBody {
 }
 
 impl ScopeRuntime {
+    fn pending_restart_shutdowns(&self) -> Vec<ChildKey> {
+        self.children
+            .keys()
+            .filter(|key| {
+                let child = &self.children[*key];
+                child.active.is_none()
+                    && matches!(child.slot.member.record().stage, MemberStage::Restarting)
+                    && child
+                        .slot
+                        .scope
+                        .as_ref()
+                        .is_some_and(|scope| scope.has_pending_incarnation_shutdown())
+            })
+            .collect()
+    }
+
     #[cfg(test)]
     fn record_storage(&self) {
         *self
@@ -2288,7 +2322,11 @@ impl ScopeRuntime {
         let Some(child) = self.children.get(key) else {
             return;
         };
-        if self.phase.is_draining() || child.is_terminal() || child.is_disposing() {
+        if self.phase.is_draining()
+            || child.active.is_some()
+            || child.is_terminal()
+            || child.is_disposing()
+        {
             return;
         }
         let child = &mut self.children[key];
@@ -3752,6 +3790,12 @@ async fn run_scope_incarnation(
         if root.take_shutdown_request(epoch) {
             pending.push((ArbitrationClass::ScopeShutdown, Pending::Shutdown));
         }
+        for child in scope.pending_restart_shutdowns() {
+            pending.push((
+                ArbitrationClass::ScopeShutdown,
+                Pending::RestartShutdown(child),
+            ));
+        }
         if !scope.ancestor_shutdown_seen
             && scope
                 .ancestor_shutdown
@@ -3870,6 +3914,7 @@ async fn run_scope_incarnation(
                     }
                     scope.begin_drain(StopReason::ShutdownRequested);
                 }
+                Pending::RestartShutdown(child) => scope.spawn_child(child),
                 Pending::AncestorShutdown => {
                     scope.begin_drain(StopReason::ShutdownRequested);
                 }
@@ -3946,6 +3991,7 @@ async fn run_scope_incarnation(
 
 enum Pending {
     Shutdown,
+    RestartShutdown(ChildKey),
     AncestorShutdown,
     AncestorAbort,
     Force,

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -3840,15 +3840,7 @@ async fn run_scope_incarnation(
             pending.push((ArbitrationClass::ScopeShutdown, Pending::Shutdown));
         }
         for child in scope.pending_restart_shutdowns() {
-            pending.push((
-                // This starts a pending incarnation, so it is restart work,
-                // not a scope-shutdown transition. In particular, a child
-                // exit collected in the same wake must first get the chance
-                // to trip intensity or fail startup; the execution-time
-                // suppression check then observes that drain.
-                ArbitrationClass::BackoffDue,
-                Pending::RestartShutdown(child),
-            ));
+            pending.push(restart_shutdown_work(child));
         }
         if !scope.ancestor_shutdown_seen
             && scope
@@ -3874,17 +3866,7 @@ async fn run_scope_incarnation(
             ));
         }
         while let Some(event) = runtime::mpsc_try_recv(&mut event_receiver) {
-            let class = match event {
-                DriverEvent::Child(ChildEvent::SelfStop { .. }) => {
-                    ArbitrationClass::MembershipRemoval
-                }
-                DriverEvent::Child(ChildEvent::Constructed { .. })
-                | DriverEvent::Child(ChildEvent::Ready { .. }) => ArbitrationClass::ReadinessSignal,
-                DriverEvent::Child(
-                    ChildEvent::Exited { .. } | ChildEvent::ConstructionDisposed { .. },
-                ) => ArbitrationClass::ChildExit,
-                DriverEvent::Admission(_) => ArbitrationClass::Admission,
-            };
+            let class = driver_event_class(&event);
             pending.push((class, Pending::Driver(event)));
         }
         let now = runtime::now();
@@ -3939,19 +3921,7 @@ async fn run_scope_incarnation(
                     continue;
                 }
                 runtime::ScopeWake::Message(Some(event)) => {
-                    let class = match event {
-                        DriverEvent::Child(ChildEvent::SelfStop { .. }) => {
-                            ArbitrationClass::MembershipRemoval
-                        }
-                        DriverEvent::Child(ChildEvent::Constructed { .. })
-                        | DriverEvent::Child(ChildEvent::Ready { .. }) => {
-                            ArbitrationClass::ReadinessSignal
-                        }
-                        DriverEvent::Child(
-                            ChildEvent::Exited { .. } | ChildEvent::ConstructionDisposed { .. },
-                        ) => ArbitrationClass::ChildExit,
-                        DriverEvent::Admission(_) => ArbitrationClass::Admission,
-                    };
+                    let class = driver_event_class(&event);
                     pending.push((class, Pending::Driver(event)));
                 }
                 runtime::ScopeWake::Message(None) => continue,
@@ -4054,6 +4024,30 @@ enum Pending {
     Deadline(DeadlineKind),
 }
 
+fn restart_shutdown_work(child: ChildKey) -> (ArbitrationClass, Pending) {
+    // This starts a pending incarnation, so it is restart work, not a
+    // scope-shutdown transition. A child exit collected in the same wake must
+    // first get the chance to trip intensity or fail startup; the
+    // execution-time suppression check then observes that drain.
+    (
+        ArbitrationClass::BackoffDue,
+        Pending::RestartShutdown(child),
+    )
+}
+
+fn driver_event_class(event: &DriverEvent) -> ArbitrationClass {
+    match event {
+        DriverEvent::Child(ChildEvent::SelfStop { .. }) => ArbitrationClass::MembershipRemoval,
+        DriverEvent::Child(ChildEvent::Constructed { .. } | ChildEvent::Ready { .. }) => {
+            ArbitrationClass::ReadinessSignal
+        }
+        DriverEvent::Child(ChildEvent::Exited { .. } | ChildEvent::ConstructionDisposed { .. }) => {
+            ArbitrationClass::ChildExit
+        }
+        DriverEvent::Admission(_) => ArbitrationClass::Admission,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -4065,11 +4059,12 @@ mod tests {
     };
 
     use crate::{
-        ActorRef, ChildId, DynamicTree, Exit, ExitError, ExitKind, LifecycleEventKind,
+        ActorRef, ChildId, DynamicTree, Exit, ExitError, ExitKind, Intensity, LifecycleEventKind,
         LifecycleItem, LifecycleTryRecvError, Readiness, ReadinessDeadline, RemoveOutcome,
         Retention, ScopeState, SendErrorKind, StartupError, StartupFailureCause, StopReason,
-        SubtreeOnceDef, TaskDef, Tree,
-        exit::RecordedOutcome,
+        SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
+        engine::arbitrate,
+        exit::{JoinVerdict, RecordedOutcome},
         identity::{FenceCounter, ScopeIdentity},
         mailbox::MailboxCell,
         runtime::Latch,
@@ -4077,10 +4072,11 @@ mod tests {
     };
 
     use super::{
-        ChildArena, ChildRuntime, DynamicControl, DynamicEntry, MemberCell, MemberStage,
-        Obligation, RemovalResponses, RuntimeStorage, ScopeCell, ScopeFlavor, ScopePhase, Signal,
-        StartupPhase, complete_removals, mint_child_incarnation, report_channel, run_nested_tree,
-        run_scope_incarnation,
+        ChildArena, ChildEvent, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
+        MemberCell, MemberStage, Obligation, Pending, RemovalResponses, RuntimeStorage, ScopeCell,
+        ScopeFlavor, ScopePhase, ScopeRuntime, Signal, StartupPhase, complete_removals,
+        driver_event_class, mint_child_incarnation, report_channel, restart_shutdown_work,
+        run_nested_tree, run_scope_incarnation,
     };
 
     fn isolated_scope(id: &'static str, flavor: ScopeFlavor) -> Arc<ScopeCell> {
@@ -4213,6 +4209,142 @@ mod tests {
             );
             assert!(!phase.begin_drain(StopReason::Finished));
         }
+    }
+
+    #[crate::runtime::test]
+    async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
+        let factories = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut tree = Tree::new();
+        tree.intensity(Intensity::new(0, Duration::from_secs(10)).expect("valid intensity"));
+        tree.add_subtree(
+            "nested",
+            SubtreeDef::factory({
+                let factories = Arc::clone(&factories);
+                move || {
+                    factories.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Tree::new()
+                }
+            }),
+        )
+        .expect("valid subtree");
+        tree.add_task("trip", TaskDef::new(|_| future::pending()))
+            .expect("valid task");
+
+        let mut plan = lower_tree_for_test(tree);
+        let root = Arc::clone(&plan.root);
+        let epoch = root.begin_incarnation();
+        root.set_admitted_children(
+            plan.children
+                .iter()
+                .map(|child| Arc::clone(&child.slot))
+                .collect(),
+        );
+        let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+        let mut children = ChildArena::with_capacity(plan.children.len());
+        plan.children.reverse();
+        while let Some(child) = plan.children.pop() {
+            children.insert(ChildRuntime::from_plan(child, &root));
+        }
+        let nested = children
+            .keys()
+            .find(|key| children[*key].slot.member.id().as_str() == "nested")
+            .expect("nested child key");
+        let trip = children
+            .keys()
+            .find(|key| children[*key].slot.member.id().as_str() == "trip")
+            .expect("tripping child key");
+        let mut scope = ScopeRuntime {
+            root: Arc::clone(&root),
+            flavor: plan.flavor,
+            defaults: plan.defaults.clone(),
+            intensity_policy: plan.config.intensity,
+            intensity: super::IntensityState::default(),
+            children,
+            events,
+            deadlines: super::DeadlineQueue::default(),
+            jitter: crate::runtime::JitterRng::from_system_entropy(),
+            phase: ScopePhase::Running,
+            next_ordered_start: 0,
+            is_root: true,
+            parent_ready: None,
+            dynamic: None,
+            epoch,
+            ancestor_shutdown: None,
+            ancestor_shutdown_seen: false,
+            ancestor_abort: None,
+            ancestor_abort_ack: None,
+            ancestor_abort_seen: false,
+            hard_forced: false,
+            completion: None,
+        };
+        plan.armed = false;
+        drop(plan);
+
+        root.transition_child(
+            &scope.children[nested].slot.member,
+            |record| {
+                record.incarnation = None;
+                record.stage = MemberStage::Restarting;
+            },
+            None,
+        );
+        scope.children[nested]
+            .slot
+            .scope
+            .as_ref()
+            .expect("nested scope cell")
+            .request_shutdown();
+        assert_eq!(scope.pending_restart_shutdowns(), vec![nested]);
+
+        scope.spawn_child(trip);
+        let incarnation = scope.children[trip]
+            .active
+            .as_ref()
+            .expect("tripping child is active")
+            .incarnation;
+        scope.children[trip]
+            .active
+            .as_ref()
+            .expect("tripping child is active")
+            .abort_handle
+            .abort();
+        let exit = DriverEvent::Child(ChildEvent::Exited {
+            child: trip,
+            incarnation,
+            recorded: Some(RecordedOutcome::Returned(Err(ExitError::message(
+                "trip intensity",
+            )))),
+            join: JoinVerdict::Completed,
+            cancelled: false,
+        });
+        let mut pending = [
+            restart_shutdown_work(nested),
+            (driver_event_class(&exit), Pending::Driver(exit)),
+        ];
+        arbitrate(&mut pending);
+        for (_, event) in pending {
+            match event {
+                Pending::RestartShutdown(child) => scope.expedite_restart_shutdown(child),
+                Pending::Driver(DriverEvent::Child(ChildEvent::Exited {
+                    child,
+                    incarnation,
+                    recorded,
+                    join,
+                    cancelled,
+                })) => scope.handle_exit(child, incarnation, recorded, join, cancelled),
+                _ => unreachable!("the fixture queues only exit and restart work"),
+            }
+        }
+
+        crate::runtime::yield_now().await;
+        crate::runtime::yield_now().await;
+
+        assert!(scope.phase.is_draining());
+        assert_eq!(
+            factories.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "the production guard must suppress the expedited factory after intensity drain"
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2332,14 +2332,18 @@ impl ScopeRuntime {
             .keys()
             .filter(|key| {
                 let child = &self.children[*key];
+                // Only a nested scope can hold a pending-incarnation stop, and
+                // only its own control plane can answer whether one exists.
+                // Both are cheap, so they gate the suppression sweep, which
+                // takes the dynamic-state lock and scans every entry.
                 child.active.is_none()
                     && matches!(child.slot.member.record().stage, MemberStage::Restarting)
-                    && !self.restart_is_suppressed(*key)
                     && child
                         .slot
                         .scope
                         .as_ref()
                         .is_some_and(|scope| scope.has_pending_incarnation_shutdown())
+                    && !self.restart_is_suppressed(*key)
             })
             .collect()
     }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -3841,7 +3841,12 @@ async fn run_scope_incarnation(
         }
         for child in scope.pending_restart_shutdowns() {
             pending.push((
-                ArbitrationClass::ScopeShutdown,
+                // This starts a pending incarnation, so it is restart work,
+                // not a scope-shutdown transition. In particular, a child
+                // exit collected in the same wake must first get the chance
+                // to trip intensity or fail startup; the execution-time
+                // suppression check then observes that drain.
+                ArbitrationClass::BackoffDue,
                 Pending::RestartShutdown(child),
             ));
         }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1180,6 +1180,14 @@ impl ScopeCell {
             })
     }
 
+    fn has_stop_request(&self, epoch: u64) -> bool {
+        let control = self.control.lock().expect("scope control mutex poisoned");
+        control
+            .shutdown
+            .is_some_and(|request| request.epoch == epoch)
+            || control.force.is_some_and(|request| request.epoch == epoch)
+    }
+
     fn take_shutdown_request(&self, epoch: u64) -> bool {
         let mut control = self.control.lock().expect("scope control mutex poisoned");
         match control.shutdown.as_mut() {
@@ -2288,6 +2296,37 @@ enum SpawnBody {
 }
 
 impl ScopeRuntime {
+    fn restart_is_suppressed(&self, key: ChildKey) -> bool {
+        if self.phase.is_draining()
+            || self.hard_forced
+            || self.root.has_stop_request(self.epoch)
+            || self.ancestor_shutdown.as_ref().is_some_and(Latch::is_fired)
+            || self.ancestor_abort.as_ref().is_some_and(Latch::is_fired)
+        {
+            return true;
+        }
+        let Some(child) = self.children.get(key) else {
+            return true;
+        };
+        let record = child.slot.member.record();
+        if record.removing || child.slot.member.removal.is_fired() {
+            return true;
+        }
+        self.dynamic.as_ref().is_some_and(|control| {
+            control
+                .state
+                .lock()
+                .expect("dynamic-state mutex poisoned")
+                .entries
+                .values()
+                .find(|entry| entry.slot.member.membership() == child.slot.member.membership())
+                .is_some_and(|entry| {
+                    entry.removal_started
+                        || entry.fused_cancel.as_ref().is_some_and(Latch::is_fired)
+                })
+        })
+    }
+
     fn pending_restart_shutdowns(&self) -> Vec<ChildKey> {
         self.children
             .keys()
@@ -2295,6 +2334,7 @@ impl ScopeRuntime {
                 let child = &self.children[*key];
                 child.active.is_none()
                     && matches!(child.slot.member.record().stage, MemberStage::Restarting)
+                    && !self.restart_is_suppressed(*key)
                     && child
                         .slot
                         .scope
@@ -2302,6 +2342,15 @@ impl ScopeRuntime {
                         .is_some_and(|scope| scope.has_pending_incarnation_shutdown())
             })
             .collect()
+    }
+
+    fn expedite_restart_shutdown(&mut self, key: ChildKey) {
+        // Collection and execution are separated by arbitration. Recheck
+        // every level-triggered stop source so teardown/removal latched in the
+        // same batch suppresses user construction immediately.
+        if !self.restart_is_suppressed(key) {
+            self.spawn_child(key);
+        }
     }
 
     #[cfg(test)]
@@ -3914,7 +3963,7 @@ async fn run_scope_incarnation(
                     }
                     scope.begin_drain(StopReason::ShutdownRequested);
                 }
-                Pending::RestartShutdown(child) => scope.spawn_child(child),
+                Pending::RestartShutdown(child) => scope.expedite_restart_shutdown(child),
                 Pending::AncestorShutdown => {
                     scope.begin_drain(StopReason::ShutdownRequested);
                 }

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -511,32 +511,6 @@ mod tests {
     }
 
     #[test]
-    fn same_batch_intensity_exit_suppresses_expedited_restart_work() {
-        enum Event {
-            IntensityTrippingExit,
-            ExpeditedRestart,
-        }
-
-        let mut events = [
-            (ArbitrationClass::BackoffDue, Event::ExpeditedRestart),
-            (ArbitrationClass::ChildExit, Event::IntensityTrippingExit),
-        ];
-        arbitrate(&mut events);
-
-        let mut draining = false;
-        let mut factory_starts = 0;
-        for (_, event) in events {
-            match event {
-                Event::IntensityTrippingExit => draining = true,
-                Event::ExpeditedRestart if !draining => factory_starts += 1,
-                Event::ExpeditedRestart => {}
-            }
-        }
-
-        assert_eq!(factory_starts, 0);
-    }
-
-    #[test]
     fn ladder_uses_cancel_escalate_and_hard_abort_for_every_policy() {
         let start = Instant::now();
         let grace = Duration::from_millis(100);

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -511,6 +511,32 @@ mod tests {
     }
 
     #[test]
+    fn same_batch_intensity_exit_suppresses_expedited_restart_work() {
+        enum Event {
+            IntensityTrippingExit,
+            ExpeditedRestart,
+        }
+
+        let mut events = [
+            (ArbitrationClass::BackoffDue, Event::ExpeditedRestart),
+            (ArbitrationClass::ChildExit, Event::IntensityTrippingExit),
+        ];
+        arbitrate(&mut events);
+
+        let mut draining = false;
+        let mut factory_starts = 0;
+        for (_, event) in events {
+            match event {
+                Event::IntensityTrippingExit => draining = true,
+                Event::ExpeditedRestart if !draining => factory_starts += 1,
+                Event::ExpeditedRestart => {}
+            }
+        }
+
+        assert_eq!(factory_starts, 0);
+    }
+
+    #[test]
     fn ladder_uses_cancel_escalate_and_hard_abort_for_every_policy() {
         let start = Instant::now();
         let grace = Duration::from_millis(100);

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -566,11 +566,17 @@ struct SharedOffloadState {
     // it, always after releasing the lock.
     state: Mutex<OffloadFutureState>,
     panic: Arc<PanicSlot>,
+    signal: Signal,
     finished: Latch,
 }
 
 impl SharedOffloadState {
-    fn new(future: OffloadFuture, panic: Arc<PanicSlot>, finished: Latch) -> SharedWork {
+    fn new(
+        future: OffloadFuture,
+        panic: Arc<PanicSlot>,
+        signal: Signal,
+        finished: Latch,
+    ) -> SharedWork {
         Arc::new(Self {
             state: Mutex::new(OffloadFutureState {
                 future: Some(future),
@@ -578,6 +584,7 @@ impl SharedOffloadState {
                 cancelled: false,
             }),
             panic,
+            signal,
             finished,
         })
     }
@@ -606,6 +613,10 @@ impl SharedOffloadState {
 
     fn record(&self, payload: PanicPayload) {
         self.panic.record(payload);
+        // Dropping a losing or cancelled operation can panic after its body
+        // has stopped running, so every retained panic must wake the actor's
+        // control plane independently of ordinary event delivery.
+        self.signal.pulse();
     }
 
     fn dispose(&self, future: Option<OffloadFuture>) {
@@ -1176,6 +1187,7 @@ impl<M: Send + 'static> RawContext<M> {
         let state = SharedOffloadState::new(
             Box::pin(operation),
             Arc::clone(&self.resources.panic),
+            self.resources.events.signal.clone(),
             finished.clone(),
         );
         let task = crate::driver::spawn_actor_work(SharedOffloadFuture(Arc::clone(&state)));
@@ -1764,7 +1776,7 @@ mod tests {
         EventQueue, OffloadResource, PanicPayload, PanicSlot, QueuedEvent, RawResources,
         SharedOffloadFuture, SharedOffloadState, resume_preferred_panic,
     };
-    use crate::runtime::Latch;
+    use crate::{driver::Signal, runtime::Latch};
 
     fn marker(value: usize) -> QueuedEvent<usize> {
         QueuedEvent::Deliver {
@@ -1974,6 +1986,7 @@ mod tests {
                 panic_on_drop: true,
             }),
             Arc::clone(&panic),
+            Signal::default(),
             finished.clone(),
         );
         let poller = {
@@ -2021,6 +2034,7 @@ mod tests {
                     panic_on_drop,
                 }),
                 Arc::clone(&resources.panic),
+                resources.events.signal.clone(),
                 completion.clone(),
             );
             resources.offloads.push(OffloadResource {

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -907,11 +907,9 @@ async fn dynamic_scope_rejects_reservations_between_incarnations() {
         .expect("root stops");
 }
 
-#[tokio::test(start_paused = true)]
-async fn pending_restart_window_stop_targets_the_next_incarnation_once() {
+async fn assert_pending_restart_shutdown_is_expedited(width: Duration) {
     let factories = Arc::new(AtomicUsize::new(0));
     let starts = Arc::new(AtomicUsize::new(0));
-    let width = Duration::from_secs(10);
     let subtree = SubtreeDef::factory({
         let factories = Arc::clone(&factories);
         let starts = Arc::clone(&starts);
@@ -978,29 +976,37 @@ async fn pending_restart_window_stop_targets_the_next_incarnation_once() {
         .await
         .expect("the first incarnation enters its explicit restart window");
 
-    let nested_wait = nested.clone();
-    let stop_started = ReleaseGate::default();
-    let stop = tokio::spawn({
-        let stop_started = stop_started.clone();
-        async move {
-            stop_started.release();
-            nested_wait.shutdown_and_wait(Duration::from_secs(1)).await
-        }
-    });
-    stop_started.wait().await;
-    assert_quiet(Duration::from_secs(1), || stop.is_finished()).await;
-    advance_time(width).await;
-    stop.await
-        .expect("stop waiter joins")
-        .expect("next incarnation cooperates");
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        nested.shutdown_and_wait(Duration::from_secs(1)),
+    )
+    .await
+    .expect("shutdown does not wait for the pending restart deadline")
+    .expect("the pending incarnation stops cooperatively");
     assert_eq!(starts.load(Ordering::SeqCst), 2);
-    advance_time(width / 2).await;
+    assert_eq!(
+        factories.load(Ordering::SeqCst),
+        2,
+        "shutdown must start exactly the pending incarnation without waiting for backoff"
+    );
+    let quiet_window = if width == Duration::MAX {
+        Duration::from_secs(1)
+    } else {
+        width / 2
+    };
+    advance_time(quiet_window).await;
     assert_eq!(
         starts.load(Ordering::SeqCst),
         2,
-        "a consumed per-incarnation latch must not cause a stop/restart storm"
+        "a consumed per-incarnation request must not cause a restart storm"
     );
     system.shutdown(Duration::ZERO).await.expect("root stops");
+}
+
+#[tokio::test(start_paused = true)]
+async fn pending_restart_shutdown_expedites_finite_and_unrepresentable_backoff() {
+    assert_pending_restart_shutdown_is_expedited(Duration::from_secs(60 * 60)).await;
+    assert_pending_restart_shutdown_is_expedited(Duration::MAX).await;
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -15,8 +15,9 @@ use crate::common::{
 use shelterwood::{
     Actor, ActorOnceDef, Backoff, ChildState, Context as ActorContext, DynamicTree, ExitError,
     ExitKind, ExitResult, NotAdmittingCause, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
-    RemoveOutcome, ReserveError, RestartCondition, RestartPolicy, Retention, SendErrorKind,
-    Shutdown, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
+    RemoveOutcome, ReserveError, RestartCondition, RestartPolicy, Retention, ScopeRef,
+    SendErrorKind, Shutdown, StopReason, SubtreeDef, SubtreeOnceDef, System, TaskDef, TaskOnceDef,
+    Tree,
 };
 
 struct DropProbe(Arc<AtomicBool>);
@@ -907,7 +908,14 @@ async fn dynamic_scope_rejects_reservations_between_incarnations() {
         .expect("root stops");
 }
 
-async fn assert_pending_restart_shutdown_is_expedited(width: Duration) {
+async fn pending_restart_fixture(
+    width: Duration,
+) -> (
+    System<shelterwood::DynamicScopeRef>,
+    ScopeRef,
+    Arc<AtomicUsize>,
+    Arc<AtomicUsize>,
+) {
     let factories = Arc::new(AtomicUsize::new(0));
     let starts = Arc::new(AtomicUsize::new(0));
     let subtree = SubtreeDef::factory({
@@ -953,7 +961,7 @@ async fn assert_pending_restart_shutdown_is_expedited(width: Duration) {
         RestartCondition::Always,
         Backoff::fixed(width, shelterwood::Jitter::None).expect("non-zero backoff"),
     ));
-    let mut root = Tree::new();
+    let mut root = DynamicTree::new();
     let nested = root.add_subtree("nested", subtree).expect("valid subtree");
     let system = root.spawn().expect("runtime is available");
     system
@@ -975,6 +983,12 @@ async fn assert_pending_restart_shutdown_is_expedited(width: Duration) {
         )
         .await
         .expect("the first incarnation enters its explicit restart window");
+
+    (system, nested, factories, starts)
+}
+
+async fn assert_pending_restart_shutdown_is_expedited(width: Duration) {
+    let (system, nested, factories, starts) = pending_restart_fixture(width).await;
 
     tokio::time::timeout(
         Duration::from_secs(1),
@@ -1007,6 +1021,27 @@ async fn assert_pending_restart_shutdown_is_expedited(width: Duration) {
 async fn pending_restart_shutdown_expedites_finite_and_unrepresentable_backoff() {
     assert_pending_restart_shutdown_is_expedited(Duration::from_secs(60 * 60)).await;
     assert_pending_restart_shutdown_is_expedited(Duration::MAX).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn same_batch_removal_suppresses_pending_restart_shutdown() {
+    let (system, nested, factories, starts) =
+        pending_restart_fixture(Duration::from_secs(60 * 60)).await;
+
+    // Both level-triggered commands are latched before yielding to the
+    // driver. Removal owns restart suppression even though the nested scope's
+    // pending shutdown would otherwise expedite its next incarnation.
+    let removal = system.scope().remove_scope(&nested);
+    nested.request_shutdown();
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), removal)
+            .await
+            .expect("removal does not wait for restart backoff"),
+        RemoveOutcome::Removed
+    );
+    assert_eq!(factories.load(Ordering::SeqCst), 1);
+    assert_eq!(starts.load(Ordering::SeqCst), 1);
+    system.shutdown(Duration::ZERO).await.expect("root stops");
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -908,19 +908,12 @@ async fn dynamic_scope_rejects_reservations_between_incarnations() {
         .expect("root stops");
 }
 
-async fn pending_restart_fixture(
+fn pending_restart_subtree(
     width: Duration,
-) -> (
-    System<shelterwood::DynamicScopeRef>,
-    ScopeRef,
-    Arc<AtomicUsize>,
-    Arc<AtomicUsize>,
-) {
-    let factories = Arc::new(AtomicUsize::new(0));
-    let starts = Arc::new(AtomicUsize::new(0));
-    let subtree = SubtreeDef::factory({
-        let factories = Arc::clone(&factories);
-        let starts = Arc::clone(&starts);
+    factories: Arc<AtomicUsize>,
+    starts: Arc<AtomicUsize>,
+) -> SubtreeDef<Tree> {
+    SubtreeDef::factory({
         move || {
             let generation = factories.fetch_add(1, Ordering::SeqCst) + 1;
             let mut tree = Tree::new();
@@ -960,7 +953,36 @@ async fn pending_restart_fixture(
     .restart(RestartPolicy::new(
         RestartCondition::Always,
         Backoff::fixed(width, shelterwood::Jitter::None).expect("non-zero backoff"),
-    ));
+    ))
+}
+
+async fn await_first_restart_window(root: &ScopeRef, starts: &Arc<AtomicUsize>) {
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            starts.load(Ordering::SeqCst) == 1
+        })
+        .await
+    );
+    root.wait_for_child(
+        "nested",
+        |child| matches!(child.state, ChildState::Restarting),
+        Duration::MAX,
+    )
+    .await
+    .expect("the first incarnation enters its explicit restart window");
+}
+
+async fn pending_restart_fixture(
+    width: Duration,
+) -> (
+    System<shelterwood::DynamicScopeRef>,
+    ScopeRef,
+    Arc<AtomicUsize>,
+    Arc<AtomicUsize>,
+) {
+    let factories = Arc::new(AtomicUsize::new(0));
+    let starts = Arc::new(AtomicUsize::new(0));
+    let subtree = pending_restart_subtree(width, Arc::clone(&factories), Arc::clone(&starts));
     let mut root = DynamicTree::new();
     let nested = root.add_subtree("nested", subtree).expect("valid subtree");
     let system = root.spawn().expect("runtime is available");
@@ -968,28 +990,46 @@ async fn pending_restart_fixture(
         .wait_started()
         .await
         .expect("first incarnation starts");
-    assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
-            starts.load(Ordering::SeqCst) == 1
-        })
-        .await
-    );
-    system
-        .scope()
-        .wait_for_child(
-            "nested",
-            |child| matches!(child.state, ChildState::Restarting),
-            Duration::MAX,
-        )
-        .await
-        .expect("the first incarnation enters its explicit restart window");
+    let root_scope = system.scope();
+    await_first_restart_window(root_scope.as_scope(), &starts).await;
 
     (system, nested, factories, starts)
 }
 
-async fn assert_pending_restart_shutdown_is_expedited(width: Duration) {
-    let (system, nested, factories, starts) = pending_restart_fixture(width).await;
+/// The ordered-parent twin of [`pending_restart_fixture`]. Restart suppression,
+/// ordered startup progression and reverse teardown all differ from the dynamic
+/// flavor, so the pending-incarnation stop needs its own coverage here.
+async fn ordered_pending_restart_fixture(
+    width: Duration,
+) -> (
+    System<ScopeRef>,
+    ScopeRef,
+    Arc<AtomicUsize>,
+    Arc<AtomicUsize>,
+) {
+    let factories = Arc::new(AtomicUsize::new(0));
+    let starts = Arc::new(AtomicUsize::new(0));
+    let subtree = pending_restart_subtree(width, Arc::clone(&factories), Arc::clone(&starts));
+    let mut root = Tree::new();
+    let nested = root.add_subtree("nested", subtree).expect("valid subtree");
+    let system = root.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("first incarnation starts");
+    let root_scope = system.scope();
+    await_first_restart_window(&root_scope, &starts).await;
 
+    (system, nested, factories, starts)
+}
+
+async fn assert_pending_restart_shutdown_is_expedited<R: Clone>(
+    width: Duration,
+    system: System<R>,
+    nested: ScopeRef,
+    factories: Arc<AtomicUsize>,
+    starts: Arc<AtomicUsize>,
+) {
     tokio::time::timeout(
         Duration::from_secs(1),
         nested.shutdown_and_wait(Duration::from_secs(1)),
@@ -1003,24 +1043,66 @@ async fn assert_pending_restart_shutdown_is_expedited(width: Duration) {
         2,
         "shutdown must start exactly the pending incarnation without waiting for backoff"
     );
-    let quiet_window = if width == Duration::MAX {
-        Duration::from_secs(1)
-    } else {
-        width / 2
-    };
-    advance_time(quiet_window).await;
+    if width == Duration::MAX {
+        // An unrepresentable deadline schedules no restart at all, so there is
+        // no later incarnation to reach. Only the quiet window applies.
+        advance_time(Duration::from_secs(1)).await;
+        assert_eq!(
+            starts.load(Ordering::SeqCst),
+            2,
+            "an unrepresentable deadline must not resurrect the stopped incarnation"
+        );
+        system.shutdown(Duration::ZERO).await.expect("root stops");
+        return;
+    }
+
+    // The expedited incarnation exited cooperatively, so `Always` schedules an
+    // ordinary backoff restart. Cross the whole window: a storm assertion that
+    // never reaches a *later* incarnation only re-measures the quiet interior
+    // of the window it already observed.
+    advance_time(width + Duration::from_secs(1)).await;
+    assert!(
+        poll_until(Duration::from_secs(5), Duration::from_millis(1), || {
+            starts.load(Ordering::SeqCst) >= 3
+        })
+        .await,
+        "a consumed pending request must not suppress the ordinary backoff restart"
+    );
     assert_eq!(
         starts.load(Ordering::SeqCst),
-        2,
-        "a consumed per-incarnation request must not cause a restart storm"
+        3,
+        "exactly one incarnation follows the expedited stop"
     );
-    system.shutdown(Duration::ZERO).await.expect("root stops");
+    assert_eq!(
+        factories.load(Ordering::SeqCst),
+        3,
+        "the backoff restart re-lowers the subtree exactly once"
+    );
+    advance_time(width * 3).await;
+    assert_quiet(Duration::from_secs(1), || {
+        starts.load(Ordering::SeqCst) != 3
+    })
+    .await;
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
 }
 
 #[tokio::test(start_paused = true)]
 async fn pending_restart_shutdown_expedites_finite_and_unrepresentable_backoff() {
-    assert_pending_restart_shutdown_is_expedited(Duration::from_secs(60 * 60)).await;
-    assert_pending_restart_shutdown_is_expedited(Duration::MAX).await;
+    for width in [Duration::from_secs(60 * 60), Duration::MAX] {
+        let (system, nested, factories, starts) = pending_restart_fixture(width).await;
+        assert_pending_restart_shutdown_is_expedited(width, system, nested, factories, starts)
+            .await;
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn ordered_parent_pending_restart_shutdown_is_expedited() {
+    let width = Duration::from_secs(60 * 60);
+    let (system, nested, factories, starts) = ordered_pending_restart_fixture(width).await;
+    assert_pending_restart_shutdown_is_expedited(width, system, nested, factories, starts).await;
 }
 
 #[tokio::test(start_paused = true)]

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -9,8 +9,8 @@ use std::{
 use crate::common::{assert_quiet, poll_until};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
-    LifecycleEventKind, LifecycleItem, Readiness, Shutdown, StartupError, StartupFailureCause,
-    Tree,
+    Guard, LifecycleEventKind, LifecycleItem, Readiness, Shutdown, StartupError,
+    StartupFailureCause, Tree,
 };
 
 enum ZeroMessage {
@@ -557,6 +557,95 @@ impl Drop for PendingDropFuture {
             panic!("offload cancellation destructor panic");
         }
     }
+}
+
+struct ExternallyCancelledOffloadActor;
+
+impl Actor for ExternallyCancelledOffloadActor {
+    type Msg = ();
+    type Args = (
+        tokio::sync::oneshot::Sender<Guard>,
+        Arc<tokio::sync::Notify>,
+        Arc<AtomicUsize>,
+    );
+
+    async fn init(
+        (guard_sender, polled, drops): Self::Args,
+        context: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        let guard = context
+            .offload_scoped(
+                PendingDropFuture {
+                    drops,
+                    panic_on_drop: true,
+                    polled: Some(polled),
+                    dropped: None,
+                },
+                |_| (),
+                Duration::MAX,
+            )
+            .expect("offload accepted");
+        guard_sender
+            .send(guard)
+            .expect("test receives the cancellation guard");
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): (), _: &mut Context<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn cancellation_destructor_panic_wakes_an_otherwise_idle_actor() {
+    let (guard_sender, guard_receiver) = tokio::sync::oneshot::channel();
+    let polled = Arc::new(tokio::sync::Notify::new());
+    let drops = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    tree.add_actor_once(
+        "idle-offload",
+        ActorOnceDef::<ExternallyCancelledOffloadActor>::new((
+            guard_sender,
+            Arc::clone(&polled),
+            Arc::clone(&drops),
+        )),
+    )
+    .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    let mut events = system.scope().subscribe_lifecycle();
+    system.wait_started().await.expect("actor becomes idle");
+    let guard = guard_receiver.await.expect("actor exports its guard");
+    polled.notified().await;
+
+    guard.cancel();
+
+    let exit = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let item = events.recv().await.expect("lifecycle remains open");
+            let LifecycleItem::Event(event) = item else {
+                panic!("small fixture must not lag");
+            };
+            if let LifecycleEventKind::Exited { id, exit, .. } = event.kind
+                && id.as_str() == "idle-offload"
+            {
+                break exit;
+            }
+        }
+    })
+    .await
+    .expect("the retained panic wakes the idle actor");
+    let ExitKind::Panicked { message } = exit.kind() else {
+        panic!("expected destructor panic, got {:?}", exit.kind());
+    };
+    assert_eq!(
+        message.as_deref(),
+        Some("offload cancellation destructor panic")
+    );
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed actor scope shuts down");
 }
 
 struct CancellationDropActor;

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -81,6 +81,54 @@ async fn ordered_startup_waits_for_manual_readiness() {
         .expect("clean shutdown");
 }
 
+#[tokio::test]
+async fn shutdown_racing_startup_reports_shutdown_requested() {
+    let entered = ReleaseGate::default();
+    let cancellation_seen = ReleaseGate::default();
+    let release_ready = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.add_task(
+        "gated",
+        TaskDef::new({
+            let entered = entered.clone();
+            let cancellation_seen = cancellation_seen.clone();
+            let release_ready = release_ready.clone();
+            move |context| {
+                let entered = entered.clone();
+                let cancellation_seen = cancellation_seen.clone();
+                let release_ready = release_ready.clone();
+                async move {
+                    entered.release();
+                    context.shutdown_token().cancelled().await;
+                    cancellation_seen.release();
+                    release_ready.wait().await;
+                    context.mark_ready();
+                    Ok(())
+                }
+            }
+        })
+        .readiness(Readiness::Manual)
+        .expect("manual readiness")
+        .readiness_deadline(ReadinessDeadline::Unbounded),
+    )
+    .expect("valid task");
+
+    let system = tree.spawn().expect("runtime is available");
+    entered.wait().await;
+    system.scope().request_shutdown();
+    cancellation_seen.wait().await;
+    release_ready.release();
+
+    assert_eq!(
+        system.wait_started().await,
+        Err(StartupError::ShutdownRequested)
+    );
+    assert_eq!(
+        system.wait().await,
+        shelterwood::StopReason::ShutdownRequested
+    );
+}
+
 #[tokio::test(start_paused = true)]
 async fn readiness_deadline_is_typed_and_absolute() {
     let deadline_width = Duration::from_secs(10);


### PR DESCRIPTION
Stack 1 of the issue #56 refactor program.

## What changed

- Expedite a nested scope's pending restart incarnation when shutdown lands during restart backoff.
- Preserve SPEC B.9 semantics: pre-spawn requests still park, and the shutdown timeout still arms only once teardown begins.
- Handle finite and unrepresentable restart deadlines without waiting for the configured backoff.
- Wake the parent driver through the member-record control plane and make duplicate same-batch restart starts inert.
- Couple every escaped offload-destructor panic recording with the actor event signal.
- Add public coverage for the shutdown-versus-startup race producing `StartupError::ShutdownRequested`.

## Why

A scope-level shutdown request issued between nested-scope incarnations only pulsed the stopped nested scope. Its parent remained asleep until the restart deadline, so a long backoff delayed shutdown and an unrepresentable deadline could hang forever. Separately, an offload future whose destructor panicked after cancellation recorded the panic without waking an otherwise idle actor.

## User impact

`ScopeRef::shutdown_and_wait` now promptly begins the pending incarnation's teardown during restart backoff, including `Duration::MAX`, while retaining incarnation-targeted and pre-spawn behavior. Escaped offload destructor panics are promptly supervised without requiring unrelated mailbox or timer activity.

## Validation

- `./scripts/dev just ci`
  - 306 nextest tests
  - 3 doctests
  - formatting and clippy with warnings denied
  - rustdoc and public API reachability
  - runtime/exit architecture checks
  - packaged-crate verification
  - Nix formatting check

Part of #56.