### PR TITLE
Route terminal outcomes after joined disposal

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -690,6 +690,15 @@ impl ScopeCell {
             if matches!(record.stage, MemberStage::Terminal(_)) {
                 return false;
             }
+            // Nested publication and closure are reached only through this
+            // residency lookup, so a supervised child must still be resident
+            // here when it is terminalized. That holds because residency is
+            // installed before the child can be spawned (`set_admitted_children`
+            // for a planned incarnation, `admit_child` before dynamic
+            // `spawn_child`) and is only withdrawn by pruning, which always
+            // follows terminality. A child that has already left residency
+            // owns its nested scope through `SlotCell::terminalize_never_started`
+            // instead.
             let nested = self.current_children.read_with(|children| {
                 children
                     .iter()

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -686,18 +686,9 @@ impl ScopeCell {
         startup_aborted: bool,
     ) -> bool {
         self.with_observation_gate(|| {
-            if matches!(member.record().stage, MemberStage::Terminal(_)) {
+            let record = member.record();
+            if matches!(record.stage, MemberStage::Terminal(_)) {
                 return false;
-            }
-            member.update_locked(|record| record.startup_aborted = startup_aborted);
-            member.terminalize(exit.clone());
-            if let Some(incarnation) = exited_incarnation {
-                self.emit_locked(LifecycleEventKind::Exited {
-                    id: member.id().clone(),
-                    membership: member.membership(),
-                    incarnation,
-                    exit: exit.clone(),
-                });
             }
             let nested = self.current_children.read_with(|children| {
                 children
@@ -706,6 +697,27 @@ impl ScopeCell {
                     .and_then(|resident| resident.projection.scope.as_ref())
                     .cloned()
             });
+            member.update_locked(|record| record.startup_aborted = startup_aborted);
+            member.terminalize(exit.clone());
+            if record.last_incarnation.is_none()
+                && let Some(scope) = &nested
+            {
+                scope.publish_never_started_locked();
+            }
+            if let Some(incarnation) = exited_incarnation {
+                self.emit_locked(LifecycleEventKind::Exited {
+                    id: member.id().clone(),
+                    membership: member.membership(),
+                    incarnation,
+                    exit: exit.clone(),
+                });
+            } else {
+                // Terminals without a current incarnation have no Exited
+                // event to carry snapshot publication. Publish the final
+                // parent projection explicitly before nested observation
+                // closes.
+                self.publish_snapshot_chain_locked();
+            }
             if let Some(scope) = nested {
                 scope.close_observation_locked();
             }
@@ -889,10 +901,6 @@ impl ScopeCell {
         // by the caller while this same observation gate remains held.
         self.snapshots.close();
         self.lifecycle.close();
-    }
-
-    pub(crate) fn close_observation(&self) {
-        self.with_observation_gate(|| self.close_observation_locked());
     }
 
     #[cfg(test)]
@@ -1189,27 +1197,31 @@ impl ScopeCell {
         }
     }
 
+    fn publish_never_started_locked(&self) {
+        self.record.modify_silently(|record| {
+            if record.startup.is_none() {
+                record.startup = Some(Err(StartupError::ShutdownRequested));
+            }
+            record.state = ScopeState::Stopped {
+                reason: StopReason::NeverStarted,
+            };
+        });
+        self.member.record.pulse();
+        self.record.pulse();
+        self.emit_locked(LifecycleEventKind::ScopeState {
+            state: ScopeState::Stopped {
+                reason: StopReason::NeverStarted,
+            },
+        });
+    }
+
     pub(crate) fn terminalize_never_started(&self) {
         self.with_observation_gate(|| {
             if self.observation_closed.load(Ordering::Acquire) {
                 return;
             }
             self.member.terminalize(Exit::never_started());
-            self.record.modify_silently(|record| {
-                if record.startup.is_none() {
-                    record.startup = Some(Err(StartupError::ShutdownRequested));
-                }
-                record.state = ScopeState::Stopped {
-                    reason: StopReason::NeverStarted,
-                };
-            });
-            self.member.record.pulse();
-            self.record.pulse();
-            self.emit_locked(LifecycleEventKind::ScopeState {
-                state: ScopeState::Stopped {
-                    reason: StopReason::NeverStarted,
-                },
-            });
+            self.publish_never_started_locked();
             self.close_observation_locked();
         });
     }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1109,37 +1109,17 @@ impl ScopeRuntime {
             self.deadlines.cancel(deadline);
         }
         let Some(incarnation) = mint_child_incarnation(&child.slot, &mut child.incarnations) else {
-            child.complete_terminality();
-            // Incarnation exhaustion terminalized the membership (§3.1):
-            // publish the observation edges, then route the terminal outcome
-            // through the same paths as a terminal exit so ordered startup
-            // fails or draining advances instead of wedging the scope.
-            self.root.transition_child(&child.slot.member, |_| {}, None);
-            if child.options.retention == crate::Retention::Remove {
-                self.root.prune_child(&child.slot.member);
-            }
-            if let Some(construction) = child.construction.take() {
-                runtime::dispose_detached(construction);
-            }
-            let exit = match child.slot.member.record().stage {
-                MemberStage::Terminal(exit) => exit,
-                _ => Exit::never_started(),
-            };
+            let exit = child
+                .slot
+                .member
+                .record()
+                .last_exit
+                .unwrap_or_else(Exit::never_started);
             let pre_ready = child.initial && !self.phase.startup_complete() && !child.initial_ready;
-            let removing = child.slot.member.record().removing;
-            let retention_remove = child.options.retention == crate::Retention::Remove;
-            if removing {
-                self.finalize_removal(key);
-            } else if pre_ready && !self.phase.is_draining() {
-                self.fail_startup(key, exit);
-            } else {
-                if retention_remove {
-                    self.prune_terminal(key);
-                }
-                if self.phase.is_draining() {
-                    self.stop_next_ordered();
-                }
-            }
+            // Exhaustion is a terminal outcome, not an exceptional cleanup
+            // path. Join retained-definition disposal before terminality,
+            // retention, removal completion, or ordered-scope progression.
+            self.begin_terminal_disposal(key, exit, None, pre_ready);
             return;
         };
 
@@ -1554,28 +1534,10 @@ impl ScopeRuntime {
             }
             let record = child.slot.member.record();
             let exit = record.last_exit.unwrap_or_else(Exit::never_started);
-            if record.last_incarnation.is_none() {
-                if let Some(scope) = &child.slot.scope {
-                    scope.terminalize_never_started();
-                }
-                // A never-ran terminal is the plain `Stopped { NeverStarted }`
-                // state (B.6), not a §6 startup abort. Its definition still
-                // owns the only user resource, so join disposal before
-                // completing the scope, while publishing the never-started
-                // member state synchronously for startup observation.
-                self.begin_terminal_disposal(key, exit, None, false);
-                self.children[key].terminalize(&self.root, Exit::never_started(), None, false);
-            } else {
-                // Between incarnations, the recorded exit already owns the
-                // child verdict. There is no incarnation left to classify a
-                // later factory destructor, so publish synchronously and
-                // isolate cleanup without turning it into a shutdown
-                // straggler (including for a zero shutdown budget).
-                child.terminalize(&self.root, exit, None, false);
-                if let Some(construction) = child.construction.take() {
-                    runtime::dispose_detached(construction);
-                }
-            }
+            // A never-ran child and a child stopped between restart
+            // incarnations share the same post-disposal terminal route. Hard
+            // shutdown still detaches disposal through `hard_forced` below.
+            self.begin_terminal_disposal(key, exit, None, false);
         }
     }
 
@@ -2006,9 +1968,14 @@ impl ScopeRuntime {
             return;
         };
         child.slot.member.set_terminal_disposal_pending(false);
-        if let Some(message) = panic
+        if terminal.exited_incarnation.is_some()
+            && let Some(message) = panic
             && !matches!(terminal.exit.kind(), ExitKind::Panicked { .. })
         {
+            // Only an exited incarnation can own a destructor failure. A
+            // never-started child or a child between restart incarnations
+            // keeps its already-authoritative verdict while disposal remains
+            // ordered ahead of terminal routing.
             terminal.exit = Exit::new(ExitKind::Panicked { message }, terminal.exit.cancelled());
         }
 
@@ -2056,16 +2023,7 @@ impl ScopeRuntime {
                     && !self.children[later].is_disposing()
                     && !self.children[later].is_terminal()
                 {
-                    if let Some(scope) = &self.children[later].slot.scope {
-                        scope.terminalize_never_started();
-                    }
                     self.begin_terminal_disposal(later, Exit::never_started(), None, false);
-                    self.children[later].terminalize(
-                        &self.root,
-                        Exit::never_started(),
-                        None,
-                        false,
-                    );
                 }
             }
         }
@@ -2388,21 +2346,7 @@ impl ScopeRuntime {
 }
 
 fn mint_child_incarnation(slot: &Arc<SlotCell>, counter: &mut FenceCounter) -> Option<Incarnation> {
-    let member = &slot.member;
-    let incarnation = ScopeIdentity::mint_incarnation(member.membership(), counter);
-    if incarnation.is_none() {
-        let record = member.record();
-        let exit = record.last_exit.unwrap_or_else(Exit::never_started);
-        member.terminalize(exit);
-        if let Some(scope) = &slot.scope {
-            if record.last_incarnation.is_none() {
-                scope.terminalize_never_started();
-            } else {
-                scope.close_observation();
-            }
-        }
-    }
-    incarnation
+    ScopeIdentity::mint_incarnation(slot.member.membership(), counter)
 }
 
 async fn run_nested_tree(
@@ -2781,10 +2725,10 @@ mod tests {
     };
 
     use crate::{
-        ActorRef, ChildId, DynamicTree, Exit, ExitError, ExitKind, Intensity, LifecycleEventKind,
-        LifecycleItem, LifecycleTryRecvError, Readiness, ReadinessDeadline, RemoveOutcome,
-        Retention, ScopeState, SendErrorKind, StartupError, StartupFailureCause, StopReason,
-        SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
+        ActorRef, ChildId, ChildState, DynamicTree, Exit, ExitError, ExitKind, Intensity,
+        LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Readiness, ReadinessDeadline,
+        RemoveOutcome, Retention, ScopeState, SendErrorKind, StartupError, StartupFailureCause,
+        StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
         engine::arbitrate,
         exit::{JoinVerdict, RecordedOutcome},
         identity::{FenceCounter, ScopeIdentity},
@@ -3959,7 +3903,7 @@ mod tests {
     }
 
     #[test]
-    fn incarnation_exhaustion_terminalizes_the_membership_as_never_restart() {
+    fn incarnation_mint_exhaustion_has_no_terminal_side_effects() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
         let id = ChildId::from("worker");
         let membership = identity.mint_membership(&id).expect("membership available");
@@ -3977,11 +3921,107 @@ mod tests {
 
         assert!(mint_child_incarnation(&slot, &mut counter).is_some());
         assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+        assert!(matches!(member.record().stage, MemberStage::Restarting));
+        assert_eq!(member.record().last_exit, Some(previous));
+        assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+    }
+
+    #[crate::runtime::test]
+    async fn incarnation_exhaustion_uses_post_disposal_retention_routing() {
+        let mut tree = Tree::new();
+        tree.add_task(
+            "worker",
+            TaskDef::new(|_| future::pending::<crate::ExitResult>()).retention(Retention::Remove),
+        )
+        .expect("valid task");
+        let mut plan = tree.lower_for_test();
+        let root = Arc::clone(&plan.root);
+        let epoch = root.begin_incarnation();
+        root.set_admitted_children(
+            plan.children
+                .iter()
+                .map(|child| resident_projection(&child.slot))
+                .collect(),
+        );
+        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(64);
+        let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+        let mut children = ChildArena::default();
+        let key = children
+            .insert(child)
+            .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+        let mut scope = ScopeRuntime {
+            root: Arc::clone(&root),
+            defaults: plan.defaults.clone(),
+            intensity_policy: plan.config.intensity,
+            intensity: super::IntensityState::default(),
+            children,
+            events,
+            deadlines: super::DeadlineQueue::default(),
+            jitter: crate::runtime::JitterRng::from_system_entropy(),
+            phase: ScopePhase::Running,
+            next_ordered_start: Some(key),
+            is_root: true,
+            parent_ready: None,
+            dynamic: None,
+            epoch,
+            ancestor_shutdown: None,
+            ancestor_shutdown_seen: false,
+            ancestor_abort: None,
+            ancestor_abort_ack: None,
+            ancestor_abort_seen: false,
+            hard_forced: false,
+            completion: None,
+        };
+        plan.armed = false;
+        drop(plan);
+
+        scope.children[key].incarnations = FenceCounter::near_exhaustion(71);
+        let first = {
+            let child = &mut scope.children[key];
+            mint_child_incarnation(&child.slot, &mut child.incarnations)
+                .expect("the last usable incarnation mints")
+        };
+        let previous = Exit::new(
+            ExitKind::Failed(ExitError::message("last completed incarnation")),
+            false,
+        );
+        root.transition_child(
+            &scope.children[key].slot.member,
+            |record| {
+                record.incarnation = None;
+                record.last_incarnation = Some(first);
+                record.last_exit = Some(previous.clone());
+                record.stage = MemberStage::Restarting;
+            },
+            None,
+        );
+
+        scope.spawn_child(key);
+        assert!(scope.children[key].is_disposing());
         assert!(matches!(
-            member.record().stage,
+            scope.children[key].slot.member.record().stage,
+            MemberStage::Restarting
+        ));
+        assert_eq!(root.snapshot().children.len(), 1);
+
+        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = event_receiver
+            .recv()
+            .await
+            .expect("disposal reports completion")
+        else {
+            panic!("only construction disposal was armed")
+        };
+        scope.handle_construction_disposed(child, panic);
+
+        assert!(!scope.children[key].is_disposing());
+        assert!(matches!(
+            scope.children[key].slot.member.record().stage,
             MemberStage::Terminal(ref exit) if exit == &previous
         ));
-        assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+        assert!(
+            root.snapshot().children.is_empty(),
+            "retention pruning follows joined disposal"
+        );
     }
 
     #[crate::runtime::test]
@@ -4045,6 +4085,7 @@ mod tests {
 
     #[crate::runtime::test]
     async fn scope_incarnation_exhaustion_closes_nested_observation() {
+        let parent = isolated_scope("parent", ScopeFlavor::Ordered);
         let mut identity = ScopeIdentity::new().expect("scope identity available");
         let id = ChildId::from("nested");
         let membership = identity.mint_membership(&id).expect("membership available");
@@ -4055,6 +4096,7 @@ mod tests {
             ScopeIdentity::new().expect("child identity available"),
         );
         let slot = SlotCell::new(Arc::clone(&member), Some(Arc::clone(&scope)));
+        parent.set_admitted_children(vec![resident_projection(&slot)]);
         let mut snapshots = scope.subscribe_snapshots();
         let mut events = scope.subscribe_lifecycle();
         let mut counter = FenceCounter::near_exhaustion(83);
@@ -4069,6 +4111,7 @@ mod tests {
         });
 
         assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+        assert!(matches!(member.record().stage, MemberStage::Restarting));
         assert!(matches!(
             events.try_recv(),
             Ok(LifecycleItem::Event(crate::LifecycleEvent {
@@ -4079,6 +4122,13 @@ mod tests {
                 },
                 ..
             }))
+        ));
+        assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Empty));
+        assert!(parent.terminalize_child(
+            &member,
+            Exit::new(ExitKind::Completed, false),
+            None,
+            false
         ));
         assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Closed));
         snapshots
@@ -4092,6 +4142,36 @@ mod tests {
             }
         ));
         assert!(snapshots.changed().await.is_err());
+    }
+
+    #[crate::runtime::test]
+    async fn never_started_nested_terminal_publishes_one_final_parent_snapshot() {
+        let parent = isolated_scope("parent", ScopeFlavor::Ordered);
+        let nested = isolated_scope("nested", ScopeFlavor::Ordered);
+        let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
+        parent.set_admitted_children(vec![resident_projection(&slot)]);
+        let mut snapshots = parent.subscribe_snapshots();
+
+        assert!(parent.terminalize_child(&nested.member, Exit::never_started(), None, false));
+        snapshots
+            .changed()
+            .await
+            .expect("no-incarnation terminal publishes the parent projection");
+
+        assert!(matches!(
+            snapshots
+                .borrow_latest()
+                .child("nested")
+                .expect("retained nested child remains resident")
+                .state,
+            ChildState::Stopped { ref exit } if matches!(exit.kind(), ExitKind::NeverStarted)
+        ));
+        assert!(matches!(
+            nested.record().state,
+            ScopeState::Stopped {
+                reason: StopReason::NeverStarted
+            }
+        ));
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1980,11 +1980,19 @@ impl ScopeRuntime {
         }
 
         let exit = terminal.exit;
+        // §6's `StartupAborted` is a startup-sequence property of a
+        // membership that *ran* and failed before its initial readiness
+        // edge. A terminal without an exited incarnation never ran, so it
+        // publishes the plain `Stopped { NeverStarted }` verdict (B.6) even
+        // when its pre-readiness position still routes the scope's startup
+        // failure below. Incarnation exhaustion is the reachable case:
+        // it terminalizes an unspawned membership while `pre_ready` holds.
+        let startup_aborted = terminal.exited_incarnation.is_some() && terminal.startup_aborted;
         self.children[key].terminalize(
             &self.root,
             exit.clone(),
             terminal.exited_incarnation,
-            terminal.startup_aborted,
+            startup_aborted,
         );
         let removing = self.children[key].slot.member.record().removing;
         if removing {
@@ -4021,6 +4029,116 @@ mod tests {
         assert!(
             root.snapshot().children.is_empty(),
             "retention pruning follows joined disposal"
+        );
+    }
+
+    /// Exhaustion terminalizes a membership that never spawned. B.6 makes
+    /// that the plain `Stopped { NeverStarted }` verdict; §6's
+    /// `StartupAborted` stays reserved for a membership that ran and failed
+    /// before its initial readiness edge. The pre-readiness position still
+    /// has to route the scope's startup failure.
+    #[crate::runtime::test]
+    async fn first_spawn_exhaustion_stops_without_reporting_a_startup_abort() {
+        let mut tree = Tree::new();
+        tree.add_task(
+            "worker",
+            TaskDef::new(|_| future::pending::<crate::ExitResult>()),
+        )
+        .expect("valid task");
+        let mut plan = tree.lower_for_test();
+        let root = Arc::clone(&plan.root);
+        let epoch = root.begin_incarnation();
+        root.set_admitted_children(
+            plan.children
+                .iter()
+                .map(|child| resident_projection(&child.slot))
+                .collect(),
+        );
+        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(64);
+        let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+        let mut children = ChildArena::default();
+        let key = children
+            .insert(child)
+            .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+        let mut scope = ScopeRuntime {
+            root: Arc::clone(&root),
+            defaults: plan.defaults.clone(),
+            intensity_policy: plan.config.intensity,
+            intensity: super::IntensityState::default(),
+            children,
+            events,
+            deadlines: super::DeadlineQueue::default(),
+            jitter: crate::runtime::JitterRng::from_system_entropy(),
+            phase: ScopePhase::Starting,
+            next_ordered_start: Some(key),
+            is_root: true,
+            parent_ready: None,
+            dynamic: None,
+            epoch,
+            ancestor_shutdown: None,
+            ancestor_shutdown_seen: false,
+            ancestor_abort: None,
+            ancestor_abort_ack: None,
+            ancestor_abort_seen: false,
+            hard_forced: false,
+            completion: None,
+        };
+        plan.armed = false;
+        drop(plan);
+
+        // Burn the counter's last usable generation without touching the
+        // member record: the child is still an unspawned initial member, so
+        // its very first `spawn_child` exhausts before any incarnation runs.
+        scope.children[key].incarnations = FenceCounter::near_exhaustion(73);
+        {
+            let child = &mut scope.children[key];
+            assert!(mint_child_incarnation(&child.slot, &mut child.incarnations).is_some());
+        }
+        assert!(scope.children[key].initial);
+        assert!(!scope.children[key].initial_ready);
+        assert_eq!(
+            scope.children[key].slot.member.record().last_incarnation,
+            None
+        );
+
+        scope.spawn_child(key);
+        assert!(scope.children[key].is_disposing());
+
+        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = event_receiver
+            .recv()
+            .await
+            .expect("disposal reports completion")
+        else {
+            panic!("only construction disposal was armed")
+        };
+        scope.handle_construction_disposed(child, panic);
+
+        assert!(matches!(
+            scope.children[key].slot.member.record().stage,
+            MemberStage::Terminal(ref exit) if matches!(exit.kind(), ExitKind::NeverStarted)
+        ));
+        let snapshot = root.snapshot();
+        let published = snapshot
+            .child("worker")
+            .expect("a retained exhausted child stays resident");
+        assert!(
+            matches!(
+                published.state,
+                ChildState::Stopped { ref exit } if matches!(exit.kind(), ExitKind::NeverStarted)
+            ),
+            "an unspawned exhausted membership is Stopped, not StartupAborted: {:?}",
+            published.state
+        );
+        assert!(
+            !scope.children[key].slot.member.record().startup_aborted,
+            "§6's startup-abort flag belongs to a membership that ran"
+        );
+        assert!(
+            matches!(
+                root.record().startup,
+                Some(Err(StartupError::StartupFailed(_)))
+            ),
+            "the pre-readiness position still routes the scope's startup failure"
         );
     }
 

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -500,6 +500,68 @@ async fn unadmitted_removal_completes_after_blocking_definition_disposal() {
         .expect("dynamic root shuts down");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn restart_window_removal_joins_factory_disposal_before_terminality() {
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = DynamicTree::new();
+    let task = tree
+        .add_task(
+            "restarting",
+            TaskDef::new({
+                let capture = BlockingDropProbe::new(&gate, dropped);
+                move |_| {
+                    let _ = &capture;
+                    async { Err(ExitError::message("restart me")) }
+                }
+            })
+            .restart(RestartPolicy::new(
+                RestartCondition::OnFailure,
+                Backoff::fixed(Duration::from_secs(60), Jitter::None).expect("fixed backoff"),
+            )),
+        )
+        .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+    let scope = system.scope();
+    system
+        .wait_started()
+        .await
+        .expect("first incarnation starts");
+    scope
+        .wait_for_child(
+            "restarting",
+            |child| matches!(child.state, ChildState::Restarting),
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("task enters restart backoff");
+
+    let mut removal = Box::pin(scope.remove_task(&task));
+    poll_pending(&mut removal).await;
+    wait_for_destructor(&gate).await;
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("factory disposal reports its thread"),
+        thread::current().id()
+    );
+    poll_pending(&mut removal).await;
+    let mut terminal = Box::pin(task.wait());
+    poll_pending(&mut terminal).await;
+
+    gate.release();
+    assert!(matches!(
+        terminal.await.kind(),
+        ExitKind::Failed(error) if error.to_string() == "restart me"
+    ));
+    assert_eq!(removal.await, RemoveOutcome::Removed);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root shuts down");
+}
+
 #[tokio::test]
 async fn unadmitted_removal_completes_when_the_panic_payload_destructor_panics() {
     let tree = DynamicTree::new();
@@ -687,6 +749,58 @@ async fn startup_rollback_detaches_never_started_one_shot_state_after_escalation
     assert!(matches!(
         completion
             .wait()
+            .await
+            .expect_err("the ordered suffix never ran")
+            .kind(),
+        ExitKind::NeverStarted
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn startup_rollback_joins_never_started_disposal_before_terminality() {
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    tree.add_task(
+        "fails",
+        TaskDef::new(|_| async { Err(ExitError::message("startup failure")) })
+            .restart(never())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness"),
+    )
+    .expect("valid failing task");
+    let (_never_started, completion) = tree
+        .add_task_once(
+            "never-started",
+            TaskOnceDef::new({
+                let state = BlockingDropProbe::new(&gate, dropped);
+                move |_| {
+                    let _ = &state;
+                    async { Ok::<_, ExitError>(()) }
+                }
+            }),
+        )
+        .expect("valid one-shot suffix");
+
+    let system = tree.spawn().expect("runtime is available");
+    let mut rollback = Box::pin(system.start_or_shutdown(Duration::from_secs(5)));
+    poll_pending(&mut rollback).await;
+    wait_for_destructor(&gate).await;
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("one-shot state reports its thread"),
+        thread::current().id()
+    );
+    poll_pending(&mut rollback).await;
+    let mut terminal = Box::pin(completion.wait());
+    poll_pending(&mut terminal).await;
+
+    gate.release();
+    assert!(rollback.await.is_err(), "startup failure is preserved");
+    assert!(matches!(
+        terminal
             .await
             .expect_err("the ordered suffix never ran")
             .kind(),

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -987,6 +987,14 @@ async fn never_ran_members_stop_rather_than_report_startup_abort() {
         .wait_started()
         .await
         .expect_err("pre-ready terminal exit aborts startup");
+    scope
+        .wait_for_child(
+            "never-ran",
+            |child| matches!(child.state, ChildState::Stopped { .. }),
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("joined suffix disposal publishes terminality");
     let snapshot = scope.snapshot();
     assert!(matches!(
         snapshot


### PR DESCRIPTION
## Summary

- route incarnation exhaustion through the same joined-disposal terminal funnel as ordinary exits
- keep dynamic removal, retention pruning, and ordered-scope progression pending until retained factory disposal finishes
- remove synchronous terminalization from restart-window shutdown and ordered startup rollback
- publish never-started nested scope state without stealing terminal ownership from the supervising scope

## Why

Issue #56 identified a divergent incarnation-exhaustion ladder that pruned retention incorrectly and completed dynamic removal before isolated disposal. The same early-completion shape was also reachable while stopping between restart incarnations and while terminalizing an ordered startup suffix.

This change leaves disposal-panic ownership unchanged: only a concrete exited incarnation can be reclassified by its retained factory destructor. Never-started and between-incarnation children keep their authoritative verdict while still joining disposal before terminal routing.

## Verification

- focused incarnation-exhaustion unit coverage
- blocking-disposal regressions for restart-window removal and ordered startup rollback
- all 18 disposal integration tests
- `./scripts/dev just ci` (329 tests plus clippy, docs, API/layering checks, and packaging)
- `./scripts/dev just ci-nix`

Part of #56. Stacked on #66.
