### PR TITLE
Pin issue 56 public contracts and coverage

### DIFF
--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -732,13 +732,49 @@ pub(crate) fn resolve_common(
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{num::NonZeroUsize, time::Duration};
 
     use super::{
         Backoff, BackoffFactor, Intensity, InvalidPolicy, Jitter, Mailbox, PolicyError,
         PolicyField, ReadinessDeadline, ResolvedDefaults, RestartCondition, RestartPolicy,
-        ScopeDefaults,
+        ScopeDefaults, Shutdown, tidy_abort_beat,
     };
+
+    #[test]
+    fn shipped_defaults_match_the_normative_policy() {
+        assert_eq!(Mailbox::default(), Mailbox::Queue(NonZeroUsize::new(64)));
+        assert_eq!(
+            Shutdown::default(),
+            Shutdown::Graceful {
+                grace: Duration::from_secs(5),
+            }
+        );
+        assert_eq!(
+            ResolvedDefaults::default().readiness_deadline,
+            ReadinessDeadline::Bounded(Duration::from_secs(30))
+        );
+        assert_eq!(
+            Intensity::default(),
+            Intensity {
+                max_restarts: 5,
+                within: Duration::from_secs(30),
+            }
+        );
+
+        assert_eq!(tidy_abort_beat(Duration::ZERO), Duration::from_millis(1));
+        assert_eq!(
+            tidy_abort_beat(Duration::from_millis(50)),
+            Duration::from_millis(5)
+        );
+        assert_eq!(
+            tidy_abort_beat(Duration::from_millis(100)),
+            Duration::from_millis(10)
+        );
+        assert_eq!(
+            tidy_abort_beat(Duration::from_secs(5)),
+            Duration::from_millis(10)
+        );
+    }
 
     #[test]
     fn backoff_progression_and_jitter_are_pure_math() {

--- a/crates/shelterwood/tests/acceptance/assistant.rs
+++ b/crates/shelterwood/tests/acceptance/assistant.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, poll_until};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, ChildState, Context, DeadlineElapsed, DynamicScopeRef,
     DynamicTree, ExitError, ExitResult, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
@@ -420,7 +420,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
     let mut lifecycle = root.subscribe_lifecycle();
 
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             gateway_scope
                 .snapshot()
                 .child("bridge")
@@ -456,7 +456,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
     let session_membership = session.membership();
 
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             session
                 .snapshot()
                 .child("stream")
@@ -477,14 +477,14 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .await
         .expect("session aggregate readiness completes");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             *stream_values.lock().expect("stream values mutex poisoned") == [3]
         })
         .await,
         "latest mailbox keeps the newest accepted streaming update"
     );
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             rehydrated.load(Ordering::SeqCst) >= 1
         })
         .await
@@ -521,7 +521,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .await
         .expect("control panic request accepted");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             session.snapshot().child("control").is_some_and(|child| {
                 matches!(child.state, ChildState::Running)
                     && child.restart_count == 1
@@ -559,7 +559,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .await
         .expect("tool panic request accepted");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             tools
                 .snapshot()
                 .child("temporary-tool")
@@ -578,7 +578,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .await
         .expect("offload request accepted");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             tool_args.completions.load(Ordering::SeqCst) == 1
         })
         .await,
@@ -612,7 +612,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .expect("redelivery of the same journal id is acknowledged");
     assert_eq!(transport.processed.load(Ordering::SeqCst), 1);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             transport.duplicate_notices.load(Ordering::SeqCst) == 1
         })
         .await
@@ -633,7 +633,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
 
     let removal = sessions.remove_scope(&session);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             stop_entered.load(Ordering::SeqCst)
         })
         .await
@@ -778,7 +778,7 @@ async fn assistant_sessions_idle_evict_on_timers_and_streams_cancel_mid_flight()
     // Mid-life streaming works and the idle timer is armed from init.
     stream.send(5).await.expect("stream accepts mid-life value");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             stream_values
                 .lock()
                 .expect("stream values mutex poisoned")
@@ -794,7 +794,7 @@ async fn assistant_sessions_idle_evict_on_timers_and_streams_cancel_mid_flight()
         .await
         .expect("live session accepts activity");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             activities.load(Ordering::SeqCst) == 1
         })
         .await,

--- a/crates/shelterwood/tests/acceptance/sidecar.rs
+++ b/crates/shelterwood/tests/acceptance/sidecar.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, policy::never, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, policy::never, poll_until};
 use shelterwood::{
     Actor, ActorOnceDef, ChildState, Context, ExitError, ExitKind, ExitResult, Readiness,
     ReadinessDeadline, Shutdown, StartOrShutdownError, StopContext, SubtreeOnceDef, TaskDef,
@@ -209,7 +209,7 @@ async fn sidecar_runs_two_host_owned_cycles_with_readiness_and_policy_exact_shut
         let system = fixture.tree.spawn().expect("runtime is available");
         let scope = system.scope();
         assert!(
-            poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
                 fixture.config_started.load(Ordering::SeqCst)
             })
             .await
@@ -336,7 +336,7 @@ async fn sidecar_startup_failure_leaves_prefix_supervised_until_host_rolls_it_ba
     let system = fixture.tree.spawn().expect("runtime is available");
     let scope = system.scope();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             fixture.prefix_one.load(Ordering::SeqCst)
         })
         .await

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -6,10 +6,11 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, assert_quiet, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until};
 use shelterwood::{
-    Actor, ActorDef, ActorOnceDef, Context, DynamicTree, ExitError, ExitResult, Handler, RawActor,
-    RawContext, RawOnceDef, Readiness, StopContext, TaskDef, Tree,
+    Actor, ActorDef, ActorOnceDef, ActorRef, Context, DynamicTree, ExitError, ExitResult, Handler,
+    Mailbox, RawActor, RawContext, RawOnceDef, Readiness, ScopeRef, SendErrorKind, StopContext,
+    TaskDef, Tree,
 };
 
 #[derive(Clone)]
@@ -330,7 +331,7 @@ async fn restartable_and_dynamic_actor_definition_surfaces_work() {
         .expect("dynamic actor admitted")
         .into_handles();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             dynamic_events
                 .lock()
                 .expect("events mutex poisoned")
@@ -396,4 +397,119 @@ async fn manual_readiness_override_on_a_wrapped_handler_stays_gated() {
         .shutdown(Duration::from_secs(1))
         .await
         .expect("tree shuts down");
+}
+
+enum ContextSurfaceMessage {
+    Enter,
+    Queued,
+    SelfSent,
+}
+
+struct ContextSurfaceActor {
+    entered: ReleaseGate,
+    release: ReleaseGate,
+    observed: Option<tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>>,
+    stopped: Option<tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>>,
+}
+
+impl Actor for ContextSurfaceActor {
+    type Msg = ContextSurfaceMessage;
+    type Args = (
+        ReleaseGate,
+        ReleaseGate,
+        tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>,
+        tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>,
+    );
+
+    async fn init(
+        (entered, release, observed, stopped): Self::Args,
+        _: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        Ok(Self {
+            entered,
+            release,
+            observed: Some(observed),
+            stopped: Some(stopped),
+        })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            ContextSurfaceMessage::Enter => {
+                self.entered.release();
+                self.release.wait().await;
+
+                let myself: ActorRef<ContextSurfaceMessage> = context.myself();
+                let scope: ScopeRef = context.scope();
+                let error = myself
+                    .try_send(ContextSurfaceMessage::SelfSent)
+                    .expect_err("the one-slot mailbox is already full");
+                assert_eq!(error.kind, SendErrorKind::Full);
+                assert!(matches!(error.message, ContextSurfaceMessage::SelfSent));
+                self.observed
+                    .take()
+                    .expect("surface observation is sent once")
+                    .send((myself, scope))
+                    .expect("test still awaits typed context handles");
+            }
+            ContextSurfaceMessage::Queued => context.stop(),
+            ContextSurfaceMessage::SelfSent => {
+                panic!("a self-send rejected from the full mailbox must not be delivered")
+            }
+        }
+        Ok(())
+    }
+
+    async fn on_stop(&mut self, context: &mut StopContext<'_, Self>) {
+        let myself: ActorRef<ContextSurfaceMessage> = context.myself();
+        let scope: ScopeRef = context.scope();
+        self.stopped
+            .take()
+            .expect("stop-context observation is sent once")
+            .send((myself, scope))
+            .expect("test still awaits typed stop-context handles");
+    }
+}
+
+#[tokio::test]
+async fn typed_context_handles_preserve_identity_and_self_send_capacity() {
+    let entered = ReleaseGate::default();
+    let release = ReleaseGate::default();
+    let (observed, observation) = tokio::sync::oneshot::channel();
+    let (stopped, stop_observation) = tokio::sync::oneshot::channel();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "context-surface",
+            ActorOnceDef::<ContextSurfaceActor>::new((
+                entered.clone(),
+                release.clone(),
+                observed,
+                stopped,
+            ))
+            .mailbox(Mailbox::queue(1).expect("non-zero capacity")),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+
+    actor
+        .send(ContextSurfaceMessage::Enter)
+        .await
+        .expect("actor enters handler");
+    entered.wait().await;
+    actor
+        .try_send(ContextSurfaceMessage::Queued)
+        .expect("the sole pending slot is filled");
+    release.release();
+
+    let (myself, scope) = observation.await.expect("actor reports its handles");
+    assert_eq!(myself, actor);
+    assert_eq!(scope, system.scope());
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    let (stopping_myself, stopping_scope) = stop_observation
+        .await
+        .expect("actor reports stop-context handles");
+    assert_eq!(stopping_myself, actor);
+    assert_eq!(stopping_scope, scope);
 }

--- a/crates/shelterwood/tests/common/mod.rs
+++ b/crates/shelterwood/tests/common/mod.rs
@@ -6,4 +6,4 @@ pub(crate) mod waiting;
 
 pub(crate) use gates::{DestructorBlocker, DestructorGate, ReleaseGate};
 pub(crate) use ownership::{ConsumeCount, ConsumeGuard, LiveFlag, PanicOnDrop};
-pub(crate) use timing::{advance_time, assert_quiet, poll_once, poll_until};
+pub(crate) use timing::{POLL_TIMEOUT, advance_time, assert_quiet, poll_once, poll_until};

--- a/crates/shelterwood/tests/common/timing.rs
+++ b/crates/shelterwood/tests/common/timing.rs
@@ -5,6 +5,9 @@ use std::{
     time::Duration,
 };
 
+/// Shared wall-clock budget for eventually-consistent test observations.
+pub(crate) const POLL_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Polls a pinned future once with a no-op waker.
 pub(crate) fn poll_once<F: Future>(future: Pin<&mut F>) -> Poll<F::Output> {
     let mut context = Context::from_waker(Waker::noop());

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
 use shelterwood::{
     Backoff, CallErrorKind, ChildState, ExitError, ExitResult, Jitter, Mailbox, RawActor,
     RawContext, RawOnceDef, Readiness, ReadinessDeadline, Reply, ReplyError, RestartCondition,
@@ -155,7 +155,7 @@ async fn acceptance_winning_the_deadline_withdrawal_race_succeeds() {
     advance_time(deadline).await;
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values.lock().expect("values mutex poisoned").contains(&1)
         })
         .await
@@ -165,7 +165,7 @@ async fn acceptance_winning_the_deadline_withdrawal_race_succeeds() {
         "acceptance is checked before successful withdrawal at the boundary"
     );
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
         })
         .await
@@ -199,7 +199,7 @@ async fn call_promotion_winning_the_deadline_race_reports_response_timeout() {
     advance_time(deadline).await;
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             calls.load(Ordering::SeqCst) == 1
         })
         .await
@@ -260,7 +260,7 @@ async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction
 
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values.lock().expect("values mutex poisoned").as_slice() == [1]
         })
         .await
@@ -519,7 +519,7 @@ async fn overflowing_restart_delay_never_restarts_immediately() {
     release_failure.release();
 
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             system.scope().child("restart").is_some_and(|child| {
                 matches!(child.state, ChildState::Restarting) && child.restart_at.is_none()
             })

--- a/crates/shelterwood/tests/defaults.rs
+++ b/crates/shelterwood/tests/defaults.rs
@@ -1,0 +1,211 @@
+//! Pins SPEC Appendix A's shipped defaults behaviorally: every other test
+//! sets policy explicitly, so without these a default regression passes the
+//! whole suite.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
+use shelterwood::{
+    Actor, ActorDef, Context, ExitError, ExitKind, ExitResult, Readiness, SendErrorKind,
+    StartupError, StopReason, TaskDef, Tree,
+};
+
+enum CapacityMessage {
+    Block,
+    Fill,
+}
+
+struct CapacityActor {
+    release: ReleaseGate,
+    entered: ReleaseGate,
+}
+
+impl Actor for CapacityActor {
+    type Msg = CapacityMessage;
+    type Args = (ReleaseGate, ReleaseGate);
+
+    async fn init(
+        (entered, release): Self::Args,
+        _: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        Ok(Self { release, entered })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+        if let CapacityMessage::Block = message {
+            self.entered.release();
+            self.release.wait().await;
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn default_mailbox_is_a_queue_of_sixty_four_messages() {
+    let entered = ReleaseGate::default();
+    let release = ReleaseGate::default();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor(
+            "unconfigured",
+            ActorDef::<CapacityActor>::cloned((entered.clone(), release.clone())),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    actor
+        .send(CapacityMessage::Block)
+        .await
+        .expect("the blocking message is accepted");
+    entered.wait().await;
+
+    let mut accepted = 0usize;
+    let full = loop {
+        match actor.try_send(CapacityMessage::Fill) {
+            Ok(_) => accepted += 1,
+            Err(error) => break error,
+        }
+        assert!(accepted <= 128, "unbounded acceptance is not a queue");
+    };
+    assert_eq!(
+        accepted, 64,
+        "Appendix A ships a bounded queue of 64 messages"
+    );
+    assert_eq!(full.kind, SendErrorKind::Full);
+
+    release.release();
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("drained actor shuts down");
+}
+
+#[tokio::test(start_paused = true)]
+async fn default_child_shutdown_grace_is_five_seconds() {
+    let mut tree = Tree::new();
+    let task = tree
+        .add_task("stubborn", TaskDef::new(|_| std::future::pending()))
+        .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("immediate task readiness");
+
+    let mut shutdown = Box::pin(system.shutdown(Duration::from_secs(60)));
+    assert_quiet(Duration::from_millis(50), || {
+        poll_once(shutdown.as_mut()).is_ready()
+    })
+    .await;
+    advance_time(Duration::from_millis(4500)).await;
+    // ~4.55s elapsed: still inside the shipped 5s grace.
+    assert_quiet(Duration::from_millis(50), || {
+        poll_once(shutdown.as_mut()).is_ready()
+    })
+    .await;
+    advance_time(Duration::from_millis(600)).await;
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            poll_once(shutdown.as_mut()).is_ready()
+        })
+        .await,
+        "grace elapses at 5s and the abort ladder completes"
+    );
+    drop(shutdown);
+
+    let exit = task.wait().await;
+    assert!(
+        matches!(exit.kind(), ExitKind::Aborted { after_grace: true }),
+        "an uncooperative task is aborted after the default grace: {exit:?}"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn default_readiness_deadline_is_thirty_seconds() {
+    // The driver arms the deadline from the paused virtual clock, so the
+    // baseline must come from the same clock: the real clock has already
+    // drifted past virtual t0 by the time the test body runs.
+    let before = tokio::time::Instant::now().into_std();
+    let mut tree = Tree::new();
+    let task = tree
+        .add_task(
+            "gated",
+            TaskDef::new(|_| std::future::pending())
+                .restart(crate::common::policy::never())
+                .readiness(Readiness::Manual)
+                .expect("manual readiness"),
+        )
+        .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+
+    let mut started = Box::pin(system.wait_started());
+    assert_quiet(Duration::from_millis(50), || {
+        poll_once(started.as_mut()).is_ready()
+    })
+    .await;
+    advance_time(Duration::from_secs(29)).await;
+    // ~29.1s elapsed: still inside the shipped 30s readiness deadline.
+    assert_quiet(Duration::from_millis(50), || {
+        poll_once(started.as_mut()).is_ready()
+    })
+    .await;
+    drop(started);
+    advance_time(Duration::from_millis(1500)).await;
+
+    let startup = system
+        .wait_started()
+        .await
+        .expect_err("unsignalled manual readiness times out at the shipped 30s deadline");
+    assert!(matches!(startup, StartupError::StartupFailed(_)));
+    let exit = task.wait().await;
+    let ExitKind::ReadinessTimedOut { deadline } = exit.kind() else {
+        panic!("expected a typed readiness timeout, got {exit:?}");
+    };
+    assert!(*deadline >= before + Duration::from_secs(30));
+    system
+        .shutdown(Duration::ZERO)
+        .await
+        .expect("terminal child leaves no straggler");
+}
+
+#[tokio::test]
+async fn default_intensity_allows_five_restarts_before_tripping() {
+    let runs = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    tree.add_task(
+        "failing",
+        TaskDef::new({
+            let runs = Arc::clone(&runs);
+            move |_| {
+                let runs = Arc::clone(&runs);
+                async move {
+                    runs.fetch_add(1, Ordering::SeqCst);
+                    Err(ExitError::message("deliberate failure"))
+                }
+            }
+        }),
+    )
+    .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+
+    // Immediate task readiness means startup may complete before the failures
+    // accumulate, so the trip is asserted on the scope's stop reason rather
+    // than the startup result.
+    let StopReason::IntensityTripped(trip) = system.wait().await else {
+        panic!("repeated failure trips the shipped budget");
+    };
+    assert_eq!(
+        trip.observed_restarts, 6,
+        "the shipped budget admits 5 restarts and trips on the 6th"
+    );
+    assert_eq!(
+        runs.load(Ordering::SeqCst),
+        6,
+        "initial run plus 5 restarts spawn; the tripping restart never does"
+    );
+}

--- a/crates/shelterwood/tests/delivery.rs
+++ b/crates/shelterwood/tests/delivery.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, assert_quiet, poll_once, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_once, poll_until};
 use shelterwood::{
     CallErrorKind, ExitError, ExitResult, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Reply,
     SendErrorKind, Shutdown, SubtreeOnceDef, Tree,
@@ -71,7 +71,7 @@ async fn accepted_but_undelivered_prefix_never_crosses_an_incarnation() {
     actor.try_send(3).expect("remainder accepts");
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             generation.load(Ordering::SeqCst) == 2
         })
         .await
@@ -81,7 +81,7 @@ async fn accepted_but_undelivered_prefix_never_crosses_an_incarnation() {
         .await
         .expect("fresh message reaches replacement");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             log.lock().expect("prefix log mutex poisoned").as_slice() == [(1, 1), (2, 4)]
         })
         .await
@@ -242,7 +242,7 @@ async fn queue_preserves_per_sender_fifo_under_interleaved_senders() {
     sender_b.await.expect("sender b joins");
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             log.lock().expect("order log mutex poisoned").len() == 4
         })
         .await
@@ -356,7 +356,7 @@ async fn send_cancellation_withdraws_before_acceptance_but_not_after() {
     drop(before);
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             log.lock().expect("send log mutex poisoned").as_slice() == [(2, 1)]
         })
         .await
@@ -365,7 +365,7 @@ async fn send_cancellation_withdraws_before_acceptance_but_not_after() {
     assert!(matches!(poll_once(after.as_mut()), Poll::Ready(Ok(_))));
     drop(after);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             log.lock().expect("send log mutex poisoned").as_slice() == [(2, 1), (2, 3)]
         })
         .await
@@ -417,7 +417,7 @@ async fn call_cancellation_withdraws_before_acceptance_but_processes_after() {
         let expected = usize::from(accepted_before_drop);
         if accepted_before_drop {
             assert!(
-                poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+                poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
                     calls.load(Ordering::SeqCst) == expected
                 })
                 .await

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -11,7 +11,8 @@ use std::{
 };
 
 use crate::common::{
-    DestructorBlocker, DestructorGate, PanicOnDrop, ReleaseGate, policy::never, poll_until,
+    DestructorBlocker, DestructorGate, POLL_TIMEOUT, PanicOnDrop, ReleaseGate, policy::never,
+    poll_until,
 };
 use shelterwood::{
     Backoff, ChildState, DynamicTree, ExitError, ExitKind, ExitResult, Jitter, LifecycleEventKind,
@@ -225,7 +226,7 @@ async fn panicking_unread_messages_are_all_disposed_without_reclassifying_the_ac
         .await
         .expect("payload panics do not unwind the scope driver");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             drops.load(Ordering::SeqCst) == 2
         })
         .await,

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, assert_quiet, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until};
 use shelterwood::{
     Actor, ActorOnceDef, Context, Exit, ExitError, ExitKind, ExitResult, LifecycleEventKind,
     LifecycleEvents, LifecycleItem, Mailbox, MailboxShutdown, SendErrorKind, Shutdown, StopContext,
@@ -114,7 +114,7 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
 
     actor.send(Message::Stop).await.expect("stop accepted");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             stop_entered.load(Ordering::SeqCst)
         })
         .await
@@ -130,7 +130,7 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
     allow_stop.release();
 
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             drain_entered.load(Ordering::SeqCst)
         })
         .await

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::common::{
-    ReleaseGate, advance_time, assert_quiet,
+    POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet,
     policy::never,
     poll_once, poll_until,
     waiting::{task as waiting_task, tree as waiting_tree},
@@ -35,7 +35,7 @@ use shelterwood::{
 /// id is free again.
 async fn wait_for_id_release(scope: &DynamicScopeRef, id: &str) {
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             scope.child(id).is_none()
         })
         .await,
@@ -132,6 +132,38 @@ fn signalled_waiting_tree(started: Arc<AtomicBool>, cancelled: Arc<AtomicBool>) 
         .expect("valid signalled task");
     drop(completion);
     tree
+}
+
+#[tokio::test]
+async fn scope_dynamic_conversion_and_exact_dynamic_scope_removal_are_publicly_usable() {
+    let ordered = Tree::new().spawn().expect("runtime is available");
+    let ordered_scope: ScopeRef = ordered.scope();
+    assert!(ordered_scope.dynamic().is_none());
+    ordered
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("ordered root stops");
+
+    let dynamic = DynamicTree::new().spawn().expect("runtime is available");
+    dynamic.wait_started().await.expect("dynamic root starts");
+    let dynamic_scope = dynamic.scope();
+    let erased: &ScopeRef = dynamic_scope.as_scope();
+    let recovered = erased.dynamic().expect("dynamic capability is recoverable");
+    assert_eq!(recovered.as_scope(), erased);
+
+    let nested = dynamic_scope
+        .add_subtree_once("nested-dynamic", SubtreeOnceDef::new(DynamicTree::new()))
+        .await
+        .expect("dynamic subtree is admitted")
+        .into_handles();
+    assert_eq!(
+        dynamic_scope.remove_dynamic_scope(&nested).await,
+        RemoveOutcome::Removed
+    );
+    dynamic
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root stops");
 }
 
 #[tokio::test]
@@ -512,7 +544,7 @@ async fn removal_is_synchronous_detached_and_shared() {
     ));
     drop(first);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             cancelled.load(Ordering::SeqCst)
         })
         .await
@@ -699,7 +731,7 @@ async fn select_and_timeout_preserve_fused_and_split_admission_ownership() {
             .is_err()
     );
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             split_started.load(Ordering::SeqCst)
         })
         .await,
@@ -757,14 +789,14 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
     ));
     assert!(poll_once(fused.as_mut()).is_pending());
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             fused_started.load(Ordering::SeqCst)
         })
         .await
     );
     drop(fused);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             fused_cancelled.load(Ordering::SeqCst)
         })
         .await
@@ -798,7 +830,7 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
     assert!(poll_once(split.as_mut()).is_pending());
     drop(split);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             split_started.load(Ordering::SeqCst)
         })
         .await
@@ -831,7 +863,7 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
     })));
     assert!(poll_once(split_after.as_mut()).is_pending());
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             split_after_started.load(Ordering::SeqCst)
         })
         .await
@@ -872,14 +904,14 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
     ));
     assert!(poll_once(fused_actor.as_mut()).is_pending());
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             actor_started.load(Ordering::SeqCst)
         })
         .await
     );
     drop(fused_actor);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             actor_cancelled.load(Ordering::SeqCst)
         })
         .await
@@ -903,14 +935,14 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
     ));
     assert!(poll_once(fused_subtree.as_mut()).is_pending());
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             subtree_started.load(Ordering::SeqCst)
         })
         .await
     );
     drop(fused_subtree);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             subtree_cancelled.load(Ordering::SeqCst)
         })
         .await
@@ -935,7 +967,7 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
     })));
     assert!(poll_once(split_actor.as_mut()).is_pending());
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             actor_started.load(Ordering::SeqCst)
         })
         .await
@@ -959,7 +991,7 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
     )));
     assert!(poll_once(split_subtree.as_mut()).is_pending());
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             subtree_started.load(Ordering::SeqCst)
         })
         .await
@@ -1005,7 +1037,7 @@ async fn removing_a_member_releases_its_factory_before_scope_shutdown() {
         .expect("task admitted")
         .into_handles();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             started.load(Ordering::SeqCst)
         })
         .await
@@ -1203,7 +1235,7 @@ async fn dynamic_scope_rejects_reservations_between_incarnations() {
     let system = root.spawn().expect("runtime is available");
 
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             first_started.load(Ordering::SeqCst)
         })
         .await
@@ -1296,7 +1328,7 @@ fn pending_restart_subtree(
 
 async fn await_first_restart_window(root: &ScopeRef, starts: &Arc<AtomicUsize>) {
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             starts.load(Ordering::SeqCst) == 1
         })
         .await
@@ -1495,7 +1527,7 @@ async fn draining_scopes_reject_admission_and_treat_removal_as_absent() {
     let scope = system.scope();
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(2)));
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             cancelled.load(Ordering::SeqCst)
         })
         .await

--- a/crates/shelterwood/tests/lifecycle.rs
+++ b/crates/shelterwood/tests/lifecycle.rs
@@ -7,7 +7,9 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{PanicOnDrop, ReleaseGate, assert_quiet, policy::never, poll_until};
+use crate::common::{
+    POLL_TIMEOUT, PanicOnDrop, ReleaseGate, assert_quiet, policy::never, poll_until,
+};
 use shelterwood::{
     Actor, ActorOnceDef, Context, DynamicTree, ExitError, ExitKind, ExitResult, Intensity,
     LifecycleEventKind, LifecycleItem, Readiness, Retention, ScopeState, Shutdown, StartupError,
@@ -258,7 +260,7 @@ async fn replacement_starts_only_after_the_old_future_is_destroyed() {
         .await
         .expect("initial incarnation starts");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             starts.load(Ordering::SeqCst) >= 2
         })
         .await
@@ -304,7 +306,7 @@ async fn ordered_teardown_is_reverse_and_joins_before_advancing() {
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(2)));
 
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             order.lock().expect("order mutex poisoned").as_slice() == [2]
         })
         .await
@@ -315,14 +317,14 @@ async fn ordered_teardown_is_reverse_and_joins_before_advancing() {
     .await;
     gates[2].release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             order.lock().expect("order mutex poisoned").as_slice() == [2, 1]
         })
         .await
     );
     gates[1].release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             order.lock().expect("order mutex poisoned").as_slice() == [2, 1, 0]
         })
         .await
@@ -363,7 +365,7 @@ async fn dynamic_teardown_cancels_children_concurrently() {
     system.wait_started().await.expect("tree starts");
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(2)));
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             cancelled.iter().all(|flag| flag.load(Ordering::SeqCst))
         })
         .await

--- a/crates/shelterwood/tests/mailbox.rs
+++ b/crates/shelterwood/tests/mailbox.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
 use shelterwood::{
     CallErrorKind, ExitResult, Mailbox, MailboxShutdown, RawActor, RawContext, RawDef, Reply,
     ReplyError, SendErrorKind, Tree,
@@ -143,7 +143,7 @@ async fn queue_backpressure_and_send_error_identity_are_exact() {
         accepting
     );
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
         })
         .await
@@ -187,7 +187,7 @@ async fn latest_mailbox_keeps_only_the_newest_accepted_value() {
     actor.try_send(Message::Value(3)).expect("replace two");
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values.lock().expect("values mutex poisoned").as_slice() == [3]
         })
         .await
@@ -237,7 +237,7 @@ async fn timed_send_withdraws_and_recovers_the_message() {
     drop(cancelled);
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values.lock().expect("values mutex poisoned").as_slice() == [1]
         })
         .await
@@ -247,7 +247,7 @@ async fn timed_send_withdraws_and_recovers_the_message() {
         .await
         .expect("recovered message is safe to resend");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
         })
         .await
@@ -290,7 +290,7 @@ async fn call_distinguishes_success_drop_and_response_timeout() {
                 async move { call_actor.call(|reply| Message::Ask(7, reply), width).await },
             );
         assert!(
-            poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
                 asks.load(Ordering::SeqCst) == 1
             })
             .await

--- a/crates/shelterwood/tests/mod.rs
+++ b/crates/shelterwood/tests/mod.rs
@@ -5,6 +5,7 @@ mod actor;
 mod api_trait_conformance;
 mod common;
 mod deadlines;
+mod defaults;
 mod delivery;
 mod disposal;
 mod drain;

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -8,14 +8,14 @@ use std::{
 };
 
 use crate::common::{
-    ReleaseGate, assert_quiet, poll_once, poll_until,
+    POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_once, poll_until,
     waiting::{task as waiting_task, tree as waiting_tree},
 };
 use shelterwood::{
-    Backoff, ChildState, DynamicScopeRef, DynamicTree, Jitter, LifecycleEvent, LifecycleEventKind,
-    LifecycleEvents, LifecycleItem, LifecycleTryRecvError, RemoveOutcome, RestartCondition,
-    RestartPolicy, Retention, ScopeRef, ScopeState, StopReason, SubtreeDef, SubtreeOnceDef,
-    TaskDef, TaskOnceDef, TaskRef, Tree, WaitError,
+    Backoff, ChildState, DynamicScopeRef, DynamicTree, Jitter, LIFECYCLE_EVENT_CAPACITY,
+    LifecycleEvent, LifecycleEventKind, LifecycleEvents, LifecycleItem, LifecycleTryRecvError,
+    RemoveOutcome, RestartCondition, RestartPolicy, Retention, ScopeRef, ScopeState, StopReason,
+    SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef, TaskRef, Tree, WaitError,
 };
 
 async fn next_item(events: &mut LifecycleEvents) -> LifecycleItem {
@@ -139,14 +139,20 @@ async fn drain_added_started_ready(events: &mut LifecycleEvents) {
 
 #[tokio::test]
 async fn lifecycle_lag_is_exact_coalesced_per_episode_and_subscribers_are_isolated() {
+    const EVENTS_PER_ADMISSION: usize = 3;
+
     let system = DynamicTree::new().spawn().expect("runtime is available");
     system.wait_started().await.expect("root starts");
     let scope = system.scope();
     let mut slow = scope.subscribe_lifecycle();
     let mut fast = scope.subscribe_lifecycle();
 
+    let admissions_per_episode = LIFECYCLE_EVENT_CAPACITY.div_ceil(EVENTS_PER_ADMISSION) + 1;
+    let emitted_per_episode = admissions_per_episode * EVENTS_PER_ADMISSION;
+    let dropped_per_episode = emitted_per_episode - LIFECYCLE_EVENT_CAPACITY;
+
     for episode in 0..2 {
-        for index in 0..50 {
+        for index in 0..admissions_per_episode {
             admit_waiter(&scope, format!("worker-{episode}-{index}")).await;
             drain_added_started_ready(&mut fast).await;
         }
@@ -154,10 +160,12 @@ async fn lifecycle_lag_is_exact_coalesced_per_episode_and_subscribers_are_isolat
         let watermark = scope.snapshot().lifecycle_seq;
         assert_eq!(
             next_item(&mut slow).await,
-            LifecycleItem::Lagged { dropped: 22 },
-            "150 events in a 128-event queue drop exactly 22"
+            LifecycleItem::Lagged {
+                dropped: dropped_per_episode as u64,
+            },
+            "each overflow episode reports its capacity-derived exact drop count"
         );
-        for _ in 0..128 {
+        for _ in 0..LIFECYCLE_EVENT_CAPACITY {
             let LifecycleItem::Event(event) = next_item(&mut slow).await else {
                 panic!("one coalesced marker must lead each overflow episode");
             };
@@ -190,7 +198,7 @@ async fn catch_up_watermarks_dedupe_initial_events_discard_stale_scopes_and_intr
         .expect("subtree admitted")
         .into_handles();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             root.snapshot()
                 .child("nested")
                 .is_some_and(|child| matches!(child.state, ChildState::Running))
@@ -287,7 +295,7 @@ async fn removed_is_the_pruning_edge_not_the_retained_terminal_edge() {
     let membership = task.membership();
     task.wait().await;
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             root.snapshot()
                 .child("retained")
                 .is_some_and(|child| child.state.is_terminal())
@@ -358,7 +366,7 @@ async fn removed_is_the_pruning_edge_not_the_retained_terminal_edge() {
     let teardown_membership = teardown_task.membership();
     teardown_task.wait().await;
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             root.snapshot()
                 .child("teardown-tombstone")
                 .is_some_and(|child| child.state.is_terminal())
@@ -570,7 +578,7 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
     };
 
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             root.snapshot()
                 .child("nested")
                 .is_some_and(|child| matches!(child.state, ChildState::Restarting))
@@ -620,7 +628,7 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
     assert_eq!(nested.snapshot().total_restarts, 0);
     assert!(nested.snapshot().lifecycle_seq >= starting.seq);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             root.snapshot().child("nested").is_some_and(|child| {
                 matches!(child.state, ChildState::Running) && child.restart_at.is_none()
             })
@@ -1132,7 +1140,7 @@ async fn snapshot_subscriptions_conflate_unobserved_transitions_to_the_latest_va
         .into_handles();
     task.wait().await;
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             scope.child("ephemeral").is_none()
         })
         .await,

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{assert_quiet, poll_until};
+use crate::common::{POLL_TIMEOUT, assert_quiet, poll_until};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
     Guard, LifecycleEventKind, LifecycleItem, Readiness, Shutdown, StartupError,
@@ -138,7 +138,7 @@ async fn timers_and_offload_completions_never_cross_an_incarnation_boundary() {
         .await
         .expect("actor live");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             generations.load(Ordering::SeqCst) >= 2
         })
         .await
@@ -227,7 +227,7 @@ async fn offload_completion_wins_at_the_exact_deadline() {
         .await
         .expect("actor live");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             armed.load(Ordering::SeqCst) && offload_started.load(Ordering::SeqCst)
         })
         .await,
@@ -300,7 +300,7 @@ async fn dropping_scoped_guard_suppresses_the_continuation() {
     system.wait_started().await.expect("actor starts");
     actor.send(GuardMessage::Start).await.expect("actor live");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             guard_dropped.load(Ordering::SeqCst)
         })
         .await,
@@ -313,6 +313,51 @@ async fn dropping_scoped_guard_suppresses_the_continuation() {
     actor.send(GuardMessage::Stop).await.expect("actor live");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert_eq!(deliveries.load(Ordering::SeqCst), 0);
+}
+
+struct ExportGuardActor;
+
+impl Actor for ExportGuardActor {
+    type Msg = ();
+    type Args = tokio::sync::oneshot::Sender<Guard>;
+
+    async fn init(
+        guard_sender: Self::Args,
+        context: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        let guard = context
+            .offload_scoped(std::future::pending::<()>(), |_| (), Duration::MAX)
+            .expect("scoped offload accepted");
+        guard_sender
+            .send(guard)
+            .expect("test still awaits cancellation guard");
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): (), _: &mut Context<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn guard_reports_incarnation_cancellation() {
+    let (guard_sender, guard_receiver) = tokio::sync::oneshot::channel();
+    let mut tree = Tree::new();
+    tree.add_actor_once(
+        "guard-exporter",
+        ActorOnceDef::<ExportGuardActor>::new(guard_sender),
+    )
+    .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    let guard = guard_receiver.await.expect("actor exports guard");
+    assert!(!guard.is_cancelled());
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("actor stops");
+    assert!(guard.is_cancelled());
 }
 
 struct DropLog {
@@ -499,7 +544,7 @@ async fn dropping_run_blocking_future_cancels_and_detaches_its_thread() {
         .expect("actor live");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             cancelled.load(Ordering::SeqCst)
         })
         .await
@@ -981,7 +1026,7 @@ async fn queued_offload_panic_survives_hard_abort() {
         .await
         .expect("mailbox accepts before readiness");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             queued.load(Ordering::SeqCst)
         })
         .await,
@@ -1057,7 +1102,7 @@ async fn hard_abort_preserves_owned_offload_panic_over_handler_destructor() {
     system.wait_started().await.expect("actor starts");
     actor.send(()).await.expect("actor accepts trigger");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             queued.load(Ordering::SeqCst)
         })
         .await,
@@ -1161,7 +1206,7 @@ async fn incarnation_offloads_are_destroyed_before_actor_state_on_panic() {
         .await
         .expect("actor live");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             log.lock().expect("drop log mutex poisoned").len() == 2
         })
         .await
@@ -1241,7 +1286,7 @@ async fn incarnation_offloads_are_destroyed_before_actor_state_on_error() {
         .await
         .expect("actor live");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             log.lock().expect("drop log mutex poisoned").len() == 2
         })
         .await

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, assert_quiet, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until};
 use shelterwood::{
     DynamicTree, ExitError, ExitResult, Mailbox, MailboxShutdown, PolicyError, RawActor,
     RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline, RemoveOutcome, ScopeDefaults,
@@ -262,7 +262,7 @@ async fn raw_manual_readiness_gates_ordered_startup_but_not_mailbox_acceptance()
         .expect("valid sibling");
     let system = tree.spawn().expect("runtime is available");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             entered.load(Ordering::SeqCst)
         })
         .await
@@ -279,7 +279,7 @@ async fn raw_manual_readiness_gates_ordered_startup_but_not_mailbox_acceptance()
     system.wait_started().await.expect("manual gate releases");
     assert!(sibling_started.load(Ordering::SeqCst));
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values
                 .lock()
                 .expect("manual values mutex poisoned")
@@ -348,7 +348,7 @@ async fn raw_recv_is_shutdown_biased_and_try_recv_controls_drain_vs_discard() {
         actor.try_send(2).expect("two accepts");
         let shutdown = tokio::spawn(async move { system.shutdown(Duration::from_secs(1)).await });
         assert!(
-            poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
                 matches!(
                     actor.try_send(3),
                     Err(ref error)
@@ -410,7 +410,7 @@ async fn dynamic_scope_admits_uses_and_exactly_removes_a_raw_actor() {
     let actor = receipt.into_handles();
     actor.send(9).await.expect("dynamic actor accepts");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values
                 .lock()
                 .expect("dynamic values mutex poisoned")
@@ -455,7 +455,7 @@ async fn deferred_queue_capacity_ignores_a_latest_scope_default() {
         .expect("second value proves queue capacity did not become latest");
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values
                 .lock()
                 .expect("default values mutex poisoned")
@@ -565,7 +565,7 @@ async fn hard_abort_offload_panic_with_panicking_raw_destructor_is_contained() {
     let mut events = system.scope().subscribe_lifecycle();
     system.wait_started().await.expect("actor starts");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             queued.load(Ordering::SeqCst)
         })
         .await,

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -6,7 +6,9 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, advance_time, assert_quiet, policy::never, poll_until};
+use crate::common::{
+    POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, policy::never, poll_until,
+};
 use shelterwood::{
     ChildState, DynamicTree, ExitError, ExitKind, Readiness, ReadinessDeadline, ScopeState,
     Shutdown, StartupError, StartupFailureCause, SubtreeOnceDef, TaskDef, Tree,
@@ -57,7 +59,7 @@ async fn ordered_startup_waits_for_manual_readiness() {
 
     let system = tree.spawn().expect("runtime is available");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             order.lock().expect("order mutex poisoned").as_slice() == ["gated"]
         })
         .await
@@ -198,7 +200,7 @@ async fn ready_at_deadline_wins_and_shutdown_disarms_the_gate() {
         .expect("valid task");
     let ready_system = ready_tree.spawn().expect("runtime is available");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             ready_started.load(Ordering::SeqCst)
         })
         .await
@@ -302,14 +304,14 @@ async fn restart_before_aggregate_readiness_rearms_the_gate() {
     .expect("valid task");
     let system = tree.spawn().expect("runtime is available");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             later_started.load(Ordering::SeqCst)
         })
         .await
     );
     fail_first.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             incarnation.load(Ordering::SeqCst) == 2
         })
         .await
@@ -474,7 +476,7 @@ async fn runtime_dynamic_additions_never_join_aggregate_readiness() {
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             initial_started.load(Ordering::SeqCst)
         })
         .await

--- a/crates/shelterwood/tests/rebind.rs
+++ b/crates/shelterwood/tests/rebind.rs
@@ -7,7 +7,8 @@ use std::{
 };
 
 use crate::common::{
-    DestructorBlocker, DestructorGate, ReleaseGate, policy::never, poll_once, poll_until,
+    DestructorBlocker, DestructorGate, POLL_TIMEOUT, ReleaseGate, policy::never, poll_once,
+    poll_until,
 };
 use shelterwood::{
     Backoff, CallErrorKind, ExitError, ExitResult, Jitter, Mailbox, RawActor, RawContext, RawDef,
@@ -151,7 +152,7 @@ async fn rebind_refreshes_all_overflow_waiter_incarnation_evidence() {
     fail_first.release();
     let mut replacement = None;
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             if let std::task::Poll::Ready(result) = poll_once(promoted.as_mut()) {
                 replacement = Some(result.expect("first waiter enters replacement capacity"));
                 true
@@ -225,7 +226,7 @@ async fn send_rides_the_frozen_destructor_and_rebind_window() {
     let accepting = parked.await.expect("send rides into replacement");
     assert!(accepting.supersedes(first));
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             deliveries
                 .lock()
                 .expect("deliveries mutex poisoned")
@@ -314,7 +315,7 @@ async fn timed_send_withdraws_while_replacement_is_in_backoff() {
     fail_first.release();
     let mut observed_rebind = None;
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             match actor.try_send(0) {
                 Err(error) if error.kind == SendErrorKind::NotRunning => {
                     observed_rebind = Some(error.incarnation_observed);
@@ -375,7 +376,7 @@ async fn dropping_a_parked_send_in_the_rebind_window_withdraws_it() {
     parked.await.expect("the retained send rides the window");
     actor.send(44).await.expect("replacement accepts");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             deliveries
                 .lock()
                 .expect("deliveries mutex poisoned")

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
 use shelterwood::{
     Actor, ActorOnceDef, Backoff, ChildState, Context, DefaultsInheritance, DynamicTree, ExitError,
     ExitKind, ExitResult, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError,
@@ -225,14 +225,14 @@ async fn intensity_window_ages_out_between_restart_schedules() {
     system.wait_started().await.expect("root starts");
     advance_time(Duration::from_secs(11)).await;
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             starts.load(Ordering::SeqCst) >= 2
         })
         .await
     );
     advance_time(Duration::from_secs(11)).await;
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             starts.load(Ordering::SeqCst) >= 3
         })
         .await
@@ -417,7 +417,7 @@ async fn dynamic_and_always_members_do_not_finish_naturally() {
     let ordered = ordered.spawn().expect("runtime is available");
     ordered.wait_started().await.expect("ordered starts");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             starts.load(Ordering::SeqCst) >= 2
         })
         .await
@@ -514,7 +514,7 @@ async fn owning_shutdown_joins_recursively_aborted_scope_drivers() {
     let system = root.spawn().expect("runtime is available");
     system.wait_started().await.expect("tree starts");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             started.load(Ordering::Acquire)
         })
         .await,
@@ -651,7 +651,7 @@ async fn locally_requested_subtree_shutdown_reads_cancelled() {
         .expect("valid subtree");
     let system = root.spawn().expect("runtime is available");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             started.load(Ordering::SeqCst)
         })
         .await

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -2,9 +2,33 @@ use std::time::Duration;
 
 use crate::common::LiveFlag;
 use shelterwood::{
-    BuildError, DynamicTree, ExitError, ExitKind, Readiness, ReadinessDeadline, RemoveOutcome,
-    ReserveError, Shutdown, StopReason, TaskDef, TaskOnceDef, Tree,
+    BuildError, DynamicTree, Exit, ExitError, ExitKind, Readiness, ReadinessDeadline,
+    RemoveOutcome, ReserveError, Shutdown, StopReason, TaskDef, TaskOnceDef, Tree,
 };
+
+#[test]
+fn public_exit_constructor_preserves_evidence_and_classifies_failures() {
+    let completed = Exit::new(ExitKind::Completed, true);
+    assert!(completed.cancelled());
+    assert!(matches!(completed.kind(), ExitKind::Completed));
+    assert!(!completed.is_failure());
+
+    for kind in [
+        ExitKind::Failed(ExitError::message("failed")),
+        ExitKind::Panicked {
+            message: Some("panicked".to_owned()),
+        },
+        ExitKind::ReadinessTimedOut {
+            deadline: std::time::Instant::now(),
+        },
+        ExitKind::Aborted { after_grace: true },
+        ExitKind::NeverStarted,
+    ] {
+        let exit = Exit::new(kind, false);
+        assert!(!exit.cancelled());
+        assert!(exit.is_failure(), "non-completed exit: {:?}", exit.kind());
+    }
+}
 
 #[test]
 fn spawn_without_runtime_is_a_build_error() {

--- a/tools/api-reachability/src/main.rs
+++ b/tools/api-reachability/src/main.rs
@@ -9,6 +9,7 @@ use std::{
 use serde_json::Value;
 
 const FORBIDDEN_ROOTS: &[&str] = &["tokio", "tokio_util"];
+const SUPPORTED_FORMAT_VERSION: u64 = 61;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let path = env::args_os()
@@ -31,6 +32,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 fn find_leaks(document: &Value) -> Result<BTreeSet<String>, Box<dyn Error>> {
+    validate_format_version(document)?;
     let index = object_field(document, "index")?;
     let paths = object_field(document, "paths")?;
 
@@ -81,6 +83,22 @@ fn find_leaks(document: &Value) -> Result<BTreeSet<String>, Box<dyn Error>> {
     }
 
     Ok(leaks)
+}
+
+fn validate_format_version(document: &Value) -> Result<(), Box<dyn Error>> {
+    let version = document
+        .get("format_version")
+        .and_then(Value::as_u64)
+        .ok_or("rustdoc JSON has no integer field `format_version`")?;
+
+    if version == SUPPORTED_FORMAT_VERSION {
+        return Ok(());
+    }
+
+    Err(format!(
+        "unsupported rustdoc JSON format version {version}; expected {SUPPORTED_FORMAT_VERSION}"
+    )
+    .into())
 }
 
 fn is_blanket_impl(item: &Value) -> bool {
@@ -176,6 +194,7 @@ mod tests {
     #[test]
     fn follows_public_type_ids_without_treating_every_number_as_an_id() {
         let document = json!({
+            "format_version": 61,
             "index": {
                 "0": {
                     "id": 0,
@@ -217,6 +236,7 @@ mod tests {
     #[test]
     fn ignores_materialized_blanket_impls_but_follows_explicit_impls() {
         let document = json!({
+            "format_version": 61,
             "index": {
                 "0": {
                     "id": 0,
@@ -267,6 +287,35 @@ mod tests {
                 "shelterwood::Explicit -> tokio_util::future::FutureExt".to_owned(),
                 "shelterwood::impl-explicit -> tokio_util::future::FutureExt".to_owned(),
             ])
+        );
+    }
+
+    #[test]
+    fn accepts_supported_format_version() {
+        let document = json!({
+            "format_version": 61,
+            "index": {},
+            "paths": {}
+        });
+
+        assert_eq!(
+            find_leaks(&document).expect("format version 61 must remain supported"),
+            BTreeSet::new()
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_format_version() {
+        let document = json!({
+            "format_version": 60,
+            "index": {},
+            "paths": {}
+        });
+
+        let error = find_leaks(&document).expect_err("older schemas must be rejected");
+        assert_eq!(
+            error.to_string(),
+            "unsupported rustdoc JSON format version 60; expected 61"
         );
     }
 }


### PR DESCRIPTION
Part of #56. Stacked on #77.

## Summary
- pin Appendix A capacity, shutdown, readiness, intensity, and tidy-beat defaults
- derive lifecycle lag expectations from the configured capacity
- exercise previously uncovered public scope, cancellation, exit, identity, and typed self-send surfaces
- raise asynchronous poll-until regression budgets from one to five seconds, including Admission-stack additions
- validate the rustdoc JSON format version before API reachability analysis
- retain the final-stack policy-validation and Admission error coverage while integrating the tests

## Verification
- ./scripts/dev just ci (363/363 tests)
- ./scripts/dev just ci-nix (all four flake checks)
- clippy, formatting, docs, rustdoc JSON/API, architecture, and packaging checks
- 88 shared five-second poll sites; zero one-second poll_until sites
- git diff --check