### PR TITLE
Trim mailbox and raw runtime machinery

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -30,22 +30,12 @@ use crate::{
 
 /// Isolated payload returned after mailbox termination has synchronously
 /// published all waiter outcomes.
-pub(crate) trait MailboxDisposal: Send {}
+pub(crate) type MailboxDisposal = Box<dyn Send>;
 
 /// Prepared terminal mailbox transition. Finishing it wakes terminal waiters
 /// before returning unread payload ownership for detached disposal.
 pub(crate) trait MailboxTermination: Send {
-    fn finish(self: Box<Self>) -> Option<Box<dyn MailboxDisposal>>;
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(crate) struct MailboxStats {
-    pub(crate) accepted: u64,
-    pub(crate) delivered: u64,
-    pub(crate) conflated: u64,
-    pub(crate) sends_rejected: u64,
-    pub(crate) depth: usize,
-    pub(crate) capacity: usize,
+    fn finish(self: Box<Self>) -> Option<MailboxDisposal>;
 }
 
 /// Type-erased mailbox lifecycle surface owned by a member cell.
@@ -57,13 +47,24 @@ pub(crate) struct MailboxStats {
 /// intentionally ignored.
 pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
     /// Installs the declaration-time mailbox policy before the first bind.
+    /// Reconfiguration may only repeat the same resolved policy.
     fn configure(&self, mailbox: Mailbox);
     /// Makes one incarnation live after configuration and prior-close cleanup.
+    /// A bind after terminal preparation is deliberately ignored because
+    /// terminality wins that race permanently.
     fn bind(&self, incarnation: Incarnation);
+    /// Stops new acceptance for the matching live incarnation.
     fn freeze(&self, incarnation: Incarnation);
-    fn close(&self, incarnation: Incarnation) -> Option<Box<dyn MailboxDisposal>>;
+    /// Unbinds the matching incarnation and returns its unread payload.
+    /// Every successful bind must be followed by this close before a rebind;
+    /// skipping it would deliver the old incarnation's messages to the new.
+    fn close(&self, incarnation: Incarnation) -> Option<MailboxDisposal>;
+    /// Irreversibly terminalizes the membership and prepares synchronous
+    /// waiter completion followed by isolated unread-payload disposal.
     fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>>;
-    fn stats(&self) -> MailboxStats;
+    /// Debug-only check for the driver's configure/close-before-bind contract.
+    #[cfg(debug_assertions)]
+    fn bind_order_valid(&self) -> bool;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -191,6 +192,11 @@ impl MemberCell {
             .store(pending, Ordering::Release);
     }
 
+    /// Mutates a member record and pulses the watch channel.
+    ///
+    /// The driver also treats this channel as its control-plane wake bus: any
+    /// field read by a loop precondition must be changed through a pulsing path
+    /// like this one, never by a silent write outside an observation gate.
     pub(crate) fn update(&self, update: impl FnOnce(&mut MemberRecord)) {
         self.record.send_modify(update);
     }
@@ -245,9 +251,9 @@ impl MemberCell {
     }
 
     pub(crate) fn terminalize(&self, exit: Exit) {
-        let (terminal_exit, mailbox) = {
+        let terminal_exit = {
             let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
-            let terminal_exit = if let Some(terminal_exit) = &state.terminal {
+            if let Some(terminal_exit) = &state.terminal {
                 terminal_exit.clone()
             } else {
                 let teardown = state
@@ -257,17 +263,9 @@ impl MemberCell {
                 state.terminal = Some(exit.clone());
                 state.teardown = teardown;
                 exit
-            };
-            (terminal_exit, state.control.clone())
+            }
         };
         self.publish_terminal(terminal_exit);
-        if let Some(mailbox) = mailbox {
-            let stats = mailbox.stats();
-            debug_assert!(stats.delivered <= stats.accepted);
-            debug_assert!(stats.conflated <= stats.accepted);
-            debug_assert!(stats.depth <= stats.capacity);
-            let _ = stats.sends_rejected;
-        }
     }
 
     fn publish_terminal(&self, terminal_exit: Exit) {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -98,6 +98,15 @@ pub(crate) struct ReportToken {
 
 pub(crate) struct ReportReceiver(mpsc::Receiver<RecordedReport>);
 
+/// Couples the child task's outcome report to its join verdict without an
+/// asynchronous handoff race.
+///
+/// `ReportToken` is owned by the child task and its fail-closed `Drop` sends a
+/// fallback synchronously. Rust drops those task locals before the join handle
+/// becomes ready, so the exit joiner may safely perform the blocking receive:
+/// a report has already been sent on every return, panic, and cancellation
+/// edge. The shutdown/local-stop latches are sampled by that same send, making
+/// the report and its cancellation evidence one ordered observation.
 pub(crate) fn report_channel(
     shutdown: Latch,
     local_stop: Option<Latch>,
@@ -1382,6 +1391,14 @@ impl ScopeRuntime {
             return;
         };
 
+        // Per-incarnation latch topology:
+        // - shutdown/abort flow from the ladder into application code;
+        // - ready and local_stop flow from application code back to helpers;
+        // - ended terminates those helpers when the child exits first;
+        // - construction_release keeps a raw actor behind the driver-owned
+        //   readiness transition after its construction report is accepted;
+        // - framework_abort/ack join nested-scope escalation before exit.
+        // Each edge is level-triggered, so helper startup cannot lose a pulse.
         let latches = SpawnLatches {
             shutdown: Latch::default(),
             abort: Latch::default(),
@@ -1401,6 +1418,11 @@ impl ScopeRuntime {
         let now = runtime::now();
         child.spawned_once = true;
         if let Some(mailbox) = child.slot.member.mailbox() {
+            #[cfg(debug_assertions)]
+            debug_assert!(
+                mailbox.bind_order_valid(),
+                "driver must configure before bind and close before rebind"
+            );
             mailbox.bind(incarnation);
         }
         self.root.transition_child(

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -6,7 +6,6 @@ use std::{
     future::Future,
     hash::{Hash, Hasher},
     num::NonZeroUsize,
-    panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll, Waker},
@@ -15,8 +14,11 @@ use std::{
 
 use crate::{
     ChildId, Incarnation, Mailbox, Membership,
-    cells::{MailboxControl, MailboxDisposal, MailboxStats, MailboxTermination, MemberCell},
-    runtime::{OneShotClose, OneShotReceiver, OneShotSender, Signal, SignalWatcher},
+    cells::{MailboxControl, MailboxDisposal, MailboxTermination, MemberCell},
+    runtime::{
+        OneShotClose, OneShotReceiver, OneShotSender, PanicAccumulator, PanicPayload, Signal,
+        SignalWatcher, resume_panic,
+    },
 };
 
 /// The kind of a failed actor send.
@@ -528,9 +530,6 @@ struct MailboxState<M> {
     latest: Option<Envelope<M>>,
     waiters: WaiterQueue<M>,
     accepted: u64,
-    delivered: u64,
-    conflated: u64,
-    sends_rejected: u64,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -630,6 +629,9 @@ impl<M: Send + 'static> Default for Promotion<M> {
 }
 
 impl<M: Send + 'static> Promotion<M> {
+    // Drop is the completion path on every ownership edge. `finish` only
+    // names the intentional consume point; its Drop still wakes all accepted
+    // senders and isolates every displaced-message destructor.
     fn finish(self) {}
 
     fn finish_isolated(mut self) {
@@ -647,24 +649,12 @@ impl<M: Send + 'static> Promotion<M> {
 
 impl<M: Send + 'static> Drop for Promotion<M> {
     fn drop(&mut self) {
-        let already_panicking = std::thread::panicking();
-        let mut first_panic = None;
+        let mut panics = PanicAccumulator::default();
         for waker in self.wakers.drain(..) {
-            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| waker.wake()))
-                && first_panic.is_none()
-            {
-                first_panic = Some(payload);
-            }
+            panics.run(|| waker.wake());
         }
         for displaced in self.displaced.drain(..) {
-            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| drop(displaced)))
-                && first_panic.is_none()
-            {
-                first_panic = Some(payload);
-            }
-        }
-        if !already_panicking && let Some(payload) = first_panic {
-            resume_unwind(payload);
+            panics.run(|| drop(displaced));
         }
     }
 }
@@ -675,25 +665,19 @@ struct Termination<M> {
 }
 
 impl<M> Termination<M> {
-    fn finish(
-        &mut self,
-        retired: &mut Vec<Arc<SendOperation<M>>>,
-    ) -> Option<Box<dyn std::any::Any + Send + 'static>> {
-        let mut first_panic = None;
+    fn finish(&mut self, retired: &mut Vec<Arc<SendOperation<M>>>) -> Option<PanicPayload> {
+        let mut panics = PanicAccumulator::default();
         let final_incarnation = self.final_incarnation;
         while let Some((registration, waiter)) = self.waiters.pop_front() {
             waiter.clear_registration(registration);
-            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| {
+            panics.run(|| {
                 waiter.terminate(final_incarnation);
-            })) && first_panic.is_none()
-            {
-                first_panic = Some(payload);
-            }
+            });
             // A withdrawn sender may leave this as the final operation owner,
             // so retain it for the same isolated path as unread messages.
             retired.push(waiter);
         }
-        first_panic
+        panics.take()
     }
 }
 
@@ -705,37 +689,20 @@ struct MailboxPayload<M> {
 
 impl<M> Drop for MailboxPayload<M> {
     fn drop(&mut self) {
-        let already_panicking = std::thread::panicking();
-        let mut first_panic = None;
+        let mut panics = PanicAccumulator::default();
         if let Some(mut queue) = self.queue.take() {
             while let Some(envelope) = queue.pop_front() {
-                if let Err(payload) = catch_unwind(AssertUnwindSafe(|| drop(envelope)))
-                    && first_panic.is_none()
-                {
-                    first_panic = Some(payload);
-                }
+                panics.run(|| drop(envelope));
             }
         }
-        if let Some(latest) = self.latest.take()
-            && let Err(payload) = catch_unwind(AssertUnwindSafe(|| drop(latest)))
-            && first_panic.is_none()
-        {
-            first_panic = Some(payload);
+        if let Some(latest) = self.latest.take() {
+            panics.run(|| drop(latest));
         }
         for waiter in self.retired.drain(..) {
-            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| drop(waiter)))
-                && first_panic.is_none()
-            {
-                first_panic = Some(payload);
-            }
-        }
-        if !already_panicking && let Some(payload) = first_panic {
-            resume_unwind(payload);
+            panics.run(|| drop(waiter));
         }
     }
 }
-
-impl<M: Send> MailboxDisposal for MailboxPayload<M> {}
 
 struct MailboxTeardown<M: Send + 'static> {
     changed: Option<Signal>,
@@ -744,35 +711,30 @@ struct MailboxTeardown<M: Send + 'static> {
 }
 
 impl<M: Send + 'static> MailboxTeardown<M> {
-    fn finish_framework(&mut self) -> Option<Box<dyn std::any::Any + Send + 'static>> {
-        let mut first_panic = None;
-        if let Some(changed) = self.changed.take()
-            && let Err(payload) = catch_unwind(AssertUnwindSafe(|| changed.pulse()))
-        {
-            first_panic = Some(payload);
+    fn finish_framework(&mut self) -> Option<PanicPayload> {
+        let mut panics = PanicAccumulator::default();
+        if let Some(changed) = self.changed.take() {
+            panics.run(|| changed.pulse());
         }
         if let Some(mut termination) = self.termination.take() {
-            let panic = termination.finish(&mut self.payload.get_mut().retired);
-            if first_panic.is_none() {
-                first_panic = panic;
-            }
+            panics.record(termination.finish(&mut self.payload.get_mut().retired));
         }
-        first_panic
+        panics.take()
     }
 }
 
 impl<M: Send + 'static> MailboxTermination for MailboxTeardown<M> {
-    fn finish(mut self: Box<Self>) -> Option<Box<dyn MailboxDisposal>> {
+    fn finish(mut self: Box<Self>) -> Option<MailboxDisposal> {
         let panic = self.finish_framework();
         let payload = self
             .payload
             .take()
-            .map(|payload| Box::new(payload) as Box<dyn MailboxDisposal>);
+            .map(|payload| Box::new(payload) as MailboxDisposal);
         if let Some(panic) = panic {
             if let Some(payload) = payload {
                 crate::runtime::dispose_detached(payload);
             }
-            resume_unwind(panic);
+            resume_panic(panic);
         }
         payload
     }
@@ -780,13 +742,10 @@ impl<M: Send + 'static> MailboxTermination for MailboxTeardown<M> {
 
 impl<M: Send + 'static> Drop for MailboxTeardown<M> {
     fn drop(&mut self) {
-        let already_panicking = std::thread::panicking();
-        let panic = self.finish_framework();
+        let mut panics = PanicAccumulator::default();
+        panics.record(self.finish_framework());
         if let Some(payload) = self.payload.take() {
             crate::runtime::dispose_detached(payload);
-        }
-        if !already_panicking && let Some(panic) = panic {
-            resume_unwind(panic);
         }
     }
 }
@@ -818,9 +777,6 @@ impl<M: Send + 'static> MailboxCell<M> {
                 latest: None,
                 waiters: WaiterQueue::default(),
                 accepted: 0,
-                delivered: 0,
-                conflated: 0,
-                sends_rejected: 0,
             }),
             changed: Signal::default(),
         })
@@ -856,16 +812,10 @@ impl<M: Send + 'static> MailboxCell<M> {
                             });
                             None
                         }
-                        Some(MailboxKind::Latest) => {
-                            let displaced = state.latest.replace(Envelope {
-                                message,
-                                accepted_sequence,
-                            });
-                            state.conflated = state
-                                .conflated
-                                .saturating_add(u64::from(displaced.is_some()));
-                            displaced
-                        }
+                        Some(MailboxKind::Latest) => state.latest.replace(Envelope {
+                            message,
+                            accepted_sequence,
+                        }),
                         None => unreachable!(),
                     };
                     drop(state);
@@ -889,38 +839,28 @@ impl<M: Send + 'static> MailboxCell<M> {
     fn try_send(&self, message: M) -> Result<Incarnation, SendError<M>> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         match state.status {
-            BindingStatus::Terminal(final_incarnation) => {
-                state.sends_rejected = state.sends_rejected.saturating_add(1);
-                Err(SendError {
-                    actor_id: self.actor_id.clone(),
-                    incarnation_observed: final_incarnation,
-                    message,
-                    kind: SendErrorKind::Terminated,
-                })
-            }
-            BindingStatus::Unbound => {
-                state.sends_rejected = state.sends_rejected.saturating_add(1);
-                Err(SendError {
-                    actor_id: self.actor_id.clone(),
-                    incarnation_observed: None,
-                    message,
-                    kind: SendErrorKind::NotRunning,
-                })
-            }
-            BindingStatus::Frozen(incarnation) => {
-                state.sends_rejected = state.sends_rejected.saturating_add(1);
-                Err(SendError {
-                    actor_id: self.actor_id.clone(),
-                    incarnation_observed: Some(incarnation),
-                    message,
-                    kind: SendErrorKind::NotRunning,
-                })
-            }
+            BindingStatus::Terminal(final_incarnation) => Err(SendError {
+                actor_id: self.actor_id.clone(),
+                incarnation_observed: final_incarnation,
+                message,
+                kind: SendErrorKind::Terminated,
+            }),
+            BindingStatus::Unbound => Err(SendError {
+                actor_id: self.actor_id.clone(),
+                incarnation_observed: None,
+                message,
+                kind: SendErrorKind::NotRunning,
+            }),
+            BindingStatus::Frozen(incarnation) => Err(SendError {
+                actor_id: self.actor_id.clone(),
+                incarnation_observed: Some(incarnation),
+                message,
+                kind: SendErrorKind::NotRunning,
+            }),
             BindingStatus::Bound(incarnation) => match state.kind {
                 Some(MailboxKind::Queue(capacity))
                     if !state.waiters.is_empty() || state.queue.len() >= capacity.get() =>
                 {
-                    state.sends_rejected = state.sends_rejected.saturating_add(1);
                     Err(SendError {
                         actor_id: self.actor_id.clone(),
                         incarnation_observed: Some(incarnation),
@@ -946,23 +886,17 @@ impl<M: Send + 'static> MailboxCell<M> {
                         message,
                         accepted_sequence,
                     });
-                    state.conflated = state
-                        .conflated
-                        .saturating_add(u64::from(displaced.is_some()));
                     drop(state);
                     self.changed.pulse();
                     drop(displaced);
                     Ok(incarnation)
                 }
-                None => {
-                    state.sends_rejected = state.sends_rejected.saturating_add(1);
-                    Err(SendError {
-                        actor_id: self.actor_id.clone(),
-                        incarnation_observed: None,
-                        message,
-                        kind: SendErrorKind::NotRunning,
-                    })
-                }
+                None => Err(SendError {
+                    actor_id: self.actor_id.clone(),
+                    incarnation_observed: None,
+                    message,
+                    kind: SendErrorKind::NotRunning,
+                }),
             },
         }
     }
@@ -1008,7 +942,6 @@ impl<M: Send + 'static> MailboxCell<M> {
         } else {
             Promotion::default()
         };
-        state.delivered = state.delivered.saturating_add(u64::from(message.is_some()));
         drop(state);
         if message.is_some() {
             self.changed.pulse();
@@ -1030,21 +963,8 @@ impl<M: Send + 'static> MailboxCell<M> {
         self.changed.watcher()
     }
 
-    pub(crate) fn stats(&self) -> MailboxStats {
-        let state = self.state.lock().expect("mailbox mutex poisoned");
-        let (depth, capacity) = match state.kind {
-            Some(MailboxKind::Queue(capacity)) => (state.queue.len(), capacity.get()),
-            Some(MailboxKind::Latest) => (usize::from(state.latest.is_some()), 1),
-            None => (0, 0),
-        };
-        MailboxStats {
-            accepted: state.accepted,
-            delivered: state.delivered,
-            conflated: state.conflated,
-            sends_rejected: state.sends_rejected,
-            depth,
-            capacity,
-        }
+    fn accepted_sequence(&self) -> u64 {
+        self.state.lock().expect("mailbox mutex poisoned").accepted
     }
 }
 
@@ -1168,7 +1088,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         }
     }
 
-    fn close(&self, incarnation: Incarnation) -> Option<Box<dyn MailboxDisposal>> {
+    fn close(&self, incarnation: Incarnation) -> Option<MailboxDisposal> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         if !matches!(
             state.status,
@@ -1186,7 +1106,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             queue: Some(queue),
             latest,
             retired: Vec::new(),
-        }))
+        }) as MailboxDisposal)
     }
 
     fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>> {
@@ -1215,8 +1135,14 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         }))
     }
 
-    fn stats(&self) -> MailboxStats {
-        self.stats()
+    #[cfg(debug_assertions)]
+    fn bind_order_valid(&self) -> bool {
+        let state = self.state.lock().expect("mailbox mutex poisoned");
+        state.kind.is_some()
+            && matches!(
+                state.status,
+                BindingStatus::Unbound | BindingStatus::Terminal(_)
+            )
     }
 }
 
@@ -1257,7 +1183,6 @@ fn promote_waiters<M: Send + 'static>(state: &mut MailboxState<M>) -> Promotion<
                     message,
                     accepted_sequence,
                 }) {
-                    state.conflated = state.conflated.saturating_add(1);
                     promotion.displaced.push(displaced);
                 }
             }
@@ -1771,7 +1696,7 @@ impl<M: Send + 'static> MailboxReceiver<M> {
     }
 
     pub(crate) fn accepted_sequence(&self) -> u64 {
-        self.mailbox.stats().accepted
+        self.mailbox.accepted_sequence()
     }
 
     pub(crate) async fn changed(&mut self) {
@@ -1842,6 +1767,26 @@ mod tests {
             .expect("incarnation available");
 
         MailboxControl::bind(&*mailbox, incarnation);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "mailbox must close the prior incarnation before rebinding")]
+    fn rebinding_before_close_trips_the_driver_contract() {
+        let (mailbox, _) = actor();
+        MailboxControl::configure(&*mailbox, Mailbox::default());
+        let mut identity = ScopeIdentity::new();
+        let membership = identity
+            .mint_membership(&ChildId::from("actor"))
+            .expect("membership available");
+        let mut incarnations = identity.incarnation_counter(membership);
+        let first = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
+            .expect("first incarnation available");
+        let second = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
+            .expect("second incarnation available");
+
+        MailboxControl::bind(&*mailbox, first);
+        MailboxControl::bind(&*mailbox, second);
     }
 
     #[test]

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -110,6 +110,9 @@ enum DefinitionState {
     Lowered,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct DefinitionAlreadyLowered;
+
 /// Stable declaration slot joining identity, observation, and owned construction.
 pub(crate) struct SlotCell {
     pub(crate) member: Arc<MemberCell>,
@@ -145,27 +148,17 @@ impl SlotCell {
         )
     }
 
-    pub(crate) fn take_definition(&self) -> Option<Isolated<ChildConstruction>> {
+    pub(crate) fn take_definition(
+        &self,
+    ) -> Result<Option<Isolated<ChildConstruction>>, DefinitionAlreadyLowered> {
         let mut state = self.definition.lock().expect("definition mutex poisoned");
         match std::mem::replace(&mut *state, DefinitionState::Lowered) {
-            DefinitionState::Defined(definition) => Some(definition),
+            DefinitionState::Defined(definition) => Ok(Some(definition)),
             DefinitionState::Undefined => {
                 *state = DefinitionState::Undefined;
-                None
+                Ok(None)
             }
-            DefinitionState::Lowered => panic!("a tree was lowered more than once"),
-        }
-    }
-
-    pub(crate) fn take_defined(&self) -> Option<Isolated<ChildConstruction>> {
-        let mut state = self.definition.lock().expect("definition mutex poisoned");
-        match std::mem::replace(&mut *state, DefinitionState::Lowered) {
-            DefinitionState::Defined(definition) => Some(definition),
-            DefinitionState::Undefined => {
-                *state = DefinitionState::Undefined;
-                None
-            }
-            DefinitionState::Lowered => None,
+            DefinitionState::Lowered => Err(DefinitionAlreadyLowered),
         }
     }
 
@@ -183,7 +176,7 @@ impl SlotCell {
 
     /// Claims an unlowered definition and publishes never-started terminality.
     pub(crate) fn take_never_started(&self) -> Option<Isolated<ChildConstruction>> {
-        let definition = self.take_defined();
+        let definition = self.take_definition().ok().flatten();
         self.terminalize_never_started();
         definition
     }
@@ -269,7 +262,7 @@ impl BuilderCore {
         let definitions = self
             .slots
             .iter()
-            .filter_map(|slot| slot.take_defined())
+            .filter_map(|slot| slot.take_definition().ok().flatten())
             .filter_map(|mut definition| definition.take())
             .collect();
         runtime::dispose_all(definitions)
@@ -364,6 +357,7 @@ impl BuilderCore {
             let resolved = resolved.expect("validated slot must have resolved options");
             let definition = slot
                 .take_definition()
+                .expect("a tree must be lowered at most once")
                 .expect("validated slot must have a definition");
             children.push(ChildPlan::with_options(
                 Arc::clone(slot),
@@ -562,6 +556,7 @@ mod tests {
             .expect("dynamic slot is defined");
         let dynamic_definition = dynamic_slot
             .take_definition()
+            .expect("dynamic slot must not already be lowered")
             .expect("dynamic slot remains claimable");
         let dynamic_plan =
             ChildPlan::with_options(dynamic_slot, dynamic_definition, dynamic_options);
@@ -583,7 +578,7 @@ mod tests {
         let competing_race = Arc::clone(&race);
         let competing_claim = std::thread::spawn(move || {
             competing_race.wait();
-            competing_slot.take_defined()
+            competing_slot.take_definition().ok().flatten()
         });
 
         let claim = slot
@@ -635,6 +630,7 @@ mod tests {
             .expect("one-shot slot is defined");
         let construction = slot
             .take_definition()
+            .expect("one-shot slot must not already be lowered")
             .expect("one-shot slot remains claimable");
         let plan = ChildPlan::with_options(slot, construction, options);
         assert!(plan.options.restart.is_never());

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -823,6 +823,13 @@ mod tests {
     }
 
     #[test]
+    fn restart_policy_is_never_matches_only_the_never_condition() {
+        assert!(RestartPolicy::new(RestartCondition::Never, Backoff::Immediate).is_never());
+        assert!(!RestartPolicy::new(RestartCondition::OnFailure, Backoff::Immediate).is_never());
+        assert!(!RestartPolicy::new(RestartCondition::Always, Backoff::Immediate).is_never());
+    }
+
+    #[test]
     fn defaults_overlay_as_one_value_and_mailbox_capacity_resolves_by_kind() {
         let library = ResolvedDefaults::default();
         let latest = library

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -22,6 +22,7 @@ use crate::{
     runtime::{
         self, ActorWork, Latch, PanicAccumulator, PanicPayload, Signal, SignalWatcher, catch_panic,
         discard_panic, keep_first_panic, resume_preferred_panic,
+        resume_preferred_panic_outside_unwind,
     },
 };
 
@@ -729,7 +730,10 @@ impl<M> RawResources<M> {
     }
 
     fn resume_pending_panic(&self) {
-        resume_preferred_panic(self.panic.take(), None);
+        // Reached from the actor's own receive path, never from cleanup. The
+        // take is destructive, so containment here would drop the retained
+        // offload diagnostic and let the loop keep running.
+        resume_preferred_panic_outside_unwind(self.panic.take(), None);
     }
 
     async fn join_offloads(&mut self) {
@@ -1590,8 +1594,12 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
             let actor_drop = catch_panic(|| owner.drop_actor()).err();
             keep_first_panic(&mut cleanup_panic, actor_drop);
             // Once actor execution has panicked, teardown is secondary: never
-            // replace the actor's original diagnostic.
-            resume_preferred_panic(owner.take_primary_panic(), cleanup_panic);
+            // replace the actor's original diagnostic. This is the incarnation
+            // body's normal return path, so the resume must be unconditional:
+            // containing the primary payload here would strand `result` at
+            // `None` and report the actor's panic as the framework expect
+            // below.
+            resume_preferred_panic_outside_unwind(owner.take_primary_panic(), cleanup_panic);
             result.expect("an incarnation without a primary panic returns a result")
         })
     }
@@ -1665,7 +1673,9 @@ mod tests {
         EventQueue, OffloadResource, PanicSlot, QueuedEvent, RawResources, SharedOffloadFuture,
         SharedOffloadState,
     };
-    use crate::runtime::{Latch, PanicPayload, Signal, resume_preferred_panic};
+    use crate::runtime::{
+        Latch, PanicPayload, Signal, resume_preferred_panic, resume_preferred_panic_outside_unwind,
+    };
 
     fn marker(value: usize) -> QueuedEvent<usize> {
         QueuedEvent {
@@ -1695,6 +1705,23 @@ mod tests {
         }))
         .expect_err("the primary panic is resumed");
         assert_eq!(panic_message(&payload), Some("primary actor panic"));
+    }
+
+    #[test]
+    fn the_incarnation_return_path_resumes_a_primary_panic_it_solely_owns() {
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            resume_preferred_panic_outside_unwind(Some(Box::new("primary actor panic")), None);
+        }))
+        .expect_err("a sole-owned primary panic is never contained");
+        assert_eq!(panic_message(&payload), Some("primary actor panic"));
+
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            resume_preferred_panic_outside_unwind(None, Some(Box::new("cleanup panic")));
+        }))
+        .expect_err("cleanup stands in when there is no primary panic");
+        assert_eq!(panic_message(&payload), Some("cleanup panic"));
+
+        resume_preferred_panic_outside_unwind(None, None);
     }
 
     struct BlockingPollDrop {

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -6,7 +6,6 @@ use std::{
     fmt,
     future::Future,
     hash::{BuildHasher, Hash},
-    panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context as TaskPollContext, Poll},
@@ -20,37 +19,15 @@ use crate::{
     definition::DefinitionSource,
     mailbox::{MailboxCell, MailboxReceiver},
     policy::CommonOptions,
-    runtime::{self, ActorWork, Latch, Signal, SignalWatcher},
+    runtime::{
+        self, ActorWork, Latch, PanicAccumulator, PanicPayload, Signal, SignalWatcher, catch_panic,
+        discard_panic, keep_first_panic, resume_preferred_panic,
+    },
 };
 
-type PanicPayload = Box<dyn Any + Send + 'static>;
 type DeferredMessage<M> = Box<dyn FnOnce() -> M + Send + 'static>;
 type OffloadFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 type SharedWork = Arc<SharedOffloadState>;
-
-fn discard_panic(payload: Option<PanicPayload>) {
-    if let Some(payload) = payload {
-        let _ = catch_unwind(AssertUnwindSafe(|| drop(payload)));
-    }
-}
-
-fn keep_first_panic(first: &mut Option<PanicPayload>, candidate: Option<PanicPayload>) {
-    if first.is_none() {
-        *first = candidate;
-    } else {
-        discard_panic(candidate);
-    }
-}
-
-fn resume_preferred_panic(primary: Option<PanicPayload>, cleanup: Option<PanicPayload>) {
-    if let Some(payload) = primary {
-        discard_panic(cleanup);
-        resume_unwind(payload);
-    }
-    if let Some(payload) = cleanup {
-        resume_unwind(payload);
-    }
-}
 
 /// Marker returned to an offload continuation when its one deadline expires.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
@@ -202,17 +179,17 @@ impl<F: Future> Future for CatchUnwindFuture<F> {
 
     fn poll(self: Pin<&mut Self>, context: &mut TaskPollContext<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
-        let polled = catch_unwind(AssertUnwindSafe(|| {
+        let polled = catch_panic(|| {
             this.future
                 .as_mut()
                 .expect("a completed panic boundary was polled again")
                 .as_mut()
                 .poll(context)
-        }));
+        });
         match polled {
             Ok(Poll::Ready(value)) => {
                 let future = this.future.take();
-                match catch_unwind(AssertUnwindSafe(|| drop(future))) {
+                match catch_panic(|| drop(future)) {
                     Ok(()) => Poll::Ready(Ok(value)),
                     Err(payload) => Poll::Ready(Err(payload)),
                 }
@@ -220,7 +197,7 @@ impl<F: Future> Future for CatchUnwindFuture<F> {
             Ok(Poll::Pending) => Poll::Pending,
             Err(payload) => {
                 let future = this.future.take();
-                let _ = catch_unwind(AssertUnwindSafe(|| drop(future)));
+                discard_panic(catch_panic(|| drop(future)).err());
                 Poll::Ready(Err(payload))
             }
         }
@@ -229,20 +206,15 @@ impl<F: Future> Future for CatchUnwindFuture<F> {
 
 impl<F> Drop for CatchUnwindFuture<F> {
     fn drop(&mut self) {
-        let already_panicking = std::thread::panicking();
         let future = self.future.take();
-        let panic = catch_unwind(AssertUnwindSafe(|| drop(future))).err();
-        if !already_panicking && let Some(payload) = panic {
-            resume_unwind(payload);
-        }
+        let mut panics = PanicAccumulator::default();
+        panics.run(|| drop(future));
     }
 }
 
-enum QueuedEvent<M> {
-    Deliver {
-        cancellation: Latch,
-        make_message: DeferredMessage<M>,
-    },
+struct QueuedEvent<M> {
+    cancellation: Latch,
+    make_message: DeferredMessage<M>,
 }
 
 #[derive(Default)]
@@ -372,7 +344,7 @@ impl<K: Send + 'static> ErasedTimerKey for StoredTimerKey<K> {
 }
 
 enum TimerMessage<M> {
-    Once(Option<M>),
+    Once(M),
     Interval(Box<dyn Fn() -> M + Send + 'static>),
 }
 
@@ -622,7 +594,7 @@ impl SharedOffloadState {
 
     fn dispose(&self, future: Option<OffloadFuture>) {
         if let Some(future) = future {
-            match catch_unwind(AssertUnwindSafe(|| drop(future))) {
+            match catch_panic(|| drop(future)) {
                 Ok(()) => {}
                 Err(payload) => self.record(payload),
             }
@@ -653,7 +625,7 @@ impl Future for SharedOffloadFuture {
         let Some(mut future) = self.0.take_for_poll() else {
             return Poll::Ready(());
         };
-        let polled = catch_unwind(AssertUnwindSafe(|| future.as_mut().poll(context)));
+        let polled = catch_panic(|| future.as_mut().poll(context));
         match polled {
             Ok(Poll::Pending) => {
                 let dispose = self.0.finish_poll(future, true);
@@ -705,6 +677,9 @@ impl OffloadResource {
 struct RawResources<M> {
     accepting: bool,
     continuations: VecDeque<M>,
+    // Set after returning a continuation and cleared after an external
+    // mailbox/offload/timer item. `next_ready` uses it to prohibit two local
+    // continuations from leading while an external source remains eligible.
     continuation_needs_external: bool,
     timers: TimerStore<M>,
     next_timer_order: u64,
@@ -754,9 +729,7 @@ impl<M> RawResources<M> {
     }
 
     fn resume_pending_panic(&self) {
-        if let Some(payload) = self.panic.take() {
-            resume_unwind(payload);
-        }
+        resume_preferred_panic(self.panic.take(), None);
     }
 
     async fn join_offloads(&mut self) {
@@ -772,17 +745,16 @@ impl<M> RawResources<M> {
 
 impl<M> Drop for RawResources<M> {
     fn drop(&mut self) {
-        let freeze_panic = catch_unwind(AssertUnwindSafe(|| {
+        let freeze_panic = catch_panic(|| {
             let _ = self.freeze();
-        }))
+        })
         .err();
-        let mut cleanup_panic = self.panic.take();
-        keep_first_panic(&mut cleanup_panic, freeze_panic);
-        if std::thread::panicking() {
-            discard_panic(cleanup_panic);
-        } else if let Some(payload) = cleanup_panic {
-            resume_unwind(payload);
-        }
+        let mut panics = PanicAccumulator::default();
+        // `freeze` can transfer a destructor panic into the shared slot. Take
+        // that retained application diagnostic after cleanup and preserve it
+        // ahead of a direct framework-cleanup panic.
+        panics.record(self.panic.take());
+        panics.record(freeze_panic);
     }
 }
 
@@ -930,10 +902,12 @@ impl<M: Send + 'static> RawContext<M> {
     ///
     /// External intake freezes at this call — the drained set is exactly the
     /// already-accepted prefix (§5.1's close point) — queued continuations
-    /// and timers are discarded, and `recv` begins yielding the frozen
-    /// prefix followed by `None`. Idempotent. This is the primitive the
-    /// blanket handler loop's `Context::stop` is built on (§1 principle 5);
-    /// the child's configured §10 ladder bounds the stop.
+    /// and timers are discarded, and [`recv`](Self::recv) returns `None`.
+    /// A raw loop honoring [`MailboxShutdown::Drain`] must then consume the
+    /// frozen prefix with [`try_recv`](Self::try_recv); `recv` never drains a
+    /// frozen mailbox. Idempotent. This is the primitive the blanket handler
+    /// loop's `Context::stop` is built on (§1 principle 5); the child's
+    /// configured §10 ladder bounds the stop.
     pub fn stop(&mut self) {
         self.mailbox.freeze(self.incarnation);
         self.freeze_and_report();
@@ -966,7 +940,7 @@ impl<M: Send + 'static> RawContext<M> {
         if self.is_stopping() || !self.resources.accepting {
             return Err(Rejected::new((key, message)));
         }
-        self.replace_timer(key, TimerMessage::Once(Some(message)), after, None);
+        self.replace_timer(key, TimerMessage::Once(message), after, None);
         Ok(())
     }
 
@@ -1069,7 +1043,7 @@ impl<M: Send + 'static> RawContext<M> {
                 self.freeze_and_report();
                 return None;
             }
-            if let Some(message) = self.next_ready(false) {
+            if let Some(message) = self.next_ready() {
                 return Some(message);
             }
             self.wait_for_event().await;
@@ -1082,7 +1056,7 @@ impl<M: Send + 'static> RawContext<M> {
             self.freeze_and_report();
             self.receiver.try_recv()
         } else {
-            self.next_ready(false)
+            self.next_ready()
         }
     }
 
@@ -1140,7 +1114,7 @@ impl<M: Send + 'static> RawContext<M> {
         let panic = Arc::clone(&self.resources.panic);
         if deadline.is_zero() {
             drop(work);
-            events.push(QueuedEvent::Deliver {
+            events.push(QueuedEvent {
                 cancellation: cancellation.clone(),
                 make_message: Box::new(move || continuation(Err(DeadlineElapsed))),
             });
@@ -1173,7 +1147,7 @@ impl<M: Send + 'static> RawContext<M> {
             match runtime::select_two(token.cancelled(), completion).await {
                 runtime::Either::Left(()) => {}
                 runtime::Either::Right(Ok(result)) => {
-                    events.push(QueuedEvent::Deliver {
+                    events.push(QueuedEvent {
                         cancellation: event_cancellation,
                         make_message: Box::new(move || continuation(result)),
                     });
@@ -1200,7 +1174,24 @@ impl<M: Send + 'static> RawContext<M> {
         Ok(guard)
     }
 
-    fn next_ready(&mut self, allow_frozen_mailbox: bool) -> Option<M> {
+    /// Selects one live-incarnation input without awaiting.
+    ///
+    /// A due timer snapshots continuations, accepted live-mailbox messages,
+    /// queued offload completions, and timer armings before any timer message
+    /// is emitted. Stage priority is: at most one fairness continuation,
+    /// mailbox prefix, offload prefix, remaining snapshotted continuations,
+    /// then timer armings. Each external delivery permits one continuation to
+    /// lead the next call, so continuations can interleave with the mailbox and
+    /// offload stages without repeatedly cutting ahead of them. Once those
+    /// external prefixes are exhausted, the captured continuation remainder
+    /// drains before timers; arrivals after any watermark cannot jump the due
+    /// timers. This prevents both an always-readable mailbox and a self-feeding
+    /// continuation queue from starving the other.
+    ///
+    /// Frozen mailbox input is deliberately absent. Once stopping begins,
+    /// [`try_recv`](Self::try_recv) bypasses this selector and drains the
+    /// accepted prefix directly according to the caller's shutdown policy.
+    fn next_ready(&mut self) -> Option<M> {
         loop {
             self.resources.resume_pending_panic();
             self.begin_fired_batch();
@@ -1216,11 +1207,7 @@ impl<M: Send + 'static> RawContext<M> {
                 }
 
                 if !batch.mailbox_complete {
-                    let message = if allow_frozen_mailbox {
-                        self.receiver.try_recv()
-                    } else {
-                        self.receiver.try_recv_live_through(batch.mailbox_through)
-                    };
+                    let message = self.receiver.try_recv_live_through(batch.mailbox_through);
                     if let Some(message) = message {
                         self.resources.continuation_needs_external = false;
                         self.resources.fired_batch = Some(batch);
@@ -1272,11 +1259,7 @@ impl<M: Send + 'static> RawContext<M> {
                 return Some(message);
             }
 
-            let mailbox = if allow_frozen_mailbox {
-                self.receiver.try_recv()
-            } else {
-                self.receiver.try_recv_live()
-            };
+            let mailbox = self.receiver.try_recv_live();
             if let Some(message) = mailbox {
                 self.resources.continuation_needs_external = false;
                 return Some(message);
@@ -1298,12 +1281,7 @@ impl<M: Send + 'static> RawContext<M> {
     }
 
     fn materialize_event(event: QueuedEvent<M>) -> Option<M> {
-        match event {
-            QueuedEvent::Deliver {
-                cancellation,
-                make_message,
-            } => (!cancellation.is_fired()).then(make_message),
-        }
+        (!event.cancellation.is_fired()).then(event.make_message)
     }
 
     fn begin_fired_batch(&mut self) {
@@ -1346,7 +1324,7 @@ impl<M: Send + 'static> RawContext<M> {
         let TimerMessage::Once(message) = entry.message else {
             unreachable!("a non-interval timer must own a one-shot message")
         };
-        message
+        Some(message)
     }
 
     fn next_timer_deadline(&self) -> Option<Instant> {
@@ -1561,15 +1539,10 @@ impl<R: RawActor> Drop for RawIncarnationOwner<R> {
         // process. The resource panic is primary: it may be an owned offload
         // panic that completed before cancellation was requested.
         let primary_panic = self.take_primary_panic();
-        let mut cleanup_panic = catch_unwind(AssertUnwindSafe(|| self.drop_raw())).err();
-        let actor_panic = catch_unwind(AssertUnwindSafe(|| self.drop_actor())).err();
-        keep_first_panic(&mut cleanup_panic, actor_panic);
-        if std::thread::panicking() {
-            discard_panic(primary_panic);
-            discard_panic(cleanup_panic);
-        } else {
-            resume_preferred_panic(primary_panic, cleanup_panic);
-        }
+        let mut cleanup = PanicAccumulator::default();
+        cleanup.run(|| self.drop_raw());
+        cleanup.run(|| self.drop_actor());
+        resume_preferred_panic(primary_panic, cleanup.take());
     }
 }
 
@@ -1599,10 +1572,10 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
                     None
                 }
             };
-            let freeze_panic = catch_unwind(AssertUnwindSafe(|| {
+            let freeze_panic = catch_panic(|| {
                 mailbox.freeze(incarnation);
                 owner.raw().freeze_resources();
-            }))
+            })
             .err();
             let mut cleanup_panic = owner.raw().take_resource_panic();
             keep_first_panic(&mut cleanup_panic, freeze_panic);
@@ -1611,10 +1584,10 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
             keep_first_panic(&mut cleanup_panic, joined.err());
             let pending = owner.raw().take_resource_panic();
             keep_first_panic(&mut cleanup_panic, pending);
-            let raw_drop = catch_unwind(AssertUnwindSafe(|| owner.drop_raw())).err();
+            let raw_drop = catch_panic(|| owner.drop_raw()).err();
             keep_first_panic(&mut cleanup_panic, raw_drop);
 
-            let actor_drop = catch_unwind(AssertUnwindSafe(|| owner.drop_actor())).err();
+            let actor_drop = catch_panic(|| owner.drop_actor()).err();
             keep_first_panic(&mut cleanup_panic, actor_drop);
             // Once actor execution has panicked, teardown is secondary: never
             // replace the actor's original diagnostic.
@@ -1689,22 +1662,20 @@ mod tests {
     };
 
     use super::{
-        EventQueue, OffloadResource, PanicPayload, PanicSlot, QueuedEvent, RawResources,
-        SharedOffloadFuture, SharedOffloadState, resume_preferred_panic,
+        EventQueue, OffloadResource, PanicSlot, QueuedEvent, RawResources, SharedOffloadFuture,
+        SharedOffloadState,
     };
-    use crate::runtime::{Latch, Signal};
+    use crate::runtime::{Latch, PanicPayload, Signal, resume_preferred_panic};
 
     fn marker(value: usize) -> QueuedEvent<usize> {
-        QueuedEvent::Deliver {
+        QueuedEvent {
             cancellation: Latch::default(),
             make_message: Box::new(move || value),
         }
     }
 
     fn value(event: QueuedEvent<usize>) -> usize {
-        match event {
-            QueuedEvent::Deliver { make_message, .. } => make_message(),
-        }
+        (event.make_message)()
     }
 
     fn panic_message(payload: &PanicPayload) -> Option<&str> {
@@ -2002,7 +1973,7 @@ mod timer_store_tests {
     }
 
     fn once(entry: super::TimerEntry<&'static str>) -> &'static str {
-        let TimerMessage::Once(Some(message)) = entry.message else {
+        let TimerMessage::Once(message) = entry.message else {
             panic!("expected a live one-shot timer")
         };
         message
@@ -2016,21 +1987,21 @@ mod timer_store_tests {
             7_u8,
             Some(start + Duration::from_secs(3)),
             1,
-            TimerMessage::Once(Some("old-u8")),
+            TimerMessage::Once("old-u8"),
             None,
         );
         timers.replace(
             7_u16,
             Some(start + Duration::from_secs(1)),
             2,
-            TimerMessage::Once(Some("u16")),
+            TimerMessage::Once("u16"),
             None,
         );
         timers.replace(
             7_u8,
             Some(start + Duration::from_secs(2)),
             3,
-            TimerMessage::Once(Some("new-u8")),
+            TimerMessage::Once("new-u8"),
             None,
         );
 
@@ -2054,25 +2025,13 @@ mod timer_store_tests {
     #[test]
     fn hash_collision_uses_exact_erased_key_equality() {
         let mut timers = TimerStore::default();
-        timers.replace(
-            CollidingKey(1),
-            None,
-            1,
-            TimerMessage::Once(Some("first")),
-            None,
-        );
-        timers.replace(
-            CollidingKey(2),
-            None,
-            2,
-            TimerMessage::Once(Some("second")),
-            None,
-        );
+        timers.replace(CollidingKey(1), None, 1, TimerMessage::Once("first"), None);
+        timers.replace(CollidingKey(2), None, 2, TimerMessage::Once("second"), None);
         timers.replace(
             CollidingKey(1),
             None,
             3,
-            TimerMessage::Once(Some("replacement")),
+            TimerMessage::Once("replacement"),
             None,
         );
 
@@ -2117,7 +2076,7 @@ mod timer_store_tests {
                 key,
                 Some(start + Duration::from_secs((TIMERS - index) as u64)),
                 index as u64,
-                TimerMessage::Once(Some(())),
+                TimerMessage::Once(()),
                 None,
             );
         }

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -1,10 +1,11 @@
 //! The only boundary between the library and its async runtime.
 
 use std::{
+    any::Any,
     fmt,
     future::Future,
     ops::RangeBounds,
-    panic::{AssertUnwindSafe, catch_unwind},
+    panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     pin::Pin,
     sync::{
         Arc, Mutex,
@@ -27,6 +28,84 @@ pub(crate) use tokio::test;
 #[cfg(test)]
 pub(crate) async fn advance(duration: Duration) {
     time::advance(duration).await;
+}
+
+/// Runtime-owned spelling for an unwind payload crossing a framework boundary.
+pub(crate) type PanicPayload = Box<dyn Any + Send + 'static>;
+
+/// Catches application code without requiring every caller to repeat the
+/// `AssertUnwindSafe` boundary vocabulary.
+pub(crate) fn catch_panic<T>(operation: impl FnOnce() -> T) -> Result<T, PanicPayload> {
+    catch_unwind(AssertUnwindSafe(operation))
+}
+
+/// Discards an optional panic payload without trusting its destructor.
+pub(crate) fn discard_panic(payload: Option<PanicPayload>) {
+    if let Some(payload) = payload
+        && let Err(hostile_payload) = catch_panic(|| drop(payload))
+    {
+        // A payload whose own destructor panics cannot be dropped safely:
+        // dropping the replacement payload would merely recurse outside the
+        // boundary. Leak only this already-panicking diagnostic.
+        std::mem::forget(hostile_payload);
+    }
+}
+
+/// Resumes one captured panic payload at the framework boundary.
+pub(crate) fn resume_panic(payload: PanicPayload) -> ! {
+    resume_unwind(payload)
+}
+
+/// Retains the first panic and safely discards a later cleanup panic.
+pub(crate) fn keep_first_panic(first: &mut Option<PanicPayload>, candidate: Option<PanicPayload>) {
+    if first.is_none() {
+        *first = candidate;
+    } else {
+        discard_panic(candidate);
+    }
+}
+
+/// Resumes the primary panic, or the cleanup panic when there is no primary.
+/// During an existing unwind both are contained to prevent a double panic.
+pub(crate) fn resume_preferred_panic(primary: Option<PanicPayload>, cleanup: Option<PanicPayload>) {
+    if std::thread::panicking() {
+        discard_panic(primary);
+        discard_panic(cleanup);
+    } else if let Some(payload) = primary {
+        discard_panic(cleanup);
+        resume_panic(payload);
+    } else if let Some(payload) = cleanup {
+        resume_panic(payload);
+    }
+}
+
+/// Collects independent cleanup panics while allowing every cleanup step to
+/// run. Dropping the accumulator resumes the first panic unless another unwind
+/// is already in progress; callers that need to defer that decision can
+/// [`take`](Self::take) the payload.
+#[derive(Default)]
+pub(crate) struct PanicAccumulator {
+    first: Option<PanicPayload>,
+}
+
+impl PanicAccumulator {
+    pub(crate) fn run(&mut self, operation: impl FnOnce()) {
+        self.record(catch_panic(operation).err());
+    }
+
+    pub(crate) fn record(&mut self, candidate: Option<PanicPayload>) {
+        keep_first_panic(&mut self.first, candidate);
+    }
+
+    pub(crate) fn take(&mut self) -> Option<PanicPayload> {
+        self.first.take()
+    }
+}
+
+impl Drop for PanicAccumulator {
+    fn drop(&mut self) {
+        resume_preferred_panic(None, self.first.take());
+    }
 }
 
 pub(crate) fn now() -> std::time::Instant {
@@ -229,13 +308,11 @@ where
         else {
             return;
         };
-        let panic = catch_unwind(AssertUnwindSafe(|| drop(value)))
-            .err()
-            .map(contain_panic_payload);
+        let panic = catch_panic(|| drop(value)).err().map(contain_panic_payload);
         // Completion is framework bookkeeping. Contain it as well so a
         // hostile waker or a runtime teardown race cannot unwind a blocking
         // worker or double-panic while the job is being dropped.
-        let _ = catch_unwind(AssertUnwindSafe(|| completion(panic)));
+        discard_panic(catch_panic(|| completion(panic)).err());
     }
 }
 
@@ -256,11 +333,12 @@ where
 {
     if is_available() {
         let worker = Arc::clone(&job);
-        if let Ok(handle) = catch_unwind(AssertUnwindSafe(|| {
-            task::spawn_blocking(move || worker.finish())
-        })) {
-            drop(handle);
-            return;
+        match catch_panic(|| task::spawn_blocking(move || worker.finish())) {
+            Ok(handle) => {
+                drop(handle);
+                return;
+            }
+            Err(payload) => discard_panic(Some(payload)),
         }
     }
 
@@ -802,7 +880,7 @@ pub(crate) async fn join_resuming<T>(handle: JoinHandle<T>) -> T {
     let JoinHandle { inner } = handle;
     match inner.await {
         Ok(value) => value,
-        Err(error) if error.is_panic() => std::panic::resume_unwind(error.into_panic()),
+        Err(error) if error.is_panic() => resume_unwind(error.into_panic()),
         Err(error) => {
             debug_assert!(error.is_cancelled());
             panic!("library-owned operation task was unexpectedly cancelled")
@@ -810,17 +888,21 @@ pub(crate) async fn join_resuming<T>(handle: JoinHandle<T>) -> T {
     }
 }
 
-fn contain_panic_payload(payload: Box<dyn std::any::Any + Send + 'static>) -> Option<String> {
-    let message = catch_unwind(AssertUnwindSafe(|| panic_message(payload.as_ref())))
-        .ok()
-        .flatten();
+fn contain_panic_payload(payload: PanicPayload) -> Option<String> {
+    let message = match catch_panic(|| panic_message(payload.as_ref())) {
+        Ok(message) => message,
+        Err(inspection_panic) => {
+            discard_panic(Some(inspection_panic));
+            None
+        }
+    };
     // A custom panic payload is user-owned too. Its destructor may panic, so
     // discard it under a fresh unwind boundary before publishing completion.
-    let _ = catch_unwind(AssertUnwindSafe(|| drop(payload)));
+    discard_panic(Some(payload));
     message
 }
 
-fn panic_message(payload: &(dyn std::any::Any + Send + 'static)) -> Option<String> {
+fn panic_message(payload: &(dyn Any + Send + 'static)) -> Option<String> {
     if let Some(message) = payload.downcast_ref::<&str>() {
         Some((*message).to_owned())
     } else {
@@ -945,9 +1027,22 @@ mod tests {
     };
 
     use super::{
-        DisposalJob, JoinOutcome, Latch, OneShotClose, Signal, Timeout, join, oneshot, spawn,
-        timeout, yield_now,
+        DisposalJob, JoinOutcome, Latch, OneShotClose, Signal, Timeout, discard_panic, join,
+        oneshot, spawn, timeout, yield_now,
     };
+
+    struct RecursivelyPanickingPayload;
+
+    impl Drop for RecursivelyPanickingPayload {
+        fn drop(&mut self) {
+            std::panic::panic_any(RecursivelyPanickingPayload);
+        }
+    }
+
+    #[test]
+    fn discarding_a_recursively_hostile_panic_payload_is_contained() {
+        discard_panic(Some(Box::new(RecursivelyPanickingPayload)));
+    }
 
     struct PanickingDrop(Arc<AtomicUsize>);
 

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -67,11 +67,40 @@ pub(crate) fn keep_first_panic(first: &mut Option<PanicPayload>, candidate: Opti
 
 /// Resumes the primary panic, or the cleanup panic when there is no primary.
 /// During an existing unwind both are contained to prevent a double panic.
+///
+/// Containment is only correct where losing the diagnostic is the lesser
+/// outcome, which is true in a destructor and false on a normal return path.
+/// Callers that own the sole surviving copy of an authoritative panic must use
+/// [`resume_preferred_panic_outside_unwind`] instead.
 pub(crate) fn resume_preferred_panic(primary: Option<PanicPayload>, cleanup: Option<PanicPayload>) {
     if std::thread::panicking() {
         discard_panic(primary);
         discard_panic(cleanup);
     } else if let Some(payload) = primary {
+        discard_panic(cleanup);
+        resume_panic(payload);
+    } else if let Some(payload) = cleanup {
+        resume_panic(payload);
+    }
+}
+
+/// Resumes exactly as [`resume_preferred_panic`], but never contains the
+/// payload.
+///
+/// This is the variant for call sites that are not destructors and have
+/// already taken sole ownership of the panic. Silently discarding there would
+/// erase the authoritative diagnostic and let the caller continue past a
+/// failure it believes it re-raised, so the caller's non-unwinding precondition
+/// is asserted rather than absorbed.
+pub(crate) fn resume_preferred_panic_outside_unwind(
+    primary: Option<PanicPayload>,
+    cleanup: Option<PanicPayload>,
+) {
+    debug_assert!(
+        !std::thread::panicking(),
+        "an unwinding caller must contain its payloads with resume_preferred_panic"
+    );
+    if let Some(payload) = primary {
         discard_panic(cleanup);
         resume_panic(payload);
     } else if let Some(payload) = cleanup {


### PR DESCRIPTION
Part of #56. Stacked on #76.

## Summary
- remove the dead frozen-mailbox branch from next_ready and correct stop/receive plus batch-fairness documentation
- trim dead mailbox diagnostics and collapse disposal, queued-event, one-shot timer, and slot-claim wrappers
- centralize hostile-safe panic-containment vocabulary in the runtime layer
- preserve mailbox ordering assertions and document Drop completion, lock order, spawn-latch/report topology, and member-watch wake-bus invariants
- directly test RestartPolicy::is_never and the consolidated mailbox/slot behavior

## Verification
- integrated with the later engine, admission, validation, and standalone-race changes
- ./scripts/dev just ci (356/356 tests; 3/3 doctests)
- ./scripts/dev just ci-nix
- git diff --check