### PR TITLE
Consolidate child planning funnels

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -10,7 +10,7 @@ use std::{
 use crate::{
     ChildId, Exit, ExitKind, Incarnation, IntensityTrip, Membership, Readiness, ReadinessDeadline,
     ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure, StartupFailureCause,
-    cells::{DynamicRoute, MemberCell, MemberStage, ResidentProjection, ScopeCell},
+    cells::{DynamicRoute, MemberStage, ResidentProjection, ScopeCell},
     deadline::Deadline,
     engine::{
         ArbitrationClass, DeadlineHandle, DeadlineQueue, ExitDispatch, IntensityState,
@@ -22,7 +22,7 @@ use crate::{
     observe::LifecycleEventKind,
     plan::{
         BuilderCore, ChildConstruction, ChildPlan, LowerError, NotAdmittingCause, RemoveOutcome,
-        ReserveError, ScopeFactory, ScopePlan, SlotCell,
+        ReserveError, ScopeFactory, ScopePlan, SlotCell, checked_id, mint_reserved_slot,
     },
     policy::{DefaultsInheritance, ResolvedDefaults, ScopeFlavor},
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
@@ -31,7 +31,7 @@ use crate::{
 };
 
 #[cfg(test)]
-use crate::cells::RuntimeStorage;
+use crate::cells::{MemberCell, RuntimeStorage};
 
 /// An exactly-once synchronous completion.
 ///
@@ -262,6 +262,7 @@ pub(crate) fn reserve_dynamic(
     id: ChildId,
     child_scope: Option<ScopeFlavor>,
 ) -> Result<DynamicReservation, ReserveError> {
+    let id = checked_id(id)?;
     if matches!(scope.member.record().stage, MemberStage::Terminal(_)) {
         return Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal));
     }
@@ -292,18 +293,7 @@ pub(crate) fn reserve_dynamic(
         }
         return Err(ReserveError::DuplicateId(id));
     }
-    let membership = scope
-        .child_identity
-        .lock()
-        .expect("scope identity mutex poisoned")
-        .mint_membership(&id)
-        .ok_or(ReserveError::IdentityExhausted)?;
-    let member = MemberCell::new(id.clone(), membership);
-    let child_scope = child_scope.map(|flavor| {
-        let identity = ScopeIdentity::new().expect("global scope identity space exhausted");
-        ScopeCell::new(Arc::clone(&member), flavor, identity)
-    });
-    let slot = SlotCell::new(member, child_scope);
+    let slot = mint_reserved_slot(scope, &id, child_scope)?;
     state.entries.insert(
         id,
         DynamicEntry {
@@ -2220,20 +2210,7 @@ impl ScopeRuntime {
             );
             return;
         };
-        let (options, one_shot) = match definition.get() {
-            ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
-            ChildConstruction::Task(definition) => (&definition.options, false),
-            ChildConstruction::TaskOnce(definition) => (&definition.options, true),
-            ChildConstruction::Scope(definition) => (&definition.options, definition.one_shot()),
-        };
-        let resolved =
-            crate::policy::resolve_common(options, &self.defaults, one_shot, Readiness::Immediate);
-        request.slot.member.set_options(resolved.clone());
-        let plan = ChildPlan {
-            slot: Arc::clone(&request.slot),
-            construction: definition,
-            options: resolved,
-        };
+        let plan = ChildPlan::resolve(Arc::clone(&request.slot), definition, &self.defaults);
         {
             let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
             let id = request.slot.member.id();

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -79,6 +79,25 @@ pub(crate) enum ChildConstruction {
     Scope(Box<ScopeConstruction>),
 }
 
+pub(crate) fn mint_reserved_slot(
+    parent: &ScopeCell,
+    id: &ChildId,
+    child_scope: Option<ScopeFlavor>,
+) -> Result<Arc<SlotCell>, ReserveError> {
+    let membership = parent
+        .child_identity
+        .lock()
+        .expect("scope identity mutex poisoned")
+        .mint_membership(id)
+        .ok_or(ReserveError::IdentityExhausted)?;
+    let member = MemberCell::new(id.clone(), membership);
+    let scope = child_scope.map(|flavor| {
+        let identity = ScopeIdentity::new().expect("global scope identity space exhausted");
+        ScopeCell::new(Arc::clone(&member), flavor, identity)
+    });
+    Ok(SlotCell::new(member, scope))
+}
+
 enum DefinitionState {
     Undefined,
     Defined(Isolated<ChildConstruction>),
@@ -193,19 +212,7 @@ impl BuilderCore {
         if self.ids.contains_key(&id) {
             return Err(ReserveError::DuplicateId(id));
         }
-        let membership = self
-            .root
-            .child_identity
-            .lock()
-            .expect("scope identity mutex poisoned")
-            .mint_membership(&id)
-            .ok_or(ReserveError::IdentityExhausted)?;
-        let member = MemberCell::new(id.clone(), membership);
-        let scope = scope.map(|flavor| {
-            let identity = ScopeIdentity::new().expect("global scope identity space exhausted");
-            ScopeCell::new(Arc::clone(&member), flavor, identity)
-        });
-        let slot = SlotCell::new(member, scope);
+        let slot = mint_reserved_slot(&self.root, &id, scope)?;
         self.ids.insert(id, Arc::clone(&slot));
         self.slots.push(Arc::clone(&slot));
         Ok(slot)
@@ -256,21 +263,7 @@ impl BuilderCore {
             let definition = slot
                 .take_definition()
                 .expect("validated slot must have a definition");
-            let (options, one_shot) = match definition.get() {
-                ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
-                ChildConstruction::Task(definition) => (&definition.options, false),
-                ChildConstruction::TaskOnce(definition) => (&definition.options, true),
-                ChildConstruction::Scope(definition) => {
-                    (&definition.options, definition.one_shot())
-                }
-            };
-            let resolved = resolve_common(options, &defaults, one_shot, Readiness::Immediate);
-            slot.member.set_options(resolved.clone());
-            children.push(ChildPlan {
-                slot: Arc::clone(slot),
-                construction: definition,
-                options: resolved,
-            });
+            children.push(ChildPlan::resolve(Arc::clone(slot), definition, &defaults));
         }
         self.armed = false;
         Ok(ScopePlan {
@@ -335,6 +328,28 @@ pub(crate) struct ChildPlan {
     pub(crate) options: ResolvedCommonOptions,
 }
 
+impl ChildPlan {
+    pub(crate) fn resolve(
+        slot: Arc<SlotCell>,
+        construction: Isolated<ChildConstruction>,
+        defaults: &ResolvedDefaults,
+    ) -> Self {
+        let (options, one_shot) = match construction.get() {
+            ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
+            ChildConstruction::Task(definition) => (&definition.options, false),
+            ChildConstruction::TaskOnce(definition) => (&definition.options, true),
+            ChildConstruction::Scope(definition) => (&definition.options, definition.one_shot()),
+        };
+        let options = resolve_common(options, defaults, one_shot, Readiness::Immediate);
+        slot.member.set_options(options.clone());
+        Self {
+            slot,
+            construction,
+            options,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) enum LowerError {
     Undefined {
@@ -374,4 +389,104 @@ pub(crate) fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError
     ChildId::validate(id.as_str().to_owned()).map_err(|error| match error {
         IdError::Empty => ReserveError::EmptyId,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Duration,
+    };
+
+    use crate::{
+        Backoff, ExitError, Readiness, RestartCondition, RestartPolicy, Retention, Shutdown,
+        TaskOnceDef,
+        policy::{ResolvedDefaults, ScopeFlavor},
+        runtime::{self, Isolated, Timeout},
+        task::TaskDef,
+    };
+
+    use super::{BuilderCore, ChildConstruction, ChildPlan};
+
+    fn configured_task() -> TaskDef {
+        TaskDef::new(|_| async { Ok(()) })
+            .restart(RestartPolicy::new(
+                RestartCondition::Always,
+                Backoff::Immediate,
+            ))
+            .shutdown(Shutdown::Abort)
+            .readiness(Readiness::Manual)
+            .expect("manual task readiness is valid")
+            .retention(Retention::Remove)
+    }
+
+    #[test]
+    fn static_and_dynamic_constructions_share_option_resolution() {
+        let defaults = ResolvedDefaults::default();
+        let mut declaration = BuilderCore::new(ScopeFlavor::Ordered);
+        let static_slot = declaration
+            .reserve("static", None)
+            .expect("static reservation succeeds");
+        static_slot.define(ChildConstruction::Task(configured_task()));
+        let static_plan = declaration
+            .lower(defaults.clone(), None)
+            .expect("defined declaration lowers");
+
+        let mut admission = BuilderCore::new(ScopeFlavor::Dynamic);
+        let dynamic_slot = admission
+            .reserve("dynamic", None)
+            .expect("dynamic reservation succeeds");
+        let dynamic_plan = ChildPlan::resolve(
+            dynamic_slot,
+            Isolated::new(ChildConstruction::Task(configured_task())),
+            &defaults,
+        );
+
+        assert_eq!(static_plan.children[0].options, dynamic_plan.options);
+    }
+
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[crate::runtime::test]
+    async fn resolving_one_shot_construction_preserves_owned_drop() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let capture = DropFlag(Arc::clone(&dropped));
+        let (completion, _claim) = runtime::oneshot();
+        let construction = TaskOnceDef::new(move |_| {
+            let _ = &capture;
+            async { Ok::<_, ExitError>(()) }
+        })
+        .erase(completion);
+        let mut declaration = BuilderCore::new(ScopeFlavor::Dynamic);
+        let slot = declaration
+            .reserve("one-shot", None)
+            .expect("reservation succeeds");
+
+        let plan = ChildPlan::resolve(
+            slot,
+            Isolated::new(ChildConstruction::TaskOnce(construction)),
+            &ResolvedDefaults::default(),
+        );
+        assert!(plan.options.restart.is_never());
+        assert_eq!(plan.options.retention, Retention::Remove);
+        assert!(!dropped.load(Ordering::SeqCst));
+
+        drop(plan);
+        let disposed = runtime::timeout(Duration::from_secs(1), async {
+            while !dropped.load(Ordering::SeqCst) {
+                runtime::yield_now().await;
+            }
+        })
+        .await;
+        assert!(matches!(disposed, Timeout::Completed(())));
+    }
 }

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -22,7 +22,7 @@ use crate::{
     mailbox::MailboxCell,
     plan::{
         BuilderCore, ChildConstruction, LowerError, RemoveOutcome, ReserveError, ScopeConstruction,
-        SlotCell, checked_id,
+        SlotCell,
     },
     policy::{CommonOptions, ResolvedDefaults, ScopeFlavor},
     raw::{RawDef, RawOnceDef},
@@ -1368,8 +1368,7 @@ impl DynamicScopeRef {
         &self,
         id: impl Into<ChildId>,
     ) -> Result<DynamicActorSlot<M>, ReserveError> {
-        let id = checked_id(id)?;
-        crate::driver::reserve_dynamic(&self.0.cell, id, None).map(|reservation| {
+        crate::driver::reserve_dynamic(&self.0.cell, id.into(), None).map(|reservation| {
             let mailbox = MailboxCell::new(reservation.slot.member.id().clone());
             reservation.slot.member.attach_mailbox(mailbox.clone());
             DynamicActorSlot {
@@ -1434,9 +1433,10 @@ impl DynamicScopeRef {
 
     /// Reserves a task id synchronously and exposes its exact handle.
     pub fn reserve_task(&self, id: impl Into<ChildId>) -> Result<DynamicTaskSlot, ReserveError> {
-        let id = checked_id(id)?;
-        crate::driver::reserve_dynamic(&self.0.cell, id, None).map(|reservation| DynamicTaskSlot {
-            core: TaskSlotCore::new(DynamicSlotEndpoint(Some(reservation))),
+        crate::driver::reserve_dynamic(&self.0.cell, id.into(), None).map(|reservation| {
+            DynamicTaskSlot {
+                core: TaskSlotCore::new(DynamicSlotEndpoint(Some(reservation))),
+            }
         })
     }
 
@@ -1465,12 +1465,10 @@ impl DynamicScopeRef {
         &self,
         id: impl Into<ChildId>,
     ) -> Result<DynamicSubtreeSlot<T>, ReserveError> {
-        let id = checked_id(id)?;
-        crate::driver::reserve_dynamic(&self.0.cell, id, Some(<T as sealed::Sealed>::FLAVOR)).map(
-            |reservation| DynamicSubtreeSlot {
+        crate::driver::reserve_dynamic(&self.0.cell, id.into(), Some(<T as sealed::Sealed>::FLAVOR))
+            .map(|reservation| DynamicSubtreeSlot {
                 core: SubtreeSlotCore::new(DynamicSlotEndpoint(Some(reservation))),
-            },
-        )
+            })
     }
 
     /// Adds a restartable subtree, resolving at admission.

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use crate::common::LiveFlag;
 use shelterwood::{
     BuildError, DynamicTree, ExitError, ExitKind, Readiness, ReadinessDeadline, RemoveOutcome,
-    Shutdown, StopReason, TaskDef, TaskOnceDef, Tree,
+    ReserveError, Shutdown, StopReason, TaskDef, TaskOnceDef, Tree,
 };
 
 #[test]
@@ -36,6 +36,25 @@ fn declaration_errors_are_eager_and_root_lowering_is_the_only_other_build_error(
         ));
         assert!(matches!(task.wait().await.kind(), ExitKind::NeverStarted));
     });
+}
+
+#[tokio::test]
+async fn dynamic_reservation_validates_ids_at_the_driver_boundary() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+
+    assert!(matches!(scope.reserve_task(""), Err(ReserveError::EmptyId)));
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root stops");
+
+    assert!(matches!(scope.reserve_task(""), Err(ReserveError::EmptyId)));
+    assert!(matches!(
+        scope.reserve_task("worker"),
+        Err(ReserveError::NotAdmitting(_))
+    ));
 }
 
 #[tokio::test]

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -18,6 +18,7 @@ readonly below_driver_layers=(
   crates/shelterwood/src/task.rs
 )
 readonly driver_path="crates/shelterwood/src/driver.rs"
+readonly tree_path="crates/shelterwood/src/tree.rs"
 
 check_forbidden() {
   local message="$1"
@@ -54,5 +55,15 @@ check_forbidden \
   "upward tree references found in the driver layer:" \
   '\btree::' \
   "$driver_path"
+
+check_forbidden \
+  "child option resolution escaped the shared plan funnel:" \
+  '\bresolve_common\b' \
+  "$driver_path"
+
+check_forbidden \
+  "dynamic child-id validation escaped the reservation boundary:" \
+  '\bchecked_id\b' \
+  "$tree_path"
 
 echo "supervision layering restrictions: clean"


### PR DESCRIPTION
Part of #56. This draft is stacked on #64 and starts Phase 4.

## What changed

- share static and dynamic member/slot minting through `plan::mint_reserved_slot`
- move dynamic child-ID validation to the trusted driver boundary, preserving `EmptyId` precedence even for terminal scopes
- make `ChildPlan::resolve` the sole `ChildConstruction -> resolve_common -> set_options -> ChildPlan` path
- enforce the new layering boundaries so validation/planning copies cannot drift back into tree/driver
- add parity, trusted-boundary, one-shot ownership, and destructor-isolation coverage

The two production funnels remove 10 net implementation lines; most additions are focused tests and architecture guards.

## Validation

- `./scripts/dev just ci` — 326/326 tests plus Clippy, docs, API reachability, layering, and package checks
- `./scripts/dev just ci-nix` — all clean Nix checks passed

Please review the single commit above `agent/issue-56-slots`.