### PR TITLE
Refactor supervision state into proper layers

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -48,8 +48,16 @@ pub(crate) struct MailboxStats {
 }
 
 /// Type-erased mailbox lifecycle surface owned by a member cell.
+///
+/// The driver must configure a mailbox before its first bind. Every live
+/// incarnation must then be closed before a later incarnation is bound; if
+/// close is skipped, messages accepted for the prior incarnation can leak
+/// into the replacement. Once termination is prepared, later binds are
+/// intentionally ignored.
 pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
+    /// Installs the declaration-time mailbox policy before the first bind.
     fn configure(&self, mailbox: Mailbox);
+    /// Makes one incarnation live after configuration and prior-close cleanup.
     fn bind(&self, incarnation: Incarnation);
     fn freeze(&self, incarnation: Incarnation);
     fn close(&self, incarnation: Incarnation) -> Option<Box<dyn MailboxDisposal>>;

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -1,0 +1,1208 @@
+//! Restart-stable shared member and scope state.
+//!
+//! These cells are the neutral synchronization and observation projection
+//! layer shared by public handles, mailboxes, actor/task contexts, and the
+//! mutable supervision driver. In particular, this module does not depend on
+//! driver state or declaration-plan slots.
+
+use std::{
+    any::Any,
+    fmt,
+    sync::{
+        Arc, Mutex, Weak,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::Instant,
+};
+
+use crate::{
+    ChildId, Exit, Incarnation, Intensity, Mailbox, Membership, Readiness, ScopeState, Strategy,
+    exit::{StartupError, StopReason},
+    identity::{FenceCounter, ScopeIdentity},
+    observe::{
+        ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
+        LifecycleHub, MembershipStatus, ScopeKind, ScopeSnapshot, SnapshotHub, SnapshotReceiver,
+    },
+    policy::{ResolvedCommonOptions, ScopeFlavor},
+    runtime::{self, Latch},
+};
+
+/// Isolated payload returned after mailbox termination has synchronously
+/// published all waiter outcomes.
+pub(crate) trait MailboxDisposal: Send {}
+
+/// Prepared terminal mailbox transition. Finishing it wakes terminal waiters
+/// before returning unread payload ownership for detached disposal.
+pub(crate) trait MailboxTermination: Send {
+    fn finish(self: Box<Self>) -> Option<Box<dyn MailboxDisposal>>;
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct MailboxStats {
+    pub(crate) accepted: u64,
+    pub(crate) delivered: u64,
+    pub(crate) conflated: u64,
+    pub(crate) sends_rejected: u64,
+    pub(crate) depth: usize,
+    pub(crate) capacity: usize,
+}
+
+/// Type-erased mailbox lifecycle surface owned by a member cell.
+pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
+    fn configure(&self, mailbox: Mailbox);
+    fn bind(&self, incarnation: Incarnation);
+    fn freeze(&self, incarnation: Incarnation);
+    fn close(&self, incarnation: Incarnation) -> Option<Box<dyn MailboxDisposal>>;
+    fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>>;
+    fn stats(&self) -> MailboxStats;
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum MemberStage {
+    Reserved,
+    Admitted,
+    Starting,
+    Running,
+    Restarting,
+    Stopping,
+    Terminal(Exit),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct MemberRecord {
+    pub(crate) stage: MemberStage,
+    pub(crate) incarnation: Option<Incarnation>,
+    pub(crate) last_incarnation: Option<Incarnation>,
+    pub(crate) last_exit: Option<Exit>,
+    pub(crate) restart_count: u64,
+    pub(crate) restart_at: Option<Instant>,
+    pub(crate) removing: bool,
+    pub(crate) startup_aborted: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct MemberCell {
+    id: ChildId,
+    membership: Mutex<Membership>,
+    record: runtime::WatchSender<MemberRecord>,
+    terminal_disposal_pending: AtomicBool,
+    mailbox: Mutex<MemberMailbox>,
+    options: Mutex<Option<ResolvedCommonOptions>>,
+    pub(crate) removal: Latch,
+}
+
+#[derive(Default)]
+struct MemberMailbox {
+    control: Option<Arc<dyn MailboxControl>>,
+    terminal: Option<Exit>,
+    teardown: Option<Box<dyn MailboxTermination>>,
+}
+
+impl fmt::Debug for MemberMailbox {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MemberMailbox")
+            .field("control", &self.control)
+            .field("terminal", &self.terminal)
+            .field("teardown_pending", &self.teardown.is_some())
+            .finish()
+    }
+}
+
+impl MemberCell {
+    pub(crate) fn new(id: ChildId, membership: Membership) -> Arc<Self> {
+        let (record, _) = runtime::watch(MemberRecord {
+            stage: MemberStage::Reserved,
+            incarnation: None,
+            last_incarnation: None,
+            last_exit: None,
+            restart_count: 0,
+            restart_at: None,
+            removing: false,
+            startup_aborted: false,
+        });
+        Arc::new(Self {
+            id,
+            membership: Mutex::new(membership),
+            record,
+            terminal_disposal_pending: AtomicBool::new(false),
+            mailbox: Mutex::new(MemberMailbox::default()),
+            options: Mutex::new(None),
+            removal: Latch::default(),
+        })
+    }
+
+    pub(crate) fn id(&self) -> &ChildId {
+        &self.id
+    }
+
+    pub(crate) fn membership(&self) -> Membership {
+        *self
+            .membership
+            .lock()
+            .expect("member identity mutex poisoned")
+    }
+
+    pub(crate) fn rebase_membership(&self, membership: Membership) {
+        let record = self.record();
+        assert!(
+            matches!(record.stage, MemberStage::Reserved)
+                && record.incarnation.is_none()
+                && record.last_incarnation.is_none(),
+            "only an unstarted reservation can be rebased"
+        );
+        *self
+            .membership
+            .lock()
+            .expect("member identity mutex poisoned") = membership;
+    }
+
+    pub(crate) fn record(&self) -> MemberRecord {
+        self.record.read_cloned()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_watcher(&self) -> runtime::WatchReceiver<MemberRecord> {
+        self.record.watcher()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn stage_terminal_before_mailbox(&self, exit: Exit) {
+        let mut mailbox = self.mailbox.lock().expect("member mailbox mutex poisoned");
+        assert!(mailbox.control.is_none());
+        mailbox.terminal = Some(exit);
+    }
+
+    pub(crate) fn terminal_disposal_pending(&self) -> bool {
+        self.terminal_disposal_pending.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn set_terminal_disposal_pending(&self, pending: bool) {
+        self.terminal_disposal_pending
+            .store(pending, Ordering::Release);
+    }
+
+    pub(crate) fn update(&self, update: impl FnOnce(&mut MemberRecord)) {
+        self.record.send_modify(update);
+    }
+
+    fn update_locked(&self, update: impl FnOnce(&mut MemberRecord)) {
+        self.record.send_modify(update);
+    }
+
+    pub(crate) fn set_options(&self, options: ResolvedCommonOptions) {
+        *self.options.lock().expect("member options mutex poisoned") = Some(options);
+    }
+
+    fn options(&self) -> ResolvedCommonOptions {
+        self.options
+            .lock()
+            .expect("member options mutex poisoned")
+            .clone()
+            .unwrap_or_else(|| {
+                crate::policy::resolve_common(
+                    &crate::policy::CommonOptions::default(),
+                    &crate::policy::ResolvedDefaults::default(),
+                    false,
+                    Readiness::Immediate,
+                )
+            })
+    }
+
+    pub(crate) fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
+        let terminal_exit = {
+            let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
+            assert!(state.control.is_none(), "a member can own only one mailbox");
+            state.control = Some(Arc::clone(&mailbox));
+            let terminal_exit = state.terminal.clone();
+            if terminal_exit.is_some() {
+                debug_assert!(state.teardown.is_none());
+                state.teardown = mailbox.prepare_termination();
+            }
+            terminal_exit
+        };
+        if let Some(terminal_exit) = terminal_exit {
+            self.publish_terminal(terminal_exit);
+        }
+    }
+
+    pub(crate) fn mailbox(&self) -> Option<Arc<dyn MailboxControl>> {
+        self.mailbox
+            .lock()
+            .expect("member mailbox mutex poisoned")
+            .control
+            .clone()
+    }
+
+    pub(crate) fn terminalize(&self, exit: Exit) {
+        let (terminal_exit, mailbox) = {
+            let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
+            let terminal_exit = if let Some(terminal_exit) = &state.terminal {
+                terminal_exit.clone()
+            } else {
+                let teardown = state
+                    .control
+                    .as_ref()
+                    .and_then(|mailbox| mailbox.prepare_termination());
+                state.terminal = Some(exit.clone());
+                state.teardown = teardown;
+                exit
+            };
+            (terminal_exit, state.control.clone())
+        };
+        self.publish_terminal(terminal_exit);
+        if let Some(mailbox) = mailbox {
+            let stats = mailbox.stats();
+            debug_assert!(stats.delivered <= stats.accepted);
+            debug_assert!(stats.conflated <= stats.accepted);
+            debug_assert!(stats.depth <= stats.capacity);
+            let _ = stats.sends_rejected;
+        }
+    }
+
+    fn publish_terminal(&self, terminal_exit: Exit) {
+        let mut published = false;
+        self.record.modify_silently(|record| {
+            if !matches!(record.stage, MemberStage::Terminal(_)) {
+                record.incarnation = None;
+                record.restart_at = None;
+                record.last_exit = Some(terminal_exit.clone());
+                record.stage = MemberStage::Terminal(terminal_exit);
+                published = true;
+            }
+        });
+        // Mailbox terminality and waiter completion must become visible before
+        // member terminality. The watch pulse is deliberately delayed until
+        // teardown has synchronously finished and unread payload ownership has
+        // moved to detached disposal.
+        let teardown = self
+            .mailbox
+            .lock()
+            .expect("member mailbox mutex poisoned")
+            .teardown
+            .take();
+        if let Some(teardown) = teardown
+            && let Some(payload) = teardown.finish()
+        {
+            runtime::dispose_detached(payload);
+        }
+        if published {
+            self.record.pulse();
+        }
+    }
+
+    pub(crate) async fn wait_terminal(&self) -> Exit {
+        let mut watcher = self.record.watcher();
+        loop {
+            if let MemberStage::Terminal(exit) = watcher.borrow_cloned().stage {
+                return exit;
+            }
+            watcher.changed().await;
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ScopeRecord {
+    pub(crate) state: ScopeState,
+    pub(crate) startup: Option<Result<(), StartupError>>,
+    pub(crate) total_restarts: u64,
+}
+
+#[derive(Clone)]
+pub(crate) struct DynamicRoute(Arc<dyn Any + Send + Sync>);
+
+impl fmt::Debug for DynamicRoute {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_tuple("DynamicRoute").finish()
+    }
+}
+
+impl DynamicRoute {
+    pub(crate) fn new<T: Any + Send + Sync>(route: Arc<T>) -> Self {
+        Self(route)
+    }
+
+    pub(crate) fn resolve<T: Any + Send + Sync>(self) -> Result<Arc<T>, Self> {
+        Arc::downcast(self.0).map_err(Self)
+    }
+}
+
+/// Driver-independent view of one declaration slot while its membership is
+/// resident in a running scope.
+#[derive(Clone)]
+pub(crate) struct ResidentProjection {
+    pub(crate) member: Arc<MemberCell>,
+    pub(crate) scope: Option<Arc<ScopeCell>>,
+}
+
+impl ResidentProjection {
+    pub(crate) fn new(member: Arc<MemberCell>, scope: Option<Arc<ScopeCell>>) -> Self {
+        Self { member, scope }
+    }
+}
+
+struct ResidencyCompletion {
+    parent: Weak<ScopeCell>,
+    projection: ResidentProjection,
+}
+
+struct ResidentChild {
+    projection: ResidentProjection,
+    removal: Option<ResidencyCompletion>,
+}
+
+impl ResidentChild {
+    fn new(parent: &Arc<ScopeCell>, projection: ResidentProjection) -> Self {
+        Self {
+            removal: Some(ResidencyCompletion {
+                parent: Arc::downgrade(parent),
+                projection: projection.clone(),
+            }),
+            projection,
+        }
+    }
+}
+
+impl Drop for ResidentChild {
+    fn drop(&mut self) {
+        let Some(completion) = self.removal.take() else {
+            return;
+        };
+        let Some(parent) = completion.parent.upgrade() else {
+            return;
+        };
+        parent.emit_locked(LifecycleEventKind::Removed {
+            id: completion.projection.member.id().clone(),
+            membership: completion.projection.member.membership(),
+            last_incarnation: completion.projection.member.record().last_incarnation,
+        });
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct ObservationConfig {
+    strategy: Strategy,
+    intensity: Intensity,
+}
+
+#[derive(Debug, Default)]
+struct ScopeControl {
+    current_epoch: u64,
+    live: bool,
+    last_stopped_epoch: u64,
+    shutdown: Option<ScopeRequest>,
+    force: Option<ScopeRequest>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ScopeRequest {
+    epoch: u64,
+    consumed: bool,
+}
+
+/// Shared scope state follows two distinct synchronization regimes.
+///
+/// One gate per resident tree serializes compound observation-visible
+/// transitions across configuration, records, resident children, and parent
+/// links. Their watch channels retain independently readable latest values;
+/// they do not make a multi-field transition atomic, so every recursive
+/// observation path continues to hold that one tree gate.
+///
+/// Control requests, identity counters, lifecycle sequences, and the dynamic
+/// route remain independent synchronization planes. The member-record watch is
+/// intentionally also the driver's wake bus.
+pub(crate) struct ScopeCell {
+    pub(crate) member: Arc<MemberCell>,
+    pub(crate) flavor: ScopeFlavor,
+    pub(crate) child_identity: Mutex<ScopeIdentity>,
+    config: runtime::WatchSender<ObservationConfig>,
+    record: runtime::WatchSender<ScopeRecord>,
+    control: Mutex<ScopeControl>,
+    dynamic_route: Mutex<Option<DynamicRoute>>,
+    current_children: runtime::WatchSender<Vec<ResidentChild>>,
+    parent: runtime::WatchSender<Option<Weak<ScopeCell>>>,
+    observation_gate: Mutex<Arc<Mutex<()>>>,
+    lifecycle_sequence: Mutex<FenceCounter>,
+    lifecycle_seq: AtomicU64,
+    lifecycle: LifecycleHub,
+    snapshots: SnapshotHub,
+    observation_closed: AtomicBool,
+    #[cfg(test)]
+    runtime_storage: Mutex<RuntimeStorage>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct RuntimeStorage {
+    pub(crate) children: usize,
+    pub(crate) child_slots: usize,
+    pub(crate) deadlines: usize,
+    pub(crate) deadline_slots: usize,
+}
+
+impl ScopeCell {
+    pub(crate) fn new(
+        member: Arc<MemberCell>,
+        flavor: ScopeFlavor,
+        child_identity: ScopeIdentity,
+    ) -> Arc<Self> {
+        let (config, _) = runtime::watch(ObservationConfig::default());
+        let (record, _) = runtime::watch(ScopeRecord {
+            state: ScopeState::Unstarted,
+            startup: None,
+            total_restarts: 0,
+        });
+        let (current_children, _) = runtime::watch(Vec::new());
+        let (parent, _) = runtime::watch(None);
+        Arc::new(Self {
+            member,
+            flavor,
+            child_identity: Mutex::new(child_identity),
+            config,
+            record,
+            control: Mutex::new(ScopeControl::default()),
+            dynamic_route: Mutex::new(None),
+            current_children,
+            parent,
+            observation_gate: Mutex::new(Arc::new(Mutex::new(()))),
+            lifecycle_sequence: Mutex::new(FenceCounter::new(0)),
+            lifecycle_seq: AtomicU64::new(0),
+            lifecycle: LifecycleHub::default(),
+            snapshots: SnapshotHub::default(),
+            observation_closed: AtomicBool::new(false),
+            #[cfg(test)]
+            runtime_storage: Mutex::new(RuntimeStorage::default()),
+        })
+    }
+
+    pub(crate) fn record(&self) -> ScopeRecord {
+        self.record.read_cloned()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_watcher(&self) -> runtime::WatchReceiver<ScopeRecord> {
+        self.record.watcher()
+    }
+
+    pub(crate) fn resident_projections(&self) -> Vec<ResidentProjection> {
+        self.current_children.read_with(|children| {
+            children
+                .iter()
+                .map(|resident| resident.projection.clone())
+                .collect()
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn runtime_storage(&self) -> RuntimeStorage {
+        *self
+            .runtime_storage
+            .lock()
+            .expect("runtime-storage mutex poisoned")
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_runtime_storage(&self, storage: RuntimeStorage) {
+        *self
+            .runtime_storage
+            .lock()
+            .expect("runtime-storage mutex poisoned") = storage;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn observation_gate(&self) -> Arc<Mutex<()>> {
+        self.current_observation_gate()
+    }
+
+    fn current_observation_gate(&self) -> Arc<Mutex<()>> {
+        Arc::clone(
+            &self
+                .observation_gate
+                .lock()
+                .expect("observation gate handoff mutex poisoned"),
+        )
+    }
+
+    fn adopt_observation_gate(&self, gate: &Arc<Mutex<()>>) {
+        loop {
+            let current = self.current_observation_gate();
+            if Arc::ptr_eq(&current, gate) {
+                return;
+            }
+
+            // An operation that passed `with_observation_gate`'s pointer
+            // check may finish its complete edge before handoff. An operation
+            // that merely captured this obsolete gate retries after acquiring
+            // it and observing the replacement.
+            let current_guard = current
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut installed = self
+                .observation_gate
+                .lock()
+                .expect("observation gate handoff mutex poisoned");
+            if Arc::ptr_eq(&current, &installed) {
+                *installed = Arc::clone(gate);
+                drop(installed);
+                self.adopt_descendant_observation_gates_locked(&current, gate);
+                drop(current_guard);
+                return;
+            }
+            drop(installed);
+            drop(current_guard);
+        }
+    }
+
+    /// Re-homes a resident subtree while its prior tree gate is held. The
+    /// destination gate is also held, so observers cannot enter either tree
+    /// while the handoff is installed recursively.
+    fn adopt_descendant_observation_gates_locked(
+        &self,
+        previous: &Arc<Mutex<()>>,
+        gate: &Arc<Mutex<()>>,
+    ) {
+        let descendants = self.current_children.read_with(|children| {
+            children
+                .iter()
+                .filter_map(|resident| resident.projection.scope.as_ref().cloned())
+                .collect::<Vec<_>>()
+        });
+        for descendant in descendants {
+            let mut installed = descendant
+                .observation_gate
+                .lock()
+                .expect("observation gate handoff mutex poisoned");
+            if Arc::ptr_eq(&installed, previous) {
+                *installed = Arc::clone(gate);
+            } else {
+                assert!(
+                    Arc::ptr_eq(&installed, gate),
+                    "one resident tree must share one observation gate"
+                );
+            }
+            drop(installed);
+            descendant.adopt_descendant_observation_gates_locked(previous, gate);
+        }
+    }
+
+    /// Runs against the current resident-tree observation gate. Adoption can
+    /// race an early pre-start observer, so an obsolete-gate acquisition is
+    /// detected and retried before the operation enters its critical section.
+    pub(crate) fn with_observation_gate<R>(&self, operation: impl FnOnce() -> R) -> R {
+        let mut operation = Some(operation);
+        loop {
+            let gate = self.current_observation_gate();
+            let guard = gate
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if Arc::ptr_eq(&gate, &self.current_observation_gate()) {
+                let operation = operation
+                    .take()
+                    .expect("observation operation runs exactly once");
+                let result = operation();
+                drop(guard);
+                return result;
+            }
+            drop(guard);
+        }
+    }
+
+    pub(crate) fn set_state(&self, state: ScopeState) {
+        self.with_observation_gate(|| {
+            self.record.send_modify(|record| {
+                if state == ScopeState::Starting {
+                    record.total_restarts = 0;
+                }
+                record.state = state.clone();
+            });
+            self.member.record.pulse();
+            self.emit_locked(LifecycleEventKind::ScopeState { state });
+        });
+    }
+
+    pub(crate) fn set_observation_config(&self, strategy: Strategy, intensity: Intensity) {
+        self.with_observation_gate(|| {
+            self.config.replace(ObservationConfig {
+                strategy,
+                intensity,
+            });
+            self.publish_snapshot_chain_locked();
+        });
+    }
+
+    pub(crate) fn transition_child(
+        &self,
+        member: &MemberCell,
+        update: impl FnOnce(&mut MemberRecord),
+        event: Option<LifecycleEventKind>,
+    ) {
+        self.with_observation_gate(|| {
+            member.update_locked(update);
+            if let Some(event) = event {
+                self.emit_locked(event);
+            } else {
+                self.publish_snapshot_chain_locked();
+            }
+        });
+    }
+
+    #[cfg(test)]
+    pub(crate) fn emit(&self, event: LifecycleEventKind) {
+        self.with_observation_gate(|| self.emit_locked(event));
+    }
+
+    pub(crate) fn publish_child_restart(
+        &self,
+        member: &MemberCell,
+        total_restarts: u64,
+        update: impl FnOnce(&mut MemberRecord),
+        exited: LifecycleEventKind,
+        scheduled: LifecycleEventKind,
+    ) {
+        self.with_observation_gate(|| {
+            self.record.send_modify(|scope| {
+                scope.total_restarts = total_restarts;
+            });
+            member.update_locked(update);
+            self.emit_locked(exited);
+            self.emit_locked(scheduled);
+        });
+    }
+
+    pub(crate) fn terminalize_child(
+        &self,
+        member: &MemberCell,
+        exit: Exit,
+        exited_incarnation: Option<Incarnation>,
+        startup_aborted: bool,
+    ) -> bool {
+        self.with_observation_gate(|| {
+            if matches!(member.record().stage, MemberStage::Terminal(_)) {
+                return false;
+            }
+            member.update_locked(|record| record.startup_aborted = startup_aborted);
+            member.terminalize(exit.clone());
+            if let Some(incarnation) = exited_incarnation {
+                self.emit_locked(LifecycleEventKind::Exited {
+                    id: member.id().clone(),
+                    membership: member.membership(),
+                    incarnation,
+                    exit: exit.clone(),
+                });
+            }
+            let nested = self.current_children.read_with(|children| {
+                children
+                    .iter()
+                    .find(|resident| resident.projection.member.membership() == member.membership())
+                    .and_then(|resident| resident.projection.scope.as_ref())
+                    .cloned()
+            });
+            if let Some(scope) = nested {
+                scope.close_observation_locked();
+            }
+            true
+        })
+    }
+
+    pub(crate) fn prune_child(&self, member: &MemberCell) -> bool {
+        self.with_observation_gate(|| {
+            let membership = member.membership();
+            let mut resident = None;
+            let removed = self.current_children.send_if_modified(|children| {
+                let Some(index) = children
+                    .iter()
+                    .position(|child| child.projection.member.membership() == membership)
+                else {
+                    return false;
+                };
+                resident = Some(children.remove(index));
+                true
+            });
+            if !removed {
+                return false;
+            }
+            let resident = resident.expect("a reported removal owns its resident entry");
+            debug_assert_eq!(resident.projection.member.membership(), membership);
+            // Dropping residency under the observation gate emits the matching
+            // Removed edge through its owned completion.
+            drop(resident);
+            true
+        })
+    }
+
+    pub(crate) fn snapshot(&self) -> Arc<ScopeSnapshot> {
+        self.with_observation_gate(|| self.snapshot_locked())
+    }
+
+    pub(crate) fn subscribe_snapshots(&self) -> SnapshotReceiver {
+        self.with_observation_gate(|| {
+            let receiver = self.snapshots.subscribe(self.snapshot_locked());
+            if self.observation_closed.load(Ordering::Acquire) {
+                self.snapshots.close();
+            }
+            receiver
+        })
+    }
+
+    pub(crate) fn subscribe_lifecycle(&self) -> LifecycleEvents {
+        self.with_observation_gate(|| {
+            let events = self.lifecycle.subscribe();
+            if self.observation_closed.load(Ordering::Acquire) {
+                self.lifecycle.close();
+            }
+            events
+        })
+    }
+
+    fn snapshot_locked(&self) -> Arc<ScopeSnapshot> {
+        let record = self.record();
+        let config = self.config.read_cloned();
+        let children = self.current_children.read_with(|children| {
+            children
+                .iter()
+                .map(|resident| resident.projection.clone())
+                .collect::<Vec<_>>()
+        });
+        let children = children
+            .iter()
+            .map(|child| self.child_snapshot_locked(child))
+            .collect::<Vec<_>>();
+        Arc::new(ScopeSnapshot {
+            state: record.state,
+            kind: match self.flavor {
+                ScopeFlavor::Ordered => ScopeKind::Ordered,
+                ScopeFlavor::Dynamic => ScopeKind::Dynamic,
+            },
+            strategy: (self.flavor == ScopeFlavor::Ordered).then_some(config.strategy),
+            intensity: config.intensity,
+            total_restarts: record.total_restarts,
+            lifecycle_seq: self.lifecycle_seq.load(Ordering::Acquire),
+            children: children.into(),
+        })
+    }
+
+    fn child_snapshot_locked(&self, child: &ResidentProjection) -> ChildSnapshot {
+        let record = child.member.record();
+        let options = child.member.options();
+        let terminal = matches!(record.stage, MemberStage::Terminal(_));
+        let nested = child.scope.as_ref().and_then(|scope| {
+            (record.incarnation.is_some() || terminal).then(|| scope.snapshot_locked())
+        });
+        ChildSnapshot {
+            id: child.member.id().clone(),
+            membership: child.member.membership(),
+            incarnation: record.incarnation,
+            state: match record.stage {
+                MemberStage::Reserved | MemberStage::Admitted => ChildState::Admitted,
+                MemberStage::Starting => ChildState::Starting,
+                MemberStage::Running => ChildState::Running,
+                MemberStage::Restarting => ChildState::Restarting,
+                MemberStage::Stopping => ChildState::Stopping,
+                MemberStage::Terminal(exit) if record.startup_aborted => {
+                    ChildState::StartupAborted { exit }
+                }
+                MemberStage::Terminal(exit) => ChildState::Stopped { exit },
+            },
+            last_exit: record.last_exit,
+            membership_status: if record.removing {
+                MembershipStatus::Removing
+            } else {
+                MembershipStatus::Active
+            },
+            restart_count: record.restart_count,
+            restart_policy: options.restart,
+            retention: options.retention,
+            restart_at: record.restart_at,
+            nested,
+            scope_seq: child
+                .scope
+                .as_ref()
+                .map(|scope| scope.lifecycle_seq.load(Ordering::Acquire)),
+        }
+    }
+
+    fn ancestors_locked(&self) -> Vec<Arc<ScopeCell>> {
+        let mut ancestors = Vec::new();
+        let mut current = self.parent.read_cloned().as_ref().and_then(Weak::upgrade);
+        while let Some(scope) = current {
+            current = scope.parent.read_cloned().as_ref().and_then(Weak::upgrade);
+            ancestors.push(scope);
+        }
+        ancestors
+    }
+
+    fn publish_snapshot_chain_locked(&self) {
+        self.snapshots.publish(|| self.snapshot_locked());
+        for ancestor in self.ancestors_locked() {
+            ancestor.snapshots.publish(|| ancestor.snapshot_locked());
+        }
+    }
+
+    fn emit_locked(&self, kind: LifecycleEventKind) {
+        let seq = self
+            .lifecycle_sequence
+            .lock()
+            .expect("lifecycle sequence mutex poisoned")
+            .mint_sequence();
+        let Some(seq) = seq else {
+            self.lifecycle_seq.store(u64::MAX, Ordering::Release);
+            self.publish_snapshot_chain_locked();
+            self.lifecycle.publish_lagged(1);
+            for ancestor in self.ancestors_locked() {
+                ancestor.lifecycle.publish_lagged(1);
+            }
+            return;
+        };
+        self.lifecycle_seq.store(seq, Ordering::Release);
+        self.publish_snapshot_chain_locked();
+
+        let scope = self.member.membership();
+        let mut event = LifecycleEvent {
+            scope_path: Vec::new(),
+            scope,
+            seq,
+            kind,
+        };
+        self.lifecycle.publish(event.clone());
+        let mut child_id = self.member.id().clone();
+        for ancestor in self.ancestors_locked() {
+            event.scope_path.insert(0, child_id);
+            child_id = ancestor.member.id().clone();
+            ancestor.lifecycle.publish(event.clone());
+        }
+    }
+
+    fn close_observation_locked(&self) {
+        if self.observation_closed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        // Closure follows the final state/snapshot/event publication performed
+        // by the caller while this same observation gate remains held.
+        self.snapshots.close();
+        self.lifecycle.close();
+    }
+
+    pub(crate) fn close_observation(&self) {
+        self.with_observation_gate(|| self.close_observation_locked());
+    }
+
+    #[cfg(test)]
+    pub(crate) fn replace_observation_gate(&self, gate: Arc<Mutex<()>>) {
+        *self
+            .observation_gate
+            .lock()
+            .expect("observation gate handoff mutex remains healthy") = gate;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_lifecycle_sequence(&self, counter: FenceCounter) {
+        *self
+            .lifecycle_sequence
+            .lock()
+            .expect("lifecycle sequence mutex poisoned") = counter;
+    }
+
+    pub(crate) fn set_startup(&self, startup: Result<(), StartupError>) {
+        let mut published = false;
+        self.record.modify_silently(|record| {
+            if record.startup.is_none() {
+                record.startup = Some(startup);
+                published = true;
+            }
+        });
+        if published {
+            // Preserve the original driver wake boundary before releasing the
+            // startup record itself.
+            self.member.record.pulse();
+            self.record.pulse();
+        }
+    }
+
+    pub(crate) fn begin_incarnation(&self) -> u64 {
+        let mut control = self.control.lock().expect("scope control mutex poisoned");
+        control.current_epoch = control.current_epoch.saturating_add(1);
+        control.live = true;
+        let epoch = control.current_epoch;
+        drop(control);
+        self.member.record.pulse();
+        epoch
+    }
+
+    pub(crate) fn finish_incarnation(&self, epoch: u64, reason: StopReason) {
+        self.finish_incarnation_with_terminal(epoch, reason, None);
+    }
+
+    pub(crate) fn finish_root_incarnation(&self, epoch: u64, reason: StopReason, exit: Exit) {
+        self.finish_incarnation_with_terminal(epoch, reason, Some(exit));
+    }
+
+    fn finish_incarnation_with_terminal(
+        &self,
+        epoch: u64,
+        reason: StopReason,
+        terminal_exit: Option<Exit>,
+    ) {
+        self.with_observation_gate(|| {
+            let state = ScopeState::Stopped {
+                reason: reason.clone(),
+            };
+            self.record.modify_silently(|record| {
+                if record.startup.is_none() {
+                    record.startup = Some(Err(StartupError::ShutdownRequested));
+                }
+                record.state = state.clone();
+            });
+            let terminal = terminal_exit.is_some();
+            if let Some(exit) = terminal_exit {
+                self.member.terminalize(exit);
+            }
+            let mut control = self.control.lock().expect("scope control mutex poisoned");
+            if control.current_epoch == epoch {
+                control.live = false;
+                control.last_stopped_epoch = control.last_stopped_epoch.max(epoch);
+                if control
+                    .shutdown
+                    .is_some_and(|request| request.epoch <= epoch)
+                {
+                    control.shutdown = None;
+                }
+                if control.force.is_some_and(|request| request.epoch <= epoch) {
+                    control.force = None;
+                }
+            }
+            drop(control);
+            self.member.record.pulse();
+            // `wait_started` must not observe terminal startup until the member
+            // and incarnation-control planes are mutually consistent.
+            self.record.pulse();
+            self.emit_locked(LifecycleEventKind::ScopeState { state });
+            if terminal {
+                self.close_observation_locked();
+            }
+        });
+    }
+
+    pub(crate) fn finish_live_root_incarnation(&self, reason: StopReason, exit: Exit) {
+        let epoch = {
+            let control = self.control.lock().expect("scope control mutex poisoned");
+            control.live.then_some(control.current_epoch)
+        };
+        if let Some(epoch) = epoch {
+            self.finish_root_incarnation(epoch, reason, exit);
+        } else {
+            self.with_observation_gate(|| {
+                let state = ScopeState::Stopped { reason };
+                self.record.modify_silently(|record| {
+                    if record.startup.is_none() {
+                        record.startup = Some(Err(StartupError::ShutdownRequested));
+                    }
+                    record.state = state.clone();
+                });
+                self.member.terminalize(exit);
+                self.member.record.pulse();
+                self.record.pulse();
+                self.emit_locked(LifecycleEventKind::ScopeState { state });
+                self.close_observation_locked();
+            });
+        }
+    }
+
+    pub(crate) fn request_shutdown(&self) -> u64 {
+        let mut control = self.control.lock().expect("scope control mutex poisoned");
+        let pending_incarnation = !control.live;
+        let target = if control.live {
+            control.current_epoch
+        } else {
+            control.current_epoch.saturating_add(1)
+        };
+        if control
+            .shutdown
+            .is_none_or(|request| request.epoch < target)
+        {
+            control.shutdown = Some(ScopeRequest {
+                epoch: target,
+                consumed: false,
+            });
+        }
+        drop(control);
+        self.member.record.pulse();
+        if pending_incarnation
+            && let Some(parent) = self.parent.read_cloned().as_ref().and_then(Weak::upgrade)
+        {
+            parent.member.record.pulse();
+        }
+        target
+    }
+
+    pub(crate) fn has_pending_incarnation_shutdown(&self) -> bool {
+        let control = self.control.lock().expect("scope control mutex poisoned");
+        !control.live
+            && control.shutdown.is_some_and(|request| {
+                !request.consumed && request.epoch > control.last_stopped_epoch
+            })
+    }
+
+    pub(crate) fn has_stop_request(&self, epoch: u64) -> bool {
+        let control = self.control.lock().expect("scope control mutex poisoned");
+        control
+            .shutdown
+            .is_some_and(|request| request.epoch == epoch)
+            || control.force.is_some_and(|request| request.epoch == epoch)
+    }
+
+    pub(crate) fn take_shutdown_request(&self, epoch: u64) -> bool {
+        let mut control = self.control.lock().expect("scope control mutex poisoned");
+        match control.shutdown.as_mut() {
+            Some(request) if request.epoch == epoch && !request.consumed => {
+                request.consumed = true;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) fn force_shutdown(&self, epoch: u64) {
+        let mut control = self.control.lock().expect("scope control mutex poisoned");
+        if control.live && control.current_epoch == epoch {
+            control.force = Some(ScopeRequest {
+                epoch,
+                consumed: false,
+            });
+        }
+        drop(control);
+        self.member.record.pulse();
+    }
+
+    pub(crate) fn take_force_request(&self, epoch: u64) -> bool {
+        let mut control = self.control.lock().expect("scope control mutex poisoned");
+        match control.force.as_mut() {
+            Some(request) if request.epoch == epoch && !request.consumed => {
+                request.consumed = true;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) fn incarnation_finished(&self, epoch: u64) -> bool {
+        let control = self.control.lock().expect("scope control mutex poisoned");
+        control.last_stopped_epoch >= epoch
+    }
+
+    pub(crate) fn set_admitted_children(self: &Arc<Self>, children: Vec<ResidentProjection>) {
+        self.with_observation_gate(|| {
+            let gate = self.current_observation_gate();
+            self.clear_residents_locked();
+            for child in children {
+                if let Some(scope) = &child.scope {
+                    scope.adopt_observation_gate(&gate);
+                    scope.parent.replace(Some(Arc::downgrade(self)));
+                }
+                child
+                    .member
+                    .update_locked(|record| record.stage = MemberStage::Admitted);
+                let id = child.member.id().clone();
+                let membership = child.member.membership();
+                self.current_children
+                    .send_modify(|children| children.push(ResidentChild::new(self, child)));
+                self.emit_locked(LifecycleEventKind::Added { id, membership });
+            }
+        });
+    }
+
+    pub(crate) fn admit_child(self: &Arc<Self>, child: ResidentProjection) {
+        self.with_observation_gate(|| {
+            let gate = self.current_observation_gate();
+            if let Some(scope) = &child.scope {
+                scope.adopt_observation_gate(&gate);
+                scope.parent.replace(Some(Arc::downgrade(self)));
+            }
+            let id = child.member.id().clone();
+            let membership = child.member.membership();
+            child
+                .member
+                .update_locked(|record| record.stage = MemberStage::Admitted);
+            self.current_children
+                .send_modify(|children| children.push(ResidentChild::new(self, child)));
+            self.emit_locked(LifecycleEventKind::Added { id, membership });
+        });
+    }
+
+    pub(crate) fn clear_residents(&self) {
+        self.with_observation_gate(|| self.clear_residents_locked());
+    }
+
+    fn clear_residents_locked(&self) {
+        let residents = self.current_children.take();
+        // Each owned residency emits Removed only after the watch guard has
+        // been released, so the recursively projected set is already empty.
+        drop(residents);
+    }
+
+    pub(crate) fn set_dynamic_route(&self, route: Option<DynamicRoute>) {
+        *self
+            .dynamic_route
+            .lock()
+            .expect("scope dynamic-route mutex poisoned") = route;
+        self.member.record.pulse();
+    }
+
+    pub(crate) fn dynamic_route(&self) -> Option<DynamicRoute> {
+        self.dynamic_route
+            .lock()
+            .expect("scope dynamic-route mutex poisoned")
+            .clone()
+    }
+
+    pub(crate) fn signal(&self) -> &runtime::WatchSender<MemberRecord> {
+        &self.member.record
+    }
+
+    pub(crate) async fn wait_started(&self) -> Result<(), StartupError> {
+        let mut watcher = self.record.watcher();
+        loop {
+            if let Some(result) = watcher.borrow_and_update_cloned().startup {
+                return result;
+            }
+            watcher.changed().await;
+        }
+    }
+
+    pub(crate) async fn wait_stopped(&self) -> StopReason {
+        self.member.wait_terminal().await;
+        match self.record().state {
+            ScopeState::Stopped { reason } => reason,
+            ScopeState::Unstarted
+            | ScopeState::Starting
+            | ScopeState::Running
+            | ScopeState::StartupFailed
+            | ScopeState::Draining => StopReason::NeverStarted,
+        }
+    }
+
+    pub(crate) fn terminalize_never_started(&self) {
+        self.with_observation_gate(|| {
+            if self.observation_closed.load(Ordering::Acquire) {
+                return;
+            }
+            self.member.terminalize(Exit::never_started());
+            self.record.modify_silently(|record| {
+                if record.startup.is_none() {
+                    record.startup = Some(Err(StartupError::ShutdownRequested));
+                }
+                record.state = ScopeState::Stopped {
+                    reason: StopReason::NeverStarted,
+                };
+            });
+            self.member.record.pulse();
+            self.record.pulse();
+            self.emit_locked(LifecycleEventKind::ScopeState {
+                state: ScopeState::Stopped {
+                    reason: StopReason::NeverStarted,
+                },
+            });
+            self.close_observation_locked();
+        });
+    }
+}

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -940,7 +940,6 @@ impl IndexMut<ChildKey> for ChildArena {
 
 struct ScopeRuntime {
     root: Arc<ScopeCell>,
-    flavor: ScopeFlavor,
     defaults: ResolvedDefaults,
     intensity_policy: crate::Intensity,
     intensity: IntensityState,
@@ -1499,7 +1498,7 @@ impl ScopeRuntime {
         if self.phase != ScopePhase::Starting {
             return;
         }
-        match self.flavor {
+        match self.root.flavor {
             ScopeFlavor::Ordered => {
                 while let Some(key) = self.next_ordered_start {
                     if !self.children[key].spawned_once {
@@ -1675,7 +1674,7 @@ impl ScopeRuntime {
             self.root.set_startup(Err(StartupError::ShutdownRequested));
         }
         self.root.set_state(ScopeState::Draining);
-        match self.flavor {
+        match self.root.flavor {
             ScopeFlavor::Ordered => self.stop_next_ordered(),
             ScopeFlavor::Dynamic => {
                 let children: Vec<_> = self.children.keys().collect();
@@ -1687,7 +1686,7 @@ impl ScopeRuntime {
     }
 
     fn stop_next_ordered(&mut self) {
-        if self.flavor != ScopeFlavor::Ordered || !self.phase.is_draining() {
+        if self.root.flavor != ScopeFlavor::Ordered || !self.phase.is_draining() {
             return;
         }
         loop {
@@ -2074,7 +2073,7 @@ impl ScopeRuntime {
         self.phase = ScopePhase::StartupFailed;
         self.root
             .set_startup(Err(StartupError::StartupFailed(failure.clone())));
-        if self.flavor == ScopeFlavor::Ordered {
+        if self.root.flavor == ScopeFlavor::Ordered {
             let later_children: Vec<_> = self.children.keys_after(key).collect();
             for later in later_children {
                 if !self.children[later].spawned_once
@@ -2161,7 +2160,7 @@ impl ScopeRuntime {
             return None;
         }
         if !self.phase.startup_failed()
-            && self.flavor == ScopeFlavor::Ordered
+            && self.root.flavor == ScopeFlavor::Ordered
             && !self.children.is_empty()
             && self
                 .children
@@ -2402,7 +2401,7 @@ impl ScopeRuntime {
             }
         }
         self.root.prune_child(&member);
-        if self.flavor == ScopeFlavor::Dynamic {
+        if self.root.flavor == ScopeFlavor::Dynamic {
             self.reclaim_child(key);
         }
         // The entry's drop completes any in-flight removal response; it must
@@ -2522,8 +2521,8 @@ async fn run_scope_incarnation(
     }
     let capacity = plan.children.len().saturating_mul(3).max(64);
     let (events, mut event_receiver) = runtime::bounded_mpsc(capacity);
-    let dynamic =
-        (plan.flavor == ScopeFlavor::Dynamic).then(|| DynamicControl::new(&root, events.clone()));
+    let dynamic = (plan.root.flavor == ScopeFlavor::Dynamic)
+        .then(|| DynamicControl::new(&root, events.clone()));
     if let Some(control) = &dynamic {
         let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
         for child in &plan.children {
@@ -2562,7 +2561,6 @@ async fn run_scope_incarnation(
     let next_ordered_start = children.keys().next();
     let mut scope = ScopeRuntime {
         root: Arc::clone(&root),
-        flavor: plan.flavor,
         defaults: plan.defaults.clone(),
         intensity_policy: plan.config.intensity,
         intensity: IntensityState::default(),
@@ -2589,7 +2587,7 @@ async fn run_scope_incarnation(
     plan.armed = false;
     drop(plan);
 
-    match scope.flavor {
+    match scope.root.flavor {
         ScopeFlavor::Ordered => scope.progress_startup(),
         ScopeFlavor::Dynamic => {
             let children: Vec<_> = scope.children.keys().collect();
@@ -2836,7 +2834,6 @@ mod tests {
         mailbox::MailboxCell,
         plan::SlotCell,
         runtime::Latch,
-        tree::{into_core_for_test, lower_tree_for_test},
     };
 
     use super::{
@@ -2995,7 +2992,7 @@ mod tests {
         tree.add_task("trip", TaskDef::new(|_| future::pending()))
             .expect("valid task");
 
-        let mut plan = lower_tree_for_test(tree);
+        let mut plan = tree.lower_for_test();
         let root = Arc::clone(&plan.root);
         let epoch = root.begin_incarnation();
         root.set_admitted_children(
@@ -3023,7 +3020,6 @@ mod tests {
         let next_ordered_start = children.keys().next();
         let mut scope = ScopeRuntime {
             root: Arc::clone(&root),
-            flavor: plan.flavor,
             defaults: plan.defaults.clone(),
             intensity_policy: plan.config.intensity,
             intensity: super::IntensityState::default(),
@@ -3181,7 +3177,7 @@ mod tests {
         let mut tree = Tree::new();
         tree.add_task("worker", TaskDef::new(|_| future::pending()))
             .expect("valid task");
-        let mut plan = lower_tree_for_test(tree);
+        let mut plan = tree.lower_for_test();
         let child =
             ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &plan.root);
         let mut arena = ChildArena::default();
@@ -3200,7 +3196,7 @@ mod tests {
         let mut tree = Tree::new();
         tree.add_task("worker", TaskDef::new(|_| future::pending()))
             .expect("valid task");
-        let mut plan = lower_tree_for_test(tree);
+        let mut plan = tree.lower_for_test();
         let child =
             ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &plan.root);
         let mut arena = ChildArena {
@@ -3419,7 +3415,7 @@ mod tests {
                 .expect("manual readiness is valid"),
         )
         .expect("valid task");
-        let plan = lower_tree_for_test(tree);
+        let plan = tree.lower_for_test();
         let scope = Arc::clone(&plan.root);
         let epoch = scope.begin_incarnation();
         let driver = crate::runtime::spawn(
@@ -3459,7 +3455,7 @@ mod tests {
 
     #[crate::runtime::test]
     async fn dropped_unpolled_scope_plan_terminalizes_its_root() {
-        let plan = lower_tree_for_test(Tree::new());
+        let plan = Tree::new().lower_for_test();
         let root = Arc::clone(&plan.root);
 
         drop(plan);
@@ -3483,7 +3479,7 @@ mod tests {
             .expect("valid nested scope");
         let mut snapshots = nested.subscribe_snapshots();
         let mut events = nested.subscribe_lifecycle();
-        let plan = lower_tree_for_test(outer);
+        let plan = outer.lower_for_test();
 
         drop(plan);
 
@@ -3527,7 +3523,7 @@ mod tests {
             tree.add_task(id, TaskDef::new(|_| future::pending()))
                 .expect("valid task");
         }
-        let plan = lower_tree_for_test(tree);
+        let plan = tree.lower_for_test();
         let root = Arc::clone(&plan.root);
         let mut events = root.subscribe_lifecycle();
         let children: Vec<_> = plan
@@ -4057,7 +4053,7 @@ mod tests {
             .expect("provisional declaration succeeds");
         let ready = Latch::default();
         let error = run_nested_tree(
-            into_core_for_test(tree),
+            tree.into_core_for_test(),
             Arc::clone(&scope),
             crate::policy::ResolvedDefaults::default(),
             ready.clone(),

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -3,9 +3,7 @@
 use std::{
     collections::HashMap,
     fmt,
-    future::Future,
     ops::{Index, IndexMut},
-    pin::Pin,
     sync::{
         Arc, Mutex, Weak,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -40,29 +38,6 @@ use crate::{
         StopReason,
     },
 };
-
-pub(crate) type DriverSleep = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
-
-pub(crate) fn deadline(duration: Duration) -> Deadline {
-    Deadline::after(runtime::now(), duration)
-}
-
-pub(crate) fn sleep_deadline(deadline: Deadline) -> DriverSleep {
-    Box::pin(async move {
-        match deadline.instant() {
-            Some(deadline) => runtime::sleep_until_std(deadline).await,
-            None => std::future::pending().await,
-        }
-    })
-}
-
-pub(crate) fn sleep_until(deadline: Instant) -> DriverSleep {
-    Box::pin(runtime::sleep_until_std(deadline))
-}
-
-pub(crate) fn now() -> Instant {
-    runtime::now()
-}
 
 /// An exactly-once synchronous completion.
 ///
@@ -105,130 +80,6 @@ impl<T> Obligation<T> {
 impl<T> Drop for Obligation<T> {
     fn drop(&mut self) {
         self.discharge();
-    }
-}
-
-pub(crate) struct ActorWork {
-    handle: Option<runtime::JoinHandle<(), ()>>,
-    abort: runtime::AbortHandle,
-}
-
-impl ActorWork {
-    pub(crate) fn abort(&self) {
-        self.abort.abort();
-    }
-
-    pub(crate) async fn join(mut self) {
-        let Some(handle) = self.handle.take() else {
-            return;
-        };
-        let _ = runtime::join(handle).await;
-    }
-}
-
-impl Drop for ActorWork {
-    fn drop(&mut self) {
-        self.abort.abort();
-    }
-}
-
-pub(crate) fn spawn_actor_work(future: impl Future<Output = ()> + Send + 'static) -> ActorWork {
-    let handle = runtime::spawn((), future);
-    let abort = handle.abort_handle();
-    ActorWork {
-        handle: Some(handle),
-        abort,
-    }
-}
-
-pub(crate) struct BlockingWork<T> {
-    handle: Option<runtime::JoinHandle<(), T>>,
-}
-
-impl<T: Send + 'static> BlockingWork<T> {
-    pub(crate) async fn join(mut self) -> T {
-        let handle = self
-            .handle
-            .take()
-            .expect("blocking operation was joined more than once");
-        runtime::join_resuming(handle).await.1
-    }
-}
-
-pub(crate) fn spawn_blocking_work<T: Send + 'static>(
-    operation: impl FnOnce() -> T + Send + 'static,
-) -> BlockingWork<T> {
-    BlockingWork {
-        handle: Some(runtime::spawn_blocking((), operation)),
-    }
-}
-
-pub(crate) enum Selected<A, B> {
-    First(A),
-    Second(B),
-}
-
-pub(crate) async fn select<A, B>(first: A, second: B) -> Selected<A::Output, B::Output>
-where
-    A: Future + Send,
-    B: Future + Send,
-{
-    match runtime::select_two(first, second).await {
-        runtime::Either::Left(value) => Selected::First(value),
-        runtime::Either::Right(value) => Selected::Second(value),
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct Signal {
-    inner: runtime::WatchSender<()>,
-}
-
-impl Default for Signal {
-    fn default() -> Self {
-        Self {
-            inner: runtime::watch(()).0,
-        }
-    }
-}
-
-impl Clone for Signal {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-        }
-    }
-}
-
-impl Signal {
-    pub(crate) fn pulse(&self) {
-        self.inner.pulse();
-    }
-
-    pub(crate) fn watcher(&self) -> SignalWatcher {
-        SignalWatcher {
-            inner: self.inner.watcher(),
-            _signal: self.clone(),
-        }
-    }
-
-    #[cfg(test)]
-    fn watcher_count(&self) -> usize {
-        self.inner.receiver_count()
-    }
-}
-
-pub(crate) struct SignalWatcher {
-    inner: runtime::WatchReceiver<()>,
-    // The previous signal implementation kept the source alive through each
-    // watcher. Preserve that ownership so `changed` cannot turn channel
-    // closure into a spurious pulse.
-    _signal: Signal,
-}
-
-impl SignalWatcher {
-    pub(crate) async fn changed(&mut self) {
-        self.inner.changed().await;
     }
 }
 
@@ -1702,10 +1553,6 @@ impl SystemRun {
             }
         }
     }
-}
-
-pub(crate) fn runtime_available() -> bool {
-    runtime::is_available()
 }
 
 fn collect_stragglers(scope: &ScopeCell, prefix: &[ChildId], out: &mut Vec<ShutdownStraggler>) {
@@ -4078,7 +3925,7 @@ mod tests {
     use super::{
         ChildArena, ChildEvent, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
         MemberCell, MemberStage, Obligation, Pending, RemovalResponses, RuntimeStorage, ScopeCell,
-        ScopeFlavor, ScopePhase, ScopeRuntime, Signal, StartupPhase, complete_removals,
+        ScopeFlavor, ScopePhase, ScopeRuntime, StartupPhase, complete_removals,
         driver_event_class, mint_child_incarnation, report_channel, restart_shutdown_work,
         run_nested_tree, run_scope_incarnation,
     };
@@ -4410,21 +4257,6 @@ mod tests {
             &root.observation_gate(),
             &nested.observation_gate()
         ));
-    }
-
-    #[test]
-    fn quiet_signal_wait_cancellation_keeps_one_watch_registration() {
-        let signal = Signal::default();
-        let mut watcher = signal.watcher();
-        assert_eq!(signal.watcher_count(), 1);
-
-        for _ in 0..10_000 {
-            let mut changed = Box::pin(watcher.changed());
-            let mut context = Context::from_waker(Waker::noop());
-            assert!(changed.as_mut().poll(&mut context).is_pending());
-            drop(changed);
-            assert_eq!(signal.watcher_count(), 1);
-        }
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -20,14 +20,14 @@ use crate::{
     exit::{JoinVerdict, RecordedOutcome, StartupError, StopReason, classify_exit},
     identity::{FenceCounter, ScopeIdentity},
     observe::LifecycleEventKind,
+    plan::{
+        BuilderCore, ChildConstruction, ChildPlan, LowerError, NotAdmittingCause, RemoveOutcome,
+        ReserveError, ScopeFactory, ScopePlan, ScopeSource, SlotCell,
+    },
     policy::{DefaultsInheritance, ResolvedDefaults, ScopeFlavor},
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
     runtime::{self, Latch},
     task::{OnceTaskBody, TaskContext, TaskFactory},
-    tree::{
-        BuilderCore, ChildConstruction, ChildPlan, LowerError, NotAdmittingCause, RemoveOutcome,
-        ReserveError, ScopeFactory, ScopePlan, ScopeSource, SlotCell,
-    },
 };
 
 #[cfg(test)]
@@ -691,7 +691,7 @@ fn discharge_child_terminality(completion: ChildTerminality) {
 }
 
 struct ChildRuntime {
-    slot: Arc<crate::tree::SlotCell>,
+    slot: Arc<SlotCell>,
     terminality: Obligation<ChildTerminality>,
     construction: runtime::Isolated<ChildConstruction>,
     pending_terminal: Option<PendingTerminal>,
@@ -2834,8 +2834,9 @@ mod tests {
         exit::{JoinVerdict, RecordedOutcome},
         identity::{FenceCounter, ScopeIdentity},
         mailbox::MailboxCell,
+        plan::SlotCell,
         runtime::Latch,
-        tree::{SlotCell, into_core_for_test, lower_tree_for_test},
+        tree::{into_core_for_test, lower_tree_for_test},
     };
 
     use super::{

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2,42 +2,36 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
-    fmt,
     ops::{Bound, Index, IndexMut},
-    sync::{
-        Arc, Mutex, Weak,
-        atomic::{AtomicBool, AtomicU64, Ordering},
-        mpsc,
-    },
+    sync::{Arc, Mutex, Weak, mpsc},
     time::{Duration, Instant},
 };
 
 use crate::{
     ChildId, Exit, ExitKind, Incarnation, IntensityTrip, Membership, Readiness, ReadinessDeadline,
     ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure, StartupFailureCause,
+    cells::{DynamicRoute, MemberCell, MemberStage, ResidentProjection, ScopeCell},
     deadline::Deadline,
     engine::{
         ArbitrationClass, DeadlineHandle, DeadlineQueue, ExitDispatch, IntensityState,
         MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState, ScopeMode,
         StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart,
     },
-    exit::{JoinVerdict, RecordedOutcome, classify_exit},
+    exit::{JoinVerdict, RecordedOutcome, StartupError, StopReason, classify_exit},
     identity::{FenceCounter, ScopeIdentity},
-    mailbox::{MailboxControl, MailboxTermination},
-    observe::{
-        ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
-        LifecycleHub, MembershipStatus, ScopeKind, ScopeSnapshot, SnapshotHub, SnapshotReceiver,
-    },
-    policy::{DefaultsInheritance, ResolvedDefaults},
+    observe::LifecycleEventKind,
+    policy::{DefaultsInheritance, ResolvedDefaults, ScopeFlavor},
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
     runtime::{self, Latch},
     task::{OnceTaskBody, TaskContext, TaskFactory},
     tree::{
         BuilderCore, ChildConstruction, ChildPlan, LowerError, NotAdmittingCause, RemoveOutcome,
-        ReserveError, ScopeFactory, ScopeFlavor, ScopePlan, ScopeSource, SlotCell, StartupError,
-        StopReason,
+        ReserveError, ScopeFactory, ScopePlan, ScopeSource, SlotCell,
     },
 };
+
+#[cfg(test)]
+use crate::cells::RuntimeStorage;
 
 /// An exactly-once synchronous completion.
 ///
@@ -80,235 +74,6 @@ impl<T> Obligation<T> {
 impl<T> Drop for Obligation<T> {
     fn drop(&mut self) {
         self.discharge();
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum MemberStage {
-    Reserved,
-    Admitted,
-    Starting,
-    Running,
-    Restarting,
-    Stopping,
-    Terminal(Exit),
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct MemberRecord {
-    pub(crate) stage: MemberStage,
-    pub(crate) incarnation: Option<Incarnation>,
-    pub(crate) last_incarnation: Option<Incarnation>,
-    pub(crate) last_exit: Option<Exit>,
-    pub(crate) restart_count: u64,
-    pub(crate) restart_at: Option<Instant>,
-    pub(crate) removing: bool,
-    pub(crate) startup_aborted: bool,
-}
-
-#[derive(Debug)]
-pub(crate) struct MemberCell {
-    id: ChildId,
-    membership: Mutex<Membership>,
-    record: runtime::WatchSender<MemberRecord>,
-    terminal_disposal_pending: AtomicBool,
-    mailbox: Mutex<MemberMailbox>,
-    options: Mutex<Option<crate::policy::ResolvedCommonOptions>>,
-    pub(crate) removal: Latch,
-}
-
-#[derive(Default)]
-struct MemberMailbox {
-    control: Option<Arc<dyn MailboxControl>>,
-    terminal: Option<Exit>,
-    teardown: Option<Box<dyn MailboxTermination>>,
-}
-
-impl fmt::Debug for MemberMailbox {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("MemberMailbox")
-            .field("control", &self.control)
-            .field("terminal", &self.terminal)
-            .field("teardown_pending", &self.teardown.is_some())
-            .finish()
-    }
-}
-
-impl MemberCell {
-    pub(crate) fn new(id: ChildId, membership: Membership) -> Arc<Self> {
-        let (record, _) = runtime::watch(MemberRecord {
-            stage: MemberStage::Reserved,
-            incarnation: None,
-            last_incarnation: None,
-            last_exit: None,
-            restart_count: 0,
-            restart_at: None,
-            removing: false,
-            startup_aborted: false,
-        });
-        Arc::new(Self {
-            id,
-            membership: Mutex::new(membership),
-            record,
-            terminal_disposal_pending: AtomicBool::new(false),
-            mailbox: Mutex::new(MemberMailbox::default()),
-            options: Mutex::new(None),
-            removal: Latch::default(),
-        })
-    }
-
-    pub(crate) fn id(&self) -> &ChildId {
-        &self.id
-    }
-
-    pub(crate) fn membership(&self) -> Membership {
-        *self
-            .membership
-            .lock()
-            .expect("member identity mutex poisoned")
-    }
-
-    pub(crate) fn rebase_membership(&self, membership: Membership) {
-        let record = self.record();
-        assert!(
-            matches!(record.stage, MemberStage::Reserved)
-                && record.incarnation.is_none()
-                && record.last_incarnation.is_none(),
-            "only an unstarted reservation can be rebased"
-        );
-        *self
-            .membership
-            .lock()
-            .expect("member identity mutex poisoned") = membership;
-    }
-
-    pub(crate) fn record(&self) -> MemberRecord {
-        self.record.read_cloned()
-    }
-
-    fn terminal_disposal_pending(&self) -> bool {
-        self.terminal_disposal_pending.load(Ordering::Acquire)
-    }
-
-    fn set_terminal_disposal_pending(&self, pending: bool) {
-        self.terminal_disposal_pending
-            .store(pending, Ordering::Release);
-    }
-
-    pub(crate) fn update(&self, update: impl FnOnce(&mut MemberRecord)) {
-        self.record.send_modify(update);
-    }
-
-    fn update_locked(&self, update: impl FnOnce(&mut MemberRecord)) {
-        self.record.send_modify(update);
-    }
-
-    pub(crate) fn set_options(&self, options: crate::policy::ResolvedCommonOptions) {
-        *self.options.lock().expect("member options mutex poisoned") = Some(options);
-    }
-
-    fn options(&self) -> crate::policy::ResolvedCommonOptions {
-        self.options
-            .lock()
-            .expect("member options mutex poisoned")
-            .clone()
-            .unwrap_or_else(|| {
-                crate::policy::resolve_common(
-                    &crate::policy::CommonOptions::default(),
-                    &crate::policy::ResolvedDefaults::default(),
-                    false,
-                    Readiness::Immediate,
-                )
-            })
-    }
-
-    pub(crate) fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
-        let terminal_exit = {
-            let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
-            assert!(state.control.is_none(), "a member can own only one mailbox");
-            state.control = Some(Arc::clone(&mailbox));
-            let terminal_exit = state.terminal.clone();
-            if terminal_exit.is_some() {
-                debug_assert!(state.teardown.is_none());
-                state.teardown = mailbox.prepare_termination();
-            }
-            terminal_exit
-        };
-        if let Some(terminal_exit) = terminal_exit {
-            self.publish_terminal(terminal_exit);
-        }
-    }
-
-    pub(crate) fn mailbox(&self) -> Option<Arc<dyn MailboxControl>> {
-        self.mailbox
-            .lock()
-            .expect("member mailbox mutex poisoned")
-            .control
-            .clone()
-    }
-
-    pub(crate) fn terminalize(&self, exit: Exit) {
-        let (terminal_exit, mailbox) = {
-            let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
-            let terminal_exit = if let Some(terminal_exit) = &state.terminal {
-                terminal_exit.clone()
-            } else {
-                let teardown = state
-                    .control
-                    .as_ref()
-                    .and_then(|mailbox| mailbox.prepare_termination());
-                state.terminal = Some(exit.clone());
-                state.teardown = teardown;
-                exit
-            };
-            (terminal_exit, state.control.clone())
-        };
-        self.publish_terminal(terminal_exit);
-        if let Some(mailbox) = mailbox {
-            let stats = mailbox.stats();
-            debug_assert!(stats.delivered <= stats.accepted);
-            debug_assert!(stats.conflated <= stats.accepted);
-            debug_assert!(stats.depth <= stats.capacity);
-            let _ = stats.sends_rejected;
-        }
-    }
-
-    fn publish_terminal(&self, terminal_exit: Exit) {
-        let mut published = false;
-        self.record.modify_silently(|record| {
-            if !matches!(record.stage, MemberStage::Terminal(_)) {
-                record.incarnation = None;
-                record.restart_at = None;
-                record.last_exit = Some(terminal_exit.clone());
-                record.stage = MemberStage::Terminal(terminal_exit);
-                published = true;
-            }
-        });
-        let teardown = self
-            .mailbox
-            .lock()
-            .expect("member mailbox mutex poisoned")
-            .teardown
-            .take();
-        if let Some(teardown) = teardown
-            && let Some(payload) = teardown.finish()
-        {
-            runtime::dispose_detached(payload);
-        }
-        if published {
-            self.record.pulse();
-        }
-    }
-
-    pub(crate) async fn wait_terminal(&self) -> Exit {
-        let mut watcher = self.record.watcher();
-        loop {
-            if let MemberStage::Terminal(exit) = watcher.borrow_cloned().stage {
-                return exit;
-            }
-            watcher.changed().await;
-        }
     }
 }
 
@@ -371,831 +136,6 @@ impl ReportReceiver {
         self.0
             .recv()
             .expect("owned report token must record or fall back")
-    }
-}
-
-struct ResidencyCompletion {
-    parent: Weak<ScopeCell>,
-    slot: Arc<SlotCell>,
-}
-
-fn discharge_residency(completion: ResidencyCompletion) {
-    let Some(parent) = completion.parent.upgrade() else {
-        return;
-    };
-    parent.emit_locked(LifecycleEventKind::Removed {
-        id: completion.slot.member.id().clone(),
-        membership: completion.slot.member.membership(),
-        last_incarnation: completion.slot.member.record().last_incarnation,
-    });
-}
-
-struct ResidentChild {
-    slot: Arc<SlotCell>,
-    _removal: Obligation<ResidencyCompletion>,
-}
-
-impl ResidentChild {
-    fn new(parent: &Arc<ScopeCell>, slot: Arc<SlotCell>) -> Self {
-        Self {
-            _removal: Obligation::new(
-                ResidencyCompletion {
-                    parent: Arc::downgrade(parent),
-                    slot: Arc::clone(&slot),
-                },
-                discharge_residency,
-            ),
-            slot,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct ScopeRecord {
-    pub(crate) state: ScopeState,
-    pub(crate) startup: Option<Result<(), StartupError>>,
-    pub(crate) total_restarts: u64,
-}
-
-/// Shared scope state follows two distinct synchronization regimes.
-///
-/// One gate per running tree serializes compound, observation-visible
-/// transitions across `config`, `record`, `current_children`, and `parent`,
-/// including recursive snapshot projection and lifecycle-event staging. Their
-/// watch channels retain the latest independently readable value; they do not
-/// make that compound transition atomic, so every multi-field observation path
-/// must continue to hold the gate.
-///
-/// The remaining mutexes are deliberately not collapsed into one state lock.
-/// `control` is an epoch-tagged request plane with concurrent callers,
-/// `child_identity` and `lifecycle_sequence` mint monotonic identities, and
-/// `current_dynamic` owns the independently published dynamic request route.
-/// Scope state therefore has multiple writers and no single-writer invariant.
-pub(crate) struct ScopeCell {
-    pub(crate) member: Arc<MemberCell>,
-    pub(crate) flavor: ScopeFlavor,
-    pub(crate) child_identity: Mutex<ScopeIdentity>,
-    config: runtime::WatchSender<crate::tree::ScopeConfig>,
-    record: runtime::WatchSender<ScopeRecord>,
-    control: Mutex<ScopeControl>,
-    current_dynamic: Mutex<Option<Arc<DynamicControl>>>,
-    current_children: runtime::WatchSender<Vec<ResidentChild>>,
-    parent: runtime::WatchSender<Option<Weak<ScopeCell>>>,
-    observation_gate: Mutex<Arc<Mutex<()>>>,
-    lifecycle_sequence: Mutex<FenceCounter>,
-    lifecycle_seq: AtomicU64,
-    lifecycle: LifecycleHub,
-    snapshots: SnapshotHub,
-    observation_closed: AtomicBool,
-    #[cfg(test)]
-    runtime_storage: Mutex<RuntimeStorage>,
-}
-
-#[cfg(test)]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-struct RuntimeStorage {
-    children: usize,
-    child_slots: usize,
-    deadlines: usize,
-    deadline_slots: usize,
-}
-
-#[derive(Debug, Default)]
-struct ScopeControl {
-    current_epoch: u64,
-    live: bool,
-    last_stopped_epoch: u64,
-    shutdown: Option<ScopeRequest>,
-    force: Option<ScopeRequest>,
-}
-
-#[derive(Clone, Copy, Debug)]
-struct ScopeRequest {
-    epoch: u64,
-    consumed: bool,
-}
-
-impl ScopeCell {
-    pub(crate) fn new(
-        member: Arc<MemberCell>,
-        flavor: ScopeFlavor,
-        child_identity: ScopeIdentity,
-    ) -> Arc<Self> {
-        let (config, _) = runtime::watch(crate::tree::ScopeConfig::default());
-        let (record, _) = runtime::watch(ScopeRecord {
-            state: ScopeState::Unstarted,
-            startup: None,
-            total_restarts: 0,
-        });
-        let (current_children, _) = runtime::watch(Vec::new());
-        let (parent, _) = runtime::watch(None);
-        Arc::new(Self {
-            member,
-            flavor,
-            child_identity: Mutex::new(child_identity),
-            config,
-            record,
-            control: Mutex::new(ScopeControl::default()),
-            current_dynamic: Mutex::new(None),
-            current_children,
-            parent,
-            observation_gate: Mutex::new(Arc::new(Mutex::new(()))),
-            lifecycle_sequence: Mutex::new(FenceCounter::new(0)),
-            lifecycle_seq: AtomicU64::new(0),
-            lifecycle: LifecycleHub::default(),
-            snapshots: SnapshotHub::default(),
-            observation_closed: AtomicBool::new(false),
-            #[cfg(test)]
-            runtime_storage: Mutex::new(RuntimeStorage::default()),
-        })
-    }
-
-    pub(crate) fn record(&self) -> ScopeRecord {
-        self.record.read_cloned()
-    }
-
-    #[cfg(test)]
-    fn runtime_storage(&self) -> RuntimeStorage {
-        *self
-            .runtime_storage
-            .lock()
-            .expect("runtime-storage mutex poisoned")
-    }
-
-    fn observation_gate(&self) -> Arc<Mutex<()>> {
-        Arc::clone(
-            &self
-                .observation_gate
-                .lock()
-                .expect("observation gate handoff mutex poisoned"),
-        )
-    }
-
-    fn adopt_observation_gate(&self, gate: &Arc<Mutex<()>>) {
-        loop {
-            let current = self.observation_gate();
-            if Arc::ptr_eq(&current, gate) {
-                return;
-            }
-
-            // An operation that passed `with_observation_gate`'s pointer
-            // check is allowed to finish its complete observation edge before
-            // the handoff. Conversely, an operation that only captured this
-            // gate will see the replacement after acquiring it and retry.
-            let current_guard = current
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let mut installed = self
-                .observation_gate
-                .lock()
-                .expect("observation gate handoff mutex poisoned");
-            if Arc::ptr_eq(&current, &installed) {
-                *installed = Arc::clone(gate);
-                drop(installed);
-                self.adopt_descendant_observation_gates_locked(&current, gate);
-                drop(current_guard);
-                return;
-            }
-            drop(installed);
-            drop(current_guard);
-        }
-    }
-
-    /// Re-homes a resident subtree while its former tree gate is held. The
-    /// caller also holds the destination gate, so observers cannot enter
-    /// either half of the tree while the handoff is being installed.
-    fn adopt_descendant_observation_gates_locked(
-        &self,
-        previous: &Arc<Mutex<()>>,
-        gate: &Arc<Mutex<()>>,
-    ) {
-        let descendants = self.current_children.read_with(|children| {
-            children
-                .iter()
-                .filter_map(|resident| resident.slot.scope.as_ref().cloned())
-                .collect::<Vec<_>>()
-        });
-        for descendant in descendants {
-            let mut installed = descendant
-                .observation_gate
-                .lock()
-                .expect("observation gate handoff mutex poisoned");
-            if Arc::ptr_eq(&installed, previous) {
-                *installed = Arc::clone(gate);
-            } else {
-                assert!(
-                    Arc::ptr_eq(&installed, gate),
-                    "one resident tree must share one observation gate"
-                );
-            }
-            drop(installed);
-            descendant.adopt_descendant_observation_gates_locked(previous, gate);
-        }
-    }
-
-    /// Runs against the cell's current tree gate. Adoption can race an early
-    /// pre-start observer, so a waiter that acquired an obsolete gate retries
-    /// before entering the observation critical section.
-    fn with_observation_gate<R>(&self, operation: impl FnOnce() -> R) -> R {
-        let mut operation = Some(operation);
-        loop {
-            let gate = self.observation_gate();
-            let guard = gate
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if Arc::ptr_eq(&gate, &self.observation_gate()) {
-                let operation = operation
-                    .take()
-                    .expect("observation operation runs exactly once");
-                let result = operation();
-                drop(guard);
-                return result;
-            }
-            drop(guard);
-        }
-    }
-
-    pub(crate) fn set_state(&self, state: ScopeState) {
-        self.with_observation_gate(|| {
-            self.record.send_modify(|record| {
-                if state == ScopeState::Starting {
-                    record.total_restarts = 0;
-                }
-                record.state = state.clone();
-            });
-            self.member.record.pulse();
-            self.emit_locked(LifecycleEventKind::ScopeState { state });
-        });
-    }
-
-    pub(crate) fn set_config(&self, config: crate::tree::ScopeConfig) {
-        self.with_observation_gate(|| {
-            self.config.replace(config);
-            self.publish_snapshot_chain_locked();
-        });
-    }
-
-    pub(crate) fn transition_child(
-        &self,
-        member: &MemberCell,
-        update: impl FnOnce(&mut MemberRecord),
-        event: Option<LifecycleEventKind>,
-    ) {
-        self.with_observation_gate(|| {
-            member.update_locked(update);
-            if let Some(event) = event {
-                self.emit_locked(event);
-            } else {
-                self.publish_snapshot_chain_locked();
-            }
-        });
-    }
-
-    #[cfg(test)]
-    pub(crate) fn emit(&self, event: LifecycleEventKind) {
-        self.with_observation_gate(|| self.emit_locked(event));
-    }
-
-    pub(crate) fn publish_child_restart(
-        &self,
-        member: &MemberCell,
-        total_restarts: u64,
-        update: impl FnOnce(&mut MemberRecord),
-        exited: LifecycleEventKind,
-        scheduled: LifecycleEventKind,
-    ) {
-        self.with_observation_gate(|| {
-            self.record.send_modify(|scope| {
-                scope.total_restarts = total_restarts;
-            });
-            member.update_locked(update);
-            self.emit_locked(exited);
-            self.emit_locked(scheduled);
-        });
-    }
-
-    pub(crate) fn terminalize_child(
-        &self,
-        member: &MemberCell,
-        exit: Exit,
-        exited_incarnation: Option<Incarnation>,
-        startup_aborted: bool,
-    ) -> bool {
-        self.with_observation_gate(|| {
-            if matches!(member.record().stage, MemberStage::Terminal(_)) {
-                return false;
-            }
-            member.update_locked(|record| record.startup_aborted = startup_aborted);
-            member.terminalize(exit.clone());
-            if let Some(incarnation) = exited_incarnation {
-                self.emit_locked(LifecycleEventKind::Exited {
-                    id: member.id().clone(),
-                    membership: member.membership(),
-                    incarnation,
-                    exit: exit.clone(),
-                });
-            }
-            let nested = self.current_children.read_with(|children| {
-                children
-                    .iter()
-                    .find(|resident| resident.slot.member.membership() == member.membership())
-                    .and_then(|resident| resident.slot.scope.as_ref())
-                    .cloned()
-            });
-            if let Some(scope) = nested {
-                scope.close_observation_locked();
-            }
-            true
-        })
-    }
-
-    pub(crate) fn prune_child(&self, member: &MemberCell) -> bool {
-        self.with_observation_gate(|| {
-            let membership = member.membership();
-            let mut resident = None;
-            let removed = self.current_children.send_if_modified(|children| {
-                let Some(index) = children
-                    .iter()
-                    .position(|child| child.slot.member.membership() == membership)
-                else {
-                    return false;
-                };
-                resident = Some(children.remove(index));
-                true
-            });
-            if !removed {
-                return false;
-            }
-            let resident = resident.expect("a reported removal owns its resident entry");
-            debug_assert_eq!(resident.slot.member.membership(), membership);
-            // Dropping residency while the observation gate is held emits the
-            // matching Removed edge through its owned completion.
-            drop(resident);
-            true
-        })
-    }
-
-    pub(crate) fn snapshot(&self) -> Arc<ScopeSnapshot> {
-        self.with_observation_gate(|| self.snapshot_locked())
-    }
-
-    pub(crate) fn subscribe_snapshots(&self) -> SnapshotReceiver {
-        self.with_observation_gate(|| {
-            let receiver = self.snapshots.subscribe(self.snapshot_locked());
-            if self.observation_closed.load(Ordering::Acquire) {
-                self.snapshots.close();
-            }
-            receiver
-        })
-    }
-
-    pub(crate) fn subscribe_lifecycle(&self) -> LifecycleEvents {
-        self.with_observation_gate(|| {
-            let events = self.lifecycle.subscribe();
-            if self.observation_closed.load(Ordering::Acquire) {
-                self.lifecycle.close();
-            }
-            events
-        })
-    }
-
-    fn snapshot_locked(&self) -> Arc<ScopeSnapshot> {
-        let record = self.record();
-        let config = self.config.read_cloned();
-        let children = self
-            .current_children
-            .read_with(|children| {
-                children
-                    .iter()
-                    .map(|resident| Arc::clone(&resident.slot))
-                    .collect::<Vec<_>>()
-            })
-            .into_iter()
-            .map(|slot| self.child_snapshot_locked(&slot))
-            .collect::<Vec<_>>();
-        Arc::new(ScopeSnapshot {
-            state: record.state,
-            kind: match self.flavor {
-                ScopeFlavor::Ordered => ScopeKind::Ordered,
-                ScopeFlavor::Dynamic => ScopeKind::Dynamic,
-            },
-            strategy: (self.flavor == ScopeFlavor::Ordered).then_some(config.strategy),
-            intensity: config.intensity,
-            total_restarts: record.total_restarts,
-            lifecycle_seq: self.lifecycle_seq.load(Ordering::Acquire),
-            children: children.into(),
-        })
-    }
-
-    fn child_snapshot_locked(&self, slot: &SlotCell) -> ChildSnapshot {
-        let record = slot.member.record();
-        let options = slot.member.options();
-        let terminal = matches!(record.stage, MemberStage::Terminal(_));
-        let nested = slot.scope.as_ref().and_then(|scope| {
-            (record.incarnation.is_some() || terminal).then(|| scope.snapshot_locked())
-        });
-        ChildSnapshot {
-            id: slot.member.id().clone(),
-            membership: slot.member.membership(),
-            incarnation: record.incarnation,
-            state: match record.stage {
-                MemberStage::Reserved | MemberStage::Admitted => ChildState::Admitted,
-                MemberStage::Starting => ChildState::Starting,
-                MemberStage::Running => ChildState::Running,
-                MemberStage::Restarting => ChildState::Restarting,
-                MemberStage::Stopping => ChildState::Stopping,
-                MemberStage::Terminal(exit) if record.startup_aborted => {
-                    ChildState::StartupAborted { exit }
-                }
-                MemberStage::Terminal(exit) => ChildState::Stopped { exit },
-            },
-            last_exit: record.last_exit,
-            membership_status: if record.removing {
-                MembershipStatus::Removing
-            } else {
-                MembershipStatus::Active
-            },
-            restart_count: record.restart_count,
-            restart_policy: options.restart,
-            retention: options.retention,
-            restart_at: record.restart_at,
-            nested,
-            scope_seq: slot
-                .scope
-                .as_ref()
-                .map(|scope| scope.lifecycle_seq.load(Ordering::Acquire)),
-        }
-    }
-
-    fn ancestors_locked(&self) -> Vec<Arc<ScopeCell>> {
-        let mut ancestors = Vec::new();
-        let mut current = self.parent.read_cloned().as_ref().and_then(Weak::upgrade);
-        while let Some(scope) = current {
-            current = scope.parent.read_cloned().as_ref().and_then(Weak::upgrade);
-            ancestors.push(scope);
-        }
-        ancestors
-    }
-
-    fn publish_snapshot_chain_locked(&self) {
-        self.snapshots.publish(|| self.snapshot_locked());
-        for ancestor in self.ancestors_locked() {
-            ancestor.snapshots.publish(|| ancestor.snapshot_locked());
-        }
-    }
-
-    fn emit_locked(&self, kind: LifecycleEventKind) {
-        let seq = self
-            .lifecycle_sequence
-            .lock()
-            .expect("lifecycle sequence mutex poisoned")
-            .mint_sequence();
-        let Some(seq) = seq else {
-            self.lifecycle_seq.store(u64::MAX, Ordering::Release);
-            self.publish_snapshot_chain_locked();
-            self.lifecycle.publish_lagged(1);
-            for ancestor in self.ancestors_locked() {
-                ancestor.lifecycle.publish_lagged(1);
-            }
-            return;
-        };
-        self.lifecycle_seq.store(seq, Ordering::Release);
-        self.publish_snapshot_chain_locked();
-
-        let scope = self.member.membership();
-        let mut event = LifecycleEvent {
-            scope_path: Vec::new(),
-            scope,
-            seq,
-            kind,
-        };
-        self.lifecycle.publish(event.clone());
-        let mut child_id = self.member.id().clone();
-        for ancestor in self.ancestors_locked() {
-            event.scope_path.insert(0, child_id);
-            child_id = ancestor.member.id().clone();
-            ancestor.lifecycle.publish(event.clone());
-        }
-    }
-
-    fn close_observation_locked(&self) {
-        if self.observation_closed.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        self.snapshots.close();
-        self.lifecycle.close();
-    }
-
-    pub(crate) fn set_startup(&self, startup: Result<(), StartupError>) {
-        let mut published = false;
-        self.record.modify_silently(|record| {
-            if record.startup.is_none() {
-                record.startup = Some(startup);
-                published = true;
-            }
-        });
-        if published {
-            // Before the record became watch-backed, startup waiters shared
-            // the member signal. Preserve that ordering boundary: publish the
-            // member-plane wake before releasing the startup result itself.
-            self.member.record.pulse();
-            self.record.pulse();
-        }
-    }
-
-    fn begin_incarnation(&self) -> u64 {
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        control.current_epoch = control.current_epoch.saturating_add(1);
-        control.live = true;
-        let epoch = control.current_epoch;
-        drop(control);
-        self.member.record.pulse();
-        epoch
-    }
-
-    fn finish_incarnation(&self, epoch: u64, reason: StopReason) {
-        self.finish_incarnation_with_terminal(epoch, reason, None);
-    }
-
-    fn finish_root_incarnation(&self, epoch: u64, reason: StopReason, exit: Exit) {
-        self.finish_incarnation_with_terminal(epoch, reason, Some(exit));
-    }
-
-    fn finish_incarnation_with_terminal(
-        &self,
-        epoch: u64,
-        reason: StopReason,
-        terminal_exit: Option<Exit>,
-    ) {
-        self.with_observation_gate(|| {
-            let state = ScopeState::Stopped {
-                reason: reason.clone(),
-            };
-            self.record.modify_silently(|record| {
-                if record.startup.is_none() {
-                    record.startup = Some(Err(StartupError::ShutdownRequested));
-                }
-                record.state = state.clone();
-            });
-            let terminal = terminal_exit.is_some();
-            if let Some(exit) = terminal_exit {
-                self.member.terminalize(exit);
-            }
-            let mut control = self.control.lock().expect("scope control mutex poisoned");
-            if control.current_epoch == epoch {
-                control.live = false;
-                control.last_stopped_epoch = control.last_stopped_epoch.max(epoch);
-                if control
-                    .shutdown
-                    .is_some_and(|request| request.epoch <= epoch)
-                {
-                    control.shutdown = None;
-                }
-                if control.force.is_some_and(|request| request.epoch <= epoch) {
-                    control.force = None;
-                }
-            }
-            drop(control);
-            self.member.record.pulse();
-            // `wait_started` must not observe terminal startup until the member
-            // and incarnation-control planes above are consistent.
-            self.record.pulse();
-            self.emit_locked(LifecycleEventKind::ScopeState { state });
-            if terminal {
-                self.close_observation_locked();
-            }
-        });
-    }
-
-    fn finish_live_root_incarnation(&self, reason: StopReason, exit: Exit) {
-        let epoch = {
-            let control = self.control.lock().expect("scope control mutex poisoned");
-            control.live.then_some(control.current_epoch)
-        };
-        if let Some(epoch) = epoch {
-            self.finish_root_incarnation(epoch, reason, exit);
-        } else {
-            self.with_observation_gate(|| {
-                let state = ScopeState::Stopped { reason };
-                self.record.modify_silently(|record| {
-                    if record.startup.is_none() {
-                        record.startup = Some(Err(StartupError::ShutdownRequested));
-                    }
-                    record.state = state.clone();
-                });
-                self.member.terminalize(exit);
-                self.member.record.pulse();
-                self.record.pulse();
-                self.emit_locked(LifecycleEventKind::ScopeState { state });
-                self.close_observation_locked();
-            });
-        }
-    }
-
-    pub(crate) fn request_shutdown(&self) -> u64 {
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        let pending_incarnation = !control.live;
-        let target = if control.live {
-            control.current_epoch
-        } else {
-            control.current_epoch.saturating_add(1)
-        };
-        if control
-            .shutdown
-            .is_none_or(|request| request.epoch < target)
-        {
-            control.shutdown = Some(ScopeRequest {
-                epoch: target,
-                consumed: false,
-            });
-        }
-        drop(control);
-        self.member.record.pulse();
-        // A nested scope has no live driver while its parent is retaining it
-        // in restart backoff. Wake that parent as well so it can start the
-        // pending incarnation immediately; that incarnation consumes the
-        // stop and begins the timeout-bounded teardown required by B.9.
-        if pending_incarnation
-            && let Some(parent) = self.parent.read_cloned().as_ref().and_then(Weak::upgrade)
-        {
-            parent.member.record.pulse();
-        }
-        target
-    }
-
-    fn has_pending_incarnation_shutdown(&self) -> bool {
-        let control = self.control.lock().expect("scope control mutex poisoned");
-        !control.live
-            && control.shutdown.is_some_and(|request| {
-                !request.consumed && request.epoch > control.last_stopped_epoch
-            })
-    }
-
-    fn has_stop_request(&self, epoch: u64) -> bool {
-        let control = self.control.lock().expect("scope control mutex poisoned");
-        control
-            .shutdown
-            .is_some_and(|request| request.epoch == epoch)
-            || control.force.is_some_and(|request| request.epoch == epoch)
-    }
-
-    fn take_shutdown_request(&self, epoch: u64) -> bool {
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        match control.shutdown.as_mut() {
-            Some(request) if request.epoch == epoch && !request.consumed => {
-                request.consumed = true;
-                true
-            }
-            _ => false,
-        }
-    }
-
-    fn force_shutdown(&self, epoch: u64) {
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        if control.live && control.current_epoch == epoch {
-            control.force = Some(ScopeRequest {
-                epoch,
-                consumed: false,
-            });
-        }
-        drop(control);
-        self.member.record.pulse();
-    }
-
-    fn take_force_request(&self, epoch: u64) -> bool {
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        match control.force.as_mut() {
-            Some(request) if request.epoch == epoch && !request.consumed => {
-                request.consumed = true;
-                true
-            }
-            _ => false,
-        }
-    }
-
-    fn incarnation_finished(&self, epoch: u64) -> bool {
-        let control = self.control.lock().expect("scope control mutex poisoned");
-        control.last_stopped_epoch >= epoch
-    }
-
-    fn set_admitted_children(self: &Arc<Self>, children: Vec<Arc<SlotCell>>) {
-        self.with_observation_gate(|| {
-            let gate = self.observation_gate();
-            self.clear_residents_locked();
-            for child in children {
-                if let Some(scope) = &child.scope {
-                    scope.adopt_observation_gate(&gate);
-                    scope.parent.replace(Some(Arc::downgrade(self)));
-                }
-                child
-                    .member
-                    .update_locked(|record| record.stage = MemberStage::Admitted);
-                self.current_children.send_modify(|children| {
-                    children.push(ResidentChild::new(self, Arc::clone(&child)))
-                });
-                self.emit_locked(LifecycleEventKind::Added {
-                    id: child.member.id().clone(),
-                    membership: child.member.membership(),
-                });
-            }
-        });
-    }
-
-    fn admit_child(self: &Arc<Self>, child: &Arc<SlotCell>) {
-        self.with_observation_gate(|| {
-            let gate = self.observation_gate();
-            if let Some(scope) = &child.scope {
-                scope.adopt_observation_gate(&gate);
-                scope.parent.replace(Some(Arc::downgrade(self)));
-            }
-            self.current_children
-                .send_modify(|children| children.push(ResidentChild::new(self, Arc::clone(child))));
-            child
-                .member
-                .update_locked(|record| record.stage = MemberStage::Admitted);
-            self.emit_locked(LifecycleEventKind::Added {
-                id: child.member.id().clone(),
-                membership: child.member.membership(),
-            });
-        });
-    }
-
-    pub(crate) fn clear_residents(&self) {
-        self.with_observation_gate(|| self.clear_residents_locked());
-    }
-
-    fn clear_residents_locked(&self) {
-        let residents = self.current_children.take();
-        // Each entry's owned completion emits Removed. Drop the vector only
-        // after releasing the child-set watch value guard so snapshot publication can
-        // project the now-empty set while this observation gate stays held.
-        drop(residents);
-    }
-
-    fn set_dynamic(&self, control: Option<Arc<DynamicControl>>) {
-        *self
-            .current_dynamic
-            .lock()
-            .expect("scope dynamic-control mutex poisoned") = control;
-        self.member.record.pulse();
-    }
-
-    fn dynamic(&self) -> Option<Arc<DynamicControl>> {
-        self.current_dynamic
-            .lock()
-            .expect("scope dynamic-control mutex poisoned")
-            .clone()
-    }
-
-    pub(crate) fn signal(&self) -> &runtime::WatchSender<MemberRecord> {
-        &self.member.record
-    }
-
-    pub(crate) async fn wait_started(&self) -> Result<(), StartupError> {
-        let mut watcher = self.record.watcher();
-        loop {
-            if let Some(result) = watcher.borrow_and_update_cloned().startup {
-                return result;
-            }
-            watcher.changed().await;
-        }
-    }
-
-    pub(crate) async fn wait_stopped(&self) -> StopReason {
-        self.member.wait_terminal().await;
-        match self.record().state {
-            ScopeState::Stopped { reason } => reason,
-            ScopeState::Unstarted
-            | ScopeState::Starting
-            | ScopeState::Running
-            | ScopeState::StartupFailed
-            | ScopeState::Draining => StopReason::NeverStarted,
-        }
-    }
-
-    pub(crate) fn terminalize_never_started(&self) {
-        self.with_observation_gate(|| {
-            if self.observation_closed.load(Ordering::Acquire) {
-                return;
-            }
-            self.member.terminalize(Exit::never_started());
-            self.record.modify_silently(|record| {
-                if record.startup.is_none() {
-                    record.startup = Some(Err(StartupError::ShutdownRequested));
-                }
-                record.state = ScopeState::Stopped {
-                    reason: StopReason::NeverStarted,
-                };
-            });
-            self.member.record.pulse();
-            self.record.pulse();
-            self.emit_locked(LifecycleEventKind::ScopeState {
-                state: ScopeState::Stopped {
-                    reason: StopReason::NeverStarted,
-                },
-            });
-            self.close_observation_locked();
-        });
     }
 }
 
@@ -1295,6 +235,14 @@ impl DynamicControl {
     }
 }
 
+fn dynamic_control(scope: &ScopeCell) -> Option<Arc<DynamicControl>> {
+    scope.dynamic_route()?.resolve().ok()
+}
+
+fn resident_projection(slot: &SlotCell) -> ResidentProjection {
+    ResidentProjection::new(Arc::clone(&slot.member), slot.scope.clone())
+}
+
 pub(crate) struct DynamicReservation {
     pub(crate) slot: Arc<SlotCell>,
     pub(crate) control: Arc<DynamicControl>,
@@ -1308,7 +256,7 @@ pub(crate) fn reserve_dynamic(
     if matches!(scope.member.record().stage, MemberStage::Terminal(_)) {
         return Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal));
     }
-    let control = scope.dynamic().ok_or(ReserveError::NotAdmitting(
+    let control = dynamic_control(scope).ok_or(ReserveError::NotAdmitting(
         NotAdmittingCause::NoLiveIncarnation,
     ))?;
     match scope.record().state {
@@ -1435,7 +383,7 @@ pub(crate) fn remove_dynamic(
     ) {
         return completed_removal(RemoveOutcome::AlreadyAbsent);
     }
-    let Some(control) = scope.dynamic() else {
+    let Some(control) = dynamic_control(scope) else {
         return completed_removal(RemoveOutcome::AlreadyAbsent);
     };
     let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
@@ -1556,12 +504,7 @@ impl SystemRun {
 }
 
 fn collect_stragglers(scope: &ScopeCell, prefix: &[ChildId], out: &mut Vec<ShutdownStraggler>) {
-    let children = scope.current_children.read_with(|children| {
-        children
-            .iter()
-            .map(|resident| Arc::clone(&resident.slot))
-            .collect::<Vec<_>>()
-    });
+    let children = scope.resident_projections();
     for child in children {
         if matches!(child.member.record().stage, MemberStage::Terminal(_))
             || child.member.terminal_disposal_pending()
@@ -2029,7 +972,7 @@ impl Drop for ScopeRuntime {
     fn drop(&mut self) {
         let dynamic_entries = if let Some(dynamic) = &self.dynamic {
             let entries = dynamic.close();
-            self.root.set_dynamic(None);
+            self.root.set_dynamic_route(None);
             Some(entries)
         } else {
             None
@@ -2157,16 +1100,12 @@ impl ScopeRuntime {
 
     #[cfg(test)]
     fn record_storage(&self) {
-        *self
-            .root
-            .runtime_storage
-            .lock()
-            .expect("runtime-storage mutex poisoned") = RuntimeStorage {
+        self.root.record_runtime_storage(RuntimeStorage {
             children: self.children.len(),
             child_slots: self.children.storage_len(),
             deadlines: self.deadlines.len(),
             deadline_slots: self.deadlines.storage_len(),
-        };
+        });
     }
 
     fn spawn_child(&mut self, key: ChildKey) {
@@ -3365,7 +2304,7 @@ impl ScopeRuntime {
                 return;
             }
         };
-        self.root.admit_child(&request.slot);
+        self.root.admit_child(resident_projection(&request.slot));
         #[cfg(test)]
         self.record_storage();
         request.complete(Ok(()));
@@ -3503,7 +2442,7 @@ fn mint_child_incarnation(slot: &Arc<SlotCell>, counter: &mut FenceCounter) -> O
             if record.last_incarnation.is_none() {
                 scope.terminalize_never_started();
             } else {
-                scope.with_observation_gate(|| scope.close_observation_locked());
+                scope.close_observation();
             }
         }
     }
@@ -3600,12 +2539,12 @@ async fn run_scope_incarnation(
             );
         }
         drop(state);
-        root.set_dynamic(Some(Arc::clone(control)));
+        root.set_dynamic_route(Some(DynamicRoute::new(Arc::clone(control))));
     }
     root.set_admitted_children(
         plan.children
             .iter()
-            .map(|child| Arc::clone(&child.slot))
+            .map(|child| resident_projection(&child.slot))
             .collect(),
     );
     // Transfer children one at a time. The not-yet-converted suffix remains
@@ -3903,8 +2842,8 @@ mod tests {
         ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
         MemberCell, MemberStage, Obligation, Pending, RemovalResponses, RuntimeStorage, ScopeCell,
         ScopeFlavor, ScopePhase, ScopeRuntime, StartupPhase, complete_removals, driver_event_class,
-        mint_child_incarnation, report_channel, restart_shutdown_work, run_nested_tree,
-        run_scope_incarnation,
+        dynamic_control, mint_child_incarnation, report_channel, resident_projection,
+        restart_shutdown_work, run_nested_tree, run_scope_incarnation,
     };
 
     fn isolated_scope(id: &'static str, flavor: ScopeFlavor) -> Arc<ScopeCell> {
@@ -3953,7 +2892,7 @@ mod tests {
         let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
         let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
 
-        root.set_admitted_children(vec![slot]);
+        root.set_admitted_children(vec![resident_projection(&slot)]);
 
         assert!(Arc::ptr_eq(
             &root.observation_gate(),
@@ -3967,14 +2906,14 @@ mod tests {
         let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
         let leaf = isolated_scope("leaf", ScopeFlavor::Ordered);
         let leaf_slot = SlotCell::new(Arc::clone(&leaf.member), Some(Arc::clone(&leaf)));
-        nested.set_admitted_children(vec![leaf_slot]);
+        nested.set_admitted_children(vec![resident_projection(&leaf_slot)]);
         assert!(Arc::ptr_eq(
             &nested.observation_gate(),
             &leaf.observation_gate()
         ));
 
         let nested_slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
-        root.set_admitted_children(vec![nested_slot]);
+        root.set_admitted_children(vec![resident_projection(&nested_slot)]);
 
         let root_gate = root.observation_gate();
         assert!(Arc::ptr_eq(&root_gate, &nested.observation_gate()));
@@ -4006,10 +2945,7 @@ mod tests {
         // Model the instant at which adoption owns the old gate and publishes
         // the replacement. The waiting observer must acquire the old gate,
         // detect this handoff, and retry on the root gate.
-        *nested
-            .observation_gate
-            .lock()
-            .expect("observation gate handoff mutex remains healthy") = root.observation_gate();
+        nested.replace_observation_gate(root.observation_gate());
         drop(held);
         worker.join().expect("observer follows the gate handoff");
 
@@ -4064,7 +3000,7 @@ mod tests {
         root.set_admitted_children(
             plan.children
                 .iter()
-                .map(|child| Arc::clone(&child.slot))
+                .map(|child| resident_projection(&child.slot))
                 .collect(),
         );
         let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
@@ -4202,7 +3138,7 @@ mod tests {
         let adopting_root = Arc::clone(&root);
         let (adopted, adopted_receiver) = std::sync::mpsc::sync_channel(0);
         let adoption = std::thread::spawn(move || {
-            adopting_root.set_admitted_children(vec![slot]);
+            adopting_root.set_admitted_children(vec![resident_projection(&slot)]);
             adopted.send(()).expect("test receiver remains available");
         });
 
@@ -4748,7 +3684,7 @@ mod tests {
         });
         let waker = Waker::from(Arc::clone(&probe));
         let mut context = Context::from_waker(&waker);
-        let mut watcher = member.record.watcher();
+        let mut watcher = member.record_watcher();
         let mut changed = Box::pin(watcher.changed());
         assert!(changed.as_mut().poll(&mut context).is_pending());
 
@@ -4813,11 +3749,7 @@ mod tests {
         let mailbox = MailboxCell::new(member.id().clone());
         let actor = ActorRef::new(Arc::clone(&member), Arc::clone(&mailbox));
         let first_exit = Exit::never_started();
-        member
-            .mailbox
-            .lock()
-            .expect("member mailbox mutex poisoned")
-            .terminal = Some(first_exit.clone());
+        member.stage_terminal_before_mailbox(first_exit.clone());
         let probe = Arc::new(ObserveMemberOnMailboxWake {
             member: Arc::clone(&member),
             competing_exit: Exit::new(ExitKind::Completed, false),
@@ -4900,7 +3832,7 @@ mod tests {
             observed: Mutex::new(None),
         });
         let waker = Waker::from(Arc::clone(&probe));
-        let mut watcher = scope.record.watcher();
+        let mut watcher = scope.record_watcher();
         let mut changed = Box::pin(watcher.changed());
         assert!(
             changed
@@ -4946,7 +3878,7 @@ mod tests {
             observed: Mutex::new(None),
         });
         let waker = Waker::from(Arc::clone(&probe));
-        let mut watcher = scope.record.watcher();
+        let mut watcher = scope.record_watcher();
         let mut changed = Box::pin(watcher.changed());
         assert!(
             changed
@@ -5014,7 +3946,7 @@ mod tests {
                 .expect("child membership available"),
         );
         let slot = SlotCell::new(Arc::clone(&member), None);
-        root.set_admitted_children(vec![Arc::clone(&slot)]);
+        root.set_admitted_children(vec![resident_projection(&slot)]);
         let (events, _receiver) = crate::runtime::bounded_mpsc(1);
         let control = DynamicControl::new(&root, events);
         let (sender, mut response) = crate::runtime::oneshot();
@@ -5056,11 +3988,8 @@ mod tests {
         let system = DynamicTree::new().spawn().expect("runtime is available");
         let root = system.scope();
         system.wait_started().await.expect("dynamic root starts");
-        let control = root
-            .as_scope()
-            .cell
-            .dynamic()
-            .expect("running dynamic root has a control");
+        let control =
+            dynamic_control(&root.as_scope().cell).expect("running dynamic root has a control");
         let weak = Arc::downgrade(&control);
         drop(control);
 
@@ -5222,10 +4151,7 @@ mod tests {
             ScopeFlavor::Ordered,
             ScopeIdentity::new().expect("child identity available"),
         );
-        *scope
-            .lifecycle_sequence
-            .lock()
-            .expect("lifecycle sequence mutex poisoned") = FenceCounter::near_exhaustion(0);
+        scope.set_lifecycle_sequence(FenceCounter::near_exhaustion(0));
         let mut events = scope.subscribe_lifecycle();
 
         scope.emit(LifecycleEventKind::ScopeState {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -236,7 +236,16 @@ impl DynamicControl {
 }
 
 fn dynamic_control(scope: &ScopeCell) -> Option<Arc<DynamicControl>> {
-    scope.dynamic_route()?.resolve().ok()
+    // The cells layer stores the route erased because it may not name a driver
+    // type. `set_dynamic_route` is the only writer, so a failed downcast is a
+    // driver bug, not an absent route: resolving it to `None` would fail open,
+    // reporting `NoLiveIncarnation` and `AlreadyAbsent` for a live scope.
+    Some(
+        scope
+            .dynamic_route()?
+            .resolve()
+            .unwrap_or_else(|_| panic!("the dynamic route is always a DynamicControl")),
+    )
 }
 
 fn resident_projection(slot: &SlotCell) -> ResidentProjection {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1,9 +1,9 @@
 //! Mutable runtime shell and shared handle state.
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     fmt,
-    ops::{Index, IndexMut},
+    ops::{Bound, Index, IndexMut},
     sync::{
         Arc, Mutex, Weak,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -1903,130 +1903,81 @@ impl ScopePhase {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct ChildKey {
-    index: usize,
-    generation: u64,
-}
-
-struct ChildArenaSlot {
-    generation: u64,
-    child: Option<ChildRuntime>,
-}
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct ChildKey(u64);
 
 #[derive(Default)]
 struct ChildArena {
-    // Vacancies are reused, but every reuse advances the generation carried
-    // by driver events and deadlines. A late event can therefore miss; it
-    // can never address the new resident of the same physical slot.
-    slots: Vec<ChildArenaSlot>,
-    free: Vec<usize>,
-    len: usize,
+    // Keys are insertion-order ids and are never reused. A late event can
+    // therefore miss; it can never address a subsequently inserted child.
+    children: BTreeMap<ChildKey, ChildRuntime>,
+    // `u64::MAX` is poison and is never minted. Once exhausted, every later
+    // insertion fails closed instead of wrapping into the live key domain.
+    next_key: u64,
 }
 
 impl ChildArena {
-    fn with_capacity(capacity: usize) -> Self {
-        Self {
-            slots: Vec::with_capacity(capacity),
-            free: Vec::new(),
-            len: 0,
+    fn insert(&mut self, child: ChildRuntime) -> Result<ChildKey, Box<ChildRuntime>> {
+        let Some(next) = self.next_key.checked_add(1) else {
+            return Err(Box::new(child));
+        };
+        if next == u64::MAX {
+            self.next_key = u64::MAX;
+            return Err(Box::new(child));
         }
-    }
-
-    fn insert(&mut self, child: ChildRuntime) -> ChildKey {
-        self.len += 1;
-        if let Some(index) = self.free.pop() {
-            let slot = &mut self.slots[index];
-            debug_assert!(slot.child.is_none());
-            slot.child = Some(child);
-            ChildKey {
-                index,
-                generation: slot.generation,
-            }
-        } else {
-            let index = self.slots.len();
-            self.slots.push(ChildArenaSlot {
-                generation: 0,
-                child: Some(child),
-            });
-            ChildKey {
-                index,
-                generation: 0,
-            }
-        }
+        self.next_key = next;
+        let key = ChildKey(next);
+        let replaced = self.children.insert(key, child);
+        debug_assert!(replaced.is_none(), "monotonic child keys are never reused");
+        Ok(key)
     }
 
     fn get(&self, key: ChildKey) -> Option<&ChildRuntime> {
-        self.slots
-            .get(key.index)
-            .filter(|slot| slot.generation == key.generation)
-            .and_then(|slot| slot.child.as_ref())
+        self.children.get(&key)
     }
 
     fn get_mut(&mut self, key: ChildKey) -> Option<&mut ChildRuntime> {
-        self.slots
-            .get_mut(key.index)
-            .filter(|slot| slot.generation == key.generation)
-            .and_then(|slot| slot.child.as_mut())
+        self.children.get_mut(&key)
     }
 
     fn remove(&mut self, key: ChildKey) -> Option<ChildRuntime> {
-        let slot = self.slots.get_mut(key.index)?;
-        if slot.generation != key.generation {
-            return None;
-        }
-        let child = slot.child.take()?;
-        self.len -= 1;
-        if let Some(next) = slot.generation.checked_add(1) {
-            slot.generation = next;
-            self.free.push(key.index);
-        }
-        Some(child)
-    }
-
-    fn key_at(&self, index: usize) -> Option<ChildKey> {
-        self.slots.get(index).and_then(|slot| {
-            slot.child.as_ref().map(|_| ChildKey {
-                index,
-                generation: slot.generation,
-            })
-        })
+        self.children.remove(&key)
     }
 
     fn keys(&self) -> impl DoubleEndedIterator<Item = ChildKey> + '_ {
-        self.slots.iter().enumerate().filter_map(|(index, slot)| {
-            slot.child.as_ref().map(|_| ChildKey {
-                index,
-                generation: slot.generation,
-            })
-        })
+        self.children.keys().copied()
+    }
+
+    fn keys_after(&self, key: ChildKey) -> impl DoubleEndedIterator<Item = ChildKey> + '_ {
+        self.children
+            .range((Bound::Excluded(key), Bound::Unbounded))
+            .map(|(key, _)| *key)
     }
 
     fn values(&self) -> impl Iterator<Item = &ChildRuntime> {
-        self.slots.iter().filter_map(|slot| slot.child.as_ref())
+        self.children.values()
     }
 
     fn values_mut(&mut self) -> impl Iterator<Item = &mut ChildRuntime> {
-        self.slots.iter_mut().filter_map(|slot| slot.child.as_mut())
+        self.children.values_mut()
     }
 
+    #[cfg(test)]
     fn len(&self) -> usize {
-        self.len
+        self.children.len()
     }
 
     fn is_empty(&self) -> bool {
-        self.len == 0
+        self.children.is_empty()
     }
 
     fn clear(&mut self) {
-        self.slots.clear();
-        self.free.clear();
-        self.len = 0;
+        self.children.clear();
     }
 
     #[cfg(test)]
     fn storage_len(&self) -> usize {
-        self.slots.len()
+        self.children.len()
     }
 }
 
@@ -2055,7 +2006,7 @@ struct ScopeRuntime {
     deadlines: DeadlineQueue<DeadlineKind>,
     jitter: runtime::JitterRng,
     phase: ScopePhase,
-    next_ordered_start: usize,
+    next_ordered_start: Option<ChildKey>,
     is_root: bool,
     parent_ready: Option<Latch>,
     dynamic: Option<Arc<DynamicControl>>,
@@ -2611,16 +2562,12 @@ impl ScopeRuntime {
         }
         match self.flavor {
             ScopeFlavor::Ordered => {
-                while self.next_ordered_start < self.children.len() {
-                    let key = self
-                        .children
-                        .key_at(self.next_ordered_start)
-                        .expect("ordered children are never reclaimed during startup");
+                while let Some(key) = self.next_ordered_start {
                     if !self.children[key].spawned_once {
                         self.spawn_child(key);
                     }
                     if self.children[key].initial_ready {
-                        self.next_ordered_start += 1;
+                        self.next_ordered_start = self.children.keys_after(key).next();
                     } else {
                         return;
                     }
@@ -3189,11 +3136,8 @@ impl ScopeRuntime {
         self.root
             .set_startup(Err(StartupError::StartupFailed(failure.clone())));
         if self.flavor == ScopeFlavor::Ordered {
-            for later_index in key.index + 1..self.children.len() {
-                let later = self
-                    .children
-                    .key_at(later_index)
-                    .expect("ordered children are never reclaimed during startup");
+            let later_children: Vec<_> = self.children.keys_after(key).collect();
+            for later in later_children {
                 if !self.children[later].spawned_once
                     && !self.children[later].is_disposing()
                     && !self.children[later].is_terminal()
@@ -3391,8 +3335,37 @@ impl ScopeRuntime {
         }
         let mut child = ChildRuntime::from_plan(plan, &self.root);
         child.initial = false;
+        let key = match self.children.insert(child) {
+            Ok(key) => key,
+            Err(child) => {
+                let mut child = *child;
+                let removed = {
+                    let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
+                    let id = request.slot.member.id();
+                    let matches_admission = state.entries.get(id).is_some_and(|entry| {
+                        entry.slot.member.membership() == request.slot.member.membership()
+                            && entry.admitted
+                    });
+                    matches_admission
+                        .then(|| state.entries.remove(id))
+                        .flatten()
+                };
+                request.slot.member.terminalize(Exit::never_started());
+                if let Some(scope) = &request.slot.scope {
+                    scope.terminalize_never_started();
+                }
+                child.complete_terminality();
+                let ChildRuntime { construction, .. } = child;
+                reject_admission_after_disposal(
+                    request,
+                    Some(construction),
+                    removed,
+                    ReserveError::IdentityExhausted,
+                );
+                return;
+            }
+        };
         self.root.admit_child(&request.slot);
-        let key = self.children.insert(child);
         #[cfg(test)]
         self.record_storage();
         request.complete(Ok(()));
@@ -3639,11 +3612,15 @@ async fn run_scope_incarnation(
     // owned by ScopePlan, while ChildRuntime::from_plan arms the current
     // child's obligation before fallible setup. Thus a panic at any point has
     // exactly one terminality owner for every child.
-    let mut children = ChildArena::with_capacity(plan.children.len());
+    let mut children = ChildArena::default();
     plan.children.reverse();
     while let Some(child) = plan.children.pop() {
-        children.insert(ChildRuntime::from_plan(child, &root));
+        let child = ChildRuntime::from_plan(child, &root);
+        if children.insert(child).is_err() {
+            unreachable!("a fresh child-key domain accommodates an in-memory child collection");
+        }
     }
+    let next_ordered_start = children.keys().next();
     let mut scope = ScopeRuntime {
         root: Arc::clone(&root),
         flavor: plan.flavor,
@@ -3655,7 +3632,7 @@ async fn run_scope_incarnation(
         deadlines: DeadlineQueue::default(),
         jitter: runtime::JitterRng::from_system_entropy(),
         phase: ScopePhase::Starting,
-        next_ordered_start: 0,
+        next_ordered_start,
         is_root,
         parent_ready,
         dynamic,
@@ -3923,11 +3900,11 @@ mod tests {
     };
 
     use super::{
-        ChildArena, ChildEvent, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
+        ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
         MemberCell, MemberStage, Obligation, Pending, RemovalResponses, RuntimeStorage, ScopeCell,
-        ScopeFlavor, ScopePhase, ScopeRuntime, StartupPhase, complete_removals,
-        driver_event_class, mint_child_incarnation, report_channel, restart_shutdown_work,
-        run_nested_tree, run_scope_incarnation,
+        ScopeFlavor, ScopePhase, ScopeRuntime, StartupPhase, complete_removals, driver_event_class,
+        mint_child_incarnation, report_channel, restart_shutdown_work, run_nested_tree,
+        run_scope_incarnation,
     };
 
     fn isolated_scope(id: &'static str, flavor: ScopeFlavor) -> Arc<ScopeCell> {
@@ -4091,10 +4068,12 @@ mod tests {
                 .collect(),
         );
         let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
-        let mut children = ChildArena::with_capacity(plan.children.len());
+        let mut children = ChildArena::default();
         plan.children.reverse();
         while let Some(child) = plan.children.pop() {
-            children.insert(ChildRuntime::from_plan(child, &root));
+            children
+                .insert(ChildRuntime::from_plan(child, &root))
+                .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
         }
         let nested = children
             .keys()
@@ -4104,6 +4083,7 @@ mod tests {
             .keys()
             .find(|key| children[*key].slot.member.id().as_str() == "trip")
             .expect("tripping child key");
+        let next_ordered_start = children.keys().next();
         let mut scope = ScopeRuntime {
             root: Arc::clone(&root),
             flavor: plan.flavor,
@@ -4115,7 +4095,7 @@ mod tests {
             deadlines: super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::from_system_entropy(),
             phase: ScopePhase::Running,
-            next_ordered_start: 0,
+            next_ordered_start,
             is_root: true,
             parent_ready: None,
             dynamic: None,
@@ -4260,7 +4240,7 @@ mod tests {
     }
 
     #[test]
-    fn stale_child_keys_cannot_target_reused_slots() {
+    fn removed_child_keys_are_never_reused() {
         let mut tree = Tree::new();
         tree.add_task("worker", TaskDef::new(|_| future::pending()))
             .expect("valid task");
@@ -4268,44 +4248,47 @@ mod tests {
         let child =
             ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &plan.root);
         let mut arena = ChildArena::default();
-        let stale = arena.insert(child);
+        let stale = arena.insert(child).unwrap_or_else(|_| panic!("key mints"));
         let child = arena.remove(stale).expect("live key removes its child");
-        let current = arena.insert(child);
+        let current = arena.insert(child).unwrap_or_else(|_| panic!("key mints"));
 
-        assert_eq!(stale.index, current.index, "the vacant slot is reused");
-        assert_ne!(stale.generation, current.generation);
+        assert!(current > stale, "keys advance monotonically across removal");
         assert!(arena.get(stale).is_none());
         assert!(arena.remove(stale).is_none());
         assert!(arena.get(current).is_some());
     }
 
     #[test]
-    fn exhausted_child_generation_retires_the_slot() {
+    fn child_key_exhaustion_poison_is_never_minted() {
         let mut tree = Tree::new();
         tree.add_task("worker", TaskDef::new(|_| future::pending()))
             .expect("valid task");
         let mut plan = lower_tree_for_test(tree);
         let child =
             ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &plan.root);
-        let mut arena = ChildArena::default();
-        let original = arena.insert(child);
-        arena.slots[original.index].generation = u64::MAX;
-        let exhausted = super::ChildKey {
-            index: original.index,
-            generation: u64::MAX,
+        let mut arena = ChildArena {
+            next_key: u64::MAX - 2,
+            ..ChildArena::default()
         };
+        let last = arena
+            .insert(child)
+            .unwrap_or_else(|_| panic!("the last usable key mints"));
+        assert_eq!(last, ChildKey(u64::MAX - 1));
+        let child = arena.remove(last).expect("the last usable key is live");
 
-        let child = arena
-            .remove(exhausted)
-            .expect("the forced exhausted generation is live");
-        let current = arena.insert(child);
-        assert_ne!(exhausted.index, current.index);
-        assert!(arena.get(exhausted).is_none());
-        assert!(arena.get(current).is_some());
+        let child = *arena
+            .insert(child)
+            .expect_err("the poison key is never minted");
+        assert_eq!(arena.next_key, u64::MAX);
+        assert!(arena.get(ChildKey(u64::MAX)).is_none());
+        assert!(
+            arena.insert(child).is_err(),
+            "the exhausted domain stays poisoned"
+        );
     }
 
     #[crate::runtime::test]
-    async fn dynamic_high_cycle_add_remove_reuses_runtime_storage() {
+    async fn dynamic_high_cycle_add_remove_keeps_only_live_runtime_storage() {
         const CYCLES: usize = 1_000;
 
         let system = DynamicTree::new().spawn().expect("runtime is available");
@@ -4337,7 +4320,7 @@ mod tests {
                     deadlines: 1,
                     deadline_slots: 1,
                 },
-                "cycle {cycle} must reuse the sole runtime slot"
+                "cycle {cycle} stores only the live child"
             );
 
             assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
@@ -4345,11 +4328,11 @@ mod tests {
                 cell.runtime_storage(),
                 RuntimeStorage {
                     children: 0,
-                    child_slots: 1,
+                    child_slots: 0,
                     deadlines: 0,
                     deadline_slots: 0,
                 },
-                "cycle {cycle} must reclaim the removed child"
+                "cycle {cycle} must release removed-child storage"
             );
 
             let automatic = scope
@@ -4365,11 +4348,11 @@ mod tests {
                 cell.runtime_storage(),
                 RuntimeStorage {
                     children: 0,
-                    child_slots: 1,
+                    child_slots: 0,
                     deadlines: 0,
                     deadline_slots: 0,
                 },
-                "cycle {cycle} must reclaim Retention::Remove registration"
+                "cycle {cycle} must release Retention::Remove storage"
             );
         }
 

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -145,6 +145,37 @@ pub struct StartupFailure {
     pub cause: StartupFailureCause,
 }
 
+/// The terminal reason for a scope incarnation or root system.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum StopReason {
+    /// A non-empty ordered workload completed naturally.
+    Finished,
+    /// Shutdown was explicitly requested.
+    ShutdownRequested,
+    /// The scope exceeded its restart budget.
+    IntensityTripped(IntensityTrip),
+    /// A nested scope could not complete startup.
+    StartupFailed(StartupFailure),
+    /// The membership terminalized without an incarnation.
+    NeverStarted,
+}
+
+/// Failure of the root startup barrier.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum StartupError {
+    /// A child or nested lowering failed terminally during startup.
+    #[error("tree startup failed")]
+    StartupFailed(StartupFailure),
+    /// Restart intensity tripped during startup.
+    #[error("restart intensity tripped during startup")]
+    IntensityTripped(IntensityTrip),
+    /// Shutdown began before startup completed.
+    #[error("shutdown was requested during startup")]
+    ShutdownRequested,
+}
+
 /// The cause of a nested-scope startup failure.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -7,7 +7,38 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{ChildId, Membership};
+use crate::{identity::Membership, policy::ChildId};
+
+/// The terminal reason for a scope incarnation or root system.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum StopReason {
+    /// A non-empty ordered workload completed naturally.
+    Finished,
+    /// Shutdown was explicitly requested.
+    ShutdownRequested,
+    /// The scope exceeded its restart budget.
+    IntensityTripped(IntensityTrip),
+    /// A nested scope could not complete startup.
+    StartupFailed(StartupFailure),
+    /// The membership terminalized without an incarnation.
+    NeverStarted,
+}
+
+/// Failure of the root startup barrier.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum StartupError {
+    /// A child or nested lowering failed terminally during startup.
+    #[error("tree startup failed")]
+    StartupFailed(StartupFailure),
+    /// Restart intensity tripped during startup.
+    #[error("restart intensity tripped during startup")]
+    IntensityTripped(IntensityTrip),
+    /// Shutdown began before startup completed.
+    #[error("shutdown was requested during startup")]
+    ShutdownRequested,
+}
 
 /// The exact result returned by restartable tasks and actor callbacks.
 pub type ExitResult = Result<(), ExitError>;

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -176,37 +176,6 @@ pub struct StartupFailure {
     pub cause: StartupFailureCause,
 }
 
-/// The terminal reason for a scope incarnation or root system.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum StopReason {
-    /// A non-empty ordered workload completed naturally.
-    Finished,
-    /// Shutdown was explicitly requested.
-    ShutdownRequested,
-    /// The scope exceeded its restart budget.
-    IntensityTripped(IntensityTrip),
-    /// A nested scope could not complete startup.
-    StartupFailed(StartupFailure),
-    /// The membership terminalized without an incarnation.
-    NeverStarted,
-}
-
-/// Failure of the root startup barrier.
-#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
-#[non_exhaustive]
-pub enum StartupError {
-    /// A child or nested lowering failed terminally during startup.
-    #[error("tree startup failed")]
-    StartupFailed(StartupFailure),
-    /// Restart intensity tripped during startup.
-    #[error("restart intensity tripped during startup")]
-    IntensityTripped(IntensityTrip),
-    /// Shutdown began before startup completed.
-    #[error("shutdown was requested during startup")]
-    ShutdownRequested,
-}
-
 /// The cause of a nested-scope startup failure.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -3,6 +3,7 @@
 //! Structured supervision and actors for asynchronous Rust systems.
 
 mod actor;
+mod cells;
 mod deadline;
 mod driver;
 mod engine;
@@ -19,7 +20,7 @@ mod tree;
 pub use actor::{Actor, ActorDef, ActorOnceDef, Context, Handler, StopContext};
 pub use exit::{
     Exit, ExitError, ExitKind, ExitResult, IntensityTrip, ShutdownStraggler, ShutdownTimeout,
-    StartupFailure, StartupFailureCause,
+    StartupError, StartupFailure, StartupFailureCause, StopReason,
 };
 pub use identity::{Incarnation, Membership};
 pub use mailbox::{
@@ -43,8 +44,8 @@ pub use task::{CancellationToken, OneShotTaskRef, TaskContext, TaskDef, TaskOnce
 pub use tree::{
     ActorSlot, Admission, AdmissionReceipt, BuildError, DynamicActorSlot, DynamicScopeRef,
     DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, NotAdmittingCause, Removal, RemoveOutcome,
-    ReserveError, ScopeRef, StartOrShutdownError, StartupError, StopReason, Subtree, SubtreeDef,
-    SubtreeOnceDef, SubtreeSlot, System, TaskSlot, Tree,
+    ReserveError, ScopeRef, StartOrShutdownError, Subtree, SubtreeDef, SubtreeOnceDef, SubtreeSlot,
+    System, TaskSlot, Tree,
 };
 
 // Keep the repository-facing examples in the same rustdoc compilation lane as

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -11,6 +11,7 @@ mod exit;
 mod identity;
 mod mailbox;
 mod observe;
+mod plan;
 mod policy;
 mod raw;
 mod runtime;
@@ -32,6 +33,7 @@ pub use observe::{
     LifecycleEvents, LifecycleItem, LifecycleTryRecvError, MembershipStatus, ScopeKind,
     ScopeSnapshot, ScopeState, SnapshotClosed, SnapshotReceiver, WaitError,
 };
+pub use plan::{NotAdmittingCause, RemoveOutcome, ReserveError};
 pub use policy::{
     Backoff, BackoffFactor, ChildId, DefaultsInheritance, Intensity, Jitter, Mailbox,
     MailboxShutdown, PolicyError, Readiness, ReadinessDeadline, RestartCondition, RestartPolicy,
@@ -43,9 +45,8 @@ pub use raw::{
 pub use task::{CancellationToken, OneShotTaskRef, TaskContext, TaskDef, TaskOnceDef, TaskRef};
 pub use tree::{
     ActorSlot, Admission, AdmissionReceipt, BuildError, DynamicActorSlot, DynamicScopeRef,
-    DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, NotAdmittingCause, Removal, RemoveOutcome,
-    ReserveError, ScopeRef, StartOrShutdownError, Subtree, SubtreeDef, SubtreeOnceDef, SubtreeSlot,
-    System, TaskSlot, Tree,
+    DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, Removal, ScopeRef, StartOrShutdownError,
+    Subtree, SubtreeDef, SubtreeOnceDef, SubtreeSlot, System, TaskSlot, Tree,
 };
 
 // Keep the repository-facing examples in the same rustdoc compilation lane as

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -15,7 +15,8 @@ use std::{
 
 use crate::{
     ChildId, Incarnation, Mailbox, Membership,
-    driver::{MemberCell, Signal, SignalWatcher},
+    driver::MemberCell,
+    runtime::{Signal, SignalWatcher},
 };
 
 /// The kind of a failed actor send.
@@ -326,7 +327,7 @@ impl<T> Drop for ReplyReceiver<T> {
 pub struct ReplyReceive<T> {
     shared: Option<Arc<ReplyShared<T>>>,
     deadline: Duration,
-    timer: Option<crate::driver::DriverSleep>,
+    timer: Option<crate::runtime::BoxedSleep>,
     started: bool,
     done: bool,
 }
@@ -347,7 +348,7 @@ impl<T: Send + 'static> Future for ReplyReceive<T> {
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
         if !self.started {
             self.started = true;
-            let budget = crate::driver::deadline(self.deadline);
+            let budget = crate::runtime::deadline(self.deadline);
             if self.deadline.is_zero() {
                 self.done = true;
                 if let Some(shared) = &self.shared {
@@ -355,7 +356,7 @@ impl<T: Send + 'static> Future for ReplyReceive<T> {
                 }
                 return Poll::Ready(Err(ReplyError::Timeout));
             }
-            self.timer = Some(crate::driver::sleep_deadline(budget));
+            self.timer = Some(crate::runtime::sleep_deadline(budget));
         }
         let shared = Arc::clone(
             self.shared
@@ -1518,7 +1519,7 @@ impl<M> Drop for SendFuture<M> {
 pub struct SendTimeout<M> {
     send: Option<SendFuture<M>>,
     deadline: Duration,
-    timer: Option<crate::driver::DriverSleep>,
+    timer: Option<crate::runtime::BoxedSleep>,
     started: bool,
     done: bool,
 }
@@ -1539,7 +1540,7 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
         if !self.started {
             self.started = true;
-            let budget = crate::driver::deadline(self.deadline);
+            let budget = crate::runtime::deadline(self.deadline);
             if self.deadline.is_zero() {
                 let actor_id = self
                     .send
@@ -1571,7 +1572,7 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
                     kind: SendErrorKind::TimedOut,
                 }));
             }
-            self.timer = Some(crate::driver::sleep_deadline(budget));
+            self.timer = Some(crate::runtime::sleep_deadline(budget));
         }
         let send = self.send.as_mut().expect("pending timed send retains send");
         if let Poll::Ready(result) = Pin::new(send).poll(context) {
@@ -1624,7 +1625,7 @@ pub struct CallFuture<M, T> {
     actor: ActorRef<M>,
     make_msg: Option<Box<dyn FnOnce(Reply<T>) -> M + Send + 'static>>,
     deadline: Duration,
-    timer: Option<crate::driver::DriverSleep>,
+    timer: Option<crate::runtime::BoxedSleep>,
     send: Option<SendFuture<M>>,
     reply: Option<Arc<ReplyShared<T>>>,
     accepted: Option<Incarnation>,
@@ -1683,7 +1684,7 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
             self.started = true;
             // Capture the one overall budget before invoking user code. A
             // slow message constructor consumes acceptance/response time.
-            let budget = crate::driver::deadline(self.deadline);
+            let budget = crate::runtime::deadline(self.deadline);
             if self.deadline.is_zero() {
                 self.done = true;
                 return Poll::Ready(Err(CallError {
@@ -1701,7 +1702,7 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
             // at the exact deadline win. Construction is different: no send
             // existed before it completed, so do not start one after the
             // captured budget is strictly in the past.
-            if budget.is_overdue(crate::driver::now()) {
+            if budget.is_overdue(crate::runtime::now()) {
                 self.done = true;
                 return Poll::Ready(Err(CallError {
                     actor_id: self.actor.id().clone(),
@@ -1711,7 +1712,7 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
             }
             self.reply = receiver.shared.take();
             self.send = Some(self.actor.send(message));
-            self.timer = Some(crate::driver::sleep_deadline(budget));
+            self.timer = Some(crate::runtime::sleep_deadline(budget));
         }
 
         if self.accepted.is_none() {

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -15,7 +15,7 @@ use std::{
 
 use crate::{
     ChildId, Incarnation, Mailbox, Membership,
-    driver::MemberCell,
+    cells::{MailboxControl, MailboxDisposal, MailboxStats, MailboxTermination, MemberCell},
     runtime::{Signal, SignalWatcher},
 };
 
@@ -639,16 +639,6 @@ impl<M> WaiterQueue<M> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(crate) struct MailboxStats {
-    pub(crate) accepted: u64,
-    pub(crate) delivered: u64,
-    pub(crate) conflated: u64,
-    pub(crate) sends_rejected: u64,
-    pub(crate) depth: usize,
-    pub(crate) capacity: usize,
-}
-
 struct Promotion<M: Send + 'static> {
     displaced: Vec<Envelope<M>>,
     wakers: Vec<Waker>,
@@ -731,8 +721,6 @@ impl<M> Termination<M> {
     }
 }
 
-pub(crate) trait MailboxDisposal: Send {}
-
 struct MailboxPayload<M> {
     queue: Option<VecDeque<Envelope<M>>>,
     latest: Option<Envelope<M>>,
@@ -772,10 +760,6 @@ impl<M> Drop for MailboxPayload<M> {
 }
 
 impl<M: Send> MailboxDisposal for MailboxPayload<M> {}
-
-pub(crate) trait MailboxTermination: Send {
-    fn finish(self: Box<Self>) -> Option<Box<dyn MailboxDisposal>>;
-}
 
 struct MailboxTeardown<M: Send + 'static> {
     changed: Option<Signal>,
@@ -829,16 +813,6 @@ impl<M: Send + 'static> Drop for MailboxTeardown<M> {
             resume_unwind(panic);
         }
     }
-}
-
-/// Type-erased control used by the supervision driver.
-pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
-    fn configure(&self, mailbox: Mailbox);
-    fn bind(&self, incarnation: Incarnation);
-    fn freeze(&self, incarnation: Incarnation);
-    fn close(&self, incarnation: Incarnation) -> Option<Box<dyn MailboxDisposal>>;
-    fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>>;
-    fn stats(&self) -> MailboxStats;
 }
 
 pub(crate) struct MailboxCell<M> {
@@ -1854,7 +1828,7 @@ mod tests {
         task::{Context, Poll, Wake, Waker},
     };
 
-    use crate::{ChildId, Mailbox, SendErrorKind, driver::MemberCell, identity::ScopeIdentity};
+    use crate::{ChildId, Mailbox, SendErrorKind, cells::MemberCell, identity::ScopeIdentity};
 
     use super::{ActorRef, MailboxCell, MailboxControl};
 

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1150,6 +1150,14 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         if matches!(state.status, BindingStatus::Terminal(_)) {
             return;
         }
+        debug_assert!(
+            state.kind.is_some(),
+            "mailbox must be configured before its first bind"
+        );
+        debug_assert!(
+            matches!(state.status, BindingStatus::Unbound),
+            "mailbox must close the prior incarnation before rebinding"
+        );
         state.status = BindingStatus::Bound(incarnation);
         state.last_bound = Some(incarnation);
         // Binding is an observation edge for every operation that remained
@@ -1863,6 +1871,22 @@ mod tests {
     fn park_with(future: &mut std::pin::Pin<Box<super::SendFuture<u8>>>, waker: &Waker) {
         let mut context = Context::from_waker(waker);
         assert!(future.as_mut().poll(&mut context).is_pending());
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "mailbox must be configured before its first bind")]
+    fn binding_before_configuration_trips_the_driver_contract() {
+        let (mailbox, _) = actor();
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let membership = identity
+            .mint_membership(&ChildId::from("actor"))
+            .expect("membership available");
+        let mut incarnations = identity.incarnation_counter(membership);
+        let incarnation = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
+            .expect("incarnation available");
+
+        MailboxControl::bind(&*mailbox, incarnation);
     }
 
     #[test]

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use crate::{
-    ChildId, Exit, Incarnation, Intensity, Membership, RestartPolicy, Retention, StopReason,
-    Strategy, runtime,
+    ChildId, Exit, Incarnation, Intensity, Membership, RestartPolicy, Retention, Strategy,
+    exit::StopReason, runtime,
 };
 
 /// Number of lifecycle events retained independently for each subscriber.

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -147,7 +147,6 @@ impl SlotCell {
 /// Erased declaration storage before inherited defaults and identities are lowered.
 pub(crate) struct BuilderCore {
     pub(crate) root: Arc<ScopeCell>,
-    pub(crate) flavor: ScopeFlavor,
     pub(crate) config: ScopeConfig,
     pub(crate) slots: Vec<Arc<SlotCell>>,
     ids: HashMap<ChildId, Arc<SlotCell>>,
@@ -177,7 +176,6 @@ impl BuilderCore {
         let root = ScopeCell::new(member, flavor, child_identity);
         Self {
             root,
-            flavor,
             config: ScopeConfig::default(),
             slots: Vec::new(),
             ids: HashMap::new(),
@@ -276,7 +274,6 @@ impl BuilderCore {
         self.armed = false;
         Ok(ScopePlan {
             root,
-            flavor: self.flavor,
             config: self.config.clone(),
             defaults,
             children,
@@ -306,7 +303,6 @@ impl Drop for BuilderCore {
 /// Fully lowered scope plan whose construction payloads still have one owner.
 pub(crate) struct ScopePlan {
     pub(crate) root: Arc<ScopeCell>,
-    pub(crate) flavor: ScopeFlavor,
     pub(crate) config: ScopeConfig,
     pub(crate) defaults: ResolvedDefaults,
     pub(crate) children: Vec<ChildPlan>,

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -1,0 +1,378 @@
+//! Declaration lowering and its owned construction plan.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use crate::{
+    ChildId, DefaultsInheritance, Exit, Intensity, Readiness, ScopeDefaults, Strategy,
+    cells::{MemberCell, ScopeCell},
+    identity::ScopeIdentity,
+    policy::{
+        CommonOptions, IdError, ResolvedCommonOptions, ResolvedDefaults, ScopeFlavor,
+        resolve_common,
+    },
+    raw::RawConstruction,
+    runtime::{self, Isolated, Latch},
+    task::{OnceTask, TaskDef},
+};
+
+/// A declaration-time reservation error.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ReserveError {
+    /// The child id was empty.
+    #[error("child id must not be empty")]
+    EmptyId,
+    /// A resident membership already occupies the id.
+    #[error("child id `{0}` is already resident")]
+    DuplicateId(ChildId),
+    /// A same-id membership is currently being removed.
+    #[error("child id `{0}` is being removed")]
+    RemovalInProgress(ChildId),
+    /// The target dynamic scope is not admitting.
+    #[error("scope is not admitting: {0:?}")]
+    NotAdmitting(NotAdmittingCause),
+    /// The scope can mint no further membership identities.
+    #[error("membership identity space is exhausted")]
+    IdentityExhausted,
+}
+
+/// Exact reason an admission operation could not proceed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum NotAdmittingCause {
+    /// The scope membership is terminal.
+    Terminal,
+    /// The live scope incarnation is draining.
+    Draining,
+    /// The dynamic root is parked after startup failure.
+    StartupFailed,
+    /// No scope incarnation is currently live.
+    NoLiveIncarnation,
+    /// This operation's reservation ended before admission.
+    ReservationEnded,
+}
+
+/// Outcome of an idempotent dynamic removal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RemoveOutcome {
+    /// A reservation or resident membership was removed.
+    Removed,
+    /// No matching membership remained to remove.
+    AlreadyAbsent,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ScopeConfig {
+    pub(crate) strategy: Strategy,
+    pub(crate) intensity: Intensity,
+    pub(crate) defaults: ScopeDefaults,
+}
+
+pub(crate) enum ChildConstruction {
+    Raw(RawConstruction),
+    Task(TaskDef),
+    TaskOnce(OnceTask),
+    Scope(Box<ScopeConstruction>),
+}
+
+enum DefinitionState {
+    Undefined,
+    Defined(Isolated<ChildConstruction>),
+    Lowered,
+}
+
+/// Stable declaration slot joining identity, observation, and owned construction.
+pub(crate) struct SlotCell {
+    pub(crate) member: Arc<MemberCell>,
+    pub(crate) scope: Option<Arc<ScopeCell>>,
+    definition: Mutex<DefinitionState>,
+}
+
+impl SlotCell {
+    pub(crate) fn new(member: Arc<MemberCell>, scope: Option<Arc<ScopeCell>>) -> Arc<Self> {
+        Arc::new(Self {
+            member,
+            scope,
+            definition: Mutex::new(DefinitionState::Undefined),
+        })
+    }
+
+    pub(crate) fn define(&self, definition: ChildConstruction) {
+        let mut state = self.definition.lock().expect("definition mutex poisoned");
+        match *state {
+            DefinitionState::Undefined => {
+                *state = DefinitionState::Defined(Isolated::new(definition));
+            }
+            DefinitionState::Defined(_) | DefinitionState::Lowered => {
+                panic!("a child slot was defined more than once")
+            }
+        }
+    }
+
+    pub(crate) fn is_undefined(&self) -> bool {
+        matches!(
+            *self.definition.lock().expect("definition mutex poisoned"),
+            DefinitionState::Undefined
+        )
+    }
+
+    pub(crate) fn take_definition(&self) -> Option<Isolated<ChildConstruction>> {
+        let mut state = self.definition.lock().expect("definition mutex poisoned");
+        match std::mem::replace(&mut *state, DefinitionState::Lowered) {
+            DefinitionState::Defined(definition) => Some(definition),
+            DefinitionState::Undefined => {
+                *state = DefinitionState::Undefined;
+                None
+            }
+            DefinitionState::Lowered => panic!("a tree was lowered more than once"),
+        }
+    }
+
+    pub(crate) fn take_defined(&self) -> Option<Isolated<ChildConstruction>> {
+        let mut state = self.definition.lock().expect("definition mutex poisoned");
+        match std::mem::replace(&mut *state, DefinitionState::Lowered) {
+            DefinitionState::Defined(definition) => Some(definition),
+            DefinitionState::Undefined => {
+                *state = DefinitionState::Undefined;
+                None
+            }
+            DefinitionState::Lowered => None,
+        }
+    }
+}
+
+/// Erased declaration storage before inherited defaults and identities are lowered.
+pub(crate) struct BuilderCore {
+    pub(crate) root: Arc<ScopeCell>,
+    pub(crate) flavor: ScopeFlavor,
+    pub(crate) config: ScopeConfig,
+    pub(crate) slots: Vec<Arc<SlotCell>>,
+    ids: HashMap<ChildId, Arc<SlotCell>>,
+    armed: bool,
+}
+
+impl BuilderCore {
+    fn begin_failed_disposal(&self) -> Latch {
+        let definitions = self
+            .slots
+            .iter()
+            .filter_map(|slot| slot.take_defined())
+            .filter_map(|mut definition| definition.take())
+            .collect();
+        runtime::dispose_all(definitions)
+    }
+
+    pub(crate) fn new(flavor: ScopeFlavor) -> Self {
+        let root_id = ChildId::from("$root");
+        let mut root_identity =
+            ScopeIdentity::new().expect("global scope identity space exhausted");
+        let membership = root_identity
+            .mint_membership(&root_id)
+            .expect("fresh scope identity must mint its root membership");
+        let member = MemberCell::new(root_id, membership);
+        let child_identity = ScopeIdentity::new().expect("global scope identity space exhausted");
+        let root = ScopeCell::new(member, flavor, child_identity);
+        Self {
+            root,
+            flavor,
+            config: ScopeConfig::default(),
+            slots: Vec::new(),
+            ids: HashMap::new(),
+            armed: true,
+        }
+    }
+
+    pub(crate) fn reserve(
+        &mut self,
+        id: impl Into<ChildId>,
+        scope: Option<ScopeFlavor>,
+    ) -> Result<Arc<SlotCell>, ReserveError> {
+        let id = checked_id(id)?;
+        if self.ids.contains_key(&id) {
+            return Err(ReserveError::DuplicateId(id));
+        }
+        let membership = self
+            .root
+            .child_identity
+            .lock()
+            .expect("scope identity mutex poisoned")
+            .mint_membership(&id)
+            .ok_or(ReserveError::IdentityExhausted)?;
+        let member = MemberCell::new(id.clone(), membership);
+        let scope = scope.map(|flavor| {
+            let identity = ScopeIdentity::new().expect("global scope identity space exhausted");
+            ScopeCell::new(Arc::clone(&member), flavor, identity)
+        });
+        let slot = SlotCell::new(member, scope);
+        self.ids.insert(id, Arc::clone(&slot));
+        self.slots.push(Arc::clone(&slot));
+        Ok(slot)
+    }
+
+    pub(crate) fn lower(
+        mut self,
+        inherited: ResolvedDefaults,
+        root_override: Option<Arc<ScopeCell>>,
+    ) -> Result<ScopePlan, LowerError> {
+        let root = root_override.unwrap_or_else(|| Arc::clone(&self.root));
+        let undefined: Vec<_> = self
+            .slots
+            .iter()
+            .filter(|slot| slot.is_undefined())
+            .map(|slot| vec![slot.member.id().clone()])
+            .collect();
+        if !undefined.is_empty() {
+            let disposal = self.begin_failed_disposal();
+            return Err(LowerError::Undefined {
+                paths: undefined,
+                disposal,
+            });
+        }
+        if !Arc::ptr_eq(&root, &self.root) {
+            let mut identity = root
+                .child_identity
+                .lock()
+                .expect("scope identity mutex poisoned");
+            for slot in &self.slots {
+                let Some(membership) =
+                    identity.adopt_or_mint_membership(slot.member.id(), slot.member.membership())
+                else {
+                    let id = slot.member.id().clone();
+                    drop(identity);
+                    let disposal = self.begin_failed_disposal();
+                    return Err(LowerError::IdentityExhausted { id, disposal });
+                };
+                if membership != slot.member.membership() {
+                    slot.member.rebase_membership(membership);
+                }
+            }
+        }
+        root.set_observation_config(self.config.strategy, self.config.intensity);
+        let defaults = inherited.overlay(&self.config.defaults);
+        let mut children = Vec::with_capacity(self.slots.len());
+        for slot in &self.slots {
+            let definition = slot
+                .take_definition()
+                .expect("validated slot must have a definition");
+            let (options, one_shot) = match definition.get() {
+                ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
+                ChildConstruction::Task(definition) => (&definition.options, false),
+                ChildConstruction::TaskOnce(definition) => (&definition.options, true),
+                ChildConstruction::Scope(definition) => {
+                    (&definition.options, definition.one_shot())
+                }
+            };
+            let resolved = resolve_common(options, &defaults, one_shot, Readiness::Immediate);
+            slot.member.set_options(resolved.clone());
+            children.push(ChildPlan {
+                slot: Arc::clone(slot),
+                construction: definition,
+                options: resolved,
+            });
+        }
+        self.armed = false;
+        Ok(ScopePlan {
+            root,
+            flavor: self.flavor,
+            config: self.config.clone(),
+            defaults,
+            children,
+            armed: true,
+        })
+    }
+
+    fn terminalize(&self) {
+        for slot in &self.slots {
+            slot.member.terminalize(Exit::never_started());
+            if let Some(scope) = &slot.scope {
+                scope.terminalize_never_started();
+            }
+        }
+        self.root.terminalize_never_started();
+    }
+}
+
+impl Drop for BuilderCore {
+    fn drop(&mut self) {
+        if self.armed {
+            self.terminalize();
+        }
+    }
+}
+
+/// Fully lowered scope plan whose construction payloads still have one owner.
+pub(crate) struct ScopePlan {
+    pub(crate) root: Arc<ScopeCell>,
+    pub(crate) flavor: ScopeFlavor,
+    pub(crate) config: ScopeConfig,
+    pub(crate) defaults: ResolvedDefaults,
+    pub(crate) children: Vec<ChildPlan>,
+    pub(crate) armed: bool,
+}
+
+impl Drop for ScopePlan {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        for child in &self.children {
+            child.slot.member.terminalize(Exit::never_started());
+            if let Some(scope) = &child.slot.scope {
+                scope.terminalize_never_started();
+            }
+        }
+        // Lowering can publish the planned children before ScopeRuntime takes
+        // ownership. If construction then unwinds, the plan fallback also
+        // owns those residencies and their matching Removed edges.
+        self.root.clear_residents();
+        self.root.terminalize_never_started();
+    }
+}
+
+pub(crate) struct ChildPlan {
+    pub(crate) slot: Arc<SlotCell>,
+    pub(crate) construction: Isolated<ChildConstruction>,
+    pub(crate) options: ResolvedCommonOptions,
+}
+
+#[derive(Debug)]
+pub(crate) enum LowerError {
+    Undefined {
+        paths: Vec<Vec<ChildId>>,
+        disposal: Latch,
+    },
+    IdentityExhausted {
+        id: ChildId,
+        disposal: Latch,
+    },
+}
+
+pub(crate) struct ScopeConstruction {
+    pub(crate) source: ScopeSource,
+    pub(crate) options: CommonOptions,
+    pub(crate) defaults: DefaultsInheritance,
+}
+
+pub(crate) type ScopeFactory = Arc<dyn Fn() -> BuilderCore + Send + Sync + 'static>;
+
+impl ScopeConstruction {
+    pub(crate) fn one_shot(&self) -> bool {
+        matches!(self.source, ScopeSource::OneShot(_) | ScopeSource::Spent)
+    }
+}
+
+pub(crate) enum ScopeSource {
+    Restartable(ScopeFactory),
+    OneShot(Box<BuilderCore>),
+    Spent,
+}
+
+pub(crate) fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError> {
+    let id = id.into();
+    ChildId::validate(id.as_str().to_owned()).map_err(|error| match error {
+        IdError::Empty => ReserveError::EmptyId,
+    })
+}

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -2,6 +2,13 @@
 
 use std::{fmt, num::NonZeroUsize, time::Duration};
 
+/// Whether a scope has fixed ordered membership or runtime-dynamic membership.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ScopeFlavor {
+    Ordered,
+    Dynamic,
+}
+
 /// The default bounded FIFO mailbox capacity.
 pub const DEFAULT_MAILBOX_CAPACITY: usize = 64;
 /// The default child shutdown grace.

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -16,6 +16,13 @@ pub const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 /// The default gated-readiness deadline.
 pub const DEFAULT_READINESS_DEADLINE: Duration = Duration::from_secs(30);
 
+/// Whether a scope has fixed ordered membership or runtime-dynamic membership.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ScopeFlavor {
+    Ordered,
+    Dynamic,
+}
+
 /// A child identifier within one scope.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ChildId(String);

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -16,13 +16,6 @@ pub const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 /// The default gated-readiness deadline.
 pub const DEFAULT_READINESS_DEADLINE: Duration = Duration::from_secs(30);
 
-/// Whether a scope has fixed ordered membership or runtime-dynamic membership.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum ScopeFlavor {
-    Ordered,
-    Dynamic,
-}
-
 /// A child identifier within one scope.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ChildId(String);

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -16,10 +16,9 @@ use std::{
 use crate::{
     ActorRef, CancellationToken, ChildId, ExitResult, Incarnation, Mailbox, MailboxShutdown,
     PolicyError, Readiness, ReadinessDeadline, RestartPolicy, Retention, ScopeRef, Shutdown,
-    driver::{ActorWork, Signal, SignalWatcher},
     mailbox::{MailboxCell, MailboxControl, MailboxReceiver},
     policy::CommonOptions,
-    runtime::Latch,
+    runtime::{self, ActorWork, Latch, Signal, SignalWatcher},
 };
 
 type PanicPayload = Box<dyn Any + Send + 'static>;
@@ -1048,7 +1047,7 @@ impl<M: Send + 'static> RawContext<M> {
     {
         let cancellation = Latch::default();
         let token = self.shutdown.child(cancellation.clone());
-        let work = crate::driver::spawn_blocking_work(move || operation(token));
+        let work = runtime::spawn_blocking_work(move || operation(token));
         Blocking {
             future: Box::pin(async move { work.join().await }),
             cancellation,
@@ -1095,7 +1094,7 @@ impl<M: Send + 'static> RawContext<M> {
         K: Hash + Eq + Send + 'static,
     {
         self.resources.next_timer_order = self.resources.next_timer_order.saturating_add(1);
-        let now = crate::driver::now();
+        let now = runtime::now();
         let deadline = crate::deadline::Deadline::after(now, after).instant();
         self.resources.timers.replace(
             key,
@@ -1154,31 +1153,30 @@ impl<M: Send + 'static> RawContext<M> {
         }
 
         let token = self.shutdown.child(cancellation.clone());
-        let started_at = crate::driver::now();
+        let started_at = runtime::now();
         let expires_at = crate::deadline::Deadline::after(started_at, deadline).instant();
         let event_cancellation = cancellation.clone();
         let operation = async move {
             let completion = async move {
                 let work = CatchUnwindFuture::new(work);
                 if let Some(expires_at) = expires_at {
-                    match crate::driver::select(work, crate::driver::sleep_until(expires_at)).await
-                    {
-                        crate::driver::Selected::First(result) => result.map(Ok),
-                        crate::driver::Selected::Second(()) => Ok(Err(DeadlineElapsed)),
+                    match runtime::select_two(work, runtime::sleep_until(expires_at)).await {
+                        runtime::Either::Left(result) => result.map(Ok),
+                        runtime::Either::Right(()) => Ok(Err(DeadlineElapsed)),
                     }
                 } else {
                     work.await.map(Ok)
                 }
             };
-            match crate::driver::select(token.cancelled(), completion).await {
-                crate::driver::Selected::First(()) => {}
-                crate::driver::Selected::Second(Ok(result)) => {
+            match runtime::select_two(token.cancelled(), completion).await {
+                runtime::Either::Left(()) => {}
+                runtime::Either::Right(Ok(result)) => {
                     events.push(QueuedEvent::Deliver {
                         cancellation: event_cancellation,
                         make_message: Box::new(move || continuation(result)),
                     });
                 }
-                crate::driver::Selected::Second(Err(payload)) => {
+                runtime::Either::Right(Err(payload)) => {
                     panic.record(payload);
                     events.signal.pulse();
                 }
@@ -1190,7 +1188,7 @@ impl<M: Send + 'static> RawContext<M> {
             self.resources.events.signal.clone(),
             finished.clone(),
         );
-        let task = crate::driver::spawn_actor_work(SharedOffloadFuture(Arc::clone(&state)));
+        let task = runtime::spawn_actor_work(SharedOffloadFuture(Arc::clone(&state)));
         self.resources.offloads.push(OffloadResource {
             cancellation,
             finished,
@@ -1310,7 +1308,7 @@ impl<M: Send + 'static> RawContext<M> {
         if self.resources.fired_batch.is_some() || self.resources.timers.is_empty() {
             return;
         }
-        let now = crate::driver::now();
+        let now = runtime::now();
         let armings = self.resources.timers.take_due(now);
         if armings.is_empty() {
             return;
@@ -1328,7 +1326,7 @@ impl<M: Send + 'static> RawContext<M> {
     fn deliver_timer(&mut self, arming: u64) -> Option<M> {
         let entry = self.resources.timers.entry_mut(arming)?;
         if let Some(period) = entry.period {
-            let deadline = crate::deadline::Deadline::after(crate::driver::now(), period).instant();
+            let deadline = crate::deadline::Deadline::after(runtime::now(), period).instant();
             entry.deadline = deadline;
             let TimerMessage::Interval(make_message) = &entry.message else {
                 unreachable!("an interval timer must own a message factory")
@@ -1355,23 +1353,23 @@ impl<M: Send + 'static> RawContext<M> {
 
     async fn wait_for_event(&mut self) {
         let sleep = self.next_timer_deadline().map_or_else(
-            || Box::pin(std::future::pending()) as crate::driver::DriverSleep,
-            crate::driver::sleep_until,
+            || Box::pin(std::future::pending()) as runtime::BoxedSleep,
+            runtime::sleep_until,
         );
         let shutdown = self.shutdown.clone();
         let local_stop = self.local_stop.clone();
         let mailbox = &mut self.receiver;
         let event_watcher = &mut self.resources.event_watcher;
         let delivery = async move {
-            let _ = crate::driver::select(
+            let _ = runtime::select_two(
                 mailbox.changed(),
-                crate::driver::select(event_watcher.changed(), sleep),
+                runtime::select_two(event_watcher.changed(), sleep),
             )
             .await;
         };
-        let _ = crate::driver::select(
+        let _ = runtime::select_two(
             shutdown.cancelled(),
-            crate::driver::select(local_stop.fired(), delivery),
+            runtime::select_two(local_stop.fired(), delivery),
         )
         .await;
     }
@@ -1776,7 +1774,7 @@ mod tests {
         EventQueue, OffloadResource, PanicPayload, PanicSlot, QueuedEvent, RawResources,
         SharedOffloadFuture, SharedOffloadState, resume_preferred_panic,
     };
-    use crate::{driver::Signal, runtime::Latch};
+    use crate::runtime::{Latch, Signal};
 
     fn marker(value: usize) -> QueuedEvent<usize> {
         QueuedEvent::Deliver {

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -16,7 +16,8 @@ use std::{
 use crate::{
     ActorRef, CancellationToken, ChildId, ExitResult, Incarnation, Mailbox, MailboxShutdown,
     PolicyError, Readiness, ReadinessDeadline, RestartPolicy, Retention, ScopeRef, Shutdown,
-    mailbox::{MailboxCell, MailboxControl, MailboxReceiver},
+    cells::{MailboxControl, MemberCell},
+    mailbox::{MailboxCell, MailboxReceiver},
     policy::CommonOptions,
     runtime::{self, ActorWork, Latch, Signal, SignalWatcher},
 };
@@ -1746,7 +1747,7 @@ pub(crate) enum RawSource {
 pub(crate) struct RawRunContext {
     pub(crate) id: ChildId,
     pub(crate) incarnation: Incarnation,
-    pub(crate) member: Arc<crate::driver::MemberCell>,
+    pub(crate) member: Arc<MemberCell>,
     pub(crate) scope: ScopeRef,
     pub(crate) shutdown: Latch,
     pub(crate) abort: Latch,

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -5,6 +5,7 @@ use std::{
     future::Future,
     ops::RangeBounds,
     panic::{AssertUnwindSafe, catch_unwind},
+    pin::Pin,
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -17,6 +18,8 @@ use tokio::{
     task, time,
 };
 
+use crate::deadline::Deadline;
+
 #[cfg(test)]
 pub(crate) use tokio::test;
 
@@ -26,6 +29,130 @@ pub(crate) fn now() -> std::time::Instant {
 
 pub(crate) fn is_available() -> bool {
     tokio::runtime::Handle::try_current().is_ok()
+}
+
+pub(crate) type BoxedSleep = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+pub(crate) fn deadline(duration: Duration) -> Deadline {
+    Deadline::after(now(), duration)
+}
+
+pub(crate) fn sleep_deadline(deadline: Deadline) -> BoxedSleep {
+    Box::pin(async move {
+        match deadline.instant() {
+            Some(deadline) => sleep_until_std(deadline).await,
+            None => std::future::pending().await,
+        }
+    })
+}
+
+pub(crate) fn sleep_until(deadline: std::time::Instant) -> BoxedSleep {
+    Box::pin(sleep_until_std(deadline))
+}
+
+pub(crate) struct ActorWork {
+    handle: Option<JoinHandle<(), ()>>,
+    abort: AbortHandle,
+}
+
+impl ActorWork {
+    pub(crate) fn abort(&self) {
+        self.abort.abort();
+    }
+
+    pub(crate) async fn join(mut self) {
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+        let _ = join(handle).await;
+    }
+}
+
+impl Drop for ActorWork {
+    fn drop(&mut self) {
+        self.abort.abort();
+    }
+}
+
+pub(crate) fn spawn_actor_work(future: impl Future<Output = ()> + Send + 'static) -> ActorWork {
+    let handle = spawn((), future);
+    let abort = handle.abort_handle();
+    ActorWork {
+        handle: Some(handle),
+        abort,
+    }
+}
+
+pub(crate) struct BlockingWork<T> {
+    handle: Option<JoinHandle<(), T>>,
+}
+
+impl<T: Send + 'static> BlockingWork<T> {
+    pub(crate) async fn join(mut self) -> T {
+        let handle = self
+            .handle
+            .take()
+            .expect("blocking operation was joined more than once");
+        join_resuming(handle).await.1
+    }
+}
+
+pub(crate) fn spawn_blocking_work<T: Send + 'static>(
+    operation: impl FnOnce() -> T + Send + 'static,
+) -> BlockingWork<T> {
+    BlockingWork {
+        handle: Some(spawn_blocking((), operation)),
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Signal {
+    inner: WatchSender<()>,
+}
+
+impl Default for Signal {
+    fn default() -> Self {
+        Self { inner: watch(()).0 }
+    }
+}
+
+impl Clone for Signal {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl Signal {
+    pub(crate) fn pulse(&self) {
+        self.inner.pulse();
+    }
+
+    pub(crate) fn watcher(&self) -> SignalWatcher {
+        SignalWatcher {
+            inner: self.inner.watcher(),
+            _signal: self.clone(),
+        }
+    }
+
+    #[cfg(test)]
+    fn watcher_count(&self) -> usize {
+        self.inner.receiver_count()
+    }
+}
+
+pub(crate) struct SignalWatcher {
+    inner: WatchReceiver<()>,
+    // Retain the source through every watcher so channel closure cannot turn
+    // into a spurious pulse.
+    _signal: Signal,
+}
+
+impl SignalWatcher {
+    pub(crate) async fn changed(&mut self) {
+        self.inner.changed().await;
+    }
 }
 
 /// Ownership wrapper for user values retained by framework state.
@@ -674,11 +801,13 @@ mod tests {
             Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
         },
-        task::Poll,
+        task::{Context, Poll, Waker},
         time::Duration,
     };
 
-    use super::{DisposalJob, JoinOutcome, Latch, Timeout, join, spawn, timeout, yield_now};
+    use super::{
+        DisposalJob, JoinOutcome, Latch, Signal, Timeout, join, spawn, timeout, yield_now,
+    };
 
     struct PanickingDrop(Arc<AtomicUsize>);
 
@@ -708,6 +837,21 @@ mod tests {
             diagnostic.as_ref(),
             Some(Some(Some(message))) if message == "cancelled disposal job payload"
         ));
+    }
+
+    #[test]
+    fn quiet_signal_wait_cancellation_keeps_one_watch_registration() {
+        let signal = Signal::default();
+        let mut watcher = signal.watcher();
+        assert_eq!(signal.watcher_count(), 1);
+
+        for _ in 0..10_000 {
+            let mut changed = Box::pin(watcher.changed());
+            let mut context = Context::from_waker(Waker::noop());
+            assert!(changed.as_mut().poll(&mut context).is_pending());
+            drop(changed);
+            assert_eq!(signal.watcher_count(), 1);
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -11,7 +11,7 @@ use std::{
 use crate::{
     ChildId, Exit, ExitError, ExitResult, Incarnation, Membership, PolicyError, Readiness,
     ReadinessDeadline, RestartPolicy, Retention, Shutdown,
-    driver::MemberCell,
+    cells::MemberCell,
     policy::CommonOptions,
     runtime::{self, Latch},
 };
@@ -380,7 +380,7 @@ mod tests {
 
     use crate::{
         ChildId, Exit, ExitKind,
-        driver::MemberCell,
+        cells::MemberCell,
         identity::ScopeIdentity,
         runtime::{self, JoinOutcome, Latch, Timeout},
     };

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -55,7 +55,7 @@ impl CancellationToken {
     /// Waits until cancellation is requested.
     pub async fn cancelled(&self) {
         if let Some(secondary) = &self.secondary {
-            let _ = crate::driver::select(self.primary.fired(), secondary.fired()).await;
+            let _ = runtime::select_two(self.primary.fired(), secondary.fired()).await;
         } else {
             self.primary.fired().await;
         }

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -13,56 +13,22 @@ use std::{
 };
 
 use crate::{
-    ActorDef, ActorOnceDef, ActorRef, ChildId, DefaultsInheritance, Exit, Intensity, IntensityTrip,
+    ActorDef, ActorOnceDef, ActorRef, ChildId, DefaultsInheritance, Exit, Intensity,
     LifecycleEvents, Membership, ReadinessDeadline, RestartPolicy, Retention, ScopeDefaults,
-    ScopeSnapshot, Shutdown, ShutdownTimeout, SnapshotReceiver, StartupFailure, Strategy,
-    WaitError,
-    driver::{DynamicReservation, MemberCell, ScopeCell},
+    ScopeSnapshot, Shutdown, ShutdownTimeout, SnapshotReceiver, Strategy, WaitError,
+    cells::{MemberCell, MemberStage, ScopeCell},
+    driver::DynamicReservation,
+    exit::{StartupError, StopReason},
     identity::ScopeIdentity,
     mailbox::MailboxCell,
-    policy::{CommonOptions, IdError, ResolvedCommonOptions, ResolvedDefaults, resolve_common},
+    policy::{
+        CommonOptions, IdError, ResolvedCommonOptions, ResolvedDefaults, ScopeFlavor,
+        resolve_common,
+    },
     raw::{RawConstruction, RawDef, RawOnceDef},
     runtime::{self, Latch},
     task::{OnceTask, OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
 };
-
-/// Whether a scope has fixed ordered membership or runtime-dynamic membership.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum ScopeFlavor {
-    Ordered,
-    Dynamic,
-}
-
-/// The terminal reason for a scope incarnation or root system.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum StopReason {
-    /// A non-empty ordered workload completed naturally.
-    Finished,
-    /// Shutdown was explicitly requested.
-    ShutdownRequested,
-    /// The scope exceeded its restart budget.
-    IntensityTripped(IntensityTrip),
-    /// A nested scope could not complete startup.
-    StartupFailed(StartupFailure),
-    /// The membership terminalized without an incarnation.
-    NeverStarted,
-}
-
-/// Failure of the root startup barrier.
-#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
-#[non_exhaustive]
-pub enum StartupError {
-    /// A child or nested lowering failed terminally during startup.
-    #[error("tree startup failed")]
-    StartupFailed(StartupFailure),
-    /// Restart intensity tripped during startup.
-    #[error("restart intensity tripped during startup")]
-    IntensityTripped(IntensityTrip),
-    /// Shutdown began before startup completed.
-    #[error("shutdown was requested during startup")]
-    ShutdownRequested,
-}
 
 /// Startup failure paired with any rollback timeout report.
 #[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
@@ -331,7 +297,7 @@ impl BuilderCore {
                 }
             }
         }
-        root.set_config(self.config.clone());
+        root.set_observation_config(self.config.strategy, self.config.intensity);
         let defaults = inherited.overlay(&self.config.defaults);
         let mut children = Vec::with_capacity(self.slots.len());
         for slot in &self.slots {
@@ -1742,10 +1708,7 @@ impl ScopeRef {
             if expires.is_due(crate::runtime::now()) {
                 return Err(WaitError::TimedOut);
             }
-            if matches!(
-                self.cell.member.record().stage,
-                crate::driver::MemberStage::Terminal(_)
-            ) {
+            if matches!(self.cell.member.record().stage, MemberStage::Terminal(_)) {
                 return Err(WaitError::ScopeTerminated {
                     state: snapshot.state.clone(),
                 });

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -746,7 +746,7 @@ fn spawn_builder<R>(
     core: BuilderCore,
     make_ref: impl FnOnce(ScopeRef) -> R,
 ) -> Result<System<R>, BuildError> {
-    if !crate::driver::runtime_available() {
+    if !runtime::is_available() {
         return Err(BuildError::NoRuntime);
     }
     let root = Arc::clone(&core.root);

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -1,33 +1,32 @@
 //! Tree declarations, scope handles, and the owning system façade.
 
 use std::{
-    collections::HashMap,
     fmt,
     future::Future,
     hash::{Hash, Hasher},
     marker::PhantomData,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::Arc,
     task::{Context, Poll},
     time::Duration,
 };
 
 use crate::{
-    ActorDef, ActorOnceDef, ActorRef, ChildId, DefaultsInheritance, Exit, Intensity,
-    LifecycleEvents, Membership, ReadinessDeadline, RestartPolicy, Retention, ScopeDefaults,
-    ScopeSnapshot, Shutdown, ShutdownTimeout, SnapshotReceiver, Strategy, WaitError,
-    cells::{MemberCell, MemberStage, ScopeCell},
+    ActorDef, ActorOnceDef, ActorRef, ChildId, DefaultsInheritance, Intensity, LifecycleEvents,
+    Membership, ReadinessDeadline, RestartPolicy, Retention, ScopeDefaults, ScopeSnapshot,
+    Shutdown, ShutdownTimeout, SnapshotReceiver, Strategy, WaitError,
+    cells::{MemberStage, ScopeCell},
     driver::DynamicReservation,
     exit::{StartupError, StopReason},
-    identity::ScopeIdentity,
     mailbox::MailboxCell,
-    policy::{
-        CommonOptions, IdError, ResolvedCommonOptions, ResolvedDefaults, ScopeFlavor,
-        resolve_common,
+    plan::{
+        BuilderCore, ChildConstruction, LowerError, RemoveOutcome, ReserveError, ScopeConstruction,
+        ScopeSource, SlotCell, checked_id,
     },
-    raw::{RawConstruction, RawDef, RawOnceDef},
+    policy::{CommonOptions, ResolvedDefaults, ScopeFlavor},
+    raw::{RawDef, RawOnceDef},
     runtime::{self, Latch},
-    task::{OnceTask, OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
+    task::{OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
 };
 
 /// Startup failure paired with any rollback timeout report.
@@ -38,43 +37,6 @@ pub struct StartOrShutdownError {
     pub startup: StartupError,
     /// Stragglers forced down after the rollback bound, if any.
     pub rollback_timeout: Option<ShutdownTimeout>,
-}
-
-/// A declaration-time reservation error.
-#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
-#[non_exhaustive]
-pub enum ReserveError {
-    /// The child id was empty.
-    #[error("child id must not be empty")]
-    EmptyId,
-    /// A resident membership already occupies the id.
-    #[error("child id `{0}` is already resident")]
-    DuplicateId(ChildId),
-    /// A same-id membership is currently being removed.
-    #[error("child id `{0}` is being removed")]
-    RemovalInProgress(ChildId),
-    /// The target dynamic scope is not admitting.
-    #[error("scope is not admitting: {0:?}")]
-    NotAdmitting(NotAdmittingCause),
-    /// The scope can mint no further membership identities.
-    #[error("membership identity space is exhausted")]
-    IdentityExhausted,
-}
-
-/// Exact reason an admission operation could not proceed.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum NotAdmittingCause {
-    /// The scope membership is terminal.
-    Terminal,
-    /// The live scope incarnation is draining.
-    Draining,
-    /// The dynamic root is parked after startup failure.
-    StartupFailed,
-    /// No scope incarnation is currently live.
-    NoLiveIncarnation,
-    /// This operation's reservation ended before admission.
-    ReservationEnded,
 }
 
 /// A root lowering error.
@@ -90,306 +52,6 @@ pub enum BuildError {
         /// Child-id paths of every undefined reservation.
         paths: Vec<Vec<ChildId>>,
     },
-}
-
-#[derive(Debug)]
-pub(crate) enum LowerError {
-    Undefined {
-        paths: Vec<Vec<ChildId>>,
-        disposal: crate::runtime::Latch,
-    },
-    IdentityExhausted {
-        id: ChildId,
-        disposal: crate::runtime::Latch,
-    },
-}
-
-/// Outcome of an idempotent dynamic removal.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum RemoveOutcome {
-    /// A reservation or resident membership was removed.
-    Removed,
-    /// No matching membership remained to remove.
-    AlreadyAbsent,
-}
-
-#[derive(Clone, Debug, Default)]
-pub(crate) struct ScopeConfig {
-    pub(crate) strategy: Strategy,
-    pub(crate) intensity: Intensity,
-    pub(crate) defaults: ScopeDefaults,
-}
-
-pub(crate) enum ChildConstruction {
-    Raw(RawConstruction),
-    Task(TaskDef),
-    TaskOnce(OnceTask),
-    Scope(Box<ScopeConstruction>),
-}
-
-enum DefinitionState {
-    Undefined,
-    Defined(crate::runtime::Isolated<ChildConstruction>),
-    Lowered,
-}
-
-pub(crate) struct SlotCell {
-    pub(crate) member: Arc<MemberCell>,
-    pub(crate) scope: Option<Arc<ScopeCell>>,
-    definition: Mutex<DefinitionState>,
-}
-
-impl SlotCell {
-    pub(crate) fn new(member: Arc<MemberCell>, scope: Option<Arc<ScopeCell>>) -> Arc<Self> {
-        Arc::new(Self {
-            member,
-            scope,
-            definition: Mutex::new(DefinitionState::Undefined),
-        })
-    }
-
-    pub(crate) fn define(&self, definition: ChildConstruction) {
-        let mut state = self.definition.lock().expect("definition mutex poisoned");
-        match *state {
-            DefinitionState::Undefined => {
-                *state = DefinitionState::Defined(crate::runtime::Isolated::new(definition));
-            }
-            DefinitionState::Defined(_) | DefinitionState::Lowered => {
-                panic!("a child slot was defined more than once")
-            }
-        }
-    }
-
-    pub(crate) fn is_undefined(&self) -> bool {
-        matches!(
-            *self.definition.lock().expect("definition mutex poisoned"),
-            DefinitionState::Undefined
-        )
-    }
-
-    pub(crate) fn take_definition(&self) -> Option<crate::runtime::Isolated<ChildConstruction>> {
-        let mut state = self.definition.lock().expect("definition mutex poisoned");
-        match std::mem::replace(&mut *state, DefinitionState::Lowered) {
-            DefinitionState::Defined(definition) => Some(definition),
-            DefinitionState::Undefined => {
-                *state = DefinitionState::Undefined;
-                None
-            }
-            DefinitionState::Lowered => panic!("a tree was lowered more than once"),
-        }
-    }
-
-    pub(crate) fn take_defined(&self) -> Option<crate::runtime::Isolated<ChildConstruction>> {
-        let mut state = self.definition.lock().expect("definition mutex poisoned");
-        match std::mem::replace(&mut *state, DefinitionState::Lowered) {
-            DefinitionState::Defined(definition) => Some(definition),
-            DefinitionState::Undefined => {
-                *state = DefinitionState::Undefined;
-                None
-            }
-            DefinitionState::Lowered => None,
-        }
-    }
-}
-
-pub(crate) struct BuilderCore {
-    root: Arc<ScopeCell>,
-    flavor: ScopeFlavor,
-    config: ScopeConfig,
-    slots: Vec<Arc<SlotCell>>,
-    ids: HashMap<ChildId, Arc<SlotCell>>,
-    armed: bool,
-}
-
-impl BuilderCore {
-    fn begin_failed_disposal(&self) -> crate::runtime::Latch {
-        let definitions = self
-            .slots
-            .iter()
-            .filter_map(|slot| slot.take_defined())
-            .filter_map(|mut definition| definition.take())
-            .collect();
-        crate::runtime::dispose_all(definitions)
-    }
-
-    fn new(flavor: ScopeFlavor) -> Self {
-        let root_id = ChildId::from("$root");
-        let mut root_identity =
-            ScopeIdentity::new().expect("global scope identity space exhausted");
-        let membership = root_identity
-            .mint_membership(&root_id)
-            .expect("fresh scope identity must mint its root membership");
-        let member = MemberCell::new(root_id, membership);
-        let child_identity = ScopeIdentity::new().expect("global scope identity space exhausted");
-        let root = ScopeCell::new(member, flavor, child_identity);
-        Self {
-            root,
-            flavor,
-            config: ScopeConfig::default(),
-            slots: Vec::new(),
-            ids: HashMap::new(),
-            armed: true,
-        }
-    }
-
-    fn reserve(
-        &mut self,
-        id: impl Into<ChildId>,
-        scope: Option<ScopeFlavor>,
-    ) -> Result<Arc<SlotCell>, ReserveError> {
-        let id = checked_id(id)?;
-        if self.ids.contains_key(&id) {
-            return Err(ReserveError::DuplicateId(id));
-        }
-        let membership = self
-            .root
-            .child_identity
-            .lock()
-            .expect("scope identity mutex poisoned")
-            .mint_membership(&id)
-            .ok_or(ReserveError::IdentityExhausted)?;
-        let member = MemberCell::new(id.clone(), membership);
-        let scope = scope.map(|flavor| {
-            let identity = ScopeIdentity::new().expect("global scope identity space exhausted");
-            ScopeCell::new(Arc::clone(&member), flavor, identity)
-        });
-        let slot = SlotCell::new(member, scope);
-        self.ids.insert(id, Arc::clone(&slot));
-        self.slots.push(Arc::clone(&slot));
-        Ok(slot)
-    }
-
-    pub(crate) fn lower(
-        mut self,
-        inherited: ResolvedDefaults,
-        root_override: Option<Arc<ScopeCell>>,
-    ) -> Result<ScopePlan, LowerError> {
-        let root = root_override.unwrap_or_else(|| Arc::clone(&self.root));
-        let undefined: Vec<_> = self
-            .slots
-            .iter()
-            .filter(|slot| slot.is_undefined())
-            .map(|slot| vec![slot.member.id().clone()])
-            .collect();
-        if !undefined.is_empty() {
-            let disposal = self.begin_failed_disposal();
-            return Err(LowerError::Undefined {
-                paths: undefined,
-                disposal,
-            });
-        }
-        if !Arc::ptr_eq(&root, &self.root) {
-            let mut identity = root
-                .child_identity
-                .lock()
-                .expect("scope identity mutex poisoned");
-            for slot in &self.slots {
-                let Some(membership) =
-                    identity.adopt_or_mint_membership(slot.member.id(), slot.member.membership())
-                else {
-                    let id = slot.member.id().clone();
-                    drop(identity);
-                    let disposal = self.begin_failed_disposal();
-                    return Err(LowerError::IdentityExhausted { id, disposal });
-                };
-                if membership != slot.member.membership() {
-                    slot.member.rebase_membership(membership);
-                }
-            }
-        }
-        root.set_observation_config(self.config.strategy, self.config.intensity);
-        let defaults = inherited.overlay(&self.config.defaults);
-        let mut children = Vec::with_capacity(self.slots.len());
-        for slot in &self.slots {
-            let definition = slot
-                .take_definition()
-                .expect("validated slot must have a definition");
-            let (options, one_shot) = match definition.get() {
-                ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
-                ChildConstruction::Task(definition) => (&definition.options, false),
-                ChildConstruction::TaskOnce(definition) => (&definition.options, true),
-                ChildConstruction::Scope(definition) => {
-                    (&definition.options, definition.one_shot())
-                }
-            };
-            let resolved =
-                resolve_common(options, &defaults, one_shot, crate::Readiness::Immediate);
-            slot.member.set_options(resolved.clone());
-            children.push(ChildPlan {
-                slot: Arc::clone(slot),
-                construction: definition,
-                options: resolved,
-            });
-        }
-        self.armed = false;
-        Ok(ScopePlan {
-            root,
-            flavor: self.flavor,
-            config: self.config.clone(),
-            defaults,
-            children,
-            armed: true,
-        })
-    }
-
-    fn terminalize(&self) {
-        for slot in &self.slots {
-            slot.member.terminalize(Exit::never_started());
-            if let Some(scope) = &slot.scope {
-                scope.terminalize_never_started();
-            }
-        }
-        self.root.terminalize_never_started();
-    }
-}
-
-impl Drop for BuilderCore {
-    fn drop(&mut self) {
-        if self.armed {
-            self.terminalize();
-        }
-    }
-}
-
-pub(crate) struct ScopePlan {
-    pub(crate) root: Arc<ScopeCell>,
-    pub(crate) flavor: ScopeFlavor,
-    pub(crate) config: ScopeConfig,
-    pub(crate) defaults: ResolvedDefaults,
-    pub(crate) children: Vec<ChildPlan>,
-    pub(crate) armed: bool,
-}
-
-impl Drop for ScopePlan {
-    fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-        for child in &self.children {
-            child.slot.member.terminalize(Exit::never_started());
-            if let Some(scope) = &child.slot.scope {
-                scope.terminalize_never_started();
-            }
-        }
-        // Lowering can publish the planned children before ScopeRuntime takes
-        // ownership. If construction then unwinds, the plan fallback also
-        // owns those residencies and their matching Removed edges.
-        self.root.clear_residents();
-        self.root.terminalize_never_started();
-    }
-}
-
-pub(crate) struct ChildPlan {
-    pub(crate) slot: Arc<SlotCell>,
-    pub(crate) construction: crate::runtime::Isolated<ChildConstruction>,
-    pub(crate) options: ResolvedCommonOptions,
-}
-
-fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError> {
-    let id = id.into();
-    ChildId::validate(id.as_str().to_owned()).map_err(|error| match error {
-        IdError::Empty => ReserveError::EmptyId,
-    })
 }
 
 fn attach_actor_slot<M: Send + 'static>(slot: Arc<SlotCell>) -> ActorSlot<M> {
@@ -734,7 +396,7 @@ fn spawn_builder<R>(
 }
 
 #[cfg(test)]
-pub(crate) fn lower_tree_for_test(tree: Tree) -> ScopePlan {
+pub(crate) fn lower_tree_for_test(tree: Tree) -> crate::plan::ScopePlan {
     tree.core
         .lower(ResolvedDefaults::default(), None)
         .expect("test tree must be fully defined")
@@ -1489,26 +1151,6 @@ impl<T: Subtree> SubtreeOnceDef<T> {
             defaults: self.defaults,
         }
     }
-}
-
-pub(crate) struct ScopeConstruction {
-    pub(crate) source: ScopeSource,
-    pub(crate) options: CommonOptions,
-    pub(crate) defaults: DefaultsInheritance,
-}
-
-pub(crate) type ScopeFactory = Arc<dyn Fn() -> BuilderCore + Send + Sync + 'static>;
-
-impl ScopeConstruction {
-    pub(crate) fn one_shot(&self) -> bool {
-        matches!(self.source, ScopeSource::OneShot(_) | ScopeSource::Spent)
-    }
-}
-
-pub(crate) enum ScopeSource {
-    Restartable(ScopeFactory),
-    OneShot(Box<BuilderCore>),
-    Spent,
 }
 
 /// A typed pre-spawn subtree slot.

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -396,15 +396,16 @@ fn spawn_builder<R>(
 }
 
 #[cfg(test)]
-pub(crate) fn lower_tree_for_test(tree: Tree) -> crate::plan::ScopePlan {
-    tree.core
-        .lower(ResolvedDefaults::default(), None)
-        .expect("test tree must be fully defined")
-}
+impl Tree {
+    pub(crate) fn lower_for_test(self) -> crate::plan::ScopePlan {
+        self.core
+            .lower(ResolvedDefaults::default(), None)
+            .expect("test tree must be fully defined")
+    }
 
-#[cfg(test)]
-pub(crate) fn into_core_for_test(tree: Tree) -> BuilderCore {
-    tree.core
+    pub(crate) fn into_core_for_test(self) -> BuilderCore {
+        self.core
+    }
 }
 
 /// An owned pre-spawn actor slot with a stable mailbox binding.

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,7 @@
                   target/doc/shelterwood.json
                 ${pkgs.bash}/bin/bash ./tools/check-runtime-paths.sh
                 ${pkgs.bash}/bin/bash ./tools/check-exit-paths.sh
+                ${pkgs.bash}/bin/bash ./tools/check-layering-paths.sh
                 ${pkgs.bash}/bin/bash ./tools/sync-packaged-docs.sh --check
                 ${pkgs.bash}/bin/bash ./tools/check-packaged-crate.sh
               '';

--- a/justfile
+++ b/justfile
@@ -34,6 +34,9 @@ runtime-path-check:
 exit-path-check:
     ./tools/check-exit-paths.sh
 
+layering-path-check:
+    ./tools/check-layering-paths.sh
+
 packaged-docs-sync:
     ./tools/sync-packaged-docs.sh --write
 
@@ -48,7 +51,7 @@ nixfmt-check:
 
 # Fast local CI mirror — reuses the local cargo cache and incremental builds.
 # The clean Nix lane retains the explicit all-target build for non-test codegen coverage.
-ci: fmt lint test doc-check runtime-api-check runtime-path-check exit-path-check packaged-docs-check package-check nixfmt-check
+ci: fmt lint test doc-check runtime-api-check runtime-path-check exit-path-check layering-path-check packaged-docs-check package-check nixfmt-check
 
 # Full clean Nix CI lane; use before pushing or when touching Nix files.
 ci-nix:

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly lower_layers=(
+  crates/shelterwood/src/mailbox.rs
+  crates/shelterwood/src/raw.rs
+  crates/shelterwood/src/task.rs
+)
+readonly cells_path="crates/shelterwood/src/cells.rs"
+
+check_forbidden() {
+  local message="$1"
+  local forbidden="$2"
+  shift 2
+
+  local matches
+  local status
+  set +e
+  matches="$({ rg --line-number "$forbidden" "$@"; } 2>&1)"
+  status=$?
+  set -e
+
+  case "$status" in
+    0)
+      echo "$message" >&2
+      echo "$matches" >&2
+      exit 1
+      ;;
+    1) ;;
+    *)
+      echo "$matches" >&2
+      exit "$status"
+      ;;
+  esac
+}
+
+check_forbidden \
+  "upward driver references found below the driver layer:" \
+  '\bdriver::' \
+  "${lower_layers[@]}"
+
+check_forbidden \
+  "upward driver or tree references found in the shared cells layer:" \
+  '\b(driver|tree)::' \
+  "$cells_path"
+
+echo "shared-cell layering restrictions: clean"

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-readonly lower_layers=(
+readonly below_driver_layers=(
+  crates/shelterwood/src/actor.rs
+  crates/shelterwood/src/cells.rs
+  crates/shelterwood/src/deadline.rs
+  crates/shelterwood/src/engine.rs
+  crates/shelterwood/src/exit.rs
+  crates/shelterwood/src/identity.rs
   crates/shelterwood/src/mailbox.rs
+  crates/shelterwood/src/observe.rs
+  crates/shelterwood/src/plan.rs
+  crates/shelterwood/src/policy.rs
   crates/shelterwood/src/raw.rs
+  crates/shelterwood/src/runtime.rs
   crates/shelterwood/src/task.rs
 )
-readonly cells_path="crates/shelterwood/src/cells.rs"
 readonly driver_path="crates/shelterwood/src/driver.rs"
 
 check_forbidden() {
@@ -36,18 +45,13 @@ check_forbidden() {
 }
 
 check_forbidden \
-  "upward driver references found below the driver layer:" \
-  '\bdriver::' \
-  "${lower_layers[@]}"
-
-check_forbidden \
-  "upward driver or tree references found in the shared cells layer:" \
+  "upward driver or tree references found below the driver layer:" \
   '\b(driver|tree)::' \
-  "$cells_path"
+  "${below_driver_layers[@]}"
 
 check_forbidden \
   "upward tree references found in the driver layer:" \
   '\btree::' \
   "$driver_path"
 
-echo "shared-cell layering restrictions: clean"
+echo "supervision layering restrictions: clean"

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -7,6 +7,7 @@ readonly lower_layers=(
   crates/shelterwood/src/task.rs
 )
 readonly cells_path="crates/shelterwood/src/cells.rs"
+readonly driver_path="crates/shelterwood/src/driver.rs"
 
 check_forbidden() {
   local message="$1"
@@ -43,5 +44,10 @@ check_forbidden \
   "upward driver or tree references found in the shared cells layer:" \
   '\b(driver|tree)::' \
   "$cells_path"
+
+check_forbidden \
+  "upward tree references found in the driver layer:" \
+  '\btree::' \
+  "$driver_path"
 
 echo "shared-cell layering restrictions: clean"


### PR DESCRIPTION
Stacked on #58. Implements Phase 1 of #56.

## Summary

- move the runtime facade (`Signal`, watchers, actor/blocking work, deadline sleeps) into `runtime.rs` and repoint lower-layer consumers
- extract restart-stable member/scope state and observation projection into `cells.rs`
- extract declaration lowering IR and construction ownership into `plan.rs`
- move `StopReason`/`StartupError` to `exit.rs` and `ScopeFlavor` to `policy.rs`
- replace `ChildArena`'s generational vector slots with monotonic `u64` keys in a `BTreeMap`
- make `ScopeCell` the single source of truth for scope flavor
- document and assert mailbox configure/bind/close ordering
- add a repository check preventing upward driver/tree imports across the new boundaries

## Invariants preserved

- mailbox termination publishes before terminal member wakeups
- observation updates share one tree-wide gate, including dynamically admitted subtrees
- declaration/plan/runtime Drop paths retain exactly one terminality owner
- child keys are monotonic, ordered, never reused, and poison on exhaustion

## Validation

- `./scripts/dev just ci` (309 tests)
- `./scripts/dev just ci-nix`

Part of #56.