### PR TITLE
Consolidate mailbox deadline operations

### DIFF
--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1,7 +1,7 @@
 //! Membership-owned actor mailboxes and request/reply capabilities.
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{BTreeMap, VecDeque},
     fmt,
     future::Future,
     hash::{Hash, Hasher},
@@ -16,7 +16,7 @@ use std::{
 use crate::{
     ChildId, Incarnation, Mailbox, Membership,
     cells::{MailboxControl, MailboxDisposal, MailboxStats, MailboxTermination, MemberCell},
-    runtime::{Signal, SignalWatcher},
+    runtime::{OneShotReceiver, OneShotSender, Signal, SignalWatcher},
 };
 
 /// The kind of a failed actor send.
@@ -168,54 +168,95 @@ impl fmt::Display for ReplyError {
 
 impl std::error::Error for ReplyError {}
 
-enum ReplyOutcome<T> {
-    Pending,
-    Value(T),
-    Dropped,
+trait DeadlineOperation {
+    type Output;
+
+    /// Polls the operation before or after the shared deadline transition.
+    ///
+    /// An elapsed poll must resolve. It is a second operation poll after the
+    /// timer becomes ready so completion or acceptance at the exact boundary
+    /// wins before operation-specific timeout cleanup runs.
+    fn poll_deadlined(
+        &mut self,
+        context: &mut Context<'_>,
+        budget: crate::deadline::Deadline,
+        elapsed: bool,
+    ) -> Poll<Self::Output>;
 }
 
-struct ReplyState<T> {
-    outcome: ReplyOutcome<T>,
-    receiver_alive: bool,
-    waker: Option<Waker>,
+/// First-poll deadline capture shared by every public mailbox deadline future.
+struct Deadlined<F> {
+    operation: F,
+    duration: Duration,
+    budget: Option<crate::deadline::Deadline>,
+    timer: Option<crate::runtime::BoxedSleep>,
+    started: bool,
+    done: bool,
 }
 
-struct ReplyShared<T> {
-    state: Mutex<ReplyState<T>>,
-}
-
-impl<T> ReplyShared<T> {
-    fn poll(&self, context: &mut Context<'_>) -> Poll<Result<T, ReplyError>> {
-        let mut state = self.state.lock().expect("reply mutex poisoned");
-        match std::mem::replace(&mut state.outcome, ReplyOutcome::Pending) {
-            ReplyOutcome::Value(value) => {
-                state.receiver_alive = false;
-                Poll::Ready(Ok(value))
-            }
-            ReplyOutcome::Dropped => {
-                state.receiver_alive = false;
-                Poll::Ready(Err(ReplyError::Dropped))
-            }
-            ReplyOutcome::Pending => {
-                state.waker = Some(context.waker().clone());
-                Poll::Pending
-            }
+impl<F> Deadlined<F> {
+    fn new(operation: F, duration: Duration) -> Self {
+        Self {
+            operation,
+            duration,
+            budget: None,
+            timer: None,
+            started: false,
+            done: false,
         }
     }
+}
 
-    fn close_receiver(&self) {
-        let mut state = self.state.lock().expect("reply mutex poisoned");
-        state.receiver_alive = false;
-        state.waker = None;
-        if matches!(state.outcome, ReplyOutcome::Value(_)) {
-            state.outcome = ReplyOutcome::Pending;
+impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
+    type Output = F::Output;
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.as_mut().get_mut();
+        if !this.started {
+            this.started = true;
+            let budget = crate::runtime::deadline(this.duration);
+            this.budget = Some(budget);
+            if !this.duration.is_zero() {
+                this.timer = Some(crate::runtime::sleep_deadline(budget));
+            }
         }
+        let budget = this
+            .budget
+            .expect("a started deadline future retains its captured budget");
+        if this.duration.is_zero() {
+            let result = this.operation.poll_deadlined(context, budget, true);
+            debug_assert!(result.is_ready(), "an elapsed operation must resolve");
+            this.done = result.is_ready();
+            return result;
+        }
+        if let Poll::Ready(result) = this.operation.poll_deadlined(context, budget, false) {
+            this.done = true;
+            return Poll::Ready(result);
+        }
+        if this
+            .timer
+            .as_mut()
+            .expect("a non-zero deadline future retains its timer")
+            .as_mut()
+            .poll(context)
+            .is_pending()
+        {
+            return Poll::Pending;
+        }
+        let result = this.operation.poll_deadlined(context, budget, true);
+        debug_assert!(result.is_ready(), "an elapsed operation must resolve");
+        this.done = result.is_ready();
+        result
     }
 }
 
 /// A consuming, infallible reply capability.
+///
+/// Dropping an unanswered capability is completion: its receiver observes
+/// [`ReplyError::Dropped`]. Dropping or timing out the receiver instead closes
+/// the channel, so a late [`Reply::send`] safely discards its value.
 pub struct Reply<T> {
-    shared: Arc<ReplyShared<T>>,
+    sender: Option<OneShotSender<T>>,
     answered: bool,
 }
 
@@ -232,20 +273,14 @@ impl<T: Send + 'static> Reply<T> {
     /// Creates a reply capability and its single owned receiver.
     #[must_use]
     pub fn channel() -> (Self, ReplyReceiver<T>) {
-        let shared = Arc::new(ReplyShared {
-            state: Mutex::new(ReplyState {
-                outcome: ReplyOutcome::Pending,
-                receiver_alive: true,
-                waker: None,
-            }),
-        });
+        let (sender, receiver) = crate::runtime::oneshot();
         (
             Self {
-                shared: Arc::clone(&shared),
+                sender: Some(sender),
                 answered: false,
             },
             ReplyReceiver {
-                shared: Some(shared),
+                receiver: Some(receiver),
             },
         )
     }
@@ -253,44 +288,17 @@ impl<T: Send + 'static> Reply<T> {
     /// Consumes the capability and delivers or discards the reply.
     pub fn send(mut self, value: T) {
         self.answered = true;
-        let wake = {
-            let mut state = self.shared.state.lock().expect("reply mutex poisoned");
-            if state.receiver_alive && matches!(state.outcome, ReplyOutcome::Pending) {
-                state.outcome = ReplyOutcome::Value(value);
-                state.waker.take()
-            } else {
-                None
-            }
-        };
-        if let Some(waker) = wake {
-            waker.wake();
-        }
-    }
-}
-
-impl<T> Drop for Reply<T> {
-    fn drop(&mut self) {
-        if self.answered {
-            return;
-        }
-        let wake = {
-            let mut state = self.shared.state.lock().expect("reply mutex poisoned");
-            if matches!(state.outcome, ReplyOutcome::Pending) {
-                state.outcome = ReplyOutcome::Dropped;
-                state.waker.take()
-            } else {
-                None
-            }
-        };
-        if let Some(waker) = wake {
-            waker.wake();
-        }
+        let sender = self
+            .sender
+            .take()
+            .expect("an unanswered reply retains its sender");
+        let _ = sender.send(value);
     }
 }
 
 /// The owned, non-cloneable receive half of [`Reply::channel`].
 pub struct ReplyReceiver<T> {
-    shared: Option<Arc<ReplyShared<T>>>,
+    receiver: Option<OneShotReceiver<T>>,
 }
 
 impl<T> fmt::Debug for ReplyReceiver<T> {
@@ -305,19 +313,38 @@ impl<T: Send + 'static> ReplyReceiver<T> {
     /// Consumes the receiver and waits within one response-only budget.
     pub fn recv(mut self, deadline: Duration) -> ReplyReceive<T> {
         ReplyReceive {
-            shared: self.shared.take(),
-            deadline,
-            timer: None,
-            started: false,
-            done: false,
+            deadlined: Deadlined::new(
+                ReplyOperation {
+                    receiver: self.receiver.take().expect("unused reply receiver is live"),
+                },
+                deadline,
+            ),
         }
     }
 }
 
-impl<T> Drop for ReplyReceiver<T> {
-    fn drop(&mut self) {
-        if let Some(shared) = &self.shared {
-            shared.close_receiver();
+struct ReplyOperation<T> {
+    receiver: OneShotReceiver<T>,
+}
+
+impl<T> DeadlineOperation for ReplyOperation<T> {
+    type Output = Result<T, ReplyError>;
+
+    fn poll_deadlined(
+        &mut self,
+        context: &mut Context<'_>,
+        _budget: crate::deadline::Deadline,
+        elapsed: bool,
+    ) -> Poll<Self::Output> {
+        match self.receiver.poll_receive(context) {
+            Poll::Ready(Some(value)) => Poll::Ready(Ok(value)),
+            Poll::Ready(None) => Poll::Ready(Err(ReplyError::Dropped)),
+            Poll::Pending if elapsed => Poll::Ready(
+                self.receiver
+                    .close_and_try_receive()
+                    .ok_or(ReplyError::Timeout),
+            ),
+            Poll::Pending => Poll::Pending,
         }
     }
 }
@@ -325,19 +352,15 @@ impl<T> Drop for ReplyReceiver<T> {
 /// Future returned by [`ReplyReceiver::recv`].
 #[must_use]
 pub struct ReplyReceive<T> {
-    shared: Option<Arc<ReplyShared<T>>>,
-    deadline: Duration,
-    timer: Option<crate::runtime::BoxedSleep>,
-    started: bool,
-    done: bool,
+    deadlined: Deadlined<ReplyOperation<T>>,
 }
 
 impl<T> fmt::Debug for ReplyReceive<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("ReplyReceive")
-            .field("started", &self.started)
-            .field("done", &self.done)
+            .field("started", &self.deadlined.started)
+            .field("done", &self.deadlined.done)
             .finish_non_exhaustive()
     }
 }
@@ -346,50 +369,7 @@ impl<T: Send + 'static> Future for ReplyReceive<T> {
     type Output = Result<T, ReplyError>;
 
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
-        if !self.started {
-            self.started = true;
-            let budget = crate::runtime::deadline(self.deadline);
-            if self.deadline.is_zero() {
-                self.done = true;
-                if let Some(shared) = &self.shared {
-                    shared.close_receiver();
-                }
-                return Poll::Ready(Err(ReplyError::Timeout));
-            }
-            self.timer = Some(crate::runtime::sleep_deadline(budget));
-        }
-        let shared = Arc::clone(
-            self.shared
-                .as_ref()
-                .expect("pending reply receive must retain its shared state"),
-        );
-        if let Poll::Ready(result) = shared.poll(context) {
-            self.done = true;
-            return Poll::Ready(result);
-        }
-        if self
-            .timer
-            .as_mut()
-            .expect("started reply receive must have a timer")
-            .as_mut()
-            .poll(context)
-            .is_ready()
-        {
-            shared.close_receiver();
-            self.done = true;
-            return Poll::Ready(Err(ReplyError::Timeout));
-        }
-        Poll::Pending
-    }
-}
-
-impl<T> Drop for ReplyReceive<T> {
-    fn drop(&mut self) {
-        if !self.done
-            && let Some(shared) = &self.shared
-        {
-            shared.close_receiver();
-        }
+        Pin::new(&mut self.deadlined).poll(context)
     }
 }
 
@@ -434,6 +414,12 @@ struct OperationState<M> {
 struct SendOperation<M> {
     state: Mutex<OperationState<M>>,
 }
+
+// Lock order is mailbox state, then send-operation state. Code that starts
+// from an operation lock must release it before entering the mailbox. Paths
+// that take only the operation lock (polling, detached teardown) never reach
+// back into mailbox state. This keeps acceptance, withdrawal, and waiter
+// registration on one acyclic ordering.
 
 impl<M> SendOperation<M> {
     fn new(message: M) -> Arc<Self> {
@@ -522,25 +508,17 @@ struct MailboxState<M> {
     sends_rejected: u64,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct WaiterId(u64);
 
-struct WaiterEntry<M> {
-    operation: Arc<SendOperation<M>>,
-    previous: Option<WaiterId>,
-    next: Option<WaiterId>,
-}
-
-/// FIFO registrations with constant-time removal by a send operation.
+/// FIFO registrations with direct removal by a send operation.
 ///
-/// The mailbox mutex serializes every mutation, so a compact intrusive list
-/// can use monotonic local ids without another synchronization layer. The ids
-/// are never reused, which also prevents a stale cancellation from unlinking
-/// a later operation.
+/// Monotonic keys are insertion order, so the first map entry is the oldest
+/// waiter. Keys are never reused, making stale cancellation ids harmless.
+/// `u64::MAX` is a poison key and is never minted; exhaustion remains poisoned
+/// instead of wrapping back into the live id domain.
 struct WaiterQueue<M> {
-    entries: HashMap<WaiterId, WaiterEntry<M>>,
-    head: Option<WaiterId>,
-    tail: Option<WaiterId>,
+    entries: BTreeMap<WaiterId, Arc<SendOperation<M>>>,
     next_id: u64,
     #[cfg(test)]
     direct_removals: usize,
@@ -549,9 +527,7 @@ struct WaiterQueue<M> {
 impl<M> Default for WaiterQueue<M> {
     fn default() -> Self {
         Self {
-            entries: HashMap::new(),
-            head: None,
-            tail: None,
+            entries: BTreeMap::new(),
             next_id: 0,
             #[cfg(test)]
             direct_removals: 0,
@@ -570,30 +546,17 @@ impl<M> WaiterQueue<M> {
     }
 
     fn push_back(&mut self, operation: Arc<SendOperation<M>>) -> WaiterId {
-        let id = WaiterId(self.next_id);
-        self.next_id = self
-            .next_id
-            .checked_add(1)
-            .expect("mailbox waiter identity space exhausted");
-        let previous = self.tail;
-        let replaced = self.entries.insert(
-            id,
-            WaiterEntry {
-                operation,
-                previous,
-                next: None,
-            },
-        );
-        debug_assert!(replaced.is_none());
-        if let Some(previous) = previous {
-            self.entries
-                .get_mut(&previous)
-                .expect("tail registration must be live")
-                .next = Some(id);
-        } else {
-            self.head = Some(id);
+        let Some(next) = self.next_id.checked_add(1) else {
+            panic!("mailbox waiter identity space exhausted");
+        };
+        if next == u64::MAX {
+            self.next_id = u64::MAX;
+            panic!("mailbox waiter identity space exhausted");
         }
-        self.tail = Some(id);
+        self.next_id = next;
+        let id = WaiterId(next);
+        let replaced = self.entries.insert(id, operation);
+        debug_assert!(replaced.is_none());
         id
     }
 
@@ -603,39 +566,27 @@ impl<M> WaiterQueue<M> {
     }
 
     fn observe_all(&self, incarnation: Incarnation) {
-        for entry in self.entries.values() {
-            entry.operation.observe(incarnation);
+        for operation in self.entries.values() {
+            operation.observe(incarnation);
         }
     }
 
     fn pop_front(&mut self) -> Option<(WaiterId, Arc<SendOperation<M>>)> {
-        let id = self.head?;
-        self.remove(id).map(|operation| (id, operation))
+        let entry = self.entries.pop_first();
+        #[cfg(test)]
+        if entry.is_some() {
+            self.direct_removals = self.direct_removals.saturating_add(1);
+        }
+        entry
     }
 
     fn remove(&mut self, id: WaiterId) -> Option<Arc<SendOperation<M>>> {
-        let entry = self.entries.remove(&id)?;
+        let operation = self.entries.remove(&id)?;
         #[cfg(test)]
         {
             self.direct_removals = self.direct_removals.saturating_add(1);
         }
-        if let Some(previous) = entry.previous {
-            self.entries
-                .get_mut(&previous)
-                .expect("previous registration must be live")
-                .next = entry.next;
-        } else {
-            self.head = entry.next;
-        }
-        if let Some(next) = entry.next {
-            self.entries
-                .get_mut(&next)
-                .expect("next registration must be live")
-                .previous = entry.previous;
-        } else {
-            self.tail = entry.previous;
-        }
-        Some(entry.operation)
+        Some(operation)
     }
 }
 
@@ -1075,6 +1026,12 @@ impl<M: Send + 'static> MailboxCell<M> {
 impl<M> MailboxCell<M> {
     fn withdraw(&self, operation: &Arc<SendOperation<M>>) -> Withdrawal<M> {
         let mut mailbox = self.state.lock().expect("mailbox mutex poisoned");
+        let current_observation = match mailbox.status {
+            BindingStatus::Bound(incarnation) | BindingStatus::Frozen(incarnation) => {
+                Some(incarnation)
+            }
+            BindingStatus::Unbound | BindingStatus::Terminal(_) => None,
+        };
         let (result, registration) = {
             let mut state = operation
                 .state
@@ -1088,7 +1045,12 @@ impl<M> MailboxCell<M> {
                     let message = message
                         .take()
                         .expect("a waiting operation must retain its message");
-                    let observed = *newest_observed;
+                    // The mailbox lock makes this one evidence snapshot: a
+                    // binding either precedes withdrawal and contributes its
+                    // incarnation, or follows the completed withdrawal. This
+                    // also covers an operation first submitted by an elapsed
+                    // (including zero-duration) deadline poll.
+                    let observed = (*newest_observed).or(current_observation);
                     state.outcome = OperationOutcome::Withdrawn;
                     state.waker = None;
                     (
@@ -1330,11 +1292,12 @@ impl<M: Send + 'static> ActorRef<M> {
     /// Sends within one acceptance budget, recovering an unaccepted message.
     pub fn send_timeout(&self, message: M, deadline: Duration) -> SendTimeout<M> {
         SendTimeout {
-            send: Some(self.send(message)),
-            deadline,
-            timer: None,
-            started: false,
-            done: false,
+            deadlined: Deadlined::new(
+                TimedSend {
+                    send: self.send(message),
+                },
+                deadline,
+            ),
         }
     }
 
@@ -1359,15 +1322,16 @@ impl<M: Send + 'static> ActorRef<M> {
         deadline: Duration,
     ) -> CallFuture<M, T> {
         CallFuture {
-            actor: self.clone(),
-            make_msg: Some(Box::new(make_msg)),
-            deadline,
-            timer: None,
-            send: None,
-            reply: None,
-            accepted: None,
-            started: false,
-            done: false,
+            deadlined: Deadlined::new(
+                CallOperation {
+                    actor: self.clone(),
+                    make_msg: Some(Box::new(make_msg)),
+                    send: None,
+                    reply: None,
+                    accepted: None,
+                },
+                deadline,
+            ),
         }
     }
 }
@@ -1499,20 +1463,59 @@ impl<M> Drop for SendFuture<M> {
 /// Cancellation-safe future returned by [`ActorRef::send_timeout`].
 #[must_use]
 pub struct SendTimeout<M> {
-    send: Option<SendFuture<M>>,
-    deadline: Duration,
-    timer: Option<crate::runtime::BoxedSleep>,
-    started: bool,
-    done: bool,
+    deadlined: Deadlined<TimedSend<M>>,
+}
+
+struct TimedSend<M> {
+    send: SendFuture<M>,
 }
 
 impl<M> fmt::Debug for SendTimeout<M> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("SendTimeout")
-            .field("started", &self.started)
-            .field("done", &self.done)
+            .field("started", &self.deadlined.started)
+            .field("done", &self.deadlined.done)
             .finish_non_exhaustive()
+    }
+}
+
+fn withdraw_send<M: Send + 'static>(send: &mut SendFuture<M>) -> Result<Incarnation, SendError<M>> {
+    let actor_id = send.actor.id().clone();
+    match send.withdraw() {
+        Withdrawal::Withdrawn { message, observed } => Err(SendError {
+            actor_id,
+            incarnation_observed: observed,
+            message,
+            kind: SendErrorKind::TimedOut,
+        }),
+        Withdrawal::Accepted(incarnation) => Ok(incarnation),
+        Withdrawal::Terminated { message, observed } => Err(SendError {
+            actor_id,
+            incarnation_observed: observed,
+            message,
+            kind: SendErrorKind::Terminated,
+        }),
+    }
+}
+
+impl<M: Send + 'static> DeadlineOperation for TimedSend<M> {
+    type Output = Result<Incarnation, SendError<M>>;
+
+    fn poll_deadlined(
+        &mut self,
+        context: &mut Context<'_>,
+        _budget: crate::deadline::Deadline,
+        elapsed: bool,
+    ) -> Poll<Self::Output> {
+        if let Poll::Ready(result) = Pin::new(&mut self.send).poll(context) {
+            return Poll::Ready(result);
+        }
+        if !elapsed {
+            Poll::Pending
+        } else {
+            Poll::Ready(withdraw_send(&mut self.send))
+        }
     }
 }
 
@@ -1520,161 +1523,95 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
     type Output = Result<Incarnation, SendError<M>>;
 
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
-        if !self.started {
-            self.started = true;
-            let budget = crate::runtime::deadline(self.deadline);
-            if self.deadline.is_zero() {
-                let actor_id = self
-                    .send
-                    .as_ref()
-                    .expect("pending timed send retains send")
-                    .actor
-                    .id()
-                    .clone();
-                let current = self
-                    .send
-                    .as_ref()
-                    .expect("pending timed send retains send")
-                    .actor
-                    .mailbox
-                    .current_observation();
-                let withdrawal = self
-                    .send
-                    .as_mut()
-                    .expect("pending timed send retains send")
-                    .withdraw();
-                let Withdrawal::Withdrawn { message, observed } = withdrawal else {
-                    unreachable!("an unpolled send cannot already be accepted")
-                };
-                self.done = true;
-                return Poll::Ready(Err(SendError {
-                    actor_id,
-                    incarnation_observed: observed.or(current),
-                    message,
-                    kind: SendErrorKind::TimedOut,
-                }));
-            }
-            self.timer = Some(crate::runtime::sleep_deadline(budget));
-        }
-        let send = self.send.as_mut().expect("pending timed send retains send");
-        if let Poll::Ready(result) = Pin::new(send).poll(context) {
-            self.done = true;
-            return Poll::Ready(result);
-        }
-        if self
-            .timer
-            .as_mut()
-            .expect("started timed send has a timer")
-            .as_mut()
-            .poll(context)
-            .is_ready()
-        {
-            let send = self.send.as_mut().expect("pending timed send retains send");
-            let actor_id = send.actor.id().clone();
-            match send.withdraw() {
-                Withdrawal::Withdrawn { message, observed } => {
-                    self.done = true;
-                    Poll::Ready(Err(SendError {
-                        actor_id,
-                        incarnation_observed: observed,
-                        message,
-                        kind: SendErrorKind::TimedOut,
-                    }))
-                }
-                Withdrawal::Accepted(incarnation) => {
-                    self.done = true;
-                    Poll::Ready(Ok(incarnation))
-                }
-                Withdrawal::Terminated { message, observed } => {
-                    self.done = true;
-                    Poll::Ready(Err(SendError {
-                        actor_id,
-                        incarnation_observed: observed,
-                        message,
-                        kind: SendErrorKind::Terminated,
-                    }))
-                }
-            }
-        } else {
-            Poll::Pending
-        }
+        Pin::new(&mut self.deadlined).poll(context)
     }
 }
 
 /// Cancellation-safe future returned by [`ActorRef::call`].
 #[must_use]
 pub struct CallFuture<M, T> {
+    deadlined: Deadlined<CallOperation<M, T>>,
+}
+
+struct CallOperation<M, T> {
     actor: ActorRef<M>,
     make_msg: Option<Box<dyn FnOnce(Reply<T>) -> M + Send + 'static>>,
-    deadline: Duration,
-    timer: Option<crate::runtime::BoxedSleep>,
     send: Option<SendFuture<M>>,
-    reply: Option<Arc<ReplyShared<T>>>,
+    reply: Option<OneShotReceiver<T>>,
     accepted: Option<Incarnation>,
-    started: bool,
-    done: bool,
 }
 
 impl<M, T> fmt::Debug for CallFuture<M, T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("CallFuture")
-            .field("started", &self.started)
-            .field("accepted", &self.accepted)
-            .field("done", &self.done)
+            .field("started", &self.deadlined.started)
+            .field("accepted", &self.deadlined.operation.accepted)
+            .field("done", &self.deadlined.done)
             .finish_non_exhaustive()
     }
 }
 
-impl<M, T> CallFuture<M, T> {
+impl<M, T> CallOperation<M, T> {
     fn poll_reply(
-        &self,
+        &mut self,
         context: &mut Context<'_>,
         incarnation: Incarnation,
         deadline_elapsed: bool,
     ) -> Poll<Result<Replied<T>, CallError>> {
         let reply = self
             .reply
-            .as_ref()
+            .as_mut()
             .expect("accepted call retains reply state");
-        match reply.poll(context) {
-            Poll::Ready(Ok(value)) => Poll::Ready(Ok(Replied { value, incarnation })),
-            Poll::Ready(Err(ReplyError::Dropped)) => Poll::Ready(Err(CallError {
+        match reply.poll_receive(context) {
+            Poll::Ready(Some(value)) => Poll::Ready(Ok(Replied { value, incarnation })),
+            Poll::Ready(None) => Poll::Ready(Err(CallError {
                 actor_id: self.actor.id().clone(),
                 incarnation_observed: Some(incarnation),
                 kind: CallErrorKind::ReplyDropped,
             })),
-            Poll::Ready(Err(ReplyError::Timeout)) => unreachable!(),
             Poll::Pending if deadline_elapsed => {
-                reply.close_receiver();
-                Poll::Ready(Err(CallError {
-                    actor_id: self.actor.id().clone(),
-                    incarnation_observed: Some(incarnation),
-                    kind: CallErrorKind::ResponseTimedOut,
-                }))
+                if let Some(value) = reply.close_and_try_receive() {
+                    Poll::Ready(Ok(Replied { value, incarnation }))
+                } else {
+                    Poll::Ready(Err(CallError {
+                        actor_id: self.actor.id().clone(),
+                        incarnation_observed: Some(incarnation),
+                        kind: CallErrorKind::ResponseTimedOut,
+                    }))
+                }
             }
             Poll::Pending => Poll::Pending,
         }
     }
+
+    fn close_reply(&mut self) {
+        if let Some(reply) = &mut self.reply {
+            let _ = reply.close_and_try_receive();
+        }
+    }
 }
 
-impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
+impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M, T> {
     type Output = Result<Replied<T>, CallError>;
 
-    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
-        if !self.started {
-            self.started = true;
-            // Capture the one overall budget before invoking user code. A
-            // slow message constructor consumes acceptance/response time.
-            let budget = crate::runtime::deadline(self.deadline);
-            if self.deadline.is_zero() {
-                self.done = true;
+    fn poll_deadlined(
+        &mut self,
+        context: &mut Context<'_>,
+        budget: crate::deadline::Deadline,
+        elapsed: bool,
+    ) -> Poll<Self::Output> {
+        if self.make_msg.is_some() {
+            if elapsed {
                 return Poll::Ready(Err(CallError {
                     actor_id: self.actor.id().clone(),
                     incarnation_observed: self.actor.mailbox.current_observation(),
                     kind: CallErrorKind::AcceptanceTimedOut,
                 }));
             }
+            // Capture the one overall budget before invoking user code. A
+            // slow message constructor consumes acceptance/response time. The
+            // shared scaffold captured `budget` before this callback runs.
             let (reply, mut receiver) = Reply::channel();
             let message =
                 self.make_msg
@@ -1685,16 +1622,14 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
             // existed before it completed, so do not start one after the
             // captured budget is strictly in the past.
             if budget.is_overdue(crate::runtime::now()) {
-                self.done = true;
                 return Poll::Ready(Err(CallError {
                     actor_id: self.actor.id().clone(),
                     incarnation_observed: self.actor.mailbox.current_observation(),
                     kind: CallErrorKind::AcceptanceTimedOut,
                 }));
             }
-            self.reply = receiver.shared.take();
+            self.reply = receiver.receiver.take();
             self.send = Some(self.actor.send(message));
-            self.timer = Some(crate::runtime::sleep_deadline(budget));
         }
 
         if self.accepted.is_none() {
@@ -1708,10 +1643,7 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
                     self.send = None;
                 }
                 Poll::Ready(Err(error)) => {
-                    if let Some(reply) = &self.reply {
-                        reply.close_receiver();
-                    }
-                    self.done = true;
+                    self.close_reply();
                     return Poll::Ready(Err(CallError {
                         actor_id: error.actor_id,
                         incarnation_observed: error.incarnation_observed,
@@ -1723,66 +1655,49 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
         }
 
         if let Some(accepted) = self.accepted
-            && let Poll::Ready(result) = self.poll_reply(context, accepted, false)
+            && let Poll::Ready(result) = self.poll_reply(context, accepted, elapsed)
         {
-            self.done = true;
             return Poll::Ready(result);
         }
 
-        if self
-            .timer
-            .as_mut()
-            .expect("started call has a timer")
-            .as_mut()
-            .poll(context)
-            .is_pending()
-        {
+        if !elapsed {
             return Poll::Pending;
         }
 
-        if let Some(accepted) = self.accepted {
-            let result = self.poll_reply(context, accepted, true);
-            self.done = true;
-            result
-        } else {
-            let actor_id = self.actor.id().clone();
-            let send = self
-                .send
+        let result = withdraw_send(
+            self.send
                 .as_mut()
-                .expect("unaccepted call retains send future");
-            let result = match send.withdraw() {
-                Withdrawal::Withdrawn { observed, .. } => CallError {
-                    actor_id,
-                    incarnation_observed: observed,
-                    kind: CallErrorKind::AcceptanceTimedOut,
-                },
-                Withdrawal::Accepted(incarnation) => {
-                    let result = self.poll_reply(context, incarnation, true);
-                    self.done = true;
-                    return result;
-                }
-                Withdrawal::Terminated { observed, .. } => CallError {
-                    actor_id,
-                    incarnation_observed: observed,
-                    kind: CallErrorKind::Terminated,
-                },
-            };
-            if let Some(reply) = &self.reply {
-                reply.close_receiver();
+                .expect("an unaccepted call retains its send future"),
+        );
+        self.send = None;
+        match result {
+            Ok(incarnation) => {
+                self.accepted = Some(incarnation);
+                self.poll_reply(context, incarnation, true)
             }
-            self.done = true;
-            Poll::Ready(Err(result))
+            Err(error) => {
+                self.close_reply();
+                Poll::Ready(Err(CallError {
+                    actor_id: error.actor_id,
+                    incarnation_observed: error.incarnation_observed,
+                    kind: match error.kind {
+                        SendErrorKind::TimedOut => CallErrorKind::AcceptanceTimedOut,
+                        SendErrorKind::Terminated => CallErrorKind::Terminated,
+                        SendErrorKind::NotRunning | SendErrorKind::Full => {
+                            unreachable!("withdrawal returns only timed-out or terminal errors")
+                        }
+                    },
+                }))
+            }
         }
     }
 }
 
-impl<M, T> Drop for CallFuture<M, T> {
-    fn drop(&mut self) {
-        if !self.done
-            && let Some(reply) = &self.reply
-        {
-            reply.close_receiver();
-        }
+impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
+    type Output = Result<Replied<T>, CallError>;
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.deadlined).poll(context)
     }
 }
 
@@ -2058,5 +1973,55 @@ mod tests {
         assert!(Arc::ptr_eq(&removed, &second));
         removed.clear_registration(second_id);
         assert!(waiters.is_empty());
+    }
+
+    #[test]
+    fn waiter_queue_preserves_fifo_across_removal() {
+        let mut waiters = super::WaiterQueue::default();
+        let first = super::SendOperation::new(1_u8);
+        let second = super::SendOperation::new(2_u8);
+        let third = super::SendOperation::new(3_u8);
+        let first_id = waiters.push_back(Arc::clone(&first));
+        let second_id = waiters.push_back(Arc::clone(&second));
+        let third_id = waiters.push_back(Arc::clone(&third));
+
+        assert!(Arc::ptr_eq(
+            &waiters.remove(second_id).expect("middle waiter is live"),
+            &second
+        ));
+        let (popped_first, operation) = waiters.pop_front().expect("head remains live");
+        assert_eq!(popped_first, first_id);
+        assert!(Arc::ptr_eq(&operation, &first));
+        let (popped_third, operation) = waiters.pop_front().expect("tail remains live");
+        assert_eq!(popped_third, third_id);
+        assert!(Arc::ptr_eq(&operation, &third));
+        assert!(waiters.is_empty());
+    }
+
+    #[test]
+    fn waiter_identity_exhaustion_poison_is_never_minted() {
+        let mut waiters = super::WaiterQueue {
+            next_id: u64::MAX - 2,
+            ..super::WaiterQueue::default()
+        };
+        let last = waiters.push_back(super::SendOperation::new(1_u8));
+        assert_eq!(last, super::WaiterId(u64::MAX - 1));
+
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                waiters.push_back(super::SendOperation::new(2_u8));
+            }))
+            .is_err(),
+            "the poison key is never minted"
+        );
+        assert_eq!(waiters.next_id, u64::MAX);
+        assert!(!waiters.entries.contains_key(&super::WaiterId(u64::MAX)));
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                waiters.push_back(super::SendOperation::new(3_u8));
+            }))
+            .is_err(),
+            "the exhausted domain stays poisoned"
+        );
     }
 }

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -16,7 +16,7 @@ use std::{
 use crate::{
     ChildId, Incarnation, Mailbox, Membership,
     cells::{MailboxControl, MailboxDisposal, MailboxStats, MailboxTermination, MemberCell},
-    runtime::{OneShotReceiver, OneShotSender, Signal, SignalWatcher},
+    runtime::{OneShotClose, OneShotReceiver, OneShotSender, Signal, SignalWatcher},
 };
 
 /// The kind of a failed actor send.
@@ -173,9 +173,11 @@ trait DeadlineOperation {
 
     /// Polls the operation before or after the shared deadline transition.
     ///
-    /// An elapsed poll must resolve. It is a second operation poll after the
-    /// timer becomes ready so completion or acceptance at the exact boundary
-    /// wins before operation-specific timeout cleanup runs.
+    /// This is a second operation poll after the timer becomes ready so
+    /// completion or acceptance at the exact boundary wins before
+    /// operation-specific timeout cleanup runs. It may remain pending only
+    /// when an atomic completion transition won but has not published its
+    /// payload yet; that transition must wake the registered operation waker.
     fn poll_deadlined(
         &mut self,
         context: &mut Context<'_>,
@@ -225,7 +227,6 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             .expect("a started deadline future retains its captured budget");
         if this.duration.is_zero() {
             let result = this.operation.poll_deadlined(context, budget, true);
-            debug_assert!(result.is_ready(), "an elapsed operation must resolve");
             this.done = result.is_ready();
             return result;
         }
@@ -244,7 +245,6 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             return Poll::Pending;
         }
         let result = this.operation.poll_deadlined(context, budget, true);
-        debug_assert!(result.is_ready(), "an elapsed operation must resolve");
         this.done = result.is_ready();
         result
     }
@@ -339,11 +339,12 @@ impl<T> DeadlineOperation for ReplyOperation<T> {
         match self.receiver.poll_receive(context) {
             Poll::Ready(Some(value)) => Poll::Ready(Ok(value)),
             Poll::Ready(None) => Poll::Ready(Err(ReplyError::Dropped)),
-            Poll::Pending if elapsed => Poll::Ready(
-                self.receiver
-                    .close_and_try_receive()
-                    .ok_or(ReplyError::Timeout),
-            ),
+            Poll::Pending if elapsed => match self.receiver.close_and_poll_receive(context) {
+                OneShotClose::Value(value) => Poll::Ready(Ok(value)),
+                OneShotClose::SenderClosed => Poll::Ready(Err(ReplyError::Dropped)),
+                OneShotClose::Empty => Poll::Ready(Err(ReplyError::Timeout)),
+                OneShotClose::Pending => Poll::Pending,
+            },
             Poll::Pending => Poll::Pending,
         }
     }
@@ -1570,24 +1571,27 @@ impl<M, T> CallOperation<M, T> {
                 incarnation_observed: Some(incarnation),
                 kind: CallErrorKind::ReplyDropped,
             })),
-            Poll::Pending if deadline_elapsed => {
-                if let Some(value) = reply.close_and_try_receive() {
-                    Poll::Ready(Ok(Replied { value, incarnation }))
-                } else {
-                    Poll::Ready(Err(CallError {
-                        actor_id: self.actor.id().clone(),
-                        incarnation_observed: Some(incarnation),
-                        kind: CallErrorKind::ResponseTimedOut,
-                    }))
-                }
-            }
+            Poll::Pending if deadline_elapsed => match reply.close_and_poll_receive(context) {
+                OneShotClose::Value(value) => Poll::Ready(Ok(Replied { value, incarnation })),
+                OneShotClose::SenderClosed => Poll::Ready(Err(CallError {
+                    actor_id: self.actor.id().clone(),
+                    incarnation_observed: Some(incarnation),
+                    kind: CallErrorKind::ReplyDropped,
+                })),
+                OneShotClose::Empty => Poll::Ready(Err(CallError {
+                    actor_id: self.actor.id().clone(),
+                    incarnation_observed: Some(incarnation),
+                    kind: CallErrorKind::ResponseTimedOut,
+                })),
+                OneShotClose::Pending => Poll::Pending,
+            },
             Poll::Pending => Poll::Pending,
         }
     }
 
     fn close_reply(&mut self) {
         if let Some(reply) = &mut self.reply {
-            let _ = reply.close_and_try_receive();
+            reply.close();
         }
     }
 }

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -184,6 +184,13 @@ trait DeadlineOperation {
         budget: crate::deadline::Deadline,
         elapsed: bool,
     ) -> Poll<Self::Output>;
+
+    /// Resolves a zero-width budget without ever attempting the operation.
+    ///
+    /// A zero budget is a short-circuit, not a raced deadline: nothing is
+    /// submitted and no completion is observed, so this reports the
+    /// operation's timeout outcome and performs only its own cleanup.
+    fn short_circuit(&mut self) -> Self::Output;
 }
 
 /// First-poll deadline capture shared by every public mailbox deadline future.
@@ -193,6 +200,7 @@ struct Deadlined<F> {
     budget: Option<crate::deadline::Deadline>,
     timer: Option<crate::runtime::BoxedSleep>,
     started: bool,
+    elapsed: bool,
     done: bool,
 }
 
@@ -204,6 +212,7 @@ impl<F> Deadlined<F> {
             budget: None,
             timer: None,
             started: false,
+            elapsed: false,
             done: false,
         }
     }
@@ -222,27 +231,37 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
                 this.timer = Some(crate::runtime::sleep_deadline(budget));
             }
         }
+        // A zero budget short-circuits: the operation is never attempted, so
+        // nothing is submitted and no completion is observed. The expiry
+        // boundary below governs only non-zero budgets, and the two rules
+        // therefore never compete.
+        if this.duration.is_zero() {
+            this.done = true;
+            return Poll::Ready(this.operation.short_circuit());
+        }
         let budget = this
             .budget
             .expect("a started deadline future retains its captured budget");
-        if this.duration.is_zero() {
-            let result = this.operation.poll_deadlined(context, budget, true);
-            this.done = result.is_ready();
-            return result;
-        }
         if let Poll::Ready(result) = this.operation.poll_deadlined(context, budget, false) {
             this.done = true;
             return Poll::Ready(result);
         }
-        if this
-            .timer
-            .as_mut()
-            .expect("a non-zero deadline future retains its timer")
-            .as_mut()
-            .poll(context)
-            .is_pending()
-        {
-            return Poll::Pending;
+        if !this.elapsed {
+            if this
+                .timer
+                .as_mut()
+                .expect("an unelapsed deadline future retains its timer")
+                .as_mut()
+                .poll(context)
+                .is_pending()
+            {
+                return Poll::Pending;
+            }
+            // The timer is a one-shot future: polling it again after it
+            // resolves panics. Latch the transition and release it, so an
+            // elapsed poll that stays pending re-polls only the operation.
+            this.elapsed = true;
+            this.timer = None;
         }
         let result = this.operation.poll_deadlined(context, budget, true);
         this.done = result.is_ready();
@@ -347,6 +366,11 @@ impl<T> DeadlineOperation for ReplyOperation<T> {
             },
             Poll::Pending => Poll::Pending,
         }
+    }
+
+    fn short_circuit(&mut self) -> Self::Output {
+        self.receiver.close();
+        Err(ReplyError::Timeout)
     }
 }
 
@@ -1518,6 +1542,13 @@ impl<M: Send + 'static> DeadlineOperation for TimedSend<M> {
             Poll::Ready(withdraw_send(&mut self.send))
         }
     }
+
+    fn short_circuit(&mut self) -> Self::Output {
+        // The send was never polled, so it was never submitted: withdrawal
+        // recovers the message and reports the mailbox's current binding as
+        // the newest incarnation observed during the attempt.
+        withdraw_send(&mut self.send)
+    }
 }
 
 impl<M: Send + 'static> Future for SendTimeout<M> {
@@ -1607,11 +1638,7 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
     ) -> Poll<Self::Output> {
         if self.make_msg.is_some() {
             if elapsed {
-                return Poll::Ready(Err(CallError {
-                    actor_id: self.actor.id().clone(),
-                    incarnation_observed: self.actor.mailbox.current_observation(),
-                    kind: CallErrorKind::AcceptanceTimedOut,
-                }));
+                return Poll::Ready(self.short_circuit());
             }
             // Capture the one overall budget before invoking user code. A
             // slow message constructor consumes acceptance/response time. The
@@ -1626,11 +1653,7 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
             // existed before it completed, so do not start one after the
             // captured budget is strictly in the past.
             if budget.is_overdue(crate::runtime::now()) {
-                return Poll::Ready(Err(CallError {
-                    actor_id: self.actor.id().clone(),
-                    incarnation_observed: self.actor.mailbox.current_observation(),
-                    kind: CallErrorKind::AcceptanceTimedOut,
-                }));
+                return Poll::Ready(self.short_circuit());
             }
             self.reply = receiver.receiver.take();
             self.send = Some(self.actor.send(message));
@@ -1658,10 +1681,13 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
             }
         }
 
-        if let Some(accepted) = self.accepted
-            && let Poll::Ready(result) = self.poll_reply(context, accepted, elapsed)
-        {
-            return Poll::Ready(result);
+        // Acceptance released the send future, so the reply is the only
+        // remaining source of an outcome. An elapsed reply poll may still be
+        // pending when a completion transition won without publishing its
+        // payload yet; that transition wakes the registered waker, so waiting
+        // is the answer rather than reaching for a send that no longer exists.
+        if let Some(accepted) = self.accepted {
+            return self.poll_reply(context, accepted, elapsed);
         }
 
         if !elapsed {
@@ -1694,6 +1720,16 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
                 }))
             }
         }
+    }
+
+    fn short_circuit(&mut self) -> Self::Output {
+        // No message was ever constructed, so there is nothing to withdraw
+        // and no accepting incarnation to report.
+        Err(CallError {
+            actor_id: self.actor.id().clone(),
+            incarnation_observed: self.actor.mailbox.current_observation(),
+            kind: CallErrorKind::AcceptanceTimedOut,
+        })
     }
 }
 
@@ -2026,6 +2062,73 @@ mod tests {
             }))
             .is_err(),
             "the exhausted domain stays poisoned"
+        );
+    }
+
+    /// Stays pending on its first elapsed poll, modelling an atomic
+    /// completion transition that won without publishing its payload yet.
+    #[derive(Default)]
+    struct PendingOnFirstExpiry {
+        elapsed_polls: usize,
+    }
+
+    impl super::DeadlineOperation for PendingOnFirstExpiry {
+        type Output = usize;
+
+        fn poll_deadlined(
+            &mut self,
+            _context: &mut Context<'_>,
+            _budget: crate::deadline::Deadline,
+            elapsed: bool,
+        ) -> Poll<usize> {
+            if !elapsed {
+                return Poll::Pending;
+            }
+            self.elapsed_polls += 1;
+            if self.elapsed_polls < 2 {
+                Poll::Pending
+            } else {
+                Poll::Ready(self.elapsed_polls)
+            }
+        }
+
+        fn short_circuit(&mut self) -> usize {
+            0
+        }
+    }
+
+    #[crate::runtime::test(start_paused = true)]
+    async fn an_expired_deadline_future_never_repolls_its_resolved_timer() {
+        let width = std::time::Duration::from_secs(1);
+        let mut future = Box::pin(super::Deadlined::new(
+            PendingOnFirstExpiry::default(),
+            width,
+        ));
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+
+        assert!(future.as_mut().poll(&mut context).is_pending());
+        crate::runtime::advance(width * 2).await;
+        // The timer resolves here and the operation stays pending, so the
+        // scaffold must latch the expiry rather than poll the timer again.
+        assert!(future.as_mut().poll(&mut context).is_pending());
+
+        assert!(matches!(future.as_mut().poll(&mut context), Poll::Ready(2)));
+    }
+
+    #[test]
+    fn a_zero_budget_short_circuits_without_polling_the_operation() {
+        let mut future = Box::pin(super::Deadlined::new(
+            PendingOnFirstExpiry::default(),
+            std::time::Duration::ZERO,
+        ));
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+
+        assert!(matches!(future.as_mut().poll(&mut context), Poll::Ready(0)));
+        assert_eq!(
+            future.operation.elapsed_polls, 0,
+            "a zero budget never attempts the operation"
         );
     }
 }

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -23,6 +23,12 @@ use crate::deadline::Deadline;
 #[cfg(test)]
 pub(crate) use tokio::test;
 
+/// Advances a paused test clock, keeping timer control in this module.
+#[cfg(test)]
+pub(crate) async fn advance(duration: Duration) {
+    time::advance(duration).await;
+}
+
 pub(crate) fn now() -> std::time::Instant {
     time::Instant::now().into_std()
 }

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -8,7 +8,7 @@ use std::{
     pin::Pin,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -373,24 +373,96 @@ impl Latch {
     }
 }
 
+const ONESHOT_OPEN: u8 = 0;
+const ONESHOT_SENDING: u8 = 1;
+const ONESHOT_SENT: u8 = 2;
+const ONESHOT_SENDER_CLOSED: u8 = 3;
+const ONESHOT_RECEIVER_CLOSED: u8 = 4;
+
 /// Sending half of a runtime-backed single-delivery channel.
-pub(crate) struct OneShotSender<T>(oneshot::Sender<T>);
+pub(crate) struct OneShotSender<T> {
+    channel: Option<oneshot::Sender<T>>,
+    state: Arc<AtomicU8>,
+}
 
 /// Receiving half of a runtime-backed single-delivery channel.
-pub(crate) struct OneShotReceiver<T>(oneshot::Receiver<T>);
+pub(crate) struct OneShotReceiver<T> {
+    channel: oneshot::Receiver<T>,
+    state: Arc<AtomicU8>,
+}
+
+/// Outcome after atomically closing a single-delivery receive side.
+pub(crate) enum OneShotClose<T> {
+    /// A value was sent before the receiver closed.
+    Value(T),
+    /// The sender was dropped before the receiver closed.
+    SenderClosed,
+    /// The receiver closed while the sender was still live and empty.
+    Empty,
+    /// The send transition won but has not published its value yet.
+    Pending,
+}
 
 pub(crate) fn oneshot<T>() -> (OneShotSender<T>, OneShotReceiver<T>) {
-    let (sender, receiver) = oneshot::channel();
-    (OneShotSender(sender), OneShotReceiver(receiver))
+    let (channel_sender, channel_receiver) = oneshot::channel();
+    let state = Arc::new(AtomicU8::new(ONESHOT_OPEN));
+    (
+        OneShotSender {
+            channel: Some(channel_sender),
+            state: Arc::clone(&state),
+        },
+        OneShotReceiver {
+            channel: channel_receiver,
+            state,
+        },
+    )
 }
 
 impl<T> OneShotSender<T> {
-    pub(crate) fn send(self, value: T) -> Result<(), T> {
-        self.0.send(value)
+    pub(crate) fn send(mut self, value: T) -> Result<(), T> {
+        if self
+            .state
+            .compare_exchange(
+                ONESHOT_OPEN,
+                ONESHOT_SENDING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return Err(value);
+        }
+        let sender = self
+            .channel
+            .take()
+            .expect("a live one-shot sender retains its channel");
+        match sender.send(value) {
+            Ok(()) => {
+                self.state.store(ONESHOT_SENT, Ordering::Release);
+                Ok(())
+            }
+            Err(value) => {
+                self.state.store(ONESHOT_RECEIVER_CLOSED, Ordering::Release);
+                Err(value)
+            }
+        }
     }
 
     pub(crate) fn is_closed(&self) -> bool {
-        self.0.is_closed()
+        self.channel.as_ref().is_none_or(oneshot::Sender::is_closed)
+    }
+}
+
+impl<T> Drop for OneShotSender<T> {
+    fn drop(&mut self) {
+        if self.channel.is_some() {
+            let _ = self.state.compare_exchange(
+                ONESHOT_OPEN,
+                ONESHOT_SENDER_CLOSED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            );
+        }
     }
 }
 
@@ -399,26 +471,59 @@ impl<T> OneShotReceiver<T> {
         &mut self,
         context: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<T>> {
-        Pin::new(&mut self.0).poll(context).map(Result::ok)
+        Pin::new(&mut self.channel).poll(context).map(Result::ok)
     }
 
-    /// Closes the receive side and returns a value whose send won the race.
+    /// Closes the receive side unless send or sender-drop won first.
     ///
-    /// `tokio::sync::oneshot` makes `close` atomic with `send`; checking the
-    /// slot after closing therefore gives deadline users one transition point
-    /// at which an already-completed delivery wins and every later send loses.
-    pub(crate) fn close_and_try_receive(&mut self) -> Option<T> {
-        self.0.close();
-        self.0.try_recv().ok()
+    /// The shared transition word distinguishes sender-drop from receiver
+    /// close, which Tokio's post-close `try_recv` result alone cannot do. A
+    /// send that wins but is preempted before publishing returns `Pending`;
+    /// the preceding channel poll registered the wake for its completion.
+    pub(crate) fn close_and_poll_receive(
+        &mut self,
+        context: &mut std::task::Context<'_>,
+    ) -> OneShotClose<T> {
+        match self.state.compare_exchange(
+            ONESHOT_OPEN,
+            ONESHOT_RECEIVER_CLOSED,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => {
+                self.channel.close();
+                OneShotClose::Empty
+            }
+            Err(ONESHOT_SENDER_CLOSED) => OneShotClose::SenderClosed,
+            Err(ONESHOT_SENDING) | Err(ONESHOT_SENT) => {
+                match Pin::new(&mut self.channel).poll(context) {
+                    std::task::Poll::Ready(Ok(value)) => OneShotClose::Value(value),
+                    std::task::Poll::Ready(Err(_)) => OneShotClose::SenderClosed,
+                    std::task::Poll::Pending => OneShotClose::Pending,
+                }
+            }
+            Err(ONESHOT_RECEIVER_CLOSED) => OneShotClose::Empty,
+            Err(other) => unreachable!("unknown one-shot transition state {other}"),
+        }
+    }
+
+    pub(crate) fn close(&mut self) {
+        let _ = self.state.compare_exchange(
+            ONESHOT_OPEN,
+            ONESHOT_RECEIVER_CLOSED,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+        self.channel.close();
     }
 
     pub(crate) async fn receive(self) -> Option<T> {
-        self.0.await.ok()
+        self.channel.await.ok()
     }
 
     #[cfg(test)]
     pub(crate) fn try_receive(&mut self) -> Option<T> {
-        self.0.try_recv().ok()
+        self.channel.try_recv().ok()
     }
 }
 
@@ -823,7 +928,8 @@ mod tests {
     };
 
     use super::{
-        DisposalJob, JoinOutcome, Latch, Signal, Timeout, join, spawn, timeout, yield_now,
+        DisposalJob, JoinOutcome, Latch, OneShotClose, Signal, Timeout, join, oneshot, spawn,
+        timeout, yield_now,
     };
 
     struct PanickingDrop(Arc<AtomicUsize>);
@@ -854,6 +960,31 @@ mod tests {
             diagnostic.as_ref(),
             Some(Some(Some(message))) if message == "cancelled disposal job payload"
         ));
+    }
+
+    #[test]
+    fn closing_oneshot_distinguishes_value_sender_drop_and_receiver_win() {
+        let mut context = Context::from_waker(Waker::noop());
+        let (sender, mut receiver) = oneshot();
+        sender.send(1_u8).expect("receiver is live");
+        assert!(matches!(
+            receiver.close_and_poll_receive(&mut context),
+            OneShotClose::Value(1)
+        ));
+
+        let (sender, mut receiver) = oneshot::<u8>();
+        drop(sender);
+        assert!(matches!(
+            receiver.close_and_poll_receive(&mut context),
+            OneShotClose::SenderClosed
+        ));
+
+        let (sender, mut receiver) = oneshot::<u8>();
+        assert!(matches!(
+            receiver.close_and_poll_receive(&mut context),
+            OneShotClose::Empty
+        ));
+        assert_eq!(sender.send(1), Err(1));
     }
 
     #[test]

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -395,6 +395,23 @@ impl<T> OneShotSender<T> {
 }
 
 impl<T> OneShotReceiver<T> {
+    pub(crate) fn poll_receive(
+        &mut self,
+        context: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<T>> {
+        Pin::new(&mut self.0).poll(context).map(Result::ok)
+    }
+
+    /// Closes the receive side and returns a value whose send won the race.
+    ///
+    /// `tokio::sync::oneshot` makes `close` atomic with `send`; checking the
+    /// slot after closing therefore gives deadline users one transition point
+    /// at which an already-completed delivery wins and every later send loses.
+    pub(crate) fn close_and_try_receive(&mut self) -> Option<T> {
+        self.0.close();
+        self.0.try_recv().ok()
+    }
+
     pub(crate) async fn receive(self) -> Option<T> {
         self.0.await.ok()
     }

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -216,7 +216,7 @@ async fn call_promotion_winning_the_deadline_race_reports_response_timeout() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction() {
+async fn zero_deadline_accepts_ready_send_but_does_not_construct_a_call() {
     let gate = ReleaseGate::default();
     let values = Arc::new(Mutex::new(Vec::new()));
     let calls = Arc::new(AtomicUsize::new(0));
@@ -235,10 +235,15 @@ async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction
         .try_send(Message::Value(1))
         .expect("identity probe accepts");
 
-    let timed = actor
+    let accepted_at_zero = actor
         .send_timeout(Message::Value(2), Duration::ZERO)
         .await
-        .expect_err("zero send deadline short-circuits");
+        .expect("immediate acceptance wins a zero send deadline");
+    assert_eq!(accepted_at_zero, accepting);
+    let timed = actor
+        .send_timeout(Message::Value(3), Duration::ZERO)
+        .await
+        .expect_err("a full mailbox cannot accept at the zero deadline");
     assert_eq!(timed.kind, SendErrorKind::TimedOut);
     assert_eq!(timed.incarnation_observed, Some(accepting));
     let constructed_in_call = Arc::clone(&constructed);
@@ -251,7 +256,7 @@ async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction
             Duration::ZERO,
         )
         .await
-        .expect_err("zero call deadline short-circuits");
+        .expect_err("a zero call deadline short-circuits user construction");
     assert_eq!(call.kind, CallErrorKind::AcceptanceTimedOut);
     assert_eq!(call.incarnation_observed, Some(accepting));
     assert!(!constructed.load(Ordering::SeqCst));
@@ -259,16 +264,16 @@ async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction
     gate.release();
     assert!(
         poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
-            values.lock().expect("values mutex poisoned").as_slice() == [1]
+            values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
         })
         .await
     );
     assert_quiet(Duration::from_millis(20), || {
-        values.lock().expect("values mutex poisoned").contains(&2)
+        values.lock().expect("values mutex poisoned").contains(&3)
             || calls.load(Ordering::SeqCst) != 0
     })
     .await;
-    assert!(matches!(timed.message, Message::Value(2)));
+    assert!(matches!(timed.message, Message::Value(3)));
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -578,4 +583,24 @@ async fn reply_receiver_reports_drop_and_is_safe_to_abandon() {
     let (reply, receiver) = Reply::<usize>::channel();
     drop(receiver);
     reply.send(1);
+
+    let (reply, receiver) = Reply::channel();
+    reply.send(2);
+    assert_eq!(
+        receiver.recv(Duration::ZERO).await,
+        Ok(2),
+        "a completed reply wins at a zero-width boundary"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn reply_completion_wins_at_the_exact_deadline() {
+    let width = Duration::from_secs(10);
+    let (reply, receiver) = Reply::channel();
+    let mut receive = Box::pin(receiver.recv(width));
+    assert!(poll_once(receive.as_mut()).is_pending());
+
+    advance_time(width).await;
+    reply.send(7);
+    assert_eq!(receive.await, Ok(7));
 }

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -216,7 +216,7 @@ async fn call_promotion_winning_the_deadline_race_reports_response_timeout() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn zero_deadline_accepts_ready_send_but_does_not_construct_a_call() {
+async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction() {
     let gate = ReleaseGate::default();
     let values = Arc::new(Mutex::new(Vec::new()));
     let calls = Arc::new(AtomicUsize::new(0));
@@ -235,15 +235,12 @@ async fn zero_deadline_accepts_ready_send_but_does_not_construct_a_call() {
         .try_send(Message::Value(1))
         .expect("identity probe accepts");
 
-    let accepted_at_zero = actor
+    // The mailbox has room, so only the zero-budget short-circuit keeps this
+    // send from being attempted at all.
+    let timed = actor
         .send_timeout(Message::Value(2), Duration::ZERO)
         .await
-        .expect("immediate acceptance wins a zero send deadline");
-    assert_eq!(accepted_at_zero, accepting);
-    let timed = actor
-        .send_timeout(Message::Value(3), Duration::ZERO)
-        .await
-        .expect_err("a full mailbox cannot accept at the zero deadline");
+        .expect_err("zero send deadline short-circuits");
     assert_eq!(timed.kind, SendErrorKind::TimedOut);
     assert_eq!(timed.incarnation_observed, Some(accepting));
     let constructed_in_call = Arc::clone(&constructed);
@@ -256,7 +253,7 @@ async fn zero_deadline_accepts_ready_send_but_does_not_construct_a_call() {
             Duration::ZERO,
         )
         .await
-        .expect_err("a zero call deadline short-circuits user construction");
+        .expect_err("zero call deadline short-circuits");
     assert_eq!(call.kind, CallErrorKind::AcceptanceTimedOut);
     assert_eq!(call.incarnation_observed, Some(accepting));
     assert!(!constructed.load(Ordering::SeqCst));
@@ -264,16 +261,16 @@ async fn zero_deadline_accepts_ready_send_but_does_not_construct_a_call() {
     gate.release();
     assert!(
         poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
-            values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
+            values.lock().expect("values mutex poisoned").as_slice() == [1]
         })
         .await
     );
     assert_quiet(Duration::from_millis(20), || {
-        values.lock().expect("values mutex poisoned").contains(&3)
+        values.lock().expect("values mutex poisoned").contains(&2)
             || calls.load(Ordering::SeqCst) != 0
     })
     .await;
-    assert!(matches!(timed.message, Message::Value(3)));
+    assert!(matches!(timed.message, Message::Value(2)));
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -588,8 +585,8 @@ async fn reply_receiver_reports_drop_and_is_safe_to_abandon() {
     reply.send(2);
     assert_eq!(
         receiver.recv(Duration::ZERO).await,
-        Ok(2),
-        "a completed reply wins at a zero-width boundary"
+        Err(ReplyError::Timeout),
+        "a zero budget short-circuits instead of observing a completed reply"
     );
 }
 


### PR DESCRIPTION
Stacked on #59. Implements Phase 2 of #56.

## Summary

- replace the three hand-rolled deadline scaffolds in `ReplyReceive`, `SendTimeout`, and `CallFuture` with one internal `Deadlined<F>` combinator
- move replies onto the existing runtime oneshot abstraction and make reply-vs-timeout arbitration atomic with close-then-receive
- share timed-send/call withdrawal routing and capture timeout incarnation evidence under the mailbox → operation lock order
- let an immediately ready send win a zero-width send deadline while preserving zero-width call construction short-circuiting
- replace the intrusive waiter linked map with monotonic never-reused `u64` keys in `BTreeMap`, including permanent poison on exhaustion
- document Drop-as-completion and mailbox/operation lock ordering

## Semantics pinned

- operation completion/acceptance wins at the exact deadline
- call construction consumes the single overall budget
- cancellation before acceptance recovers the message
- reply send racing timeout has one atomic winner
- timed-out sends report the latest bound incarnation consistently
- stale waiter IDs cannot remove later registrations

## Validation

- `./scripts/dev just ci` (312 tests)
- `./scripts/dev just ci-nix`

Part of #56.