### PR TITLE
Make dynamic admission an explicit state machine

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1526,8 +1526,9 @@ Rules (normative):
   point for the id errors — `EmptyId` and `DuplicateId` on either flavor
   (a retained tombstone counts as a duplicate — retention semantics
   above); on dynamic scopes additionally `RemovalInProgress` (same id
-  mid-removal, §11) and `NotAdmitting` (stage rule below). From success the slot's
-  handles resolve through the cell like any other handle; the slot is
+  mid-removal, §11), `NoRuntime` (runtime boundary below), and
+  `NotAdmitting` (stage rule below). From success the slot's handles
+  resolve through the cell like any other handle; the slot is
   parameterized by exactly what a handle needs (`M` for the wire type,
   `T` for the subtree's ref dispatch) so refs exist before any actor type
   or factory is named.
@@ -1551,10 +1552,11 @@ Rules (normative):
   and cannot fail — spec-level validation already happened eagerly at
   spec construction (§9.3). On a dynamic scope, `define` *is* the
   admission call: a future resolving at admission to the receipt (B.8).
-  Its only error is `NotAdmitting`: the id errors were already spent at
+  Its operation errors are `NotAdmitting` and the first-poll
+  `NoRuntime` rejection below: the id errors were already spent at
   reserve, and definition validation was spent at spec construction
   (§9.3's eager rule), exactly as on the builder flavor — admission
-  validates nothing. Whether the builder and dynamic flavors
+  validates no definition data. Whether the builder and dynamic flavors
   are one generic slot type or two parallel families is implementation
   latitude; the operation inventory and this error split are not.
 - **Fused admission futures abort on drop; split ones detach.** Dropping
@@ -1599,6 +1601,23 @@ Rules (normative):
   dropped before ever being polled has submitted nothing, and the cell
   terminalizes exactly as if the slot had been dropped undefined
   (§3.2).
+- **Runtime availability is checked before dynamic mutation.** A dynamic
+  `reserve_*` validates the id syntax first, then requires an ambient
+  runtime, and only then reads the scope's admitting state or resident-id
+  table. The error precedence is therefore `EmptyId` before `NoRuntime`,
+  and `NoRuntime` before `NotAdmitting`, `RemovalInProgress`, or
+  `DuplicateId` (and before identity minting can yield
+  `IdentityExhausted`); a no-runtime rejection mints no cell and claims
+  no id.
+  The admission future rechecks runtime availability at its first poll,
+  before spawning or submitting the admission command. If a slot was
+  reserved inside a runtime but its `define` future is first-polled
+  outside one, both fused and split forms return `NoRuntime`, release the
+  reservation, and publish the cell as terminal `NeverStarted`; the id is
+  reusable before that poll returns `Ready`. This failed poll never
+  crosses the split form's in-flight/detach edge. A completed admission
+  future is fuse-like: any later poll remains pending rather than
+  repeating the outcome or panicking.
 - **Stage semantics: dynamic operations are admission-stage-exact.** A
   dynamic scope is *admitting* exactly while its membership is
   non-terminal and it has a live incarnation in `Starting` or `Running`
@@ -3312,10 +3331,14 @@ it fires no `Removed` event and leaves no tombstone, §3.2's
 minting/admission split) — §11's idempotency, made concrete. `remove`
 futures are observation only: removal latches synchronously at the
 call (§11's remove rule), so dropping the future — polled or not —
-detaches, and a latched removal still completes. Dynamic `add_*`
+detaches, and a latched removal still completes. The public
+`ReserveError` enum is non-exhaustive and includes `NoRuntime`: it names
+the absent ambient runtime at dynamic reservation or first poll, with
+the cleanup and precedence pinned in §8. Dynamic `add_*`
 fails with exactly the union of its two halves (§8): `EmptyId`,
-`DuplicateId` (tombstones included), and `RemovalInProgress` (same id
-mid-removal — await removal and retry) from reserve — plus §3.1's
+`NoRuntime`, `DuplicateId` (tombstones included), and
+`RemovalInProgress` (same id mid-removal — await removal and retry) from
+reserve, with `NoRuntime` also possible at first poll — plus §3.1's
 enumerated identity-exhaustion rejection, unreachable in practice but
 named so fail-closed has a shape; `NotAdmitting`
 from either half. `NotAdmitting` is one outcome with an enumerated,
@@ -3330,10 +3353,12 @@ reached admission (removed by id, §8's orphaned-slot rule; or annulled
 by the fused drop latch). That last cause is cell-level, enumerated
 distinctly so a caller can tell "the scope closed" from "my
 reservation is gone".
-Defines add no errors of their own: definition
-validation is spent eagerly at spec construction (§9.3), on both
-flavors. Declaration builders share the reserve id errors (`EmptyId`,
-`DuplicateId`); their defines cannot fail (§8).
+Defines add no definition-validation errors: validation is spent eagerly
+at spec construction (§9.3), on both flavors. A dynamic define still
+crosses §8's admission boundary, so it can return `NoRuntime` at first
+poll or `NotAdmitting`; declaration builders share the reserve id errors
+(`EmptyId`, `DuplicateId`), require no runtime for reservation or define,
+and their defines cannot fail (§8).
 
 `BuildError` (spawn-time, §11) is enumerated and non-exhaustive:
 `NoRuntime` (no ambient async runtime reachable through D.3's `runtime`

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -263,6 +263,9 @@ pub(crate) fn reserve_dynamic(
     child_scope: Option<ScopeFlavor>,
 ) -> Result<DynamicReservation, ReserveError> {
     let id = checked_id(id)?;
+    if !runtime::is_available() {
+        return Err(ReserveError::NoRuntime);
+    }
     if matches!(scope.member.record().stage, MemberStage::Terminal(_)) {
         return Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal));
     }
@@ -314,7 +317,10 @@ pub(crate) fn start_admission(
     control: Arc<DynamicControl>,
     slot: Arc<SlotCell>,
     fused_cancel: Option<Latch>,
-) -> runtime::OneShotReceiver<Result<(), ReserveError>> {
+) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError> {
+    if !runtime::is_available() {
+        return Err(ReserveError::NoRuntime);
+    }
     let (sender, response) = runtime::oneshot();
     let request = AdmissionRequest {
         control: Arc::downgrade(&control),
@@ -327,7 +333,7 @@ pub(crate) fn start_admission(
     runtime::spawn(async move {
         let _ = runtime::mpsc_send(&control.events, DriverEvent::Admission(request)).await;
     });
-    response
+    Ok(response)
 }
 
 fn cancel_dynamic_reservation_parts(

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -19,10 +19,13 @@ use crate::{
     task::{OnceTask, TaskDef},
 };
 
-/// A declaration-time reservation error.
+/// A child reservation or dynamic admission error.
 #[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
 #[non_exhaustive]
 pub enum ReserveError {
+    /// No ambient supported async runtime exists.
+    #[error("no ambient Tokio runtime is available")]
+    NoRuntime,
     /// The child id was empty.
     #[error("child id must not be empty")]
     EmptyId,

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -664,27 +664,94 @@ impl<H> AdmissionReceipt<H> {
     }
 }
 
-/// An admission future. Fused additions abort on drop; split definitions
-/// detach after their first poll.
+/// An admission future.
+///
+/// Fused additions abort on drop; split definitions detach after their first
+/// poll starts admission. Reservation and that first poll require an ambient
+/// Tokio runtime. A first poll outside one returns [`ReserveError::NoRuntime`]
+/// and releases the reservation. Like a fused future, it remains pending if
+/// polled again after completion.
 #[must_use]
 pub struct Admission<H> {
-    reservation: Option<DynamicReservation>,
-    receipt: Option<AdmissionReceipt<H>>,
-    fused_cancel: Option<Latch>,
-    inner: Option<AdmissionWait>,
-    immediate: Option<ReserveError>,
-    polled: bool,
-    done: bool,
+    state: AdmissionState<H>,
 }
 
 type AdmissionWait = Pin<Box<dyn Future<Output = Result<(), ReserveError>> + Send + 'static>>;
+
+struct PendingAdmission<H> {
+    reservation: DynamicReservation,
+    receipt: AdmissionReceipt<H>,
+    fused_cancel: Option<Latch>,
+}
+
+impl<H> PendingAdmission<H> {
+    fn start(&self) -> Result<AdmissionWait, ReserveError> {
+        let response = crate::driver::start_admission(
+            Arc::clone(&self.reservation.control),
+            Arc::clone(&self.reservation.slot),
+            self.fused_cancel.clone(),
+        )?;
+        Ok(Box::pin(async move {
+            response
+                .receive()
+                .await
+                .unwrap_or(Err(ReserveError::NotAdmitting(
+                    crate::NotAdmittingCause::Terminal,
+                )))
+        }))
+    }
+
+    fn cancel_reservation(&self) {
+        crate::driver::cancel_dynamic_reservation(
+            &self.reservation.control,
+            &self.reservation.slot,
+        );
+    }
+}
+
+enum AdmissionState<H> {
+    Immediate(ReserveError),
+    Unpolled(PendingAdmission<H>),
+    InFlight {
+        pending: PendingAdmission<H>,
+        wait: AdmissionWait,
+    },
+    Done,
+}
+
+impl<H> AdmissionState<H> {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Immediate(_) => "Immediate",
+            Self::Unpolled(_) => "Unpolled",
+            Self::InFlight { .. } => "InFlight",
+            Self::Done => "Done",
+        }
+    }
+
+    fn begin(self, wait: AdmissionWait) -> Self {
+        match self {
+            Self::Unpolled(pending) => Self::InFlight { pending, wait },
+            other => other,
+        }
+    }
+
+    fn complete(
+        self,
+        result: Result<(), ReserveError>,
+    ) -> (Self, Option<Result<AdmissionReceipt<H>, ReserveError>>) {
+        match self {
+            Self::InFlight { pending, .. } => (Self::Done, Some(result.map(|()| pending.receipt))),
+            other => (other, None),
+        }
+    }
+}
 
 impl<H> fmt::Debug for Admission<H> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("Admission")
-            .field("polled", &self.polled)
-            .field("done", &self.done)
+            .field("state", &self.state.name())
             .finish_non_exhaustive()
     }
 }
@@ -692,29 +759,21 @@ impl<H> fmt::Debug for Admission<H> {
 impl<H> Admission<H> {
     fn error(error: ReserveError) -> Self {
         Self {
-            reservation: None,
-            receipt: None,
-            fused_cancel: None,
-            inner: None,
-            immediate: Some(error),
-            polled: false,
-            done: false,
+            state: AdmissionState::Immediate(error),
         }
     }
 
     fn new(reservation: DynamicReservation, handles: H, fused: bool) -> Self {
         let membership = reservation.slot.member.membership();
         Self {
-            reservation: Some(reservation),
-            receipt: Some(AdmissionReceipt {
-                membership,
-                handles,
+            state: AdmissionState::Unpolled(PendingAdmission {
+                reservation,
+                receipt: AdmissionReceipt {
+                    membership,
+                    handles,
+                },
+                fused_cancel: fused.then(Latch::default),
             }),
-            fused_cancel: fused.then(Latch::default),
-            inner: None,
-            immediate: None,
-            polled: false,
-            done: false,
         }
     }
 }
@@ -723,64 +782,54 @@ impl<H: Unpin> Future for Admission<H> {
     type Output = Result<AdmissionReceipt<H>, ReserveError>;
 
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
-        if let Some(error) = self.immediate.take() {
-            self.done = true;
-            return Poll::Ready(Err(error));
-        }
-        if !self.polled {
-            self.polled = true;
-            let reservation = self
-                .reservation
-                .as_ref()
-                .expect("pending admission must carry its reservation");
-            let response = crate::driver::start_admission(
-                Arc::clone(&reservation.control),
-                Arc::clone(&reservation.slot),
-                self.fused_cancel.clone(),
-            );
-            self.inner = Some(Box::pin(async move {
-                response
-                    .receive()
-                    .await
-                    .expect("admission response obligation must complete")
-            }));
-        }
-        let poll = self
-            .inner
-            .as_mut()
-            .expect("polled admission must carry its response future")
-            .as_mut()
-            .poll(context);
-        match poll {
-            Poll::Ready(Ok(())) => {
-                self.done = true;
-                Poll::Ready(Ok(self
-                    .receipt
-                    .take()
-                    .expect("successful admission must carry a receipt")))
+        let this = self.as_mut().get_mut();
+        loop {
+            match &mut this.state {
+                AdmissionState::Immediate(error) => {
+                    let error = error.clone();
+                    this.state = AdmissionState::Done;
+                    return Poll::Ready(Err(error));
+                }
+                AdmissionState::Unpolled(pending) => {
+                    let wait = match pending.start() {
+                        Ok(wait) => wait,
+                        Err(error) => {
+                            pending.cancel_reservation();
+                            this.state = AdmissionState::Done;
+                            return Poll::Ready(Err(error));
+                        }
+                    };
+                    let previous = std::mem::replace(&mut this.state, AdmissionState::Done);
+                    this.state = previous.begin(wait);
+                }
+                AdmissionState::InFlight { wait, .. } => match wait.as_mut().poll(context) {
+                    Poll::Ready(result) => {
+                        let previous = std::mem::replace(&mut this.state, AdmissionState::Done);
+                        let (state, output) = previous.complete(result);
+                        this.state = state;
+                        if let Some(output) = output {
+                            return Poll::Ready(output);
+                        }
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
+                AdmissionState::Done => return Poll::Pending,
             }
-            Poll::Ready(Err(error)) => {
-                self.done = true;
-                Poll::Ready(Err(error))
-            }
-            Poll::Pending => Poll::Pending,
         }
     }
 }
 
 impl<H> Drop for Admission<H> {
     fn drop(&mut self) {
-        if self.done {
-            return;
-        }
-        let Some(reservation) = &self.reservation else {
-            return;
-        };
-        if let Some(cancel) = &self.fused_cancel {
-            crate::driver::signal_fused_cancel(&reservation.control, cancel);
-            crate::driver::cancel_dynamic_reservation(&reservation.control, &reservation.slot);
-        } else if !self.polled {
-            crate::driver::cancel_dynamic_reservation(&reservation.control, &reservation.slot);
+        match &self.state {
+            AdmissionState::Unpolled(pending) => pending.cancel_reservation(),
+            AdmissionState::InFlight { pending, .. } => {
+                if let Some(cancel) = &pending.fused_cancel {
+                    crate::driver::signal_fused_cancel(&pending.reservation.control, cancel);
+                    pending.cancel_reservation();
+                }
+            }
+            AdmissionState::Immediate(_) | AdmissionState::Done => {}
         }
     }
 }
@@ -1364,6 +1413,8 @@ impl DynamicScopeRef {
     }
 
     /// Reserves an actor id synchronously and exposes its exact handle.
+    ///
+    /// Returns [`ReserveError::NoRuntime`] outside an ambient Tokio runtime.
     pub fn reserve_actor<M: Send + 'static>(
         &self,
         id: impl Into<ChildId>,
@@ -1432,6 +1483,8 @@ impl DynamicScopeRef {
     }
 
     /// Reserves a task id synchronously and exposes its exact handle.
+    ///
+    /// Returns [`ReserveError::NoRuntime`] outside an ambient Tokio runtime.
     pub fn reserve_task(&self, id: impl Into<ChildId>) -> Result<DynamicTaskSlot, ReserveError> {
         crate::driver::reserve_dynamic(&self.0.cell, id.into(), None).map(|reservation| {
             DynamicTaskSlot {
@@ -1461,6 +1514,8 @@ impl DynamicScopeRef {
     }
 
     /// Reserves a typed subtree id synchronously.
+    ///
+    /// Returns [`ReserveError::NoRuntime`] outside an ambient Tokio runtime.
     pub fn reserve_subtree<T: Subtree>(
         &self,
         id: impl Into<ChildId>,

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -692,12 +692,17 @@ impl<H> PendingAdmission<H> {
             self.fused_cancel.clone(),
         )?;
         Ok(Box::pin(async move {
-            response
-                .receive()
-                .await
-                .unwrap_or(Err(ReserveError::NotAdmitting(
+            response.receive().await.unwrap_or_else(|| {
+                // The driver's admission `Obligation` publishes an outcome on
+                // every path, including its drop fallback. Treat a missing
+                // response as the scope having gone terminal so a caller is
+                // never stranded, but fail loudly in debug builds: silence
+                // here would mask an obligation regression.
+                debug_assert!(false, "admission response obligation must complete");
+                Err(ReserveError::NotAdmitting(
                     crate::NotAdmittingCause::Terminal,
-                )))
+                ))
+            })
         }))
     }
 
@@ -822,7 +827,16 @@ impl<H: Unpin> Future for Admission<H> {
 impl<H> Drop for Admission<H> {
     fn drop(&mut self) {
         match &self.state {
-            AdmissionState::Unpolled(pending) => pending.cancel_reservation(),
+            AdmissionState::Unpolled(pending) => {
+                // A fused admission annuls its reservation on every drop edge,
+                // polled or not. Firing the latch before cancelling keeps the
+                // scope's control-plane wake and the cancellation evidence in
+                // the same order the in-flight path uses.
+                if let Some(cancel) = &pending.fused_cancel {
+                    crate::driver::signal_fused_cancel(&pending.reservation.control, cancel);
+                }
+                pending.cancel_reservation();
+            }
             AdmissionState::InFlight { pending, .. } => {
                 if let Some(cancel) = &pending.fused_cancel {
                     crate::driver::signal_fused_cancel(&pending.reservation.control, cancel);

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -588,6 +588,140 @@ async fn reserved_cell_removal_wins_a_queued_split_definition() {
         .expect("root stops");
 }
 
+#[test]
+fn admission_runtime_guards_leave_reservation_ids_reusable() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("test runtime");
+    let (system, scope, task, mut admission) = runtime.block_on(async {
+        let system = DynamicTree::new().spawn().expect("runtime is available");
+        system.wait_started().await.expect("root starts");
+        let scope = system.scope();
+        let slot = scope
+            .reserve_task("poll-outside")
+            .expect("reservation starts inside the runtime");
+        let task = slot.task_ref();
+        let admission = Box::pin(slot.define(waiting_task()));
+        (system, scope, task, admission)
+    });
+
+    assert!(matches!(scope.reserve_task(""), Err(ReserveError::EmptyId)));
+    assert!(matches!(
+        scope.reserve_task("poll-outside"),
+        Err(ReserveError::NoRuntime)
+    ));
+    assert!(matches!(
+        scope.reserve_task("reserve-outside"),
+        Err(ReserveError::NoRuntime)
+    ));
+    let mut immediate = Box::pin(scope.add_task("add-outside", waiting_task()));
+    assert!(matches!(
+        poll_once(immediate.as_mut()),
+        std::task::Poll::Ready(Err(ReserveError::NoRuntime))
+    ));
+    assert!(matches!(
+        poll_once(admission.as_mut()),
+        std::task::Poll::Ready(Err(ReserveError::NoRuntime))
+    ));
+    assert!(poll_once(admission.as_mut()).is_pending());
+
+    runtime.block_on(async {
+        assert!(matches!(task.wait().await.kind(), ExitKind::NeverStarted));
+        for id in ["reserve-outside", "add-outside", "poll-outside"] {
+            let task = scope
+                .add_task(id, waiting_task())
+                .await
+                .unwrap_or_else(|error| panic!("id `{id}` remains reusable: {error:?}"))
+                .into_handles();
+            assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
+        }
+        system
+            .shutdown(Duration::from_secs(1))
+            .await
+            .expect("root stops");
+    });
+    assert!(matches!(
+        scope.reserve_task("stopped-outside"),
+        Err(ReserveError::NoRuntime)
+    ));
+}
+
+#[tokio::test]
+async fn select_and_timeout_preserve_fused_and_split_admission_ownership() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+
+    let mut fused = Box::pin(scope.add_task("fused-select", waiting_task()));
+    assert!(poll_once(fused.as_mut()).is_pending());
+    tokio::select! {
+        biased;
+        () = std::future::ready(()) => {}
+        result = fused => panic!("ready branch must win over admission: {result:?}"),
+    }
+    let reused = scope
+        .add_task("fused-select", waiting_task())
+        .await
+        .expect("select dropping a fused admission frees its id")
+        .into_handles();
+    assert_eq!(scope.remove_task(&reused).await, RemoveOutcome::Removed);
+
+    let split_started = Arc::new(AtomicBool::new(false));
+    let split_cancelled = Arc::new(AtomicBool::new(false));
+    let slot = scope
+        .reserve_task("split-timeout")
+        .expect("split reservation");
+    let task = slot.task_ref();
+    let mut split = Box::pin(slot.define(TaskDef::new({
+        let split_started = Arc::clone(&split_started);
+        let split_cancelled = Arc::clone(&split_cancelled);
+        move |context| {
+            let split_started = Arc::clone(&split_started);
+            let split_cancelled = Arc::clone(&split_cancelled);
+            async move {
+                split_started.store(true, Ordering::SeqCst);
+                context.shutdown_token().cancelled().await;
+                split_cancelled.store(true, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+    })));
+    assert!(poll_once(split.as_mut()).is_pending());
+    let timed_admission = async move {
+        let _split = split;
+        std::future::pending::<()>().await;
+    };
+    assert!(
+        tokio::time::timeout(Duration::ZERO, timed_admission)
+            .await
+            .is_err()
+    );
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            split_started.load(Ordering::SeqCst)
+        })
+        .await,
+        "timing out a polled split admission detaches the running child"
+    );
+    assert!(matches!(
+        scope.reserve_task("split-timeout"),
+        Err(ReserveError::DuplicateId(_))
+    ));
+    assert_quiet(Duration::from_millis(20), || {
+        split_cancelled.load(Ordering::SeqCst)
+    })
+    .await;
+    assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
+    assert!(split_cancelled.load(Ordering::SeqCst));
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
 #[tokio::test]
 async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
     let system = DynamicTree::new().spawn().expect("runtime is available");


### PR DESCRIPTION
Part of #56. Stacked on #73.

## Summary
- replace Admission correlated Options and booleans with Immediate, Unpolled, InFlight, and Done states
- guard runtime availability at reservation and first poll, returning ReserveError::NoRuntime
- cancel and terminalize failed first polls synchronously so IDs are immediately reusable
- preserve fused cancellation and split detachment semantics under select and timeout
- make post-completion polling safely fused
- document NoRuntime timing, error precedence, ownership, terminalization, reuse, and fused polling in the normative SPEC

## Verification
- dynamic integration tests: 25/25 before stacking
- focused NoRuntime/error-precedence regressions
- ./scripts/dev just ci after final stacking (341/341 tests)
- ./scripts/dev just ci-nix
- git diff --check