### PR TITLE
Consolidate definition source state and setters

### DIFF
--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -505,54 +505,15 @@ impl<A: Actor> ActorDef<A> {
         }
     }
 
-    /// Overrides the restart policy.
-    #[must_use]
-    pub fn restart(mut self, restart: RestartPolicy) -> Self {
-        self.options.restart = Some(restart);
-        self
-    }
-
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor mailbox kind and capacity.
-    #[must_use]
-    pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
-        self.options.mailbox = Some(mailbox);
-        self
-    }
-
-    /// Overrides frozen-prefix drain versus discard behavior.
-    #[must_use]
-    pub fn mailbox_shutdown(mut self, shutdown: MailboxShutdown) -> Self {
-        self.options.mailbox_shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor's declared readiness mode.
-    #[must_use]
-    pub fn readiness(mut self, readiness: Readiness) -> Self {
-        self.options.readiness = Some(readiness);
-        self
-    }
-
-    /// Overrides the structural readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(
+        restart,
+        shutdown,
+        mailbox,
+        mailbox_shutdown,
+        actor_readiness,
+        structural_readiness_deadline,
+        retention,
+    );
 
     pub(crate) fn into_raw(self) -> RawDef<Handler<A>> {
         let factory = self.factory;
@@ -594,47 +555,14 @@ impl<A: Actor> ActorOnceDef<A> {
         }
     }
 
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor mailbox kind and capacity.
-    #[must_use]
-    pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
-        self.options.mailbox = Some(mailbox);
-        self
-    }
-
-    /// Overrides frozen-prefix drain versus discard behavior.
-    #[must_use]
-    pub fn mailbox_shutdown(mut self, shutdown: MailboxShutdown) -> Self {
-        self.options.mailbox_shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor's declared readiness mode.
-    #[must_use]
-    pub fn readiness(mut self, readiness: Readiness) -> Self {
-        self.options.readiness = Some(readiness);
-        self
-    }
-
-    /// Overrides the structural readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(
+        shutdown,
+        mailbox,
+        mailbox_shutdown,
+        actor_readiness,
+        structural_readiness_deadline,
+        retention,
+    );
 
     pub(crate) fn into_raw(self) -> RawOnceDef<Handler<A>> {
         let readiness = self.options.readiness.unwrap_or(Readiness::AfterInit);

--- a/crates/shelterwood/src/definition.rs
+++ b/crates/shelterwood/src/definition.rs
@@ -1,0 +1,190 @@
+//! Shared private machinery for declaration definitions.
+
+/// Repeatable or consuming definition payload state.
+///
+/// The explicit `Spent` state lets consumers move a one-shot payload without
+/// wrapping that payload in a second `Option`. Repeatable payloads remain
+/// borrowed in place and therefore survive every construction attempt.
+pub(crate) enum DefinitionSource<R, O> {
+    Restartable(R),
+    OneShot(O),
+    Spent,
+}
+
+impl<R, O> DefinitionSource<R, O> {
+    pub(crate) fn is_one_shot(&self) -> bool {
+        matches!(self, Self::OneShot(_) | Self::Spent)
+    }
+
+    pub(crate) fn restartable(&self) -> Option<&R> {
+        match self {
+            Self::Restartable(source) => Some(source),
+            Self::OneShot(_) | Self::Spent => None,
+        }
+    }
+
+    pub(crate) fn take_one_shot(&mut self) -> Option<O> {
+        match std::mem::replace(self, Self::Spent) {
+            Self::OneShot(source) => Some(source),
+            Self::Restartable(source) => {
+                *self = Self::Restartable(source);
+                None
+            }
+            Self::Spent => None,
+        }
+    }
+}
+
+/// Generates the option setters shared by the public definition families.
+macro_rules! common_options_setters {
+    ($($setter:ident),* $(,)?) => {
+        $(common_options_setters!(@emit $setter);)*
+    };
+
+    (@emit restart) => {
+        /// Overrides the restart policy.
+        #[must_use]
+        pub fn restart(mut self, restart: RestartPolicy) -> Self {
+            self.options.restart = Some(restart);
+            self
+        }
+    };
+
+    (@emit shutdown) => {
+        /// Overrides the shutdown policy.
+        #[must_use]
+        pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
+            self.options.shutdown = Some(shutdown);
+            self
+        }
+    };
+
+    (@emit mailbox) => {
+        /// Overrides the actor mailbox kind and capacity.
+        #[must_use]
+        pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
+            self.options.mailbox = Some(mailbox);
+            self
+        }
+    };
+
+    (@emit mailbox_shutdown) => {
+        /// Overrides frozen-prefix drain versus discard behavior.
+        #[must_use]
+        pub fn mailbox_shutdown(mut self, shutdown: MailboxShutdown) -> Self {
+            self.options.mailbox_shutdown = Some(shutdown);
+            self
+        }
+    };
+
+    (@emit actor_readiness) => {
+        /// Overrides the actor's declared readiness mode.
+        #[must_use]
+        pub fn readiness(mut self, readiness: Readiness) -> Self {
+            self.options.readiness = Some(readiness);
+            self
+        }
+    };
+
+    (@emit raw_readiness) => {
+        /// Overrides the actor's declared readiness mode.
+        pub fn readiness(mut self, readiness: Readiness) -> Result<Self, PolicyError> {
+            if readiness == Readiness::AfterInit {
+                return Err(PolicyError::UnsupportedReadiness);
+            }
+            self.options.readiness = Some(readiness);
+            Ok(self)
+        }
+    };
+
+    (@emit task_readiness) => {
+        /// Overrides task readiness (`Immediate` or `Manual`).
+        pub fn readiness(mut self, readiness: Readiness) -> Result<Self, PolicyError> {
+            if readiness == Readiness::AfterInit {
+                return Err(PolicyError::UnsupportedReadiness);
+            }
+            self.options.readiness = Some(readiness);
+            Ok(self)
+        }
+    };
+
+    (@emit structural_readiness_deadline) => {
+        /// Overrides the structural readiness deadline.
+        #[must_use]
+        pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
+            self.options.readiness_deadline = deadline;
+            self
+        }
+    };
+
+    (@emit task_readiness_deadline) => {
+        /// Overrides the readiness deadline.
+        #[must_use]
+        pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
+            self.options.readiness_deadline = deadline;
+            self
+        }
+    };
+
+    (@emit retention) => {
+        /// Overrides terminal-membership retention.
+        #[must_use]
+        pub fn retention(mut self, retention: Retention) -> Self {
+            self.options.retention = Some(retention);
+            self
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::DefinitionSource;
+
+    #[test]
+    fn restartable_source_remains_available() {
+        let mut source = DefinitionSource::<_, ()>::Restartable(String::from("factory"));
+
+        assert!(!source.is_one_shot());
+        assert_eq!(source.restartable().map(String::as_str), Some("factory"));
+        assert_eq!(source.take_one_shot(), None);
+        assert_eq!(source.restartable().map(String::as_str), Some("factory"));
+    }
+
+    #[test]
+    fn one_shot_source_transitions_directly_to_spent() {
+        let mut source = DefinitionSource::<(), _>::OneShot(String::from("body"));
+
+        assert!(source.is_one_shot());
+        assert_eq!(source.take_one_shot().as_deref(), Some("body"));
+        assert!(source.is_one_shot());
+        assert!(source.take_one_shot().is_none());
+        assert!(matches!(source, DefinitionSource::Spent));
+    }
+
+    #[test]
+    fn source_keeps_exactly_one_owner_across_consumption() {
+        struct DropProbe(Arc<AtomicUsize>);
+
+        impl Drop for DropProbe {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut source = DefinitionSource::<(), _>::OneShot(DropProbe(Arc::clone(&drops)));
+        let payload = source
+            .take_one_shot()
+            .expect("payload is initially available");
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+        drop(source);
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+        drop(payload);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -22,12 +22,12 @@ use crate::{
     observe::LifecycleEventKind,
     plan::{
         BuilderCore, ChildConstruction, ChildPlan, LowerError, NotAdmittingCause, RemoveOutcome,
-        ReserveError, ScopeFactory, ScopePlan, ScopeSource, SlotCell,
+        ReserveError, ScopeFactory, ScopePlan, SlotCell,
     },
     policy::{DefaultsInheritance, ResolvedDefaults, ScopeFlavor},
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
     runtime::{self, Latch},
-    task::{OnceTaskBody, TaskContext, TaskFactory},
+    task::{TaskContext, TaskFactory},
 };
 
 #[cfg(test)]
@@ -1216,25 +1216,20 @@ impl ScopeRuntime {
                 )
             }
             ChildConstruction::TaskOnce(definition) => {
-                let body = std::mem::replace(&mut definition.body, OnceTaskBody::Spent);
-                match body {
-                    OnceTaskBody::Available(body) => (
-                        SpawnBody::TaskOnce(body),
-                        Some(child.options.readiness),
-                        true,
-                    ),
-                    OnceTaskBody::Spent => {
-                        panic!("one-shot task construction invoked more than once")
-                    }
-                }
+                let body = definition.take_body();
+                (
+                    SpawnBody::TaskOnce(body),
+                    Some(child.options.readiness),
+                    true,
+                )
             }
             ChildConstruction::Scope(definition) => {
                 let inherited = match definition.defaults {
                     DefaultsInheritance::Inherit => self.defaults.clone(),
                     DefaultsInheritance::Reset => ResolvedDefaults::default(),
                 };
-                match &mut definition.source {
-                    ScopeSource::Restartable(factory) => (
+                if let Some(factory) = definition.restartable() {
+                    (
                         SpawnBody::ScopeRestartable {
                             factory: Arc::clone(factory),
                             scope: Arc::clone(
@@ -1248,31 +1243,26 @@ impl ScopeRuntime {
                         },
                         Some(Readiness::Manual),
                         false,
-                    ),
-                    ScopeSource::OneShot(_) => {
-                        let source = std::mem::replace(&mut definition.source, ScopeSource::Spent);
-                        let ScopeSource::OneShot(tree) = source else {
-                            unreachable!()
-                        };
-                        (
-                            SpawnBody::ScopeOnce {
-                                tree,
-                                scope: Arc::clone(
-                                    child
-                                        .slot
-                                        .scope
-                                        .as_ref()
-                                        .expect("scope construction needs a scope cell"),
-                                ),
-                                inherited,
-                            },
-                            Some(Readiness::Manual),
-                            true,
-                        )
-                    }
-                    ScopeSource::Spent => {
-                        panic!("one-shot subtree construction invoked more than once")
-                    }
+                    )
+                } else {
+                    let tree = definition
+                        .take_one_shot()
+                        .expect("one-shot subtree construction invoked more than once");
+                    (
+                        SpawnBody::ScopeOnce {
+                            tree,
+                            scope: Arc::clone(
+                                child
+                                    .slot
+                                    .scope
+                                    .as_ref()
+                                    .expect("scope construction needs a scope cell"),
+                            ),
+                            inherited,
+                        },
+                        Some(Readiness::Manual),
+                        true,
+                    )
                 }
             }
         };

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -2,6 +2,8 @@
 
 //! Structured supervision and actors for asynchronous Rust systems.
 
+#[macro_use]
+mod definition;
 mod actor;
 mod cells;
 mod deadline;

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -8,6 +8,7 @@ use std::{
 use crate::{
     ChildId, DefaultsInheritance, Exit, Intensity, Readiness, ScopeDefaults, Strategy,
     cells::{MemberCell, ScopeCell},
+    definition::DefinitionSource,
     identity::ScopeIdentity,
     policy::{
         CommonOptions, IdError, ResolvedCommonOptions, ResolvedDefaults, ScopeFlavor,
@@ -347,7 +348,7 @@ pub(crate) enum LowerError {
 }
 
 pub(crate) struct ScopeConstruction {
-    pub(crate) source: ScopeSource,
+    pub(crate) source: DefinitionSource<ScopeFactory, Box<BuilderCore>>,
     pub(crate) options: CommonOptions,
     pub(crate) defaults: DefaultsInheritance,
 }
@@ -356,14 +357,16 @@ pub(crate) type ScopeFactory = Arc<dyn Fn() -> BuilderCore + Send + Sync + 'stat
 
 impl ScopeConstruction {
     pub(crate) fn one_shot(&self) -> bool {
-        matches!(self.source, ScopeSource::OneShot(_) | ScopeSource::Spent)
+        self.source.is_one_shot()
     }
-}
 
-pub(crate) enum ScopeSource {
-    Restartable(ScopeFactory),
-    OneShot(Box<BuilderCore>),
-    Spent,
+    pub(crate) fn restartable(&self) -> Option<&ScopeFactory> {
+        self.source.restartable()
+    }
+
+    pub(crate) fn take_one_shot(&mut self) -> Option<Box<BuilderCore>> {
+        self.source.take_one_shot()
+    }
 }
 
 pub(crate) fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError> {

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -17,6 +17,7 @@ use crate::{
     ActorRef, CancellationToken, ChildId, ExitResult, Incarnation, Mailbox, MailboxShutdown,
     PolicyError, Readiness, ReadinessDeadline, RestartPolicy, Retention, ScopeRef, Shutdown,
     cells::{MailboxControl, MemberCell},
+    definition::DefinitionSource,
     mailbox::{MailboxCell, MailboxReceiver},
     policy::CommonOptions,
     runtime::{self, ActorWork, Latch, Signal, SignalWatcher},
@@ -1426,61 +1427,20 @@ impl<R: RawActor> RawDef<R> {
         }
     }
 
-    /// Overrides the restart policy.
-    #[must_use]
-    pub fn restart(mut self, restart: RestartPolicy) -> Self {
-        self.options.restart = Some(restart);
-        self
-    }
-
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor mailbox kind and capacity.
-    #[must_use]
-    pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
-        self.options.mailbox = Some(mailbox);
-        self
-    }
-
-    /// Overrides frozen-prefix drain versus discard behavior.
-    #[must_use]
-    pub fn mailbox_shutdown(mut self, shutdown: MailboxShutdown) -> Self {
-        self.options.mailbox_shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor's declared readiness mode.
-    pub fn readiness(mut self, readiness: Readiness) -> Result<Self, PolicyError> {
-        if readiness == Readiness::AfterInit {
-            return Err(PolicyError::UnsupportedReadiness);
-        }
-        self.options.readiness = Some(readiness);
-        Ok(self)
-    }
-
-    /// Overrides the structural readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(
+        restart,
+        shutdown,
+        mailbox,
+        mailbox_shutdown,
+        raw_readiness,
+        structural_readiness_deadline,
+        retention,
+    );
 
     pub(crate) fn erase(self, mailbox: Arc<MailboxCell<R::Msg>>) -> RawConstruction {
         let factory = self.factory;
         RawConstruction {
-            source: RawSource::Restartable(Arc::new(move || {
+            source: DefinitionSource::Restartable(Arc::new(move || {
                 let actor = factory();
                 Box::new(RawInstance {
                     actor,
@@ -1517,56 +1477,21 @@ impl<R: RawActor> RawOnceDef<R> {
         }
     }
 
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor mailbox kind and capacity.
-    #[must_use]
-    pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
-        self.options.mailbox = Some(mailbox);
-        self
-    }
-
-    /// Overrides frozen-prefix drain versus discard behavior.
-    #[must_use]
-    pub fn mailbox_shutdown(mut self, shutdown: MailboxShutdown) -> Self {
-        self.options.mailbox_shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor's declared readiness mode.
-    pub fn readiness(mut self, readiness: Readiness) -> Result<Self, PolicyError> {
-        if readiness == Readiness::AfterInit {
-            return Err(PolicyError::UnsupportedReadiness);
-        }
-        self.options.readiness = Some(readiness);
-        Ok(self)
-    }
-
-    /// Overrides the structural readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(
+        shutdown,
+        mailbox,
+        mailbox_shutdown,
+        raw_readiness,
+        structural_readiness_deadline,
+        retention,
+    );
 
     pub(crate) fn erase(self, mailbox: Arc<MailboxCell<R::Msg>>) -> RawConstruction {
         RawConstruction {
-            source: RawSource::OneShot(Some(Box::new(RawInstance {
+            source: DefinitionSource::OneShot(Box::new(RawInstance {
                 actor: self.actor,
                 mailbox,
-            }))),
+            })),
             options: self.options,
         }
     }
@@ -1700,26 +1625,24 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
 }
 
 pub(crate) struct RawConstruction {
-    pub(crate) source: RawSource,
+    pub(crate) source: DefinitionSource<RawFactory, Box<dyn ErasedRawInstance>>,
     pub(crate) options: CommonOptions,
 }
 
 impl RawConstruction {
     pub(crate) fn one_shot(&self) -> bool {
-        matches!(self.source, RawSource::OneShot(_) | RawSource::Spent)
+        self.source.is_one_shot()
     }
 
     pub(crate) fn take_spawn(&mut self) -> RawSpawn {
-        match &mut self.source {
-            RawSource::Restartable(factory) => RawSpawn::Restartable(Arc::clone(factory)),
-            RawSource::OneShot(instance) => {
-                let instance = instance
-                    .take()
-                    .expect("one-shot raw actor construction invoked more than once");
-                self.source = RawSource::Spent;
-                RawSpawn::OneShot(instance)
-            }
-            RawSource::Spent => panic!("one-shot raw actor construction invoked more than once"),
+        if let Some(factory) = self.source.restartable() {
+            RawSpawn::Restartable(Arc::clone(factory))
+        } else {
+            RawSpawn::OneShot(
+                self.source
+                    .take_one_shot()
+                    .expect("one-shot raw actor construction invoked more than once"),
+            )
         }
     }
 }
@@ -1736,12 +1659,6 @@ impl RawSpawn {
             Self::OneShot(instance) => instance,
         }
     }
-}
-
-pub(crate) enum RawSource {
-    Restartable(RawFactory),
-    OneShot(Option<Box<dyn ErasedRawInstance>>),
-    Spent,
 }
 
 pub(crate) struct RawRunContext {

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -1,6 +1,7 @@
 //! Supervised task definitions, contexts, and handles.
 
 use std::{
+    convert::Infallible,
     fmt,
     future::Future,
     hash::{Hash, Hasher},
@@ -12,6 +13,7 @@ use crate::{
     ChildId, Exit, ExitError, ExitResult, Incarnation, Membership, PolicyError, Readiness,
     ReadinessDeadline, RestartPolicy, Retention, Shutdown,
     cells::MemberCell,
+    definition::DefinitionSource,
     policy::CommonOptions,
     runtime::{self, Latch},
 };
@@ -157,42 +159,13 @@ impl TaskDef {
         }
     }
 
-    /// Overrides the restart policy.
-    #[must_use]
-    pub fn restart(mut self, restart: RestartPolicy) -> Self {
-        self.options.restart = Some(restart);
-        self
-    }
-
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides task readiness (`Immediate` or `Manual`).
-    pub fn readiness(mut self, readiness: Readiness) -> Result<Self, PolicyError> {
-        if readiness == Readiness::AfterInit {
-            return Err(PolicyError::UnsupportedReadiness);
-        }
-        self.options.readiness = Some(readiness);
-        Ok(self)
-    }
-
-    /// Overrides the readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(
+        restart,
+        shutdown,
+        task_readiness,
+        task_readiness_deadline,
+        retention,
+    );
 }
 
 type OnceTaskFuture<T> = Pin<Box<dyn Future<Output = Result<T, ExitError>> + Send + 'static>>;
@@ -228,40 +201,12 @@ impl<T: Send + 'static> TaskOnceDef<T> {
         }
     }
 
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides task readiness (`Immediate` or `Manual`).
-    pub fn readiness(mut self, readiness: Readiness) -> Result<Self, PolicyError> {
-        if readiness == Readiness::AfterInit {
-            return Err(PolicyError::UnsupportedReadiness);
-        }
-        self.options.readiness = Some(readiness);
-        Ok(self)
-    }
-
-    /// Overrides the readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(shutdown, task_readiness, task_readiness_deadline, retention,);
 
     pub(crate) fn erase(self, completion: runtime::OneShotSender<T>) -> OnceTask {
         let body = self.body;
         OnceTask {
-            body: OnceTaskBody::Available(Box::new(move |context| {
+            source: DefinitionSource::OneShot(Box::new(move |context| {
                 Box::pin(async move {
                     match body(context).await {
                         Ok(value) => {
@@ -278,13 +223,18 @@ impl<T: Send + 'static> TaskOnceDef<T> {
 }
 
 pub(crate) struct OnceTask {
-    pub(crate) body: OnceTaskBody,
+    source: DefinitionSource<Infallible, OnceTaskFactory>,
     pub(crate) options: CommonOptions,
 }
 
-pub(crate) enum OnceTaskBody {
-    Available(Box<dyn FnOnce(TaskContext) -> TaskFuture + Send + 'static>),
-    Spent,
+type OnceTaskFactory = Box<dyn FnOnce(TaskContext) -> TaskFuture + Send + 'static>;
+
+impl OnceTask {
+    pub(crate) fn take_body(&mut self) -> OnceTaskFactory {
+        self.source
+            .take_one_shot()
+            .expect("one-shot task construction invoked more than once")
+    }
 }
 
 /// A cheap membership-addressed task handle.

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -16,12 +16,13 @@ use crate::{
     Membership, ReadinessDeadline, RestartPolicy, Retention, ScopeDefaults, ScopeSnapshot,
     Shutdown, ShutdownTimeout, SnapshotReceiver, Strategy, WaitError,
     cells::{MemberStage, ScopeCell},
+    definition::DefinitionSource,
     driver::DynamicReservation,
     exit::{StartupError, StopReason},
     mailbox::MailboxCell,
     plan::{
         BuilderCore, ChildConstruction, LowerError, RemoveOutcome, ReserveError, ScopeConstruction,
-        ScopeSource, SlotCell, checked_id,
+        SlotCell, checked_id,
     },
     policy::{CommonOptions, ResolvedDefaults, ScopeFlavor},
     raw::{RawDef, RawOnceDef},
@@ -1041,33 +1042,7 @@ impl<T: Subtree> SubtreeDef<T> {
         }
     }
 
-    /// Overrides the restart policy.
-    #[must_use]
-    pub fn restart(mut self, restart: RestartPolicy) -> Self {
-        self.options.restart = Some(restart);
-        self
-    }
-
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the structural readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(restart, shutdown, structural_readiness_deadline, retention,);
 
     /// Selects inheritance or reset for unset nested defaults.
     #[must_use]
@@ -1079,7 +1054,7 @@ impl<T: Subtree> SubtreeDef<T> {
     fn erase(self) -> ScopeConstruction {
         let factory = self.factory;
         ScopeConstruction {
-            source: ScopeSource::Restartable(Arc::new(move || {
+            source: DefinitionSource::Restartable(Arc::new(move || {
                 <T as sealed::Sealed>::into_core(factory())
             })),
             options: self.options,
@@ -1117,26 +1092,7 @@ impl<T: Subtree> SubtreeOnceDef<T> {
         }
     }
 
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the structural readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(shutdown, structural_readiness_deadline, retention,);
 
     /// Selects inheritance or reset for unset nested defaults.
     #[must_use]
@@ -1147,7 +1103,9 @@ impl<T: Subtree> SubtreeOnceDef<T> {
 
     fn erase(self) -> ScopeConstruction {
         ScopeConstruction {
-            source: ScopeSource::OneShot(Box::new(<T as sealed::Sealed>::into_core(self.tree))),
+            source: DefinitionSource::OneShot(Box::new(<T as sealed::Sealed>::into_core(
+                self.tree,
+            ))),
             options: self.options,
             defaults: self.defaults,
         }

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -2,12 +2,14 @@ use std::{cell::Cell, error::Error, hash::Hash, time::Duration};
 
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, ActorSlot, Admission, Blocking, CallError, CallFuture,
-    CancellationToken, Context, DeadlineElapsed, DynamicActorSlot, DynamicScopeRef,
-    DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, ExitError, ExitResult, Guard, Handler,
-    Incarnation, LifecycleEvents, LifecycleTryRecvError, Membership, OneShotTaskRef, RawActor,
-    RawContext, RawDef, RawOnceDef, Removal, Reply, ReplyReceive, ReplyReceiver, ScopeRef,
-    SendError, SendFuture, SendTimeout, SnapshotClosed, SnapshotReceiver, StopContext, SubtreeDef,
-    SubtreeOnceDef, SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, Tree, WaitError,
+    CancellationToken, Context, DeadlineElapsed, DefaultsInheritance, DynamicActorSlot,
+    DynamicScopeRef, DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, ExitError, ExitResult,
+    Guard, Handler, Incarnation, LifecycleEvents, LifecycleTryRecvError, Mailbox, MailboxShutdown,
+    Membership, OneShotTaskRef, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
+    ReadinessDeadline, Removal, Reply, ReplyReceive, ReplyReceiver, RestartPolicy, Retention,
+    ScopeRef, SendError, SendFuture, SendTimeout, Shutdown, SnapshotClosed, SnapshotReceiver,
+    StopContext, SubtreeDef, SubtreeOnceDef, SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef,
+    TaskSlot, Tree, WaitError,
 };
 
 fn assert_error<T: Error>() {}
@@ -193,6 +195,77 @@ fn raw_types_obey_error_and_future_trait_contracts() {
     let (reply, receiver) = Reply::<Cell<()>>::channel();
     assert_send(reply);
     assert_send(receiver);
+}
+
+#[test]
+fn all_definition_option_setters_compile() {
+    let _ = RawDef::<OpaqueRaw>::factory(|| OpaqueRaw {
+        _not_sync: Cell::new(()),
+    })
+    .restart(RestartPolicy::default())
+    .shutdown(Shutdown::default())
+    .mailbox(Mailbox::default())
+    .mailbox_shutdown(MailboxShutdown::default())
+    .readiness(Readiness::Immediate)
+    .expect("immediate raw readiness is supported")
+    .readiness_deadline(ReadinessDeadline::Inherit)
+    .retention(Retention::Retain);
+
+    let _ = RawOnceDef::new(OpaqueRaw {
+        _not_sync: Cell::new(()),
+    })
+    .shutdown(Shutdown::default())
+    .mailbox(Mailbox::default())
+    .mailbox_shutdown(MailboxShutdown::default())
+    .readiness(Readiness::Manual)
+    .expect("manual raw readiness is supported")
+    .readiness_deadline(ReadinessDeadline::Inherit)
+    .retention(Retention::Retain);
+
+    let _ = ActorDef::<OpaqueActor>::factory(|| Cell::new(()))
+        .restart(RestartPolicy::default())
+        .shutdown(Shutdown::default())
+        .mailbox(Mailbox::default())
+        .mailbox_shutdown(MailboxShutdown::default())
+        .readiness(Readiness::AfterInit)
+        .readiness_deadline(ReadinessDeadline::Inherit)
+        .retention(Retention::Retain);
+
+    let _ = ActorOnceDef::<OpaqueActor>::new(Cell::new(()))
+        .shutdown(Shutdown::default())
+        .mailbox(Mailbox::default())
+        .mailbox_shutdown(MailboxShutdown::default())
+        .readiness(Readiness::AfterInit)
+        .readiness_deadline(ReadinessDeadline::Inherit)
+        .retention(Retention::Retain);
+
+    let _ = TaskDef::new(|_| async { Ok(()) })
+        .restart(RestartPolicy::default())
+        .shutdown(Shutdown::default())
+        .readiness(Readiness::Immediate)
+        .expect("immediate task readiness is supported")
+        .readiness_deadline(ReadinessDeadline::Inherit)
+        .retention(Retention::Retain);
+
+    let _ = TaskOnceDef::new(|_| async { Ok::<_, ExitError>(()) })
+        .shutdown(Shutdown::default())
+        .readiness(Readiness::Manual)
+        .expect("manual task readiness is supported")
+        .readiness_deadline(ReadinessDeadline::Inherit)
+        .retention(Retention::Retain);
+
+    let _ = SubtreeDef::factory(Tree::new)
+        .restart(RestartPolicy::default())
+        .shutdown(Shutdown::default())
+        .readiness_deadline(ReadinessDeadline::Inherit)
+        .retention(Retention::Retain)
+        .defaults(DefaultsInheritance::Inherit);
+
+    let _ = SubtreeOnceDef::new(Tree::new())
+        .shutdown(Shutdown::default())
+        .readiness_deadline(ReadinessDeadline::Inherit)
+        .retention(Retention::Retain)
+        .defaults(DefaultsInheritance::Reset);
 }
 
 #[test]

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -5,6 +5,7 @@ readonly below_driver_layers=(
   crates/shelterwood/src/actor.rs
   crates/shelterwood/src/cells.rs
   crates/shelterwood/src/deadline.rs
+  crates/shelterwood/src/definition.rs
   crates/shelterwood/src/engine.rs
   crates/shelterwood/src/exit.rs
   crates/shelterwood/src/identity.rs


### PR DESCRIPTION
Part of #56. This draft is stacked on #61.

## What changed

- replace the separate raw, scope, and one-shot source state machines with one private `DefinitionSource<R, O>`
- generate the shared option setters across all eight definition families from one private macro while retaining each family's special surfaces
- extend layering enforcement for the new module
- add ownership/transition tests and exact setter API coverage

The implementation/tooling code is net 61 lines smaller; the commit is net +12 only because it adds 73 lines of integration coverage.

## Validation

- `./scripts/dev just ci` — 320/320 tests plus Clippy, docs, API reachability, layering, and package checks
- `./scripts/dev just ci-nix` — all clean Nix checks passed

Please review the single commit above `agent/issue-56-contexts`.