### PR TITLE
Unify actor contexts and guard task readiness

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2926,7 +2926,10 @@ outcome during the beat classifies by that outcome, while a future
 destroyed by the ensuing hard abort records `Aborted { after_grace }`),
 `mark_ready()` (one-shot by construction; no-op only where declared
 readiness makes it meaningless, and that is a documented no-op, not a silent
-state change).
+state change — the same rule covers a stopping incarnation: once either
+cooperative shutdown or escalation has begun, readiness can no longer be
+published and the call is likewise a documented no-op, matching B.1's
+during-drain rule for the actor contexts).
 
 ### B.3 Send/call errors
 

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -39,9 +39,116 @@ pub trait Actor: Sized + Send + 'static {
     }
 }
 
+struct ActorContextCore<'a, M> {
+    raw: &'a mut RawContext<M>,
+}
+
+impl<'a, M: Send + 'static> ActorContextCore<'a, M> {
+    fn new(raw: &'a mut RawContext<M>) -> Self {
+        Self { raw }
+    }
+
+    fn reborrow(&mut self) -> ActorContextCore<'_, M> {
+        ActorContextCore::new(&mut *self.raw)
+    }
+
+    fn id(&self) -> &ChildId {
+        self.raw.id()
+    }
+
+    fn incarnation(&self) -> Incarnation {
+        self.raw.incarnation()
+    }
+
+    fn myself(&self) -> ActorRef<M> {
+        self.raw.myself()
+    }
+
+    fn scope(&self) -> ScopeRef {
+        self.raw.scope()
+    }
+
+    fn shutdown_token(&self) -> CancellationToken {
+        self.raw.shutdown_token()
+    }
+
+    fn abort_token(&self) -> CancellationToken {
+        self.raw.abort_token()
+    }
+
+    fn request_scope_shutdown(&self) {
+        self.raw.request_scope_shutdown();
+    }
+
+    fn run_blocking<F, T>(&self, operation: F) -> Blocking<T>
+    where
+        F: FnOnce(CancellationToken) -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        self.raw.run_blocking(operation)
+    }
+}
+
+macro_rules! actor_context_forwarders {
+    ($actor:ident) => {
+        /// Returns this actor's child id.
+        #[must_use]
+        pub fn id(&self) -> &ChildId {
+            self.core.id()
+        }
+
+        /// Returns this actor's current incarnation.
+        #[must_use]
+        pub fn incarnation(&self) -> Incarnation {
+            self.core.incarnation()
+        }
+
+        /// Returns a membership-addressed handle to this actor.
+        #[must_use]
+        pub fn myself(&self) -> ActorRef<$actor::Msg> {
+            self.core.myself()
+        }
+
+        /// Returns this actor's supervising scope.
+        #[must_use]
+        pub fn scope(&self) -> ScopeRef {
+            self.core.scope()
+        }
+
+        /// Returns the cooperative shutdown token.
+        #[must_use]
+        pub fn shutdown_token(&self) -> CancellationToken {
+            self.core.shutdown_token()
+        }
+
+        /// Returns the escalation token.
+        #[must_use]
+        pub fn abort_token(&self) -> CancellationToken {
+            self.core.abort_token()
+        }
+
+        /// Requests shutdown of the supervising scope without waiting.
+        pub fn request_scope_shutdown(&self) {
+            self.core.request_scope_shutdown();
+        }
+
+        /// Starts blocking work tied to actor shutdown and returned-future drop.
+        ///
+        /// Cancellation is cooperative; a hard-aborted operation's OS thread
+        /// detaches and may outlive this actor incarnation.
+        pub fn run_blocking<F, T>(&self, operation: F) -> Blocking<T>
+        where
+            F: FnOnce(CancellationToken) -> T + Send + 'static,
+            T: Send + 'static,
+        {
+            self.core.run_blocking(operation)
+        }
+    };
+}
+
 /// Callback context used by both live and frozen-prefix handler deliveries.
 pub struct Context<'a, A: Actor> {
-    raw: &'a mut RawContext<A::Msg>,
+    core: ActorContextCore<'a, A::Msg>,
     draining: bool,
     actor: PhantomData<fn() -> A>,
 }
@@ -50,8 +157,8 @@ impl<A: Actor> fmt::Debug for Context<'_, A> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("Context")
-            .field("id", self.raw.id())
-            .field("incarnation", &self.raw.incarnation())
+            .field("id", self.core.id())
+            .field("incarnation", &self.core.incarnation())
             .field("draining", &self.draining)
             .finish_non_exhaustive()
     }
@@ -60,64 +167,25 @@ impl<A: Actor> fmt::Debug for Context<'_, A> {
 impl<'a, A: Actor> Context<'a, A> {
     fn new(raw: &'a mut RawContext<A::Msg>, draining: bool) -> Self {
         Self {
-            raw,
+            core: ActorContextCore::new(raw),
             draining,
             actor: PhantomData,
         }
     }
 
-    /// Returns this actor's child id.
-    #[must_use]
-    pub fn id(&self) -> &ChildId {
-        self.raw.id()
-    }
-
-    /// Returns this actor's current incarnation.
-    #[must_use]
-    pub fn incarnation(&self) -> Incarnation {
-        self.raw.incarnation()
-    }
-
-    /// Returns a membership-addressed handle to this actor.
-    #[must_use]
-    pub fn myself(&self) -> ActorRef<A::Msg> {
-        self.raw.myself()
-    }
-
-    /// Returns this actor's supervising scope.
-    #[must_use]
-    pub fn scope(&self) -> ScopeRef {
-        self.raw.scope()
-    }
-
-    /// Returns the cooperative shutdown token.
-    #[must_use]
-    pub fn shutdown_token(&self) -> CancellationToken {
-        self.raw.shutdown_token()
-    }
-
-    /// Returns the escalation token.
-    #[must_use]
-    pub fn abort_token(&self) -> CancellationToken {
-        self.raw.abort_token()
-    }
-
-    /// Requests shutdown of the supervising scope without waiting.
-    pub fn request_scope_shutdown(&self) {
-        self.raw.request_scope_shutdown();
-    }
+    actor_context_forwarders!(A);
 
     /// Releases this incarnation's readiness gate while live.
     pub fn mark_ready(&self) {
         if !self.draining {
-            self.raw.mark_ready();
+            self.core.raw.mark_ready();
         }
     }
 
     /// Requests a clean local stop after the current callback.
     pub fn stop(&mut self) {
         if !self.draining {
-            self.raw.stop();
+            self.core.raw.stop();
         }
     }
 
@@ -132,7 +200,7 @@ impl<'a, A: Actor> Context<'a, A> {
         if self.draining {
             Err(Rejected::new(message))
         } else {
-            self.raw.continue_with(message)
+            self.core.raw.continue_with(message)
         }
     }
 
@@ -149,7 +217,7 @@ impl<'a, A: Actor> Context<'a, A> {
         if self.draining {
             Err(Rejected::new((key, message)))
         } else {
-            self.raw.set_timeout(key, message, after)
+            self.core.raw.set_timeout(key, message, after)
         }
     }
 
@@ -167,7 +235,7 @@ impl<'a, A: Actor> Context<'a, A> {
         if self.draining {
             Err(Rejected::new((key, message)))
         } else {
-            self.raw.set_interval(key, message, period)
+            self.core.raw.set_interval(key, message, period)
         }
     }
 
@@ -179,7 +247,7 @@ impl<'a, A: Actor> Context<'a, A> {
         if self.draining {
             Err(Rejected::new(()))
         } else {
-            Ok(self.raw.clear_timer(key))
+            Ok(self.core.raw.clear_timer(key))
         }
     }
 
@@ -198,7 +266,7 @@ impl<'a, A: Actor> Context<'a, A> {
         if self.draining {
             Err(Rejected::new((work, continuation)))
         } else {
-            self.raw.offload(work, continuation, deadline)
+            self.core.raw.offload(work, continuation, deadline)
         }
     }
 
@@ -217,31 +285,24 @@ impl<'a, A: Actor> Context<'a, A> {
         if self.draining {
             Err(Rejected::new((work, continuation)))
         } else {
-            self.raw.offload_scoped(work, continuation, deadline)
+            self.core.raw.offload_scoped(work, continuation, deadline)
         }
-    }
-
-    /// Starts blocking work tied to actor shutdown and returned-future drop.
-    ///
-    /// Cancellation is cooperative; a hard-aborted operation's OS thread
-    /// detaches and may outlive this actor incarnation.
-    pub fn run_blocking<F, T>(&self, operation: F) -> Blocking<T>
-    where
-        F: FnOnce(CancellationToken) -> T + Send + 'static,
-        T: Send + 'static,
-    {
-        self.raw.run_blocking(operation)
     }
 
     /// Re-enters a same-message actor with this exact context and stage.
     pub fn for_actor<B: Actor<Msg = A::Msg>>(&mut self) -> Context<'_, B> {
-        Context::new(self.raw, self.draining)
+        let draining = self.draining;
+        Context {
+            core: self.core.reborrow(),
+            draining,
+            actor: PhantomData,
+        }
     }
 }
 
 /// Narrowed context supplied only to [`Actor::on_stop`].
 pub struct StopContext<'a, A: Actor> {
-    raw: &'a mut RawContext<A::Msg>,
+    core: ActorContextCore<'a, A::Msg>,
     actor: PhantomData<fn() -> A>,
 }
 
@@ -249,8 +310,8 @@ impl<A: Actor> fmt::Debug for StopContext<'_, A> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("StopContext")
-            .field("id", self.raw.id())
-            .field("incarnation", &self.raw.incarnation())
+            .field("id", self.core.id())
+            .field("incarnation", &self.core.incarnation())
             .finish_non_exhaustive()
     }
 }
@@ -258,67 +319,19 @@ impl<A: Actor> fmt::Debug for StopContext<'_, A> {
 impl<'a, A: Actor> StopContext<'a, A> {
     fn new(raw: &'a mut RawContext<A::Msg>) -> Self {
         Self {
-            raw,
+            core: ActorContextCore::new(raw),
             actor: PhantomData,
         }
     }
 
-    /// Returns this actor's child id.
-    #[must_use]
-    pub fn id(&self) -> &ChildId {
-        self.raw.id()
-    }
-
-    /// Returns this actor's current incarnation.
-    #[must_use]
-    pub fn incarnation(&self) -> Incarnation {
-        self.raw.incarnation()
-    }
-
-    /// Returns a membership-addressed handle to this actor.
-    #[must_use]
-    pub fn myself(&self) -> ActorRef<A::Msg> {
-        self.raw.myself()
-    }
-
-    /// Returns this actor's supervising scope.
-    #[must_use]
-    pub fn scope(&self) -> ScopeRef {
-        self.raw.scope()
-    }
-
-    /// Returns the cooperative shutdown token.
-    #[must_use]
-    pub fn shutdown_token(&self) -> CancellationToken {
-        self.raw.shutdown_token()
-    }
-
-    /// Returns the escalation token.
-    #[must_use]
-    pub fn abort_token(&self) -> CancellationToken {
-        self.raw.abort_token()
-    }
-
-    /// Requests shutdown of the supervising scope without waiting.
-    pub fn request_scope_shutdown(&self) {
-        self.raw.request_scope_shutdown();
-    }
-
-    /// Starts blocking work tied to actor shutdown and returned-future drop.
-    ///
-    /// Cancellation is cooperative; a hard-aborted operation's OS thread
-    /// detaches and may outlive this actor incarnation.
-    pub fn run_blocking<F, T>(&self, operation: F) -> Blocking<T>
-    where
-        F: FnOnce(CancellationToken) -> T + Send + 'static,
-        T: Send + 'static,
-    {
-        self.raw.run_blocking(operation)
-    }
+    actor_context_forwarders!(A);
 
     /// Re-enters a same-message actor with the same narrowed stop context.
     pub fn for_actor<B: Actor<Msg = A::Msg>>(&mut self) -> StopContext<'_, B> {
-        StopContext::new(self.raw)
+        StopContext {
+            core: self.core.reborrow(),
+            actor: PhantomData,
+        }
     }
 }
 

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -115,7 +115,13 @@ impl TaskContext {
 
     /// Releases manual readiness. Repeated calls are no-ops.
     pub fn mark_ready(&self) {
-        self.ready.fire();
+        if !self.is_stopping() {
+            self.ready.fire();
+        }
+    }
+
+    pub(crate) fn is_stopping(&self) -> bool {
+        self.shutdown.is_cancelled() || self.abort.is_cancelled()
     }
 }
 
@@ -385,7 +391,63 @@ mod tests {
         runtime::{self, JoinOutcome, Latch, Timeout},
     };
 
-    use super::{CancellationToken, OneShotTaskRef, TaskRef};
+    use super::{CancellationToken, OneShotTaskRef, TaskContext, TaskRef};
+
+    fn task_context() -> (TaskContext, Latch, Latch, Latch) {
+        let id = ChildId::from("task");
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let membership = identity.mint_membership(&id).expect("membership available");
+        let mut incarnations = identity.incarnation_counter(membership);
+        let incarnation = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
+            .expect("incarnation available");
+        let shutdown = Latch::default();
+        let abort = Latch::default();
+        let ready = Latch::default();
+        let context = TaskContext::new(
+            id,
+            incarnation,
+            shutdown.clone(),
+            abort.clone(),
+            ready.clone(),
+        );
+        (context, shutdown, abort, ready)
+    }
+
+    #[test]
+    fn live_task_context_can_publish_readiness() {
+        let (context, shutdown, abort, ready) = task_context();
+
+        assert!(!context.is_stopping());
+        context.mark_ready();
+
+        assert!(ready.is_fired());
+        assert!(!shutdown.is_fired());
+        assert!(!abort.is_fired());
+    }
+
+    #[test]
+    fn shutdown_first_prevents_task_readiness_publication() {
+        let (context, shutdown, abort, ready) = task_context();
+
+        assert!(shutdown.fire());
+        assert!(context.is_stopping());
+        context.mark_ready();
+
+        assert!(!ready.is_fired());
+        assert!(!abort.is_fired());
+    }
+
+    #[test]
+    fn abort_first_prevents_task_readiness_publication() {
+        let (context, shutdown, abort, ready) = task_context();
+
+        assert!(abort.fire());
+        assert!(context.is_stopping());
+        context.mark_ready();
+
+        assert!(!ready.is_fired());
+        assert!(!shutdown.is_fired());
+    }
 
     fn one_shot_claim<T>() -> (
         runtime::OneShotSender<T>,

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -114,6 +114,10 @@ impl TaskContext {
     }
 
     /// Releases manual readiness. Repeated calls are no-ops.
+    ///
+    /// Once cooperative shutdown or escalation has begun this incarnation is
+    /// already stopping, so readiness can no longer be published and the call
+    /// is a no-op as well.
     pub fn mark_ready(&self) {
         if !self.is_stopping() {
             self.ready.fire();

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -6,7 +6,7 @@ use shelterwood::{
     DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, ExitError, ExitResult, Guard, Handler,
     Incarnation, LifecycleEvents, LifecycleTryRecvError, Membership, OneShotTaskRef, RawActor,
     RawContext, RawDef, RawOnceDef, Removal, Reply, ReplyReceive, ReplyReceiver, ScopeRef,
-    SendError, SendFuture, SendTimeout, SnapshotClosed, SnapshotReceiver, SubtreeDef,
+    SendError, SendFuture, SendTimeout, SnapshotClosed, SnapshotReceiver, StopContext, SubtreeDef,
     SubtreeOnceDef, SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, Tree, WaitError,
 };
 
@@ -123,6 +123,8 @@ impl Actor for ClonedActor {
 fn actor_types_obey_resource_and_payload_trait_contracts() {
     assert_error::<DeadlineElapsed>();
     assert_raw::<Handler<OpaqueActor>>();
+    assert_send_type::<Context<'static, OpaqueActor>>();
+    assert_send_type::<StopContext<'static, OpaqueActor>>();
     assert_send_type::<Blocking<Cell<()>>>();
     assert_static::<Blocking<Cell<()>>>();
     assert_send_type::<Guard>();


### PR DESCRIPTION
Part of #56. This draft is stacked on #60.

## What changed

- share the private actor context core across all public `Context`/`StopContext` variants while preserving their nominal public APIs
- make task readiness fail closed once either shutdown or abort has begun
- add exact public API and readiness-transition coverage

## Validation

- `./scripts/dev just ci` — 316/316 tests plus Clippy, docs, API reachability, layering, and package checks
- `./scripts/dev just ci-nix` — all clean Nix checks passed

Please review the single commit above `agent/issue-56-deadlined`.