### PR TITLE
Close standalone supervision races

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -406,9 +406,12 @@ pub(crate) fn remove_dynamic(
     // registration is reclaimed before the removal response completes.
     let member = Arc::clone(&entry.slot.member);
     // Dynamic-state protects admission/removal bookkeeping; the observation
-    // gate protects the public projection. Never nest the former around the
-    // latter: shutdown takes the same resources in the opposite order while
-    // clearing residents and closing dynamic state.
+    // gate protects the public projection. Release the former before entering
+    // the latter. No path takes the two in the opposite order, so this is not
+    // breaking an existing cycle; it keeps an unbounded wait out of the
+    // bookkeeping mutex. Any thread may hold the gate across arbitrary
+    // observation work, and blocking there while holding dynamic state would
+    // stall every concurrent reservation, removal, and driver admission.
     drop(state);
     scope.transition_child(&member, |record| record.removing = true, None);
     member.removal.fire();
@@ -2676,6 +2679,16 @@ async fn run_scope_incarnation(
             let class = driver_event_class(&event);
             pending.push((class, Pending::Driver(event)));
         }
+        // Disposal completions drain after the bounded lane, and `arbitrate`
+        // sorts stably, so a `ConstructionDisposed` always trails every
+        // same-class `Exited` collected in the same wake — even one produced
+        // later. A disposal is therefore a batch-tail event: the exit it
+        // trails may begin a drain first, after which
+        // `handle_construction_disposed` sees `is_draining` and routes the
+        // disposed child through stop progression instead of `fail_startup`.
+        // That is a widening of an order that was already reachable, not a new
+        // one: disposal runs on the blocking pool, so its completion never had
+        // a fixed position relative to concurrent exits.
         while let Some(event) = runtime::unbounded_mpsc_try_recv(&mut disposal_event_receiver) {
             let class = driver_event_class(&event);
             pending.push((class, Pending::Driver(event)));

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -405,9 +405,13 @@ pub(crate) fn remove_dynamic(
     // through the normal removal path, like live residents, so that
     // registration is reclaimed before the removal response completes.
     let member = Arc::clone(&entry.slot.member);
-    scope.transition_child(&member, |record| record.removing = true, None);
-    entry.slot.member.removal.fire();
+    // Dynamic-state protects admission/removal bookkeeping; the observation
+    // gate protects the public projection. Never nest the former around the
+    // latter: shutdown takes the same resources in the opposite order while
+    // clearing residents and closing dynamic state.
     drop(state);
+    scope.transition_child(&member, |record| record.removing = true, None);
+    member.removal.fire();
     scope.signal().pulse();
     response
 }
@@ -877,6 +881,7 @@ struct ScopeRuntime {
     intensity: IntensityState,
     children: ChildArena,
     events: runtime::MpscSender<DriverEvent>,
+    disposal_events: runtime::UnboundedMpscSender<DriverEvent>,
     deadlines: DeadlineQueue<DeadlineKind>,
     jitter: runtime::JitterRng,
     lifecycle: ScopeLifecycle,
@@ -1998,12 +2003,17 @@ impl ScopeRuntime {
         // The retained factory is user-owned. Destroy it on the blocking
         // pool. The disposal job itself owns completion, so cancellation or
         // failure to spawn an auxiliary async joiner cannot strand the child.
-        let sender = self.events.clone();
+        let sender = self.disposal_events.clone();
+        let signal = self.root.signal().clone();
         runtime::dispose_then(construction, move |panic| {
-            let _ = sender.blocking_send(DriverEvent::Child(ChildEvent::ConstructionDisposed {
-                child: key,
-                panic,
-            }));
+            if runtime::unbounded_mpsc_send(
+                &sender,
+                DriverEvent::Child(ChildEvent::ConstructionDisposed { child: key, panic }),
+            )
+            .is_ok()
+            {
+                signal.pulse();
+            }
         });
     }
 
@@ -2060,6 +2070,10 @@ impl ScopeRuntime {
     }
 
     fn fail_startup(&mut self, key: ChildKey, exit: Exit) {
+        // Several initial children can fail in one arbitration batch. The
+        // first failure owns the startup verdict and its sole lifecycle edge;
+        // later exits are still terminalized, but cannot republish the scope
+        // transition or replace the authoritative cause.
         let child = &self.children[key];
         let failure = StartupFailure {
             cause: StartupFailureCause::Child {
@@ -2542,6 +2556,7 @@ async fn run_scope_incarnation(
     }
     let capacity = plan.children.len().saturating_mul(3).max(64);
     let (events, mut event_receiver) = runtime::bounded_mpsc(capacity);
+    let (disposal_events, mut disposal_event_receiver) = runtime::unbounded_mpsc();
     let dynamic = (plan.root.flavor == ScopeFlavor::Dynamic)
         .then(|| DynamicControl::new(&root, events.clone()));
     if let Some(control) = &dynamic {
@@ -2587,6 +2602,7 @@ async fn run_scope_incarnation(
         intensity: IntensityState::default(),
         children,
         events,
+        disposal_events,
         deadlines: DeadlineQueue::default(),
         jitter: runtime::JitterRng::from_system_entropy(),
         lifecycle: ScopeLifecycle::starting(),
@@ -2657,6 +2673,10 @@ async fn run_scope_incarnation(
             ));
         }
         while let Some(event) = runtime::mpsc_try_recv(&mut event_receiver) {
+            let class = driver_event_class(&event);
+            pending.push((class, Pending::Driver(event)));
+        }
+        while let Some(event) = runtime::unbounded_mpsc_try_recv(&mut disposal_event_receiver) {
             let class = driver_event_class(&event);
             pending.push((class, Pending::Driver(event)));
         }
@@ -3099,6 +3119,7 @@ mod tests {
                 .collect(),
         );
         let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+        let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
         let mut children = ChildArena::default();
         plan.children.reverse();
         while let Some(child) = plan.children.pop() {
@@ -3114,6 +3135,7 @@ mod tests {
             intensity: super::IntensityState::default(),
             children,
             events,
+            disposal_events,
             deadlines: super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::from_system_entropy(),
             lifecycle: ScopeLifecycle::running(),
@@ -3233,6 +3255,7 @@ mod tests {
                 .collect(),
         );
         let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+        let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
         let mut children = ChildArena::default();
         plan.children.reverse();
         while let Some(child) = plan.children.pop() {
@@ -3256,6 +3279,7 @@ mod tests {
             intensity: super::IntensityState::default(),
             children,
             events,
+            disposal_events,
             deadlines: super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::from_system_entropy(),
             lifecycle: ScopeLifecycle::running(),
@@ -4206,6 +4230,89 @@ mod tests {
         assert_eq!(response.try_receive(), Some(RemoveOutcome::Removed));
     }
 
+    #[test]
+    fn reserve_dynamic_rejects_an_empty_id_at_the_driver_boundary() {
+        let root = isolated_scope("root", ScopeFlavor::Dynamic);
+
+        assert!(matches!(
+            super::reserve_dynamic(&root, ChildId::from(""), None),
+            Err(crate::ReserveError::EmptyId)
+        ));
+    }
+
+    #[test]
+    fn dynamic_removal_releases_state_before_waiting_for_the_observation_gate() {
+        let root = isolated_scope("root", ScopeFlavor::Dynamic);
+        let child_id = ChildId::from("worker");
+        let member = MemberCell::new(
+            child_id.clone(),
+            root.child_identity
+                .lock()
+                .expect("scope identity mutex poisoned")
+                .mint_membership(&child_id)
+                .expect("child membership available"),
+        );
+        let slot = SlotCell::new(Arc::clone(&member), None);
+        root.set_admitted_children(vec![resident_projection(&slot)]);
+        let (events, _receiver) = crate::runtime::bounded_mpsc(1);
+        let control = DynamicControl::new(&root, events);
+        control
+            .state
+            .lock()
+            .expect("dynamic-state mutex poisoned")
+            .entries
+            .insert(
+                child_id.clone(),
+                DynamicEntry {
+                    slot,
+                    admitted: true,
+                    fused_cancel: None,
+                    removal: Obligation::new(RemovalResponses::default(), complete_removals),
+                    removal_started: false,
+                },
+            );
+        root.set_dynamic_route(Some(super::DynamicRoute::new(Arc::clone(&control))));
+
+        let gate = root.observation_gate();
+        let held_gate = gate.lock().expect("observation gate starts healthy");
+        let baseline_member_owners = Arc::strong_count(&member);
+        let removal_root = Arc::clone(&root);
+        let removal_id = child_id.clone();
+        let worker =
+            std::thread::spawn(move || super::remove_dynamic(&removal_root, &removal_id, None));
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while Arc::strong_count(&member) == baseline_member_owners {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "removal reaches its observation transition"
+            );
+            std::thread::yield_now();
+        }
+        loop {
+            match control.state.try_lock() {
+                Ok(state) => {
+                    drop(state);
+                    break;
+                }
+                Err(std::sync::TryLockError::WouldBlock) => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "a removal blocked on observation must release dynamic state"
+                    );
+                    std::thread::yield_now();
+                }
+                Err(std::sync::TryLockError::Poisoned(_)) => {
+                    panic!("dynamic-state mutex poisoned")
+                }
+            }
+        }
+
+        drop(held_gate);
+        let response = worker.join().expect("removal transition completes");
+        drop(response);
+    }
+
     #[crate::runtime::test]
     async fn system_shutdown_joins_root_driver_teardown() {
         let system = DynamicTree::new().spawn().expect("runtime is available");
@@ -4270,7 +4377,8 @@ mod tests {
                 .map(|child| resident_projection(&child.slot))
                 .collect(),
         );
-        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(64);
+        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(1);
+        let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
         let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
         let mut children = ChildArena::default();
         let key = children
@@ -4283,6 +4391,7 @@ mod tests {
             intensity: super::IntensityState::default(),
             children,
             events,
+            disposal_events,
             deadlines: super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::from_system_entropy(),
             lifecycle: ScopeLifecycle::running(),
@@ -4323,6 +4432,17 @@ mod tests {
             None,
         );
 
+        assert!(
+            scope
+                .events
+                .try_send(DriverEvent::Child(ChildEvent::Ready {
+                    child: key,
+                    incarnation: first,
+                }))
+                .is_ok(),
+            "the bounded driver queue is deliberately saturated"
+        );
+
         scope.spawn_child(key);
         assert!(scope.children[key].is_disposing());
         assert!(matches!(
@@ -4331,13 +4451,18 @@ mod tests {
         ));
         assert_eq!(root.snapshot().children.len(), 1);
 
-        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = event_receiver
-            .recv()
-            .await
-            .expect("disposal reports completion")
+        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) =
+            disposal_event_receiver
+                .recv()
+                .await
+                .expect("disposal reports completion")
         else {
             panic!("only construction disposal was armed")
         };
+        assert!(matches!(
+            event_receiver.try_recv(),
+            Ok(DriverEvent::Child(ChildEvent::Ready { .. }))
+        ));
         scope.handle_construction_disposed(child, panic);
 
         assert!(!scope.children[key].is_disposing());
@@ -4375,7 +4500,8 @@ mod tests {
                 .map(|child| resident_projection(&child.slot))
                 .collect(),
         );
-        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(64);
+        let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+        let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
         let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
         let mut children = ChildArena::default();
         let key = children
@@ -4388,6 +4514,7 @@ mod tests {
             intensity: super::IntensityState::default(),
             children,
             events,
+            disposal_events,
             deadlines: super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::from_system_entropy(),
             lifecycle: ScopeLifecycle::starting(),
@@ -4425,10 +4552,11 @@ mod tests {
         scope.spawn_child(key);
         assert!(scope.children[key].is_disposing());
 
-        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = event_receiver
-            .recv()
-            .await
-            .expect("disposal reports completion")
+        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) =
+            disposal_event_receiver
+                .recv()
+                .await
+                .expect("disposal reports completion")
         else {
             panic!("only construction disposal was armed")
         };

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -14,6 +14,11 @@ use crate::{
 /// Number of lifecycle events retained independently for each subscriber.
 pub const LIFECYCLE_EVENT_CAPACITY: usize = 128;
 
+// Tokio rounds broadcast capacity up to a power of two. `try_recv` compares
+// receiver length with this requested capacity and therefore requires the
+// requested and effective capacities to remain equal.
+const _: () = assert!(LIFECYCLE_EVENT_CAPACITY.is_power_of_two());
+
 /// One item read from a lifecycle subscription.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -853,9 +853,15 @@ where
 
 pub(crate) type MpscSender<T> = mpsc::Sender<T>;
 pub(crate) type MpscReceiver<T> = mpsc::Receiver<T>;
+pub(crate) type UnboundedMpscSender<T> = mpsc::UnboundedSender<T>;
+pub(crate) type UnboundedMpscReceiver<T> = mpsc::UnboundedReceiver<T>;
 
 pub(crate) fn bounded_mpsc<T>(capacity: usize) -> (MpscSender<T>, MpscReceiver<T>) {
     mpsc::channel(capacity)
+}
+
+pub(crate) fn unbounded_mpsc<T>() -> (UnboundedMpscSender<T>, UnboundedMpscReceiver<T>) {
+    mpsc::unbounded_channel()
 }
 
 pub(crate) async fn mpsc_send<T>(sender: &MpscSender<T>, value: T) -> Result<(), T> {
@@ -863,6 +869,14 @@ pub(crate) async fn mpsc_send<T>(sender: &MpscSender<T>, value: T) -> Result<(),
 }
 
 pub(crate) fn mpsc_try_recv<T>(receiver: &mut MpscReceiver<T>) -> Option<T> {
+    receiver.try_recv().ok()
+}
+
+pub(crate) fn unbounded_mpsc_send<T>(sender: &UnboundedMpscSender<T>, value: T) -> Result<(), T> {
+    sender.send(value).map_err(|error| error.0)
+}
+
+pub(crate) fn unbounded_mpsc_try_recv<T>(receiver: &mut UnboundedMpscReceiver<T>) -> Option<T> {
     receiver.try_recv().ok()
 }
 

--- a/crates/shelterwood/tests/lifecycle.rs
+++ b/crates/shelterwood/tests/lifecycle.rs
@@ -10,8 +10,8 @@ use std::{
 use crate::common::{PanicOnDrop, ReleaseGate, assert_quiet, policy::never, poll_until};
 use shelterwood::{
     Actor, ActorOnceDef, Context, DynamicTree, ExitError, ExitKind, ExitResult, Intensity,
-    Readiness, Retention, Shutdown, StartupError, StartupFailureCause, StopReason, SubtreeOnceDef,
-    TaskDef, TaskOnceDef, Tree,
+    LifecycleEventKind, LifecycleItem, Readiness, Retention, ScopeState, Shutdown, StartupError,
+    StartupFailureCause, StopReason, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
 };
 
 #[tokio::test]
@@ -374,6 +374,77 @@ async fn dynamic_teardown_cancels_children_concurrently() {
         .await
         .expect("shutdown task joins")
         .expect("clean shutdown");
+}
+
+#[tokio::test]
+async fn concurrent_initial_failures_publish_one_startup_failed_scope_edge() {
+    let release = Arc::new(tokio::sync::Barrier::new(3));
+    let mut tree = DynamicTree::new();
+    for index in 0..2 {
+        tree.add_task(
+            format!("child-{index}"),
+            TaskDef::new({
+                let release = Arc::clone(&release);
+                move |_| {
+                    let release = Arc::clone(&release);
+                    async move {
+                        release.wait().await;
+                        Err(ExitError::message(format!("failure-{index}")))
+                    }
+                }
+            })
+            .restart(never())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness"),
+        )
+        .expect("valid task");
+    }
+
+    let system = tree.spawn().expect("runtime is available");
+    let mut lifecycle = system.scope().subscribe_lifecycle();
+    release.wait().await;
+
+    let mut exits = 0;
+    let mut startup_failed_edges = 0;
+    while exits < 2 {
+        let item = tokio::time::timeout(Duration::from_secs(2), lifecycle.recv())
+            .await
+            .expect("both concurrent exits are bounded")
+            .expect("the root lifecycle remains open");
+        let LifecycleItem::Event(event) = item else {
+            panic!("the small fixture cannot lag");
+        };
+        match event.kind {
+            LifecycleEventKind::Exited { .. } => exits += 1,
+            LifecycleEventKind::ScopeState {
+                state: ScopeState::StartupFailed,
+            } => startup_failed_edges += 1,
+            _ => {}
+        }
+    }
+    while let Ok(item) = lifecycle.try_recv() {
+        if matches!(
+            item,
+            LifecycleItem::Event(shelterwood::LifecycleEvent {
+                kind: LifecycleEventKind::ScopeState {
+                    state: ScopeState::StartupFailed,
+                },
+                ..
+            })
+        ) {
+            startup_failed_edges += 1;
+        }
+    }
+
+    assert_eq!(
+        startup_failed_edges, 1,
+        "the first initial failure owns the root startup transition"
+    );
+    assert!(system.wait_started().await.is_err());
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed dynamic root shuts down");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Part of #56. Stacked on #75.

## Summary
- assert the lifecycle event ring capacity is a power of two at compile time
- publish only the first root StartupFailed outcome under concurrent startup failures
- route construction disposal completion through a runtime-independent, nonblocking completion lane
- release dynamic-state locking before entering the observation transition gate
- exercise trusted-ID validation directly at the driver boundary

## Verification
- concurrent startup-failure, disposal fallback, lock-order, and EmptyId regressions
- ./scripts/dev just ci (353/353 tests)
- ./scripts/dev just ci-nix
- git diff --check