### PR TITLE
Centralize never-started slot terminalization

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -218,11 +218,7 @@ impl DynamicControl {
         let mut retained = HashMap::new();
         for (id, entry) in entries {
             if !entry.admitted {
-                let definition = entry.slot.take_defined();
-                entry.slot.member.terminalize(Exit::never_started());
-                if let Some(scope) = &entry.slot.scope {
-                    scope.terminalize_never_started();
-                }
+                let definition = entry.slot.take_never_started();
                 dispose_definition_then(definition, move || drop(entry));
             } else {
                 retained.insert(id, entry);
@@ -345,12 +341,7 @@ fn cancel_dynamic_reservation_parts(
     let removed = cancelled.then(|| state.entries.remove(&id)).flatten();
     drop(state);
     let definition = if cancelled {
-        let definition = slot.take_defined();
-        slot.member.terminalize(Exit::never_started());
-        if let Some(scope) = &slot.scope {
-            scope.terminalize_never_started();
-        }
-        definition
+        slot.take_never_started()
     } else {
         None
     };
@@ -396,11 +387,7 @@ pub(crate) fn remove_dynamic(
     if !entry.admitted {
         let entry = state.entries.remove(id).expect("entry was just resolved");
         drop(state);
-        let definition = entry.slot.take_defined();
-        entry.slot.member.terminalize(Exit::never_started());
-        if let Some(scope) = &entry.slot.scope {
-            scope.terminalize_never_started();
-        }
+        let definition = entry.slot.take_never_started();
         dispose_definition_then(definition, move || drop(entry));
         return response;
     }
@@ -2223,10 +2210,7 @@ impl ScopeRuntime {
                     .then(|| state.entries.remove(id))
                     .flatten();
                 drop(state);
-                request.slot.member.terminalize(Exit::never_started());
-                if let Some(scope) = &request.slot.scope {
-                    scope.terminalize_never_started();
-                }
+                request.slot.terminalize_never_started();
                 // The entry's drop completes its removal response; preserve
                 // the same terminality-before-completion ordering as every
                 // other reservation-cancellation path. Definition disposal
@@ -2264,10 +2248,7 @@ impl ScopeRuntime {
                         .then(|| state.entries.remove(id))
                         .flatten()
                 };
-                request.slot.member.terminalize(Exit::never_started());
-                if let Some(scope) = &request.slot.scope {
-                    scope.terminalize_never_started();
-                }
+                request.slot.terminalize_never_started();
                 child.complete_terminality();
                 let ChildRuntime { construction, .. } = child;
                 reject_admission_after_disposal(

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -162,6 +162,25 @@ impl SlotCell {
             DefinitionState::Lowered => None,
         }
     }
+
+    /// Publishes the canonical never-started terminal state for this slot.
+    ///
+    /// Member terminality closes any mailbox before the nested scope closes
+    /// its observation surfaces. Every static and dynamic path uses this
+    /// method so those edges cannot drift independently.
+    pub(crate) fn terminalize_never_started(&self) {
+        self.member.terminalize(Exit::never_started());
+        if let Some(scope) = &self.scope {
+            scope.terminalize_never_started();
+        }
+    }
+
+    /// Claims an unlowered definition and publishes never-started terminality.
+    pub(crate) fn take_never_started(&self) -> Option<Isolated<ChildConstruction>> {
+        let definition = self.take_defined();
+        self.terminalize_never_started();
+        definition
+    }
 }
 
 /// Erased declaration storage before inherited defaults and identities are lowered.
@@ -277,10 +296,7 @@ impl BuilderCore {
 
     fn terminalize(&self) {
         for slot in &self.slots {
-            slot.member.terminalize(Exit::never_started());
-            if let Some(scope) = &slot.scope {
-                scope.terminalize_never_started();
-            }
+            slot.terminalize_never_started();
         }
         self.root.terminalize_never_started();
     }
@@ -309,10 +325,7 @@ impl Drop for ScopePlan {
             return;
         }
         for child in &self.children {
-            child.slot.member.terminalize(Exit::never_started());
-            if let Some(scope) = &child.slot.scope {
-                scope.terminalize_never_started();
-            }
+            child.slot.terminalize_never_started();
         }
         // Lowering can publish the planned children before ScopeRuntime takes
         // ownership. If construction then unwinds, the plan fallback also


### PR DESCRIPTION
Part of #56. This draft is stacked on #65.

## What changed

- make `SlotCell` the single implementation of member-plus-nested-scope never-started publication
- combine unlowered definition claiming with that publication for reservation/removal paths
- route builder drop, plan drop, dynamic close, reservation cancellation, pre-admission removal, and admission rejection through the shared slot ritual
- retain the existing isolated disposal funnel so dynamic removal completion still follows terminal publication and user-definition destruction

This removes all structural copies of the slot-level ritual and is net 6 production lines smaller.

## Validation

- focused dynamic module — 22/22 tests
- focused disposal module — 16/16 tests
- `./scripts/dev just ci` — 326/326 tests plus Clippy, docs, API reachability, layering, and package checks
- `./scripts/dev just ci-nix` — all clean Nix checks passed

Please review the single commit above `agent/issue-56-child-planning`.