### PR TITLE
Trim runtime task and incarnation identity

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -144,7 +144,7 @@ impl ReportReceiver {
 
 pub(crate) struct SystemRun {
     pub(crate) root: Arc<ScopeCell>,
-    driver: Option<runtime::JoinHandle<(), StopReason>>,
+    driver: Option<runtime::JoinHandle<StopReason>>,
 }
 
 pub(crate) type RemovalResponse = runtime::OneShotReceiver<RemoveOutcome>;
@@ -323,7 +323,7 @@ pub(crate) fn start_admission(
             let _ = sender.send(Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal)));
         }),
     };
-    runtime::spawn((), async move {
+    runtime::spawn(async move {
         let _ = runtime::mpsc_send(&control.events, DriverEvent::Admission(request)).await;
     });
     response
@@ -567,8 +567,8 @@ pub(crate) async fn shutdown_scope(
 pub(crate) fn spawn_system(plan: ScopePlan) -> SystemRun {
     let root = Arc::clone(&plan.root);
     let monitor_root = Arc::clone(&root);
-    let driver = runtime::spawn((), async move { run_scope(plan, true, None).await });
-    let lifecycle = runtime::spawn((), async move {
+    let driver = runtime::spawn(async move { run_scope(plan, true, None).await });
+    let lifecycle = runtime::spawn(async move {
         match runtime::join(driver).await {
             runtime::JoinOutcome::Ok { value, .. } => value,
             runtime::JoinOutcome::Panic { message, .. } => {
@@ -1302,7 +1302,7 @@ impl ScopeRuntime {
             // terminal publication or restart-window arbitration.
             drop(child.construction.take());
         }
-        let handle = runtime::spawn(incarnation, async move {
+        let handle = runtime::spawn(async move {
             let body = async move {
                 match body {
                     SpawnBody::Raw { spawn, context } => {
@@ -1373,7 +1373,7 @@ impl ScopeRuntime {
         let abort_handle = handle.abort_handle();
         let exit_sender = self.events.clone();
         let exit_ended = ended.clone();
-        runtime::spawn((), async move {
+        runtime::spawn(async move {
             let join = match runtime::join(handle).await {
                 runtime::JoinOutcome::Ok { .. } => JoinVerdict::Completed,
                 runtime::JoinOutcome::Panic { message, .. } => JoinVerdict::Panicked { message },
@@ -1398,7 +1398,7 @@ impl ScopeRuntime {
         let self_stop_ended = ended.clone();
         if gated {
             let ready_sender = self.events.clone();
-            runtime::spawn((), async move {
+            runtime::spawn(async move {
                 if matches!(
                     runtime::select_two(ready.fired(), ended.fired()).await,
                     runtime::Either::Left(())
@@ -1415,7 +1415,7 @@ impl ScopeRuntime {
             });
         }
         let self_stop_sender = self.events.clone();
-        runtime::spawn((), async move {
+        runtime::spawn(async move {
             if matches!(
                 runtime::select_two(local_stop.fired(), self_stop_ended.fired()).await,
                 runtime::Either::Left(())
@@ -2757,17 +2757,13 @@ mod tests {
     };
 
     fn isolated_scope(id: &'static str, flavor: ScopeFlavor) -> Arc<ScopeCell> {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from(id);
         let member = MemberCell::new(
             id.clone(),
             identity.mint_membership(&id).expect("membership available"),
         );
-        ScopeCell::new(
-            member,
-            flavor,
-            ScopeIdentity::new().expect("child identity available"),
-        )
+        ScopeCell::new(member, flavor, ScopeIdentity::new())
     }
 
     #[test]
@@ -3262,7 +3258,7 @@ mod tests {
             hasher.finish()
         }
 
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let member = MemberCell::new(
             id.clone(),
@@ -3290,7 +3286,7 @@ mod tests {
 
     #[crate::runtime::test]
     async fn attaching_after_terminality_closes_the_mailbox() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let member = MemberCell::new(
             id.clone(),
@@ -3330,10 +3326,15 @@ mod tests {
         let plan = tree.lower_for_test();
         let scope = Arc::clone(&plan.root);
         let epoch = scope.begin_incarnation();
-        let driver = crate::runtime::spawn(
-            (),
-            run_scope_incarnation(plan, false, Some(Latch::default()), None, None, None, epoch),
-        );
+        let driver = crate::runtime::spawn(run_scope_incarnation(
+            plan,
+            false,
+            Some(Latch::default()),
+            None,
+            None,
+            None,
+            epoch,
+        ));
         let abort = driver.abort_handle();
         let reached_startup = crate::runtime::timeout(Duration::from_secs(1), async {
             while !matches!(scope.record().state, ScopeState::Starting) {
@@ -3577,7 +3578,7 @@ mod tests {
 
     #[test]
     fn terminality_signal_follows_mailbox_termination() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let member = MemberCell::new(
             id.clone(),
@@ -3608,7 +3609,7 @@ mod tests {
 
     #[test]
     fn mailbox_wake_observes_terminal_record_and_reentrant_terminality_is_idempotent() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let member = MemberCell::new(
             id.clone(),
@@ -3649,7 +3650,7 @@ mod tests {
 
     #[test]
     fn attach_during_terminal_publication_finishes_record_before_mailbox_wake() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let member = MemberCell::new(
             id.clone(),
@@ -3690,7 +3691,7 @@ mod tests {
 
     #[test]
     fn concurrent_terminalizers_return_after_one_consistent_record_is_visible() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let member = MemberCell::new(
             id.clone(),
@@ -3723,17 +3724,13 @@ mod tests {
 
     #[test]
     fn terminal_startup_wake_follows_member_and_incarnation_publication() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("root");
         let member = MemberCell::new(
             id.clone(),
             identity.mint_membership(&id).expect("membership available"),
         );
-        let scope = ScopeCell::new(
-            member,
-            ScopeFlavor::Ordered,
-            ScopeIdentity::new().expect("child identity available"),
-        );
+        let scope = ScopeCell::new(member, ScopeFlavor::Ordered, ScopeIdentity::new());
         let epoch = scope.begin_incarnation();
         let probe = Arc::new(ObserveScopeOnStartupWake {
             scope: Arc::clone(&scope),
@@ -3770,17 +3767,13 @@ mod tests {
 
     #[test]
     fn no_live_root_startup_wake_follows_member_publication() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("root");
         let member = MemberCell::new(
             id.clone(),
             identity.mint_membership(&id).expect("membership available"),
         );
-        let scope = ScopeCell::new(
-            member,
-            ScopeFlavor::Ordered,
-            ScopeIdentity::new().expect("child identity available"),
-        );
+        let scope = ScopeCell::new(member, ScopeFlavor::Ordered, ScopeIdentity::new());
         let probe = Arc::new(ObserveScopeOnStartupWake {
             scope: Arc::clone(&scope),
             epoch: None,
@@ -3832,7 +3825,7 @@ mod tests {
 
     #[test]
     fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let root_id = ChildId::from("root");
         let root_member = MemberCell::new(
             root_id.clone(),
@@ -3840,11 +3833,7 @@ mod tests {
                 .mint_membership(&root_id)
                 .expect("root membership available"),
         );
-        let root = ScopeCell::new(
-            root_member,
-            ScopeFlavor::Dynamic,
-            ScopeIdentity::new().expect("child identity available"),
-        );
+        let root = ScopeCell::new(root_member, ScopeFlavor::Dynamic, ScopeIdentity::new());
         let child_id = ChildId::from("worker");
         let member = MemberCell::new(
             child_id.clone(),
@@ -3915,7 +3904,7 @@ mod tests {
 
     #[test]
     fn incarnation_mint_exhaustion_has_no_terminal_side_effects() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let membership = identity.mint_membership(&id).expect("membership available");
         let member = MemberCell::new(id, membership);
@@ -4148,7 +4137,7 @@ mod tests {
     #[crate::runtime::test]
     async fn nested_membership_exhaustion_is_structured_and_fail_closed() {
         let nested_id = ChildId::from("nested");
-        let mut parent_identity = ScopeIdentity::new().expect("parent identity available");
+        let mut parent_identity = ScopeIdentity::new();
         let nested_membership = parent_identity
             .mint_membership(&nested_id)
             .expect("nested membership available");
@@ -4207,14 +4196,14 @@ mod tests {
     #[crate::runtime::test]
     async fn scope_incarnation_exhaustion_closes_nested_observation() {
         let parent = isolated_scope("parent", ScopeFlavor::Ordered);
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("nested");
         let membership = identity.mint_membership(&id).expect("membership available");
         let member = MemberCell::new(id, membership);
         let scope = ScopeCell::new(
             Arc::clone(&member),
             ScopeFlavor::Ordered,
-            ScopeIdentity::new().expect("child identity available"),
+            ScopeIdentity::new(),
         );
         let slot = SlotCell::new(Arc::clone(&member), Some(Arc::clone(&scope)));
         parent.set_admitted_children(vec![resident_projection(&slot)]);
@@ -4297,15 +4286,11 @@ mod tests {
 
     #[test]
     fn lifecycle_sequence_exhaustion_poison_is_never_minted_and_becomes_lag() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("scope");
         let membership = identity.mint_membership(&id).expect("membership available");
         let member = MemberCell::new(id, membership);
-        let scope = ScopeCell::new(
-            member,
-            ScopeFlavor::Ordered,
-            ScopeIdentity::new().expect("child identity available"),
-        );
+        let scope = ScopeCell::new(member, ScopeFlavor::Ordered, ScopeIdentity::new());
         scope.set_lifecycle_sequence(FenceCounter::near_exhaustion(0));
         let mut events = scope.subscribe_lifecycle();
 

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -41,7 +41,7 @@ impl Membership {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Incarnation {
     membership: Membership,
-    generation: Fence,
+    generation: Generation,
 }
 
 impl Incarnation {
@@ -61,19 +61,41 @@ impl Incarnation {
     }
 }
 
-/// The one ordered fencing value used for membership and incarnation checks.
+/// An ordered generation within one identity lineage.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct Generation(u64);
+
+impl Generation {
+    const POISON: Self = Self(u64::MAX);
+
+    fn new(value: u64) -> Option<Self> {
+        (value != Self::POISON.0).then_some(Self(value))
+    }
+
+    fn get(self) -> u64 {
+        self.0
+    }
+
+    fn supersedes(self, other: Self) -> bool {
+        self != Self::POISON && other != Self::POISON && self.0 > other.0
+    }
+
+    #[cfg(test)]
+    fn fixture(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// A complete membership fence: its lineage and ordered generation.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct Fence {
     lineage: u64,
-    generation: u64,
+    generation: Generation,
 }
 
 impl Fence {
     fn supersedes(self, other: Self) -> bool {
-        self.lineage == other.lineage
-            && self.generation != u64::MAX
-            && other.generation != u64::MAX
-            && self.generation > other.generation
+        self.lineage == other.lineage && self.generation.supersedes(other.generation)
     }
 }
 
@@ -105,14 +127,14 @@ impl FenceCounter {
 
     fn mint(&mut self) -> Option<Fence> {
         let next = self.current.checked_add(1)?;
-        if next == u64::MAX {
+        let Some(generation) = Generation::new(next) else {
             self.current = u64::MAX;
             return None;
-        }
+        };
         self.current = next;
         Some(Fence {
             lineage: self.lineage,
-            generation: next,
+            generation,
         })
     }
 
@@ -121,7 +143,7 @@ impl FenceCounter {
     /// Observation uses the same saturating, poison-never-minted primitive as
     /// membership and incarnation fencing.
     pub(crate) fn mint_sequence(&mut self) -> Option<u64> {
-        self.mint().map(|fence| fence.generation)
+        self.mint().map(|fence| fence.generation.get())
     }
 }
 
@@ -132,14 +154,14 @@ pub(crate) struct ScopeIdentity {
 }
 
 impl ScopeIdentity {
-    pub(crate) fn new() -> Option<Self> {
+    pub(crate) fn new() -> Self {
         #[cfg(test)]
         CURRENT_THREAD_SCOPE_CREATIONS.with(|creations| {
             creations.set(creations.get().saturating_add(1));
         });
-        Some(Self {
+        Self {
             memberships: HashMap::new(),
-        })
+        }
     }
 
     fn fresh_counter() -> Option<FenceCounter> {
@@ -191,35 +213,29 @@ impl ScopeIdentity {
         match self.memberships.entry(id.clone()) {
             Entry::Occupied(mut entry) => entry.get_mut().mint().map(Membership),
             Entry::Vacant(entry) => {
-                debug_assert_ne!(provisional.0.generation, u64::MAX);
+                debug_assert_ne!(provisional.0.generation, Generation::POISON);
                 entry.insert(FenceCounter {
                     lineage: provisional.0.lineage,
-                    current: provisional.0.generation,
+                    current: provisional.0.generation.get(),
                 });
                 Some(provisional)
             }
         }
     }
 
-    pub(crate) fn incarnation_counter(&self, membership: Membership) -> FenceCounter {
-        // The membership's complete fence is compressed into a unique local
-        // lineage. The membership scope lineage remains part of the mixing, so
-        // matching child ids in different scopes cannot compare equal.
-        //
-        // A nested builder mints its public handles before it is attached to
-        // the parent scope. Deriving from the membership itself keeps those
-        // handles valid after lowering under the parent's runtime cell.
-        let lineage = membership.0.lineage.rotate_left(17) ^ membership.0.generation;
-        FenceCounter::new(lineage)
+    pub(crate) fn incarnation_counter(&self, _membership: Membership) -> FenceCounter {
+        // Membership already supplies the complete incarnation lineage. The
+        // per-membership counter therefore needs only an ordered generation.
+        FenceCounter::new(0)
     }
 
     pub(crate) fn mint_incarnation(
         membership: Membership,
         counter: &mut FenceCounter,
     ) -> Option<Incarnation> {
-        counter.mint().map(|generation| Incarnation {
+        counter.mint().map(|fence| Incarnation {
             membership,
-            generation,
+            generation: fence.generation,
         })
     }
 }
@@ -228,12 +244,12 @@ impl ScopeIdentity {
 mod tests {
     use crate::ChildId;
 
-    use super::{FenceCounter, ScopeIdentity};
+    use super::{FenceCounter, Generation, ScopeIdentity};
 
     #[test]
     fn cross_scope_tokens_fail_closed() {
-        let mut left = ScopeIdentity::new().expect("scope identity available");
-        let mut right = ScopeIdentity::new().expect("scope identity available");
+        let mut left = ScopeIdentity::new();
+        let mut right = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let left_member = left.mint_membership(&id).expect("membership available");
         let right_member = right.mint_membership(&id).expect("membership available");
@@ -245,7 +261,7 @@ mod tests {
 
     #[test]
     fn membership_and_incarnation_order_is_scoped_by_owner_and_id() {
-        let mut scope = ScopeIdentity::new().expect("scope identity available");
+        let mut scope = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let first = scope.mint_membership(&id).expect("membership available");
         let second = scope.mint_membership(&id).expect("membership available");
@@ -277,19 +293,19 @@ mod tests {
     fn stable_scope_adopts_the_first_declaration_then_orders_rebuilds() {
         let id = ChildId::from("worker");
         let other_id = ChildId::from("other");
-        let mut first_builder = ScopeIdentity::new().expect("builder identity available");
+        let mut first_builder = ScopeIdentity::new();
         let first = first_builder
             .mint_membership(&id)
             .expect("first provisional membership available");
         let other = first_builder
             .mint_membership(&other_id)
             .expect("other provisional membership available");
-        let mut rebuilt_builder = ScopeIdentity::new().expect("builder identity available");
+        let mut rebuilt_builder = ScopeIdentity::new();
         let rebuilt = rebuilt_builder
             .mint_membership(&id)
             .expect("rebuilt provisional membership available");
 
-        let mut stable = ScopeIdentity::new().expect("stable identity available");
+        let mut stable = ScopeIdentity::new();
         assert_eq!(
             stable.adopt_or_mint_membership(&id, first),
             Some(first),
@@ -314,8 +330,11 @@ mod tests {
 
     #[test]
     fn exhaustion_never_mints_the_poison_value_or_a_duplicate() {
+        const TEST_LINEAGE: u64 = u64::MAX;
         let id = ChildId::from("worker");
-        let counter = FenceCounter::near_exhaustion(7);
+        // The production allocator never mints the poison lineage, so this
+        // fixture cannot collide with an unrelated identity created below.
+        let counter = FenceCounter::near_exhaustion(TEST_LINEAGE);
         let mut scope = ScopeIdentity::with_counter(id.clone(), counter);
         let last = scope
             .mint_membership(&id)
@@ -323,7 +342,7 @@ mod tests {
         assert!(scope.mint_membership(&id).is_none());
         assert!(scope.mint_membership(&id).is_none());
 
-        let other = MembershipFixture::at(7, u64::MAX);
+        let other = MembershipFixture::at(TEST_LINEAGE, u64::MAX);
         assert_ne!(last, other);
         assert!(!last.supersedes(other));
         assert!(!other.supersedes(last));
@@ -342,7 +361,7 @@ mod tests {
         stable
             .mint_membership(&id)
             .expect("last usable stable membership is minted");
-        let mut builder = ScopeIdentity::new().expect("builder identity available");
+        let mut builder = ScopeIdentity::new();
         let provisional = builder
             .mint_membership(&id)
             .expect("provisional membership available");
@@ -357,7 +376,7 @@ mod tests {
 
     #[test]
     fn incarnation_exhaustion_also_mints_nothing() {
-        let mut scope = ScopeIdentity::new().expect("scope identity available");
+        let mut scope = ScopeIdentity::new();
         let membership = scope
             .mint_membership(&ChildId::from("worker"))
             .expect("membership available");
@@ -369,13 +388,27 @@ mod tests {
         assert_eq!(last.membership(), membership);
     }
 
+    #[test]
+    fn generation_ordering_is_typed_and_poison_fails_closed() {
+        let first = Generation::fixture(1);
+        let second = Generation::fixture(2);
+
+        assert!(second.supersedes(first));
+        assert!(!first.supersedes(second));
+        assert!(!Generation::POISON.supersedes(second));
+        assert!(!second.supersedes(Generation::POISON));
+
+        let mut sequence = FenceCounter::new(0);
+        assert_eq!(sequence.mint_sequence(), Some(1));
+    }
+
     struct MembershipFixture;
 
     impl MembershipFixture {
         fn at(lineage: u64, generation: u64) -> super::Membership {
             super::Membership(super::Fence {
                 lineage,
-                generation,
+                generation: super::Generation::fixture(generation),
             })
         }
     }

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -332,8 +332,8 @@ mod tests {
     fn exhaustion_never_mints_the_poison_value_or_a_duplicate() {
         const TEST_LINEAGE: u64 = u64::MAX;
         let id = ChildId::from("worker");
-        // The production allocator never mints the poison lineage, so this
-        // fixture cannot collide with an unrelated identity created below.
+        // A fixture lineage this test does not otherwise allocate, so it
+        // cannot collide with an unrelated identity created below.
         let counter = FenceCounter::near_exhaustion(TEST_LINEAGE);
         let mut scope = ScopeIdentity::with_counter(id.clone(), counter);
         let last = scope

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1812,7 +1812,7 @@ mod tests {
     }
 
     fn actor() -> (Arc<MailboxCell<u8>>, ActorRef<u8>) {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("actor");
         let member = MemberCell::new(
             id.clone(),
@@ -1833,7 +1833,7 @@ mod tests {
     #[should_panic(expected = "mailbox must be configured before its first bind")]
     fn binding_before_configuration_trips_the_driver_contract() {
         let (mailbox, _) = actor();
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let membership = identity
             .mint_membership(&ChildId::from("actor"))
             .expect("membership available");
@@ -1903,7 +1903,7 @@ mod tests {
         park_with(&mut third, &counting);
         MailboxControl::configure(&*mailbox, Mailbox::default());
         let mut generations = {
-            let mut identity = ScopeIdentity::new().expect("scope identity available");
+            let mut identity = ScopeIdentity::new();
             let membership = identity
                 .mint_membership(&ChildId::from("actor"))
                 .expect("membership available");

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -607,7 +607,7 @@ mod tests {
 
     #[test]
     fn a_retained_event_after_explicit_lag_remains_subject_to_later_overflow() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let membership = identity
             .mint_membership(&crate::ChildId::from("scope"))
             .expect("membership available");

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -92,7 +92,7 @@ pub(crate) fn mint_reserved_slot(
         .ok_or(ReserveError::IdentityExhausted)?;
     let member = MemberCell::new(id.clone(), membership);
     let scope = child_scope.map(|flavor| {
-        let identity = ScopeIdentity::new().expect("global scope identity space exhausted");
+        let identity = ScopeIdentity::new();
         ScopeCell::new(Arc::clone(&member), flavor, identity)
     });
     Ok(SlotCell::new(member, scope))
@@ -205,13 +205,12 @@ impl BuilderCore {
 
     pub(crate) fn new(flavor: ScopeFlavor) -> Self {
         let root_id = ChildId::from("$root");
-        let mut root_identity =
-            ScopeIdentity::new().expect("global scope identity space exhausted");
+        let mut root_identity = ScopeIdentity::new();
         let membership = root_identity
             .mint_membership(&root_id)
             .expect("fresh scope identity must mint its root membership");
         let member = MemberCell::new(root_id, membership);
-        let child_identity = ScopeIdentity::new().expect("global scope identity space exhausted");
+        let child_identity = ScopeIdentity::new();
         let root = ScopeCell::new(member, flavor, child_identity);
         Self {
             root,

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -57,7 +57,7 @@ pub(crate) fn sleep_until(deadline: std::time::Instant) -> BoxedSleep {
 }
 
 pub(crate) struct ActorWork {
-    handle: Option<JoinHandle<(), ()>>,
+    handle: Option<JoinHandle<()>>,
     abort: AbortHandle,
 }
 
@@ -81,7 +81,7 @@ impl Drop for ActorWork {
 }
 
 pub(crate) fn spawn_actor_work(future: impl Future<Output = ()> + Send + 'static) -> ActorWork {
-    let handle = spawn((), future);
+    let handle = spawn(future);
     let abort = handle.abort_handle();
     ActorWork {
         handle: Some(handle),
@@ -90,7 +90,7 @@ pub(crate) fn spawn_actor_work(future: impl Future<Output = ()> + Send + 'static
 }
 
 pub(crate) struct BlockingWork<T> {
-    handle: Option<JoinHandle<(), T>>,
+    handle: Option<JoinHandle<T>>,
 }
 
 impl<T: Send + 'static> BlockingWork<T> {
@@ -99,7 +99,7 @@ impl<T: Send + 'static> BlockingWork<T> {
             .handle
             .take()
             .expect("blocking operation was joined more than once");
-        join_resuming(handle).await.1
+        join_resuming(handle).await
     }
 }
 
@@ -107,7 +107,7 @@ pub(crate) fn spawn_blocking_work<T: Send + 'static>(
     operation: impl FnOnce() -> T + Send + 'static,
 ) -> BlockingWork<T> {
     BlockingWork {
-        handle: Some(spawn_blocking((), operation)),
+        handle: Some(spawn_blocking(operation)),
     }
 }
 
@@ -718,9 +718,8 @@ impl<T> fmt::Debug for BroadcastReceiver<T> {
     }
 }
 
-/// A spawned operation whose identity is retained through joining.
-pub(crate) struct JoinHandle<I, T> {
-    id: I,
+/// A spawned operation owned by the library.
+pub(crate) struct JoinHandle<T> {
     inner: task::JoinHandle<T>,
 }
 
@@ -733,7 +732,7 @@ impl AbortHandle {
     }
 }
 
-impl<I, T> JoinHandle<I, T> {
+impl<T> JoinHandle<T> {
     pub(crate) fn abort_handle(&self) -> AbortHandle {
         AbortHandle(self.inner.abort_handle())
     }
@@ -765,30 +764,28 @@ pub(crate) enum JoinOutcome<T> {
     Cancelled,
 }
 
-pub(crate) fn spawn<I, F>(id: I, future: F) -> JoinHandle<I, F::Output>
+pub(crate) fn spawn<F>(future: F) -> JoinHandle<F::Output>
 where
     F: Future + Send + 'static,
     F::Output: Send + 'static,
 {
     JoinHandle {
-        id,
         inner: task::spawn(future),
     }
 }
 
-pub(crate) fn spawn_blocking<I, F, T>(id: I, operation: F) -> JoinHandle<I, T>
+pub(crate) fn spawn_blocking<F, T>(operation: F) -> JoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
     JoinHandle {
-        id,
         inner: task::spawn_blocking(operation),
     }
 }
 
-pub(crate) async fn join<I, T>(handle: JoinHandle<I, T>) -> JoinOutcome<T> {
-    let JoinHandle { inner, .. } = handle;
+pub(crate) async fn join<T>(handle: JoinHandle<T>) -> JoinOutcome<T> {
+    let JoinHandle { inner } = handle;
     match inner.await {
         Ok(value) => JoinOutcome::Ok { value },
         Err(error) if error.is_panic() => JoinOutcome::Panic {
@@ -801,10 +798,10 @@ pub(crate) async fn join<I, T>(handle: JoinHandle<I, T>) -> JoinOutcome<T> {
     }
 }
 
-pub(crate) async fn join_resuming<I, T>(handle: JoinHandle<I, T>) -> (I, T) {
-    let JoinHandle { id, inner } = handle;
+pub(crate) async fn join_resuming<T>(handle: JoinHandle<T>) -> T {
+    let JoinHandle { inner } = handle;
     match inner.await {
-        Ok(value) => (id, value),
+        Ok(value) => value,
         Err(error) if error.is_panic() => std::panic::resume_unwind(error.into_panic()),
         Err(error) => {
             debug_assert!(error.is_cancelled());
@@ -1018,7 +1015,7 @@ mod tests {
         for _ in 0..FIRERS {
             let latch = latch.clone();
             let ready = Arc::clone(&ready);
-            firers.push(spawn((), async move {
+            firers.push(spawn(async move {
                 ready.fetch_add(1, Ordering::AcqRel);
                 while ready.load(Ordering::Acquire) != FIRERS {
                     yield_now().await;
@@ -1050,7 +1047,7 @@ mod tests {
         for _ in 0..WAITERS {
             let latch = latch.clone();
             let parked = Arc::clone(&parked);
-            waiters.push(spawn((), async move {
+            waiters.push(spawn(async move {
                 let mut fired = Box::pin(latch.fired());
                 let first_poll =
                     std::future::poll_fn(|context| Poll::Ready(fired.as_mut().poll(context))).await;

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -360,7 +360,7 @@ mod tests {
 
     fn task_context() -> (TaskContext, Latch, Latch, Latch) {
         let id = ChildId::from("task");
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let membership = identity.mint_membership(&id).expect("membership available");
         let mut incarnations = identity.incarnation_counter(membership);
         let incarnation = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
@@ -419,7 +419,7 @@ mod tests {
         OneShotTaskRef<T>,
         std::sync::Arc<MemberCell>,
     ) {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("task");
         let membership = identity.mint_membership(&id).expect("membership available");
         let member = MemberCell::new(id, membership);
@@ -503,15 +503,15 @@ mod tests {
             let primary = Latch::default();
             let local = Latch::default();
             let operation = CancellationToken::from_latch(primary.clone()).child(local.clone());
-            let waiter = runtime::spawn((), async move {
+            let waiter = runtime::spawn(async move {
                 operation.cancelled().await;
             });
 
-            let primary_firer = runtime::spawn((), async move {
+            let primary_firer = runtime::spawn(async move {
                 runtime::yield_now().await;
                 primary.fire()
             });
-            let local_firer = runtime::spawn((), async move {
+            let local_firer = runtime::spawn(async move {
                 runtime::yield_now().await;
                 local.fire()
             });


### PR DESCRIPTION
Part of #56. Stacked on #68.

## Summary
- remove redundant Tokio task IDs and the generic runtime task identity parameter
- make scope identity construction infallible at its actual invariant boundary
- represent incarnation generations with a private Generation newtype while preserving membership lineage and fail-closed poison/exhaustion behavior
- update internal runtime, driver, mailbox, observation, plan, and task call sites without widening the public API

## Verification
- focused identity tests: 7/7
- ./scripts/dev just ci (333/333 tests)
- ./scripts/dev just ci-nix
- git diff --check