### PR TITLE
Validate public policy literals at admission

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -215,6 +215,7 @@ impl MemberCell {
                     false,
                     Readiness::Immediate,
                 )
+                .expect("library defaults must be valid")
             })
     }
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2478,6 +2478,11 @@ async fn run_nested_tree(
                     (StartupFailureCause::IdentityExhausted { id }, disposal)
                 }
                 LowerError::InvalidPolicy { invalid, disposal } => {
+                    // `InvalidPolicy::path` is relative to the scope being
+                    // lowered, which here is this nested scope itself. The
+                    // owning child id is already carried by the enclosing
+                    // `StartupFailureCause::Child`, so prepending it here
+                    // would double-count this frame.
                     (StartupFailureCause::InvalidPolicy(invalid), disposal)
                 }
             };

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2187,17 +2187,31 @@ impl ScopeRuntime {
             return;
         }
 
-        let Some(definition) = request.slot.take_defined() else {
-            let (_, removed) = cancel_dynamic_reservation_parts(&control, &request.slot);
-            reject_admission_after_disposal(
-                request,
-                None,
-                removed,
-                ReserveError::NotAdmitting(NotAdmittingCause::ReservationEnded),
-            );
-            return;
+        let (definition, resolved) = match request.slot.resolve_and_take_defined(&self.defaults) {
+            Ok(Some(claimed)) => claimed,
+            Ok(None) => {
+                let (_, removed) = cancel_dynamic_reservation_parts(&control, &request.slot);
+                reject_admission_after_disposal(
+                    request,
+                    None,
+                    removed,
+                    ReserveError::NotAdmitting(NotAdmittingCause::ReservationEnded),
+                );
+                return;
+            }
+            Err(invalid) => {
+                let (definition, removed) =
+                    cancel_dynamic_reservation_parts(&control, &request.slot);
+                reject_admission_after_disposal(
+                    request,
+                    definition,
+                    removed,
+                    ReserveError::InvalidPolicy(invalid),
+                );
+                return;
+            }
         };
-        let plan = ChildPlan::resolve(Arc::clone(&request.slot), definition, &self.defaults);
+        let plan = ChildPlan::with_options(Arc::clone(&request.slot), definition, resolved);
         {
             let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
             let id = request.slot.member.id();
@@ -2462,6 +2476,9 @@ async fn run_nested_tree(
                 }
                 LowerError::IdentityExhausted { id, disposal } => {
                     (StartupFailureCause::IdentityExhausted { id }, disposal)
+                }
+                LowerError::InvalidPolicy { invalid, disposal } => {
+                    (StartupFailureCause::InvalidPolicy(invalid), disposal)
                 }
             };
             // Lowering never created a nested driver to own teardown. Keep

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -199,6 +199,8 @@ pub enum StartupFailureCause {
         /// Child whose stable membership could not be minted.
         id: ChildId,
     },
+    /// A produced subtree contained an invalid public policy literal.
+    InvalidPolicy(crate::policy::InvalidPolicy),
 }
 
 #[derive(Debug)]
@@ -219,6 +221,7 @@ impl fmt::Display for StructuredStartupFailure {
                     "membership identity space is exhausted for child `{id}`"
                 )
             }
+            StartupFailureCause::InvalidPolicy(invalid) => invalid.fmt(formatter),
         }
     }
 }

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -37,9 +37,9 @@ pub use observe::{
 };
 pub use plan::{NotAdmittingCause, RemoveOutcome, ReserveError};
 pub use policy::{
-    Backoff, BackoffFactor, ChildId, DefaultsInheritance, Intensity, Jitter, Mailbox,
-    MailboxShutdown, PolicyError, Readiness, ReadinessDeadline, RestartCondition, RestartPolicy,
-    Retention, ScopeDefaults, Shutdown, Strategy,
+    Backoff, BackoffFactor, ChildId, DefaultsInheritance, Intensity, InvalidPolicy, Jitter,
+    Mailbox, MailboxShutdown, PolicyError, PolicyField, Readiness, ReadinessDeadline,
+    RestartCondition, RestartPolicy, Retention, ScopeDefaults, Shutdown, Strategy,
 };
 pub use raw::{
     Blocking, DeadlineElapsed, Guard, RawActor, RawContext, RawDef, RawOnceDef, Rejected,

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -355,7 +355,13 @@ impl BuilderCore {
         }
         root.set_observation_config(self.config.strategy, self.config.intensity);
         let mut children = Vec::with_capacity(self.slots.len());
+        debug_assert_eq!(
+            self.slots.len(),
+            resolved.len(),
+            "policy resolution is one entry per slot, in slot order"
+        );
         for (slot, resolved) in self.slots.iter().zip(resolved) {
+            let resolved = resolved.expect("validated slot must have resolved options");
             let definition = slot
                 .take_definition()
                 .expect("validated slot must have a definition");
@@ -378,17 +384,18 @@ impl BuilderCore {
     fn validate_policies(
         &self,
         inherited: &ResolvedDefaults,
-    ) -> Result<(ResolvedDefaults, Vec<ResolvedCommonOptions>), InvalidPolicy> {
+    ) -> Result<(ResolvedDefaults, Vec<Option<ResolvedCommonOptions>>), InvalidPolicy> {
         self.config
             .intensity
             .validate()
             .map_err(|error| InvalidPolicy::new(PolicyField::Intensity, error))?;
         let defaults = inherited.overlay(&self.config.defaults)?;
+        // One entry per slot, in slot order. An undefined slot resolves to
+        // `None` rather than being skipped, so this vector can never shift a
+        // later child onto another child's options.
         let mut resolved = Vec::with_capacity(self.slots.len());
         for slot in &self.slots {
-            if let Some(options) = slot.resolve_policy(&defaults)? {
-                resolved.push(options);
-            }
+            resolved.push(slot.resolve_policy(&defaults)?);
         }
         Ok((defaults, resolved))
     }

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -11,8 +11,8 @@ use crate::{
     definition::DefinitionSource,
     identity::ScopeIdentity,
     policy::{
-        CommonOptions, IdError, ResolvedCommonOptions, ResolvedDefaults, ScopeFlavor,
-        resolve_common,
+        CommonOptions, IdError, InvalidPolicy, PolicyField, ResolvedCommonOptions,
+        ResolvedDefaults, ScopeFlavor, resolve_common,
     },
     raw::RawConstruction,
     runtime::{self, Isolated, Latch},
@@ -41,6 +41,9 @@ pub enum ReserveError {
     /// The scope can mint no further membership identities.
     #[error("membership identity space is exhausted")]
     IdentityExhausted,
+    /// A public policy representation contained an invalid literal value.
+    #[error(transparent)]
+    InvalidPolicy(InvalidPolicy),
 }
 
 /// Exact reason an admission operation could not proceed.
@@ -184,6 +187,72 @@ impl SlotCell {
         self.terminalize_never_started();
         definition
     }
+
+    pub(crate) fn resolve_policy(
+        &self,
+        defaults: &ResolvedDefaults,
+    ) -> Result<Option<ResolvedCommonOptions>, InvalidPolicy> {
+        let state = self.definition.lock().expect("definition mutex poisoned");
+        let DefinitionState::Defined(definition) = &*state else {
+            return Ok(None);
+        };
+        self.resolve_defined_policy(definition, defaults).map(Some)
+    }
+
+    /// Resolves policy and claims the matching construction under one
+    /// definition lock. Dynamic removal can therefore observe either the
+    /// unclaimed definition or the completed claim, never the gap between
+    /// those operations.
+    pub(crate) fn resolve_and_take_defined(
+        &self,
+        defaults: &ResolvedDefaults,
+    ) -> Result<Option<(Isolated<ChildConstruction>, ResolvedCommonOptions)>, InvalidPolicy> {
+        self.resolve_and_take_defined_with(defaults, || {})
+    }
+
+    fn resolve_and_take_defined_with(
+        &self,
+        defaults: &ResolvedDefaults,
+        before_claim: impl FnOnce(),
+    ) -> Result<Option<(Isolated<ChildConstruction>, ResolvedCommonOptions)>, InvalidPolicy> {
+        let mut state = self.definition.lock().expect("definition mutex poisoned");
+        let DefinitionState::Defined(definition) = &*state else {
+            return Ok(None);
+        };
+        let resolved = self.resolve_defined_policy(definition, defaults)?;
+        before_claim();
+        let DefinitionState::Defined(definition) =
+            std::mem::replace(&mut *state, DefinitionState::Lowered)
+        else {
+            unreachable!("the definition lock keeps resolution and claim atomic")
+        };
+        Ok(Some((definition, resolved)))
+    }
+
+    fn resolve_defined_policy(
+        &self,
+        definition: &Isolated<ChildConstruction>,
+        defaults: &ResolvedDefaults,
+    ) -> Result<ResolvedCommonOptions, InvalidPolicy> {
+        let (options, one_shot) = match definition.get() {
+            ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
+            ChildConstruction::Task(definition) => (&definition.options, false),
+            ChildConstruction::TaskOnce(definition) => (&definition.options, true),
+            ChildConstruction::Scope(definition) => {
+                if let DefinitionSource::OneShot(tree) = &definition.source {
+                    let inherited = match definition.defaults {
+                        DefaultsInheritance::Inherit => defaults.clone(),
+                        DefaultsInheritance::Reset => ResolvedDefaults::default(),
+                    };
+                    tree.validate_policies(&inherited)
+                        .map_err(|invalid| invalid.prepend(self.member.id()))?;
+                }
+                (&definition.options, definition.one_shot())
+            }
+        };
+        resolve_common(options, defaults, one_shot, Readiness::Immediate)
+            .map_err(|invalid| invalid.prepend(self.member.id()))
+    }
 }
 
 /// Erased declaration storage before inherited defaults and identities are lowered.
@@ -258,6 +327,13 @@ impl BuilderCore {
                 disposal,
             });
         }
+        let (defaults, resolved) = match self.validate_policies(&inherited) {
+            Ok(resolved) => resolved,
+            Err(invalid) => {
+                let disposal = self.begin_failed_disposal();
+                return Err(LowerError::InvalidPolicy { invalid, disposal });
+            }
+        };
         if !Arc::ptr_eq(&root, &self.root) {
             let mut identity = root
                 .child_identity
@@ -278,13 +354,16 @@ impl BuilderCore {
             }
         }
         root.set_observation_config(self.config.strategy, self.config.intensity);
-        let defaults = inherited.overlay(&self.config.defaults);
         let mut children = Vec::with_capacity(self.slots.len());
-        for slot in &self.slots {
+        for (slot, resolved) in self.slots.iter().zip(resolved) {
             let definition = slot
                 .take_definition()
                 .expect("validated slot must have a definition");
-            children.push(ChildPlan::resolve(Arc::clone(slot), definition, &defaults));
+            children.push(ChildPlan::with_options(
+                Arc::clone(slot),
+                definition,
+                resolved,
+            ));
         }
         self.armed = false;
         Ok(ScopePlan {
@@ -294,6 +373,24 @@ impl BuilderCore {
             children,
             armed: true,
         })
+    }
+
+    fn validate_policies(
+        &self,
+        inherited: &ResolvedDefaults,
+    ) -> Result<(ResolvedDefaults, Vec<ResolvedCommonOptions>), InvalidPolicy> {
+        self.config
+            .intensity
+            .validate()
+            .map_err(|error| InvalidPolicy::new(PolicyField::Intensity, error))?;
+        let defaults = inherited.overlay(&self.config.defaults)?;
+        let mut resolved = Vec::with_capacity(self.slots.len());
+        for slot in &self.slots {
+            if let Some(options) = slot.resolve_policy(&defaults)? {
+                resolved.push(options);
+            }
+        }
+        Ok((defaults, resolved))
     }
 
     fn terminalize(&self) {
@@ -344,18 +441,11 @@ pub(crate) struct ChildPlan {
 }
 
 impl ChildPlan {
-    pub(crate) fn resolve(
+    pub(crate) fn with_options(
         slot: Arc<SlotCell>,
         construction: Isolated<ChildConstruction>,
-        defaults: &ResolvedDefaults,
+        options: ResolvedCommonOptions,
     ) -> Self {
-        let (options, one_shot) = match construction.get() {
-            ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
-            ChildConstruction::Task(definition) => (&definition.options, false),
-            ChildConstruction::TaskOnce(definition) => (&definition.options, true),
-            ChildConstruction::Scope(definition) => (&definition.options, definition.one_shot()),
-        };
-        let options = resolve_common(options, defaults, one_shot, Readiness::Immediate);
         slot.member.set_options(options.clone());
         Self {
             slot,
@@ -373,6 +463,10 @@ pub(crate) enum LowerError {
     },
     IdentityExhausted {
         id: ChildId,
+        disposal: Latch,
+    },
+    InvalidPolicy {
+        invalid: InvalidPolicy,
         disposal: Latch,
     },
 }
@@ -410,7 +504,7 @@ pub(crate) fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError
 mod tests {
     use std::{
         sync::{
-            Arc,
+            Arc, Barrier,
             atomic::{AtomicBool, Ordering},
         },
         time::Duration,
@@ -420,7 +514,7 @@ mod tests {
         Backoff, ExitError, Readiness, RestartCondition, RestartPolicy, Retention, Shutdown,
         TaskOnceDef,
         policy::{ResolvedDefaults, ScopeFlavor},
-        runtime::{self, Isolated, Timeout},
+        runtime::{self, Timeout},
         task::TaskDef,
     };
 
@@ -454,13 +548,54 @@ mod tests {
         let dynamic_slot = admission
             .reserve("dynamic", None)
             .expect("dynamic reservation succeeds");
-        let dynamic_plan = ChildPlan::resolve(
-            dynamic_slot,
-            Isolated::new(ChildConstruction::Task(configured_task())),
-            &defaults,
-        );
+        dynamic_slot.define(ChildConstruction::Task(configured_task()));
+        let dynamic_options = dynamic_slot
+            .resolve_policy(&defaults)
+            .expect("dynamic policy is valid")
+            .expect("dynamic slot is defined");
+        let dynamic_definition = dynamic_slot
+            .take_definition()
+            .expect("dynamic slot remains claimable");
+        let dynamic_plan =
+            ChildPlan::with_options(dynamic_slot, dynamic_definition, dynamic_options);
 
         assert_eq!(static_plan.children[0].options, dynamic_plan.options);
+    }
+
+    #[test]
+    fn dynamic_policy_resolution_and_definition_claim_are_atomic() {
+        let defaults = ResolvedDefaults::default();
+        let mut declaration = BuilderCore::new(ScopeFlavor::Dynamic);
+        let slot = declaration
+            .reserve("dynamic", None)
+            .expect("dynamic reservation succeeds");
+        slot.define(ChildConstruction::Task(configured_task()));
+
+        let race = Arc::new(Barrier::new(2));
+        let competing_slot = Arc::clone(&slot);
+        let competing_race = Arc::clone(&race);
+        let competing_claim = std::thread::spawn(move || {
+            competing_race.wait();
+            competing_slot.take_defined()
+        });
+
+        let claim = slot
+            .resolve_and_take_defined_with(&defaults, || {
+                // The competing remover is released only after resolution,
+                // while this method still owns the definition lock.
+                race.wait();
+                std::thread::yield_now();
+            })
+            .expect("dynamic policy is valid")
+            .expect("admission claims the defined construction");
+        assert!(
+            competing_claim
+                .join()
+                .expect("competing claim thread does not panic")
+                .is_none(),
+            "removal cannot claim between policy resolution and admission"
+        );
+        drop(claim);
     }
 
     struct DropFlag(Arc<AtomicBool>);
@@ -485,12 +620,16 @@ mod tests {
         let slot = declaration
             .reserve("one-shot", None)
             .expect("reservation succeeds");
-
-        let plan = ChildPlan::resolve(
-            slot,
-            Isolated::new(ChildConstruction::TaskOnce(construction)),
-            &ResolvedDefaults::default(),
-        );
+        slot.define(ChildConstruction::TaskOnce(construction));
+        let defaults = ResolvedDefaults::default();
+        let options = slot
+            .resolve_policy(&defaults)
+            .expect("one-shot policy is valid")
+            .expect("one-shot slot is defined");
+        let construction = slot
+            .take_definition()
+            .expect("one-shot slot remains claimable");
+        let plan = ChildPlan::with_options(slot, construction, options);
         assert!(plan.options.restart.is_never());
         assert_eq!(plan.options.retention, Retention::Remove);
         assert!(!dropped.load(Ordering::SeqCst));

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -97,6 +97,14 @@ impl BackoffFactor {
     fn get(self) -> f64 {
         self.0
     }
+
+    fn validate(self) -> Result<(), PolicyError> {
+        if self.0.is_finite() && self.0 >= 1.0 {
+            Ok(())
+        } else {
+            Err(PolicyError::InvalidBackoffFactor)
+        }
+    }
 }
 
 impl fmt::Debug for BackoffFactor {
@@ -213,6 +221,26 @@ impl Backoff {
         // with exact Duration ordering after every conversion and jitter.
         delay.min(maximum)
     }
+
+    fn validate(self) -> Result<(), PolicyError> {
+        match self {
+            Self::Immediate => Ok(()),
+            Self::Fixed { delay, .. } if delay.is_zero() => Err(PolicyError::ZeroDuration),
+            Self::Fixed { .. } => Ok(()),
+            Self::Exponential {
+                base, factor, max, ..
+            } => {
+                if base.is_zero() || max.is_zero() {
+                    return Err(PolicyError::ZeroDuration);
+                }
+                factor.validate()?;
+                if max < base {
+                    return Err(PolicyError::BackoffMaximumBeforeBase);
+                }
+                Ok(())
+            }
+        }
+    }
 }
 
 fn duration_nanos(duration: Duration) -> f64 {
@@ -262,6 +290,10 @@ impl RestartPolicy {
     #[must_use]
     pub const fn is_never(self) -> bool {
         matches!(self.condition, RestartCondition::Never)
+    }
+
+    fn validate(self) -> Result<(), PolicyError> {
+        self.backoff.validate()
     }
 
     pub(crate) fn should_restart(self, failure: bool) -> bool {
@@ -331,6 +363,20 @@ impl ReadinessDeadline {
             Ok(Self::Bounded(duration))
         }
     }
+
+    fn validate_declared(self) -> Result<(), PolicyError> {
+        match self {
+            Self::Bounded(duration) if duration.is_zero() => Err(PolicyError::ZeroDuration),
+            Self::Inherit | Self::Bounded(_) | Self::Unbounded => Ok(()),
+        }
+    }
+
+    fn validate_resolved(self) -> Result<(), PolicyError> {
+        match self {
+            Self::Inherit => Err(PolicyError::UnresolvedReadinessDeadline),
+            value => value.validate_declared(),
+        }
+    }
 }
 
 /// The scope-wide restart budget.
@@ -352,6 +398,14 @@ impl Intensity {
                 max_restarts,
                 within,
             })
+        }
+    }
+
+    pub(crate) fn validate(self) -> Result<(), PolicyError> {
+        if self.within.is_zero() {
+            Err(PolicyError::ZeroDuration)
+        } else {
+            Ok(())
         }
     }
 }
@@ -471,9 +525,62 @@ pub enum PolicyError {
     /// An exponential maximum preceded its base delay.
     #[error("backoff maximum must not be shorter than its base")]
     BackoffMaximumBeforeBase,
+    /// An inherited readiness deadline remained unresolved at execution.
+    #[error("readiness deadline must be resolved before execution")]
+    UnresolvedReadinessDeadline,
     /// A readiness mode is not meaningful for this child kind.
     #[error("readiness mode is not supported by this child kind")]
     UnsupportedReadiness,
+}
+
+/// Policy field rejected at a trusted lowering or admission boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum PolicyField {
+    /// A scope restart-intensity window.
+    Intensity,
+    /// A default or child restart backoff.
+    RestartBackoff,
+    /// A default or child readiness deadline.
+    ReadinessDeadline,
+}
+
+impl fmt::Display for PolicyField {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Intensity => formatter.write_str("restart intensity"),
+            Self::RestartBackoff => formatter.write_str("restart backoff"),
+            Self::ReadinessDeadline => formatter.write_str("readiness deadline"),
+        }
+    }
+}
+
+/// Structured evidence for a policy value rejected during lowering.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("invalid {field} at child path {path:?}: {error}")]
+#[non_exhaustive]
+pub struct InvalidPolicy {
+    /// Child-id path relative to the scope being lowered; empty for scope policy.
+    pub path: Vec<ChildId>,
+    /// Policy field whose public representation bypassed validation.
+    pub field: PolicyField,
+    /// Exact validation failure.
+    pub error: PolicyError,
+}
+
+impl InvalidPolicy {
+    pub(crate) fn new(field: PolicyField, error: PolicyError) -> Self {
+        Self {
+            path: Vec::new(),
+            field,
+            error,
+        }
+    }
+
+    pub(crate) fn prepend(mut self, id: &ChildId) -> Self {
+        self.path.insert(0, id.clone());
+        self
+    }
 }
 
 pub(crate) fn tidy_abort_beat(grace: Duration) -> Duration {
@@ -513,8 +620,19 @@ impl Default for ResolvedDefaults {
 }
 
 impl ResolvedDefaults {
-    pub(crate) fn overlay(&self, values: &ScopeDefaults) -> Self {
-        Self {
+    pub(crate) fn overlay(&self, values: &ScopeDefaults) -> Result<Self, InvalidPolicy> {
+        self.validate()?;
+        if let Some(restart) = values.child_restart {
+            restart
+                .validate()
+                .map_err(|error| InvalidPolicy::new(PolicyField::RestartBackoff, error))?;
+        }
+        if let Some(deadline) = values.readiness_deadline {
+            deadline
+                .validate_declared()
+                .map_err(|error| InvalidPolicy::new(PolicyField::ReadinessDeadline, error))?;
+        }
+        let resolved = Self {
             child_restart: values.child_restart.unwrap_or(self.child_restart),
             child_shutdown: values.child_shutdown.unwrap_or(self.child_shutdown),
             mailbox: resolve_default_mailbox(values.mailbox, self.mailbox),
@@ -523,7 +641,18 @@ impl ResolvedDefaults {
                 ReadinessDeadline::Inherit => self.readiness_deadline,
                 value => value,
             },
-        }
+        };
+        resolved.validate()?;
+        Ok(resolved)
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), InvalidPolicy> {
+        self.child_restart
+            .validate()
+            .map_err(|error| InvalidPolicy::new(PolicyField::RestartBackoff, error))?;
+        self.readiness_deadline
+            .validate_resolved()
+            .map_err(|error| InvalidPolicy::new(PolicyField::ReadinessDeadline, error))
     }
 }
 
@@ -555,12 +684,22 @@ pub(crate) fn resolve_common(
     defaults: &ResolvedDefaults,
     one_shot: bool,
     default_readiness: Readiness,
-) -> ResolvedCommonOptions {
+) -> Result<ResolvedCommonOptions, InvalidPolicy> {
+    defaults.validate()?;
+    if let Some(restart) = options.restart {
+        restart
+            .validate()
+            .map_err(|error| InvalidPolicy::new(PolicyField::RestartBackoff, error))?;
+    }
+    options
+        .readiness_deadline
+        .validate_declared()
+        .map_err(|error| InvalidPolicy::new(PolicyField::ReadinessDeadline, error))?;
     let readiness_deadline = match options.readiness_deadline {
         ReadinessDeadline::Inherit => defaults.readiness_deadline,
         value => value,
     };
-    ResolvedCommonOptions {
+    let resolved = ResolvedCommonOptions {
         restart: if one_shot {
             RestartPolicy::new(RestartCondition::Never, Backoff::Immediate)
         } else {
@@ -579,7 +718,16 @@ pub(crate) fn resolve_common(
         } else {
             Retention::Retain
         }),
-    }
+    };
+    resolved
+        .restart
+        .validate()
+        .map_err(|error| InvalidPolicy::new(PolicyField::RestartBackoff, error))?;
+    resolved
+        .readiness_deadline
+        .validate_resolved()
+        .map_err(|error| InvalidPolicy::new(PolicyField::ReadinessDeadline, error))?;
+    Ok(resolved)
 }
 
 #[cfg(test)]
@@ -587,8 +735,9 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        Backoff, BackoffFactor, Intensity, Jitter, Mailbox, PolicyError, ReadinessDeadline,
-        ResolvedDefaults, ScopeDefaults,
+        Backoff, BackoffFactor, Intensity, InvalidPolicy, Jitter, Mailbox, PolicyError,
+        PolicyField, ReadinessDeadline, ResolvedDefaults, RestartCondition, RestartPolicy,
+        ScopeDefaults,
     };
 
     #[test]
@@ -676,18 +825,146 @@ mod tests {
     #[test]
     fn defaults_overlay_as_one_value_and_mailbox_capacity_resolves_by_kind() {
         let library = ResolvedDefaults::default();
-        let latest = library.overlay(&ScopeDefaults {
-            mailbox: Some(Mailbox::latest()),
-            ..ScopeDefaults::default()
-        });
+        let latest = library
+            .overlay(&ScopeDefaults {
+                mailbox: Some(Mailbox::latest()),
+                ..ScopeDefaults::default()
+            })
+            .expect("valid defaults");
         assert_eq!(latest.mailbox, Mailbox::Latest);
 
-        let deferred_queue = latest.overlay(&ScopeDefaults {
-            mailbox: Some(Mailbox::queue_inherit()),
-            ..ScopeDefaults::default()
-        });
+        let deferred_queue = latest
+            .overlay(&ScopeDefaults {
+                mailbox: Some(Mailbox::queue_inherit()),
+                ..ScopeDefaults::default()
+            })
+            .expect("valid defaults");
         assert_eq!(deferred_queue.mailbox, Mailbox::default());
         assert_eq!(deferred_queue.child_restart, latest.child_restart);
         assert_eq!(deferred_queue.child_shutdown, latest.child_shutdown);
+    }
+
+    #[test]
+    fn public_literal_representations_are_revalidated() {
+        assert_eq!(
+            Backoff::Fixed {
+                delay: Duration::ZERO,
+                jitter: Jitter::None,
+            }
+            .validate(),
+            Err(PolicyError::ZeroDuration)
+        );
+        assert_eq!(
+            Backoff::Exponential {
+                base: Duration::ZERO,
+                factor: BackoffFactor(2.0),
+                max: Duration::from_secs(1),
+                jitter: Jitter::None,
+            }
+            .validate(),
+            Err(PolicyError::ZeroDuration)
+        );
+        assert_eq!(
+            Backoff::Exponential {
+                base: Duration::from_secs(1),
+                factor: BackoffFactor(f64::NAN),
+                max: Duration::from_secs(2),
+                jitter: Jitter::None,
+            }
+            .validate(),
+            Err(PolicyError::InvalidBackoffFactor)
+        );
+        assert_eq!(
+            Backoff::Exponential {
+                base: Duration::from_secs(2),
+                factor: BackoffFactor(2.0),
+                max: Duration::from_secs(1),
+                jitter: Jitter::None,
+            }
+            .validate(),
+            Err(PolicyError::BackoffMaximumBeforeBase)
+        );
+        assert_eq!(
+            ReadinessDeadline::Bounded(Duration::ZERO).validate_declared(),
+            Err(PolicyError::ZeroDuration)
+        );
+        assert_eq!(
+            Intensity {
+                max_restarts: 0,
+                within: Duration::ZERO,
+            }
+            .validate(),
+            Err(PolicyError::ZeroDuration)
+        );
+    }
+
+    #[test]
+    fn inherited_and_resolved_policy_values_are_revalidated() {
+        let invalid_restart = ResolvedDefaults {
+            child_restart: RestartPolicy::new(
+                RestartCondition::Always,
+                Backoff::Fixed {
+                    delay: Duration::ZERO,
+                    jitter: Jitter::None,
+                },
+            ),
+            ..ResolvedDefaults::default()
+        };
+        assert_eq!(
+            invalid_restart.overlay(&ScopeDefaults {
+                child_restart: Some(RestartPolicy::default()),
+                ..ScopeDefaults::default()
+            }),
+            Err(InvalidPolicy::new(
+                PolicyField::RestartBackoff,
+                PolicyError::ZeroDuration
+            ))
+        );
+
+        let unresolved = ResolvedDefaults {
+            readiness_deadline: ReadinessDeadline::Inherit,
+            ..ResolvedDefaults::default()
+        };
+        assert_eq!(
+            unresolved.overlay(&ScopeDefaults::default()),
+            Err(InvalidPolicy::new(
+                PolicyField::ReadinessDeadline,
+                PolicyError::UnresolvedReadinessDeadline
+            ))
+        );
+    }
+
+    #[test]
+    fn minimum_valid_literal_edges_are_accepted() {
+        assert_eq!(
+            Backoff::Fixed {
+                delay: Duration::from_nanos(1),
+                jitter: Jitter::None,
+            }
+            .validate(),
+            Ok(())
+        );
+        assert_eq!(
+            Backoff::Exponential {
+                base: Duration::from_nanos(1),
+                factor: BackoffFactor(1.0),
+                max: Duration::from_nanos(1),
+                jitter: Jitter::Equal,
+            }
+            .validate(),
+            Ok(())
+        );
+        assert_eq!(
+            ReadinessDeadline::Bounded(Duration::from_nanos(1)).validate_resolved(),
+            Ok(())
+        );
+        assert_eq!(
+            Intensity {
+                max_restarts: 0,
+                within: Duration::from_nanos(1),
+            }
+            .validate(),
+            Ok(())
+        );
     }
 }

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -24,7 +24,7 @@ use crate::{
         BuilderCore, ChildConstruction, LowerError, RemoveOutcome, ReserveError, ScopeConstruction,
         SlotCell,
     },
-    policy::{CommonOptions, ResolvedDefaults, ScopeFlavor},
+    policy::{CommonOptions, InvalidPolicy, ResolvedDefaults, ScopeFlavor},
     raw::{RawDef, RawOnceDef},
     runtime::{self, Latch},
     task::{OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
@@ -53,6 +53,9 @@ pub enum BuildError {
         /// Child-id paths of every undefined reservation.
         paths: Vec<Vec<ChildId>>,
     },
+    /// A public policy representation contained an invalid literal value.
+    #[error(transparent)]
+    InvalidPolicy(InvalidPolicy),
 }
 
 #[derive(Clone, Copy)]
@@ -533,6 +536,7 @@ fn spawn_builder<R>(
             LowerError::IdentityExhausted { .. } => {
                 unreachable!("root lowering does not mint memberships")
             }
+            LowerError::InvalidPolicy { invalid, .. } => BuildError::InvalidPolicy(invalid),
         })?;
     let scope_ref = ScopeRef { cell: root };
     let run = crate::driver::spawn_system(plan);

--- a/crates/shelterwood/tests/mod.rs
+++ b/crates/shelterwood/tests/mod.rs
@@ -15,6 +15,7 @@ mod mailbox;
 mod observation;
 mod offloads;
 mod one_shot_resource_ownership;
+mod policy_validation;
 mod raw;
 mod readiness;
 mod rebind;

--- a/crates/shelterwood/tests/policy_validation.rs
+++ b/crates/shelterwood/tests/policy_validation.rs
@@ -1,0 +1,406 @@
+use std::time::Duration;
+
+use shelterwood::{
+    Actor, ActorDef, Backoff, BackoffFactor, BuildError, ChildId, Context, DynamicTree, ExitError,
+    ExitKind, ExitResult, Intensity, InvalidPolicy, Jitter, PolicyError, PolicyField, RawActor,
+    RawContext, RawDef, Readiness, ReadinessDeadline, ReserveError, RestartCondition,
+    RestartPolicy, ScopeDefaults, StartupError, StartupFailureCause, SubtreeDef, SubtreeOnceDef,
+    TaskDef, Tree,
+};
+
+struct InertActor;
+
+impl Actor for InertActor {
+    type Msg = ();
+    type Args = ();
+
+    async fn init((): (), _context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): (), _context: &mut Context<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+}
+
+struct InertRaw;
+
+impl RawActor for InertRaw {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        context.shutdown_token().cancelled().await;
+        Ok(())
+    }
+}
+
+fn zero_fixed_restart() -> RestartPolicy {
+    RestartPolicy::new(
+        RestartCondition::Always,
+        Backoff::Fixed {
+            delay: Duration::ZERO,
+            jitter: Jitter::None,
+        },
+    )
+}
+
+fn reversed_exponential_restart() -> RestartPolicy {
+    RestartPolicy::new(
+        RestartCondition::Always,
+        Backoff::Exponential {
+            base: Duration::from_secs(2),
+            factor: BackoffFactor::new(2.0).expect("valid factor"),
+            max: Duration::from_secs(1),
+            jitter: Jitter::None,
+        },
+    )
+}
+
+fn assert_invalid(invalid: InvalidPolicy, path: &[&str], field: PolicyField, error: PolicyError) {
+    assert_eq!(
+        invalid.path,
+        path.iter().copied().map(ChildId::from).collect::<Vec<_>>()
+    );
+    assert_eq!(invalid.field, field);
+    assert_eq!(invalid.error, error);
+}
+
+fn build_invalid(tree: Tree) -> InvalidPolicy {
+    match tree.spawn() {
+        Err(BuildError::InvalidPolicy(invalid)) => invalid,
+        Err(other) => panic!("expected invalid policy, got {other:?}"),
+        Ok(_) => panic!("invalid policy unexpectedly built"),
+    }
+}
+
+fn admission_invalid(error: ReserveError) -> InvalidPolicy {
+    match error {
+        ReserveError::InvalidPolicy(invalid) => invalid,
+        other => panic!("expected invalid policy, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn static_build_revalidates_actor_task_raw_and_subtree_literals() {
+    let mut actor = Tree::new();
+    actor
+        .add_actor(
+            "actor",
+            ActorDef::<InertActor>::cloned(())
+                .readiness_deadline(ReadinessDeadline::Bounded(Duration::ZERO)),
+        )
+        .expect("valid id");
+    assert_invalid(
+        build_invalid(actor),
+        &["actor"],
+        PolicyField::ReadinessDeadline,
+        PolicyError::ZeroDuration,
+    );
+
+    let mut task = Tree::new();
+    task.add_task(
+        "task",
+        TaskDef::new(|_| async { Ok(()) }).restart(zero_fixed_restart()),
+    )
+    .expect("valid id");
+    assert_invalid(
+        build_invalid(task),
+        &["task"],
+        PolicyField::RestartBackoff,
+        PolicyError::ZeroDuration,
+    );
+
+    let mut raw = Tree::new();
+    raw.add_raw(
+        "raw",
+        RawDef::factory(|| InertRaw).restart(reversed_exponential_restart()),
+    )
+    .expect("valid id");
+    assert_invalid(
+        build_invalid(raw),
+        &["raw"],
+        PolicyField::RestartBackoff,
+        PolicyError::BackoffMaximumBeforeBase,
+    );
+
+    let mut subtree = Tree::new();
+    subtree
+        .add_subtree(
+            "subtree",
+            SubtreeDef::factory(Tree::new)
+                .readiness_deadline(ReadinessDeadline::Bounded(Duration::ZERO)),
+        )
+        .expect("valid id");
+    assert_invalid(
+        build_invalid(subtree),
+        &["subtree"],
+        PolicyField::ReadinessDeadline,
+        PolicyError::ZeroDuration,
+    );
+}
+
+#[tokio::test]
+async fn static_build_revalidates_scope_defaults_and_owned_nested_policy() {
+    let mut intensity = Tree::new();
+    intensity.intensity(Intensity {
+        max_restarts: 1,
+        within: Duration::ZERO,
+    });
+    assert_invalid(
+        build_invalid(intensity),
+        &[],
+        PolicyField::Intensity,
+        PolicyError::ZeroDuration,
+    );
+
+    let mut defaults = Tree::new();
+    defaults.defaults(ScopeDefaults {
+        child_restart: Some(zero_fixed_restart()),
+        ..ScopeDefaults::default()
+    });
+    assert_invalid(
+        build_invalid(defaults),
+        &[],
+        PolicyField::RestartBackoff,
+        PolicyError::ZeroDuration,
+    );
+
+    let mut nested = Tree::new();
+    nested.intensity(Intensity {
+        max_restarts: 1,
+        within: Duration::ZERO,
+    });
+    let mut root = Tree::new();
+    root.add_subtree_once("nested", SubtreeOnceDef::new(nested))
+        .expect("valid id");
+    assert_invalid(
+        build_invalid(root),
+        &["nested"],
+        PolicyField::Intensity,
+        PolicyError::ZeroDuration,
+    );
+}
+
+#[tokio::test]
+async fn dynamic_admission_revalidates_actor_task_raw_and_subtree_literals() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+
+    let actor = scope
+        .add_actor(
+            "actor",
+            ActorDef::<InertActor>::cloned(())
+                .readiness_deadline(ReadinessDeadline::Bounded(Duration::ZERO)),
+        )
+        .await
+        .expect_err("zero actor deadline is rejected");
+    assert_invalid(
+        admission_invalid(actor),
+        &["actor"],
+        PolicyField::ReadinessDeadline,
+        PolicyError::ZeroDuration,
+    );
+
+    let task = scope
+        .add_task(
+            "task",
+            TaskDef::new(|_| async { Ok(()) }).restart(zero_fixed_restart()),
+        )
+        .await
+        .expect_err("zero task backoff is rejected");
+    assert_invalid(
+        admission_invalid(task),
+        &["task"],
+        PolicyField::RestartBackoff,
+        PolicyError::ZeroDuration,
+    );
+
+    let raw = scope
+        .add_raw(
+            "raw",
+            RawDef::factory(|| InertRaw).restart(reversed_exponential_restart()),
+        )
+        .await
+        .expect_err("reversed raw backoff is rejected");
+    assert_invalid(
+        admission_invalid(raw),
+        &["raw"],
+        PolicyField::RestartBackoff,
+        PolicyError::BackoffMaximumBeforeBase,
+    );
+
+    let subtree = scope
+        .add_subtree(
+            "subtree",
+            SubtreeDef::factory(Tree::new)
+                .readiness_deadline(ReadinessDeadline::Bounded(Duration::ZERO)),
+        )
+        .await
+        .expect_err("zero subtree deadline is rejected");
+    assert_invalid(
+        admission_invalid(subtree),
+        &["subtree"],
+        PolicyField::ReadinessDeadline,
+        PolicyError::ZeroDuration,
+    );
+
+    let split = scope.reserve_task("split").expect("valid reservation");
+    let split = split
+        .define(TaskDef::new(|_| async { Ok(()) }).restart(zero_fixed_restart()))
+        .await
+        .expect_err("split definition validates at admission");
+    assert_invalid(
+        admission_invalid(split),
+        &["split"],
+        PolicyField::RestartBackoff,
+        PolicyError::ZeroDuration,
+    );
+
+    scope
+        .reserve_task("split")
+        .expect("rejected admission releases the id");
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[tokio::test]
+async fn dynamic_owned_subtree_policy_is_rejected_before_incarnation_start() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+    let mut nested = Tree::new();
+    nested.intensity(Intensity {
+        max_restarts: 0,
+        within: Duration::ZERO,
+    });
+
+    let error = scope
+        .add_subtree_once("nested", SubtreeOnceDef::new(nested))
+        .await
+        .expect_err("owned invalid subtree is rejected at admission");
+    assert_invalid(
+        admission_invalid(error),
+        &["nested"],
+        PolicyField::Intensity,
+        PolicyError::ZeroDuration,
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[tokio::test]
+async fn restartable_subtree_factory_output_reports_structured_policy_failure() {
+    let mut root = Tree::new();
+    root.add_subtree(
+        "nested",
+        SubtreeDef::factory(|| {
+            let mut nested = Tree::new();
+            nested.intensity(Intensity {
+                max_restarts: 1,
+                within: Duration::ZERO,
+            });
+            nested
+        })
+        .restart(RestartPolicy::new(
+            RestartCondition::Never,
+            Backoff::Immediate,
+        )),
+    )
+    .expect("valid subtree edge");
+    let system = root
+        .spawn()
+        .expect("factory output is produced after root lowering");
+    let StartupError::StartupFailed(failure) = system
+        .wait_started()
+        .await
+        .expect_err("factory output fails policy validation")
+    else {
+        panic!("expected structured startup failure");
+    };
+    let StartupFailureCause::Child { id, exit, .. } = failure.cause else {
+        panic!("root failure must name its nested child");
+    };
+    assert_eq!(id.as_str(), "nested");
+    let ExitKind::Failed(error) = exit.kind() else {
+        panic!("nested lowering is a child failure");
+    };
+    let nested = error
+        .startup_failure()
+        .expect("framework provenance is retained");
+    let StartupFailureCause::InvalidPolicy(invalid) = &nested.cause else {
+        panic!("nested failure must retain invalid-policy evidence");
+    };
+    assert_invalid(
+        invalid.clone(),
+        &[],
+        PolicyField::Intensity,
+        PolicyError::ZeroDuration,
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed root rolls back");
+}
+
+#[tokio::test]
+async fn minimum_valid_policy_literals_survive_lowering_and_admission() {
+    let factor = BackoffFactor::new(1.0).expect("minimum factor is valid");
+    let valid_restart = RestartPolicy::new(
+        RestartCondition::Always,
+        Backoff::Exponential {
+            base: Duration::from_nanos(1),
+            factor,
+            max: Duration::from_nanos(1),
+            jitter: Jitter::None,
+        },
+    );
+    let mut tree = DynamicTree::new();
+    tree.intensity(Intensity {
+        max_restarts: 0,
+        within: Duration::from_nanos(1),
+    });
+    tree.defaults(ScopeDefaults {
+        child_restart: Some(valid_restart),
+        readiness_deadline: Some(ReadinessDeadline::Inherit),
+        ..ScopeDefaults::default()
+    });
+    tree.add_actor(
+        "actor",
+        ActorDef::<InertActor>::cloned(())
+            .readiness(Readiness::Immediate)
+            .readiness_deadline(ReadinessDeadline::Bounded(Duration::from_nanos(1))),
+    )
+    .expect("minimum bounded deadline is valid");
+    tree.add_raw("raw", RawDef::factory(|| InertRaw).restart(valid_restart))
+        .expect("minimum exponential backoff is valid");
+    tree.add_task(
+        "task",
+        TaskDef::new(|context| async move {
+            context.shutdown_token().cancelled().await;
+            Ok(())
+        })
+        .restart(RestartPolicy::new(
+            RestartCondition::Always,
+            Backoff::Fixed {
+                delay: Duration::from_nanos(1),
+                jitter: Jitter::Equal,
+            },
+        )),
+    )
+    .expect("minimum fixed backoff is valid");
+
+    let system = tree.spawn().expect("valid edge policies lower");
+    system
+        .wait_started()
+        .await
+        .expect("valid edge policies start");
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}


### PR DESCRIPTION
Part of #56. Stacked on #74.

## Summary
- validate public readiness, intensity, backoff, defaults, and inherited policy literals before ownership transfer
- reject invalid static trees, dynamic admissions, nested one-shot trees, and runtime-produced subtrees with structured provenance
- revalidate resolved values so literal enum fields cannot bypass constructor checks
- preserve the shared static/dynamic ChildPlan construction funnel and cleanup ordering

## Verification
- table and integration coverage for every invalid literal/admission surface
- ./scripts/dev just ci (350/350 tests)
- ./scripts/dev just ci-nix
- git diff --check