### PR TITLE
Unify forced shutdown escalation

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -647,7 +647,6 @@ struct ActiveChild {
     construction_release: Latch,
     framework_abort: Option<Latch>,
     framework_abort_ack: Option<Latch>,
-    framework_abort_deadline: Option<Instant>,
     stop_deadline: Option<DeadlineHandle>,
 }
 
@@ -1446,7 +1445,6 @@ impl ScopeRuntime {
             construction_release,
             framework_abort: scope_child.then_some(framework_abort),
             framework_abort_ack: scope_child.then_some(framework_abort_ack),
-            framework_abort_deadline: None,
             stop_deadline: None,
         });
         #[cfg(test)]
@@ -1529,7 +1527,11 @@ impl ScopeRuntime {
             if active.forced_outcome.is_none() {
                 active.readiness.step(ReadinessEvent::Shutdown);
             }
-            active.ladder = Some(StopLadder::new(child.options.shutdown));
+            active.ladder = Some(if active.framework_abort.is_some() {
+                StopLadder::for_framework_driver(child.options.shutdown)
+            } else {
+                StopLadder::new(child.options.shutdown)
+            });
             self.advance_ladder(key, runtime::now());
         } else {
             if let Some(deadline) = child.restart_deadline.take() {
@@ -1557,6 +1559,13 @@ impl ScopeRuntime {
         let Some(ladder) = &mut active.ladder else {
             return;
         };
+        if active
+            .framework_abort_ack
+            .as_ref()
+            .is_some_and(Latch::is_fired)
+        {
+            ladder.acknowledge_framework_abort();
+        }
         while let Some(action) = ladder.advance(now) {
             match action {
                 StopAction::Cancel => {
@@ -1565,37 +1574,25 @@ impl ScopeRuntime {
                 StopAction::Escalate => {
                     active.abort.fire();
                 }
+                StopAction::AbortFramework { after_grace } => {
+                    active.hard_abort_after_grace = Some(after_grace);
+                    if active.forced_outcome.is_none() {
+                        active.forced_outcome = Some(RecordedOutcome::Aborted { after_grace });
+                    }
+                    active
+                        .framework_abort
+                        .as_ref()
+                        .expect("framework action belongs only to a framework driver")
+                        .fire();
+                }
                 StopAction::HardAbort { after_grace } => {
                     active.hard_abort_after_grace = Some(after_grace);
-                    if let Some(abort) = &active.framework_abort {
-                        if active.forced_outcome.is_none() {
-                            active.forced_outcome = Some(RecordedOutcome::Aborted { after_grace });
-                        }
-                        abort.fire();
-                        active.framework_abort_deadline =
-                            Deadline::after(now, crate::policy::tidy_abort_beat(Duration::ZERO))
-                                .instant();
-                    } else {
-                        active.abort_handle.abort();
-                    }
+                    active.abort_handle.abort();
                 }
             }
         }
         let ladder_deadline = ladder.deadline();
-        if active
-            .framework_abort_deadline
-            .is_some_and(|deadline| now >= deadline)
-        {
-            active.framework_abort_deadline = None;
-            if active
-                .framework_abort_ack
-                .as_ref()
-                .is_none_or(|ack| !ack.is_fired())
-            {
-                active.abort_handle.abort();
-            }
-        }
-        if let Some(deadline) = ladder_deadline.or(active.framework_abort_deadline) {
+        if let Some(deadline) = ladder_deadline {
             active.stop_deadline = Some(self.deadlines.push(
                 deadline,
                 DeadlineKind::Stop {
@@ -1651,16 +1648,18 @@ impl ScopeRuntime {
         let now = runtime::now();
         let children: Vec<_> = self.children.keys().collect();
         for key in children {
-            let child = &mut self.children[key];
-            let Some(active) = &mut child.active else {
-                continue;
-            };
-            let mut ladder = StopLadder::new(crate::Shutdown::Abort);
-            let _ = ladder.advance(now);
-            let _ = ladder.advance(now);
-            active.shutdown.fire();
-            active.abort.fire();
-            active.ladder = Some(ladder);
+            // Every live membership enters the same stop funnel first. That
+            // owns mailbox freeze, readiness disarm, ordered-child handling,
+            // and the initial cooperative action.
+            self.begin_stop_child(key, None);
+            if let Some(ladder) = self
+                .children
+                .get_mut(key)
+                .and_then(|child| child.active.as_mut())
+                .and_then(|active| active.ladder.as_mut())
+            {
+                ladder.force(now);
+            }
             self.advance_ladder(key, now);
         }
         let disposing = self
@@ -2534,7 +2533,9 @@ async fn run_scope_incarnation(
             pending.push((ArbitrationClass::ScopeShutdown, Pending::AncestorAbort));
         }
         if root.take_force_request(epoch) {
-            pending.push((ArbitrationClass::StopDeadline, Pending::Force));
+            // Force owns shutdown arbitration: readiness from the same wake
+            // cannot publish Running after the stop boundary.
+            pending.push((ArbitrationClass::ScopeShutdown, Pending::Force));
         }
         for membership in scope.pending_removals() {
             pending.push((
@@ -2740,7 +2741,7 @@ mod tests {
         LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Readiness, ReadinessDeadline,
         RemoveOutcome, Retention, ScopeState, SendErrorKind, StartupError, StartupFailureCause,
         StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
-        engine::arbitrate,
+        engine::{StopLadder, arbitrate},
         exit::{JoinVerdict, RecordedOutcome},
         identity::{FenceCounter, ScopeIdentity},
         mailbox::MailboxCell,
@@ -2764,6 +2765,20 @@ mod tests {
             identity.mint_membership(&id).expect("membership available"),
         );
         ScopeCell::new(member, flavor, ScopeIdentity::new())
+    }
+
+    struct PendingRaw;
+
+    impl crate::RawActor for PendingRaw {
+        type Msg = u8;
+
+        fn readiness(&self) -> Readiness {
+            Readiness::Manual
+        }
+
+        async fn run(&mut self, _: &mut crate::RawContext<Self::Msg>) -> crate::ExitResult {
+            future::pending().await
+        }
     }
 
     #[test]
@@ -2878,6 +2893,128 @@ mod tests {
                 }
             );
             assert!(!phase.begin_drain(StopReason::Finished));
+        }
+    }
+
+    #[crate::runtime::test]
+    async fn force_uses_the_stop_funnel_for_every_ordered_child() {
+        let mut tree = Tree::new();
+        let first = tree
+            .add_raw("first", crate::RawDef::factory(|| PendingRaw))
+            .expect("valid first actor");
+        let second = tree
+            .add_raw("second", crate::RawDef::factory(|| PendingRaw))
+            .expect("valid second actor");
+        let mut plan = tree.lower_for_test();
+        let root = Arc::clone(&plan.root);
+        let epoch = root.begin_incarnation();
+        root.set_admitted_children(
+            plan.children
+                .iter()
+                .map(|child| resident_projection(&child.slot))
+                .collect(),
+        );
+        let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+        let mut children = ChildArena::default();
+        plan.children.reverse();
+        while let Some(child) = plan.children.pop() {
+            children
+                .insert(ChildRuntime::from_plan(child, &root))
+                .unwrap_or_else(|_| panic!("the fixture fits in the child-key domain"));
+        }
+        let keys = children.keys().collect::<Vec<_>>();
+        let mut scope = ScopeRuntime {
+            root: Arc::clone(&root),
+            defaults: plan.defaults.clone(),
+            intensity_policy: plan.config.intensity,
+            intensity: super::IntensityState::default(),
+            children,
+            events,
+            deadlines: super::DeadlineQueue::default(),
+            jitter: crate::runtime::JitterRng::from_system_entropy(),
+            phase: ScopePhase::Running,
+            next_ordered_start: None,
+            is_root: true,
+            parent_ready: None,
+            dynamic: None,
+            epoch,
+            ancestor_shutdown: None,
+            ancestor_shutdown_seen: false,
+            ancestor_abort: None,
+            ancestor_abort_ack: None,
+            ancestor_abort_seen: false,
+            hard_forced: false,
+            completion: None,
+        };
+        plan.armed = false;
+        drop(plan);
+
+        for key in &keys {
+            scope.spawn_child(*key);
+        }
+        let incarnations = keys
+            .iter()
+            .map(|key| {
+                scope.children[*key]
+                    .active
+                    .as_ref()
+                    .expect("child is active")
+                    .incarnation
+            })
+            .collect::<Vec<_>>();
+
+        scope.force_all();
+
+        for key in &keys {
+            let active = scope.children[*key]
+                .active
+                .as_ref()
+                .expect("forced child remains active through the tidy beat");
+            assert!(active.shutdown.is_fired(), "force sends cancellation");
+            assert!(active.abort.is_fired(), "force immediately escalates");
+        }
+        assert_eq!(
+            first.try_send(1).expect_err("first mailbox freezes").kind,
+            SendErrorKind::NotRunning
+        );
+        assert_eq!(
+            second.try_send(2).expect_err("second mailbox freezes").kind,
+            SendErrorKind::NotRunning
+        );
+
+        // Model readiness messages that shared the driver's wake with force.
+        // The force boundary disarmed both gates before either can publish a
+        // late Running transition.
+        for (key, incarnation) in keys.iter().zip(incarnations) {
+            scope.handle_ready(*key, incarnation);
+            assert!(matches!(
+                scope.children[*key].slot.member.record().stage,
+                MemberStage::Stopping
+            ));
+        }
+
+        let deadlines = keys
+            .iter()
+            .map(|key| {
+                scope.children[*key]
+                    .active
+                    .as_ref()
+                    .and_then(|active| active.ladder)
+                    .and_then(StopLadder::deadline)
+                    .expect("each ladder retains its tidy deadline")
+            })
+            .collect::<Vec<_>>();
+        scope.force_all();
+        for (key, deadline) in keys.iter().zip(deadlines) {
+            assert_eq!(
+                scope.children[*key]
+                    .active
+                    .as_ref()
+                    .and_then(|active| active.ladder)
+                    .and_then(StopLadder::deadline),
+                Some(deadline),
+                "repeated force cannot rewind or skip the ladder"
+            );
         }
     }
 

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -133,7 +133,18 @@ impl StopLadder {
                     Shutdown::Abort => Duration::ZERO,
                 };
                 self.phase = StopPhase::Escalated;
-                self.deadline = Deadline::after(now, tidy_abort_beat(grace)).instant();
+                // A forced ladder is the `Abort` policy's zero-grace point on
+                // this same ladder (§10), so it takes the zero-grace tidy beat
+                // rather than one scaled to the grace force just skipped. The
+                // `after_grace` provenance above is unaffected: whether grace
+                // actually expired is a separate fact from how long the beat
+                // between escalation and hard abort runs.
+                let beat = if self.force_requested {
+                    Duration::ZERO
+                } else {
+                    grace
+                };
+                self.deadline = Deadline::after(now, tidy_abort_beat(beat)).instant();
                 Some(StopAction::Escalate)
             }
             StopPhase::Escalated if self.deadline.is_some_and(|deadline| now >= deadline) => {
@@ -552,7 +563,7 @@ mod tests {
     use super::{
         ArbitrationClass, DeadlineHandle, DeadlineQueue, ExitDispatch, IntensityState,
         MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState, ScopeMode,
-        StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart,
+        StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart, tidy_abort_beat,
     };
 
     #[test]
@@ -611,6 +622,22 @@ mod tests {
         let tidy = ladder
             .deadline()
             .expect("forced ladder keeps its tidy beat");
+        assert_eq!(
+            tidy,
+            start + tidy_abort_beat(Duration::ZERO),
+            "a forced ladder takes the zero-grace tidy beat, not one scaled \
+             to the grace it skipped"
+        );
+
+        let mut unforced = StopLadder::new(Shutdown::Graceful { grace });
+        assert_eq!(unforced.advance(start), Some(StopAction::Cancel));
+        assert_eq!(unforced.advance(start + grace), Some(StopAction::Escalate));
+        assert_eq!(
+            unforced.deadline(),
+            Some(start + grace + tidy_abort_beat(grace)),
+            "an unforced ladder still scales its tidy beat to its grace"
+        );
+
         ladder.force(start);
         assert_eq!(
             ladder.advance(start),

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -31,6 +31,7 @@ pub(crate) fn arbitrate<T>(events: &mut [(ArbitrationClass, T)]) {
 pub(crate) enum StopAction {
     Cancel,
     Escalate,
+    AbortFramework { after_grace: bool },
     HardAbort { after_grace: bool },
 }
 
@@ -39,6 +40,7 @@ enum StopPhase {
     Idle,
     Cooperative,
     Escalated,
+    AbortingFramework,
     Finished,
 }
 
@@ -49,15 +51,29 @@ pub(crate) struct StopLadder {
     phase: StopPhase,
     deadline: Option<Instant>,
     after_grace: bool,
+    force_requested: bool,
+    framework_driver: bool,
+    framework_abort_acked: bool,
 }
 
 impl StopLadder {
     pub(crate) fn new(policy: Shutdown) -> Self {
+        Self::with_framework_driver(policy, false)
+    }
+
+    pub(crate) fn for_framework_driver(policy: Shutdown) -> Self {
+        Self::with_framework_driver(policy, true)
+    }
+
+    fn with_framework_driver(policy: Shutdown, framework_driver: bool) -> Self {
         Self {
             policy,
             phase: StopPhase::Idle,
             deadline: None,
             after_grace: false,
+            force_requested: false,
+            framework_driver,
+            framework_abort_acked: false,
         }
     }
 
@@ -65,16 +81,43 @@ impl StopLadder {
         self.deadline
     }
 
+    /// Expedites this ladder without replacing or rewinding it.
+    pub(crate) fn force(&mut self, now: Instant) {
+        if self.phase == StopPhase::Finished {
+            return;
+        }
+        if self.phase == StopPhase::Cooperative {
+            if !self.force_requested
+                && matches!(self.policy, Shutdown::Graceful { .. })
+                && self.deadline.is_some_and(|deadline| now >= deadline)
+            {
+                self.after_grace = true;
+            }
+            self.deadline = Some(now);
+        }
+        self.force_requested = true;
+    }
+
+    pub(crate) fn acknowledge_framework_abort(&mut self) {
+        if self.phase == StopPhase::AbortingFramework {
+            self.framework_abort_acked = true;
+        }
+    }
+
     pub(crate) fn advance(&mut self, now: Instant) -> Option<StopAction> {
         match self.phase {
             StopPhase::Idle => {
                 self.phase = StopPhase::Cooperative;
-                match self.policy {
-                    Shutdown::Graceful { grace } => {
-                        self.deadline = Deadline::after(now, grace).instant();
-                    }
-                    Shutdown::Abort => {
-                        self.deadline = Some(now);
+                if self.force_requested {
+                    self.deadline = Some(now);
+                } else {
+                    match self.policy {
+                        Shutdown::Graceful { grace } => {
+                            self.deadline = Deadline::after(now, grace).instant();
+                        }
+                        Shutdown::Abort => {
+                            self.deadline = Some(now);
+                        }
                     }
                 }
                 Some(StopAction::Cancel)
@@ -82,7 +125,9 @@ impl StopLadder {
             StopPhase::Cooperative if self.deadline.is_some_and(|deadline| now >= deadline) => {
                 let grace = match self.policy {
                     Shutdown::Graceful { grace } => {
-                        self.after_grace = true;
+                        if !self.force_requested {
+                            self.after_grace = true;
+                        }
                         grace
                     }
                     Shutdown::Abort => Duration::ZERO,
@@ -92,13 +137,33 @@ impl StopLadder {
                 Some(StopAction::Escalate)
             }
             StopPhase::Escalated if self.deadline.is_some_and(|deadline| now >= deadline) => {
+                if self.framework_driver {
+                    self.phase = StopPhase::AbortingFramework;
+                    self.deadline = Deadline::after(now, tidy_abort_beat(Duration::ZERO)).instant();
+                    Some(StopAction::AbortFramework {
+                        after_grace: self.after_grace,
+                    })
+                } else {
+                    self.phase = StopPhase::Finished;
+                    self.deadline = None;
+                    Some(StopAction::HardAbort {
+                        after_grace: self.after_grace,
+                    })
+                }
+            }
+            StopPhase::AbortingFramework
+                if self.deadline.is_some_and(|deadline| now >= deadline) =>
+            {
                 self.phase = StopPhase::Finished;
                 self.deadline = None;
-                Some(StopAction::HardAbort {
+                (!self.framework_abort_acked).then_some(StopAction::HardAbort {
                     after_grace: self.after_grace,
                 })
             }
-            StopPhase::Cooperative | StopPhase::Escalated | StopPhase::Finished => None,
+            StopPhase::Cooperative
+            | StopPhase::Escalated
+            | StopPhase::AbortingFramework
+            | StopPhase::Finished => None,
         }
     }
 }
@@ -528,6 +593,74 @@ mod tests {
         assert_eq!(abort.advance(start), Some(StopAction::Escalate));
         assert_eq!(
             abort.advance(abort.deadline().expect("tidy deadline")),
+            Some(StopAction::HardAbort { after_grace: false })
+        );
+    }
+
+    #[test]
+    fn repeated_force_expedites_without_rewinding_the_ladder() {
+        let start = Instant::now();
+        let grace = Duration::from_secs(30);
+        let mut ladder = StopLadder::new(Shutdown::Graceful { grace });
+
+        assert_eq!(ladder.advance(start), Some(StopAction::Cancel));
+        ladder.force(start);
+        ladder.force(start);
+        assert_eq!(ladder.advance(start), Some(StopAction::Escalate));
+
+        let tidy = ladder
+            .deadline()
+            .expect("forced ladder keeps its tidy beat");
+        ladder.force(start);
+        assert_eq!(
+            ladder.advance(start),
+            None,
+            "force does not skip the tidy beat"
+        );
+        assert_eq!(
+            ladder.advance(tidy),
+            Some(StopAction::HardAbort { after_grace: false })
+        );
+        ladder.force(tidy);
+        assert_eq!(
+            ladder.advance(tidy),
+            None,
+            "a finished ladder stays finished"
+        );
+    }
+
+    #[test]
+    fn framework_abort_and_ack_are_owned_by_the_same_stop_ladder() {
+        let start = Instant::now();
+        let mut ladder = StopLadder::for_framework_driver(Shutdown::Abort);
+
+        assert_eq!(ladder.advance(start), Some(StopAction::Cancel));
+        assert_eq!(ladder.advance(start), Some(StopAction::Escalate));
+        let tidy = ladder
+            .deadline()
+            .expect("abort policy keeps the first tidy beat");
+        assert_eq!(
+            ladder.advance(tidy),
+            Some(StopAction::AbortFramework { after_grace: false })
+        );
+        ladder.acknowledge_framework_abort();
+        let framework_tidy = ladder
+            .deadline()
+            .expect("framework acknowledgment has a bounded tidy beat");
+        assert_eq!(ladder.advance(framework_tidy), None);
+        assert_eq!(ladder.deadline(), None);
+
+        let mut unacked = StopLadder::for_framework_driver(Shutdown::Abort);
+        assert_eq!(unacked.advance(start), Some(StopAction::Cancel));
+        assert_eq!(unacked.advance(start), Some(StopAction::Escalate));
+        let tidy = unacked.deadline().expect("abort tidy beat");
+        assert_eq!(
+            unacked.advance(tidy),
+            Some(StopAction::AbortFramework { after_grace: false })
+        );
+        let framework_tidy = unacked.deadline().expect("framework tidy beat");
+        assert_eq!(
+            unacked.advance(framework_tidy),
             Some(StopAction::HardAbort { after_grace: false })
         );
     }


### PR DESCRIPTION
Part of #56. Stacked on #69.

## Summary
- make force expedite the existing monotonic stop ladder instead of replacing it
- route ordered children through the same stop funnel so mailboxes freeze and readiness gates disarm consistently
- integrate framework abort, acknowledgement, tidy-beat, and fallback handling into the ladder
- keep repeated force requests idempotent without rewinding escalation

## Verification
- ./scripts/dev just ci (336/336 tests)
- ./scripts/dev just ci-nix
- git diff --check