### PR TITLE
Preserve authoritative task exit evidence

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1232,14 +1232,36 @@ One classification, produced at one point, used by every consumer.
   already says nothing ran.
 - **Verdict precedence.** When one incarnation's end admits several
   readings, classification picks the highest of: `Panicked` >
-  `ReadinessTimedOut` > `Aborted` > `Failed` > `Completed`; `cancelled` is
+  `ReadinessTimedOut` > `Failed` > `Aborted` > `Completed`; `cancelled` is
   orthogonal and never competes. Concretely: a panic is never masked,
   wherever it lands (`run`, `on_stop` — superseding the run's outcome,
-  §4.1 — or a destructor, via the fallback report token); a
+  §4.1 — or a destructor, via the fallback report token); and a
   readiness-deadline expiry names the *cause* even when the teardown it
-  triggers ends in a grace-expiry abort (the mechanism); and `Aborted`
-  describes a future destroyed before yielding an outcome, so it cannot
-  genuinely conflict with `Failed`/`Completed`, which require one.
+  triggers ends in a grace-expiry abort (the mechanism).
+- **`Aborted` genuinely competes with a recorded outcome, and the rule is
+  asymmetric.** `Aborted` describes a future destroyed before yielding an
+  outcome, so it reads as if it could never conflict with
+  `Failed`/`Completed`, which require one. It conflicts anyway, by race:
+  the body can record its result and the destruction still land before
+  the join retires, and §10's ladder can arm a supervisor-forced abort
+  verdict against a membership that has already recorded one. Precedence
+  resolves that race in one direction only, and the asymmetry is
+  deliberate rather than an artifact of the ordering:
+  - A recorded `Failed(error)` **survives** a later abort. Destruction
+    proves only that teardown ended the task; it must not erase the
+    structured application error the task already produced, which is the
+    only evidence naming *why* the child was failing.
+  - A recorded `Completed` does **not** survive: cancellation overrides
+    it and the exit reads `Aborted { after_grace }` with
+    `cancelled: true`. A supervisor that destroyed a child before its
+    success was observable did not get a successful child. Concretely, a
+    one-shot task whose body returned `Ok(value)` inside that window
+    exits `Aborted` and `OneShotTaskRef::wait` yields `Err(exit)` — the
+    typed value is dropped rather than released past a stop the
+    supervisor had already committed to.
+
+  Only the recorded-vs-abort pair is asymmetric this way; the ordering
+  above is otherwise a total precedence over the whole variant set.
 - **Failure classification (feeds §9.2):** an exit is a *failure* iff it is
   not `Completed`. So `Failed`, `Panicked`, `ReadinessTimedOut`, and
   `Aborted` all restart under `OnFailure`; `Always` restarts even clean
@@ -1799,7 +1821,11 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
   exits `Completed`/`Failed` (with `cancelled: true`), and
   `Aborted { after_grace: false }` records only a hard abort actually
   reached — the future destroyed before yielding — distinguishable from
-  grace-expiry abort (`after_grace: true`). Grace is a supervisor-side
+  grace-expiry abort (`after_grace: true`). The one boundary case, where
+  the beat expires and the hard abort lands *after* the body recorded its
+  outcome but before the join retires, is settled by §7's precedence and
+  not here: a recorded `Failed` survives that abort, a recorded
+  `Completed` does not. Grace is a supervisor-side
   upper bound; child-local time after
   cancellation wakeup is scheduler-dependent — this is documented
   contract. Cancellation-before-escalation ordering is observable to the

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -17,7 +17,10 @@ use crate::{
         MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState, ScopeMode,
         StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart,
     },
-    exit::{JoinVerdict, RecordedOutcome, StartupError, StopReason, classify_exit},
+    exit::{
+        JoinVerdict, RecordedOutcome, StartupError, StopReason, classify_exit,
+        reconcile_recorded_outcomes,
+    },
     identity::{FenceCounter, ScopeIdentity},
     observe::LifecycleEventKind,
     plan::{
@@ -1825,7 +1828,7 @@ impl ScopeRuntime {
         {
             join = JoinVerdict::Cancelled { after_grace };
         }
-        let recorded = active.forced_outcome.or(recorded);
+        let recorded = reconcile_recorded_outcomes(recorded, active.forced_outcome);
         let exit = classify_exit(recorded, join, cancelled);
         let ran_for = runtime::now().saturating_duration_since(active.started_at);
         if ran_for >= self.intensity_policy.within {

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -336,7 +336,36 @@ pub(crate) enum JoinVerdict {
     Cancelled { after_grace: bool },
 }
 
+/// Reconciles task-produced evidence with a later supervisor-forced outcome.
+///
+/// The same diagnostic precedence used for the final join applies here, and
+/// equal-ranked evidence keeps the task-produced value because it was
+/// recorded first. This prevents a forced abort from erasing a structured
+/// application failure while still allowing readiness timeout or panic to
+/// supersede ordinary completion.
+pub(crate) fn reconcile_recorded_outcomes(
+    recorded: Option<RecordedOutcome>,
+    forced: Option<RecordedOutcome>,
+) -> Option<RecordedOutcome> {
+    match (recorded, forced) {
+        (Some(recorded), Some(forced)) if recorded_rank(&recorded) >= recorded_rank(&forced) => {
+            Some(recorded)
+        }
+        (_, Some(forced)) => Some(forced),
+        (Some(recorded), None) => Some(recorded),
+        (None, None) => None,
+    }
+}
+
 /// Purely folds the provisional run outcome and post-destruction join verdict.
+///
+/// Precedence follows the amount of diagnostic evidence retained by each
+/// outcome: a panic is strongest, followed by a readiness timeout, an
+/// application failure, an abort, and successful completion. In particular,
+/// cancellation reported while joining only proves that destruction ended the
+/// task; it must not erase an application error recorded before destruction.
+/// Equal-ranked outcomes keep the earlier recorded evidence, including its
+/// panic payload or abort provenance.
 pub(crate) fn classify_exit(
     recorded: Option<RecordedOutcome>,
     join: JoinVerdict,
@@ -368,14 +397,38 @@ fn recorded_kind(recorded: RecordedOutcome) -> ExitKind {
     }
 }
 
-fn rank(kind: &ExitKind) -> u8 {
+/// Diagnostic precedence shared by provisional and final exit evidence.
+///
+/// Variant order is weakest to strongest so derived ordering selects the
+/// outcome that preserves the most useful evidence.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum OutcomeRank {
+    NeverStarted,
+    Completed,
+    Aborted,
+    Failed,
+    ReadinessTimedOut,
+    Panicked,
+}
+
+fn recorded_rank(recorded: &RecordedOutcome) -> OutcomeRank {
+    match recorded {
+        RecordedOutcome::Panicked { .. } => OutcomeRank::Panicked,
+        RecordedOutcome::ReadinessTimedOut { .. } => OutcomeRank::ReadinessTimedOut,
+        RecordedOutcome::Returned(Err(_)) => OutcomeRank::Failed,
+        RecordedOutcome::Aborted { .. } => OutcomeRank::Aborted,
+        RecordedOutcome::Returned(Ok(())) => OutcomeRank::Completed,
+    }
+}
+
+fn rank(kind: &ExitKind) -> OutcomeRank {
     match kind {
-        ExitKind::Panicked { .. } => 5,
-        ExitKind::ReadinessTimedOut { .. } => 4,
-        ExitKind::Aborted { .. } => 3,
-        ExitKind::Failed(_) => 2,
-        ExitKind::Completed => 1,
-        ExitKind::NeverStarted => 0,
+        ExitKind::Panicked { .. } => OutcomeRank::Panicked,
+        ExitKind::ReadinessTimedOut { .. } => OutcomeRank::ReadinessTimedOut,
+        ExitKind::Failed(_) => OutcomeRank::Failed,
+        ExitKind::Aborted { .. } => OutcomeRank::Aborted,
+        ExitKind::Completed => OutcomeRank::Completed,
+        ExitKind::NeverStarted => OutcomeRank::NeverStarted,
     }
 }
 
@@ -400,72 +453,164 @@ pub struct ShutdownTimeout {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use super::{ExitError, ExitKind, JoinVerdict, RecordedOutcome, classify_exit};
+    use super::{
+        ChildId, Exit, ExitError, ExitKind, JoinVerdict, RecordedOutcome, StartupFailure,
+        StartupFailureCause, classify_exit, reconcile_recorded_outcomes,
+    };
 
     #[test]
     fn classification_precedence_is_table_driven() {
         let deadline = Instant::now() + Duration::from_secs(1);
+        let failure = ExitError::message("failed");
         let cases = [
             (
-                RecordedOutcome::Returned(Ok(())),
+                "recorded completion",
+                Some(RecordedOutcome::Returned(Ok(()))),
                 JoinVerdict::Completed,
-                "completed",
+                false,
+                Exit::new(ExitKind::Completed, false),
             ),
             (
-                RecordedOutcome::Returned(Err(ExitError::message("failed"))),
-                JoinVerdict::Completed,
-                "failed",
-            ),
-            (
-                RecordedOutcome::ReadinessTimedOut { deadline },
+                "cancellation overrides recorded completion",
+                Some(RecordedOutcome::Returned(Ok(()))),
                 JoinVerdict::Cancelled { after_grace: true },
-                "readiness",
+                true,
+                Exit::new(ExitKind::Aborted { after_grace: true }, true),
             ),
             (
-                RecordedOutcome::Returned(Ok(())),
+                "recorded failure",
+                Some(RecordedOutcome::Returned(Err(failure.clone()))),
+                JoinVerdict::Completed,
+                false,
+                Exit::new(ExitKind::Failed(failure.clone()), false),
+            ),
+            (
+                "late cancellation preserves recorded failure",
+                Some(RecordedOutcome::Returned(Err(failure.clone()))),
+                JoinVerdict::Cancelled { after_grace: true },
+                true,
+                Exit::new(ExitKind::Failed(failure.clone()), true),
+            ),
+            (
+                "join panic overrides recorded failure",
+                Some(RecordedOutcome::Returned(Err(failure.clone()))),
                 JoinVerdict::Panicked {
                     message: Some("drop panic".to_owned()),
                 },
-                "panic",
+                false,
+                Exit::new(
+                    ExitKind::Panicked {
+                        message: Some("drop panic".to_owned()),
+                    },
+                    false,
+                ),
             ),
             (
-                RecordedOutcome::Panicked {
+                "readiness timeout overrides cancellation",
+                Some(RecordedOutcome::ReadinessTimedOut { deadline }),
+                JoinVerdict::Cancelled { after_grace: true },
+                true,
+                Exit::new(ExitKind::ReadinessTimedOut { deadline }, true),
+            ),
+            (
+                "join panic overrides recorded completion",
+                Some(RecordedOutcome::Returned(Ok(()))),
+                JoinVerdict::Panicked {
+                    message: Some("drop panic".to_owned()),
+                },
+                false,
+                Exit::new(
+                    ExitKind::Panicked {
+                        message: Some("drop panic".to_owned()),
+                    },
+                    false,
+                ),
+            ),
+            (
+                "earlier recorded panic wins a tie",
+                Some(RecordedOutcome::Panicked {
                     message: Some("callback panic".to_owned()),
-                },
+                }),
                 JoinVerdict::Panicked {
                     message: Some("drop panic".to_owned()),
                 },
-                "callback panic",
+                true,
+                Exit::new(
+                    ExitKind::Panicked {
+                        message: Some("callback panic".to_owned()),
+                    },
+                    true,
+                ),
+            ),
+            (
+                "earlier recorded abort wins a tie",
+                Some(RecordedOutcome::Aborted { after_grace: false }),
+                JoinVerdict::Cancelled { after_grace: true },
+                true,
+                Exit::new(ExitKind::Aborted { after_grace: false }, true),
+            ),
+            (
+                "join cancellation supplies a missing outcome",
+                None,
+                JoinVerdict::Cancelled { after_grace: true },
+                true,
+                Exit::new(ExitKind::Aborted { after_grace: true }, true),
+            ),
+            (
+                "missing outcome fails closed",
+                None,
+                JoinVerdict::Completed,
+                false,
+                Exit::new(ExitKind::Aborted { after_grace: false }, false),
             ),
         ];
 
-        for (recorded, join, expected) in cases {
-            let exit = classify_exit(Some(recorded), join, true);
-            assert!(exit.cancelled());
-            match (expected, exit.kind()) {
-                ("completed", ExitKind::Completed)
-                | ("failed", ExitKind::Failed(_))
-                | ("readiness", ExitKind::ReadinessTimedOut { .. }) => {}
-                ("panic", ExitKind::Panicked { message }) => {
-                    assert_eq!(message.as_deref(), Some("drop panic"));
-                }
-                ("callback panic", ExitKind::Panicked { message }) => {
-                    assert_eq!(message.as_deref(), Some("callback panic"));
-                }
-                _ => panic!("unexpected classification: {:?}", exit.kind()),
-            }
+        for (case, recorded, join, cancelled, expected) in cases {
+            assert_eq!(classify_exit(recorded, join, cancelled), expected, "{case}");
         }
+    }
 
-        let aborted = classify_exit(None, JoinVerdict::Cancelled { after_grace: true }, true);
-        assert!(matches!(
-            aborted.kind(),
-            ExitKind::Aborted { after_grace: true }
-        ));
-        let missing_report = classify_exit(None, JoinVerdict::Completed, false);
-        assert!(matches!(
-            missing_report.kind(),
-            ExitKind::Aborted { after_grace: false }
-        ));
+    #[test]
+    fn forced_outcomes_do_not_erase_stronger_recorded_evidence() {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let failure = ExitError::from_startup_failure(StartupFailure {
+            cause: StartupFailureCause::IdentityExhausted {
+                id: ChildId::from("nested"),
+            },
+        });
+        let cases = [
+            (
+                "application failure survives forced abort",
+                Some(RecordedOutcome::Returned(Err(failure.clone()))),
+                Some(RecordedOutcome::Aborted { after_grace: true }),
+                Exit::new(ExitKind::Failed(failure), true),
+            ),
+            (
+                "forced readiness timeout overrides completion",
+                Some(RecordedOutcome::Returned(Ok(()))),
+                Some(RecordedOutcome::ReadinessTimedOut { deadline }),
+                Exit::new(ExitKind::ReadinessTimedOut { deadline }, true),
+            ),
+            (
+                "earlier abort evidence wins a tie",
+                Some(RecordedOutcome::Aborted { after_grace: false }),
+                Some(RecordedOutcome::Aborted { after_grace: true }),
+                Exit::new(ExitKind::Aborted { after_grace: false }, true),
+            ),
+        ];
+
+        for (case, recorded, forced, expected) in cases {
+            let reconciled = reconcile_recorded_outcomes(recorded, forced);
+            assert_eq!(
+                classify_exit(
+                    reconciled,
+                    JoinVerdict::Cancelled { after_grace: true },
+                    true
+                ),
+                expected,
+                "{case}"
+            );
+        }
     }
 
     #[derive(Debug, thiserror::Error)]

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -326,7 +326,14 @@ impl<T> OneShotTaskRef<T> {
         if !matches!(exit.kind(), crate::ExitKind::Completed) {
             return Err(exit);
         }
-        completion.receive().await.ok_or(exit)
+        // The erased one-shot body sends before returning success, and this
+        // receiver is the sole completion claim. A published Completed verdict
+        // with a closed, empty channel is therefore a framework invariant
+        // violation, not an application exit that can be reported as `Err`.
+        Ok(completion
+            .receive()
+            .await
+            .expect("completed one-shot task must publish its typed value"))
     }
 }
 
@@ -440,6 +447,16 @@ mod tests {
         assert!(matches!(waiting.as_mut().poll(&mut context), Poll::Pending));
         member.terminalize(exit.clone());
         assert_eq!(waiting.await, Err(exit));
+    }
+
+    #[crate::runtime::test]
+    #[should_panic(expected = "completed one-shot task must publish its typed value")]
+    async fn completed_terminal_publication_requires_a_typed_value() {
+        let (sender, claim, member) = one_shot_claim::<u8>();
+        drop(sender);
+        member.terminalize(Exit::new(ExitKind::Completed, false));
+
+        let _ = claim.wait().await;
     }
 
     #[crate::runtime::test]

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -319,7 +319,11 @@ impl<T> OneShotTaskRef<T> {
     /// The typed value is released only when terminal publication classifies
     /// the membership as [`crate::ExitKind::Completed`]. Any competing
     /// failure, panic, abort, readiness timeout, or never-started verdict wins
-    /// even if the task body produced a value first.
+    /// even if the task body produced a value first. That precedence is
+    /// deliberately asymmetric: a body that returned `Err` keeps its
+    /// [`crate::ExitKind::Failed`] verdict through a racing forced abort,
+    /// while a body that returned `Ok` does not — the value is dropped and
+    /// the claim resolves `Err` with the abort verdict.
     pub async fn wait(self) -> Result<T, Exit> {
         let Self { completion, task } = self;
         let exit = task.wait().await;


### PR DESCRIPTION
## Summary

- make exit precedence explicit and table-driven: panic, readiness timeout, application failure, abort, completion, then never-started
- preserve an already-recorded application error when the task join is later cancelled by forced shutdown
- keep panic authoritative and retain the first verdict on equal precedence
- make `OneShotTaskRef::wait` fail loudly on the impossible `Completed`-without-value invariant instead of returning `Err(Completed)`

## Why

Issue #56 identified two contradictory diagnostics: forced cancellation could discard an application error, and a completed one-shot could surface its completed exit through the error branch. The new classifier separates authoritative task evidence from join fallback and exhaustively tests the precedence matrix.

## Verification

- 102 library tests
- `./scripts/dev just ci` (330 tests plus clippy, docs, API/layering checks, and packaging)
- `./scripts/dev just ci-nix`

Part of #56. Stacked on #67.
