### PR TITLE
Land the issue-56 stack on main

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1526,8 +1526,9 @@ Rules (normative):
   point for the id errors — `EmptyId` and `DuplicateId` on either flavor
   (a retained tombstone counts as a duplicate — retention semantics
   above); on dynamic scopes additionally `RemovalInProgress` (same id
-  mid-removal, §11) and `NotAdmitting` (stage rule below). From success the slot's
-  handles resolve through the cell like any other handle; the slot is
+  mid-removal, §11), `NoRuntime` (runtime boundary below), and
+  `NotAdmitting` (stage rule below). From success the slot's handles
+  resolve through the cell like any other handle; the slot is
   parameterized by exactly what a handle needs (`M` for the wire type,
   `T` for the subtree's ref dispatch) so refs exist before any actor type
   or factory is named.
@@ -1551,10 +1552,11 @@ Rules (normative):
   and cannot fail — spec-level validation already happened eagerly at
   spec construction (§9.3). On a dynamic scope, `define` *is* the
   admission call: a future resolving at admission to the receipt (B.8).
-  Its only error is `NotAdmitting`: the id errors were already spent at
+  Its operation errors are `NotAdmitting` and the first-poll
+  `NoRuntime` rejection below: the id errors were already spent at
   reserve, and definition validation was spent at spec construction
   (§9.3's eager rule), exactly as on the builder flavor — admission
-  validates nothing. Whether the builder and dynamic flavors
+  validates no definition data. Whether the builder and dynamic flavors
   are one generic slot type or two parallel families is implementation
   latitude; the operation inventory and this error split are not.
 - **Fused admission futures abort on drop; split ones detach.** Dropping
@@ -1599,6 +1601,23 @@ Rules (normative):
   dropped before ever being polled has submitted nothing, and the cell
   terminalizes exactly as if the slot had been dropped undefined
   (§3.2).
+- **Runtime availability is checked before dynamic mutation.** A dynamic
+  `reserve_*` validates the id syntax first, then requires an ambient
+  runtime, and only then reads the scope's admitting state or resident-id
+  table. The error precedence is therefore `EmptyId` before `NoRuntime`,
+  and `NoRuntime` before `NotAdmitting`, `RemovalInProgress`, or
+  `DuplicateId` (and before identity minting can yield
+  `IdentityExhausted`); a no-runtime rejection mints no cell and claims
+  no id.
+  The admission future rechecks runtime availability at its first poll,
+  before spawning or submitting the admission command. If a slot was
+  reserved inside a runtime but its `define` future is first-polled
+  outside one, both fused and split forms return `NoRuntime`, release the
+  reservation, and publish the cell as terminal `NeverStarted`; the id is
+  reusable before that poll returns `Ready`. This failed poll never
+  crosses the split form's in-flight/detach edge. A completed admission
+  future is fuse-like: any later poll remains pending rather than
+  repeating the outcome or panicking.
 - **Stage semantics: dynamic operations are admission-stage-exact.** A
   dynamic scope is *admitting* exactly while its membership is
   non-terminal and it has a live incarnation in `Starting` or `Running`
@@ -3312,10 +3331,14 @@ it fires no `Removed` event and leaves no tombstone, §3.2's
 minting/admission split) — §11's idempotency, made concrete. `remove`
 futures are observation only: removal latches synchronously at the
 call (§11's remove rule), so dropping the future — polled or not —
-detaches, and a latched removal still completes. Dynamic `add_*`
+detaches, and a latched removal still completes. The public
+`ReserveError` enum is non-exhaustive and includes `NoRuntime`: it names
+the absent ambient runtime at dynamic reservation or first poll, with
+the cleanup and precedence pinned in §8. Dynamic `add_*`
 fails with exactly the union of its two halves (§8): `EmptyId`,
-`DuplicateId` (tombstones included), and `RemovalInProgress` (same id
-mid-removal — await removal and retry) from reserve — plus §3.1's
+`NoRuntime`, `DuplicateId` (tombstones included), and
+`RemovalInProgress` (same id mid-removal — await removal and retry) from
+reserve, with `NoRuntime` also possible at first poll — plus §3.1's
 enumerated identity-exhaustion rejection, unreachable in practice but
 named so fail-closed has a shape; `NotAdmitting`
 from either half. `NotAdmitting` is one outcome with an enumerated,
@@ -3330,10 +3353,12 @@ reached admission (removed by id, §8's orphaned-slot rule; or annulled
 by the fused drop latch). That last cause is cell-level, enumerated
 distinctly so a caller can tell "the scope closed" from "my
 reservation is gone".
-Defines add no errors of their own: definition
-validation is spent eagerly at spec construction (§9.3), on both
-flavors. Declaration builders share the reserve id errors (`EmptyId`,
-`DuplicateId`); their defines cannot fail (§8).
+Defines add no definition-validation errors: validation is spent eagerly
+at spec construction (§9.3), on both flavors. A dynamic define still
+crosses §8's admission boundary, so it can return `NoRuntime` at first
+poll or `NotAdmitting`; declaration builders share the reserve id errors
+(`EmptyId`, `DuplicateId`), require no runtime for reservation or define,
+and their defines cannot fail (§8).
 
 `BuildError` (spawn-time, §11) is enumerated and non-exhaustive:
 `NoRuntime` (no ambient async runtime reachable through D.3's `runtime`

--- a/SPEC.md
+++ b/SPEC.md
@@ -2926,7 +2926,10 @@ outcome during the beat classifies by that outcome, while a future
 destroyed by the ensuing hard abort records `Aborted { after_grace }`),
 `mark_ready()` (one-shot by construction; no-op only where declared
 readiness makes it meaningless, and that is a documented no-op, not a silent
-state change).
+state change — the same rule covers a stopping incarnation: once either
+cooperative shutdown or escalation has begun, readiness can no longer be
+published and the call is likewise a documented no-op, matching B.1's
+during-drain rule for the actor contexts).
 
 ### B.3 Send/call errors
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1232,14 +1232,36 @@ One classification, produced at one point, used by every consumer.
   already says nothing ran.
 - **Verdict precedence.** When one incarnation's end admits several
   readings, classification picks the highest of: `Panicked` >
-  `ReadinessTimedOut` > `Aborted` > `Failed` > `Completed`; `cancelled` is
+  `ReadinessTimedOut` > `Failed` > `Aborted` > `Completed`; `cancelled` is
   orthogonal and never competes. Concretely: a panic is never masked,
   wherever it lands (`run`, `on_stop` — superseding the run's outcome,
-  §4.1 — or a destructor, via the fallback report token); a
+  §4.1 — or a destructor, via the fallback report token); and a
   readiness-deadline expiry names the *cause* even when the teardown it
-  triggers ends in a grace-expiry abort (the mechanism); and `Aborted`
-  describes a future destroyed before yielding an outcome, so it cannot
-  genuinely conflict with `Failed`/`Completed`, which require one.
+  triggers ends in a grace-expiry abort (the mechanism).
+- **`Aborted` genuinely competes with a recorded outcome, and the rule is
+  asymmetric.** `Aborted` describes a future destroyed before yielding an
+  outcome, so it reads as if it could never conflict with
+  `Failed`/`Completed`, which require one. It conflicts anyway, by race:
+  the body can record its result and the destruction still land before
+  the join retires, and §10's ladder can arm a supervisor-forced abort
+  verdict against a membership that has already recorded one. Precedence
+  resolves that race in one direction only, and the asymmetry is
+  deliberate rather than an artifact of the ordering:
+  - A recorded `Failed(error)` **survives** a later abort. Destruction
+    proves only that teardown ended the task; it must not erase the
+    structured application error the task already produced, which is the
+    only evidence naming *why* the child was failing.
+  - A recorded `Completed` does **not** survive: cancellation overrides
+    it and the exit reads `Aborted { after_grace }` with
+    `cancelled: true`. A supervisor that destroyed a child before its
+    success was observable did not get a successful child. Concretely, a
+    one-shot task whose body returned `Ok(value)` inside that window
+    exits `Aborted` and `OneShotTaskRef::wait` yields `Err(exit)` — the
+    typed value is dropped rather than released past a stop the
+    supervisor had already committed to.
+
+  Only the recorded-vs-abort pair is asymmetric this way; the ordering
+  above is otherwise a total precedence over the whole variant set.
 - **Failure classification (feeds §9.2):** an exit is a *failure* iff it is
   not `Completed`. So `Failed`, `Panicked`, `ReadinessTimedOut`, and
   `Aborted` all restart under `OnFailure`; `Always` restarts even clean
@@ -1799,7 +1821,11 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
   exits `Completed`/`Failed` (with `cancelled: true`), and
   `Aborted { after_grace: false }` records only a hard abort actually
   reached — the future destroyed before yielding — distinguishable from
-  grace-expiry abort (`after_grace: true`). Grace is a supervisor-side
+  grace-expiry abort (`after_grace: true`). The one boundary case, where
+  the beat expires and the hard abort lands *after* the body recorded its
+  outcome but before the join retires, is settled by §7's precedence and
+  not here: a recorded `Failed` survives that abort, a recorded
+  `Completed` does not. Grace is a supervisor-side
   upper bound; child-local time after
   cancellation wakeup is scheduler-dependent — this is documented
   contract. Cancellation-before-escalation ordering is observable to the

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -505,54 +505,15 @@ impl<A: Actor> ActorDef<A> {
         }
     }
 
-    /// Overrides the restart policy.
-    #[must_use]
-    pub fn restart(mut self, restart: RestartPolicy) -> Self {
-        self.options.restart = Some(restart);
-        self
-    }
-
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor mailbox kind and capacity.
-    #[must_use]
-    pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
-        self.options.mailbox = Some(mailbox);
-        self
-    }
-
-    /// Overrides frozen-prefix drain versus discard behavior.
-    #[must_use]
-    pub fn mailbox_shutdown(mut self, shutdown: MailboxShutdown) -> Self {
-        self.options.mailbox_shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor's declared readiness mode.
-    #[must_use]
-    pub fn readiness(mut self, readiness: Readiness) -> Self {
-        self.options.readiness = Some(readiness);
-        self
-    }
-
-    /// Overrides the structural readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(
+        restart,
+        shutdown,
+        mailbox,
+        mailbox_shutdown,
+        actor_readiness,
+        structural_readiness_deadline,
+        retention,
+    );
 
     pub(crate) fn into_raw(self) -> RawDef<Handler<A>> {
         let factory = self.factory;
@@ -594,47 +555,14 @@ impl<A: Actor> ActorOnceDef<A> {
         }
     }
 
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor mailbox kind and capacity.
-    #[must_use]
-    pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
-        self.options.mailbox = Some(mailbox);
-        self
-    }
-
-    /// Overrides frozen-prefix drain versus discard behavior.
-    #[must_use]
-    pub fn mailbox_shutdown(mut self, shutdown: MailboxShutdown) -> Self {
-        self.options.mailbox_shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor's declared readiness mode.
-    #[must_use]
-    pub fn readiness(mut self, readiness: Readiness) -> Self {
-        self.options.readiness = Some(readiness);
-        self
-    }
-
-    /// Overrides the structural readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(
+        shutdown,
+        mailbox,
+        mailbox_shutdown,
+        actor_readiness,
+        structural_readiness_deadline,
+        retention,
+    );
 
     pub(crate) fn into_raw(self) -> RawOnceDef<Handler<A>> {
         let readiness = self.options.readiness.unwrap_or(Readiness::AfterInit);

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -39,9 +39,116 @@ pub trait Actor: Sized + Send + 'static {
     }
 }
 
+struct ActorContextCore<'a, M> {
+    raw: &'a mut RawContext<M>,
+}
+
+impl<'a, M: Send + 'static> ActorContextCore<'a, M> {
+    fn new(raw: &'a mut RawContext<M>) -> Self {
+        Self { raw }
+    }
+
+    fn reborrow(&mut self) -> ActorContextCore<'_, M> {
+        ActorContextCore::new(&mut *self.raw)
+    }
+
+    fn id(&self) -> &ChildId {
+        self.raw.id()
+    }
+
+    fn incarnation(&self) -> Incarnation {
+        self.raw.incarnation()
+    }
+
+    fn myself(&self) -> ActorRef<M> {
+        self.raw.myself()
+    }
+
+    fn scope(&self) -> ScopeRef {
+        self.raw.scope()
+    }
+
+    fn shutdown_token(&self) -> CancellationToken {
+        self.raw.shutdown_token()
+    }
+
+    fn abort_token(&self) -> CancellationToken {
+        self.raw.abort_token()
+    }
+
+    fn request_scope_shutdown(&self) {
+        self.raw.request_scope_shutdown();
+    }
+
+    fn run_blocking<F, T>(&self, operation: F) -> Blocking<T>
+    where
+        F: FnOnce(CancellationToken) -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        self.raw.run_blocking(operation)
+    }
+}
+
+macro_rules! actor_context_forwarders {
+    ($actor:ident) => {
+        /// Returns this actor's child id.
+        #[must_use]
+        pub fn id(&self) -> &ChildId {
+            self.core.id()
+        }
+
+        /// Returns this actor's current incarnation.
+        #[must_use]
+        pub fn incarnation(&self) -> Incarnation {
+            self.core.incarnation()
+        }
+
+        /// Returns a membership-addressed handle to this actor.
+        #[must_use]
+        pub fn myself(&self) -> ActorRef<$actor::Msg> {
+            self.core.myself()
+        }
+
+        /// Returns this actor's supervising scope.
+        #[must_use]
+        pub fn scope(&self) -> ScopeRef {
+            self.core.scope()
+        }
+
+        /// Returns the cooperative shutdown token.
+        #[must_use]
+        pub fn shutdown_token(&self) -> CancellationToken {
+            self.core.shutdown_token()
+        }
+
+        /// Returns the escalation token.
+        #[must_use]
+        pub fn abort_token(&self) -> CancellationToken {
+            self.core.abort_token()
+        }
+
+        /// Requests shutdown of the supervising scope without waiting.
+        pub fn request_scope_shutdown(&self) {
+            self.core.request_scope_shutdown();
+        }
+
+        /// Starts blocking work tied to actor shutdown and returned-future drop.
+        ///
+        /// Cancellation is cooperative; a hard-aborted operation's OS thread
+        /// detaches and may outlive this actor incarnation.
+        pub fn run_blocking<F, T>(&self, operation: F) -> Blocking<T>
+        where
+            F: FnOnce(CancellationToken) -> T + Send + 'static,
+            T: Send + 'static,
+        {
+            self.core.run_blocking(operation)
+        }
+    };
+}
+
 /// Callback context used by both live and frozen-prefix handler deliveries.
 pub struct Context<'a, A: Actor> {
-    raw: &'a mut RawContext<A::Msg>,
+    core: ActorContextCore<'a, A::Msg>,
     draining: bool,
     actor: PhantomData<fn() -> A>,
 }
@@ -50,8 +157,8 @@ impl<A: Actor> fmt::Debug for Context<'_, A> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("Context")
-            .field("id", self.raw.id())
-            .field("incarnation", &self.raw.incarnation())
+            .field("id", self.core.id())
+            .field("incarnation", &self.core.incarnation())
             .field("draining", &self.draining)
             .finish_non_exhaustive()
     }
@@ -60,64 +167,25 @@ impl<A: Actor> fmt::Debug for Context<'_, A> {
 impl<'a, A: Actor> Context<'a, A> {
     fn new(raw: &'a mut RawContext<A::Msg>, draining: bool) -> Self {
         Self {
-            raw,
+            core: ActorContextCore::new(raw),
             draining,
             actor: PhantomData,
         }
     }
 
-    /// Returns this actor's child id.
-    #[must_use]
-    pub fn id(&self) -> &ChildId {
-        self.raw.id()
-    }
-
-    /// Returns this actor's current incarnation.
-    #[must_use]
-    pub fn incarnation(&self) -> Incarnation {
-        self.raw.incarnation()
-    }
-
-    /// Returns a membership-addressed handle to this actor.
-    #[must_use]
-    pub fn myself(&self) -> ActorRef<A::Msg> {
-        self.raw.myself()
-    }
-
-    /// Returns this actor's supervising scope.
-    #[must_use]
-    pub fn scope(&self) -> ScopeRef {
-        self.raw.scope()
-    }
-
-    /// Returns the cooperative shutdown token.
-    #[must_use]
-    pub fn shutdown_token(&self) -> CancellationToken {
-        self.raw.shutdown_token()
-    }
-
-    /// Returns the escalation token.
-    #[must_use]
-    pub fn abort_token(&self) -> CancellationToken {
-        self.raw.abort_token()
-    }
-
-    /// Requests shutdown of the supervising scope without waiting.
-    pub fn request_scope_shutdown(&self) {
-        self.raw.request_scope_shutdown();
-    }
+    actor_context_forwarders!(A);
 
     /// Releases this incarnation's readiness gate while live.
     pub fn mark_ready(&self) {
         if !self.draining {
-            self.raw.mark_ready();
+            self.core.raw.mark_ready();
         }
     }
 
     /// Requests a clean local stop after the current callback.
     pub fn stop(&mut self) {
         if !self.draining {
-            self.raw.stop();
+            self.core.raw.stop();
         }
     }
 
@@ -132,7 +200,7 @@ impl<'a, A: Actor> Context<'a, A> {
         if self.draining {
             Err(Rejected::new(message))
         } else {
-            self.raw.continue_with(message)
+            self.core.raw.continue_with(message)
         }
     }
 
@@ -149,7 +217,7 @@ impl<'a, A: Actor> Context<'a, A> {
         if self.draining {
             Err(Rejected::new((key, message)))
         } else {
-            self.raw.set_timeout(key, message, after)
+            self.core.raw.set_timeout(key, message, after)
         }
     }
 
@@ -167,7 +235,7 @@ impl<'a, A: Actor> Context<'a, A> {
         if self.draining {
             Err(Rejected::new((key, message)))
         } else {
-            self.raw.set_interval(key, message, period)
+            self.core.raw.set_interval(key, message, period)
         }
     }
 
@@ -179,7 +247,7 @@ impl<'a, A: Actor> Context<'a, A> {
         if self.draining {
             Err(Rejected::new(()))
         } else {
-            Ok(self.raw.clear_timer(key))
+            Ok(self.core.raw.clear_timer(key))
         }
     }
 
@@ -198,7 +266,7 @@ impl<'a, A: Actor> Context<'a, A> {
         if self.draining {
             Err(Rejected::new((work, continuation)))
         } else {
-            self.raw.offload(work, continuation, deadline)
+            self.core.raw.offload(work, continuation, deadline)
         }
     }
 
@@ -217,31 +285,24 @@ impl<'a, A: Actor> Context<'a, A> {
         if self.draining {
             Err(Rejected::new((work, continuation)))
         } else {
-            self.raw.offload_scoped(work, continuation, deadline)
+            self.core.raw.offload_scoped(work, continuation, deadline)
         }
-    }
-
-    /// Starts blocking work tied to actor shutdown and returned-future drop.
-    ///
-    /// Cancellation is cooperative; a hard-aborted operation's OS thread
-    /// detaches and may outlive this actor incarnation.
-    pub fn run_blocking<F, T>(&self, operation: F) -> Blocking<T>
-    where
-        F: FnOnce(CancellationToken) -> T + Send + 'static,
-        T: Send + 'static,
-    {
-        self.raw.run_blocking(operation)
     }
 
     /// Re-enters a same-message actor with this exact context and stage.
     pub fn for_actor<B: Actor<Msg = A::Msg>>(&mut self) -> Context<'_, B> {
-        Context::new(self.raw, self.draining)
+        let draining = self.draining;
+        Context {
+            core: self.core.reborrow(),
+            draining,
+            actor: PhantomData,
+        }
     }
 }
 
 /// Narrowed context supplied only to [`Actor::on_stop`].
 pub struct StopContext<'a, A: Actor> {
-    raw: &'a mut RawContext<A::Msg>,
+    core: ActorContextCore<'a, A::Msg>,
     actor: PhantomData<fn() -> A>,
 }
 
@@ -249,8 +310,8 @@ impl<A: Actor> fmt::Debug for StopContext<'_, A> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("StopContext")
-            .field("id", self.raw.id())
-            .field("incarnation", &self.raw.incarnation())
+            .field("id", self.core.id())
+            .field("incarnation", &self.core.incarnation())
             .finish_non_exhaustive()
     }
 }
@@ -258,67 +319,19 @@ impl<A: Actor> fmt::Debug for StopContext<'_, A> {
 impl<'a, A: Actor> StopContext<'a, A> {
     fn new(raw: &'a mut RawContext<A::Msg>) -> Self {
         Self {
-            raw,
+            core: ActorContextCore::new(raw),
             actor: PhantomData,
         }
     }
 
-    /// Returns this actor's child id.
-    #[must_use]
-    pub fn id(&self) -> &ChildId {
-        self.raw.id()
-    }
-
-    /// Returns this actor's current incarnation.
-    #[must_use]
-    pub fn incarnation(&self) -> Incarnation {
-        self.raw.incarnation()
-    }
-
-    /// Returns a membership-addressed handle to this actor.
-    #[must_use]
-    pub fn myself(&self) -> ActorRef<A::Msg> {
-        self.raw.myself()
-    }
-
-    /// Returns this actor's supervising scope.
-    #[must_use]
-    pub fn scope(&self) -> ScopeRef {
-        self.raw.scope()
-    }
-
-    /// Returns the cooperative shutdown token.
-    #[must_use]
-    pub fn shutdown_token(&self) -> CancellationToken {
-        self.raw.shutdown_token()
-    }
-
-    /// Returns the escalation token.
-    #[must_use]
-    pub fn abort_token(&self) -> CancellationToken {
-        self.raw.abort_token()
-    }
-
-    /// Requests shutdown of the supervising scope without waiting.
-    pub fn request_scope_shutdown(&self) {
-        self.raw.request_scope_shutdown();
-    }
-
-    /// Starts blocking work tied to actor shutdown and returned-future drop.
-    ///
-    /// Cancellation is cooperative; a hard-aborted operation's OS thread
-    /// detaches and may outlive this actor incarnation.
-    pub fn run_blocking<F, T>(&self, operation: F) -> Blocking<T>
-    where
-        F: FnOnce(CancellationToken) -> T + Send + 'static,
-        T: Send + 'static,
-    {
-        self.raw.run_blocking(operation)
-    }
+    actor_context_forwarders!(A);
 
     /// Re-enters a same-message actor with the same narrowed stop context.
     pub fn for_actor<B: Actor<Msg = A::Msg>>(&mut self) -> StopContext<'_, B> {
-        StopContext::new(self.raw)
+        StopContext {
+            core: self.core.reborrow(),
+            actor: PhantomData,
+        }
     }
 }
 

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -982,7 +982,17 @@ impl ScopeCell {
             let mut control = self.control.lock().expect("scope control mutex poisoned");
             if !control.epochs.finish(epoch) {
                 // A stale driver must not overwrite the observation
-                // projection of a newer live incarnation.
+                // projection of a newer live incarnation. Membership
+                // terminality is not part of that projection: whoever owns a
+                // terminal exit still publishes it exactly once, so declining
+                // the epoch can never strand `wait_terminal`.
+                drop(control);
+                if let Some(exit) = terminal_exit {
+                    self.member.terminalize(exit);
+                    self.member.record.pulse();
+                    self.record.pulse();
+                    self.close_observation_locked();
+                }
                 return;
             }
             if control

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -690,6 +690,15 @@ impl ScopeCell {
             if matches!(record.stage, MemberStage::Terminal(_)) {
                 return false;
             }
+            // Nested publication and closure are reached only through this
+            // residency lookup, so a supervised child must still be resident
+            // here when it is terminalized. That holds because residency is
+            // installed before the child can be spawned (`set_admitted_children`
+            // for a planned incarnation, `admit_child` before dynamic
+            // `spawn_child`) and is only withdrawn by pruning, which always
+            // follows terminality. A child that has already left residency
+            // owns its nested scope through `SlotCell::terminalize_never_started`
+            // instead.
             let nested = self.current_children.read_with(|children| {
                 children
                     .iter()

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -215,6 +215,7 @@ impl MemberCell {
                     false,
                     Readiness::Immediate,
                 )
+                .expect("library defaults must be valid")
             })
     }
 

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -48,8 +48,16 @@ pub(crate) struct MailboxStats {
 }
 
 /// Type-erased mailbox lifecycle surface owned by a member cell.
+///
+/// The driver must configure a mailbox before its first bind. Every live
+/// incarnation must then be closed before a later incarnation is bound; if
+/// close is skipped, messages accepted for the prior incarnation can leak
+/// into the replacement. Once termination is prepared, later binds are
+/// intentionally ignored.
 pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
+    /// Installs the declaration-time mailbox policy before the first bind.
     fn configure(&self, mailbox: Mailbox);
+    /// Makes one incarnation live after configuration and prior-close cleanup.
     fn bind(&self, incarnation: Incarnation);
     fn freeze(&self, incarnation: Incarnation);
     fn close(&self, incarnation: Incarnation) -> Option<Box<dyn MailboxDisposal>>;

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -17,6 +17,7 @@ use std::{
 
 use crate::{
     ChildId, Exit, Incarnation, Intensity, Mailbox, Membership, Readiness, ScopeState, Strategy,
+    engine::ScopeEpochs,
     exit::{StartupError, StopReason},
     identity::{FenceCounter, ScopeIdentity},
     observe::{
@@ -310,6 +311,8 @@ impl MemberCell {
     }
 }
 
+/// Observation-only projection of the authoritative engine lifecycle.
+/// Driver decisions never read this record back as liveness policy.
 #[derive(Clone, Debug)]
 pub(crate) struct ScopeRecord {
     pub(crate) state: ScopeState,
@@ -396,9 +399,7 @@ struct ObservationConfig {
 
 #[derive(Debug, Default)]
 struct ScopeControl {
-    current_epoch: u64,
-    live: bool,
-    last_stopped_epoch: u64,
+    epochs: ScopeEpochs,
     shutdown: Option<ScopeRequest>,
     force: Option<ScopeRequest>,
 }
@@ -944,14 +945,23 @@ impl ScopeCell {
         }
     }
 
-    pub(crate) fn begin_incarnation(&self) -> u64 {
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        control.current_epoch = control.current_epoch.saturating_add(1);
-        control.live = true;
-        let epoch = control.current_epoch;
-        drop(control);
-        self.member.record.pulse();
-        epoch
+    pub(crate) fn begin_incarnation(&self) -> Option<u64> {
+        self.with_observation_gate(|| {
+            let mut control = self.control.lock().expect("scope control mutex poisoned");
+            let epoch = control.epochs.begin()?;
+            let state = ScopeState::Starting;
+            self.record.send_modify(|record| {
+                record.total_restarts = 0;
+                record.state = state.clone();
+            });
+            // Hold epoch ownership through its observation projection. A
+            // stale finish and a newer begin can no longer cross these two
+            // state planes in opposite orders.
+            drop(control);
+            self.member.record.pulse();
+            self.emit_locked(LifecycleEventKind::ScopeState { state });
+            Some(epoch)
+        })
     }
 
     pub(crate) fn finish_incarnation(&self, epoch: u64, reason: StopReason) {
@@ -969,6 +979,21 @@ impl ScopeCell {
         terminal_exit: Option<Exit>,
     ) {
         self.with_observation_gate(|| {
+            let mut control = self.control.lock().expect("scope control mutex poisoned");
+            if !control.epochs.finish(epoch) {
+                // A stale driver must not overwrite the observation
+                // projection of a newer live incarnation.
+                return;
+            }
+            if control
+                .shutdown
+                .is_some_and(|request| request.epoch <= epoch)
+            {
+                control.shutdown = None;
+            }
+            if control.force.is_some_and(|request| request.epoch <= epoch) {
+                control.force = None;
+            }
             let state = ScopeState::Stopped {
                 reason: reason.clone(),
             };
@@ -982,20 +1007,8 @@ impl ScopeCell {
             if let Some(exit) = terminal_exit {
                 self.member.terminalize(exit);
             }
-            let mut control = self.control.lock().expect("scope control mutex poisoned");
-            if control.current_epoch == epoch {
-                control.live = false;
-                control.last_stopped_epoch = control.last_stopped_epoch.max(epoch);
-                if control
-                    .shutdown
-                    .is_some_and(|request| request.epoch <= epoch)
-                {
-                    control.shutdown = None;
-                }
-                if control.force.is_some_and(|request| request.epoch <= epoch) {
-                    control.force = None;
-                }
-            }
+            // Keep epoch ownership through the final record mutation so a
+            // newer begin cannot race an old driver into publishing Stopped.
             drop(control);
             self.member.record.pulse();
             // `wait_started` must not observe terminal startup until the member
@@ -1011,7 +1024,7 @@ impl ScopeCell {
     pub(crate) fn finish_live_root_incarnation(&self, reason: StopReason, exit: Exit) {
         let epoch = {
             let control = self.control.lock().expect("scope control mutex poisoned");
-            control.live.then_some(control.current_epoch)
+            control.epochs.live_epoch()
         };
         if let Some(epoch) = epoch {
             self.finish_root_incarnation(epoch, reason, exit);
@@ -1033,14 +1046,9 @@ impl ScopeCell {
         }
     }
 
-    pub(crate) fn request_shutdown(&self) -> u64 {
+    pub(crate) fn request_shutdown(&self) -> Option<u64> {
         let mut control = self.control.lock().expect("scope control mutex poisoned");
-        let pending_incarnation = !control.live;
-        let target = if control.live {
-            control.current_epoch
-        } else {
-            control.current_epoch.saturating_add(1)
-        };
+        let (target, pending_incarnation) = control.epochs.request_target()?;
         if control
             .shutdown
             .is_none_or(|request| request.epoch < target)
@@ -1057,15 +1065,14 @@ impl ScopeCell {
         {
             parent.member.record.pulse();
         }
-        target
+        Some(target)
     }
 
     pub(crate) fn has_pending_incarnation_shutdown(&self) -> bool {
         let control = self.control.lock().expect("scope control mutex poisoned");
-        !control.live
-            && control.shutdown.is_some_and(|request| {
-                !request.consumed && request.epoch > control.last_stopped_epoch
-            })
+        control.shutdown.is_some_and(|request| {
+            !request.consumed && control.epochs.request_is_pending(request.epoch)
+        })
     }
 
     pub(crate) fn has_stop_request(&self, epoch: u64) -> bool {
@@ -1089,7 +1096,7 @@ impl ScopeCell {
 
     pub(crate) fn force_shutdown(&self, epoch: u64) {
         let mut control = self.control.lock().expect("scope control mutex poisoned");
-        if control.live && control.current_epoch == epoch {
+        if control.epochs.is_current(epoch) {
             control.force = Some(ScopeRequest {
                 epoch,
                 consumed: false,
@@ -1112,7 +1119,7 @@ impl ScopeCell {
 
     pub(crate) fn incarnation_finished(&self, epoch: u64) -> bool {
         let control = self.control.lock().expect("scope control mutex poisoned");
-        control.last_stopped_epoch >= epoch
+        control.epochs.finished(epoch)
     }
 
     pub(crate) fn set_admitted_children(self: &Arc<Self>, children: Vec<ResidentProjection>) {

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -686,18 +686,9 @@ impl ScopeCell {
         startup_aborted: bool,
     ) -> bool {
         self.with_observation_gate(|| {
-            if matches!(member.record().stage, MemberStage::Terminal(_)) {
+            let record = member.record();
+            if matches!(record.stage, MemberStage::Terminal(_)) {
                 return false;
-            }
-            member.update_locked(|record| record.startup_aborted = startup_aborted);
-            member.terminalize(exit.clone());
-            if let Some(incarnation) = exited_incarnation {
-                self.emit_locked(LifecycleEventKind::Exited {
-                    id: member.id().clone(),
-                    membership: member.membership(),
-                    incarnation,
-                    exit: exit.clone(),
-                });
             }
             let nested = self.current_children.read_with(|children| {
                 children
@@ -706,6 +697,27 @@ impl ScopeCell {
                     .and_then(|resident| resident.projection.scope.as_ref())
                     .cloned()
             });
+            member.update_locked(|record| record.startup_aborted = startup_aborted);
+            member.terminalize(exit.clone());
+            if record.last_incarnation.is_none()
+                && let Some(scope) = &nested
+            {
+                scope.publish_never_started_locked();
+            }
+            if let Some(incarnation) = exited_incarnation {
+                self.emit_locked(LifecycleEventKind::Exited {
+                    id: member.id().clone(),
+                    membership: member.membership(),
+                    incarnation,
+                    exit: exit.clone(),
+                });
+            } else {
+                // Terminals without a current incarnation have no Exited
+                // event to carry snapshot publication. Publish the final
+                // parent projection explicitly before nested observation
+                // closes.
+                self.publish_snapshot_chain_locked();
+            }
             if let Some(scope) = nested {
                 scope.close_observation_locked();
             }
@@ -889,10 +901,6 @@ impl ScopeCell {
         // by the caller while this same observation gate remains held.
         self.snapshots.close();
         self.lifecycle.close();
-    }
-
-    pub(crate) fn close_observation(&self) {
-        self.with_observation_gate(|| self.close_observation_locked());
     }
 
     #[cfg(test)]
@@ -1189,27 +1197,31 @@ impl ScopeCell {
         }
     }
 
+    fn publish_never_started_locked(&self) {
+        self.record.modify_silently(|record| {
+            if record.startup.is_none() {
+                record.startup = Some(Err(StartupError::ShutdownRequested));
+            }
+            record.state = ScopeState::Stopped {
+                reason: StopReason::NeverStarted,
+            };
+        });
+        self.member.record.pulse();
+        self.record.pulse();
+        self.emit_locked(LifecycleEventKind::ScopeState {
+            state: ScopeState::Stopped {
+                reason: StopReason::NeverStarted,
+            },
+        });
+    }
+
     pub(crate) fn terminalize_never_started(&self) {
         self.with_observation_gate(|| {
             if self.observation_closed.load(Ordering::Acquire) {
                 return;
             }
             self.member.terminalize(Exit::never_started());
-            self.record.modify_silently(|record| {
-                if record.startup.is_none() {
-                    record.startup = Some(Err(StartupError::ShutdownRequested));
-                }
-                record.state = ScopeState::Stopped {
-                    reason: StopReason::NeverStarted,
-                };
-            });
-            self.member.record.pulse();
-            self.record.pulse();
-            self.emit_locked(LifecycleEventKind::ScopeState {
-                state: ScopeState::Stopped {
-                    reason: StopReason::NeverStarted,
-                },
-            });
+            self.publish_never_started_locked();
             self.close_observation_locked();
         });
     }

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -1,0 +1,1208 @@
+//! Restart-stable shared member and scope state.
+//!
+//! These cells are the neutral synchronization and observation projection
+//! layer shared by public handles, mailboxes, actor/task contexts, and the
+//! mutable supervision driver. In particular, this module does not depend on
+//! driver state or declaration-plan slots.
+
+use std::{
+    any::Any,
+    fmt,
+    sync::{
+        Arc, Mutex, Weak,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::Instant,
+};
+
+use crate::{
+    ChildId, Exit, Incarnation, Intensity, Mailbox, Membership, Readiness, ScopeState, Strategy,
+    exit::{StartupError, StopReason},
+    identity::{FenceCounter, ScopeIdentity},
+    observe::{
+        ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
+        LifecycleHub, MembershipStatus, ScopeKind, ScopeSnapshot, SnapshotHub, SnapshotReceiver,
+    },
+    policy::{ResolvedCommonOptions, ScopeFlavor},
+    runtime::{self, Latch},
+};
+
+/// Isolated payload returned after mailbox termination has synchronously
+/// published all waiter outcomes.
+pub(crate) trait MailboxDisposal: Send {}
+
+/// Prepared terminal mailbox transition. Finishing it wakes terminal waiters
+/// before returning unread payload ownership for detached disposal.
+pub(crate) trait MailboxTermination: Send {
+    fn finish(self: Box<Self>) -> Option<Box<dyn MailboxDisposal>>;
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct MailboxStats {
+    pub(crate) accepted: u64,
+    pub(crate) delivered: u64,
+    pub(crate) conflated: u64,
+    pub(crate) sends_rejected: u64,
+    pub(crate) depth: usize,
+    pub(crate) capacity: usize,
+}
+
+/// Type-erased mailbox lifecycle surface owned by a member cell.
+pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
+    fn configure(&self, mailbox: Mailbox);
+    fn bind(&self, incarnation: Incarnation);
+    fn freeze(&self, incarnation: Incarnation);
+    fn close(&self, incarnation: Incarnation) -> Option<Box<dyn MailboxDisposal>>;
+    fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>>;
+    fn stats(&self) -> MailboxStats;
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum MemberStage {
+    Reserved,
+    Admitted,
+    Starting,
+    Running,
+    Restarting,
+    Stopping,
+    Terminal(Exit),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct MemberRecord {
+    pub(crate) stage: MemberStage,
+    pub(crate) incarnation: Option<Incarnation>,
+    pub(crate) last_incarnation: Option<Incarnation>,
+    pub(crate) last_exit: Option<Exit>,
+    pub(crate) restart_count: u64,
+    pub(crate) restart_at: Option<Instant>,
+    pub(crate) removing: bool,
+    pub(crate) startup_aborted: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct MemberCell {
+    id: ChildId,
+    membership: Mutex<Membership>,
+    record: runtime::WatchSender<MemberRecord>,
+    terminal_disposal_pending: AtomicBool,
+    mailbox: Mutex<MemberMailbox>,
+    options: Mutex<Option<ResolvedCommonOptions>>,
+    pub(crate) removal: Latch,
+}
+
+#[derive(Default)]
+struct MemberMailbox {
+    control: Option<Arc<dyn MailboxControl>>,
+    terminal: Option<Exit>,
+    teardown: Option<Box<dyn MailboxTermination>>,
+}
+
+impl fmt::Debug for MemberMailbox {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MemberMailbox")
+            .field("control", &self.control)
+            .field("terminal", &self.terminal)
+            .field("teardown_pending", &self.teardown.is_some())
+            .finish()
+    }
+}
+
+impl MemberCell {
+    pub(crate) fn new(id: ChildId, membership: Membership) -> Arc<Self> {
+        let (record, _) = runtime::watch(MemberRecord {
+            stage: MemberStage::Reserved,
+            incarnation: None,
+            last_incarnation: None,
+            last_exit: None,
+            restart_count: 0,
+            restart_at: None,
+            removing: false,
+            startup_aborted: false,
+        });
+        Arc::new(Self {
+            id,
+            membership: Mutex::new(membership),
+            record,
+            terminal_disposal_pending: AtomicBool::new(false),
+            mailbox: Mutex::new(MemberMailbox::default()),
+            options: Mutex::new(None),
+            removal: Latch::default(),
+        })
+    }
+
+    pub(crate) fn id(&self) -> &ChildId {
+        &self.id
+    }
+
+    pub(crate) fn membership(&self) -> Membership {
+        *self
+            .membership
+            .lock()
+            .expect("member identity mutex poisoned")
+    }
+
+    pub(crate) fn rebase_membership(&self, membership: Membership) {
+        let record = self.record();
+        assert!(
+            matches!(record.stage, MemberStage::Reserved)
+                && record.incarnation.is_none()
+                && record.last_incarnation.is_none(),
+            "only an unstarted reservation can be rebased"
+        );
+        *self
+            .membership
+            .lock()
+            .expect("member identity mutex poisoned") = membership;
+    }
+
+    pub(crate) fn record(&self) -> MemberRecord {
+        self.record.read_cloned()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_watcher(&self) -> runtime::WatchReceiver<MemberRecord> {
+        self.record.watcher()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn stage_terminal_before_mailbox(&self, exit: Exit) {
+        let mut mailbox = self.mailbox.lock().expect("member mailbox mutex poisoned");
+        assert!(mailbox.control.is_none());
+        mailbox.terminal = Some(exit);
+    }
+
+    pub(crate) fn terminal_disposal_pending(&self) -> bool {
+        self.terminal_disposal_pending.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn set_terminal_disposal_pending(&self, pending: bool) {
+        self.terminal_disposal_pending
+            .store(pending, Ordering::Release);
+    }
+
+    pub(crate) fn update(&self, update: impl FnOnce(&mut MemberRecord)) {
+        self.record.send_modify(update);
+    }
+
+    fn update_locked(&self, update: impl FnOnce(&mut MemberRecord)) {
+        self.record.send_modify(update);
+    }
+
+    pub(crate) fn set_options(&self, options: ResolvedCommonOptions) {
+        *self.options.lock().expect("member options mutex poisoned") = Some(options);
+    }
+
+    fn options(&self) -> ResolvedCommonOptions {
+        self.options
+            .lock()
+            .expect("member options mutex poisoned")
+            .clone()
+            .unwrap_or_else(|| {
+                crate::policy::resolve_common(
+                    &crate::policy::CommonOptions::default(),
+                    &crate::policy::ResolvedDefaults::default(),
+                    false,
+                    Readiness::Immediate,
+                )
+            })
+    }
+
+    pub(crate) fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
+        let terminal_exit = {
+            let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
+            assert!(state.control.is_none(), "a member can own only one mailbox");
+            state.control = Some(Arc::clone(&mailbox));
+            let terminal_exit = state.terminal.clone();
+            if terminal_exit.is_some() {
+                debug_assert!(state.teardown.is_none());
+                state.teardown = mailbox.prepare_termination();
+            }
+            terminal_exit
+        };
+        if let Some(terminal_exit) = terminal_exit {
+            self.publish_terminal(terminal_exit);
+        }
+    }
+
+    pub(crate) fn mailbox(&self) -> Option<Arc<dyn MailboxControl>> {
+        self.mailbox
+            .lock()
+            .expect("member mailbox mutex poisoned")
+            .control
+            .clone()
+    }
+
+    pub(crate) fn terminalize(&self, exit: Exit) {
+        let (terminal_exit, mailbox) = {
+            let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
+            let terminal_exit = if let Some(terminal_exit) = &state.terminal {
+                terminal_exit.clone()
+            } else {
+                let teardown = state
+                    .control
+                    .as_ref()
+                    .and_then(|mailbox| mailbox.prepare_termination());
+                state.terminal = Some(exit.clone());
+                state.teardown = teardown;
+                exit
+            };
+            (terminal_exit, state.control.clone())
+        };
+        self.publish_terminal(terminal_exit);
+        if let Some(mailbox) = mailbox {
+            let stats = mailbox.stats();
+            debug_assert!(stats.delivered <= stats.accepted);
+            debug_assert!(stats.conflated <= stats.accepted);
+            debug_assert!(stats.depth <= stats.capacity);
+            let _ = stats.sends_rejected;
+        }
+    }
+
+    fn publish_terminal(&self, terminal_exit: Exit) {
+        let mut published = false;
+        self.record.modify_silently(|record| {
+            if !matches!(record.stage, MemberStage::Terminal(_)) {
+                record.incarnation = None;
+                record.restart_at = None;
+                record.last_exit = Some(terminal_exit.clone());
+                record.stage = MemberStage::Terminal(terminal_exit);
+                published = true;
+            }
+        });
+        // Mailbox terminality and waiter completion must become visible before
+        // member terminality. The watch pulse is deliberately delayed until
+        // teardown has synchronously finished and unread payload ownership has
+        // moved to detached disposal.
+        let teardown = self
+            .mailbox
+            .lock()
+            .expect("member mailbox mutex poisoned")
+            .teardown
+            .take();
+        if let Some(teardown) = teardown
+            && let Some(payload) = teardown.finish()
+        {
+            runtime::dispose_detached(payload);
+        }
+        if published {
+            self.record.pulse();
+        }
+    }
+
+    pub(crate) async fn wait_terminal(&self) -> Exit {
+        let mut watcher = self.record.watcher();
+        loop {
+            if let MemberStage::Terminal(exit) = watcher.borrow_cloned().stage {
+                return exit;
+            }
+            watcher.changed().await;
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ScopeRecord {
+    pub(crate) state: ScopeState,
+    pub(crate) startup: Option<Result<(), StartupError>>,
+    pub(crate) total_restarts: u64,
+}
+
+#[derive(Clone)]
+pub(crate) struct DynamicRoute(Arc<dyn Any + Send + Sync>);
+
+impl fmt::Debug for DynamicRoute {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_tuple("DynamicRoute").finish()
+    }
+}
+
+impl DynamicRoute {
+    pub(crate) fn new<T: Any + Send + Sync>(route: Arc<T>) -> Self {
+        Self(route)
+    }
+
+    pub(crate) fn resolve<T: Any + Send + Sync>(self) -> Result<Arc<T>, Self> {
+        Arc::downcast(self.0).map_err(Self)
+    }
+}
+
+/// Driver-independent view of one declaration slot while its membership is
+/// resident in a running scope.
+#[derive(Clone)]
+pub(crate) struct ResidentProjection {
+    pub(crate) member: Arc<MemberCell>,
+    pub(crate) scope: Option<Arc<ScopeCell>>,
+}
+
+impl ResidentProjection {
+    pub(crate) fn new(member: Arc<MemberCell>, scope: Option<Arc<ScopeCell>>) -> Self {
+        Self { member, scope }
+    }
+}
+
+struct ResidencyCompletion {
+    parent: Weak<ScopeCell>,
+    projection: ResidentProjection,
+}
+
+struct ResidentChild {
+    projection: ResidentProjection,
+    removal: Option<ResidencyCompletion>,
+}
+
+impl ResidentChild {
+    fn new(parent: &Arc<ScopeCell>, projection: ResidentProjection) -> Self {
+        Self {
+            removal: Some(ResidencyCompletion {
+                parent: Arc::downgrade(parent),
+                projection: projection.clone(),
+            }),
+            projection,
+        }
+    }
+}
+
+impl Drop for ResidentChild {
+    fn drop(&mut self) {
+        let Some(completion) = self.removal.take() else {
+            return;
+        };
+        let Some(parent) = completion.parent.upgrade() else {
+            return;
+        };
+        parent.emit_locked(LifecycleEventKind::Removed {
+            id: completion.projection.member.id().clone(),
+            membership: completion.projection.member.membership(),
+            last_incarnation: completion.projection.member.record().last_incarnation,
+        });
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct ObservationConfig {
+    strategy: Strategy,
+    intensity: Intensity,
+}
+
+#[derive(Debug, Default)]
+struct ScopeControl {
+    current_epoch: u64,
+    live: bool,
+    last_stopped_epoch: u64,
+    shutdown: Option<ScopeRequest>,
+    force: Option<ScopeRequest>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ScopeRequest {
+    epoch: u64,
+    consumed: bool,
+}
+
+/// Shared scope state follows two distinct synchronization regimes.
+///
+/// One gate per resident tree serializes compound observation-visible
+/// transitions across configuration, records, resident children, and parent
+/// links. Their watch channels retain independently readable latest values;
+/// they do not make a multi-field transition atomic, so every recursive
+/// observation path continues to hold that one tree gate.
+///
+/// Control requests, identity counters, lifecycle sequences, and the dynamic
+/// route remain independent synchronization planes. The member-record watch is
+/// intentionally also the driver's wake bus.
+pub(crate) struct ScopeCell {
+    pub(crate) member: Arc<MemberCell>,
+    pub(crate) flavor: ScopeFlavor,
+    pub(crate) child_identity: Mutex<ScopeIdentity>,
+    config: runtime::WatchSender<ObservationConfig>,
+    record: runtime::WatchSender<ScopeRecord>,
+    control: Mutex<ScopeControl>,
+    dynamic_route: Mutex<Option<DynamicRoute>>,
+    current_children: runtime::WatchSender<Vec<ResidentChild>>,
+    parent: runtime::WatchSender<Option<Weak<ScopeCell>>>,
+    observation_gate: Mutex<Arc<Mutex<()>>>,
+    lifecycle_sequence: Mutex<FenceCounter>,
+    lifecycle_seq: AtomicU64,
+    lifecycle: LifecycleHub,
+    snapshots: SnapshotHub,
+    observation_closed: AtomicBool,
+    #[cfg(test)]
+    runtime_storage: Mutex<RuntimeStorage>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct RuntimeStorage {
+    pub(crate) children: usize,
+    pub(crate) child_slots: usize,
+    pub(crate) deadlines: usize,
+    pub(crate) deadline_slots: usize,
+}
+
+impl ScopeCell {
+    pub(crate) fn new(
+        member: Arc<MemberCell>,
+        flavor: ScopeFlavor,
+        child_identity: ScopeIdentity,
+    ) -> Arc<Self> {
+        let (config, _) = runtime::watch(ObservationConfig::default());
+        let (record, _) = runtime::watch(ScopeRecord {
+            state: ScopeState::Unstarted,
+            startup: None,
+            total_restarts: 0,
+        });
+        let (current_children, _) = runtime::watch(Vec::new());
+        let (parent, _) = runtime::watch(None);
+        Arc::new(Self {
+            member,
+            flavor,
+            child_identity: Mutex::new(child_identity),
+            config,
+            record,
+            control: Mutex::new(ScopeControl::default()),
+            dynamic_route: Mutex::new(None),
+            current_children,
+            parent,
+            observation_gate: Mutex::new(Arc::new(Mutex::new(()))),
+            lifecycle_sequence: Mutex::new(FenceCounter::new(0)),
+            lifecycle_seq: AtomicU64::new(0),
+            lifecycle: LifecycleHub::default(),
+            snapshots: SnapshotHub::default(),
+            observation_closed: AtomicBool::new(false),
+            #[cfg(test)]
+            runtime_storage: Mutex::new(RuntimeStorage::default()),
+        })
+    }
+
+    pub(crate) fn record(&self) -> ScopeRecord {
+        self.record.read_cloned()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_watcher(&self) -> runtime::WatchReceiver<ScopeRecord> {
+        self.record.watcher()
+    }
+
+    pub(crate) fn resident_projections(&self) -> Vec<ResidentProjection> {
+        self.current_children.read_with(|children| {
+            children
+                .iter()
+                .map(|resident| resident.projection.clone())
+                .collect()
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn runtime_storage(&self) -> RuntimeStorage {
+        *self
+            .runtime_storage
+            .lock()
+            .expect("runtime-storage mutex poisoned")
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_runtime_storage(&self, storage: RuntimeStorage) {
+        *self
+            .runtime_storage
+            .lock()
+            .expect("runtime-storage mutex poisoned") = storage;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn observation_gate(&self) -> Arc<Mutex<()>> {
+        self.current_observation_gate()
+    }
+
+    fn current_observation_gate(&self) -> Arc<Mutex<()>> {
+        Arc::clone(
+            &self
+                .observation_gate
+                .lock()
+                .expect("observation gate handoff mutex poisoned"),
+        )
+    }
+
+    fn adopt_observation_gate(&self, gate: &Arc<Mutex<()>>) {
+        loop {
+            let current = self.current_observation_gate();
+            if Arc::ptr_eq(&current, gate) {
+                return;
+            }
+
+            // An operation that passed `with_observation_gate`'s pointer
+            // check may finish its complete edge before handoff. An operation
+            // that merely captured this obsolete gate retries after acquiring
+            // it and observing the replacement.
+            let current_guard = current
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut installed = self
+                .observation_gate
+                .lock()
+                .expect("observation gate handoff mutex poisoned");
+            if Arc::ptr_eq(&current, &installed) {
+                *installed = Arc::clone(gate);
+                drop(installed);
+                self.adopt_descendant_observation_gates_locked(&current, gate);
+                drop(current_guard);
+                return;
+            }
+            drop(installed);
+            drop(current_guard);
+        }
+    }
+
+    /// Re-homes a resident subtree while its prior tree gate is held. The
+    /// destination gate is also held, so observers cannot enter either tree
+    /// while the handoff is installed recursively.
+    fn adopt_descendant_observation_gates_locked(
+        &self,
+        previous: &Arc<Mutex<()>>,
+        gate: &Arc<Mutex<()>>,
+    ) {
+        let descendants = self.current_children.read_with(|children| {
+            children
+                .iter()
+                .filter_map(|resident| resident.projection.scope.as_ref().cloned())
+                .collect::<Vec<_>>()
+        });
+        for descendant in descendants {
+            let mut installed = descendant
+                .observation_gate
+                .lock()
+                .expect("observation gate handoff mutex poisoned");
+            if Arc::ptr_eq(&installed, previous) {
+                *installed = Arc::clone(gate);
+            } else {
+                assert!(
+                    Arc::ptr_eq(&installed, gate),
+                    "one resident tree must share one observation gate"
+                );
+            }
+            drop(installed);
+            descendant.adopt_descendant_observation_gates_locked(previous, gate);
+        }
+    }
+
+    /// Runs against the current resident-tree observation gate. Adoption can
+    /// race an early pre-start observer, so an obsolete-gate acquisition is
+    /// detected and retried before the operation enters its critical section.
+    pub(crate) fn with_observation_gate<R>(&self, operation: impl FnOnce() -> R) -> R {
+        let mut operation = Some(operation);
+        loop {
+            let gate = self.current_observation_gate();
+            let guard = gate
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if Arc::ptr_eq(&gate, &self.current_observation_gate()) {
+                let operation = operation
+                    .take()
+                    .expect("observation operation runs exactly once");
+                let result = operation();
+                drop(guard);
+                return result;
+            }
+            drop(guard);
+        }
+    }
+
+    pub(crate) fn set_state(&self, state: ScopeState) {
+        self.with_observation_gate(|| {
+            self.record.send_modify(|record| {
+                if state == ScopeState::Starting {
+                    record.total_restarts = 0;
+                }
+                record.state = state.clone();
+            });
+            self.member.record.pulse();
+            self.emit_locked(LifecycleEventKind::ScopeState { state });
+        });
+    }
+
+    pub(crate) fn set_observation_config(&self, strategy: Strategy, intensity: Intensity) {
+        self.with_observation_gate(|| {
+            self.config.replace(ObservationConfig {
+                strategy,
+                intensity,
+            });
+            self.publish_snapshot_chain_locked();
+        });
+    }
+
+    pub(crate) fn transition_child(
+        &self,
+        member: &MemberCell,
+        update: impl FnOnce(&mut MemberRecord),
+        event: Option<LifecycleEventKind>,
+    ) {
+        self.with_observation_gate(|| {
+            member.update_locked(update);
+            if let Some(event) = event {
+                self.emit_locked(event);
+            } else {
+                self.publish_snapshot_chain_locked();
+            }
+        });
+    }
+
+    #[cfg(test)]
+    pub(crate) fn emit(&self, event: LifecycleEventKind) {
+        self.with_observation_gate(|| self.emit_locked(event));
+    }
+
+    pub(crate) fn publish_child_restart(
+        &self,
+        member: &MemberCell,
+        total_restarts: u64,
+        update: impl FnOnce(&mut MemberRecord),
+        exited: LifecycleEventKind,
+        scheduled: LifecycleEventKind,
+    ) {
+        self.with_observation_gate(|| {
+            self.record.send_modify(|scope| {
+                scope.total_restarts = total_restarts;
+            });
+            member.update_locked(update);
+            self.emit_locked(exited);
+            self.emit_locked(scheduled);
+        });
+    }
+
+    pub(crate) fn terminalize_child(
+        &self,
+        member: &MemberCell,
+        exit: Exit,
+        exited_incarnation: Option<Incarnation>,
+        startup_aborted: bool,
+    ) -> bool {
+        self.with_observation_gate(|| {
+            if matches!(member.record().stage, MemberStage::Terminal(_)) {
+                return false;
+            }
+            member.update_locked(|record| record.startup_aborted = startup_aborted);
+            member.terminalize(exit.clone());
+            if let Some(incarnation) = exited_incarnation {
+                self.emit_locked(LifecycleEventKind::Exited {
+                    id: member.id().clone(),
+                    membership: member.membership(),
+                    incarnation,
+                    exit: exit.clone(),
+                });
+            }
+            let nested = self.current_children.read_with(|children| {
+                children
+                    .iter()
+                    .find(|resident| resident.projection.member.membership() == member.membership())
+                    .and_then(|resident| resident.projection.scope.as_ref())
+                    .cloned()
+            });
+            if let Some(scope) = nested {
+                scope.close_observation_locked();
+            }
+            true
+        })
+    }
+
+    pub(crate) fn prune_child(&self, member: &MemberCell) -> bool {
+        self.with_observation_gate(|| {
+            let membership = member.membership();
+            let mut resident = None;
+            let removed = self.current_children.send_if_modified(|children| {
+                let Some(index) = children
+                    .iter()
+                    .position(|child| child.projection.member.membership() == membership)
+                else {
+                    return false;
+                };
+                resident = Some(children.remove(index));
+                true
+            });
+            if !removed {
+                return false;
+            }
+            let resident = resident.expect("a reported removal owns its resident entry");
+            debug_assert_eq!(resident.projection.member.membership(), membership);
+            // Dropping residency under the observation gate emits the matching
+            // Removed edge through its owned completion.
+            drop(resident);
+            true
+        })
+    }
+
+    pub(crate) fn snapshot(&self) -> Arc<ScopeSnapshot> {
+        self.with_observation_gate(|| self.snapshot_locked())
+    }
+
+    pub(crate) fn subscribe_snapshots(&self) -> SnapshotReceiver {
+        self.with_observation_gate(|| {
+            let receiver = self.snapshots.subscribe(self.snapshot_locked());
+            if self.observation_closed.load(Ordering::Acquire) {
+                self.snapshots.close();
+            }
+            receiver
+        })
+    }
+
+    pub(crate) fn subscribe_lifecycle(&self) -> LifecycleEvents {
+        self.with_observation_gate(|| {
+            let events = self.lifecycle.subscribe();
+            if self.observation_closed.load(Ordering::Acquire) {
+                self.lifecycle.close();
+            }
+            events
+        })
+    }
+
+    fn snapshot_locked(&self) -> Arc<ScopeSnapshot> {
+        let record = self.record();
+        let config = self.config.read_cloned();
+        let children = self.current_children.read_with(|children| {
+            children
+                .iter()
+                .map(|resident| resident.projection.clone())
+                .collect::<Vec<_>>()
+        });
+        let children = children
+            .iter()
+            .map(|child| self.child_snapshot_locked(child))
+            .collect::<Vec<_>>();
+        Arc::new(ScopeSnapshot {
+            state: record.state,
+            kind: match self.flavor {
+                ScopeFlavor::Ordered => ScopeKind::Ordered,
+                ScopeFlavor::Dynamic => ScopeKind::Dynamic,
+            },
+            strategy: (self.flavor == ScopeFlavor::Ordered).then_some(config.strategy),
+            intensity: config.intensity,
+            total_restarts: record.total_restarts,
+            lifecycle_seq: self.lifecycle_seq.load(Ordering::Acquire),
+            children: children.into(),
+        })
+    }
+
+    fn child_snapshot_locked(&self, child: &ResidentProjection) -> ChildSnapshot {
+        let record = child.member.record();
+        let options = child.member.options();
+        let terminal = matches!(record.stage, MemberStage::Terminal(_));
+        let nested = child.scope.as_ref().and_then(|scope| {
+            (record.incarnation.is_some() || terminal).then(|| scope.snapshot_locked())
+        });
+        ChildSnapshot {
+            id: child.member.id().clone(),
+            membership: child.member.membership(),
+            incarnation: record.incarnation,
+            state: match record.stage {
+                MemberStage::Reserved | MemberStage::Admitted => ChildState::Admitted,
+                MemberStage::Starting => ChildState::Starting,
+                MemberStage::Running => ChildState::Running,
+                MemberStage::Restarting => ChildState::Restarting,
+                MemberStage::Stopping => ChildState::Stopping,
+                MemberStage::Terminal(exit) if record.startup_aborted => {
+                    ChildState::StartupAborted { exit }
+                }
+                MemberStage::Terminal(exit) => ChildState::Stopped { exit },
+            },
+            last_exit: record.last_exit,
+            membership_status: if record.removing {
+                MembershipStatus::Removing
+            } else {
+                MembershipStatus::Active
+            },
+            restart_count: record.restart_count,
+            restart_policy: options.restart,
+            retention: options.retention,
+            restart_at: record.restart_at,
+            nested,
+            scope_seq: child
+                .scope
+                .as_ref()
+                .map(|scope| scope.lifecycle_seq.load(Ordering::Acquire)),
+        }
+    }
+
+    fn ancestors_locked(&self) -> Vec<Arc<ScopeCell>> {
+        let mut ancestors = Vec::new();
+        let mut current = self.parent.read_cloned().as_ref().and_then(Weak::upgrade);
+        while let Some(scope) = current {
+            current = scope.parent.read_cloned().as_ref().and_then(Weak::upgrade);
+            ancestors.push(scope);
+        }
+        ancestors
+    }
+
+    fn publish_snapshot_chain_locked(&self) {
+        self.snapshots.publish(|| self.snapshot_locked());
+        for ancestor in self.ancestors_locked() {
+            ancestor.snapshots.publish(|| ancestor.snapshot_locked());
+        }
+    }
+
+    fn emit_locked(&self, kind: LifecycleEventKind) {
+        let seq = self
+            .lifecycle_sequence
+            .lock()
+            .expect("lifecycle sequence mutex poisoned")
+            .mint_sequence();
+        let Some(seq) = seq else {
+            self.lifecycle_seq.store(u64::MAX, Ordering::Release);
+            self.publish_snapshot_chain_locked();
+            self.lifecycle.publish_lagged(1);
+            for ancestor in self.ancestors_locked() {
+                ancestor.lifecycle.publish_lagged(1);
+            }
+            return;
+        };
+        self.lifecycle_seq.store(seq, Ordering::Release);
+        self.publish_snapshot_chain_locked();
+
+        let scope = self.member.membership();
+        let mut event = LifecycleEvent {
+            scope_path: Vec::new(),
+            scope,
+            seq,
+            kind,
+        };
+        self.lifecycle.publish(event.clone());
+        let mut child_id = self.member.id().clone();
+        for ancestor in self.ancestors_locked() {
+            event.scope_path.insert(0, child_id);
+            child_id = ancestor.member.id().clone();
+            ancestor.lifecycle.publish(event.clone());
+        }
+    }
+
+    fn close_observation_locked(&self) {
+        if self.observation_closed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        // Closure follows the final state/snapshot/event publication performed
+        // by the caller while this same observation gate remains held.
+        self.snapshots.close();
+        self.lifecycle.close();
+    }
+
+    pub(crate) fn close_observation(&self) {
+        self.with_observation_gate(|| self.close_observation_locked());
+    }
+
+    #[cfg(test)]
+    pub(crate) fn replace_observation_gate(&self, gate: Arc<Mutex<()>>) {
+        *self
+            .observation_gate
+            .lock()
+            .expect("observation gate handoff mutex remains healthy") = gate;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_lifecycle_sequence(&self, counter: FenceCounter) {
+        *self
+            .lifecycle_sequence
+            .lock()
+            .expect("lifecycle sequence mutex poisoned") = counter;
+    }
+
+    pub(crate) fn set_startup(&self, startup: Result<(), StartupError>) {
+        let mut published = false;
+        self.record.modify_silently(|record| {
+            if record.startup.is_none() {
+                record.startup = Some(startup);
+                published = true;
+            }
+        });
+        if published {
+            // Preserve the original driver wake boundary before releasing the
+            // startup record itself.
+            self.member.record.pulse();
+            self.record.pulse();
+        }
+    }
+
+    pub(crate) fn begin_incarnation(&self) -> u64 {
+        let mut control = self.control.lock().expect("scope control mutex poisoned");
+        control.current_epoch = control.current_epoch.saturating_add(1);
+        control.live = true;
+        let epoch = control.current_epoch;
+        drop(control);
+        self.member.record.pulse();
+        epoch
+    }
+
+    pub(crate) fn finish_incarnation(&self, epoch: u64, reason: StopReason) {
+        self.finish_incarnation_with_terminal(epoch, reason, None);
+    }
+
+    pub(crate) fn finish_root_incarnation(&self, epoch: u64, reason: StopReason, exit: Exit) {
+        self.finish_incarnation_with_terminal(epoch, reason, Some(exit));
+    }
+
+    fn finish_incarnation_with_terminal(
+        &self,
+        epoch: u64,
+        reason: StopReason,
+        terminal_exit: Option<Exit>,
+    ) {
+        self.with_observation_gate(|| {
+            let state = ScopeState::Stopped {
+                reason: reason.clone(),
+            };
+            self.record.modify_silently(|record| {
+                if record.startup.is_none() {
+                    record.startup = Some(Err(StartupError::ShutdownRequested));
+                }
+                record.state = state.clone();
+            });
+            let terminal = terminal_exit.is_some();
+            if let Some(exit) = terminal_exit {
+                self.member.terminalize(exit);
+            }
+            let mut control = self.control.lock().expect("scope control mutex poisoned");
+            if control.current_epoch == epoch {
+                control.live = false;
+                control.last_stopped_epoch = control.last_stopped_epoch.max(epoch);
+                if control
+                    .shutdown
+                    .is_some_and(|request| request.epoch <= epoch)
+                {
+                    control.shutdown = None;
+                }
+                if control.force.is_some_and(|request| request.epoch <= epoch) {
+                    control.force = None;
+                }
+            }
+            drop(control);
+            self.member.record.pulse();
+            // `wait_started` must not observe terminal startup until the member
+            // and incarnation-control planes are mutually consistent.
+            self.record.pulse();
+            self.emit_locked(LifecycleEventKind::ScopeState { state });
+            if terminal {
+                self.close_observation_locked();
+            }
+        });
+    }
+
+    pub(crate) fn finish_live_root_incarnation(&self, reason: StopReason, exit: Exit) {
+        let epoch = {
+            let control = self.control.lock().expect("scope control mutex poisoned");
+            control.live.then_some(control.current_epoch)
+        };
+        if let Some(epoch) = epoch {
+            self.finish_root_incarnation(epoch, reason, exit);
+        } else {
+            self.with_observation_gate(|| {
+                let state = ScopeState::Stopped { reason };
+                self.record.modify_silently(|record| {
+                    if record.startup.is_none() {
+                        record.startup = Some(Err(StartupError::ShutdownRequested));
+                    }
+                    record.state = state.clone();
+                });
+                self.member.terminalize(exit);
+                self.member.record.pulse();
+                self.record.pulse();
+                self.emit_locked(LifecycleEventKind::ScopeState { state });
+                self.close_observation_locked();
+            });
+        }
+    }
+
+    pub(crate) fn request_shutdown(&self) -> u64 {
+        let mut control = self.control.lock().expect("scope control mutex poisoned");
+        let pending_incarnation = !control.live;
+        let target = if control.live {
+            control.current_epoch
+        } else {
+            control.current_epoch.saturating_add(1)
+        };
+        if control
+            .shutdown
+            .is_none_or(|request| request.epoch < target)
+        {
+            control.shutdown = Some(ScopeRequest {
+                epoch: target,
+                consumed: false,
+            });
+        }
+        drop(control);
+        self.member.record.pulse();
+        if pending_incarnation
+            && let Some(parent) = self.parent.read_cloned().as_ref().and_then(Weak::upgrade)
+        {
+            parent.member.record.pulse();
+        }
+        target
+    }
+
+    pub(crate) fn has_pending_incarnation_shutdown(&self) -> bool {
+        let control = self.control.lock().expect("scope control mutex poisoned");
+        !control.live
+            && control.shutdown.is_some_and(|request| {
+                !request.consumed && request.epoch > control.last_stopped_epoch
+            })
+    }
+
+    pub(crate) fn has_stop_request(&self, epoch: u64) -> bool {
+        let control = self.control.lock().expect("scope control mutex poisoned");
+        control
+            .shutdown
+            .is_some_and(|request| request.epoch == epoch)
+            || control.force.is_some_and(|request| request.epoch == epoch)
+    }
+
+    pub(crate) fn take_shutdown_request(&self, epoch: u64) -> bool {
+        let mut control = self.control.lock().expect("scope control mutex poisoned");
+        match control.shutdown.as_mut() {
+            Some(request) if request.epoch == epoch && !request.consumed => {
+                request.consumed = true;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) fn force_shutdown(&self, epoch: u64) {
+        let mut control = self.control.lock().expect("scope control mutex poisoned");
+        if control.live && control.current_epoch == epoch {
+            control.force = Some(ScopeRequest {
+                epoch,
+                consumed: false,
+            });
+        }
+        drop(control);
+        self.member.record.pulse();
+    }
+
+    pub(crate) fn take_force_request(&self, epoch: u64) -> bool {
+        let mut control = self.control.lock().expect("scope control mutex poisoned");
+        match control.force.as_mut() {
+            Some(request) if request.epoch == epoch && !request.consumed => {
+                request.consumed = true;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) fn incarnation_finished(&self, epoch: u64) -> bool {
+        let control = self.control.lock().expect("scope control mutex poisoned");
+        control.last_stopped_epoch >= epoch
+    }
+
+    pub(crate) fn set_admitted_children(self: &Arc<Self>, children: Vec<ResidentProjection>) {
+        self.with_observation_gate(|| {
+            let gate = self.current_observation_gate();
+            self.clear_residents_locked();
+            for child in children {
+                if let Some(scope) = &child.scope {
+                    scope.adopt_observation_gate(&gate);
+                    scope.parent.replace(Some(Arc::downgrade(self)));
+                }
+                child
+                    .member
+                    .update_locked(|record| record.stage = MemberStage::Admitted);
+                let id = child.member.id().clone();
+                let membership = child.member.membership();
+                self.current_children
+                    .send_modify(|children| children.push(ResidentChild::new(self, child)));
+                self.emit_locked(LifecycleEventKind::Added { id, membership });
+            }
+        });
+    }
+
+    pub(crate) fn admit_child(self: &Arc<Self>, child: ResidentProjection) {
+        self.with_observation_gate(|| {
+            let gate = self.current_observation_gate();
+            if let Some(scope) = &child.scope {
+                scope.adopt_observation_gate(&gate);
+                scope.parent.replace(Some(Arc::downgrade(self)));
+            }
+            let id = child.member.id().clone();
+            let membership = child.member.membership();
+            child
+                .member
+                .update_locked(|record| record.stage = MemberStage::Admitted);
+            self.current_children
+                .send_modify(|children| children.push(ResidentChild::new(self, child)));
+            self.emit_locked(LifecycleEventKind::Added { id, membership });
+        });
+    }
+
+    pub(crate) fn clear_residents(&self) {
+        self.with_observation_gate(|| self.clear_residents_locked());
+    }
+
+    fn clear_residents_locked(&self) {
+        let residents = self.current_children.take();
+        // Each owned residency emits Removed only after the watch guard has
+        // been released, so the recursively projected set is already empty.
+        drop(residents);
+    }
+
+    pub(crate) fn set_dynamic_route(&self, route: Option<DynamicRoute>) {
+        *self
+            .dynamic_route
+            .lock()
+            .expect("scope dynamic-route mutex poisoned") = route;
+        self.member.record.pulse();
+    }
+
+    pub(crate) fn dynamic_route(&self) -> Option<DynamicRoute> {
+        self.dynamic_route
+            .lock()
+            .expect("scope dynamic-route mutex poisoned")
+            .clone()
+    }
+
+    pub(crate) fn signal(&self) -> &runtime::WatchSender<MemberRecord> {
+        &self.member.record
+    }
+
+    pub(crate) async fn wait_started(&self) -> Result<(), StartupError> {
+        let mut watcher = self.record.watcher();
+        loop {
+            if let Some(result) = watcher.borrow_and_update_cloned().startup {
+                return result;
+            }
+            watcher.changed().await;
+        }
+    }
+
+    pub(crate) async fn wait_stopped(&self) -> StopReason {
+        self.member.wait_terminal().await;
+        match self.record().state {
+            ScopeState::Stopped { reason } => reason,
+            ScopeState::Unstarted
+            | ScopeState::Starting
+            | ScopeState::Running
+            | ScopeState::StartupFailed
+            | ScopeState::Draining => StopReason::NeverStarted,
+        }
+    }
+
+    pub(crate) fn terminalize_never_started(&self) {
+        self.with_observation_gate(|| {
+            if self.observation_closed.load(Ordering::Acquire) {
+                return;
+            }
+            self.member.terminalize(Exit::never_started());
+            self.record.modify_silently(|record| {
+                if record.startup.is_none() {
+                    record.startup = Some(Err(StartupError::ShutdownRequested));
+                }
+                record.state = ScopeState::Stopped {
+                    reason: StopReason::NeverStarted,
+                };
+            });
+            self.member.record.pulse();
+            self.record.pulse();
+            self.emit_locked(LifecycleEventKind::ScopeState {
+                state: ScopeState::Stopped {
+                    reason: StopReason::NeverStarted,
+                },
+            });
+            self.close_observation_locked();
+        });
+    }
+}

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -30,22 +30,12 @@ use crate::{
 
 /// Isolated payload returned after mailbox termination has synchronously
 /// published all waiter outcomes.
-pub(crate) trait MailboxDisposal: Send {}
+pub(crate) type MailboxDisposal = Box<dyn Send>;
 
 /// Prepared terminal mailbox transition. Finishing it wakes terminal waiters
 /// before returning unread payload ownership for detached disposal.
 pub(crate) trait MailboxTermination: Send {
-    fn finish(self: Box<Self>) -> Option<Box<dyn MailboxDisposal>>;
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(crate) struct MailboxStats {
-    pub(crate) accepted: u64,
-    pub(crate) delivered: u64,
-    pub(crate) conflated: u64,
-    pub(crate) sends_rejected: u64,
-    pub(crate) depth: usize,
-    pub(crate) capacity: usize,
+    fn finish(self: Box<Self>) -> Option<MailboxDisposal>;
 }
 
 /// Type-erased mailbox lifecycle surface owned by a member cell.
@@ -57,13 +47,24 @@ pub(crate) struct MailboxStats {
 /// intentionally ignored.
 pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
     /// Installs the declaration-time mailbox policy before the first bind.
+    /// Reconfiguration may only repeat the same resolved policy.
     fn configure(&self, mailbox: Mailbox);
     /// Makes one incarnation live after configuration and prior-close cleanup.
+    /// A bind after terminal preparation is deliberately ignored because
+    /// terminality wins that race permanently.
     fn bind(&self, incarnation: Incarnation);
+    /// Stops new acceptance for the matching live incarnation.
     fn freeze(&self, incarnation: Incarnation);
-    fn close(&self, incarnation: Incarnation) -> Option<Box<dyn MailboxDisposal>>;
+    /// Unbinds the matching incarnation and returns its unread payload.
+    /// Every successful bind must be followed by this close before a rebind;
+    /// skipping it would deliver the old incarnation's messages to the new.
+    fn close(&self, incarnation: Incarnation) -> Option<MailboxDisposal>;
+    /// Irreversibly terminalizes the membership and prepares synchronous
+    /// waiter completion followed by isolated unread-payload disposal.
     fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>>;
-    fn stats(&self) -> MailboxStats;
+    /// Debug-only check for the driver's configure/close-before-bind contract.
+    #[cfg(debug_assertions)]
+    fn bind_order_valid(&self) -> bool;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -191,6 +192,11 @@ impl MemberCell {
             .store(pending, Ordering::Release);
     }
 
+    /// Mutates a member record and pulses the watch channel.
+    ///
+    /// The driver also treats this channel as its control-plane wake bus: any
+    /// field read by a loop precondition must be changed through a pulsing path
+    /// like this one, never by a silent write outside an observation gate.
     pub(crate) fn update(&self, update: impl FnOnce(&mut MemberRecord)) {
         self.record.send_modify(update);
     }
@@ -245,9 +251,9 @@ impl MemberCell {
     }
 
     pub(crate) fn terminalize(&self, exit: Exit) {
-        let (terminal_exit, mailbox) = {
+        let terminal_exit = {
             let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
-            let terminal_exit = if let Some(terminal_exit) = &state.terminal {
+            if let Some(terminal_exit) = &state.terminal {
                 terminal_exit.clone()
             } else {
                 let teardown = state
@@ -257,17 +263,9 @@ impl MemberCell {
                 state.terminal = Some(exit.clone());
                 state.teardown = teardown;
                 exit
-            };
-            (terminal_exit, state.control.clone())
+            }
         };
         self.publish_terminal(terminal_exit);
-        if let Some(mailbox) = mailbox {
-            let stats = mailbox.stats();
-            debug_assert!(stats.delivered <= stats.accepted);
-            debug_assert!(stats.conflated <= stats.accepted);
-            debug_assert!(stats.depth <= stats.capacity);
-            let _ = stats.sends_rejected;
-        }
     }
 
     fn publish_terminal(&self, terminal_exit: Exit) {

--- a/crates/shelterwood/src/definition.rs
+++ b/crates/shelterwood/src/definition.rs
@@ -1,0 +1,190 @@
+//! Shared private machinery for declaration definitions.
+
+/// Repeatable or consuming definition payload state.
+///
+/// The explicit `Spent` state lets consumers move a one-shot payload without
+/// wrapping that payload in a second `Option`. Repeatable payloads remain
+/// borrowed in place and therefore survive every construction attempt.
+pub(crate) enum DefinitionSource<R, O> {
+    Restartable(R),
+    OneShot(O),
+    Spent,
+}
+
+impl<R, O> DefinitionSource<R, O> {
+    pub(crate) fn is_one_shot(&self) -> bool {
+        matches!(self, Self::OneShot(_) | Self::Spent)
+    }
+
+    pub(crate) fn restartable(&self) -> Option<&R> {
+        match self {
+            Self::Restartable(source) => Some(source),
+            Self::OneShot(_) | Self::Spent => None,
+        }
+    }
+
+    pub(crate) fn take_one_shot(&mut self) -> Option<O> {
+        match std::mem::replace(self, Self::Spent) {
+            Self::OneShot(source) => Some(source),
+            Self::Restartable(source) => {
+                *self = Self::Restartable(source);
+                None
+            }
+            Self::Spent => None,
+        }
+    }
+}
+
+/// Generates the option setters shared by the public definition families.
+macro_rules! common_options_setters {
+    ($($setter:ident),* $(,)?) => {
+        $(common_options_setters!(@emit $setter);)*
+    };
+
+    (@emit restart) => {
+        /// Overrides the restart policy.
+        #[must_use]
+        pub fn restart(mut self, restart: RestartPolicy) -> Self {
+            self.options.restart = Some(restart);
+            self
+        }
+    };
+
+    (@emit shutdown) => {
+        /// Overrides the shutdown policy.
+        #[must_use]
+        pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
+            self.options.shutdown = Some(shutdown);
+            self
+        }
+    };
+
+    (@emit mailbox) => {
+        /// Overrides the actor mailbox kind and capacity.
+        #[must_use]
+        pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
+            self.options.mailbox = Some(mailbox);
+            self
+        }
+    };
+
+    (@emit mailbox_shutdown) => {
+        /// Overrides frozen-prefix drain versus discard behavior.
+        #[must_use]
+        pub fn mailbox_shutdown(mut self, shutdown: MailboxShutdown) -> Self {
+            self.options.mailbox_shutdown = Some(shutdown);
+            self
+        }
+    };
+
+    (@emit actor_readiness) => {
+        /// Overrides the actor's declared readiness mode.
+        #[must_use]
+        pub fn readiness(mut self, readiness: Readiness) -> Self {
+            self.options.readiness = Some(readiness);
+            self
+        }
+    };
+
+    (@emit raw_readiness) => {
+        /// Overrides the actor's declared readiness mode.
+        pub fn readiness(mut self, readiness: Readiness) -> Result<Self, PolicyError> {
+            if readiness == Readiness::AfterInit {
+                return Err(PolicyError::UnsupportedReadiness);
+            }
+            self.options.readiness = Some(readiness);
+            Ok(self)
+        }
+    };
+
+    (@emit task_readiness) => {
+        /// Overrides task readiness (`Immediate` or `Manual`).
+        pub fn readiness(mut self, readiness: Readiness) -> Result<Self, PolicyError> {
+            if readiness == Readiness::AfterInit {
+                return Err(PolicyError::UnsupportedReadiness);
+            }
+            self.options.readiness = Some(readiness);
+            Ok(self)
+        }
+    };
+
+    (@emit structural_readiness_deadline) => {
+        /// Overrides the structural readiness deadline.
+        #[must_use]
+        pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
+            self.options.readiness_deadline = deadline;
+            self
+        }
+    };
+
+    (@emit task_readiness_deadline) => {
+        /// Overrides the readiness deadline.
+        #[must_use]
+        pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
+            self.options.readiness_deadline = deadline;
+            self
+        }
+    };
+
+    (@emit retention) => {
+        /// Overrides terminal-membership retention.
+        #[must_use]
+        pub fn retention(mut self, retention: Retention) -> Self {
+            self.options.retention = Some(retention);
+            self
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::DefinitionSource;
+
+    #[test]
+    fn restartable_source_remains_available() {
+        let mut source = DefinitionSource::<_, ()>::Restartable(String::from("factory"));
+
+        assert!(!source.is_one_shot());
+        assert_eq!(source.restartable().map(String::as_str), Some("factory"));
+        assert_eq!(source.take_one_shot(), None);
+        assert_eq!(source.restartable().map(String::as_str), Some("factory"));
+    }
+
+    #[test]
+    fn one_shot_source_transitions_directly_to_spent() {
+        let mut source = DefinitionSource::<(), _>::OneShot(String::from("body"));
+
+        assert!(source.is_one_shot());
+        assert_eq!(source.take_one_shot().as_deref(), Some("body"));
+        assert!(source.is_one_shot());
+        assert!(source.take_one_shot().is_none());
+        assert!(matches!(source, DefinitionSource::Spent));
+    }
+
+    #[test]
+    fn source_keeps_exactly_one_owner_across_consumption() {
+        struct DropProbe(Arc<AtomicUsize>);
+
+        impl Drop for DropProbe {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut source = DefinitionSource::<(), _>::OneShot(DropProbe(Arc::clone(&drops)));
+        let payload = source
+            .take_one_shot()
+            .expect("payload is initially available");
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+        drop(source);
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+        drop(payload);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -940,7 +940,6 @@ impl IndexMut<ChildKey> for ChildArena {
 
 struct ScopeRuntime {
     root: Arc<ScopeCell>,
-    flavor: ScopeFlavor,
     defaults: ResolvedDefaults,
     intensity_policy: crate::Intensity,
     intensity: IntensityState,
@@ -1499,7 +1498,7 @@ impl ScopeRuntime {
         if self.phase != ScopePhase::Starting {
             return;
         }
-        match self.flavor {
+        match self.root.flavor {
             ScopeFlavor::Ordered => {
                 while let Some(key) = self.next_ordered_start {
                     if !self.children[key].spawned_once {
@@ -1675,7 +1674,7 @@ impl ScopeRuntime {
             self.root.set_startup(Err(StartupError::ShutdownRequested));
         }
         self.root.set_state(ScopeState::Draining);
-        match self.flavor {
+        match self.root.flavor {
             ScopeFlavor::Ordered => self.stop_next_ordered(),
             ScopeFlavor::Dynamic => {
                 let children: Vec<_> = self.children.keys().collect();
@@ -1687,7 +1686,7 @@ impl ScopeRuntime {
     }
 
     fn stop_next_ordered(&mut self) {
-        if self.flavor != ScopeFlavor::Ordered || !self.phase.is_draining() {
+        if self.root.flavor != ScopeFlavor::Ordered || !self.phase.is_draining() {
             return;
         }
         loop {
@@ -2074,7 +2073,7 @@ impl ScopeRuntime {
         self.phase = ScopePhase::StartupFailed;
         self.root
             .set_startup(Err(StartupError::StartupFailed(failure.clone())));
-        if self.flavor == ScopeFlavor::Ordered {
+        if self.root.flavor == ScopeFlavor::Ordered {
             let later_children: Vec<_> = self.children.keys_after(key).collect();
             for later in later_children {
                 if !self.children[later].spawned_once
@@ -2161,7 +2160,7 @@ impl ScopeRuntime {
             return None;
         }
         if !self.phase.startup_failed()
-            && self.flavor == ScopeFlavor::Ordered
+            && self.root.flavor == ScopeFlavor::Ordered
             && !self.children.is_empty()
             && self
                 .children
@@ -2402,7 +2401,7 @@ impl ScopeRuntime {
             }
         }
         self.root.prune_child(&member);
-        if self.flavor == ScopeFlavor::Dynamic {
+        if self.root.flavor == ScopeFlavor::Dynamic {
             self.reclaim_child(key);
         }
         // The entry's drop completes any in-flight removal response; it must
@@ -2522,8 +2521,8 @@ async fn run_scope_incarnation(
     }
     let capacity = plan.children.len().saturating_mul(3).max(64);
     let (events, mut event_receiver) = runtime::bounded_mpsc(capacity);
-    let dynamic =
-        (plan.flavor == ScopeFlavor::Dynamic).then(|| DynamicControl::new(&root, events.clone()));
+    let dynamic = (plan.root.flavor == ScopeFlavor::Dynamic)
+        .then(|| DynamicControl::new(&root, events.clone()));
     if let Some(control) = &dynamic {
         let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
         for child in &plan.children {
@@ -2562,7 +2561,6 @@ async fn run_scope_incarnation(
     let next_ordered_start = children.keys().next();
     let mut scope = ScopeRuntime {
         root: Arc::clone(&root),
-        flavor: plan.flavor,
         defaults: plan.defaults.clone(),
         intensity_policy: plan.config.intensity,
         intensity: IntensityState::default(),
@@ -2589,7 +2587,7 @@ async fn run_scope_incarnation(
     plan.armed = false;
     drop(plan);
 
-    match scope.flavor {
+    match scope.root.flavor {
         ScopeFlavor::Ordered => scope.progress_startup(),
         ScopeFlavor::Dynamic => {
             let children: Vec<_> = scope.children.keys().collect();
@@ -2836,7 +2834,6 @@ mod tests {
         mailbox::MailboxCell,
         plan::SlotCell,
         runtime::Latch,
-        tree::{into_core_for_test, lower_tree_for_test},
     };
 
     use super::{
@@ -2995,7 +2992,7 @@ mod tests {
         tree.add_task("trip", TaskDef::new(|_| future::pending()))
             .expect("valid task");
 
-        let mut plan = lower_tree_for_test(tree);
+        let mut plan = tree.lower_for_test();
         let root = Arc::clone(&plan.root);
         let epoch = root.begin_incarnation();
         root.set_admitted_children(
@@ -3023,7 +3020,6 @@ mod tests {
         let next_ordered_start = children.keys().next();
         let mut scope = ScopeRuntime {
             root: Arc::clone(&root),
-            flavor: plan.flavor,
             defaults: plan.defaults.clone(),
             intensity_policy: plan.config.intensity,
             intensity: super::IntensityState::default(),
@@ -3181,7 +3177,7 @@ mod tests {
         let mut tree = Tree::new();
         tree.add_task("worker", TaskDef::new(|_| future::pending()))
             .expect("valid task");
-        let mut plan = lower_tree_for_test(tree);
+        let mut plan = tree.lower_for_test();
         let child =
             ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &plan.root);
         let mut arena = ChildArena::default();
@@ -3200,7 +3196,7 @@ mod tests {
         let mut tree = Tree::new();
         tree.add_task("worker", TaskDef::new(|_| future::pending()))
             .expect("valid task");
-        let mut plan = lower_tree_for_test(tree);
+        let mut plan = tree.lower_for_test();
         let child =
             ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &plan.root);
         let mut arena = ChildArena {
@@ -3419,7 +3415,7 @@ mod tests {
                 .expect("manual readiness is valid"),
         )
         .expect("valid task");
-        let plan = lower_tree_for_test(tree);
+        let plan = tree.lower_for_test();
         let scope = Arc::clone(&plan.root);
         let epoch = scope.begin_incarnation();
         let driver = crate::runtime::spawn(
@@ -3459,7 +3455,7 @@ mod tests {
 
     #[crate::runtime::test]
     async fn dropped_unpolled_scope_plan_terminalizes_its_root() {
-        let plan = lower_tree_for_test(Tree::new());
+        let plan = Tree::new().lower_for_test();
         let root = Arc::clone(&plan.root);
 
         drop(plan);
@@ -3483,7 +3479,7 @@ mod tests {
             .expect("valid nested scope");
         let mut snapshots = nested.subscribe_snapshots();
         let mut events = nested.subscribe_lifecycle();
-        let plan = lower_tree_for_test(outer);
+        let plan = outer.lower_for_test();
 
         drop(plan);
 
@@ -3527,7 +3523,7 @@ mod tests {
             tree.add_task(id, TaskDef::new(|_| future::pending()))
                 .expect("valid task");
         }
-        let plan = lower_tree_for_test(tree);
+        let plan = tree.lower_for_test();
         let root = Arc::clone(&plan.root);
         let mut events = root.subscribe_lifecycle();
         let children: Vec<_> = plan
@@ -4057,7 +4053,7 @@ mod tests {
             .expect("provisional declaration succeeds");
         let ready = Latch::default();
         let error = run_nested_tree(
-            into_core_for_test(tree),
+            tree.into_core_for_test(),
             Arc::clone(&scope),
             crate::policy::ResolvedDefaults::default(),
             ready.clone(),

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -10,7 +10,7 @@ use std::{
 use crate::{
     ChildId, Exit, ExitKind, Incarnation, IntensityTrip, Membership, Readiness, ReadinessDeadline,
     ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure, StartupFailureCause,
-    cells::{DynamicRoute, MemberCell, MemberStage, ResidentProjection, ScopeCell},
+    cells::{DynamicRoute, MemberStage, ResidentProjection, ScopeCell},
     deadline::Deadline,
     engine::{
         ArbitrationClass, DeadlineHandle, DeadlineQueue, ExitDispatch, IntensityState,
@@ -22,7 +22,7 @@ use crate::{
     observe::LifecycleEventKind,
     plan::{
         BuilderCore, ChildConstruction, ChildPlan, LowerError, NotAdmittingCause, RemoveOutcome,
-        ReserveError, ScopeFactory, ScopePlan, SlotCell,
+        ReserveError, ScopeFactory, ScopePlan, SlotCell, checked_id, mint_reserved_slot,
     },
     policy::{DefaultsInheritance, ResolvedDefaults, ScopeFlavor},
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
@@ -31,7 +31,7 @@ use crate::{
 };
 
 #[cfg(test)]
-use crate::cells::RuntimeStorage;
+use crate::cells::{MemberCell, RuntimeStorage};
 
 /// An exactly-once synchronous completion.
 ///
@@ -262,6 +262,7 @@ pub(crate) fn reserve_dynamic(
     id: ChildId,
     child_scope: Option<ScopeFlavor>,
 ) -> Result<DynamicReservation, ReserveError> {
+    let id = checked_id(id)?;
     if matches!(scope.member.record().stage, MemberStage::Terminal(_)) {
         return Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal));
     }
@@ -292,18 +293,7 @@ pub(crate) fn reserve_dynamic(
         }
         return Err(ReserveError::DuplicateId(id));
     }
-    let membership = scope
-        .child_identity
-        .lock()
-        .expect("scope identity mutex poisoned")
-        .mint_membership(&id)
-        .ok_or(ReserveError::IdentityExhausted)?;
-    let member = MemberCell::new(id.clone(), membership);
-    let child_scope = child_scope.map(|flavor| {
-        let identity = ScopeIdentity::new().expect("global scope identity space exhausted");
-        ScopeCell::new(Arc::clone(&member), flavor, identity)
-    });
-    let slot = SlotCell::new(member, child_scope);
+    let slot = mint_reserved_slot(scope, &id, child_scope)?;
     state.entries.insert(
         id,
         DynamicEntry {
@@ -2220,20 +2210,7 @@ impl ScopeRuntime {
             );
             return;
         };
-        let (options, one_shot) = match definition.get() {
-            ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
-            ChildConstruction::Task(definition) => (&definition.options, false),
-            ChildConstruction::TaskOnce(definition) => (&definition.options, true),
-            ChildConstruction::Scope(definition) => (&definition.options, definition.one_shot()),
-        };
-        let resolved =
-            crate::policy::resolve_common(options, &self.defaults, one_shot, Readiness::Immediate);
-        request.slot.member.set_options(resolved.clone());
-        let plan = ChildPlan {
-            slot: Arc::clone(&request.slot),
-            construction: definition,
-            options: resolved,
-        };
+        let plan = ChildPlan::resolve(Arc::clone(&request.slot), definition, &self.defaults);
         {
             let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
             let id = request.slot.member.id();

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -3,9 +3,7 @@
 use std::{
     collections::HashMap,
     fmt,
-    future::Future,
     ops::{Index, IndexMut},
-    pin::Pin,
     sync::{
         Arc, Mutex, Weak,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -40,29 +38,6 @@ use crate::{
         StopReason,
     },
 };
-
-pub(crate) type DriverSleep = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
-
-pub(crate) fn deadline(duration: Duration) -> Deadline {
-    Deadline::after(runtime::now(), duration)
-}
-
-pub(crate) fn sleep_deadline(deadline: Deadline) -> DriverSleep {
-    Box::pin(async move {
-        match deadline.instant() {
-            Some(deadline) => runtime::sleep_until_std(deadline).await,
-            None => std::future::pending().await,
-        }
-    })
-}
-
-pub(crate) fn sleep_until(deadline: Instant) -> DriverSleep {
-    Box::pin(runtime::sleep_until_std(deadline))
-}
-
-pub(crate) fn now() -> Instant {
-    runtime::now()
-}
 
 /// An exactly-once synchronous completion.
 ///
@@ -105,130 +80,6 @@ impl<T> Obligation<T> {
 impl<T> Drop for Obligation<T> {
     fn drop(&mut self) {
         self.discharge();
-    }
-}
-
-pub(crate) struct ActorWork {
-    handle: Option<runtime::JoinHandle<(), ()>>,
-    abort: runtime::AbortHandle,
-}
-
-impl ActorWork {
-    pub(crate) fn abort(&self) {
-        self.abort.abort();
-    }
-
-    pub(crate) async fn join(mut self) {
-        let Some(handle) = self.handle.take() else {
-            return;
-        };
-        let _ = runtime::join(handle).await;
-    }
-}
-
-impl Drop for ActorWork {
-    fn drop(&mut self) {
-        self.abort.abort();
-    }
-}
-
-pub(crate) fn spawn_actor_work(future: impl Future<Output = ()> + Send + 'static) -> ActorWork {
-    let handle = runtime::spawn((), future);
-    let abort = handle.abort_handle();
-    ActorWork {
-        handle: Some(handle),
-        abort,
-    }
-}
-
-pub(crate) struct BlockingWork<T> {
-    handle: Option<runtime::JoinHandle<(), T>>,
-}
-
-impl<T: Send + 'static> BlockingWork<T> {
-    pub(crate) async fn join(mut self) -> T {
-        let handle = self
-            .handle
-            .take()
-            .expect("blocking operation was joined more than once");
-        runtime::join_resuming(handle).await.1
-    }
-}
-
-pub(crate) fn spawn_blocking_work<T: Send + 'static>(
-    operation: impl FnOnce() -> T + Send + 'static,
-) -> BlockingWork<T> {
-    BlockingWork {
-        handle: Some(runtime::spawn_blocking((), operation)),
-    }
-}
-
-pub(crate) enum Selected<A, B> {
-    First(A),
-    Second(B),
-}
-
-pub(crate) async fn select<A, B>(first: A, second: B) -> Selected<A::Output, B::Output>
-where
-    A: Future + Send,
-    B: Future + Send,
-{
-    match runtime::select_two(first, second).await {
-        runtime::Either::Left(value) => Selected::First(value),
-        runtime::Either::Right(value) => Selected::Second(value),
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct Signal {
-    inner: runtime::WatchSender<()>,
-}
-
-impl Default for Signal {
-    fn default() -> Self {
-        Self {
-            inner: runtime::watch(()).0,
-        }
-    }
-}
-
-impl Clone for Signal {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-        }
-    }
-}
-
-impl Signal {
-    pub(crate) fn pulse(&self) {
-        self.inner.pulse();
-    }
-
-    pub(crate) fn watcher(&self) -> SignalWatcher {
-        SignalWatcher {
-            inner: self.inner.watcher(),
-            _signal: self.clone(),
-        }
-    }
-
-    #[cfg(test)]
-    fn watcher_count(&self) -> usize {
-        self.inner.receiver_count()
-    }
-}
-
-pub(crate) struct SignalWatcher {
-    inner: runtime::WatchReceiver<()>,
-    // The previous signal implementation kept the source alive through each
-    // watcher. Preserve that ownership so `changed` cannot turn channel
-    // closure into a spurious pulse.
-    _signal: Signal,
-}
-
-impl SignalWatcher {
-    pub(crate) async fn changed(&mut self) {
-        self.inner.changed().await;
     }
 }
 
@@ -1702,10 +1553,6 @@ impl SystemRun {
             }
         }
     }
-}
-
-pub(crate) fn runtime_available() -> bool {
-    runtime::is_available()
 }
 
 fn collect_stragglers(scope: &ScopeCell, prefix: &[ChildId], out: &mut Vec<ShutdownStraggler>) {
@@ -4078,7 +3925,7 @@ mod tests {
     use super::{
         ChildArena, ChildEvent, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
         MemberCell, MemberStage, Obligation, Pending, RemovalResponses, RuntimeStorage, ScopeCell,
-        ScopeFlavor, ScopePhase, ScopeRuntime, Signal, StartupPhase, complete_removals,
+        ScopeFlavor, ScopePhase, ScopeRuntime, StartupPhase, complete_removals,
         driver_event_class, mint_child_incarnation, report_channel, restart_shutdown_work,
         run_nested_tree, run_scope_incarnation,
     };
@@ -4410,21 +4257,6 @@ mod tests {
             &root.observation_gate(),
             &nested.observation_gate()
         ));
-    }
-
-    #[test]
-    fn quiet_signal_wait_cancellation_keeps_one_watch_registration() {
-        let signal = Signal::default();
-        let mut watcher = signal.watcher();
-        assert_eq!(signal.watcher_count(), 1);
-
-        for _ in 0..10_000 {
-            let mut changed = Box::pin(watcher.changed());
-            let mut context = Context::from_waker(Waker::noop());
-            assert!(changed.as_mut().poll(&mut context).is_pending());
-            drop(changed);
-            assert_eq!(signal.watcher_count(), 1);
-        }
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -263,6 +263,9 @@ pub(crate) fn reserve_dynamic(
     child_scope: Option<ScopeFlavor>,
 ) -> Result<DynamicReservation, ReserveError> {
     let id = checked_id(id)?;
+    if !runtime::is_available() {
+        return Err(ReserveError::NoRuntime);
+    }
     if matches!(scope.member.record().stage, MemberStage::Terminal(_)) {
         return Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal));
     }
@@ -314,7 +317,10 @@ pub(crate) fn start_admission(
     control: Arc<DynamicControl>,
     slot: Arc<SlotCell>,
     fused_cancel: Option<Latch>,
-) -> runtime::OneShotReceiver<Result<(), ReserveError>> {
+) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError> {
+    if !runtime::is_available() {
+        return Err(ReserveError::NoRuntime);
+    }
     let (sender, response) = runtime::oneshot();
     let request = AdmissionRequest {
         control: Arc::downgrade(&control),
@@ -327,7 +333,7 @@ pub(crate) fn start_admission(
     runtime::spawn(async move {
         let _ = runtime::mpsc_send(&control.events, DriverEvent::Admission(request)).await;
     });
-    response
+    Ok(response)
 }
 
 fn cancel_dynamic_reservation_parts(

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -20,14 +20,14 @@ use crate::{
     exit::{JoinVerdict, RecordedOutcome, StartupError, StopReason, classify_exit},
     identity::{FenceCounter, ScopeIdentity},
     observe::LifecycleEventKind,
+    plan::{
+        BuilderCore, ChildConstruction, ChildPlan, LowerError, NotAdmittingCause, RemoveOutcome,
+        ReserveError, ScopeFactory, ScopePlan, ScopeSource, SlotCell,
+    },
     policy::{DefaultsInheritance, ResolvedDefaults, ScopeFlavor},
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
     runtime::{self, Latch},
     task::{OnceTaskBody, TaskContext, TaskFactory},
-    tree::{
-        BuilderCore, ChildConstruction, ChildPlan, LowerError, NotAdmittingCause, RemoveOutcome,
-        ReserveError, ScopeFactory, ScopePlan, ScopeSource, SlotCell,
-    },
 };
 
 #[cfg(test)]
@@ -691,7 +691,7 @@ fn discharge_child_terminality(completion: ChildTerminality) {
 }
 
 struct ChildRuntime {
-    slot: Arc<crate::tree::SlotCell>,
+    slot: Arc<SlotCell>,
     terminality: Obligation<ChildTerminality>,
     construction: runtime::Isolated<ChildConstruction>,
     pending_terminal: Option<PendingTerminal>,
@@ -2834,8 +2834,9 @@ mod tests {
         exit::{JoinVerdict, RecordedOutcome},
         identity::{FenceCounter, ScopeIdentity},
         mailbox::MailboxCell,
+        plan::SlotCell,
         runtime::Latch,
-        tree::{SlotCell, into_core_for_test, lower_tree_for_test},
+        tree::{into_core_for_test, lower_tree_for_test},
     };
 
     use super::{

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -218,11 +218,7 @@ impl DynamicControl {
         let mut retained = HashMap::new();
         for (id, entry) in entries {
             if !entry.admitted {
-                let definition = entry.slot.take_defined();
-                entry.slot.member.terminalize(Exit::never_started());
-                if let Some(scope) = &entry.slot.scope {
-                    scope.terminalize_never_started();
-                }
+                let definition = entry.slot.take_never_started();
                 dispose_definition_then(definition, move || drop(entry));
             } else {
                 retained.insert(id, entry);
@@ -345,12 +341,7 @@ fn cancel_dynamic_reservation_parts(
     let removed = cancelled.then(|| state.entries.remove(&id)).flatten();
     drop(state);
     let definition = if cancelled {
-        let definition = slot.take_defined();
-        slot.member.terminalize(Exit::never_started());
-        if let Some(scope) = &slot.scope {
-            scope.terminalize_never_started();
-        }
-        definition
+        slot.take_never_started()
     } else {
         None
     };
@@ -396,11 +387,7 @@ pub(crate) fn remove_dynamic(
     if !entry.admitted {
         let entry = state.entries.remove(id).expect("entry was just resolved");
         drop(state);
-        let definition = entry.slot.take_defined();
-        entry.slot.member.terminalize(Exit::never_started());
-        if let Some(scope) = &entry.slot.scope {
-            scope.terminalize_never_started();
-        }
+        let definition = entry.slot.take_never_started();
         dispose_definition_then(definition, move || drop(entry));
         return response;
     }
@@ -2223,10 +2210,7 @@ impl ScopeRuntime {
                     .then(|| state.entries.remove(id))
                     .flatten();
                 drop(state);
-                request.slot.member.terminalize(Exit::never_started());
-                if let Some(scope) = &request.slot.scope {
-                    scope.terminalize_never_started();
-                }
+                request.slot.terminalize_never_started();
                 // The entry's drop completes its removal response; preserve
                 // the same terminality-before-completion ordering as every
                 // other reservation-cancellation path. Definition disposal
@@ -2264,10 +2248,7 @@ impl ScopeRuntime {
                         .then(|| state.entries.remove(id))
                         .flatten()
                 };
-                request.slot.member.terminalize(Exit::never_started());
-                if let Some(scope) = &request.slot.scope {
-                    scope.terminalize_never_started();
-                }
+                request.slot.terminalize_never_started();
                 child.complete_terminality();
                 let ChildRuntime { construction, .. } = child;
                 reject_admission_after_disposal(

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1109,37 +1109,17 @@ impl ScopeRuntime {
             self.deadlines.cancel(deadline);
         }
         let Some(incarnation) = mint_child_incarnation(&child.slot, &mut child.incarnations) else {
-            child.complete_terminality();
-            // Incarnation exhaustion terminalized the membership (§3.1):
-            // publish the observation edges, then route the terminal outcome
-            // through the same paths as a terminal exit so ordered startup
-            // fails or draining advances instead of wedging the scope.
-            self.root.transition_child(&child.slot.member, |_| {}, None);
-            if child.options.retention == crate::Retention::Remove {
-                self.root.prune_child(&child.slot.member);
-            }
-            if let Some(construction) = child.construction.take() {
-                runtime::dispose_detached(construction);
-            }
-            let exit = match child.slot.member.record().stage {
-                MemberStage::Terminal(exit) => exit,
-                _ => Exit::never_started(),
-            };
+            let exit = child
+                .slot
+                .member
+                .record()
+                .last_exit
+                .unwrap_or_else(Exit::never_started);
             let pre_ready = child.initial && !self.phase.startup_complete() && !child.initial_ready;
-            let removing = child.slot.member.record().removing;
-            let retention_remove = child.options.retention == crate::Retention::Remove;
-            if removing {
-                self.finalize_removal(key);
-            } else if pre_ready && !self.phase.is_draining() {
-                self.fail_startup(key, exit);
-            } else {
-                if retention_remove {
-                    self.prune_terminal(key);
-                }
-                if self.phase.is_draining() {
-                    self.stop_next_ordered();
-                }
-            }
+            // Exhaustion is a terminal outcome, not an exceptional cleanup
+            // path. Join retained-definition disposal before terminality,
+            // retention, removal completion, or ordered-scope progression.
+            self.begin_terminal_disposal(key, exit, None, pre_ready);
             return;
         };
 
@@ -1554,28 +1534,10 @@ impl ScopeRuntime {
             }
             let record = child.slot.member.record();
             let exit = record.last_exit.unwrap_or_else(Exit::never_started);
-            if record.last_incarnation.is_none() {
-                if let Some(scope) = &child.slot.scope {
-                    scope.terminalize_never_started();
-                }
-                // A never-ran terminal is the plain `Stopped { NeverStarted }`
-                // state (B.6), not a §6 startup abort. Its definition still
-                // owns the only user resource, so join disposal before
-                // completing the scope, while publishing the never-started
-                // member state synchronously for startup observation.
-                self.begin_terminal_disposal(key, exit, None, false);
-                self.children[key].terminalize(&self.root, Exit::never_started(), None, false);
-            } else {
-                // Between incarnations, the recorded exit already owns the
-                // child verdict. There is no incarnation left to classify a
-                // later factory destructor, so publish synchronously and
-                // isolate cleanup without turning it into a shutdown
-                // straggler (including for a zero shutdown budget).
-                child.terminalize(&self.root, exit, None, false);
-                if let Some(construction) = child.construction.take() {
-                    runtime::dispose_detached(construction);
-                }
-            }
+            // A never-ran child and a child stopped between restart
+            // incarnations share the same post-disposal terminal route. Hard
+            // shutdown still detaches disposal through `hard_forced` below.
+            self.begin_terminal_disposal(key, exit, None, false);
         }
     }
 
@@ -2006,9 +1968,14 @@ impl ScopeRuntime {
             return;
         };
         child.slot.member.set_terminal_disposal_pending(false);
-        if let Some(message) = panic
+        if terminal.exited_incarnation.is_some()
+            && let Some(message) = panic
             && !matches!(terminal.exit.kind(), ExitKind::Panicked { .. })
         {
+            // Only an exited incarnation can own a destructor failure. A
+            // never-started child or a child between restart incarnations
+            // keeps its already-authoritative verdict while disposal remains
+            // ordered ahead of terminal routing.
             terminal.exit = Exit::new(ExitKind::Panicked { message }, terminal.exit.cancelled());
         }
 
@@ -2056,16 +2023,7 @@ impl ScopeRuntime {
                     && !self.children[later].is_disposing()
                     && !self.children[later].is_terminal()
                 {
-                    if let Some(scope) = &self.children[later].slot.scope {
-                        scope.terminalize_never_started();
-                    }
                     self.begin_terminal_disposal(later, Exit::never_started(), None, false);
-                    self.children[later].terminalize(
-                        &self.root,
-                        Exit::never_started(),
-                        None,
-                        false,
-                    );
                 }
             }
         }
@@ -2388,21 +2346,7 @@ impl ScopeRuntime {
 }
 
 fn mint_child_incarnation(slot: &Arc<SlotCell>, counter: &mut FenceCounter) -> Option<Incarnation> {
-    let member = &slot.member;
-    let incarnation = ScopeIdentity::mint_incarnation(member.membership(), counter);
-    if incarnation.is_none() {
-        let record = member.record();
-        let exit = record.last_exit.unwrap_or_else(Exit::never_started);
-        member.terminalize(exit);
-        if let Some(scope) = &slot.scope {
-            if record.last_incarnation.is_none() {
-                scope.terminalize_never_started();
-            } else {
-                scope.close_observation();
-            }
-        }
-    }
-    incarnation
+    ScopeIdentity::mint_incarnation(slot.member.membership(), counter)
 }
 
 async fn run_nested_tree(
@@ -2781,10 +2725,10 @@ mod tests {
     };
 
     use crate::{
-        ActorRef, ChildId, DynamicTree, Exit, ExitError, ExitKind, Intensity, LifecycleEventKind,
-        LifecycleItem, LifecycleTryRecvError, Readiness, ReadinessDeadline, RemoveOutcome,
-        Retention, ScopeState, SendErrorKind, StartupError, StartupFailureCause, StopReason,
-        SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
+        ActorRef, ChildId, ChildState, DynamicTree, Exit, ExitError, ExitKind, Intensity,
+        LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Readiness, ReadinessDeadline,
+        RemoveOutcome, Retention, ScopeState, SendErrorKind, StartupError, StartupFailureCause,
+        StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
         engine::arbitrate,
         exit::{JoinVerdict, RecordedOutcome},
         identity::{FenceCounter, ScopeIdentity},
@@ -3959,7 +3903,7 @@ mod tests {
     }
 
     #[test]
-    fn incarnation_exhaustion_terminalizes_the_membership_as_never_restart() {
+    fn incarnation_mint_exhaustion_has_no_terminal_side_effects() {
         let mut identity = ScopeIdentity::new().expect("scope identity available");
         let id = ChildId::from("worker");
         let membership = identity.mint_membership(&id).expect("membership available");
@@ -3977,11 +3921,107 @@ mod tests {
 
         assert!(mint_child_incarnation(&slot, &mut counter).is_some());
         assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+        assert!(matches!(member.record().stage, MemberStage::Restarting));
+        assert_eq!(member.record().last_exit, Some(previous));
+        assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+    }
+
+    #[crate::runtime::test]
+    async fn incarnation_exhaustion_uses_post_disposal_retention_routing() {
+        let mut tree = Tree::new();
+        tree.add_task(
+            "worker",
+            TaskDef::new(|_| future::pending::<crate::ExitResult>()).retention(Retention::Remove),
+        )
+        .expect("valid task");
+        let mut plan = tree.lower_for_test();
+        let root = Arc::clone(&plan.root);
+        let epoch = root.begin_incarnation();
+        root.set_admitted_children(
+            plan.children
+                .iter()
+                .map(|child| resident_projection(&child.slot))
+                .collect(),
+        );
+        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(64);
+        let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+        let mut children = ChildArena::default();
+        let key = children
+            .insert(child)
+            .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+        let mut scope = ScopeRuntime {
+            root: Arc::clone(&root),
+            defaults: plan.defaults.clone(),
+            intensity_policy: plan.config.intensity,
+            intensity: super::IntensityState::default(),
+            children,
+            events,
+            deadlines: super::DeadlineQueue::default(),
+            jitter: crate::runtime::JitterRng::from_system_entropy(),
+            phase: ScopePhase::Running,
+            next_ordered_start: Some(key),
+            is_root: true,
+            parent_ready: None,
+            dynamic: None,
+            epoch,
+            ancestor_shutdown: None,
+            ancestor_shutdown_seen: false,
+            ancestor_abort: None,
+            ancestor_abort_ack: None,
+            ancestor_abort_seen: false,
+            hard_forced: false,
+            completion: None,
+        };
+        plan.armed = false;
+        drop(plan);
+
+        scope.children[key].incarnations = FenceCounter::near_exhaustion(71);
+        let first = {
+            let child = &mut scope.children[key];
+            mint_child_incarnation(&child.slot, &mut child.incarnations)
+                .expect("the last usable incarnation mints")
+        };
+        let previous = Exit::new(
+            ExitKind::Failed(ExitError::message("last completed incarnation")),
+            false,
+        );
+        root.transition_child(
+            &scope.children[key].slot.member,
+            |record| {
+                record.incarnation = None;
+                record.last_incarnation = Some(first);
+                record.last_exit = Some(previous.clone());
+                record.stage = MemberStage::Restarting;
+            },
+            None,
+        );
+
+        scope.spawn_child(key);
+        assert!(scope.children[key].is_disposing());
         assert!(matches!(
-            member.record().stage,
+            scope.children[key].slot.member.record().stage,
+            MemberStage::Restarting
+        ));
+        assert_eq!(root.snapshot().children.len(), 1);
+
+        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = event_receiver
+            .recv()
+            .await
+            .expect("disposal reports completion")
+        else {
+            panic!("only construction disposal was armed")
+        };
+        scope.handle_construction_disposed(child, panic);
+
+        assert!(!scope.children[key].is_disposing());
+        assert!(matches!(
+            scope.children[key].slot.member.record().stage,
             MemberStage::Terminal(ref exit) if exit == &previous
         ));
-        assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+        assert!(
+            root.snapshot().children.is_empty(),
+            "retention pruning follows joined disposal"
+        );
     }
 
     #[crate::runtime::test]
@@ -4045,6 +4085,7 @@ mod tests {
 
     #[crate::runtime::test]
     async fn scope_incarnation_exhaustion_closes_nested_observation() {
+        let parent = isolated_scope("parent", ScopeFlavor::Ordered);
         let mut identity = ScopeIdentity::new().expect("scope identity available");
         let id = ChildId::from("nested");
         let membership = identity.mint_membership(&id).expect("membership available");
@@ -4055,6 +4096,7 @@ mod tests {
             ScopeIdentity::new().expect("child identity available"),
         );
         let slot = SlotCell::new(Arc::clone(&member), Some(Arc::clone(&scope)));
+        parent.set_admitted_children(vec![resident_projection(&slot)]);
         let mut snapshots = scope.subscribe_snapshots();
         let mut events = scope.subscribe_lifecycle();
         let mut counter = FenceCounter::near_exhaustion(83);
@@ -4069,6 +4111,7 @@ mod tests {
         });
 
         assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+        assert!(matches!(member.record().stage, MemberStage::Restarting));
         assert!(matches!(
             events.try_recv(),
             Ok(LifecycleItem::Event(crate::LifecycleEvent {
@@ -4079,6 +4122,13 @@ mod tests {
                 },
                 ..
             }))
+        ));
+        assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Empty));
+        assert!(parent.terminalize_child(
+            &member,
+            Exit::new(ExitKind::Completed, false),
+            None,
+            false
         ));
         assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Closed));
         snapshots
@@ -4092,6 +4142,36 @@ mod tests {
             }
         ));
         assert!(snapshots.changed().await.is_err());
+    }
+
+    #[crate::runtime::test]
+    async fn never_started_nested_terminal_publishes_one_final_parent_snapshot() {
+        let parent = isolated_scope("parent", ScopeFlavor::Ordered);
+        let nested = isolated_scope("nested", ScopeFlavor::Ordered);
+        let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
+        parent.set_admitted_children(vec![resident_projection(&slot)]);
+        let mut snapshots = parent.subscribe_snapshots();
+
+        assert!(parent.terminalize_child(&nested.member, Exit::never_started(), None, false));
+        snapshots
+            .changed()
+            .await
+            .expect("no-incarnation terminal publishes the parent projection");
+
+        assert!(matches!(
+            snapshots
+                .borrow_latest()
+                .child("nested")
+                .expect("retained nested child remains resident")
+                .state,
+            ChildState::Stopped { ref exit } if matches!(exit.kind(), ExitKind::NeverStarted)
+        ));
+        assert!(matches!(
+            nested.record().state,
+            ScopeState::Stopped {
+                reason: StopReason::NeverStarted
+            }
+        ));
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -647,7 +647,6 @@ struct ActiveChild {
     construction_release: Latch,
     framework_abort: Option<Latch>,
     framework_abort_ack: Option<Latch>,
-    framework_abort_deadline: Option<Instant>,
     stop_deadline: Option<DeadlineHandle>,
 }
 
@@ -1446,7 +1445,6 @@ impl ScopeRuntime {
             construction_release,
             framework_abort: scope_child.then_some(framework_abort),
             framework_abort_ack: scope_child.then_some(framework_abort_ack),
-            framework_abort_deadline: None,
             stop_deadline: None,
         });
         #[cfg(test)]
@@ -1529,7 +1527,11 @@ impl ScopeRuntime {
             if active.forced_outcome.is_none() {
                 active.readiness.step(ReadinessEvent::Shutdown);
             }
-            active.ladder = Some(StopLadder::new(child.options.shutdown));
+            active.ladder = Some(if active.framework_abort.is_some() {
+                StopLadder::for_framework_driver(child.options.shutdown)
+            } else {
+                StopLadder::new(child.options.shutdown)
+            });
             self.advance_ladder(key, runtime::now());
         } else {
             if let Some(deadline) = child.restart_deadline.take() {
@@ -1557,6 +1559,13 @@ impl ScopeRuntime {
         let Some(ladder) = &mut active.ladder else {
             return;
         };
+        if active
+            .framework_abort_ack
+            .as_ref()
+            .is_some_and(Latch::is_fired)
+        {
+            ladder.acknowledge_framework_abort();
+        }
         while let Some(action) = ladder.advance(now) {
             match action {
                 StopAction::Cancel => {
@@ -1565,37 +1574,25 @@ impl ScopeRuntime {
                 StopAction::Escalate => {
                     active.abort.fire();
                 }
+                StopAction::AbortFramework { after_grace } => {
+                    active.hard_abort_after_grace = Some(after_grace);
+                    if active.forced_outcome.is_none() {
+                        active.forced_outcome = Some(RecordedOutcome::Aborted { after_grace });
+                    }
+                    active
+                        .framework_abort
+                        .as_ref()
+                        .expect("framework action belongs only to a framework driver")
+                        .fire();
+                }
                 StopAction::HardAbort { after_grace } => {
                     active.hard_abort_after_grace = Some(after_grace);
-                    if let Some(abort) = &active.framework_abort {
-                        if active.forced_outcome.is_none() {
-                            active.forced_outcome = Some(RecordedOutcome::Aborted { after_grace });
-                        }
-                        abort.fire();
-                        active.framework_abort_deadline =
-                            Deadline::after(now, crate::policy::tidy_abort_beat(Duration::ZERO))
-                                .instant();
-                    } else {
-                        active.abort_handle.abort();
-                    }
+                    active.abort_handle.abort();
                 }
             }
         }
         let ladder_deadline = ladder.deadline();
-        if active
-            .framework_abort_deadline
-            .is_some_and(|deadline| now >= deadline)
-        {
-            active.framework_abort_deadline = None;
-            if active
-                .framework_abort_ack
-                .as_ref()
-                .is_none_or(|ack| !ack.is_fired())
-            {
-                active.abort_handle.abort();
-            }
-        }
-        if let Some(deadline) = ladder_deadline.or(active.framework_abort_deadline) {
+        if let Some(deadline) = ladder_deadline {
             active.stop_deadline = Some(self.deadlines.push(
                 deadline,
                 DeadlineKind::Stop {
@@ -1651,16 +1648,18 @@ impl ScopeRuntime {
         let now = runtime::now();
         let children: Vec<_> = self.children.keys().collect();
         for key in children {
-            let child = &mut self.children[key];
-            let Some(active) = &mut child.active else {
-                continue;
-            };
-            let mut ladder = StopLadder::new(crate::Shutdown::Abort);
-            let _ = ladder.advance(now);
-            let _ = ladder.advance(now);
-            active.shutdown.fire();
-            active.abort.fire();
-            active.ladder = Some(ladder);
+            // Every live membership enters the same stop funnel first. That
+            // owns mailbox freeze, readiness disarm, ordered-child handling,
+            // and the initial cooperative action.
+            self.begin_stop_child(key, None);
+            if let Some(ladder) = self
+                .children
+                .get_mut(key)
+                .and_then(|child| child.active.as_mut())
+                .and_then(|active| active.ladder.as_mut())
+            {
+                ladder.force(now);
+            }
             self.advance_ladder(key, now);
         }
         let disposing = self
@@ -2534,7 +2533,9 @@ async fn run_scope_incarnation(
             pending.push((ArbitrationClass::ScopeShutdown, Pending::AncestorAbort));
         }
         if root.take_force_request(epoch) {
-            pending.push((ArbitrationClass::StopDeadline, Pending::Force));
+            // Force owns shutdown arbitration: readiness from the same wake
+            // cannot publish Running after the stop boundary.
+            pending.push((ArbitrationClass::ScopeShutdown, Pending::Force));
         }
         for membership in scope.pending_removals() {
             pending.push((
@@ -2740,7 +2741,7 @@ mod tests {
         LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Readiness, ReadinessDeadline,
         RemoveOutcome, Retention, ScopeState, SendErrorKind, StartupError, StartupFailureCause,
         StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
-        engine::arbitrate,
+        engine::{StopLadder, arbitrate},
         exit::{JoinVerdict, RecordedOutcome},
         identity::{FenceCounter, ScopeIdentity},
         mailbox::MailboxCell,
@@ -2764,6 +2765,20 @@ mod tests {
             identity.mint_membership(&id).expect("membership available"),
         );
         ScopeCell::new(member, flavor, ScopeIdentity::new())
+    }
+
+    struct PendingRaw;
+
+    impl crate::RawActor for PendingRaw {
+        type Msg = u8;
+
+        fn readiness(&self) -> Readiness {
+            Readiness::Manual
+        }
+
+        async fn run(&mut self, _: &mut crate::RawContext<Self::Msg>) -> crate::ExitResult {
+            future::pending().await
+        }
     }
 
     #[test]
@@ -2878,6 +2893,128 @@ mod tests {
                 }
             );
             assert!(!phase.begin_drain(StopReason::Finished));
+        }
+    }
+
+    #[crate::runtime::test]
+    async fn force_uses_the_stop_funnel_for_every_ordered_child() {
+        let mut tree = Tree::new();
+        let first = tree
+            .add_raw("first", crate::RawDef::factory(|| PendingRaw))
+            .expect("valid first actor");
+        let second = tree
+            .add_raw("second", crate::RawDef::factory(|| PendingRaw))
+            .expect("valid second actor");
+        let mut plan = tree.lower_for_test();
+        let root = Arc::clone(&plan.root);
+        let epoch = root.begin_incarnation();
+        root.set_admitted_children(
+            plan.children
+                .iter()
+                .map(|child| resident_projection(&child.slot))
+                .collect(),
+        );
+        let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+        let mut children = ChildArena::default();
+        plan.children.reverse();
+        while let Some(child) = plan.children.pop() {
+            children
+                .insert(ChildRuntime::from_plan(child, &root))
+                .unwrap_or_else(|_| panic!("the fixture fits in the child-key domain"));
+        }
+        let keys = children.keys().collect::<Vec<_>>();
+        let mut scope = ScopeRuntime {
+            root: Arc::clone(&root),
+            defaults: plan.defaults.clone(),
+            intensity_policy: plan.config.intensity,
+            intensity: super::IntensityState::default(),
+            children,
+            events,
+            deadlines: super::DeadlineQueue::default(),
+            jitter: crate::runtime::JitterRng::from_system_entropy(),
+            phase: ScopePhase::Running,
+            next_ordered_start: None,
+            is_root: true,
+            parent_ready: None,
+            dynamic: None,
+            epoch,
+            ancestor_shutdown: None,
+            ancestor_shutdown_seen: false,
+            ancestor_abort: None,
+            ancestor_abort_ack: None,
+            ancestor_abort_seen: false,
+            hard_forced: false,
+            completion: None,
+        };
+        plan.armed = false;
+        drop(plan);
+
+        for key in &keys {
+            scope.spawn_child(*key);
+        }
+        let incarnations = keys
+            .iter()
+            .map(|key| {
+                scope.children[*key]
+                    .active
+                    .as_ref()
+                    .expect("child is active")
+                    .incarnation
+            })
+            .collect::<Vec<_>>();
+
+        scope.force_all();
+
+        for key in &keys {
+            let active = scope.children[*key]
+                .active
+                .as_ref()
+                .expect("forced child remains active through the tidy beat");
+            assert!(active.shutdown.is_fired(), "force sends cancellation");
+            assert!(active.abort.is_fired(), "force immediately escalates");
+        }
+        assert_eq!(
+            first.try_send(1).expect_err("first mailbox freezes").kind,
+            SendErrorKind::NotRunning
+        );
+        assert_eq!(
+            second.try_send(2).expect_err("second mailbox freezes").kind,
+            SendErrorKind::NotRunning
+        );
+
+        // Model readiness messages that shared the driver's wake with force.
+        // The force boundary disarmed both gates before either can publish a
+        // late Running transition.
+        for (key, incarnation) in keys.iter().zip(incarnations) {
+            scope.handle_ready(*key, incarnation);
+            assert!(matches!(
+                scope.children[*key].slot.member.record().stage,
+                MemberStage::Stopping
+            ));
+        }
+
+        let deadlines = keys
+            .iter()
+            .map(|key| {
+                scope.children[*key]
+                    .active
+                    .as_ref()
+                    .and_then(|active| active.ladder)
+                    .and_then(StopLadder::deadline)
+                    .expect("each ladder retains its tidy deadline")
+            })
+            .collect::<Vec<_>>();
+        scope.force_all();
+        for (key, deadline) in keys.iter().zip(deadlines) {
+            assert_eq!(
+                scope.children[*key]
+                    .active
+                    .as_ref()
+                    .and_then(|active| active.ladder)
+                    .and_then(StopLadder::deadline),
+                Some(deadline),
+                "repeated force cannot rewind or skip the ladder"
+            );
         }
     }
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1980,11 +1980,19 @@ impl ScopeRuntime {
         }
 
         let exit = terminal.exit;
+        // §6's `StartupAborted` is a startup-sequence property of a
+        // membership that *ran* and failed before its initial readiness
+        // edge. A terminal without an exited incarnation never ran, so it
+        // publishes the plain `Stopped { NeverStarted }` verdict (B.6) even
+        // when its pre-readiness position still routes the scope's startup
+        // failure below. Incarnation exhaustion is the reachable case:
+        // it terminalizes an unspawned membership while `pre_ready` holds.
+        let startup_aborted = terminal.exited_incarnation.is_some() && terminal.startup_aborted;
         self.children[key].terminalize(
             &self.root,
             exit.clone(),
             terminal.exited_incarnation,
-            terminal.startup_aborted,
+            startup_aborted,
         );
         let removing = self.children[key].slot.member.record().removing;
         if removing {
@@ -4021,6 +4029,116 @@ mod tests {
         assert!(
             root.snapshot().children.is_empty(),
             "retention pruning follows joined disposal"
+        );
+    }
+
+    /// Exhaustion terminalizes a membership that never spawned. B.6 makes
+    /// that the plain `Stopped { NeverStarted }` verdict; §6's
+    /// `StartupAborted` stays reserved for a membership that ran and failed
+    /// before its initial readiness edge. The pre-readiness position still
+    /// has to route the scope's startup failure.
+    #[crate::runtime::test]
+    async fn first_spawn_exhaustion_stops_without_reporting_a_startup_abort() {
+        let mut tree = Tree::new();
+        tree.add_task(
+            "worker",
+            TaskDef::new(|_| future::pending::<crate::ExitResult>()),
+        )
+        .expect("valid task");
+        let mut plan = tree.lower_for_test();
+        let root = Arc::clone(&plan.root);
+        let epoch = root.begin_incarnation();
+        root.set_admitted_children(
+            plan.children
+                .iter()
+                .map(|child| resident_projection(&child.slot))
+                .collect(),
+        );
+        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(64);
+        let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+        let mut children = ChildArena::default();
+        let key = children
+            .insert(child)
+            .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+        let mut scope = ScopeRuntime {
+            root: Arc::clone(&root),
+            defaults: plan.defaults.clone(),
+            intensity_policy: plan.config.intensity,
+            intensity: super::IntensityState::default(),
+            children,
+            events,
+            deadlines: super::DeadlineQueue::default(),
+            jitter: crate::runtime::JitterRng::from_system_entropy(),
+            phase: ScopePhase::Starting,
+            next_ordered_start: Some(key),
+            is_root: true,
+            parent_ready: None,
+            dynamic: None,
+            epoch,
+            ancestor_shutdown: None,
+            ancestor_shutdown_seen: false,
+            ancestor_abort: None,
+            ancestor_abort_ack: None,
+            ancestor_abort_seen: false,
+            hard_forced: false,
+            completion: None,
+        };
+        plan.armed = false;
+        drop(plan);
+
+        // Burn the counter's last usable generation without touching the
+        // member record: the child is still an unspawned initial member, so
+        // its very first `spawn_child` exhausts before any incarnation runs.
+        scope.children[key].incarnations = FenceCounter::near_exhaustion(73);
+        {
+            let child = &mut scope.children[key];
+            assert!(mint_child_incarnation(&child.slot, &mut child.incarnations).is_some());
+        }
+        assert!(scope.children[key].initial);
+        assert!(!scope.children[key].initial_ready);
+        assert_eq!(
+            scope.children[key].slot.member.record().last_incarnation,
+            None
+        );
+
+        scope.spawn_child(key);
+        assert!(scope.children[key].is_disposing());
+
+        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = event_receiver
+            .recv()
+            .await
+            .expect("disposal reports completion")
+        else {
+            panic!("only construction disposal was armed")
+        };
+        scope.handle_construction_disposed(child, panic);
+
+        assert!(matches!(
+            scope.children[key].slot.member.record().stage,
+            MemberStage::Terminal(ref exit) if matches!(exit.kind(), ExitKind::NeverStarted)
+        ));
+        let snapshot = root.snapshot();
+        let published = snapshot
+            .child("worker")
+            .expect("a retained exhausted child stays resident");
+        assert!(
+            matches!(
+                published.state,
+                ChildState::Stopped { ref exit } if matches!(exit.kind(), ExitKind::NeverStarted)
+            ),
+            "an unspawned exhausted membership is Stopped, not StartupAborted: {:?}",
+            published.state
+        );
+        assert!(
+            !scope.children[key].slot.member.record().startup_aborted,
+            "§6's startup-abort flag belongs to a membership that ran"
+        );
+        assert!(
+            matches!(
+                root.record().startup,
+                Some(Err(StartupError::StartupFailed(_)))
+            ),
+            "the pre-readiness position still routes the scope's startup failure"
         );
     }
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -144,7 +144,7 @@ impl ReportReceiver {
 
 pub(crate) struct SystemRun {
     pub(crate) root: Arc<ScopeCell>,
-    driver: Option<runtime::JoinHandle<(), StopReason>>,
+    driver: Option<runtime::JoinHandle<StopReason>>,
 }
 
 pub(crate) type RemovalResponse = runtime::OneShotReceiver<RemoveOutcome>;
@@ -323,7 +323,7 @@ pub(crate) fn start_admission(
             let _ = sender.send(Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal)));
         }),
     };
-    runtime::spawn((), async move {
+    runtime::spawn(async move {
         let _ = runtime::mpsc_send(&control.events, DriverEvent::Admission(request)).await;
     });
     response
@@ -567,8 +567,8 @@ pub(crate) async fn shutdown_scope(
 pub(crate) fn spawn_system(plan: ScopePlan) -> SystemRun {
     let root = Arc::clone(&plan.root);
     let monitor_root = Arc::clone(&root);
-    let driver = runtime::spawn((), async move { run_scope(plan, true, None).await });
-    let lifecycle = runtime::spawn((), async move {
+    let driver = runtime::spawn(async move { run_scope(plan, true, None).await });
+    let lifecycle = runtime::spawn(async move {
         match runtime::join(driver).await {
             runtime::JoinOutcome::Ok { value, .. } => value,
             runtime::JoinOutcome::Panic { message, .. } => {
@@ -1302,7 +1302,7 @@ impl ScopeRuntime {
             // terminal publication or restart-window arbitration.
             drop(child.construction.take());
         }
-        let handle = runtime::spawn(incarnation, async move {
+        let handle = runtime::spawn(async move {
             let body = async move {
                 match body {
                     SpawnBody::Raw { spawn, context } => {
@@ -1373,7 +1373,7 @@ impl ScopeRuntime {
         let abort_handle = handle.abort_handle();
         let exit_sender = self.events.clone();
         let exit_ended = ended.clone();
-        runtime::spawn((), async move {
+        runtime::spawn(async move {
             let join = match runtime::join(handle).await {
                 runtime::JoinOutcome::Ok { .. } => JoinVerdict::Completed,
                 runtime::JoinOutcome::Panic { message, .. } => JoinVerdict::Panicked { message },
@@ -1398,7 +1398,7 @@ impl ScopeRuntime {
         let self_stop_ended = ended.clone();
         if gated {
             let ready_sender = self.events.clone();
-            runtime::spawn((), async move {
+            runtime::spawn(async move {
                 if matches!(
                     runtime::select_two(ready.fired(), ended.fired()).await,
                     runtime::Either::Left(())
@@ -1415,7 +1415,7 @@ impl ScopeRuntime {
             });
         }
         let self_stop_sender = self.events.clone();
-        runtime::spawn((), async move {
+        runtime::spawn(async move {
             if matches!(
                 runtime::select_two(local_stop.fired(), self_stop_ended.fired()).await,
                 runtime::Either::Left(())
@@ -2757,17 +2757,13 @@ mod tests {
     };
 
     fn isolated_scope(id: &'static str, flavor: ScopeFlavor) -> Arc<ScopeCell> {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from(id);
         let member = MemberCell::new(
             id.clone(),
             identity.mint_membership(&id).expect("membership available"),
         );
-        ScopeCell::new(
-            member,
-            flavor,
-            ScopeIdentity::new().expect("child identity available"),
-        )
+        ScopeCell::new(member, flavor, ScopeIdentity::new())
     }
 
     #[test]
@@ -3262,7 +3258,7 @@ mod tests {
             hasher.finish()
         }
 
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let member = MemberCell::new(
             id.clone(),
@@ -3290,7 +3286,7 @@ mod tests {
 
     #[crate::runtime::test]
     async fn attaching_after_terminality_closes_the_mailbox() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let member = MemberCell::new(
             id.clone(),
@@ -3330,10 +3326,15 @@ mod tests {
         let plan = tree.lower_for_test();
         let scope = Arc::clone(&plan.root);
         let epoch = scope.begin_incarnation();
-        let driver = crate::runtime::spawn(
-            (),
-            run_scope_incarnation(plan, false, Some(Latch::default()), None, None, None, epoch),
-        );
+        let driver = crate::runtime::spawn(run_scope_incarnation(
+            plan,
+            false,
+            Some(Latch::default()),
+            None,
+            None,
+            None,
+            epoch,
+        ));
         let abort = driver.abort_handle();
         let reached_startup = crate::runtime::timeout(Duration::from_secs(1), async {
             while !matches!(scope.record().state, ScopeState::Starting) {
@@ -3577,7 +3578,7 @@ mod tests {
 
     #[test]
     fn terminality_signal_follows_mailbox_termination() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let member = MemberCell::new(
             id.clone(),
@@ -3608,7 +3609,7 @@ mod tests {
 
     #[test]
     fn mailbox_wake_observes_terminal_record_and_reentrant_terminality_is_idempotent() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let member = MemberCell::new(
             id.clone(),
@@ -3649,7 +3650,7 @@ mod tests {
 
     #[test]
     fn attach_during_terminal_publication_finishes_record_before_mailbox_wake() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let member = MemberCell::new(
             id.clone(),
@@ -3690,7 +3691,7 @@ mod tests {
 
     #[test]
     fn concurrent_terminalizers_return_after_one_consistent_record_is_visible() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let member = MemberCell::new(
             id.clone(),
@@ -3723,17 +3724,13 @@ mod tests {
 
     #[test]
     fn terminal_startup_wake_follows_member_and_incarnation_publication() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("root");
         let member = MemberCell::new(
             id.clone(),
             identity.mint_membership(&id).expect("membership available"),
         );
-        let scope = ScopeCell::new(
-            member,
-            ScopeFlavor::Ordered,
-            ScopeIdentity::new().expect("child identity available"),
-        );
+        let scope = ScopeCell::new(member, ScopeFlavor::Ordered, ScopeIdentity::new());
         let epoch = scope.begin_incarnation();
         let probe = Arc::new(ObserveScopeOnStartupWake {
             scope: Arc::clone(&scope),
@@ -3770,17 +3767,13 @@ mod tests {
 
     #[test]
     fn no_live_root_startup_wake_follows_member_publication() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("root");
         let member = MemberCell::new(
             id.clone(),
             identity.mint_membership(&id).expect("membership available"),
         );
-        let scope = ScopeCell::new(
-            member,
-            ScopeFlavor::Ordered,
-            ScopeIdentity::new().expect("child identity available"),
-        );
+        let scope = ScopeCell::new(member, ScopeFlavor::Ordered, ScopeIdentity::new());
         let probe = Arc::new(ObserveScopeOnStartupWake {
             scope: Arc::clone(&scope),
             epoch: None,
@@ -3832,7 +3825,7 @@ mod tests {
 
     #[test]
     fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let root_id = ChildId::from("root");
         let root_member = MemberCell::new(
             root_id.clone(),
@@ -3840,11 +3833,7 @@ mod tests {
                 .mint_membership(&root_id)
                 .expect("root membership available"),
         );
-        let root = ScopeCell::new(
-            root_member,
-            ScopeFlavor::Dynamic,
-            ScopeIdentity::new().expect("child identity available"),
-        );
+        let root = ScopeCell::new(root_member, ScopeFlavor::Dynamic, ScopeIdentity::new());
         let child_id = ChildId::from("worker");
         let member = MemberCell::new(
             child_id.clone(),
@@ -3915,7 +3904,7 @@ mod tests {
 
     #[test]
     fn incarnation_mint_exhaustion_has_no_terminal_side_effects() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let membership = identity.mint_membership(&id).expect("membership available");
         let member = MemberCell::new(id, membership);
@@ -4148,7 +4137,7 @@ mod tests {
     #[crate::runtime::test]
     async fn nested_membership_exhaustion_is_structured_and_fail_closed() {
         let nested_id = ChildId::from("nested");
-        let mut parent_identity = ScopeIdentity::new().expect("parent identity available");
+        let mut parent_identity = ScopeIdentity::new();
         let nested_membership = parent_identity
             .mint_membership(&nested_id)
             .expect("nested membership available");
@@ -4207,14 +4196,14 @@ mod tests {
     #[crate::runtime::test]
     async fn scope_incarnation_exhaustion_closes_nested_observation() {
         let parent = isolated_scope("parent", ScopeFlavor::Ordered);
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("nested");
         let membership = identity.mint_membership(&id).expect("membership available");
         let member = MemberCell::new(id, membership);
         let scope = ScopeCell::new(
             Arc::clone(&member),
             ScopeFlavor::Ordered,
-            ScopeIdentity::new().expect("child identity available"),
+            ScopeIdentity::new(),
         );
         let slot = SlotCell::new(Arc::clone(&member), Some(Arc::clone(&scope)));
         parent.set_admitted_children(vec![resident_projection(&slot)]);
@@ -4297,15 +4286,11 @@ mod tests {
 
     #[test]
     fn lifecycle_sequence_exhaustion_poison_is_never_minted_and_becomes_lag() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("scope");
         let membership = identity.mint_membership(&id).expect("membership available");
         let member = MemberCell::new(id, membership);
-        let scope = ScopeCell::new(
-            member,
-            ScopeFlavor::Ordered,
-            ScopeIdentity::new().expect("child identity available"),
-        );
+        let scope = ScopeCell::new(member, ScopeFlavor::Ordered, ScopeIdentity::new());
         scope.set_lifecycle_sequence(FenceCounter::near_exhaustion(0));
         let mut events = scope.subscribe_lifecycle();
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2,42 +2,36 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
-    fmt,
     ops::{Bound, Index, IndexMut},
-    sync::{
-        Arc, Mutex, Weak,
-        atomic::{AtomicBool, AtomicU64, Ordering},
-        mpsc,
-    },
+    sync::{Arc, Mutex, Weak, mpsc},
     time::{Duration, Instant},
 };
 
 use crate::{
     ChildId, Exit, ExitKind, Incarnation, IntensityTrip, Membership, Readiness, ReadinessDeadline,
     ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure, StartupFailureCause,
+    cells::{DynamicRoute, MemberCell, MemberStage, ResidentProjection, ScopeCell},
     deadline::Deadline,
     engine::{
         ArbitrationClass, DeadlineHandle, DeadlineQueue, ExitDispatch, IntensityState,
         MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState, ScopeMode,
         StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart,
     },
-    exit::{JoinVerdict, RecordedOutcome, classify_exit},
+    exit::{JoinVerdict, RecordedOutcome, StartupError, StopReason, classify_exit},
     identity::{FenceCounter, ScopeIdentity},
-    mailbox::{MailboxControl, MailboxTermination},
-    observe::{
-        ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
-        LifecycleHub, MembershipStatus, ScopeKind, ScopeSnapshot, SnapshotHub, SnapshotReceiver,
-    },
-    policy::{DefaultsInheritance, ResolvedDefaults},
+    observe::LifecycleEventKind,
+    policy::{DefaultsInheritance, ResolvedDefaults, ScopeFlavor},
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
     runtime::{self, Latch},
     task::{OnceTaskBody, TaskContext, TaskFactory},
     tree::{
         BuilderCore, ChildConstruction, ChildPlan, LowerError, NotAdmittingCause, RemoveOutcome,
-        ReserveError, ScopeFactory, ScopeFlavor, ScopePlan, ScopeSource, SlotCell, StartupError,
-        StopReason,
+        ReserveError, ScopeFactory, ScopePlan, ScopeSource, SlotCell,
     },
 };
+
+#[cfg(test)]
+use crate::cells::RuntimeStorage;
 
 /// An exactly-once synchronous completion.
 ///
@@ -80,235 +74,6 @@ impl<T> Obligation<T> {
 impl<T> Drop for Obligation<T> {
     fn drop(&mut self) {
         self.discharge();
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum MemberStage {
-    Reserved,
-    Admitted,
-    Starting,
-    Running,
-    Restarting,
-    Stopping,
-    Terminal(Exit),
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct MemberRecord {
-    pub(crate) stage: MemberStage,
-    pub(crate) incarnation: Option<Incarnation>,
-    pub(crate) last_incarnation: Option<Incarnation>,
-    pub(crate) last_exit: Option<Exit>,
-    pub(crate) restart_count: u64,
-    pub(crate) restart_at: Option<Instant>,
-    pub(crate) removing: bool,
-    pub(crate) startup_aborted: bool,
-}
-
-#[derive(Debug)]
-pub(crate) struct MemberCell {
-    id: ChildId,
-    membership: Mutex<Membership>,
-    record: runtime::WatchSender<MemberRecord>,
-    terminal_disposal_pending: AtomicBool,
-    mailbox: Mutex<MemberMailbox>,
-    options: Mutex<Option<crate::policy::ResolvedCommonOptions>>,
-    pub(crate) removal: Latch,
-}
-
-#[derive(Default)]
-struct MemberMailbox {
-    control: Option<Arc<dyn MailboxControl>>,
-    terminal: Option<Exit>,
-    teardown: Option<Box<dyn MailboxTermination>>,
-}
-
-impl fmt::Debug for MemberMailbox {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("MemberMailbox")
-            .field("control", &self.control)
-            .field("terminal", &self.terminal)
-            .field("teardown_pending", &self.teardown.is_some())
-            .finish()
-    }
-}
-
-impl MemberCell {
-    pub(crate) fn new(id: ChildId, membership: Membership) -> Arc<Self> {
-        let (record, _) = runtime::watch(MemberRecord {
-            stage: MemberStage::Reserved,
-            incarnation: None,
-            last_incarnation: None,
-            last_exit: None,
-            restart_count: 0,
-            restart_at: None,
-            removing: false,
-            startup_aborted: false,
-        });
-        Arc::new(Self {
-            id,
-            membership: Mutex::new(membership),
-            record,
-            terminal_disposal_pending: AtomicBool::new(false),
-            mailbox: Mutex::new(MemberMailbox::default()),
-            options: Mutex::new(None),
-            removal: Latch::default(),
-        })
-    }
-
-    pub(crate) fn id(&self) -> &ChildId {
-        &self.id
-    }
-
-    pub(crate) fn membership(&self) -> Membership {
-        *self
-            .membership
-            .lock()
-            .expect("member identity mutex poisoned")
-    }
-
-    pub(crate) fn rebase_membership(&self, membership: Membership) {
-        let record = self.record();
-        assert!(
-            matches!(record.stage, MemberStage::Reserved)
-                && record.incarnation.is_none()
-                && record.last_incarnation.is_none(),
-            "only an unstarted reservation can be rebased"
-        );
-        *self
-            .membership
-            .lock()
-            .expect("member identity mutex poisoned") = membership;
-    }
-
-    pub(crate) fn record(&self) -> MemberRecord {
-        self.record.read_cloned()
-    }
-
-    fn terminal_disposal_pending(&self) -> bool {
-        self.terminal_disposal_pending.load(Ordering::Acquire)
-    }
-
-    fn set_terminal_disposal_pending(&self, pending: bool) {
-        self.terminal_disposal_pending
-            .store(pending, Ordering::Release);
-    }
-
-    pub(crate) fn update(&self, update: impl FnOnce(&mut MemberRecord)) {
-        self.record.send_modify(update);
-    }
-
-    fn update_locked(&self, update: impl FnOnce(&mut MemberRecord)) {
-        self.record.send_modify(update);
-    }
-
-    pub(crate) fn set_options(&self, options: crate::policy::ResolvedCommonOptions) {
-        *self.options.lock().expect("member options mutex poisoned") = Some(options);
-    }
-
-    fn options(&self) -> crate::policy::ResolvedCommonOptions {
-        self.options
-            .lock()
-            .expect("member options mutex poisoned")
-            .clone()
-            .unwrap_or_else(|| {
-                crate::policy::resolve_common(
-                    &crate::policy::CommonOptions::default(),
-                    &crate::policy::ResolvedDefaults::default(),
-                    false,
-                    Readiness::Immediate,
-                )
-            })
-    }
-
-    pub(crate) fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
-        let terminal_exit = {
-            let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
-            assert!(state.control.is_none(), "a member can own only one mailbox");
-            state.control = Some(Arc::clone(&mailbox));
-            let terminal_exit = state.terminal.clone();
-            if terminal_exit.is_some() {
-                debug_assert!(state.teardown.is_none());
-                state.teardown = mailbox.prepare_termination();
-            }
-            terminal_exit
-        };
-        if let Some(terminal_exit) = terminal_exit {
-            self.publish_terminal(terminal_exit);
-        }
-    }
-
-    pub(crate) fn mailbox(&self) -> Option<Arc<dyn MailboxControl>> {
-        self.mailbox
-            .lock()
-            .expect("member mailbox mutex poisoned")
-            .control
-            .clone()
-    }
-
-    pub(crate) fn terminalize(&self, exit: Exit) {
-        let (terminal_exit, mailbox) = {
-            let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
-            let terminal_exit = if let Some(terminal_exit) = &state.terminal {
-                terminal_exit.clone()
-            } else {
-                let teardown = state
-                    .control
-                    .as_ref()
-                    .and_then(|mailbox| mailbox.prepare_termination());
-                state.terminal = Some(exit.clone());
-                state.teardown = teardown;
-                exit
-            };
-            (terminal_exit, state.control.clone())
-        };
-        self.publish_terminal(terminal_exit);
-        if let Some(mailbox) = mailbox {
-            let stats = mailbox.stats();
-            debug_assert!(stats.delivered <= stats.accepted);
-            debug_assert!(stats.conflated <= stats.accepted);
-            debug_assert!(stats.depth <= stats.capacity);
-            let _ = stats.sends_rejected;
-        }
-    }
-
-    fn publish_terminal(&self, terminal_exit: Exit) {
-        let mut published = false;
-        self.record.modify_silently(|record| {
-            if !matches!(record.stage, MemberStage::Terminal(_)) {
-                record.incarnation = None;
-                record.restart_at = None;
-                record.last_exit = Some(terminal_exit.clone());
-                record.stage = MemberStage::Terminal(terminal_exit);
-                published = true;
-            }
-        });
-        let teardown = self
-            .mailbox
-            .lock()
-            .expect("member mailbox mutex poisoned")
-            .teardown
-            .take();
-        if let Some(teardown) = teardown
-            && let Some(payload) = teardown.finish()
-        {
-            runtime::dispose_detached(payload);
-        }
-        if published {
-            self.record.pulse();
-        }
-    }
-
-    pub(crate) async fn wait_terminal(&self) -> Exit {
-        let mut watcher = self.record.watcher();
-        loop {
-            if let MemberStage::Terminal(exit) = watcher.borrow_cloned().stage {
-                return exit;
-            }
-            watcher.changed().await;
-        }
     }
 }
 
@@ -371,831 +136,6 @@ impl ReportReceiver {
         self.0
             .recv()
             .expect("owned report token must record or fall back")
-    }
-}
-
-struct ResidencyCompletion {
-    parent: Weak<ScopeCell>,
-    slot: Arc<SlotCell>,
-}
-
-fn discharge_residency(completion: ResidencyCompletion) {
-    let Some(parent) = completion.parent.upgrade() else {
-        return;
-    };
-    parent.emit_locked(LifecycleEventKind::Removed {
-        id: completion.slot.member.id().clone(),
-        membership: completion.slot.member.membership(),
-        last_incarnation: completion.slot.member.record().last_incarnation,
-    });
-}
-
-struct ResidentChild {
-    slot: Arc<SlotCell>,
-    _removal: Obligation<ResidencyCompletion>,
-}
-
-impl ResidentChild {
-    fn new(parent: &Arc<ScopeCell>, slot: Arc<SlotCell>) -> Self {
-        Self {
-            _removal: Obligation::new(
-                ResidencyCompletion {
-                    parent: Arc::downgrade(parent),
-                    slot: Arc::clone(&slot),
-                },
-                discharge_residency,
-            ),
-            slot,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct ScopeRecord {
-    pub(crate) state: ScopeState,
-    pub(crate) startup: Option<Result<(), StartupError>>,
-    pub(crate) total_restarts: u64,
-}
-
-/// Shared scope state follows two distinct synchronization regimes.
-///
-/// One gate per running tree serializes compound, observation-visible
-/// transitions across `config`, `record`, `current_children`, and `parent`,
-/// including recursive snapshot projection and lifecycle-event staging. Their
-/// watch channels retain the latest independently readable value; they do not
-/// make that compound transition atomic, so every multi-field observation path
-/// must continue to hold the gate.
-///
-/// The remaining mutexes are deliberately not collapsed into one state lock.
-/// `control` is an epoch-tagged request plane with concurrent callers,
-/// `child_identity` and `lifecycle_sequence` mint monotonic identities, and
-/// `current_dynamic` owns the independently published dynamic request route.
-/// Scope state therefore has multiple writers and no single-writer invariant.
-pub(crate) struct ScopeCell {
-    pub(crate) member: Arc<MemberCell>,
-    pub(crate) flavor: ScopeFlavor,
-    pub(crate) child_identity: Mutex<ScopeIdentity>,
-    config: runtime::WatchSender<crate::tree::ScopeConfig>,
-    record: runtime::WatchSender<ScopeRecord>,
-    control: Mutex<ScopeControl>,
-    current_dynamic: Mutex<Option<Arc<DynamicControl>>>,
-    current_children: runtime::WatchSender<Vec<ResidentChild>>,
-    parent: runtime::WatchSender<Option<Weak<ScopeCell>>>,
-    observation_gate: Mutex<Arc<Mutex<()>>>,
-    lifecycle_sequence: Mutex<FenceCounter>,
-    lifecycle_seq: AtomicU64,
-    lifecycle: LifecycleHub,
-    snapshots: SnapshotHub,
-    observation_closed: AtomicBool,
-    #[cfg(test)]
-    runtime_storage: Mutex<RuntimeStorage>,
-}
-
-#[cfg(test)]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-struct RuntimeStorage {
-    children: usize,
-    child_slots: usize,
-    deadlines: usize,
-    deadline_slots: usize,
-}
-
-#[derive(Debug, Default)]
-struct ScopeControl {
-    current_epoch: u64,
-    live: bool,
-    last_stopped_epoch: u64,
-    shutdown: Option<ScopeRequest>,
-    force: Option<ScopeRequest>,
-}
-
-#[derive(Clone, Copy, Debug)]
-struct ScopeRequest {
-    epoch: u64,
-    consumed: bool,
-}
-
-impl ScopeCell {
-    pub(crate) fn new(
-        member: Arc<MemberCell>,
-        flavor: ScopeFlavor,
-        child_identity: ScopeIdentity,
-    ) -> Arc<Self> {
-        let (config, _) = runtime::watch(crate::tree::ScopeConfig::default());
-        let (record, _) = runtime::watch(ScopeRecord {
-            state: ScopeState::Unstarted,
-            startup: None,
-            total_restarts: 0,
-        });
-        let (current_children, _) = runtime::watch(Vec::new());
-        let (parent, _) = runtime::watch(None);
-        Arc::new(Self {
-            member,
-            flavor,
-            child_identity: Mutex::new(child_identity),
-            config,
-            record,
-            control: Mutex::new(ScopeControl::default()),
-            current_dynamic: Mutex::new(None),
-            current_children,
-            parent,
-            observation_gate: Mutex::new(Arc::new(Mutex::new(()))),
-            lifecycle_sequence: Mutex::new(FenceCounter::new(0)),
-            lifecycle_seq: AtomicU64::new(0),
-            lifecycle: LifecycleHub::default(),
-            snapshots: SnapshotHub::default(),
-            observation_closed: AtomicBool::new(false),
-            #[cfg(test)]
-            runtime_storage: Mutex::new(RuntimeStorage::default()),
-        })
-    }
-
-    pub(crate) fn record(&self) -> ScopeRecord {
-        self.record.read_cloned()
-    }
-
-    #[cfg(test)]
-    fn runtime_storage(&self) -> RuntimeStorage {
-        *self
-            .runtime_storage
-            .lock()
-            .expect("runtime-storage mutex poisoned")
-    }
-
-    fn observation_gate(&self) -> Arc<Mutex<()>> {
-        Arc::clone(
-            &self
-                .observation_gate
-                .lock()
-                .expect("observation gate handoff mutex poisoned"),
-        )
-    }
-
-    fn adopt_observation_gate(&self, gate: &Arc<Mutex<()>>) {
-        loop {
-            let current = self.observation_gate();
-            if Arc::ptr_eq(&current, gate) {
-                return;
-            }
-
-            // An operation that passed `with_observation_gate`'s pointer
-            // check is allowed to finish its complete observation edge before
-            // the handoff. Conversely, an operation that only captured this
-            // gate will see the replacement after acquiring it and retry.
-            let current_guard = current
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let mut installed = self
-                .observation_gate
-                .lock()
-                .expect("observation gate handoff mutex poisoned");
-            if Arc::ptr_eq(&current, &installed) {
-                *installed = Arc::clone(gate);
-                drop(installed);
-                self.adopt_descendant_observation_gates_locked(&current, gate);
-                drop(current_guard);
-                return;
-            }
-            drop(installed);
-            drop(current_guard);
-        }
-    }
-
-    /// Re-homes a resident subtree while its former tree gate is held. The
-    /// caller also holds the destination gate, so observers cannot enter
-    /// either half of the tree while the handoff is being installed.
-    fn adopt_descendant_observation_gates_locked(
-        &self,
-        previous: &Arc<Mutex<()>>,
-        gate: &Arc<Mutex<()>>,
-    ) {
-        let descendants = self.current_children.read_with(|children| {
-            children
-                .iter()
-                .filter_map(|resident| resident.slot.scope.as_ref().cloned())
-                .collect::<Vec<_>>()
-        });
-        for descendant in descendants {
-            let mut installed = descendant
-                .observation_gate
-                .lock()
-                .expect("observation gate handoff mutex poisoned");
-            if Arc::ptr_eq(&installed, previous) {
-                *installed = Arc::clone(gate);
-            } else {
-                assert!(
-                    Arc::ptr_eq(&installed, gate),
-                    "one resident tree must share one observation gate"
-                );
-            }
-            drop(installed);
-            descendant.adopt_descendant_observation_gates_locked(previous, gate);
-        }
-    }
-
-    /// Runs against the cell's current tree gate. Adoption can race an early
-    /// pre-start observer, so a waiter that acquired an obsolete gate retries
-    /// before entering the observation critical section.
-    fn with_observation_gate<R>(&self, operation: impl FnOnce() -> R) -> R {
-        let mut operation = Some(operation);
-        loop {
-            let gate = self.observation_gate();
-            let guard = gate
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if Arc::ptr_eq(&gate, &self.observation_gate()) {
-                let operation = operation
-                    .take()
-                    .expect("observation operation runs exactly once");
-                let result = operation();
-                drop(guard);
-                return result;
-            }
-            drop(guard);
-        }
-    }
-
-    pub(crate) fn set_state(&self, state: ScopeState) {
-        self.with_observation_gate(|| {
-            self.record.send_modify(|record| {
-                if state == ScopeState::Starting {
-                    record.total_restarts = 0;
-                }
-                record.state = state.clone();
-            });
-            self.member.record.pulse();
-            self.emit_locked(LifecycleEventKind::ScopeState { state });
-        });
-    }
-
-    pub(crate) fn set_config(&self, config: crate::tree::ScopeConfig) {
-        self.with_observation_gate(|| {
-            self.config.replace(config);
-            self.publish_snapshot_chain_locked();
-        });
-    }
-
-    pub(crate) fn transition_child(
-        &self,
-        member: &MemberCell,
-        update: impl FnOnce(&mut MemberRecord),
-        event: Option<LifecycleEventKind>,
-    ) {
-        self.with_observation_gate(|| {
-            member.update_locked(update);
-            if let Some(event) = event {
-                self.emit_locked(event);
-            } else {
-                self.publish_snapshot_chain_locked();
-            }
-        });
-    }
-
-    #[cfg(test)]
-    pub(crate) fn emit(&self, event: LifecycleEventKind) {
-        self.with_observation_gate(|| self.emit_locked(event));
-    }
-
-    pub(crate) fn publish_child_restart(
-        &self,
-        member: &MemberCell,
-        total_restarts: u64,
-        update: impl FnOnce(&mut MemberRecord),
-        exited: LifecycleEventKind,
-        scheduled: LifecycleEventKind,
-    ) {
-        self.with_observation_gate(|| {
-            self.record.send_modify(|scope| {
-                scope.total_restarts = total_restarts;
-            });
-            member.update_locked(update);
-            self.emit_locked(exited);
-            self.emit_locked(scheduled);
-        });
-    }
-
-    pub(crate) fn terminalize_child(
-        &self,
-        member: &MemberCell,
-        exit: Exit,
-        exited_incarnation: Option<Incarnation>,
-        startup_aborted: bool,
-    ) -> bool {
-        self.with_observation_gate(|| {
-            if matches!(member.record().stage, MemberStage::Terminal(_)) {
-                return false;
-            }
-            member.update_locked(|record| record.startup_aborted = startup_aborted);
-            member.terminalize(exit.clone());
-            if let Some(incarnation) = exited_incarnation {
-                self.emit_locked(LifecycleEventKind::Exited {
-                    id: member.id().clone(),
-                    membership: member.membership(),
-                    incarnation,
-                    exit: exit.clone(),
-                });
-            }
-            let nested = self.current_children.read_with(|children| {
-                children
-                    .iter()
-                    .find(|resident| resident.slot.member.membership() == member.membership())
-                    .and_then(|resident| resident.slot.scope.as_ref())
-                    .cloned()
-            });
-            if let Some(scope) = nested {
-                scope.close_observation_locked();
-            }
-            true
-        })
-    }
-
-    pub(crate) fn prune_child(&self, member: &MemberCell) -> bool {
-        self.with_observation_gate(|| {
-            let membership = member.membership();
-            let mut resident = None;
-            let removed = self.current_children.send_if_modified(|children| {
-                let Some(index) = children
-                    .iter()
-                    .position(|child| child.slot.member.membership() == membership)
-                else {
-                    return false;
-                };
-                resident = Some(children.remove(index));
-                true
-            });
-            if !removed {
-                return false;
-            }
-            let resident = resident.expect("a reported removal owns its resident entry");
-            debug_assert_eq!(resident.slot.member.membership(), membership);
-            // Dropping residency while the observation gate is held emits the
-            // matching Removed edge through its owned completion.
-            drop(resident);
-            true
-        })
-    }
-
-    pub(crate) fn snapshot(&self) -> Arc<ScopeSnapshot> {
-        self.with_observation_gate(|| self.snapshot_locked())
-    }
-
-    pub(crate) fn subscribe_snapshots(&self) -> SnapshotReceiver {
-        self.with_observation_gate(|| {
-            let receiver = self.snapshots.subscribe(self.snapshot_locked());
-            if self.observation_closed.load(Ordering::Acquire) {
-                self.snapshots.close();
-            }
-            receiver
-        })
-    }
-
-    pub(crate) fn subscribe_lifecycle(&self) -> LifecycleEvents {
-        self.with_observation_gate(|| {
-            let events = self.lifecycle.subscribe();
-            if self.observation_closed.load(Ordering::Acquire) {
-                self.lifecycle.close();
-            }
-            events
-        })
-    }
-
-    fn snapshot_locked(&self) -> Arc<ScopeSnapshot> {
-        let record = self.record();
-        let config = self.config.read_cloned();
-        let children = self
-            .current_children
-            .read_with(|children| {
-                children
-                    .iter()
-                    .map(|resident| Arc::clone(&resident.slot))
-                    .collect::<Vec<_>>()
-            })
-            .into_iter()
-            .map(|slot| self.child_snapshot_locked(&slot))
-            .collect::<Vec<_>>();
-        Arc::new(ScopeSnapshot {
-            state: record.state,
-            kind: match self.flavor {
-                ScopeFlavor::Ordered => ScopeKind::Ordered,
-                ScopeFlavor::Dynamic => ScopeKind::Dynamic,
-            },
-            strategy: (self.flavor == ScopeFlavor::Ordered).then_some(config.strategy),
-            intensity: config.intensity,
-            total_restarts: record.total_restarts,
-            lifecycle_seq: self.lifecycle_seq.load(Ordering::Acquire),
-            children: children.into(),
-        })
-    }
-
-    fn child_snapshot_locked(&self, slot: &SlotCell) -> ChildSnapshot {
-        let record = slot.member.record();
-        let options = slot.member.options();
-        let terminal = matches!(record.stage, MemberStage::Terminal(_));
-        let nested = slot.scope.as_ref().and_then(|scope| {
-            (record.incarnation.is_some() || terminal).then(|| scope.snapshot_locked())
-        });
-        ChildSnapshot {
-            id: slot.member.id().clone(),
-            membership: slot.member.membership(),
-            incarnation: record.incarnation,
-            state: match record.stage {
-                MemberStage::Reserved | MemberStage::Admitted => ChildState::Admitted,
-                MemberStage::Starting => ChildState::Starting,
-                MemberStage::Running => ChildState::Running,
-                MemberStage::Restarting => ChildState::Restarting,
-                MemberStage::Stopping => ChildState::Stopping,
-                MemberStage::Terminal(exit) if record.startup_aborted => {
-                    ChildState::StartupAborted { exit }
-                }
-                MemberStage::Terminal(exit) => ChildState::Stopped { exit },
-            },
-            last_exit: record.last_exit,
-            membership_status: if record.removing {
-                MembershipStatus::Removing
-            } else {
-                MembershipStatus::Active
-            },
-            restart_count: record.restart_count,
-            restart_policy: options.restart,
-            retention: options.retention,
-            restart_at: record.restart_at,
-            nested,
-            scope_seq: slot
-                .scope
-                .as_ref()
-                .map(|scope| scope.lifecycle_seq.load(Ordering::Acquire)),
-        }
-    }
-
-    fn ancestors_locked(&self) -> Vec<Arc<ScopeCell>> {
-        let mut ancestors = Vec::new();
-        let mut current = self.parent.read_cloned().as_ref().and_then(Weak::upgrade);
-        while let Some(scope) = current {
-            current = scope.parent.read_cloned().as_ref().and_then(Weak::upgrade);
-            ancestors.push(scope);
-        }
-        ancestors
-    }
-
-    fn publish_snapshot_chain_locked(&self) {
-        self.snapshots.publish(|| self.snapshot_locked());
-        for ancestor in self.ancestors_locked() {
-            ancestor.snapshots.publish(|| ancestor.snapshot_locked());
-        }
-    }
-
-    fn emit_locked(&self, kind: LifecycleEventKind) {
-        let seq = self
-            .lifecycle_sequence
-            .lock()
-            .expect("lifecycle sequence mutex poisoned")
-            .mint_sequence();
-        let Some(seq) = seq else {
-            self.lifecycle_seq.store(u64::MAX, Ordering::Release);
-            self.publish_snapshot_chain_locked();
-            self.lifecycle.publish_lagged(1);
-            for ancestor in self.ancestors_locked() {
-                ancestor.lifecycle.publish_lagged(1);
-            }
-            return;
-        };
-        self.lifecycle_seq.store(seq, Ordering::Release);
-        self.publish_snapshot_chain_locked();
-
-        let scope = self.member.membership();
-        let mut event = LifecycleEvent {
-            scope_path: Vec::new(),
-            scope,
-            seq,
-            kind,
-        };
-        self.lifecycle.publish(event.clone());
-        let mut child_id = self.member.id().clone();
-        for ancestor in self.ancestors_locked() {
-            event.scope_path.insert(0, child_id);
-            child_id = ancestor.member.id().clone();
-            ancestor.lifecycle.publish(event.clone());
-        }
-    }
-
-    fn close_observation_locked(&self) {
-        if self.observation_closed.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        self.snapshots.close();
-        self.lifecycle.close();
-    }
-
-    pub(crate) fn set_startup(&self, startup: Result<(), StartupError>) {
-        let mut published = false;
-        self.record.modify_silently(|record| {
-            if record.startup.is_none() {
-                record.startup = Some(startup);
-                published = true;
-            }
-        });
-        if published {
-            // Before the record became watch-backed, startup waiters shared
-            // the member signal. Preserve that ordering boundary: publish the
-            // member-plane wake before releasing the startup result itself.
-            self.member.record.pulse();
-            self.record.pulse();
-        }
-    }
-
-    fn begin_incarnation(&self) -> u64 {
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        control.current_epoch = control.current_epoch.saturating_add(1);
-        control.live = true;
-        let epoch = control.current_epoch;
-        drop(control);
-        self.member.record.pulse();
-        epoch
-    }
-
-    fn finish_incarnation(&self, epoch: u64, reason: StopReason) {
-        self.finish_incarnation_with_terminal(epoch, reason, None);
-    }
-
-    fn finish_root_incarnation(&self, epoch: u64, reason: StopReason, exit: Exit) {
-        self.finish_incarnation_with_terminal(epoch, reason, Some(exit));
-    }
-
-    fn finish_incarnation_with_terminal(
-        &self,
-        epoch: u64,
-        reason: StopReason,
-        terminal_exit: Option<Exit>,
-    ) {
-        self.with_observation_gate(|| {
-            let state = ScopeState::Stopped {
-                reason: reason.clone(),
-            };
-            self.record.modify_silently(|record| {
-                if record.startup.is_none() {
-                    record.startup = Some(Err(StartupError::ShutdownRequested));
-                }
-                record.state = state.clone();
-            });
-            let terminal = terminal_exit.is_some();
-            if let Some(exit) = terminal_exit {
-                self.member.terminalize(exit);
-            }
-            let mut control = self.control.lock().expect("scope control mutex poisoned");
-            if control.current_epoch == epoch {
-                control.live = false;
-                control.last_stopped_epoch = control.last_stopped_epoch.max(epoch);
-                if control
-                    .shutdown
-                    .is_some_and(|request| request.epoch <= epoch)
-                {
-                    control.shutdown = None;
-                }
-                if control.force.is_some_and(|request| request.epoch <= epoch) {
-                    control.force = None;
-                }
-            }
-            drop(control);
-            self.member.record.pulse();
-            // `wait_started` must not observe terminal startup until the member
-            // and incarnation-control planes above are consistent.
-            self.record.pulse();
-            self.emit_locked(LifecycleEventKind::ScopeState { state });
-            if terminal {
-                self.close_observation_locked();
-            }
-        });
-    }
-
-    fn finish_live_root_incarnation(&self, reason: StopReason, exit: Exit) {
-        let epoch = {
-            let control = self.control.lock().expect("scope control mutex poisoned");
-            control.live.then_some(control.current_epoch)
-        };
-        if let Some(epoch) = epoch {
-            self.finish_root_incarnation(epoch, reason, exit);
-        } else {
-            self.with_observation_gate(|| {
-                let state = ScopeState::Stopped { reason };
-                self.record.modify_silently(|record| {
-                    if record.startup.is_none() {
-                        record.startup = Some(Err(StartupError::ShutdownRequested));
-                    }
-                    record.state = state.clone();
-                });
-                self.member.terminalize(exit);
-                self.member.record.pulse();
-                self.record.pulse();
-                self.emit_locked(LifecycleEventKind::ScopeState { state });
-                self.close_observation_locked();
-            });
-        }
-    }
-
-    pub(crate) fn request_shutdown(&self) -> u64 {
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        let pending_incarnation = !control.live;
-        let target = if control.live {
-            control.current_epoch
-        } else {
-            control.current_epoch.saturating_add(1)
-        };
-        if control
-            .shutdown
-            .is_none_or(|request| request.epoch < target)
-        {
-            control.shutdown = Some(ScopeRequest {
-                epoch: target,
-                consumed: false,
-            });
-        }
-        drop(control);
-        self.member.record.pulse();
-        // A nested scope has no live driver while its parent is retaining it
-        // in restart backoff. Wake that parent as well so it can start the
-        // pending incarnation immediately; that incarnation consumes the
-        // stop and begins the timeout-bounded teardown required by B.9.
-        if pending_incarnation
-            && let Some(parent) = self.parent.read_cloned().as_ref().and_then(Weak::upgrade)
-        {
-            parent.member.record.pulse();
-        }
-        target
-    }
-
-    fn has_pending_incarnation_shutdown(&self) -> bool {
-        let control = self.control.lock().expect("scope control mutex poisoned");
-        !control.live
-            && control.shutdown.is_some_and(|request| {
-                !request.consumed && request.epoch > control.last_stopped_epoch
-            })
-    }
-
-    fn has_stop_request(&self, epoch: u64) -> bool {
-        let control = self.control.lock().expect("scope control mutex poisoned");
-        control
-            .shutdown
-            .is_some_and(|request| request.epoch == epoch)
-            || control.force.is_some_and(|request| request.epoch == epoch)
-    }
-
-    fn take_shutdown_request(&self, epoch: u64) -> bool {
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        match control.shutdown.as_mut() {
-            Some(request) if request.epoch == epoch && !request.consumed => {
-                request.consumed = true;
-                true
-            }
-            _ => false,
-        }
-    }
-
-    fn force_shutdown(&self, epoch: u64) {
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        if control.live && control.current_epoch == epoch {
-            control.force = Some(ScopeRequest {
-                epoch,
-                consumed: false,
-            });
-        }
-        drop(control);
-        self.member.record.pulse();
-    }
-
-    fn take_force_request(&self, epoch: u64) -> bool {
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        match control.force.as_mut() {
-            Some(request) if request.epoch == epoch && !request.consumed => {
-                request.consumed = true;
-                true
-            }
-            _ => false,
-        }
-    }
-
-    fn incarnation_finished(&self, epoch: u64) -> bool {
-        let control = self.control.lock().expect("scope control mutex poisoned");
-        control.last_stopped_epoch >= epoch
-    }
-
-    fn set_admitted_children(self: &Arc<Self>, children: Vec<Arc<SlotCell>>) {
-        self.with_observation_gate(|| {
-            let gate = self.observation_gate();
-            self.clear_residents_locked();
-            for child in children {
-                if let Some(scope) = &child.scope {
-                    scope.adopt_observation_gate(&gate);
-                    scope.parent.replace(Some(Arc::downgrade(self)));
-                }
-                child
-                    .member
-                    .update_locked(|record| record.stage = MemberStage::Admitted);
-                self.current_children.send_modify(|children| {
-                    children.push(ResidentChild::new(self, Arc::clone(&child)))
-                });
-                self.emit_locked(LifecycleEventKind::Added {
-                    id: child.member.id().clone(),
-                    membership: child.member.membership(),
-                });
-            }
-        });
-    }
-
-    fn admit_child(self: &Arc<Self>, child: &Arc<SlotCell>) {
-        self.with_observation_gate(|| {
-            let gate = self.observation_gate();
-            if let Some(scope) = &child.scope {
-                scope.adopt_observation_gate(&gate);
-                scope.parent.replace(Some(Arc::downgrade(self)));
-            }
-            self.current_children
-                .send_modify(|children| children.push(ResidentChild::new(self, Arc::clone(child))));
-            child
-                .member
-                .update_locked(|record| record.stage = MemberStage::Admitted);
-            self.emit_locked(LifecycleEventKind::Added {
-                id: child.member.id().clone(),
-                membership: child.member.membership(),
-            });
-        });
-    }
-
-    pub(crate) fn clear_residents(&self) {
-        self.with_observation_gate(|| self.clear_residents_locked());
-    }
-
-    fn clear_residents_locked(&self) {
-        let residents = self.current_children.take();
-        // Each entry's owned completion emits Removed. Drop the vector only
-        // after releasing the child-set watch value guard so snapshot publication can
-        // project the now-empty set while this observation gate stays held.
-        drop(residents);
-    }
-
-    fn set_dynamic(&self, control: Option<Arc<DynamicControl>>) {
-        *self
-            .current_dynamic
-            .lock()
-            .expect("scope dynamic-control mutex poisoned") = control;
-        self.member.record.pulse();
-    }
-
-    fn dynamic(&self) -> Option<Arc<DynamicControl>> {
-        self.current_dynamic
-            .lock()
-            .expect("scope dynamic-control mutex poisoned")
-            .clone()
-    }
-
-    pub(crate) fn signal(&self) -> &runtime::WatchSender<MemberRecord> {
-        &self.member.record
-    }
-
-    pub(crate) async fn wait_started(&self) -> Result<(), StartupError> {
-        let mut watcher = self.record.watcher();
-        loop {
-            if let Some(result) = watcher.borrow_and_update_cloned().startup {
-                return result;
-            }
-            watcher.changed().await;
-        }
-    }
-
-    pub(crate) async fn wait_stopped(&self) -> StopReason {
-        self.member.wait_terminal().await;
-        match self.record().state {
-            ScopeState::Stopped { reason } => reason,
-            ScopeState::Unstarted
-            | ScopeState::Starting
-            | ScopeState::Running
-            | ScopeState::StartupFailed
-            | ScopeState::Draining => StopReason::NeverStarted,
-        }
-    }
-
-    pub(crate) fn terminalize_never_started(&self) {
-        self.with_observation_gate(|| {
-            if self.observation_closed.load(Ordering::Acquire) {
-                return;
-            }
-            self.member.terminalize(Exit::never_started());
-            self.record.modify_silently(|record| {
-                if record.startup.is_none() {
-                    record.startup = Some(Err(StartupError::ShutdownRequested));
-                }
-                record.state = ScopeState::Stopped {
-                    reason: StopReason::NeverStarted,
-                };
-            });
-            self.member.record.pulse();
-            self.record.pulse();
-            self.emit_locked(LifecycleEventKind::ScopeState {
-                state: ScopeState::Stopped {
-                    reason: StopReason::NeverStarted,
-                },
-            });
-            self.close_observation_locked();
-        });
     }
 }
 
@@ -1295,6 +235,14 @@ impl DynamicControl {
     }
 }
 
+fn dynamic_control(scope: &ScopeCell) -> Option<Arc<DynamicControl>> {
+    scope.dynamic_route()?.resolve().ok()
+}
+
+fn resident_projection(slot: &SlotCell) -> ResidentProjection {
+    ResidentProjection::new(Arc::clone(&slot.member), slot.scope.clone())
+}
+
 pub(crate) struct DynamicReservation {
     pub(crate) slot: Arc<SlotCell>,
     pub(crate) control: Arc<DynamicControl>,
@@ -1308,7 +256,7 @@ pub(crate) fn reserve_dynamic(
     if matches!(scope.member.record().stage, MemberStage::Terminal(_)) {
         return Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal));
     }
-    let control = scope.dynamic().ok_or(ReserveError::NotAdmitting(
+    let control = dynamic_control(scope).ok_or(ReserveError::NotAdmitting(
         NotAdmittingCause::NoLiveIncarnation,
     ))?;
     match scope.record().state {
@@ -1435,7 +383,7 @@ pub(crate) fn remove_dynamic(
     ) {
         return completed_removal(RemoveOutcome::AlreadyAbsent);
     }
-    let Some(control) = scope.dynamic() else {
+    let Some(control) = dynamic_control(scope) else {
         return completed_removal(RemoveOutcome::AlreadyAbsent);
     };
     let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
@@ -1556,12 +504,7 @@ impl SystemRun {
 }
 
 fn collect_stragglers(scope: &ScopeCell, prefix: &[ChildId], out: &mut Vec<ShutdownStraggler>) {
-    let children = scope.current_children.read_with(|children| {
-        children
-            .iter()
-            .map(|resident| Arc::clone(&resident.slot))
-            .collect::<Vec<_>>()
-    });
+    let children = scope.resident_projections();
     for child in children {
         if matches!(child.member.record().stage, MemberStage::Terminal(_))
             || child.member.terminal_disposal_pending()
@@ -2029,7 +972,7 @@ impl Drop for ScopeRuntime {
     fn drop(&mut self) {
         let dynamic_entries = if let Some(dynamic) = &self.dynamic {
             let entries = dynamic.close();
-            self.root.set_dynamic(None);
+            self.root.set_dynamic_route(None);
             Some(entries)
         } else {
             None
@@ -2157,16 +1100,12 @@ impl ScopeRuntime {
 
     #[cfg(test)]
     fn record_storage(&self) {
-        *self
-            .root
-            .runtime_storage
-            .lock()
-            .expect("runtime-storage mutex poisoned") = RuntimeStorage {
+        self.root.record_runtime_storage(RuntimeStorage {
             children: self.children.len(),
             child_slots: self.children.storage_len(),
             deadlines: self.deadlines.len(),
             deadline_slots: self.deadlines.storage_len(),
-        };
+        });
     }
 
     fn spawn_child(&mut self, key: ChildKey) {
@@ -3365,7 +2304,7 @@ impl ScopeRuntime {
                 return;
             }
         };
-        self.root.admit_child(&request.slot);
+        self.root.admit_child(resident_projection(&request.slot));
         #[cfg(test)]
         self.record_storage();
         request.complete(Ok(()));
@@ -3503,7 +2442,7 @@ fn mint_child_incarnation(slot: &Arc<SlotCell>, counter: &mut FenceCounter) -> O
             if record.last_incarnation.is_none() {
                 scope.terminalize_never_started();
             } else {
-                scope.with_observation_gate(|| scope.close_observation_locked());
+                scope.close_observation();
             }
         }
     }
@@ -3600,12 +2539,12 @@ async fn run_scope_incarnation(
             );
         }
         drop(state);
-        root.set_dynamic(Some(Arc::clone(control)));
+        root.set_dynamic_route(Some(DynamicRoute::new(Arc::clone(control))));
     }
     root.set_admitted_children(
         plan.children
             .iter()
-            .map(|child| Arc::clone(&child.slot))
+            .map(|child| resident_projection(&child.slot))
             .collect(),
     );
     // Transfer children one at a time. The not-yet-converted suffix remains
@@ -3903,8 +2842,8 @@ mod tests {
         ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
         MemberCell, MemberStage, Obligation, Pending, RemovalResponses, RuntimeStorage, ScopeCell,
         ScopeFlavor, ScopePhase, ScopeRuntime, StartupPhase, complete_removals, driver_event_class,
-        mint_child_incarnation, report_channel, restart_shutdown_work, run_nested_tree,
-        run_scope_incarnation,
+        dynamic_control, mint_child_incarnation, report_channel, resident_projection,
+        restart_shutdown_work, run_nested_tree, run_scope_incarnation,
     };
 
     fn isolated_scope(id: &'static str, flavor: ScopeFlavor) -> Arc<ScopeCell> {
@@ -3953,7 +2892,7 @@ mod tests {
         let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
         let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
 
-        root.set_admitted_children(vec![slot]);
+        root.set_admitted_children(vec![resident_projection(&slot)]);
 
         assert!(Arc::ptr_eq(
             &root.observation_gate(),
@@ -3967,14 +2906,14 @@ mod tests {
         let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
         let leaf = isolated_scope("leaf", ScopeFlavor::Ordered);
         let leaf_slot = SlotCell::new(Arc::clone(&leaf.member), Some(Arc::clone(&leaf)));
-        nested.set_admitted_children(vec![leaf_slot]);
+        nested.set_admitted_children(vec![resident_projection(&leaf_slot)]);
         assert!(Arc::ptr_eq(
             &nested.observation_gate(),
             &leaf.observation_gate()
         ));
 
         let nested_slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
-        root.set_admitted_children(vec![nested_slot]);
+        root.set_admitted_children(vec![resident_projection(&nested_slot)]);
 
         let root_gate = root.observation_gate();
         assert!(Arc::ptr_eq(&root_gate, &nested.observation_gate()));
@@ -4006,10 +2945,7 @@ mod tests {
         // Model the instant at which adoption owns the old gate and publishes
         // the replacement. The waiting observer must acquire the old gate,
         // detect this handoff, and retry on the root gate.
-        *nested
-            .observation_gate
-            .lock()
-            .expect("observation gate handoff mutex remains healthy") = root.observation_gate();
+        nested.replace_observation_gate(root.observation_gate());
         drop(held);
         worker.join().expect("observer follows the gate handoff");
 
@@ -4064,7 +3000,7 @@ mod tests {
         root.set_admitted_children(
             plan.children
                 .iter()
-                .map(|child| Arc::clone(&child.slot))
+                .map(|child| resident_projection(&child.slot))
                 .collect(),
         );
         let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
@@ -4202,7 +3138,7 @@ mod tests {
         let adopting_root = Arc::clone(&root);
         let (adopted, adopted_receiver) = std::sync::mpsc::sync_channel(0);
         let adoption = std::thread::spawn(move || {
-            adopting_root.set_admitted_children(vec![slot]);
+            adopting_root.set_admitted_children(vec![resident_projection(&slot)]);
             adopted.send(()).expect("test receiver remains available");
         });
 
@@ -4748,7 +3684,7 @@ mod tests {
         });
         let waker = Waker::from(Arc::clone(&probe));
         let mut context = Context::from_waker(&waker);
-        let mut watcher = member.record.watcher();
+        let mut watcher = member.record_watcher();
         let mut changed = Box::pin(watcher.changed());
         assert!(changed.as_mut().poll(&mut context).is_pending());
 
@@ -4813,11 +3749,7 @@ mod tests {
         let mailbox = MailboxCell::new(member.id().clone());
         let actor = ActorRef::new(Arc::clone(&member), Arc::clone(&mailbox));
         let first_exit = Exit::never_started();
-        member
-            .mailbox
-            .lock()
-            .expect("member mailbox mutex poisoned")
-            .terminal = Some(first_exit.clone());
+        member.stage_terminal_before_mailbox(first_exit.clone());
         let probe = Arc::new(ObserveMemberOnMailboxWake {
             member: Arc::clone(&member),
             competing_exit: Exit::new(ExitKind::Completed, false),
@@ -4900,7 +3832,7 @@ mod tests {
             observed: Mutex::new(None),
         });
         let waker = Waker::from(Arc::clone(&probe));
-        let mut watcher = scope.record.watcher();
+        let mut watcher = scope.record_watcher();
         let mut changed = Box::pin(watcher.changed());
         assert!(
             changed
@@ -4946,7 +3878,7 @@ mod tests {
             observed: Mutex::new(None),
         });
         let waker = Waker::from(Arc::clone(&probe));
-        let mut watcher = scope.record.watcher();
+        let mut watcher = scope.record_watcher();
         let mut changed = Box::pin(watcher.changed());
         assert!(
             changed
@@ -5014,7 +3946,7 @@ mod tests {
                 .expect("child membership available"),
         );
         let slot = SlotCell::new(Arc::clone(&member), None);
-        root.set_admitted_children(vec![Arc::clone(&slot)]);
+        root.set_admitted_children(vec![resident_projection(&slot)]);
         let (events, _receiver) = crate::runtime::bounded_mpsc(1);
         let control = DynamicControl::new(&root, events);
         let (sender, mut response) = crate::runtime::oneshot();
@@ -5056,11 +3988,8 @@ mod tests {
         let system = DynamicTree::new().spawn().expect("runtime is available");
         let root = system.scope();
         system.wait_started().await.expect("dynamic root starts");
-        let control = root
-            .as_scope()
-            .cell
-            .dynamic()
-            .expect("running dynamic root has a control");
+        let control =
+            dynamic_control(&root.as_scope().cell).expect("running dynamic root has a control");
         let weak = Arc::downgrade(&control);
         drop(control);
 
@@ -5222,10 +4151,7 @@ mod tests {
             ScopeFlavor::Ordered,
             ScopeIdentity::new().expect("child identity available"),
         );
-        *scope
-            .lifecycle_sequence
-            .lock()
-            .expect("lifecycle sequence mutex poisoned") = FenceCounter::near_exhaustion(0);
+        scope.set_lifecycle_sequence(FenceCounter::near_exhaustion(0));
         let mut events = scope.subscribe_lifecycle();
 
         scope.emit(LifecycleEventKind::ScopeState {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2478,6 +2478,11 @@ async fn run_nested_tree(
                     (StartupFailureCause::IdentityExhausted { id }, disposal)
                 }
                 LowerError::InvalidPolicy { invalid, disposal } => {
+                    // `InvalidPolicy::path` is relative to the scope being
+                    // lowered, which here is this nested scope itself. The
+                    // owning child id is already carried by the enclosing
+                    // `StartupFailureCause::Child`, so prepending it here
+                    // would double-count this frame.
                     (StartupFailureCause::InvalidPolicy(invalid), disposal)
                 }
             };

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2187,17 +2187,31 @@ impl ScopeRuntime {
             return;
         }
 
-        let Some(definition) = request.slot.take_defined() else {
-            let (_, removed) = cancel_dynamic_reservation_parts(&control, &request.slot);
-            reject_admission_after_disposal(
-                request,
-                None,
-                removed,
-                ReserveError::NotAdmitting(NotAdmittingCause::ReservationEnded),
-            );
-            return;
+        let (definition, resolved) = match request.slot.resolve_and_take_defined(&self.defaults) {
+            Ok(Some(claimed)) => claimed,
+            Ok(None) => {
+                let (_, removed) = cancel_dynamic_reservation_parts(&control, &request.slot);
+                reject_admission_after_disposal(
+                    request,
+                    None,
+                    removed,
+                    ReserveError::NotAdmitting(NotAdmittingCause::ReservationEnded),
+                );
+                return;
+            }
+            Err(invalid) => {
+                let (definition, removed) =
+                    cancel_dynamic_reservation_parts(&control, &request.slot);
+                reject_admission_after_disposal(
+                    request,
+                    definition,
+                    removed,
+                    ReserveError::InvalidPolicy(invalid),
+                );
+                return;
+            }
         };
-        let plan = ChildPlan::resolve(Arc::clone(&request.slot), definition, &self.defaults);
+        let plan = ChildPlan::with_options(Arc::clone(&request.slot), definition, resolved);
         {
             let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
             let id = request.slot.member.id();
@@ -2462,6 +2476,9 @@ async fn run_nested_tree(
                 }
                 LowerError::IdentityExhausted { id, disposal } => {
                     (StartupFailureCause::IdentityExhausted { id }, disposal)
+                }
+                LowerError::InvalidPolicy { invalid, disposal } => {
+                    (StartupFailureCause::InvalidPolicy(invalid), disposal)
                 }
             };
             // Lowering never created a nested driver to own teardown. Keep

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -22,12 +22,12 @@ use crate::{
     observe::LifecycleEventKind,
     plan::{
         BuilderCore, ChildConstruction, ChildPlan, LowerError, NotAdmittingCause, RemoveOutcome,
-        ReserveError, ScopeFactory, ScopePlan, ScopeSource, SlotCell,
+        ReserveError, ScopeFactory, ScopePlan, SlotCell,
     },
     policy::{DefaultsInheritance, ResolvedDefaults, ScopeFlavor},
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
     runtime::{self, Latch},
-    task::{OnceTaskBody, TaskContext, TaskFactory},
+    task::{TaskContext, TaskFactory},
 };
 
 #[cfg(test)]
@@ -1216,25 +1216,20 @@ impl ScopeRuntime {
                 )
             }
             ChildConstruction::TaskOnce(definition) => {
-                let body = std::mem::replace(&mut definition.body, OnceTaskBody::Spent);
-                match body {
-                    OnceTaskBody::Available(body) => (
-                        SpawnBody::TaskOnce(body),
-                        Some(child.options.readiness),
-                        true,
-                    ),
-                    OnceTaskBody::Spent => {
-                        panic!("one-shot task construction invoked more than once")
-                    }
-                }
+                let body = definition.take_body();
+                (
+                    SpawnBody::TaskOnce(body),
+                    Some(child.options.readiness),
+                    true,
+                )
             }
             ChildConstruction::Scope(definition) => {
                 let inherited = match definition.defaults {
                     DefaultsInheritance::Inherit => self.defaults.clone(),
                     DefaultsInheritance::Reset => ResolvedDefaults::default(),
                 };
-                match &mut definition.source {
-                    ScopeSource::Restartable(factory) => (
+                if let Some(factory) = definition.restartable() {
+                    (
                         SpawnBody::ScopeRestartable {
                             factory: Arc::clone(factory),
                             scope: Arc::clone(
@@ -1248,31 +1243,26 @@ impl ScopeRuntime {
                         },
                         Some(Readiness::Manual),
                         false,
-                    ),
-                    ScopeSource::OneShot(_) => {
-                        let source = std::mem::replace(&mut definition.source, ScopeSource::Spent);
-                        let ScopeSource::OneShot(tree) = source else {
-                            unreachable!()
-                        };
-                        (
-                            SpawnBody::ScopeOnce {
-                                tree,
-                                scope: Arc::clone(
-                                    child
-                                        .slot
-                                        .scope
-                                        .as_ref()
-                                        .expect("scope construction needs a scope cell"),
-                                ),
-                                inherited,
-                            },
-                            Some(Readiness::Manual),
-                            true,
-                        )
-                    }
-                    ScopeSource::Spent => {
-                        panic!("one-shot subtree construction invoked more than once")
-                    }
+                    )
+                } else {
+                    let tree = definition
+                        .take_one_shot()
+                        .expect("one-shot subtree construction invoked more than once");
+                    (
+                        SpawnBody::ScopeOnce {
+                            tree,
+                            scope: Arc::clone(
+                                child
+                                    .slot
+                                    .scope
+                                    .as_ref()
+                                    .expect("scope construction needs a scope cell"),
+                            ),
+                            inherited,
+                        },
+                        Some(Readiness::Manual),
+                        true,
+                    )
                 }
             }
         };

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -406,9 +406,12 @@ pub(crate) fn remove_dynamic(
     // registration is reclaimed before the removal response completes.
     let member = Arc::clone(&entry.slot.member);
     // Dynamic-state protects admission/removal bookkeeping; the observation
-    // gate protects the public projection. Never nest the former around the
-    // latter: shutdown takes the same resources in the opposite order while
-    // clearing residents and closing dynamic state.
+    // gate protects the public projection. Release the former before entering
+    // the latter. No path takes the two in the opposite order, so this is not
+    // breaking an existing cycle; it keeps an unbounded wait out of the
+    // bookkeeping mutex. Any thread may hold the gate across arbitrary
+    // observation work, and blocking there while holding dynamic state would
+    // stall every concurrent reservation, removal, and driver admission.
     drop(state);
     scope.transition_child(&member, |record| record.removing = true, None);
     member.removal.fire();
@@ -2676,6 +2679,16 @@ async fn run_scope_incarnation(
             let class = driver_event_class(&event);
             pending.push((class, Pending::Driver(event)));
         }
+        // Disposal completions drain after the bounded lane, and `arbitrate`
+        // sorts stably, so a `ConstructionDisposed` always trails every
+        // same-class `Exited` collected in the same wake — even one produced
+        // later. A disposal is therefore a batch-tail event: the exit it
+        // trails may begin a drain first, after which
+        // `handle_construction_disposed` sees `is_draining` and routes the
+        // disposed child through stop progression instead of `fail_startup`.
+        // That is a widening of an order that was already reachable, not a new
+        // one: disposal runs on the blocking pool, so its completion never had
+        // a fixed position relative to concurrent exits.
         while let Some(event) = runtime::unbounded_mpsc_try_recv(&mut disposal_event_receiver) {
             let class = driver_event_class(&event);
             pending.push((class, Pending::Driver(event)));

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -405,9 +405,13 @@ pub(crate) fn remove_dynamic(
     // through the normal removal path, like live residents, so that
     // registration is reclaimed before the removal response completes.
     let member = Arc::clone(&entry.slot.member);
-    scope.transition_child(&member, |record| record.removing = true, None);
-    entry.slot.member.removal.fire();
+    // Dynamic-state protects admission/removal bookkeeping; the observation
+    // gate protects the public projection. Never nest the former around the
+    // latter: shutdown takes the same resources in the opposite order while
+    // clearing residents and closing dynamic state.
     drop(state);
+    scope.transition_child(&member, |record| record.removing = true, None);
+    member.removal.fire();
     scope.signal().pulse();
     response
 }
@@ -877,6 +881,7 @@ struct ScopeRuntime {
     intensity: IntensityState,
     children: ChildArena,
     events: runtime::MpscSender<DriverEvent>,
+    disposal_events: runtime::UnboundedMpscSender<DriverEvent>,
     deadlines: DeadlineQueue<DeadlineKind>,
     jitter: runtime::JitterRng,
     lifecycle: ScopeLifecycle,
@@ -1998,12 +2003,17 @@ impl ScopeRuntime {
         // The retained factory is user-owned. Destroy it on the blocking
         // pool. The disposal job itself owns completion, so cancellation or
         // failure to spawn an auxiliary async joiner cannot strand the child.
-        let sender = self.events.clone();
+        let sender = self.disposal_events.clone();
+        let signal = self.root.signal().clone();
         runtime::dispose_then(construction, move |panic| {
-            let _ = sender.blocking_send(DriverEvent::Child(ChildEvent::ConstructionDisposed {
-                child: key,
-                panic,
-            }));
+            if runtime::unbounded_mpsc_send(
+                &sender,
+                DriverEvent::Child(ChildEvent::ConstructionDisposed { child: key, panic }),
+            )
+            .is_ok()
+            {
+                signal.pulse();
+            }
         });
     }
 
@@ -2060,6 +2070,10 @@ impl ScopeRuntime {
     }
 
     fn fail_startup(&mut self, key: ChildKey, exit: Exit) {
+        // Several initial children can fail in one arbitration batch. The
+        // first failure owns the startup verdict and its sole lifecycle edge;
+        // later exits are still terminalized, but cannot republish the scope
+        // transition or replace the authoritative cause.
         let child = &self.children[key];
         let failure = StartupFailure {
             cause: StartupFailureCause::Child {
@@ -2542,6 +2556,7 @@ async fn run_scope_incarnation(
     }
     let capacity = plan.children.len().saturating_mul(3).max(64);
     let (events, mut event_receiver) = runtime::bounded_mpsc(capacity);
+    let (disposal_events, mut disposal_event_receiver) = runtime::unbounded_mpsc();
     let dynamic = (plan.root.flavor == ScopeFlavor::Dynamic)
         .then(|| DynamicControl::new(&root, events.clone()));
     if let Some(control) = &dynamic {
@@ -2587,6 +2602,7 @@ async fn run_scope_incarnation(
         intensity: IntensityState::default(),
         children,
         events,
+        disposal_events,
         deadlines: DeadlineQueue::default(),
         jitter: runtime::JitterRng::from_system_entropy(),
         lifecycle: ScopeLifecycle::starting(),
@@ -2657,6 +2673,10 @@ async fn run_scope_incarnation(
             ));
         }
         while let Some(event) = runtime::mpsc_try_recv(&mut event_receiver) {
+            let class = driver_event_class(&event);
+            pending.push((class, Pending::Driver(event)));
+        }
+        while let Some(event) = runtime::unbounded_mpsc_try_recv(&mut disposal_event_receiver) {
             let class = driver_event_class(&event);
             pending.push((class, Pending::Driver(event)));
         }
@@ -3099,6 +3119,7 @@ mod tests {
                 .collect(),
         );
         let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+        let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
         let mut children = ChildArena::default();
         plan.children.reverse();
         while let Some(child) = plan.children.pop() {
@@ -3114,6 +3135,7 @@ mod tests {
             intensity: super::IntensityState::default(),
             children,
             events,
+            disposal_events,
             deadlines: super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::from_system_entropy(),
             lifecycle: ScopeLifecycle::running(),
@@ -3233,6 +3255,7 @@ mod tests {
                 .collect(),
         );
         let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+        let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
         let mut children = ChildArena::default();
         plan.children.reverse();
         while let Some(child) = plan.children.pop() {
@@ -3256,6 +3279,7 @@ mod tests {
             intensity: super::IntensityState::default(),
             children,
             events,
+            disposal_events,
             deadlines: super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::from_system_entropy(),
             lifecycle: ScopeLifecycle::running(),
@@ -4206,6 +4230,89 @@ mod tests {
         assert_eq!(response.try_receive(), Some(RemoveOutcome::Removed));
     }
 
+    #[test]
+    fn reserve_dynamic_rejects_an_empty_id_at_the_driver_boundary() {
+        let root = isolated_scope("root", ScopeFlavor::Dynamic);
+
+        assert!(matches!(
+            super::reserve_dynamic(&root, ChildId::from(""), None),
+            Err(crate::ReserveError::EmptyId)
+        ));
+    }
+
+    #[test]
+    fn dynamic_removal_releases_state_before_waiting_for_the_observation_gate() {
+        let root = isolated_scope("root", ScopeFlavor::Dynamic);
+        let child_id = ChildId::from("worker");
+        let member = MemberCell::new(
+            child_id.clone(),
+            root.child_identity
+                .lock()
+                .expect("scope identity mutex poisoned")
+                .mint_membership(&child_id)
+                .expect("child membership available"),
+        );
+        let slot = SlotCell::new(Arc::clone(&member), None);
+        root.set_admitted_children(vec![resident_projection(&slot)]);
+        let (events, _receiver) = crate::runtime::bounded_mpsc(1);
+        let control = DynamicControl::new(&root, events);
+        control
+            .state
+            .lock()
+            .expect("dynamic-state mutex poisoned")
+            .entries
+            .insert(
+                child_id.clone(),
+                DynamicEntry {
+                    slot,
+                    admitted: true,
+                    fused_cancel: None,
+                    removal: Obligation::new(RemovalResponses::default(), complete_removals),
+                    removal_started: false,
+                },
+            );
+        root.set_dynamic_route(Some(super::DynamicRoute::new(Arc::clone(&control))));
+
+        let gate = root.observation_gate();
+        let held_gate = gate.lock().expect("observation gate starts healthy");
+        let baseline_member_owners = Arc::strong_count(&member);
+        let removal_root = Arc::clone(&root);
+        let removal_id = child_id.clone();
+        let worker =
+            std::thread::spawn(move || super::remove_dynamic(&removal_root, &removal_id, None));
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while Arc::strong_count(&member) == baseline_member_owners {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "removal reaches its observation transition"
+            );
+            std::thread::yield_now();
+        }
+        loop {
+            match control.state.try_lock() {
+                Ok(state) => {
+                    drop(state);
+                    break;
+                }
+                Err(std::sync::TryLockError::WouldBlock) => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "a removal blocked on observation must release dynamic state"
+                    );
+                    std::thread::yield_now();
+                }
+                Err(std::sync::TryLockError::Poisoned(_)) => {
+                    panic!("dynamic-state mutex poisoned")
+                }
+            }
+        }
+
+        drop(held_gate);
+        let response = worker.join().expect("removal transition completes");
+        drop(response);
+    }
+
     #[crate::runtime::test]
     async fn system_shutdown_joins_root_driver_teardown() {
         let system = DynamicTree::new().spawn().expect("runtime is available");
@@ -4270,7 +4377,8 @@ mod tests {
                 .map(|child| resident_projection(&child.slot))
                 .collect(),
         );
-        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(64);
+        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(1);
+        let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
         let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
         let mut children = ChildArena::default();
         let key = children
@@ -4283,6 +4391,7 @@ mod tests {
             intensity: super::IntensityState::default(),
             children,
             events,
+            disposal_events,
             deadlines: super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::from_system_entropy(),
             lifecycle: ScopeLifecycle::running(),
@@ -4323,6 +4432,17 @@ mod tests {
             None,
         );
 
+        assert!(
+            scope
+                .events
+                .try_send(DriverEvent::Child(ChildEvent::Ready {
+                    child: key,
+                    incarnation: first,
+                }))
+                .is_ok(),
+            "the bounded driver queue is deliberately saturated"
+        );
+
         scope.spawn_child(key);
         assert!(scope.children[key].is_disposing());
         assert!(matches!(
@@ -4331,13 +4451,18 @@ mod tests {
         ));
         assert_eq!(root.snapshot().children.len(), 1);
 
-        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = event_receiver
-            .recv()
-            .await
-            .expect("disposal reports completion")
+        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) =
+            disposal_event_receiver
+                .recv()
+                .await
+                .expect("disposal reports completion")
         else {
             panic!("only construction disposal was armed")
         };
+        assert!(matches!(
+            event_receiver.try_recv(),
+            Ok(DriverEvent::Child(ChildEvent::Ready { .. }))
+        ));
         scope.handle_construction_disposed(child, panic);
 
         assert!(!scope.children[key].is_disposing());
@@ -4375,7 +4500,8 @@ mod tests {
                 .map(|child| resident_projection(&child.slot))
                 .collect(),
         );
-        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(64);
+        let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+        let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
         let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
         let mut children = ChildArena::default();
         let key = children
@@ -4388,6 +4514,7 @@ mod tests {
             intensity: super::IntensityState::default(),
             children,
             events,
+            disposal_events,
             deadlines: super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::from_system_entropy(),
             lifecycle: ScopeLifecycle::starting(),
@@ -4425,10 +4552,11 @@ mod tests {
         scope.spawn_child(key);
         assert!(scope.children[key].is_disposing());
 
-        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = event_receiver
-            .recv()
-            .await
-            .expect("disposal reports completion")
+        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) =
+            disposal_event_receiver
+                .recv()
+                .await
+                .expect("disposal reports completion")
         else {
             panic!("only construction disposal was armed")
         };

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -236,7 +236,16 @@ impl DynamicControl {
 }
 
 fn dynamic_control(scope: &ScopeCell) -> Option<Arc<DynamicControl>> {
-    scope.dynamic_route()?.resolve().ok()
+    // The cells layer stores the route erased because it may not name a driver
+    // type. `set_dynamic_route` is the only writer, so a failed downcast is a
+    // driver bug, not an absent route: resolving it to `None` would fail open,
+    // reporting `NoLiveIncarnation` and `AlreadyAbsent` for a live scope.
+    Some(
+        scope
+            .dynamic_route()?
+            .resolve()
+            .unwrap_or_else(|_| panic!("the dynamic route is always a DynamicControl")),
+    )
 }
 
 fn resident_projection(slot: &SlotCell) -> ResidentProjection {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2951,6 +2951,36 @@ mod tests {
     }
 
     #[test]
+    fn a_declined_epoch_still_publishes_its_owned_terminal_exit() {
+        let scope = isolated_scope("scope", ScopeFlavor::Ordered);
+        let epoch = scope.begin_incarnation().expect("scope epoch is available");
+        // The orderly finisher retires the epoch without a terminal exit, so
+        // a second owner still holds the only membership verdict.
+        scope.finish_incarnation(epoch, StopReason::Finished);
+        assert!(!matches!(
+            scope.member.record().stage,
+            MemberStage::Terminal(_)
+        ));
+
+        scope.finish_root_incarnation(
+            epoch,
+            StopReason::ShutdownRequested,
+            Exit::new(ExitKind::Aborted { after_grace: false }, true),
+        );
+        assert!(matches!(
+            scope.member.record().stage,
+            MemberStage::Terminal(_)
+        ));
+        assert_eq!(
+            scope.record().state,
+            ScopeState::Stopped {
+                reason: StopReason::Finished,
+            },
+            "a declined epoch must not rewrite the retired stop reason"
+        );
+    }
+
+    #[test]
     fn admitted_subtrees_share_their_parent_observation_gate() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
         let nested = isolated_scope("nested", ScopeFlavor::Dynamic);

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1,9 +1,9 @@
 //! Mutable runtime shell and shared handle state.
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     fmt,
-    ops::{Index, IndexMut},
+    ops::{Bound, Index, IndexMut},
     sync::{
         Arc, Mutex, Weak,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -1903,130 +1903,81 @@ impl ScopePhase {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct ChildKey {
-    index: usize,
-    generation: u64,
-}
-
-struct ChildArenaSlot {
-    generation: u64,
-    child: Option<ChildRuntime>,
-}
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct ChildKey(u64);
 
 #[derive(Default)]
 struct ChildArena {
-    // Vacancies are reused, but every reuse advances the generation carried
-    // by driver events and deadlines. A late event can therefore miss; it
-    // can never address the new resident of the same physical slot.
-    slots: Vec<ChildArenaSlot>,
-    free: Vec<usize>,
-    len: usize,
+    // Keys are insertion-order ids and are never reused. A late event can
+    // therefore miss; it can never address a subsequently inserted child.
+    children: BTreeMap<ChildKey, ChildRuntime>,
+    // `u64::MAX` is poison and is never minted. Once exhausted, every later
+    // insertion fails closed instead of wrapping into the live key domain.
+    next_key: u64,
 }
 
 impl ChildArena {
-    fn with_capacity(capacity: usize) -> Self {
-        Self {
-            slots: Vec::with_capacity(capacity),
-            free: Vec::new(),
-            len: 0,
+    fn insert(&mut self, child: ChildRuntime) -> Result<ChildKey, Box<ChildRuntime>> {
+        let Some(next) = self.next_key.checked_add(1) else {
+            return Err(Box::new(child));
+        };
+        if next == u64::MAX {
+            self.next_key = u64::MAX;
+            return Err(Box::new(child));
         }
-    }
-
-    fn insert(&mut self, child: ChildRuntime) -> ChildKey {
-        self.len += 1;
-        if let Some(index) = self.free.pop() {
-            let slot = &mut self.slots[index];
-            debug_assert!(slot.child.is_none());
-            slot.child = Some(child);
-            ChildKey {
-                index,
-                generation: slot.generation,
-            }
-        } else {
-            let index = self.slots.len();
-            self.slots.push(ChildArenaSlot {
-                generation: 0,
-                child: Some(child),
-            });
-            ChildKey {
-                index,
-                generation: 0,
-            }
-        }
+        self.next_key = next;
+        let key = ChildKey(next);
+        let replaced = self.children.insert(key, child);
+        debug_assert!(replaced.is_none(), "monotonic child keys are never reused");
+        Ok(key)
     }
 
     fn get(&self, key: ChildKey) -> Option<&ChildRuntime> {
-        self.slots
-            .get(key.index)
-            .filter(|slot| slot.generation == key.generation)
-            .and_then(|slot| slot.child.as_ref())
+        self.children.get(&key)
     }
 
     fn get_mut(&mut self, key: ChildKey) -> Option<&mut ChildRuntime> {
-        self.slots
-            .get_mut(key.index)
-            .filter(|slot| slot.generation == key.generation)
-            .and_then(|slot| slot.child.as_mut())
+        self.children.get_mut(&key)
     }
 
     fn remove(&mut self, key: ChildKey) -> Option<ChildRuntime> {
-        let slot = self.slots.get_mut(key.index)?;
-        if slot.generation != key.generation {
-            return None;
-        }
-        let child = slot.child.take()?;
-        self.len -= 1;
-        if let Some(next) = slot.generation.checked_add(1) {
-            slot.generation = next;
-            self.free.push(key.index);
-        }
-        Some(child)
-    }
-
-    fn key_at(&self, index: usize) -> Option<ChildKey> {
-        self.slots.get(index).and_then(|slot| {
-            slot.child.as_ref().map(|_| ChildKey {
-                index,
-                generation: slot.generation,
-            })
-        })
+        self.children.remove(&key)
     }
 
     fn keys(&self) -> impl DoubleEndedIterator<Item = ChildKey> + '_ {
-        self.slots.iter().enumerate().filter_map(|(index, slot)| {
-            slot.child.as_ref().map(|_| ChildKey {
-                index,
-                generation: slot.generation,
-            })
-        })
+        self.children.keys().copied()
+    }
+
+    fn keys_after(&self, key: ChildKey) -> impl DoubleEndedIterator<Item = ChildKey> + '_ {
+        self.children
+            .range((Bound::Excluded(key), Bound::Unbounded))
+            .map(|(key, _)| *key)
     }
 
     fn values(&self) -> impl Iterator<Item = &ChildRuntime> {
-        self.slots.iter().filter_map(|slot| slot.child.as_ref())
+        self.children.values()
     }
 
     fn values_mut(&mut self) -> impl Iterator<Item = &mut ChildRuntime> {
-        self.slots.iter_mut().filter_map(|slot| slot.child.as_mut())
+        self.children.values_mut()
     }
 
+    #[cfg(test)]
     fn len(&self) -> usize {
-        self.len
+        self.children.len()
     }
 
     fn is_empty(&self) -> bool {
-        self.len == 0
+        self.children.is_empty()
     }
 
     fn clear(&mut self) {
-        self.slots.clear();
-        self.free.clear();
-        self.len = 0;
+        self.children.clear();
     }
 
     #[cfg(test)]
     fn storage_len(&self) -> usize {
-        self.slots.len()
+        self.children.len()
     }
 }
 
@@ -2055,7 +2006,7 @@ struct ScopeRuntime {
     deadlines: DeadlineQueue<DeadlineKind>,
     jitter: runtime::JitterRng,
     phase: ScopePhase,
-    next_ordered_start: usize,
+    next_ordered_start: Option<ChildKey>,
     is_root: bool,
     parent_ready: Option<Latch>,
     dynamic: Option<Arc<DynamicControl>>,
@@ -2611,16 +2562,12 @@ impl ScopeRuntime {
         }
         match self.flavor {
             ScopeFlavor::Ordered => {
-                while self.next_ordered_start < self.children.len() {
-                    let key = self
-                        .children
-                        .key_at(self.next_ordered_start)
-                        .expect("ordered children are never reclaimed during startup");
+                while let Some(key) = self.next_ordered_start {
                     if !self.children[key].spawned_once {
                         self.spawn_child(key);
                     }
                     if self.children[key].initial_ready {
-                        self.next_ordered_start += 1;
+                        self.next_ordered_start = self.children.keys_after(key).next();
                     } else {
                         return;
                     }
@@ -3189,11 +3136,8 @@ impl ScopeRuntime {
         self.root
             .set_startup(Err(StartupError::StartupFailed(failure.clone())));
         if self.flavor == ScopeFlavor::Ordered {
-            for later_index in key.index + 1..self.children.len() {
-                let later = self
-                    .children
-                    .key_at(later_index)
-                    .expect("ordered children are never reclaimed during startup");
+            let later_children: Vec<_> = self.children.keys_after(key).collect();
+            for later in later_children {
                 if !self.children[later].spawned_once
                     && !self.children[later].is_disposing()
                     && !self.children[later].is_terminal()
@@ -3391,8 +3335,37 @@ impl ScopeRuntime {
         }
         let mut child = ChildRuntime::from_plan(plan, &self.root);
         child.initial = false;
+        let key = match self.children.insert(child) {
+            Ok(key) => key,
+            Err(child) => {
+                let mut child = *child;
+                let removed = {
+                    let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
+                    let id = request.slot.member.id();
+                    let matches_admission = state.entries.get(id).is_some_and(|entry| {
+                        entry.slot.member.membership() == request.slot.member.membership()
+                            && entry.admitted
+                    });
+                    matches_admission
+                        .then(|| state.entries.remove(id))
+                        .flatten()
+                };
+                request.slot.member.terminalize(Exit::never_started());
+                if let Some(scope) = &request.slot.scope {
+                    scope.terminalize_never_started();
+                }
+                child.complete_terminality();
+                let ChildRuntime { construction, .. } = child;
+                reject_admission_after_disposal(
+                    request,
+                    Some(construction),
+                    removed,
+                    ReserveError::IdentityExhausted,
+                );
+                return;
+            }
+        };
         self.root.admit_child(&request.slot);
-        let key = self.children.insert(child);
         #[cfg(test)]
         self.record_storage();
         request.complete(Ok(()));
@@ -3639,11 +3612,15 @@ async fn run_scope_incarnation(
     // owned by ScopePlan, while ChildRuntime::from_plan arms the current
     // child's obligation before fallible setup. Thus a panic at any point has
     // exactly one terminality owner for every child.
-    let mut children = ChildArena::with_capacity(plan.children.len());
+    let mut children = ChildArena::default();
     plan.children.reverse();
     while let Some(child) = plan.children.pop() {
-        children.insert(ChildRuntime::from_plan(child, &root));
+        let child = ChildRuntime::from_plan(child, &root);
+        if children.insert(child).is_err() {
+            unreachable!("a fresh child-key domain accommodates an in-memory child collection");
+        }
     }
+    let next_ordered_start = children.keys().next();
     let mut scope = ScopeRuntime {
         root: Arc::clone(&root),
         flavor: plan.flavor,
@@ -3655,7 +3632,7 @@ async fn run_scope_incarnation(
         deadlines: DeadlineQueue::default(),
         jitter: runtime::JitterRng::from_system_entropy(),
         phase: ScopePhase::Starting,
-        next_ordered_start: 0,
+        next_ordered_start,
         is_root,
         parent_ready,
         dynamic,
@@ -3923,11 +3900,11 @@ mod tests {
     };
 
     use super::{
-        ChildArena, ChildEvent, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
+        ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
         MemberCell, MemberStage, Obligation, Pending, RemovalResponses, RuntimeStorage, ScopeCell,
-        ScopeFlavor, ScopePhase, ScopeRuntime, StartupPhase, complete_removals,
-        driver_event_class, mint_child_incarnation, report_channel, restart_shutdown_work,
-        run_nested_tree, run_scope_incarnation,
+        ScopeFlavor, ScopePhase, ScopeRuntime, StartupPhase, complete_removals, driver_event_class,
+        mint_child_incarnation, report_channel, restart_shutdown_work, run_nested_tree,
+        run_scope_incarnation,
     };
 
     fn isolated_scope(id: &'static str, flavor: ScopeFlavor) -> Arc<ScopeCell> {
@@ -4091,10 +4068,12 @@ mod tests {
                 .collect(),
         );
         let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
-        let mut children = ChildArena::with_capacity(plan.children.len());
+        let mut children = ChildArena::default();
         plan.children.reverse();
         while let Some(child) = plan.children.pop() {
-            children.insert(ChildRuntime::from_plan(child, &root));
+            children
+                .insert(ChildRuntime::from_plan(child, &root))
+                .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
         }
         let nested = children
             .keys()
@@ -4104,6 +4083,7 @@ mod tests {
             .keys()
             .find(|key| children[*key].slot.member.id().as_str() == "trip")
             .expect("tripping child key");
+        let next_ordered_start = children.keys().next();
         let mut scope = ScopeRuntime {
             root: Arc::clone(&root),
             flavor: plan.flavor,
@@ -4115,7 +4095,7 @@ mod tests {
             deadlines: super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::from_system_entropy(),
             phase: ScopePhase::Running,
-            next_ordered_start: 0,
+            next_ordered_start,
             is_root: true,
             parent_ready: None,
             dynamic: None,
@@ -4260,7 +4240,7 @@ mod tests {
     }
 
     #[test]
-    fn stale_child_keys_cannot_target_reused_slots() {
+    fn removed_child_keys_are_never_reused() {
         let mut tree = Tree::new();
         tree.add_task("worker", TaskDef::new(|_| future::pending()))
             .expect("valid task");
@@ -4268,44 +4248,47 @@ mod tests {
         let child =
             ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &plan.root);
         let mut arena = ChildArena::default();
-        let stale = arena.insert(child);
+        let stale = arena.insert(child).unwrap_or_else(|_| panic!("key mints"));
         let child = arena.remove(stale).expect("live key removes its child");
-        let current = arena.insert(child);
+        let current = arena.insert(child).unwrap_or_else(|_| panic!("key mints"));
 
-        assert_eq!(stale.index, current.index, "the vacant slot is reused");
-        assert_ne!(stale.generation, current.generation);
+        assert!(current > stale, "keys advance monotonically across removal");
         assert!(arena.get(stale).is_none());
         assert!(arena.remove(stale).is_none());
         assert!(arena.get(current).is_some());
     }
 
     #[test]
-    fn exhausted_child_generation_retires_the_slot() {
+    fn child_key_exhaustion_poison_is_never_minted() {
         let mut tree = Tree::new();
         tree.add_task("worker", TaskDef::new(|_| future::pending()))
             .expect("valid task");
         let mut plan = lower_tree_for_test(tree);
         let child =
             ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &plan.root);
-        let mut arena = ChildArena::default();
-        let original = arena.insert(child);
-        arena.slots[original.index].generation = u64::MAX;
-        let exhausted = super::ChildKey {
-            index: original.index,
-            generation: u64::MAX,
+        let mut arena = ChildArena {
+            next_key: u64::MAX - 2,
+            ..ChildArena::default()
         };
+        let last = arena
+            .insert(child)
+            .unwrap_or_else(|_| panic!("the last usable key mints"));
+        assert_eq!(last, ChildKey(u64::MAX - 1));
+        let child = arena.remove(last).expect("the last usable key is live");
 
-        let child = arena
-            .remove(exhausted)
-            .expect("the forced exhausted generation is live");
-        let current = arena.insert(child);
-        assert_ne!(exhausted.index, current.index);
-        assert!(arena.get(exhausted).is_none());
-        assert!(arena.get(current).is_some());
+        let child = *arena
+            .insert(child)
+            .expect_err("the poison key is never minted");
+        assert_eq!(arena.next_key, u64::MAX);
+        assert!(arena.get(ChildKey(u64::MAX)).is_none());
+        assert!(
+            arena.insert(child).is_err(),
+            "the exhausted domain stays poisoned"
+        );
     }
 
     #[crate::runtime::test]
-    async fn dynamic_high_cycle_add_remove_reuses_runtime_storage() {
+    async fn dynamic_high_cycle_add_remove_keeps_only_live_runtime_storage() {
         const CYCLES: usize = 1_000;
 
         let system = DynamicTree::new().spawn().expect("runtime is available");
@@ -4337,7 +4320,7 @@ mod tests {
                     deadlines: 1,
                     deadline_slots: 1,
                 },
-                "cycle {cycle} must reuse the sole runtime slot"
+                "cycle {cycle} stores only the live child"
             );
 
             assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
@@ -4345,11 +4328,11 @@ mod tests {
                 cell.runtime_storage(),
                 RuntimeStorage {
                     children: 0,
-                    child_slots: 1,
+                    child_slots: 0,
                     deadlines: 0,
                     deadline_slots: 0,
                 },
-                "cycle {cycle} must reclaim the removed child"
+                "cycle {cycle} must release removed-child storage"
             );
 
             let automatic = scope
@@ -4365,11 +4348,11 @@ mod tests {
                 cell.runtime_storage(),
                 RuntimeStorage {
                     children: 0,
-                    child_slots: 1,
+                    child_slots: 0,
                     deadlines: 0,
                     deadline_slots: 0,
                 },
-                "cycle {cycle} must reclaim Retention::Remove registration"
+                "cycle {cycle} must release Retention::Remove storage"
             );
         }
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -14,8 +14,9 @@ use crate::{
     deadline::Deadline,
     engine::{
         ArbitrationClass, DeadlineHandle, DeadlineQueue, ExitDispatch, IntensityState,
-        MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState, ScopeMode,
-        StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart,
+        MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState,
+        ScopeLifecycle, ScopeMode, StopAction, StopLadder, arbitrate, dispatch_exit,
+        schedule_restart,
     },
     exit::{
         JoinVerdict, RecordedOutcome, StartupError, StopReason, classify_exit,
@@ -456,7 +457,7 @@ enum DriverEvent {
 
 impl SystemRun {
     pub(crate) fn request_shutdown(&self) {
-        self.root.request_shutdown();
+        let _ = self.root.request_shutdown();
     }
 
     pub(crate) async fn shutdown(&mut self, timeout: Duration) -> Result<(), ShutdownTimeout> {
@@ -534,7 +535,10 @@ pub(crate) async fn shutdown_scope(
     if matches!(scope.member.record().stage, MemberStage::Terminal(_)) {
         return Ok(());
     }
-    let epoch = scope.request_shutdown();
+    let Some(epoch) = scope.request_shutdown() else {
+        // An exhausted idle scope has no incarnation that can remain live.
+        return Ok(());
+    };
     let mut watcher = scope.signal().watcher();
     loop {
         if scope.incarnation_finished(epoch)
@@ -768,72 +772,6 @@ impl ChildRuntime {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum StartupPhase {
-    Pending,
-    Complete,
-    Failed,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-/// Driver-loop lifecycle state. `ScopeRecord` remains the observation projection and
-/// `ScopeControl` remains the epoch-tagged request plane; neither duplicates these phases.
-enum ScopePhase {
-    Starting,
-    Running,
-    StartupFailed,
-    Draining {
-        reason: StopReason,
-        startup: StartupPhase,
-    },
-}
-
-impl ScopePhase {
-    fn startup_complete(&self) -> bool {
-        matches!(
-            self,
-            Self::Running
-                | Self::Draining {
-                    startup: StartupPhase::Complete,
-                    ..
-                }
-        )
-    }
-
-    fn startup_failed(&self) -> bool {
-        matches!(
-            self,
-            Self::StartupFailed
-                | Self::Draining {
-                    startup: StartupPhase::Failed,
-                    ..
-                }
-        )
-    }
-
-    fn is_draining(&self) -> bool {
-        matches!(self, Self::Draining { .. })
-    }
-
-    fn draining_reason(&self) -> Option<&StopReason> {
-        match self {
-            Self::Draining { reason, .. } => Some(reason),
-            Self::Starting | Self::Running | Self::StartupFailed => None,
-        }
-    }
-
-    fn begin_drain(&mut self, reason: StopReason) -> bool {
-        let startup = match self {
-            Self::Starting => StartupPhase::Pending,
-            Self::Running => StartupPhase::Complete,
-            Self::StartupFailed => StartupPhase::Failed,
-            Self::Draining { .. } => return false,
-        };
-        *self = Self::Draining { reason, startup };
-        true
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct ChildKey(u64);
 
@@ -935,7 +873,7 @@ struct ScopeRuntime {
     events: runtime::MpscSender<DriverEvent>,
     deadlines: DeadlineQueue<DeadlineKind>,
     jitter: runtime::JitterRng,
-    phase: ScopePhase,
+    lifecycle: ScopeLifecycle,
     next_ordered_start: Option<ChildKey>,
     is_root: bool,
     parent_ready: Option<Latch>,
@@ -993,7 +931,7 @@ impl Drop for ScopeRuntime {
             let reason = completion
                 .as_ref()
                 .map(|completion| completion.reason.clone())
-                .or_else(|| self.phase.draining_reason().cloned())
+                .or_else(|| self.lifecycle.draining_reason().cloned())
                 .unwrap_or(StopReason::ShutdownRequested);
             if let Some(exit) = completion.and_then(|completion| completion.root_exit) {
                 self.root.finish_root_incarnation(self.epoch, reason, exit);
@@ -1009,23 +947,327 @@ enum SpawnBody {
         spawn: RawSpawn,
         context: RawRunContext,
     },
-    TaskRestartable(TaskFactory),
-    TaskOnce(Box<dyn FnOnce(TaskContext) -> crate::task::TaskFuture + Send + 'static>),
+    TaskRestartable {
+        factory: TaskFactory,
+        context: TaskContext,
+    },
+    TaskOnce {
+        body: Box<dyn FnOnce(TaskContext) -> crate::task::TaskFuture + Send + 'static>,
+        context: TaskContext,
+    },
     ScopeRestartable {
         factory: ScopeFactory,
         scope: Arc<ScopeCell>,
         inherited: ResolvedDefaults,
+        ready: Latch,
+        cancel: Latch,
+        abort: Latch,
+        abort_ack: Latch,
     },
     ScopeOnce {
         tree: Box<BuilderCore>,
         scope: Arc<ScopeCell>,
         inherited: ResolvedDefaults,
+        ready: Latch,
+        cancel: Latch,
+        abort: Latch,
+        abort_ack: Latch,
     },
+}
+
+struct SpawnDispatch {
+    body: SpawnBody,
+    declared_readiness: Option<Readiness>,
+    construction_spent: bool,
+    scope_child: bool,
+}
+
+/// Latches have deliberately separate ownership:
+///
+/// - `shutdown`/`abort` are the child-facing cooperative ladder;
+/// - `framework_abort`/`framework_abort_ack` bound a nested scope driver's
+///   recursive drain before its task is aborted;
+/// - `construction_release` prevents a raw actor from running before the
+///   driver has installed the readiness mode reported by construction;
+/// - `ended` makes readiness and self-stop watcher tasks finite.
+struct SpawnLatches {
+    shutdown: Latch,
+    abort: Latch,
+    ready: Latch,
+    ended: Latch,
+    construction_release: Latch,
+    local_stop: Latch,
+    framework_abort: Latch,
+    framework_abort_ack: Latch,
+}
+
+struct ChildTaskLaunch {
+    events: runtime::MpscSender<DriverEvent>,
+    key: ChildKey,
+    incarnation: Incarnation,
+    body: SpawnBody,
+    readiness_override: Option<Readiness>,
+    watch_readiness: bool,
+    shutdown: Latch,
+    ready: Latch,
+    ended: Latch,
+    construction_release: Latch,
+    local_stop: Latch,
+}
+
+fn dispatch_child_construction(
+    child: &mut ChildRuntime,
+    root: &Arc<ScopeCell>,
+    defaults: &ResolvedDefaults,
+    incarnation: Incarnation,
+    latches: &SpawnLatches,
+) -> SpawnDispatch {
+    let id = child.slot.member.id().clone();
+    let construction = child.construction.get_mut();
+    match construction {
+        ChildConstruction::Raw(definition) => {
+            let construction_spent = definition.one_shot();
+            SpawnDispatch {
+                body: SpawnBody::Raw {
+                    spawn: definition.take_spawn(),
+                    context: RawRunContext {
+                        id,
+                        incarnation,
+                        member: Arc::clone(&child.slot.member),
+                        scope: crate::ScopeRef {
+                            cell: Arc::clone(root),
+                        },
+                        shutdown: latches.shutdown.clone(),
+                        abort: latches.abort.clone(),
+                        ready: latches.ready.clone(),
+                        local_stop: latches.local_stop.clone(),
+                        mailbox_shutdown: child.options.mailbox_shutdown,
+                    },
+                },
+                declared_readiness: None,
+                construction_spent,
+                scope_child: false,
+            }
+        }
+        ChildConstruction::Task(definition) => SpawnDispatch {
+            body: SpawnBody::TaskRestartable {
+                factory: Arc::clone(&definition.factory),
+                context: TaskContext::new(
+                    id,
+                    incarnation,
+                    latches.shutdown.clone(),
+                    latches.abort.clone(),
+                    latches.ready.clone(),
+                ),
+            },
+            declared_readiness: Some(child.options.readiness),
+            construction_spent: false,
+            scope_child: false,
+        },
+        ChildConstruction::TaskOnce(definition) => SpawnDispatch {
+            body: SpawnBody::TaskOnce {
+                body: definition.take_body(),
+                context: TaskContext::new(
+                    id,
+                    incarnation,
+                    latches.shutdown.clone(),
+                    latches.abort.clone(),
+                    latches.ready.clone(),
+                ),
+            },
+            declared_readiness: Some(child.options.readiness),
+            construction_spent: true,
+            scope_child: false,
+        },
+        ChildConstruction::Scope(definition) => {
+            let inherited = match definition.defaults {
+                DefaultsInheritance::Inherit => defaults.clone(),
+                DefaultsInheritance::Reset => ResolvedDefaults::default(),
+            };
+            let scope = Arc::clone(
+                child
+                    .slot
+                    .scope
+                    .as_ref()
+                    .expect("scope construction needs a scope cell"),
+            );
+            let (body, construction_spent) = if let Some(factory) = definition.restartable() {
+                (
+                    SpawnBody::ScopeRestartable {
+                        factory: Arc::clone(factory),
+                        scope,
+                        inherited,
+                        ready: latches.ready.clone(),
+                        cancel: latches.shutdown.clone(),
+                        abort: latches.framework_abort.clone(),
+                        abort_ack: latches.framework_abort_ack.clone(),
+                    },
+                    false,
+                )
+            } else {
+                (
+                    SpawnBody::ScopeOnce {
+                        tree: definition
+                            .take_one_shot()
+                            .expect("one-shot subtree construction invoked more than once"),
+                        scope,
+                        inherited,
+                        ready: latches.ready.clone(),
+                        cancel: latches.shutdown.clone(),
+                        abort: latches.framework_abort.clone(),
+                        abort_ack: latches.framework_abort_ack.clone(),
+                    },
+                    true,
+                )
+            };
+            SpawnDispatch {
+                body,
+                declared_readiness: Some(Readiness::Manual),
+                construction_spent,
+                scope_child: true,
+            }
+        }
+    }
+}
+
+fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
+    let ChildTaskLaunch {
+        events,
+        key,
+        incarnation,
+        body,
+        readiness_override,
+        watch_readiness,
+        shutdown,
+        ready,
+        ended,
+        construction_release,
+        local_stop,
+    } = launch;
+    let (report, report_receiver) = report_channel(shutdown, Some(local_stop.clone()));
+    let constructed_sender = events.clone();
+    let handle = runtime::spawn(async move {
+        let body = async move {
+            match body {
+                SpawnBody::Raw { spawn, context } => {
+                    let instance = spawn.construct();
+                    let readiness = readiness_override.unwrap_or_else(|| instance.readiness());
+                    let _ = runtime::mpsc_send(
+                        &constructed_sender,
+                        DriverEvent::Child(ChildEvent::Constructed {
+                            child: key,
+                            incarnation,
+                            readiness,
+                        }),
+                    )
+                    .await;
+                    construction_release.fired().await;
+                    instance.run(context, readiness).await
+                }
+                SpawnBody::TaskRestartable { factory, context } => factory(context).await,
+                SpawnBody::TaskOnce { body, context } => body(context).await,
+                SpawnBody::ScopeRestartable {
+                    factory,
+                    scope,
+                    inherited,
+                    ready,
+                    cancel,
+                    abort,
+                    abort_ack,
+                } => {
+                    run_nested_tree(factory(), scope, inherited, ready, cancel, abort, abort_ack)
+                        .await
+                }
+                SpawnBody::ScopeOnce {
+                    tree,
+                    scope,
+                    inherited,
+                    ready,
+                    cancel,
+                    abort,
+                    abort_ack,
+                } => {
+                    run_nested_tree(*tree, scope, inherited, ready, cancel, abort, abort_ack).await
+                }
+            }
+        };
+        let outcome = CatchUnwindFuture::new(body).await;
+        let result = match outcome {
+            Ok(result) => result,
+            Err(payload) => std::panic::resume_unwind(payload),
+        };
+        report.record(RecordedOutcome::Returned(result));
+    });
+    let abort_handle = handle.abort_handle();
+
+    let exit_sender = events.clone();
+    let exit_ended = ended.clone();
+    runtime::spawn(async move {
+        let join = match runtime::join(handle).await {
+            runtime::JoinOutcome::Ok { .. } => JoinVerdict::Completed,
+            runtime::JoinOutcome::Panic { message, .. } => JoinVerdict::Panicked { message },
+            runtime::JoinOutcome::Cancelled => JoinVerdict::Cancelled { after_grace: false },
+        };
+        exit_ended.fire();
+        // The task owns `report`, whose explicit record or Drop fallback runs
+        // before the join completes. Therefore this blocking receive cannot
+        // wait on a producer that is still schedulable on this worker.
+        let report = report_receiver.receive();
+        let _ = runtime::mpsc_send(
+            &exit_sender,
+            DriverEvent::Child(ChildEvent::Exited {
+                child: key,
+                incarnation,
+                recorded: report.outcome,
+                join,
+                cancelled: report.cancelled,
+            }),
+        )
+        .await;
+    });
+
+    if watch_readiness {
+        let ready_sender = events.clone();
+        let ready_ended = ended.clone();
+        runtime::spawn(async move {
+            if matches!(
+                runtime::select_two(ready.fired(), ready_ended.fired()).await,
+                runtime::Either::Left(())
+            ) {
+                let _ = runtime::mpsc_send(
+                    &ready_sender,
+                    DriverEvent::Child(ChildEvent::Ready {
+                        child: key,
+                        incarnation,
+                    }),
+                )
+                .await;
+            }
+        });
+    }
+
+    runtime::spawn(async move {
+        if matches!(
+            runtime::select_two(local_stop.fired(), ended.fired()).await,
+            runtime::Either::Left(())
+        ) {
+            let _ = runtime::mpsc_send(
+                &events,
+                DriverEvent::Child(ChildEvent::SelfStop {
+                    child: key,
+                    incarnation,
+                }),
+            )
+            .await;
+        }
+    });
+
+    abort_handle
 }
 
 impl ScopeRuntime {
     fn restart_is_suppressed(&self, key: ChildKey) -> bool {
-        if self.phase.is_draining()
+        if self.lifecycle.is_draining()
             || self.hard_forced
             || self.root.has_stop_request(self.epoch)
             || self.ancestor_shutdown.as_ref().is_some_and(Latch::is_fired)
@@ -1099,7 +1341,7 @@ impl ScopeRuntime {
         let Some(child) = self.children.get(key) else {
             return;
         };
-        if self.phase.is_draining()
+        if self.lifecycle.is_draining()
             || child.active.is_some()
             || child.is_terminal()
             || child.is_disposing()
@@ -1117,7 +1359,8 @@ impl ScopeRuntime {
                 .record()
                 .last_exit
                 .unwrap_or_else(Exit::never_started);
-            let pre_ready = child.initial && !self.phase.startup_complete() && !child.initial_ready;
+            let pre_ready =
+                child.initial && !self.lifecycle.startup_complete() && !child.initial_ready;
             // Exhaustion is a terminal outcome, not an exceptional cleanup
             // path. Join retained-definition disposal before terminality,
             // retention, removal completion, or ordered-scope progression.
@@ -1125,110 +1368,22 @@ impl ScopeRuntime {
             return;
         };
 
-        let shutdown = Latch::default();
-        let abort = Latch::default();
-        let ready = Latch::default();
-        let ended = Latch::default();
-        let construction_release = Latch::default();
-        let local_stop = Latch::default();
-        let id = child.slot.member.id().clone();
-        let task_context = TaskContext::new(
-            id.clone(),
-            incarnation,
-            shutdown.clone(),
-            abort.clone(),
-            ready.clone(),
-        );
-        let construction = child.construction.get_mut();
-        let scope_child = matches!(construction, ChildConstruction::Scope(_));
-        let (body, declared_readiness, construction_spent) = match construction {
-            ChildConstruction::Raw(definition) => {
-                let one_shot = definition.one_shot();
-                let spawn = definition.take_spawn();
-                (
-                    SpawnBody::Raw {
-                        spawn,
-                        context: RawRunContext {
-                            id,
-                            incarnation,
-                            member: Arc::clone(&child.slot.member),
-                            scope: crate::ScopeRef {
-                                cell: Arc::clone(&self.root),
-                            },
-                            shutdown: shutdown.clone(),
-                            abort: abort.clone(),
-                            ready: ready.clone(),
-                            local_stop: local_stop.clone(),
-                            mailbox_shutdown: child.options.mailbox_shutdown,
-                        },
-                    },
-                    None,
-                    one_shot,
-                )
-            }
-            ChildConstruction::Task(definition) => {
-                let factory = Arc::clone(&definition.factory);
-                (
-                    SpawnBody::TaskRestartable(factory),
-                    Some(child.options.readiness),
-                    false,
-                )
-            }
-            ChildConstruction::TaskOnce(definition) => {
-                let body = definition.take_body();
-                (
-                    SpawnBody::TaskOnce(body),
-                    Some(child.options.readiness),
-                    true,
-                )
-            }
-            ChildConstruction::Scope(definition) => {
-                let inherited = match definition.defaults {
-                    DefaultsInheritance::Inherit => self.defaults.clone(),
-                    DefaultsInheritance::Reset => ResolvedDefaults::default(),
-                };
-                if let Some(factory) = definition.restartable() {
-                    (
-                        SpawnBody::ScopeRestartable {
-                            factory: Arc::clone(factory),
-                            scope: Arc::clone(
-                                child
-                                    .slot
-                                    .scope
-                                    .as_ref()
-                                    .expect("scope construction needs a scope cell"),
-                            ),
-                            inherited,
-                        },
-                        Some(Readiness::Manual),
-                        false,
-                    )
-                } else {
-                    let tree = definition
-                        .take_one_shot()
-                        .expect("one-shot subtree construction invoked more than once");
-                    (
-                        SpawnBody::ScopeOnce {
-                            tree,
-                            scope: Arc::clone(
-                                child
-                                    .slot
-                                    .scope
-                                    .as_ref()
-                                    .expect("scope construction needs a scope cell"),
-                            ),
-                            inherited,
-                        },
-                        Some(Readiness::Manual),
-                        true,
-                    )
-                }
-            }
+        let latches = SpawnLatches {
+            shutdown: Latch::default(),
+            abort: Latch::default(),
+            ready: Latch::default(),
+            ended: Latch::default(),
+            construction_release: Latch::default(),
+            local_stop: Latch::default(),
+            framework_abort: Latch::default(),
+            framework_abort_ack: Latch::default(),
         };
-        let construction_pending = declared_readiness.is_none();
-        let gated = scope_child
-            || declared_readiness.is_none_or(|readiness| readiness != Readiness::Immediate);
-
+        let SpawnDispatch {
+            body,
+            declared_readiness,
+            construction_spent,
+            scope_child,
+        } = dispatch_child_construction(child, &self.root, &self.defaults, incarnation, &latches);
         let now = runtime::now();
         child.spawned_once = true;
         if let Some(mailbox) = child.slot.member.mailbox() {
@@ -1249,50 +1404,19 @@ impl ScopeRuntime {
             }),
         );
 
-        let (readiness, readiness_deadline) = if construction_pending {
-            (ReadinessGate::Waiting { deadline: None }, None)
-        } else if !gated {
-            ready.fire();
-            child.initial_ready = true;
-            self.root.transition_child(
-                &child.slot.member,
-                |record| record.stage = MemberStage::Running,
-                Some(LifecycleEventKind::Ready {
-                    id: child.slot.member.id().clone(),
-                    membership: child.slot.member.membership(),
-                    incarnation,
-                }),
-            );
-            (ReadinessGate::Immediate, None)
-        } else {
-            let (deadline, handle) = match child.options.readiness_deadline {
-                ReadinessDeadline::Bounded(duration) => {
-                    let deadline = Deadline::after(now, duration).instant();
-                    let handle = deadline.map(|deadline| {
-                        self.deadlines.push(
-                            deadline,
-                            DeadlineKind::Readiness {
-                                child: key,
-                                incarnation,
-                            },
-                        )
-                    });
-                    (deadline, handle)
-                }
-                ReadinessDeadline::Unbounded | ReadinessDeadline::Inherit => (None, None),
+        let mut readiness = ReadinessGate::new();
+        let readiness_effect = declared_readiness.and_then(|readiness_mode| {
+            let deadline = match child.options.readiness_deadline {
+                ReadinessDeadline::Bounded(duration) => Deadline::after(now, duration).instant(),
+                ReadinessDeadline::Unbounded | ReadinessDeadline::Inherit => None,
             };
-            (ReadinessGate::Waiting { deadline }, handle)
-        };
+            readiness.step(ReadinessEvent::Configure {
+                readiness: readiness_mode,
+                deadline,
+            })
+        });
+        let gated = readiness.needs_signal_watch();
 
-        let (report, report_receiver) = report_channel(shutdown.clone(), Some(local_stop.clone()));
-        let nested_ready = ready.clone();
-        let nested_cancel = shutdown.clone();
-        let framework_abort = Latch::default();
-        let nested_abort = framework_abort.clone();
-        let framework_abort_ack = Latch::default();
-        let nested_abort_ack = framework_abort_ack.clone();
-        let constructed_sender = self.events.clone();
-        let run_release = construction_release.clone();
         let child_readiness_override = child.options.readiness_override;
         if construction_spent {
             // One-shot actor/task/subtree state has moved into `body`; the
@@ -1301,158 +1425,111 @@ impl ScopeRuntime {
             // terminal publication or restart-window arbitration.
             drop(child.construction.take());
         }
-        let handle = runtime::spawn(async move {
-            let body = async move {
-                match body {
-                    SpawnBody::Raw { spawn, context } => {
-                        let instance = spawn.construct();
-                        let readiness = match child_readiness_override {
-                            Some(readiness) => readiness,
-                            None => instance.readiness(),
-                        };
-                        let _ = runtime::mpsc_send(
-                            &constructed_sender,
-                            DriverEvent::Child(ChildEvent::Constructed {
-                                child: key,
-                                incarnation,
-                                readiness,
-                            }),
-                        )
-                        .await;
-                        run_release.fired().await;
-                        instance.run(context, readiness).await
-                    }
-                    SpawnBody::TaskRestartable(factory) => {
-                        let future = factory(task_context);
-                        future.await
-                    }
-                    SpawnBody::TaskOnce(body) => body(task_context).await,
-                    SpawnBody::ScopeRestartable {
-                        factory,
-                        scope,
-                        inherited,
-                    } => {
-                        let tree = factory();
-                        run_nested_tree(
-                            tree,
-                            scope,
-                            inherited,
-                            nested_ready,
-                            nested_cancel,
-                            nested_abort,
-                            nested_abort_ack,
-                        )
-                        .await
-                    }
-                    SpawnBody::ScopeOnce {
-                        tree,
-                        scope,
-                        inherited,
-                    } => {
-                        run_nested_tree(
-                            *tree,
-                            scope,
-                            inherited,
-                            nested_ready,
-                            nested_cancel,
-                            nested_abort,
-                            nested_abort_ack,
-                        )
-                        .await
-                    }
-                }
-            };
-            let outcome = CatchUnwindFuture::new(body).await;
-            let result = match outcome {
-                Ok(result) => result,
-                Err(payload) => std::panic::resume_unwind(payload),
-            };
-            report.record(RecordedOutcome::Returned(result));
-        });
-        let abort_handle = handle.abort_handle();
-        let exit_sender = self.events.clone();
-        let exit_ended = ended.clone();
-        runtime::spawn(async move {
-            let join = match runtime::join(handle).await {
-                runtime::JoinOutcome::Ok { .. } => JoinVerdict::Completed,
-                runtime::JoinOutcome::Panic { message, .. } => JoinVerdict::Panicked { message },
-                runtime::JoinOutcome::Cancelled => JoinVerdict::Cancelled { after_grace: false },
-            };
-            exit_ended.fire();
-            let report = report_receiver.receive();
-            let _ = runtime::mpsc_send(
-                &exit_sender,
-                DriverEvent::Child(ChildEvent::Exited {
-                    child: key,
-                    incarnation,
-                    recorded: report.outcome,
-                    join,
-                    cancelled: report.cancelled,
-                }),
-            )
-            .await;
-        });
-
-        let readiness_signal = ready.clone();
-        let self_stop_ended = ended.clone();
-        if gated {
-            let ready_sender = self.events.clone();
-            runtime::spawn(async move {
-                if matches!(
-                    runtime::select_two(ready.fired(), ended.fired()).await,
-                    runtime::Either::Left(())
-                ) {
-                    let _ = runtime::mpsc_send(
-                        &ready_sender,
-                        DriverEvent::Child(ChildEvent::Ready {
-                            child: key,
-                            incarnation,
-                        }),
-                    )
-                    .await;
-                }
-            });
-        }
-        let self_stop_sender = self.events.clone();
-        runtime::spawn(async move {
-            if matches!(
-                runtime::select_two(local_stop.fired(), self_stop_ended.fired()).await,
-                runtime::Either::Left(())
-            ) {
-                let _ = runtime::mpsc_send(
-                    &self_stop_sender,
-                    DriverEvent::Child(ChildEvent::SelfStop {
-                        child: key,
-                        incarnation,
-                    }),
-                )
-                .await;
-            }
+        let abort_handle = spawn_child_tasks(ChildTaskLaunch {
+            events: self.events.clone(),
+            key,
+            incarnation,
+            body,
+            readiness_override: child_readiness_override,
+            watch_readiness: gated,
+            shutdown: latches.shutdown.clone(),
+            ready: latches.ready.clone(),
+            ended: latches.ended.clone(),
+            construction_release: latches.construction_release.clone(),
+            local_stop: latches.local_stop.clone(),
         });
 
         child.active = Some(ActiveChild {
             incarnation,
             started_at: now,
-            shutdown,
-            abort,
+            shutdown: latches.shutdown,
+            abort: latches.abort,
             abort_handle,
             ladder: None,
             forced_outcome: None,
             hard_abort_after_grace: None,
             readiness,
-            readiness_deadline,
-            ready_signal: readiness_signal,
-            construction_release,
-            framework_abort: scope_child.then_some(framework_abort),
-            framework_abort_ack: scope_child.then_some(framework_abort_ack),
+            readiness_deadline: None,
+            ready_signal: latches.ready,
+            construction_release: latches.construction_release,
+            framework_abort: scope_child.then_some(latches.framework_abort),
+            framework_abort_ack: scope_child.then_some(latches.framework_abort_ack),
             stop_deadline: None,
         });
+        if let Some(effect) = readiness_effect {
+            // `progress_startup` already owns this ordered-startup loop. Do
+            // not re-enter it synchronously for an immediate child.
+            let _ = self.apply_readiness_effect(key, incarnation, effect);
+        }
         #[cfg(test)]
         self.record_storage();
     }
 
+    fn apply_readiness_effect(
+        &mut self,
+        key: ChildKey,
+        incarnation: Incarnation,
+        effect: ReadinessEffect,
+    ) -> bool {
+        match effect {
+            ReadinessEffect::ArmDeadline { deadline } => {
+                let handle = self.deadlines.push(
+                    deadline,
+                    DeadlineKind::Readiness {
+                        child: key,
+                        incarnation,
+                    },
+                );
+                if let Some(active) = self
+                    .children
+                    .get_mut(key)
+                    .and_then(|child| child.active.as_mut())
+                    && active.incarnation == incarnation
+                {
+                    active.readiness_deadline = Some(handle);
+                } else {
+                    self.deadlines.cancel(handle);
+                }
+                false
+            }
+            ReadinessEffect::BecameReady => {
+                let Some(child) = self.children.get_mut(key) else {
+                    return false;
+                };
+                let Some(active) = child.active.as_mut() else {
+                    return false;
+                };
+                if active.incarnation != incarnation {
+                    return false;
+                }
+                if let Some(deadline) = active.readiness_deadline.take() {
+                    self.deadlines.cancel(deadline);
+                }
+                active.ready_signal.fire();
+                if !self.lifecycle.startup_complete() {
+                    child.initial_ready = true;
+                }
+                self.root.transition_child(
+                    &child.slot.member,
+                    |record| record.stage = MemberStage::Running,
+                    Some(LifecycleEventKind::Ready {
+                        id: child.slot.member.id().clone(),
+                        membership: child.slot.member.membership(),
+                        incarnation,
+                    }),
+                );
+                true
+            }
+            ReadinessEffect::TimedOut { deadline } => {
+                self.begin_stop_child(key, Some(RecordedOutcome::ReadinessTimedOut { deadline }));
+                false
+            }
+            ReadinessEffect::Disarmed => false,
+        }
+    }
+
     fn progress_startup(&mut self) {
-        if self.phase != ScopePhase::Starting {
+        if !self.lifecycle.is_starting() {
             return;
         }
         match self.root.flavor {
@@ -1490,7 +1567,9 @@ impl ScopeRuntime {
     }
 
     fn complete_startup(&mut self) {
-        self.phase = ScopePhase::Running;
+        if !self.lifecycle.complete_startup() {
+            return;
+        }
         self.root.set_state(ScopeState::Running);
         self.root.set_startup(Ok(()));
         if let Some(parent_ready) = &self.parent_ready {
@@ -1604,11 +1683,10 @@ impl ScopeRuntime {
     }
 
     fn begin_drain(&mut self, reason: StopReason) {
-        let startup_pending = self.phase == ScopePhase::Starting;
-        if !self.phase.begin_drain(reason) {
+        let Some(effect) = self.lifecycle.begin_drain(reason) else {
             return;
-        }
-        if startup_pending {
+        };
+        if effect.startup_pending {
             self.root.set_startup(Err(StartupError::ShutdownRequested));
         }
         self.root.set_state(ScopeState::Draining);
@@ -1624,7 +1702,7 @@ impl ScopeRuntime {
     }
 
     fn stop_next_ordered(&mut self) {
-        if self.root.flavor != ScopeFlavor::Ordered || !self.phase.is_draining() {
+        if self.root.flavor != ScopeFlavor::Ordered || !self.lifecycle.is_draining() {
             return;
         }
         loop {
@@ -1642,7 +1720,7 @@ impl ScopeRuntime {
 
     fn force_all(&mut self) {
         self.hard_forced = true;
-        if !self.phase.is_draining() {
+        if !self.lifecycle.is_draining() {
             self.begin_drain(StopReason::ShutdownRequested);
         }
         let now = runtime::now();
@@ -1681,9 +1759,7 @@ impl ScopeRuntime {
         incarnation: Incarnation,
         readiness: Readiness,
     ) {
-        let mut became_ready = false;
-        let mut deadline_to_arm = None;
-        {
+        let effect = {
             let Some(child) = self.children.get_mut(key) else {
                 return;
             };
@@ -1697,49 +1773,29 @@ impl ScopeRuntime {
                 active.construction_release.fire();
                 return;
             }
-            if readiness == Readiness::Immediate {
-                active.readiness = ReadinessGate::Immediate;
-                active.ready_signal.fire();
-                if !self.phase.startup_complete() {
-                    child.initial_ready = true;
+            let deadline = match child.options.readiness_deadline {
+                ReadinessDeadline::Bounded(duration) => {
+                    Deadline::after(active.started_at, duration).instant()
                 }
-                self.root.transition_child(
-                    &child.slot.member,
-                    |record| record.stage = MemberStage::Running,
-                    Some(LifecycleEventKind::Ready {
-                        id: child.slot.member.id().clone(),
-                        membership: child.slot.member.membership(),
-                        incarnation,
-                    }),
-                );
-                became_ready = true;
-            } else {
-                let deadline = match child.options.readiness_deadline {
-                    ReadinessDeadline::Bounded(duration) => {
-                        Deadline::after(active.started_at, duration).instant()
-                    }
-                    ReadinessDeadline::Unbounded | ReadinessDeadline::Inherit => None,
-                };
-                active.readiness = ReadinessGate::Waiting { deadline };
-                deadline_to_arm = deadline;
-            }
-            active.construction_release.fire();
-        }
-        if let Some(deadline) = deadline_to_arm {
-            let handle = self.deadlines.push(
+                ReadinessDeadline::Unbounded | ReadinessDeadline::Inherit => None,
+            };
+            active.readiness.step(ReadinessEvent::Configure {
+                readiness,
                 deadline,
-                DeadlineKind::Readiness {
-                    child: key,
-                    incarnation,
-                },
-            );
-            if let Some(active) = self.children[key].active.as_mut()
-                && active.incarnation == incarnation
-            {
-                active.readiness_deadline = Some(handle);
-            } else {
-                self.deadlines.cancel(handle);
-            }
+            })
+        };
+        let became_ready = effect
+            .map(|effect| self.apply_readiness_effect(key, incarnation, effect))
+            .unwrap_or(false);
+        if let Some(active) = self
+            .children
+            .get(key)
+            .and_then(|child| child.active.as_ref())
+            .filter(|active| active.incarnation == incarnation)
+        {
+            // Readiness state and all shell effects are installed before raw
+            // actor execution is released.
+            active.construction_release.fire();
         }
         if became_ready {
             self.progress_startup();
@@ -1747,38 +1803,20 @@ impl ScopeRuntime {
     }
 
     fn handle_ready(&mut self, key: ChildKey, incarnation: Incarnation) {
-        let Some(child) = self.children.get_mut(key) else {
-            return;
-        };
-        let Some(active) = child.active.as_mut() else {
-            return;
-        };
-        if active.incarnation != incarnation
-            || !matches!(
-                active.readiness.step(ReadinessEvent::Signal),
-                Some(ReadinessEffect::BecameReady)
-            )
-        {
-            return;
+        let effect = self
+            .children
+            .get_mut(key)
+            .and_then(|child| child.active.as_mut())
+            .filter(|active| active.incarnation == incarnation)
+            .and_then(|active| active.readiness.step(ReadinessEvent::Signal));
+        let became_ready = effect
+            .map(|effect| self.apply_readiness_effect(key, incarnation, effect))
+            .unwrap_or(false);
+        if became_ready {
+            self.progress_startup();
         }
-        if let Some(deadline) = active.readiness_deadline.take() {
-            self.deadlines.cancel(deadline);
-        }
-        if !self.phase.startup_complete() {
-            child.initial_ready = true;
-        }
-        self.root.transition_child(
-            &child.slot.member,
-            |record| record.stage = MemberStage::Running,
-            Some(LifecycleEventKind::Ready {
-                id: child.slot.member.id().clone(),
-                membership: child.slot.member.membership(),
-                incarnation,
-            }),
-        );
         #[cfg(test)]
         self.record_storage();
-        self.progress_startup();
     }
 
     fn handle_self_stop(&mut self, key: ChildKey, incarnation: Incarnation) {
@@ -1829,12 +1867,13 @@ impl ScopeRuntime {
         }
         let recorded = reconcile_recorded_outcomes(recorded, active.forced_outcome);
         let exit = classify_exit(recorded, join, cancelled);
-        let ran_for = runtime::now().saturating_duration_since(active.started_at);
-        if ran_for >= self.intensity_policy.within {
-            child.restarts.settled();
-        }
+        child.restarts.settle_if_stable(
+            active.started_at,
+            runtime::now(),
+            self.intensity_policy.within,
+        );
 
-        let mode = if self.phase.is_draining() {
+        let mode = if self.lifecycle.is_draining() {
             ScopeMode::Draining
         } else {
             ScopeMode::Running
@@ -1851,11 +1890,11 @@ impl ScopeRuntime {
                 // later incarnation stopped pre-ready (e.g. during drain)
                 // does not rewind it.
                 let pre_ready =
-                    child.initial && !self.phase.startup_complete() && !child.initial_ready;
+                    child.initial && !self.lifecycle.startup_complete() && !child.initial_ready;
                 self.begin_terminal_disposal(key, exit, Some(incarnation), pre_ready);
             }
             ExitDispatch::ScheduleRestart => {
-                if !self.phase.startup_complete() {
+                if !self.lifecycle.startup_complete() {
                     child.initial_ready = false;
                 }
                 let sample = self.jitter.sample(0..u64::MAX) as f64 / u64::MAX as f64;
@@ -1900,7 +1939,7 @@ impl ScopeRuntime {
                         observed_restarts: decision.charge.in_window,
                         within: self.intensity_policy.within,
                     };
-                    if self.phase == ScopePhase::Starting {
+                    if self.lifecycle.is_starting() {
                         self.root
                             .set_startup(Err(StartupError::IntensityTripped(trip.clone())));
                     }
@@ -1999,7 +2038,7 @@ impl ScopeRuntime {
         let removing = self.children[key].slot.member.record().removing;
         if removing {
             self.finalize_removal(key);
-        } else if terminal.startup_aborted && !self.phase.is_draining() {
+        } else if terminal.startup_aborted && !self.lifecycle.is_draining() {
             self.fail_startup(key, exit);
             if self.children[key].options.retention == crate::Retention::Remove {
                 self.prune_terminal(key);
@@ -2008,7 +2047,7 @@ impl ScopeRuntime {
             if self.children[key].options.retention == crate::Retention::Remove {
                 self.prune_terminal(key);
             }
-            if self.phase.is_draining() {
+            if self.lifecycle.is_draining() {
                 self.stop_next_ordered();
             }
         }
@@ -2023,7 +2062,10 @@ impl ScopeRuntime {
                 exit,
             },
         };
-        self.phase = ScopePhase::StartupFailed;
+        let first_failure = self.lifecycle.fail_startup();
+        if !first_failure {
+            return;
+        }
         self.root
             .set_startup(Err(StartupError::StartupFailed(failure.clone())));
         if self.root.flavor == ScopeFlavor::Ordered {
@@ -2050,17 +2092,6 @@ impl ScopeRuntime {
                 child: key,
                 incarnation,
             } => {
-                if self
-                    .children
-                    .get(key)
-                    .and_then(|child| child.active.as_ref())
-                    .is_some_and(|active| {
-                        active.incarnation == incarnation && active.ready_signal.is_fired()
-                    })
-                {
-                    self.handle_ready(key, incarnation);
-                    return;
-                }
                 let Some(child) = self.children.get_mut(key) else {
                     return;
                 };
@@ -2070,13 +2101,20 @@ impl ScopeRuntime {
                 if active.incarnation != incarnation {
                     return;
                 }
-                let Some(ReadinessEffect::TimedOut { deadline }) = active
-                    .readiness
-                    .step(ReadinessEvent::Deadline(runtime::now()))
-                else {
-                    return;
-                };
-                self.begin_stop_child(key, Some(RecordedOutcome::ReadinessTimedOut { deadline }));
+                // The queue already consumed this registration. Feed the
+                // retained latch into the engine so signal-at-deadline policy
+                // is decided in exactly one place.
+                active.readiness_deadline.take();
+                let effect = active.readiness.step(ReadinessEvent::Deadline {
+                    now: runtime::now(),
+                    signal_seen: active.ready_signal.is_fired(),
+                });
+                if effect
+                    .map(|effect| self.apply_readiness_effect(key, incarnation, effect))
+                    .unwrap_or(false)
+                {
+                    self.progress_startup();
+                }
             }
             DeadlineKind::Restart { child } => self.spawn_child(child),
             DeadlineKind::Stop { child, incarnation } => {
@@ -2093,27 +2131,15 @@ impl ScopeRuntime {
     }
 
     fn finish_if_ready(&mut self) -> Option<StopReason> {
-        if let Some(reason) = self.phase.draining_reason() {
-            if self
-                .children
-                .values()
-                .all(|child| child.is_terminal() && !child.is_disposing())
-            {
-                return Some(reason.clone());
-            }
-            return None;
-        }
-        if !self.phase.startup_failed()
-            && self.root.flavor == ScopeFlavor::Ordered
-            && !self.children.is_empty()
-            && self
-                .children
-                .values()
-                .all(|child| child.is_terminal() && !child.is_disposing())
-        {
-            return Some(StopReason::Finished);
-        }
-        None
+        let all_terminal = self
+            .children
+            .values()
+            .all(|child| child.is_terminal() && !child.is_disposing());
+        self.lifecycle.finish_if_ready(
+            self.root.flavor == ScopeFlavor::Ordered,
+            !self.children.is_empty(),
+            all_terminal,
+        )
     }
 
     fn handle_admission(&mut self, mut request: AdmissionRequest) {
@@ -2125,12 +2151,12 @@ impl ScopeRuntime {
             .dynamic
             .as_ref()
             .is_none_or(|current| !Arc::ptr_eq(current, &control))
-            || self.phase.is_draining()
-            || self.phase.startup_failed()
+            || self.lifecycle.is_draining()
+            || self.lifecycle.startup_failed()
         {
-            let cause = if self.phase.is_draining() {
+            let cause = if self.lifecycle.is_draining() {
                 NotAdmittingCause::Draining
-            } else if self.phase.startup_failed() {
+            } else if self.lifecycle.startup_failed() {
                 NotAdmittingCause::StartupFailed
             } else {
                 NotAdmittingCause::NoLiveIncarnation
@@ -2359,6 +2385,50 @@ fn mint_child_incarnation(slot: &Arc<SlotCell>, counter: &mut FenceCounter) -> O
     ScopeIdentity::mint_incarnation(slot.member.membership(), counter)
 }
 
+/// Owns a scope epoch until a `ScopeRuntime` has taken over its teardown.
+///
+/// Nested lowering can await isolated disposal before a driver exists. If
+/// that setup future is cancelled or unwinds, dropping this guard retires the
+/// epoch so a later restart cannot mistake the still-live reservation for
+/// identity exhaustion.
+struct ScopeEpochGuard {
+    scope: Arc<ScopeCell>,
+    epoch: Option<u64>,
+}
+
+impl ScopeEpochGuard {
+    fn begin(scope: &Arc<ScopeCell>) -> Option<Self> {
+        let epoch = scope.begin_incarnation()?;
+        Some(Self {
+            scope: Arc::clone(scope),
+            epoch: Some(epoch),
+        })
+    }
+
+    fn finish(mut self, reason: StopReason) {
+        let epoch = self
+            .epoch
+            .take()
+            .expect("an owned scope epoch finishes at most once");
+        self.scope.finish_incarnation(epoch, reason);
+    }
+
+    fn transfer(mut self) -> u64 {
+        self.epoch
+            .take()
+            .expect("an owned scope epoch transfers at most once")
+    }
+}
+
+impl Drop for ScopeEpochGuard {
+    fn drop(&mut self) {
+        if let Some(epoch) = self.epoch.take() {
+            self.scope
+                .finish_incarnation(epoch, StopReason::ShutdownRequested);
+        }
+    }
+}
+
 async fn run_nested_tree(
     tree: BuilderCore,
     scope: Arc<ScopeCell>,
@@ -2368,7 +2438,15 @@ async fn run_nested_tree(
     abort: Latch,
     abort_ack: Latch,
 ) -> crate::ExitResult {
-    let epoch = scope.begin_incarnation();
+    let Some(epoch) = ScopeEpochGuard::begin(&scope) else {
+        let failure = StartupFailure {
+            cause: StartupFailureCause::IdentityExhausted {
+                id: scope.member.id().clone(),
+            },
+        };
+        scope.set_startup(Err(StartupError::StartupFailed(failure.clone())));
+        return Err(crate::ExitError::from_startup_failure(failure));
+    };
     let plan = match tree.lower(inherited, Some(Arc::clone(&scope))) {
         Ok(plan) => plan,
         Err(error) => {
@@ -2387,7 +2465,7 @@ async fn run_nested_tree(
             disposal.fired().await;
             let failure = StartupFailure { cause };
             scope.set_startup(Err(StartupError::StartupFailed(failure.clone())));
-            scope.finish_incarnation(epoch, StopReason::StartupFailed(failure.clone()));
+            epoch.finish(StopReason::StartupFailed(failure.clone()));
             return Err(crate::ExitError::from_startup_failure(failure));
         }
     };
@@ -2411,7 +2489,12 @@ async fn run_nested_tree(
 
 async fn run_scope(plan: ScopePlan, is_root: bool, parent_ready: Option<Latch>) -> StopReason {
     let root = Arc::clone(&plan.root);
-    let epoch = root.begin_incarnation();
+    let Some(epoch) = ScopeEpochGuard::begin(&root) else {
+        // Dropping the still-armed plan terminalizes every never-started
+        // declaration and the root; no aliased driver epoch is created.
+        drop(plan);
+        return StopReason::NeverStarted;
+    };
     run_scope_incarnation(plan, is_root, parent_ready, None, None, None, epoch).await
 }
 
@@ -2422,10 +2505,9 @@ async fn run_scope_incarnation(
     incarnation_cancel: Option<Latch>,
     incarnation_abort: Option<Latch>,
     incarnation_abort_ack: Option<Latch>,
-    epoch: u64,
+    epoch: ScopeEpochGuard,
 ) -> StopReason {
     let root = Arc::clone(&plan.root);
-    root.set_state(ScopeState::Starting);
     if is_root {
         root.member
             .update(|record| record.stage = MemberStage::Running);
@@ -2479,12 +2561,11 @@ async fn run_scope_incarnation(
         events,
         deadlines: DeadlineQueue::default(),
         jitter: runtime::JitterRng::from_system_entropy(),
-        phase: ScopePhase::Starting,
+        lifecycle: ScopeLifecycle::starting(),
         next_ordered_start,
         is_root,
         parent_ready,
         dynamic,
-        epoch,
         ancestor_shutdown: incarnation_cancel,
         ancestor_shutdown_seen: false,
         ancestor_abort: incarnation_abort,
@@ -2492,6 +2573,10 @@ async fn run_scope_incarnation(
         ancestor_abort_seen: false,
         hard_forced: false,
         completion: None,
+        // Transfer last: every fallible setup expression above remains
+        // covered by the pre-driver guard, and completed construction moves
+        // the raw epoch directly into ScopeRuntime's synchronous epilogue.
+        epoch: epoch.transfer(),
     };
     #[cfg(test)]
     scope.record_storage();
@@ -2512,7 +2597,7 @@ async fn run_scope_incarnation(
     let mut signal = root.signal().watcher();
     loop {
         let mut pending = Vec::new();
-        if root.take_shutdown_request(epoch) {
+        if root.take_shutdown_request(scope.epoch) {
             pending.push((ArbitrationClass::ScopeShutdown, Pending::Shutdown));
         }
         for child in scope.pending_restart_shutdowns() {
@@ -2532,7 +2617,7 @@ async fn run_scope_incarnation(
             scope.ancestor_abort_seen = true;
             pending.push((ArbitrationClass::ScopeShutdown, Pending::AncestorAbort));
         }
-        if root.take_force_request(epoch) {
+        if root.take_force_request(scope.epoch) {
             // Force owns shutdown arbitration: readiness from the same wake
             // cannot publish Running after the stop boundary.
             pending.push((ArbitrationClass::ScopeShutdown, Pending::Force));
@@ -2741,7 +2826,7 @@ mod tests {
         LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Readiness, ReadinessDeadline,
         RemoveOutcome, Retention, ScopeState, SendErrorKind, StartupError, StartupFailureCause,
         StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
-        engine::{StopLadder, arbitrate},
+        engine::{ScopeLifecycle, StopLadder, arbitrate},
         exit::{JoinVerdict, RecordedOutcome},
         identity::{FenceCounter, ScopeIdentity},
         mailbox::MailboxCell,
@@ -2752,7 +2837,7 @@ mod tests {
     use super::{
         ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
         MemberCell, MemberStage, Obligation, Pending, RemovalResponses, RuntimeStorage, ScopeCell,
-        ScopeFlavor, ScopePhase, ScopeRuntime, StartupPhase, complete_removals, driver_event_class,
+        ScopeEpochGuard, ScopeFlavor, ScopeRuntime, complete_removals, driver_event_class,
         dynamic_control, mint_child_incarnation, report_channel, resident_projection,
         restart_shutdown_work, run_nested_tree, run_scope_incarnation,
     };
@@ -2805,6 +2890,64 @@ mod tests {
             Ok(()),
             "holding one system's gate must not stall another system"
         );
+    }
+
+    #[test]
+    fn stale_scope_driver_cannot_stop_a_newer_live_incarnation_projection() {
+        let scope = isolated_scope("scope", ScopeFlavor::Ordered);
+        let first = scope
+            .begin_incarnation()
+            .expect("first scope epoch is available");
+        scope.finish_incarnation(first, StopReason::Finished);
+        let second = scope
+            .begin_incarnation()
+            .expect("second scope epoch is available");
+        scope.set_state(ScopeState::Running);
+
+        scope.finish_incarnation(first, StopReason::Finished);
+        assert_eq!(scope.record().state, ScopeState::Running);
+        assert!(!scope.incarnation_finished(second));
+
+        scope.finish_incarnation(second, StopReason::Finished);
+        assert_eq!(
+            scope.record().state,
+            ScopeState::Stopped {
+                reason: StopReason::Finished,
+            }
+        );
+        assert!(scope.incarnation_finished(second));
+    }
+
+    #[test]
+    fn pre_driver_epoch_guard_releases_on_cancellation_and_unwind() {
+        let cancelled = isolated_scope("cancelled", ScopeFlavor::Ordered);
+        let guard = ScopeEpochGuard::begin(&cancelled).expect("first epoch is available");
+        let mut setup = Box::pin(async move {
+            let _guard = guard;
+            future::pending::<()>().await;
+        });
+        assert!(
+            setup
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        drop(setup);
+        let successor = ScopeEpochGuard::begin(&cancelled)
+            .expect("cancelling pre-driver setup retires its epoch");
+        successor.finish(StopReason::NeverStarted);
+
+        let unwound = isolated_scope("unwound", ScopeFlavor::Ordered);
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                let _guard = ScopeEpochGuard::begin(&unwound).expect("unwind epoch is available");
+                panic!("injected pre-driver unwind");
+            }))
+            .is_err()
+        );
+        let successor =
+            ScopeEpochGuard::begin(&unwound).expect("unwinding pre-driver setup retires its epoch");
+        successor.finish(StopReason::NeverStarted);
     }
 
     #[test]
@@ -2877,25 +3020,6 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn scope_phase_preserves_startup_status_while_draining() {
-        for (mut phase, startup) in [
-            (ScopePhase::Starting, StartupPhase::Pending),
-            (ScopePhase::Running, StartupPhase::Complete),
-            (ScopePhase::StartupFailed, StartupPhase::Failed),
-        ] {
-            assert!(phase.begin_drain(StopReason::ShutdownRequested));
-            assert_eq!(
-                phase,
-                ScopePhase::Draining {
-                    reason: StopReason::ShutdownRequested,
-                    startup,
-                }
-            );
-            assert!(!phase.begin_drain(StopReason::Finished));
-        }
-    }
-
     #[crate::runtime::test]
     async fn force_uses_the_stop_funnel_for_every_ordered_child() {
         let mut tree = Tree::new();
@@ -2907,7 +3031,9 @@ mod tests {
             .expect("valid second actor");
         let mut plan = tree.lower_for_test();
         let root = Arc::clone(&plan.root);
-        let epoch = root.begin_incarnation();
+        let epoch = root
+            .begin_incarnation()
+            .expect("test scope epoch is available");
         root.set_admitted_children(
             plan.children
                 .iter()
@@ -2932,7 +3058,7 @@ mod tests {
             events,
             deadlines: super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::from_system_entropy(),
-            phase: ScopePhase::Running,
+            lifecycle: ScopeLifecycle::running(),
             next_ordered_start: None,
             is_root: true,
             parent_ready: None,
@@ -3039,7 +3165,9 @@ mod tests {
 
         let mut plan = tree.lower_for_test();
         let root = Arc::clone(&plan.root);
-        let epoch = root.begin_incarnation();
+        let epoch = root
+            .begin_incarnation()
+            .expect("test scope epoch is available");
         root.set_admitted_children(
             plan.children
                 .iter()
@@ -3072,7 +3200,7 @@ mod tests {
             events,
             deadlines: super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::from_system_entropy(),
-            phase: ScopePhase::Running,
+            lifecycle: ScopeLifecycle::running(),
             next_ordered_start,
             is_root: true,
             parent_ready: None,
@@ -3097,7 +3225,7 @@ mod tests {
             },
             None,
         );
-        scope.children[nested]
+        let _ = scope.children[nested]
             .slot
             .scope
             .as_ref()
@@ -3148,7 +3276,7 @@ mod tests {
         crate::runtime::yield_now().await;
         crate::runtime::yield_now().await;
 
-        assert!(scope.phase.is_draining());
+        assert!(scope.lifecycle.is_draining());
         assert_eq!(
             factories.load(std::sync::atomic::Ordering::SeqCst),
             0,
@@ -3462,7 +3590,7 @@ mod tests {
         .expect("valid task");
         let plan = tree.lower_for_test();
         let scope = Arc::clone(&plan.root);
-        let epoch = scope.begin_incarnation();
+        let epoch = ScopeEpochGuard::begin(&scope).expect("test scope epoch is available");
         let driver = crate::runtime::spawn(run_scope_incarnation(
             plan,
             false,
@@ -3581,7 +3709,7 @@ mod tests {
             .iter()
             .map(|child| Arc::clone(&child.slot.member))
             .collect();
-        let epoch = root.begin_incarnation();
+        let epoch = ScopeEpochGuard::begin(&root).expect("test scope epoch is available");
 
         assert!(
             catch_unwind(AssertUnwindSafe(|| {
@@ -3868,7 +3996,9 @@ mod tests {
             identity.mint_membership(&id).expect("membership available"),
         );
         let scope = ScopeCell::new(member, ScopeFlavor::Ordered, ScopeIdentity::new());
-        let epoch = scope.begin_incarnation();
+        let epoch = scope
+            .begin_incarnation()
+            .expect("test scope epoch is available");
         let probe = Arc::new(ObserveScopeOnStartupWake {
             scope: Arc::clone(&scope),
             epoch: Some(epoch),
@@ -4073,7 +4203,9 @@ mod tests {
         .expect("valid task");
         let mut plan = tree.lower_for_test();
         let root = Arc::clone(&plan.root);
-        let epoch = root.begin_incarnation();
+        let epoch = root
+            .begin_incarnation()
+            .expect("test scope epoch is available");
         root.set_admitted_children(
             plan.children
                 .iter()
@@ -4095,7 +4227,7 @@ mod tests {
             events,
             deadlines: super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::from_system_entropy(),
-            phase: ScopePhase::Running,
+            lifecycle: ScopeLifecycle::running(),
             next_ordered_start: Some(key),
             is_root: true,
             parent_ready: None,
@@ -4176,7 +4308,9 @@ mod tests {
         .expect("valid task");
         let mut plan = tree.lower_for_test();
         let root = Arc::clone(&plan.root);
-        let epoch = root.begin_incarnation();
+        let epoch = root
+            .begin_incarnation()
+            .expect("test scope epoch is available");
         root.set_admitted_children(
             plan.children
                 .iter()
@@ -4198,7 +4332,7 @@ mod tests {
             events,
             deadlines: super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::from_system_entropy(),
-            phase: ScopePhase::Starting,
+            lifecycle: ScopeLifecycle::starting(),
             next_ordered_start: Some(key),
             is_root: true,
             parent_ready: None,

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -98,6 +98,15 @@ pub(crate) struct ReportToken {
 
 pub(crate) struct ReportReceiver(mpsc::Receiver<RecordedReport>);
 
+/// Couples the child task's outcome report to its join verdict without an
+/// asynchronous handoff race.
+///
+/// `ReportToken` is owned by the child task and its fail-closed `Drop` sends a
+/// fallback synchronously. Rust drops those task locals before the join handle
+/// becomes ready, so the exit joiner may safely perform the blocking receive:
+/// a report has already been sent on every return, panic, and cancellation
+/// edge. The shutdown/local-stop latches are sampled by that same send, making
+/// the report and its cancellation evidence one ordered observation.
 pub(crate) fn report_channel(
     shutdown: Latch,
     local_stop: Option<Latch>,
@@ -1382,6 +1391,14 @@ impl ScopeRuntime {
             return;
         };
 
+        // Per-incarnation latch topology:
+        // - shutdown/abort flow from the ladder into application code;
+        // - ready and local_stop flow from application code back to helpers;
+        // - ended terminates those helpers when the child exits first;
+        // - construction_release keeps a raw actor behind the driver-owned
+        //   readiness transition after its construction report is accepted;
+        // - framework_abort/ack join nested-scope escalation before exit.
+        // Each edge is level-triggered, so helper startup cannot lose a pulse.
         let latches = SpawnLatches {
             shutdown: Latch::default(),
             abort: Latch::default(),
@@ -1401,6 +1418,11 @@ impl ScopeRuntime {
         let now = runtime::now();
         child.spawned_once = true;
         if let Some(mailbox) = child.slot.member.mailbox() {
+            #[cfg(debug_assertions)]
+            debug_assert!(
+                mailbox.bind_order_valid(),
+                "driver must configure before bind and close before rebind"
+            );
             mailbox.bind(incarnation);
         }
         self.root.transition_child(

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -17,7 +17,10 @@ use crate::{
         MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState, ScopeMode,
         StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart,
     },
-    exit::{JoinVerdict, RecordedOutcome, StartupError, StopReason, classify_exit},
+    exit::{
+        JoinVerdict, RecordedOutcome, StartupError, StopReason, classify_exit,
+        reconcile_recorded_outcomes,
+    },
     identity::{FenceCounter, ScopeIdentity},
     observe::LifecycleEventKind,
     plan::{
@@ -1825,7 +1828,7 @@ impl ScopeRuntime {
         {
             join = JoinVerdict::Cancelled { after_grace };
         }
-        let recorded = active.forced_outcome.or(recorded);
+        let recorded = reconcile_recorded_outcomes(recorded, active.forced_outcome);
         let exit = classify_exit(recorded, join, cancelled);
         let ran_for = runtime::now().saturating_duration_since(active.started_at);
         if ran_for >= self.intensity_policy.within {

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -487,11 +487,6 @@ impl<K> DeadlineQueue<K> {
     pub(crate) fn storage_len(&self) -> usize {
         self.entries.len()
     }
-
-    #[cfg(test)]
-    fn registration_storage_len(&self) -> usize {
-        self.registrations.len()
-    }
 }
 
 #[cfg(test)]
@@ -799,15 +794,14 @@ mod tests {
         for _ in 0..10_000 {
             let cancelled = deadlines.push(far_future, "cancelled");
             assert!(deadlines.cancel(cancelled));
-            assert_eq!(deadlines.len(), 1);
+            assert_eq!(
+                deadlines.len(),
+                1,
+                "the registration map keeps only live payloads"
+            );
             assert!(
                 deadlines.storage_len() <= 2,
                 "heap tombstones must stay proportional to live deadlines"
-            );
-            assert_eq!(
-                deadlines.registration_storage_len(),
-                deadlines.len(),
-                "the registration map stores only live payloads"
             );
         }
 

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -133,7 +133,18 @@ impl StopLadder {
                     Shutdown::Abort => Duration::ZERO,
                 };
                 self.phase = StopPhase::Escalated;
-                self.deadline = Deadline::after(now, tidy_abort_beat(grace)).instant();
+                // A forced ladder is the `Abort` policy's zero-grace point on
+                // this same ladder (§10), so it takes the zero-grace tidy beat
+                // rather than one scaled to the grace force just skipped. The
+                // `after_grace` provenance above is unaffected: whether grace
+                // actually expired is a separate fact from how long the beat
+                // between escalation and hard abort runs.
+                let beat = if self.force_requested {
+                    Duration::ZERO
+                } else {
+                    grace
+                };
+                self.deadline = Deadline::after(now, tidy_abort_beat(beat)).instant();
                 Some(StopAction::Escalate)
             }
             StopPhase::Escalated if self.deadline.is_some_and(|deadline| now >= deadline) => {
@@ -552,7 +563,7 @@ mod tests {
     use super::{
         ArbitrationClass, DeadlineHandle, DeadlineQueue, ExitDispatch, IntensityState,
         MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState, ScopeMode,
-        StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart,
+        StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart, tidy_abort_beat,
     };
 
     #[test]
@@ -611,6 +622,22 @@ mod tests {
         let tidy = ladder
             .deadline()
             .expect("forced ladder keeps its tidy beat");
+        assert_eq!(
+            tidy,
+            start + tidy_abort_beat(Duration::ZERO),
+            "a forced ladder takes the zero-grace tidy beat, not one scaled \
+             to the grace it skipped"
+        );
+
+        let mut unforced = StopLadder::new(Shutdown::Graceful { grace });
+        assert_eq!(unforced.advance(start), Some(StopAction::Cancel));
+        assert_eq!(unforced.advance(start + grace), Some(StopAction::Escalate));
+        assert_eq!(
+            unforced.deadline(),
+            Some(start + grace + tidy_abort_beat(grace)),
+            "an unforced ladder still scales its tidy beat to its grace"
+        );
+
         ladder.force(start);
         assert_eq!(
             ladder.advance(start),

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -2,7 +2,7 @@
 
 use std::{
     cmp::Ordering,
-    collections::{BinaryHeap, VecDeque},
+    collections::{BTreeMap, BinaryHeap, VecDeque},
     time::{Duration, Instant},
 };
 
@@ -352,7 +352,7 @@ impl ReadinessGate {
 
 impl PartialEq for DeadlineEntry {
     fn eq(&self, other: &Self) -> bool {
-        self.at == other.at && self.order == other.order
+        self.at == other.at && self.handle == other.handle
     }
 }
 
@@ -369,76 +369,49 @@ impl Ord for DeadlineEntry {
         other
             .at
             .cmp(&self.at)
-            .then_with(|| other.order.cmp(&self.order))
+            .then_with(|| other.handle.cmp(&self.handle))
     }
 }
 
 /// The engine's single deadline priority queue.
 #[derive(Debug)]
 pub(crate) struct DeadlineQueue<K> {
-    next_order: u64,
+    // Keys are both registration identity and equal-deadline arming order.
+    // They are never reused, so a stale handle can only miss.
+    next_key: u64,
     entries: BinaryHeap<DeadlineEntry>,
-    slots: Vec<DeadlineSlot<K>>,
-    free: Vec<usize>,
-    len: usize,
+    registrations: BTreeMap<DeadlineHandle, K>,
 }
 
-/// A generation-checked registration for one armed deadline.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct DeadlineHandle {
-    index: usize,
-    generation: u64,
-}
-
-#[derive(Debug)]
-struct DeadlineSlot<K> {
-    generation: u64,
-    key: Option<K>,
-}
+/// A never-reused registration for one armed deadline.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct DeadlineHandle(u64);
 
 #[derive(Debug)]
 struct DeadlineEntry {
     at: Instant,
-    order: u64,
     handle: DeadlineHandle,
 }
 
 impl<K> Default for DeadlineQueue<K> {
     fn default() -> Self {
         Self {
-            next_order: 0,
+            next_key: 0,
             entries: BinaryHeap::new(),
-            slots: Vec::new(),
-            free: Vec::new(),
-            len: 0,
+            registrations: BTreeMap::new(),
         }
     }
 }
 
 impl<K> DeadlineQueue<K> {
     pub(crate) fn push(&mut self, at: Instant, key: K) -> DeadlineHandle {
-        let order = self.next_arming_order();
-        let handle = if let Some(index) = self.free.pop() {
-            let slot = &mut self.slots[index];
-            debug_assert!(slot.key.is_none());
-            slot.key = Some(key);
-            DeadlineHandle {
-                index,
-                generation: slot.generation,
-            }
-        } else {
-            let index = self.slots.len();
-            self.slots.push(DeadlineSlot {
-                generation: 0,
-                key: Some(key),
-            });
-            DeadlineHandle {
-                index,
-                generation: 0,
-            }
-        };
-        self.len += 1;
-        self.entries.push(DeadlineEntry { at, order, handle });
+        let handle = self.next_handle();
+        let replaced = self.registrations.insert(handle, key);
+        debug_assert!(
+            replaced.is_none(),
+            "monotonic deadline keys are never reused"
+        );
+        self.entries.push(DeadlineEntry { at, handle });
         handle
     }
 
@@ -465,51 +438,26 @@ impl<K> DeadlineQueue<K> {
         }
     }
 
-    fn next_arming_order(&mut self) -> u64 {
-        if self.next_order == u64::MAX {
-            // Preserve the relative arming order of every live registration,
-            // while dropping tombstones, before the sequence space wraps.
-            // Handles address the separate generational arena and remain
-            // valid across this rebuild.
-            let slots = &self.slots;
-            let mut entries = std::mem::take(&mut self.entries).into_vec();
-            entries.retain(|entry| Self::is_active_in(slots, entry.handle));
-            entries.sort_unstable_by_key(|entry| entry.order);
-            for (order, entry) in entries.iter_mut().enumerate() {
-                entry.order = u64::try_from(order)
-                    .expect("live deadline count cannot exceed the arming sequence space");
-            }
-            self.next_order = u64::try_from(entries.len())
-                .expect("live deadline count cannot exceed the arming sequence space");
-            self.entries = BinaryHeap::from(entries);
+    fn next_handle(&mut self) -> DeadlineHandle {
+        let Some(next) = self.next_key.checked_add(1) else {
+            panic!("deadline key space exhausted");
+        };
+        // Reserve the maximum value as poison. Once reached, the counter stays
+        // poisoned and every later push fails instead of wrapping or reusing.
+        if next == u64::MAX {
+            self.next_key = u64::MAX;
+            panic!("deadline key space exhausted");
         }
-        let order = self.next_order;
-        self.next_order += 1;
-        order
+        self.next_key = next;
+        DeadlineHandle(next)
     }
 
     fn take(&mut self, handle: DeadlineHandle) -> Option<K> {
-        let slot = self.slots.get_mut(handle.index)?;
-        if slot.generation != handle.generation {
-            return None;
-        }
-        let key = slot.key.take()?;
-        self.len -= 1;
-        if let Some(next) = slot.generation.checked_add(1) {
-            slot.generation = next;
-            self.free.push(handle.index);
-        }
-        Some(key)
+        self.registrations.remove(&handle)
     }
 
     fn is_active(&self, handle: DeadlineHandle) -> bool {
-        Self::is_active_in(&self.slots, handle)
-    }
-
-    fn is_active_in(slots: &[DeadlineSlot<K>], handle: DeadlineHandle) -> bool {
-        slots
-            .get(handle.index)
-            .is_some_and(|slot| slot.generation == handle.generation && slot.key.is_some())
+        self.registrations.contains_key(&handle)
     }
 
     fn prune_stale_head(&mut self) {
@@ -523,16 +471,16 @@ impl<K> DeadlineQueue<K> {
     }
 
     fn compact_if_sparse(&mut self) {
-        if self.entries.len() > self.len.saturating_mul(2) {
-            let slots = &self.slots;
+        if self.entries.len() > self.registrations.len().saturating_mul(2) {
+            let registrations = &self.registrations;
             self.entries
-                .retain(|entry| Self::is_active_in(slots, entry.handle));
+                .retain(|entry| registrations.contains_key(&entry.handle));
         }
     }
 
     #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
-        self.len
+        self.registrations.len()
     }
 
     #[cfg(test)]
@@ -541,14 +489,15 @@ impl<K> DeadlineQueue<K> {
     }
 
     #[cfg(test)]
-    fn registration_slots_len(&self) -> usize {
-        self.slots.len()
+    fn registration_storage_len(&self) -> usize {
+        self.registrations.len()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -823,14 +772,22 @@ mod tests {
     }
 
     #[test]
-    fn one_priority_queue_orders_equal_deadlines_by_arming_order() {
+    fn one_priority_queue_orders_deadlines_then_equal_deadline_fifo() {
         let now = Instant::now();
+        let later = now + Duration::from_secs(1);
         let mut deadlines = DeadlineQueue::default();
-        deadlines.push(now, "first");
-        deadlines.push(now, "second");
+        deadlines.push(later, "later-first");
+        deadlines.push(now, "now-first");
+        deadlines.push(later, "later-second");
+        deadlines.push(now, "now-second");
+
         assert_eq!(deadlines.next(), Some(now));
-        assert_eq!(deadlines.pop_due(now), Some("first"));
-        assert_eq!(deadlines.pop_due(now), Some("second"));
+        assert_eq!(deadlines.pop_due(now), Some("now-first"));
+        assert_eq!(deadlines.pop_due(now), Some("now-second"));
+        assert_eq!(deadlines.pop_due(now), None);
+        assert_eq!(deadlines.next(), Some(later));
+        assert_eq!(deadlines.pop_due(later), Some("later-first"));
+        assert_eq!(deadlines.pop_due(later), Some("later-second"));
     }
 
     #[test]
@@ -848,9 +805,9 @@ mod tests {
                 "heap tombstones must stay proportional to live deadlines"
             );
             assert_eq!(
-                deadlines.registration_slots_len(),
-                2,
-                "registration slots must be reused"
+                deadlines.registration_storage_len(),
+                deadlines.len(),
+                "the registration map stores only live payloads"
             );
         }
 
@@ -860,7 +817,7 @@ mod tests {
     }
 
     #[test]
-    fn cancelled_deadline_drops_payload_and_stale_handle_misses_reused_slot() {
+    fn cancellation_and_queue_drop_own_payloads_while_stale_handles_stay_absent() {
         struct DropProbe(Arc<AtomicUsize>);
 
         impl Drop for DropProbe {
@@ -880,45 +837,47 @@ mod tests {
         );
 
         let current = deadlines.push(Instant::now(), DropProbe(Arc::clone(&drops)));
-        assert_eq!(stale.index, current.index, "the vacant slot is reused");
-        assert_ne!(stale.generation, current.generation);
         assert!(
-            !deadlines.cancel(stale),
-            "a stale handle misses the replacement"
+            current > stale,
+            "deadline keys are monotonic and never reused"
         );
-        assert!(deadlines.cancel(current));
+        assert!(!deadlines.cancel(stale), "a stale handle remains absent");
+        assert_eq!(
+            deadlines.len(),
+            1,
+            "stale cancellation preserves the live key"
+        );
+        drop(deadlines);
         assert_eq!(drops.load(Ordering::SeqCst), 2);
     }
 
     #[test]
-    fn deadline_generation_exhaustion_retires_the_slot() {
-        let mut deadlines = DeadlineQueue::default();
-        let original = deadlines.push(Instant::now(), "retired");
-        deadlines.slots[original.index].generation = u64::MAX;
-        let exhausted = DeadlineHandle {
-            index: original.index,
-            generation: u64::MAX,
-        };
-
-        assert!(deadlines.cancel(exhausted));
-        let current = deadlines.push(Instant::now(), "current");
-        assert_ne!(exhausted.index, current.index);
-        assert!(!deadlines.cancel(exhausted));
-        assert_eq!(deadlines.pop_due(Instant::now()), Some("current"));
-    }
-
-    #[test]
-    fn arming_order_exhaustion_rebases_without_changing_equal_deadline_order() {
+    fn deadline_key_exhaustion_never_mints_poison_or_reuses_a_key() {
         let now = Instant::now();
-        let mut deadlines = DeadlineQueue::default();
-        deadlines.push(now, "first");
-        deadlines.push(now, "second");
-        deadlines.next_order = u64::MAX;
-        deadlines.push(now, "third");
+        let mut deadlines = DeadlineQueue {
+            next_key: u64::MAX - 2,
+            ..DeadlineQueue::default()
+        };
+        let last = deadlines.push(now, "last usable");
+        assert_eq!(last, DeadlineHandle(u64::MAX - 1));
+        assert!(deadlines.cancel(last));
 
-        assert_eq!(deadlines.pop_due(now), Some("first"));
-        assert_eq!(deadlines.pop_due(now), Some("second"));
-        assert_eq!(deadlines.pop_due(now), Some("third"));
+        let first_exhausted = catch_unwind(AssertUnwindSafe(|| deadlines.push(now, "poison")));
+        assert!(first_exhausted.is_err(), "the poison key is never minted");
+        assert_eq!(deadlines.next_key, u64::MAX);
+        assert!(
+            !deadlines
+                .registrations
+                .contains_key(&DeadlineHandle(u64::MAX))
+        );
+
+        let still_exhausted = catch_unwind(AssertUnwindSafe(|| deadlines.push(now, "wrapped")));
+        assert!(
+            still_exhausted.is_err(),
+            "the exhausted domain stays poisoned"
+        );
+        assert!(deadlines.registrations.is_empty());
+        assert!(deadlines.entries.is_empty());
     }
 
     #[test]

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -31,6 +31,7 @@ pub(crate) fn arbitrate<T>(events: &mut [(ArbitrationClass, T)]) {
 pub(crate) enum StopAction {
     Cancel,
     Escalate,
+    AbortFramework { after_grace: bool },
     HardAbort { after_grace: bool },
 }
 
@@ -39,6 +40,7 @@ enum StopPhase {
     Idle,
     Cooperative,
     Escalated,
+    AbortingFramework,
     Finished,
 }
 
@@ -49,15 +51,29 @@ pub(crate) struct StopLadder {
     phase: StopPhase,
     deadline: Option<Instant>,
     after_grace: bool,
+    force_requested: bool,
+    framework_driver: bool,
+    framework_abort_acked: bool,
 }
 
 impl StopLadder {
     pub(crate) fn new(policy: Shutdown) -> Self {
+        Self::with_framework_driver(policy, false)
+    }
+
+    pub(crate) fn for_framework_driver(policy: Shutdown) -> Self {
+        Self::with_framework_driver(policy, true)
+    }
+
+    fn with_framework_driver(policy: Shutdown, framework_driver: bool) -> Self {
         Self {
             policy,
             phase: StopPhase::Idle,
             deadline: None,
             after_grace: false,
+            force_requested: false,
+            framework_driver,
+            framework_abort_acked: false,
         }
     }
 
@@ -65,16 +81,43 @@ impl StopLadder {
         self.deadline
     }
 
+    /// Expedites this ladder without replacing or rewinding it.
+    pub(crate) fn force(&mut self, now: Instant) {
+        if self.phase == StopPhase::Finished {
+            return;
+        }
+        if self.phase == StopPhase::Cooperative {
+            if !self.force_requested
+                && matches!(self.policy, Shutdown::Graceful { .. })
+                && self.deadline.is_some_and(|deadline| now >= deadline)
+            {
+                self.after_grace = true;
+            }
+            self.deadline = Some(now);
+        }
+        self.force_requested = true;
+    }
+
+    pub(crate) fn acknowledge_framework_abort(&mut self) {
+        if self.phase == StopPhase::AbortingFramework {
+            self.framework_abort_acked = true;
+        }
+    }
+
     pub(crate) fn advance(&mut self, now: Instant) -> Option<StopAction> {
         match self.phase {
             StopPhase::Idle => {
                 self.phase = StopPhase::Cooperative;
-                match self.policy {
-                    Shutdown::Graceful { grace } => {
-                        self.deadline = Deadline::after(now, grace).instant();
-                    }
-                    Shutdown::Abort => {
-                        self.deadline = Some(now);
+                if self.force_requested {
+                    self.deadline = Some(now);
+                } else {
+                    match self.policy {
+                        Shutdown::Graceful { grace } => {
+                            self.deadline = Deadline::after(now, grace).instant();
+                        }
+                        Shutdown::Abort => {
+                            self.deadline = Some(now);
+                        }
                     }
                 }
                 Some(StopAction::Cancel)
@@ -82,7 +125,9 @@ impl StopLadder {
             StopPhase::Cooperative if self.deadline.is_some_and(|deadline| now >= deadline) => {
                 let grace = match self.policy {
                     Shutdown::Graceful { grace } => {
-                        self.after_grace = true;
+                        if !self.force_requested {
+                            self.after_grace = true;
+                        }
                         grace
                     }
                     Shutdown::Abort => Duration::ZERO,
@@ -92,13 +137,33 @@ impl StopLadder {
                 Some(StopAction::Escalate)
             }
             StopPhase::Escalated if self.deadline.is_some_and(|deadline| now >= deadline) => {
+                if self.framework_driver {
+                    self.phase = StopPhase::AbortingFramework;
+                    self.deadline = Deadline::after(now, tidy_abort_beat(Duration::ZERO)).instant();
+                    Some(StopAction::AbortFramework {
+                        after_grace: self.after_grace,
+                    })
+                } else {
+                    self.phase = StopPhase::Finished;
+                    self.deadline = None;
+                    Some(StopAction::HardAbort {
+                        after_grace: self.after_grace,
+                    })
+                }
+            }
+            StopPhase::AbortingFramework
+                if self.deadline.is_some_and(|deadline| now >= deadline) =>
+            {
                 self.phase = StopPhase::Finished;
                 self.deadline = None;
-                Some(StopAction::HardAbort {
+                (!self.framework_abort_acked).then_some(StopAction::HardAbort {
                     after_grace: self.after_grace,
                 })
             }
-            StopPhase::Cooperative | StopPhase::Escalated | StopPhase::Finished => None,
+            StopPhase::Cooperative
+            | StopPhase::Escalated
+            | StopPhase::AbortingFramework
+            | StopPhase::Finished => None,
         }
     }
 }
@@ -528,6 +593,74 @@ mod tests {
         assert_eq!(abort.advance(start), Some(StopAction::Escalate));
         assert_eq!(
             abort.advance(abort.deadline().expect("tidy deadline")),
+            Some(StopAction::HardAbort { after_grace: false })
+        );
+    }
+
+    #[test]
+    fn repeated_force_expedites_without_rewinding_the_ladder() {
+        let start = Instant::now();
+        let grace = Duration::from_secs(30);
+        let mut ladder = StopLadder::new(Shutdown::Graceful { grace });
+
+        assert_eq!(ladder.advance(start), Some(StopAction::Cancel));
+        ladder.force(start);
+        ladder.force(start);
+        assert_eq!(ladder.advance(start), Some(StopAction::Escalate));
+
+        let tidy = ladder
+            .deadline()
+            .expect("forced ladder keeps its tidy beat");
+        ladder.force(start);
+        assert_eq!(
+            ladder.advance(start),
+            None,
+            "force does not skip the tidy beat"
+        );
+        assert_eq!(
+            ladder.advance(tidy),
+            Some(StopAction::HardAbort { after_grace: false })
+        );
+        ladder.force(tidy);
+        assert_eq!(
+            ladder.advance(tidy),
+            None,
+            "a finished ladder stays finished"
+        );
+    }
+
+    #[test]
+    fn framework_abort_and_ack_are_owned_by_the_same_stop_ladder() {
+        let start = Instant::now();
+        let mut ladder = StopLadder::for_framework_driver(Shutdown::Abort);
+
+        assert_eq!(ladder.advance(start), Some(StopAction::Cancel));
+        assert_eq!(ladder.advance(start), Some(StopAction::Escalate));
+        let tidy = ladder
+            .deadline()
+            .expect("abort policy keeps the first tidy beat");
+        assert_eq!(
+            ladder.advance(tidy),
+            Some(StopAction::AbortFramework { after_grace: false })
+        );
+        ladder.acknowledge_framework_abort();
+        let framework_tidy = ladder
+            .deadline()
+            .expect("framework acknowledgment has a bounded tidy beat");
+        assert_eq!(ladder.advance(framework_tidy), None);
+        assert_eq!(ladder.deadline(), None);
+
+        let mut unacked = StopLadder::for_framework_driver(Shutdown::Abort);
+        assert_eq!(unacked.advance(start), Some(StopAction::Cancel));
+        assert_eq!(unacked.advance(start), Some(StopAction::Escalate));
+        let tidy = unacked.deadline().expect("abort tidy beat");
+        assert_eq!(
+            unacked.advance(tidy),
+            Some(StopAction::AbortFramework { after_grace: false })
+        );
+        let framework_tidy = unacked.deadline().expect("framework tidy beat");
+        assert_eq!(
+            unacked.advance(framework_tidy),
             Some(StopAction::HardAbort { after_grace: false })
         );
     }

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -7,7 +7,8 @@ use std::{
 };
 
 use crate::{
-    Exit, Intensity, RestartPolicy, Shutdown, deadline::Deadline, policy::tidy_abort_beat,
+    Exit, Intensity, Readiness, RestartPolicy, Shutdown, deadline::Deadline, exit::StopReason,
+    policy::tidy_abort_beat,
 };
 
 /// Deterministic priority when one driver wake exposes several events.
@@ -268,6 +269,23 @@ impl RestartState {
     pub(crate) fn settled(&mut self) {
         self.attempt = 0;
     }
+
+    /// Resets the consecutive-attempt counter after one stable incarnation.
+    ///
+    /// Saturating elapsed time deliberately treats a clock regression as a
+    /// zero-length run, so it cannot accidentally forgive restart pressure.
+    pub(crate) fn settle_if_stable(
+        &mut self,
+        started_at: Instant,
+        stopped_at: Instant,
+        stable_for: Duration,
+    ) -> bool {
+        if stopped_at.saturating_duration_since(started_at) < stable_for {
+            return false;
+        }
+        self.settled();
+        true
+    }
 }
 
 /// Complete restart verdict consumed verbatim by the scope driver.
@@ -302,17 +320,34 @@ pub(crate) fn schedule_restart(
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum ReadinessGate {
+enum ReadinessState {
+    Unconfigured,
     Immediate,
     Waiting { deadline: Option<Instant> },
     Ready,
     Disarmed,
 }
 
+/// The authoritative per-incarnation readiness state machine.
+///
+/// The shell only applies returned effects (publish ready, arm/cancel a
+/// deadline, or begin timeout shutdown); it never assigns readiness state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ReadinessGate {
+    state: ReadinessState,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ReadinessEvent {
+    Configure {
+        readiness: Readiness,
+        deadline: Option<Instant>,
+    },
     Signal,
-    Deadline(Instant),
+    Deadline {
+        now: Instant,
+        signal_seen: bool,
+    },
     Shutdown,
     Exit,
 }
@@ -320,33 +355,308 @@ pub(crate) enum ReadinessEvent {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ReadinessEffect {
     BecameReady,
+    ArmDeadline { deadline: Instant },
     TimedOut { deadline: Instant },
     Disarmed,
 }
 
 impl ReadinessGate {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: ReadinessState::Unconfigured,
+        }
+    }
+
+    /// Whether a retained signal watcher is needed for this incarnation.
+    pub(crate) fn needs_signal_watch(self) -> bool {
+        matches!(
+            self.state,
+            ReadinessState::Unconfigured | ReadinessState::Waiting { .. }
+        )
+    }
+
     pub(crate) fn step(&mut self, event: ReadinessEvent) -> Option<ReadinessEffect> {
-        match (*self, event) {
-            (Self::Immediate, _) | (Self::Ready, _) | (Self::Disarmed, _) => None,
-            (Self::Waiting { .. }, ReadinessEvent::Signal) => {
-                *self = Self::Ready;
+        match (self.state, event) {
+            (
+                ReadinessState::Unconfigured,
+                ReadinessEvent::Configure {
+                    readiness: Readiness::Immediate,
+                    ..
+                },
+            ) => {
+                self.state = ReadinessState::Immediate;
                 Some(ReadinessEffect::BecameReady)
             }
             (
-                Self::Waiting {
+                ReadinessState::Unconfigured,
+                ReadinessEvent::Configure {
+                    readiness: Readiness::Manual | Readiness::AfterInit,
+                    deadline,
+                },
+            ) => {
+                self.state = ReadinessState::Waiting { deadline };
+                deadline.map(|deadline| ReadinessEffect::ArmDeadline { deadline })
+            }
+            (ReadinessState::Waiting { .. }, ReadinessEvent::Signal)
+            | (
+                ReadinessState::Waiting { .. },
+                ReadinessEvent::Deadline {
+                    signal_seen: true, ..
+                },
+            ) => {
+                self.state = ReadinessState::Ready;
+                Some(ReadinessEffect::BecameReady)
+            }
+            (
+                ReadinessState::Waiting {
                     deadline: Some(deadline),
                 },
-                ReadinessEvent::Deadline(now),
+                ReadinessEvent::Deadline {
+                    now,
+                    signal_seen: false,
+                },
             ) if now >= deadline => {
-                *self = Self::Disarmed;
+                self.state = ReadinessState::Disarmed;
                 Some(ReadinessEffect::TimedOut { deadline })
             }
-            (Self::Waiting { .. }, ReadinessEvent::Shutdown | ReadinessEvent::Exit) => {
-                *self = Self::Disarmed;
+            (
+                ReadinessState::Unconfigured | ReadinessState::Waiting { .. },
+                ReadinessEvent::Shutdown | ReadinessEvent::Exit,
+            ) => {
+                self.state = ReadinessState::Disarmed;
                 Some(ReadinessEffect::Disarmed)
             }
-            (Self::Waiting { .. }, ReadinessEvent::Deadline(_)) => None,
+            (
+                ReadinessState::Waiting { .. },
+                ReadinessEvent::Deadline {
+                    signal_seen: false, ..
+                },
+            )
+            | (ReadinessState::Immediate | ReadinessState::Ready | ReadinessState::Disarmed, _)
+            | (
+                ReadinessState::Unconfigured,
+                ReadinessEvent::Signal | ReadinessEvent::Deadline { .. },
+            )
+            | (ReadinessState::Waiting { .. }, ReadinessEvent::Configure { .. }) => None,
         }
+    }
+}
+
+/// Cross-incarnation liveness encoded once as an epoch state, rather than an
+/// epoch pair plus an independently mutable `live` bit.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ScopeEpochs {
+    Idle { last_stopped: u64 },
+    Live { current: u64, last_stopped: u64 },
+    Exhausted { last_stopped: u64 },
+}
+
+impl Default for ScopeEpochs {
+    fn default() -> Self {
+        Self::Idle { last_stopped: 0 }
+    }
+}
+
+impl ScopeEpochs {
+    pub(crate) fn begin(&mut self) -> Option<u64> {
+        let last_stopped = match *self {
+            Self::Idle { last_stopped } => last_stopped,
+            // One scope cell cannot own two simultaneous drivers. Rejecting
+            // a second begin also prevents it from invalidating the live
+            // driver's epoch while trying to advance the counter.
+            Self::Live { .. } | Self::Exhausted { .. } => return None,
+        };
+        let Some(current) = last_stopped.checked_add(1) else {
+            *self = Self::Exhausted { last_stopped };
+            return None;
+        };
+        // Reserve MAX as poison so no observable epoch can alias the
+        // permanently exhausted state.
+        if current == u64::MAX {
+            *self = Self::Exhausted { last_stopped };
+            return None;
+        }
+        *self = Self::Live {
+            current,
+            last_stopped,
+        };
+        Some(current)
+    }
+
+    pub(crate) fn live_epoch(self) -> Option<u64> {
+        match self {
+            Self::Idle { .. } | Self::Exhausted { .. } => None,
+            Self::Live { current, .. } => Some(current),
+        }
+    }
+
+    pub(crate) fn request_target(self) -> Option<(u64, bool)> {
+        match self {
+            Self::Live { current, .. } => Some((current, false)),
+            Self::Idle { last_stopped } => last_stopped
+                .checked_add(1)
+                .filter(|target| *target != u64::MAX)
+                .map(|target| (target, true)),
+            Self::Exhausted { .. } => None,
+        }
+    }
+
+    pub(crate) fn finish(&mut self, epoch: u64) -> bool {
+        match *self {
+            Self::Live {
+                current,
+                last_stopped,
+            } if current == epoch => {
+                *self = Self::Idle {
+                    last_stopped: last_stopped.max(epoch),
+                };
+                true
+            }
+            Self::Idle { .. } | Self::Live { .. } | Self::Exhausted { .. } => false,
+        }
+    }
+
+    pub(crate) fn is_current(self, epoch: u64) -> bool {
+        self.live_epoch() == Some(epoch)
+    }
+
+    pub(crate) fn request_is_pending(self, epoch: u64) -> bool {
+        matches!(self, Self::Idle { last_stopped } if epoch > last_stopped)
+    }
+
+    pub(crate) fn finished(self, epoch: u64) -> bool {
+        match self {
+            Self::Idle { last_stopped }
+            | Self::Live { last_stopped, .. }
+            | Self::Exhausted { last_stopped } => last_stopped >= epoch,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StartupPhase {
+    Pending,
+    Complete,
+    Failed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ScopePhase {
+    Starting,
+    Running,
+    StartupFailed,
+    Draining {
+        reason: StopReason,
+        startup: StartupPhase,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct DrainEffect {
+    pub(crate) startup_pending: bool,
+}
+
+/// Authoritative lifecycle and finish policy for one scope incarnation.
+///
+/// `ScopeRecord` is only this machine's observation projection; epoch-tagged
+/// requests use [`ScopeEpochs`] and do not encode this phase a second time.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ScopeLifecycle {
+    phase: ScopePhase,
+}
+
+impl ScopeLifecycle {
+    pub(crate) fn starting() -> Self {
+        Self {
+            phase: ScopePhase::Starting,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn running() -> Self {
+        Self {
+            phase: ScopePhase::Running,
+        }
+    }
+
+    pub(crate) fn is_starting(&self) -> bool {
+        self.phase == ScopePhase::Starting
+    }
+
+    pub(crate) fn startup_complete(&self) -> bool {
+        matches!(
+            self.phase,
+            ScopePhase::Running
+                | ScopePhase::Draining {
+                    startup: StartupPhase::Complete,
+                    ..
+                }
+        )
+    }
+
+    pub(crate) fn startup_failed(&self) -> bool {
+        matches!(
+            self.phase,
+            ScopePhase::StartupFailed
+                | ScopePhase::Draining {
+                    startup: StartupPhase::Failed,
+                    ..
+                }
+        )
+    }
+
+    pub(crate) fn is_draining(&self) -> bool {
+        matches!(self.phase, ScopePhase::Draining { .. })
+    }
+
+    pub(crate) fn draining_reason(&self) -> Option<&StopReason> {
+        match &self.phase {
+            ScopePhase::Draining { reason, .. } => Some(reason),
+            ScopePhase::Starting | ScopePhase::Running | ScopePhase::StartupFailed => None,
+        }
+    }
+
+    pub(crate) fn complete_startup(&mut self) -> bool {
+        if self.phase != ScopePhase::Starting {
+            return false;
+        }
+        self.phase = ScopePhase::Running;
+        true
+    }
+
+    /// Records only the first startup failure, so simultaneous failing
+    /// initial children cannot publish the transition twice.
+    pub(crate) fn fail_startup(&mut self) -> bool {
+        if self.phase != ScopePhase::Starting {
+            return false;
+        }
+        self.phase = ScopePhase::StartupFailed;
+        true
+    }
+
+    pub(crate) fn begin_drain(&mut self, reason: StopReason) -> Option<DrainEffect> {
+        let startup = match self.phase {
+            ScopePhase::Starting => StartupPhase::Pending,
+            ScopePhase::Running => StartupPhase::Complete,
+            ScopePhase::StartupFailed => StartupPhase::Failed,
+            ScopePhase::Draining { .. } => return None,
+        };
+        let startup_pending = startup == StartupPhase::Pending;
+        self.phase = ScopePhase::Draining { reason, startup };
+        Some(DrainEffect { startup_pending })
+    }
+
+    pub(crate) fn finish_if_ready(
+        &self,
+        ordered: bool,
+        has_children: bool,
+        all_terminal: bool,
+    ) -> Option<StopReason> {
+        if let Some(reason) = self.draining_reason() {
+            return all_terminal.then(|| reason.clone());
+        }
+        (!self.startup_failed() && ordered && has_children && all_terminal)
+            .then_some(StopReason::Finished)
     }
 }
 
@@ -506,8 +816,9 @@ mod tests {
 
     use super::{
         ArbitrationClass, DeadlineHandle, DeadlineQueue, ExitDispatch, IntensityState,
-        MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState, ScopeMode,
-        StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart, tidy_abort_beat,
+        MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState, ScopeEpochs,
+        ScopeLifecycle, ScopeMode, StopAction, StopLadder, arbitrate, dispatch_exit,
+        schedule_restart, tidy_abort_beat,
     };
 
     #[test]
@@ -745,25 +1056,142 @@ mod tests {
     }
 
     #[test]
-    fn readiness_signal_wins_at_its_deadline_and_shutdown_disarms() {
+    fn stable_run_settles_restart_attempt_at_the_exact_boundary() {
+        let start = Instant::now();
+        let stable_for = Duration::from_secs(10);
+        let mut restarts = RestartState::new();
+        assert_eq!(restarts.schedule(), (1, 1));
+        assert!(!restarts.settle_if_stable(
+            start,
+            start + stable_for - Duration::from_nanos(1),
+            stable_for,
+        ));
+        assert_eq!(restarts.schedule(), (2, 2));
+        assert!(restarts.settle_if_stable(start, start + stable_for, stable_for));
+        assert_eq!(restarts.schedule(), (1, 3));
+
+        assert!(
+            !restarts.settle_if_stable(start, start - Duration::from_nanos(1), stable_for),
+            "a regressed clock cannot forgive restart pressure"
+        );
+    }
+
+    #[test]
+    fn readiness_configuration_and_signal_deadline_race_are_engine_owned() {
         let deadline = Instant::now();
-        let mut ready = ReadinessGate::Waiting {
-            deadline: Some(deadline),
-        };
+        let mut ready = ReadinessGate::new();
         assert_eq!(
-            ready.step(ReadinessEvent::Signal),
+            ready.step(ReadinessEvent::Configure {
+                readiness: crate::Readiness::Manual,
+                deadline: Some(deadline),
+            }),
+            Some(ReadinessEffect::ArmDeadline { deadline })
+        );
+        assert_eq!(
+            ready.step(ReadinessEvent::Deadline {
+                now: deadline,
+                signal_seen: true,
+            }),
             Some(ReadinessEffect::BecameReady)
         );
-        assert_eq!(ready.step(ReadinessEvent::Deadline(deadline)), None);
+        assert_eq!(
+            ready.step(ReadinessEvent::Deadline {
+                now: deadline,
+                signal_seen: false,
+            }),
+            None
+        );
 
-        let mut shutdown = ReadinessGate::Waiting {
-            deadline: Some(deadline),
-        };
+        let mut timed_out = ReadinessGate::new();
+        assert_eq!(
+            timed_out.step(ReadinessEvent::Configure {
+                readiness: crate::Readiness::AfterInit,
+                deadline: Some(deadline),
+            }),
+            Some(ReadinessEffect::ArmDeadline { deadline })
+        );
+        assert_eq!(
+            timed_out.step(ReadinessEvent::Deadline {
+                now: deadline,
+                signal_seen: false,
+            }),
+            Some(ReadinessEffect::TimedOut { deadline })
+        );
+
+        let mut shutdown = ReadinessGate::new();
+        assert_eq!(
+            shutdown.step(ReadinessEvent::Configure {
+                readiness: crate::Readiness::Manual,
+                deadline: None,
+            }),
+            None
+        );
         assert_eq!(
             shutdown.step(ReadinessEvent::Shutdown),
             Some(ReadinessEffect::Disarmed)
         );
-        assert_eq!(shutdown.step(ReadinessEvent::Deadline(deadline)), None);
+    }
+
+    #[test]
+    fn scope_lifecycle_owns_first_failure_drain_status_and_finish_policy() {
+        let mut lifecycle = ScopeLifecycle::starting();
+        assert!(lifecycle.fail_startup());
+        assert!(
+            !lifecycle.fail_startup(),
+            "simultaneous initial failures publish one transition"
+        );
+        assert_eq!(lifecycle.finish_if_ready(true, true, true), None);
+        let drain = lifecycle
+            .begin_drain(crate::exit::StopReason::ShutdownRequested)
+            .expect("a failed startup can begin draining");
+        assert!(!drain.startup_pending);
+        assert_eq!(
+            lifecycle.finish_if_ready(false, true, true),
+            Some(crate::exit::StopReason::ShutdownRequested)
+        );
+
+        let mut running = ScopeLifecycle::starting();
+        assert!(running.complete_startup());
+        assert_eq!(running.finish_if_ready(true, false, true), None);
+        assert_eq!(
+            running.finish_if_ready(true, true, true),
+            Some(crate::exit::StopReason::Finished)
+        );
+
+        let mut starting = ScopeLifecycle::starting();
+        let drain = starting
+            .begin_drain(crate::exit::StopReason::ShutdownRequested)
+            .expect("starting can begin draining");
+        assert!(drain.startup_pending);
+    }
+
+    #[test]
+    fn scope_epoch_exhaustion_is_poisoned_without_minting_or_reuse() {
+        let mut epochs = ScopeEpochs::default();
+        assert_eq!(epochs.request_target(), Some((1, true)));
+        let first = epochs.begin().expect("first epoch is available");
+        assert_eq!(epochs.live_epoch(), Some(first));
+        assert_eq!(epochs.request_target(), Some((first, false)));
+        assert_eq!(epochs.begin(), None, "a live epoch cannot be replaced");
+        assert!(!epochs.finish(first + 1));
+        assert_eq!(epochs.live_epoch(), Some(first));
+        assert!(epochs.finish(first));
+        assert!(!epochs.finish(first), "a stopped epoch cannot finish twice");
+        assert_eq!(epochs.live_epoch(), None);
+        assert!(epochs.finished(first));
+        assert!(epochs.request_is_pending(first + 1));
+
+        let mut exhausted = ScopeEpochs::Idle {
+            last_stopped: u64::MAX - 2,
+        };
+        let last = exhausted.begin().expect("last non-poison epoch");
+        assert_eq!(last, u64::MAX - 1);
+        assert!(exhausted.finish(last));
+        assert_eq!(exhausted.begin(), None, "MAX is reserved as poison");
+        assert_eq!(exhausted.live_epoch(), None);
+        assert_eq!(exhausted.request_target(), None);
+        assert_eq!(exhausted.begin(), None, "poisoning is permanent");
+        assert!(!exhausted.finish(u64::MAX));
     }
 
     #[test]

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -145,6 +145,37 @@ pub struct StartupFailure {
     pub cause: StartupFailureCause,
 }
 
+/// The terminal reason for a scope incarnation or root system.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum StopReason {
+    /// A non-empty ordered workload completed naturally.
+    Finished,
+    /// Shutdown was explicitly requested.
+    ShutdownRequested,
+    /// The scope exceeded its restart budget.
+    IntensityTripped(IntensityTrip),
+    /// A nested scope could not complete startup.
+    StartupFailed(StartupFailure),
+    /// The membership terminalized without an incarnation.
+    NeverStarted,
+}
+
+/// Failure of the root startup barrier.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum StartupError {
+    /// A child or nested lowering failed terminally during startup.
+    #[error("tree startup failed")]
+    StartupFailed(StartupFailure),
+    /// Restart intensity tripped during startup.
+    #[error("restart intensity tripped during startup")]
+    IntensityTripped(IntensityTrip),
+    /// Shutdown began before startup completed.
+    #[error("shutdown was requested during startup")]
+    ShutdownRequested,
+}
+
 /// The cause of a nested-scope startup failure.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -336,7 +336,36 @@ pub(crate) enum JoinVerdict {
     Cancelled { after_grace: bool },
 }
 
+/// Reconciles task-produced evidence with a later supervisor-forced outcome.
+///
+/// The same diagnostic precedence used for the final join applies here, and
+/// equal-ranked evidence keeps the task-produced value because it was
+/// recorded first. This prevents a forced abort from erasing a structured
+/// application failure while still allowing readiness timeout or panic to
+/// supersede ordinary completion.
+pub(crate) fn reconcile_recorded_outcomes(
+    recorded: Option<RecordedOutcome>,
+    forced: Option<RecordedOutcome>,
+) -> Option<RecordedOutcome> {
+    match (recorded, forced) {
+        (Some(recorded), Some(forced)) if recorded_rank(&recorded) >= recorded_rank(&forced) => {
+            Some(recorded)
+        }
+        (_, Some(forced)) => Some(forced),
+        (Some(recorded), None) => Some(recorded),
+        (None, None) => None,
+    }
+}
+
 /// Purely folds the provisional run outcome and post-destruction join verdict.
+///
+/// Precedence follows the amount of diagnostic evidence retained by each
+/// outcome: a panic is strongest, followed by a readiness timeout, an
+/// application failure, an abort, and successful completion. In particular,
+/// cancellation reported while joining only proves that destruction ended the
+/// task; it must not erase an application error recorded before destruction.
+/// Equal-ranked outcomes keep the earlier recorded evidence, including its
+/// panic payload or abort provenance.
 pub(crate) fn classify_exit(
     recorded: Option<RecordedOutcome>,
     join: JoinVerdict,
@@ -368,14 +397,38 @@ fn recorded_kind(recorded: RecordedOutcome) -> ExitKind {
     }
 }
 
-fn rank(kind: &ExitKind) -> u8 {
+/// Diagnostic precedence shared by provisional and final exit evidence.
+///
+/// Variant order is weakest to strongest so derived ordering selects the
+/// outcome that preserves the most useful evidence.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum OutcomeRank {
+    NeverStarted,
+    Completed,
+    Aborted,
+    Failed,
+    ReadinessTimedOut,
+    Panicked,
+}
+
+fn recorded_rank(recorded: &RecordedOutcome) -> OutcomeRank {
+    match recorded {
+        RecordedOutcome::Panicked { .. } => OutcomeRank::Panicked,
+        RecordedOutcome::ReadinessTimedOut { .. } => OutcomeRank::ReadinessTimedOut,
+        RecordedOutcome::Returned(Err(_)) => OutcomeRank::Failed,
+        RecordedOutcome::Aborted { .. } => OutcomeRank::Aborted,
+        RecordedOutcome::Returned(Ok(())) => OutcomeRank::Completed,
+    }
+}
+
+fn rank(kind: &ExitKind) -> OutcomeRank {
     match kind {
-        ExitKind::Panicked { .. } => 5,
-        ExitKind::ReadinessTimedOut { .. } => 4,
-        ExitKind::Aborted { .. } => 3,
-        ExitKind::Failed(_) => 2,
-        ExitKind::Completed => 1,
-        ExitKind::NeverStarted => 0,
+        ExitKind::Panicked { .. } => OutcomeRank::Panicked,
+        ExitKind::ReadinessTimedOut { .. } => OutcomeRank::ReadinessTimedOut,
+        ExitKind::Failed(_) => OutcomeRank::Failed,
+        ExitKind::Aborted { .. } => OutcomeRank::Aborted,
+        ExitKind::Completed => OutcomeRank::Completed,
+        ExitKind::NeverStarted => OutcomeRank::NeverStarted,
     }
 }
 
@@ -400,72 +453,164 @@ pub struct ShutdownTimeout {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use super::{ExitError, ExitKind, JoinVerdict, RecordedOutcome, classify_exit};
+    use super::{
+        ChildId, Exit, ExitError, ExitKind, JoinVerdict, RecordedOutcome, StartupFailure,
+        StartupFailureCause, classify_exit, reconcile_recorded_outcomes,
+    };
 
     #[test]
     fn classification_precedence_is_table_driven() {
         let deadline = Instant::now() + Duration::from_secs(1);
+        let failure = ExitError::message("failed");
         let cases = [
             (
-                RecordedOutcome::Returned(Ok(())),
+                "recorded completion",
+                Some(RecordedOutcome::Returned(Ok(()))),
                 JoinVerdict::Completed,
-                "completed",
+                false,
+                Exit::new(ExitKind::Completed, false),
             ),
             (
-                RecordedOutcome::Returned(Err(ExitError::message("failed"))),
-                JoinVerdict::Completed,
-                "failed",
-            ),
-            (
-                RecordedOutcome::ReadinessTimedOut { deadline },
+                "cancellation overrides recorded completion",
+                Some(RecordedOutcome::Returned(Ok(()))),
                 JoinVerdict::Cancelled { after_grace: true },
-                "readiness",
+                true,
+                Exit::new(ExitKind::Aborted { after_grace: true }, true),
             ),
             (
-                RecordedOutcome::Returned(Ok(())),
+                "recorded failure",
+                Some(RecordedOutcome::Returned(Err(failure.clone()))),
+                JoinVerdict::Completed,
+                false,
+                Exit::new(ExitKind::Failed(failure.clone()), false),
+            ),
+            (
+                "late cancellation preserves recorded failure",
+                Some(RecordedOutcome::Returned(Err(failure.clone()))),
+                JoinVerdict::Cancelled { after_grace: true },
+                true,
+                Exit::new(ExitKind::Failed(failure.clone()), true),
+            ),
+            (
+                "join panic overrides recorded failure",
+                Some(RecordedOutcome::Returned(Err(failure.clone()))),
                 JoinVerdict::Panicked {
                     message: Some("drop panic".to_owned()),
                 },
-                "panic",
+                false,
+                Exit::new(
+                    ExitKind::Panicked {
+                        message: Some("drop panic".to_owned()),
+                    },
+                    false,
+                ),
             ),
             (
-                RecordedOutcome::Panicked {
+                "readiness timeout overrides cancellation",
+                Some(RecordedOutcome::ReadinessTimedOut { deadline }),
+                JoinVerdict::Cancelled { after_grace: true },
+                true,
+                Exit::new(ExitKind::ReadinessTimedOut { deadline }, true),
+            ),
+            (
+                "join panic overrides recorded completion",
+                Some(RecordedOutcome::Returned(Ok(()))),
+                JoinVerdict::Panicked {
+                    message: Some("drop panic".to_owned()),
+                },
+                false,
+                Exit::new(
+                    ExitKind::Panicked {
+                        message: Some("drop panic".to_owned()),
+                    },
+                    false,
+                ),
+            ),
+            (
+                "earlier recorded panic wins a tie",
+                Some(RecordedOutcome::Panicked {
                     message: Some("callback panic".to_owned()),
-                },
+                }),
                 JoinVerdict::Panicked {
                     message: Some("drop panic".to_owned()),
                 },
-                "callback panic",
+                true,
+                Exit::new(
+                    ExitKind::Panicked {
+                        message: Some("callback panic".to_owned()),
+                    },
+                    true,
+                ),
+            ),
+            (
+                "earlier recorded abort wins a tie",
+                Some(RecordedOutcome::Aborted { after_grace: false }),
+                JoinVerdict::Cancelled { after_grace: true },
+                true,
+                Exit::new(ExitKind::Aborted { after_grace: false }, true),
+            ),
+            (
+                "join cancellation supplies a missing outcome",
+                None,
+                JoinVerdict::Cancelled { after_grace: true },
+                true,
+                Exit::new(ExitKind::Aborted { after_grace: true }, true),
+            ),
+            (
+                "missing outcome fails closed",
+                None,
+                JoinVerdict::Completed,
+                false,
+                Exit::new(ExitKind::Aborted { after_grace: false }, false),
             ),
         ];
 
-        for (recorded, join, expected) in cases {
-            let exit = classify_exit(Some(recorded), join, true);
-            assert!(exit.cancelled());
-            match (expected, exit.kind()) {
-                ("completed", ExitKind::Completed)
-                | ("failed", ExitKind::Failed(_))
-                | ("readiness", ExitKind::ReadinessTimedOut { .. }) => {}
-                ("panic", ExitKind::Panicked { message }) => {
-                    assert_eq!(message.as_deref(), Some("drop panic"));
-                }
-                ("callback panic", ExitKind::Panicked { message }) => {
-                    assert_eq!(message.as_deref(), Some("callback panic"));
-                }
-                _ => panic!("unexpected classification: {:?}", exit.kind()),
-            }
+        for (case, recorded, join, cancelled, expected) in cases {
+            assert_eq!(classify_exit(recorded, join, cancelled), expected, "{case}");
         }
+    }
 
-        let aborted = classify_exit(None, JoinVerdict::Cancelled { after_grace: true }, true);
-        assert!(matches!(
-            aborted.kind(),
-            ExitKind::Aborted { after_grace: true }
-        ));
-        let missing_report = classify_exit(None, JoinVerdict::Completed, false);
-        assert!(matches!(
-            missing_report.kind(),
-            ExitKind::Aborted { after_grace: false }
-        ));
+    #[test]
+    fn forced_outcomes_do_not_erase_stronger_recorded_evidence() {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let failure = ExitError::from_startup_failure(StartupFailure {
+            cause: StartupFailureCause::IdentityExhausted {
+                id: ChildId::from("nested"),
+            },
+        });
+        let cases = [
+            (
+                "application failure survives forced abort",
+                Some(RecordedOutcome::Returned(Err(failure.clone()))),
+                Some(RecordedOutcome::Aborted { after_grace: true }),
+                Exit::new(ExitKind::Failed(failure), true),
+            ),
+            (
+                "forced readiness timeout overrides completion",
+                Some(RecordedOutcome::Returned(Ok(()))),
+                Some(RecordedOutcome::ReadinessTimedOut { deadline }),
+                Exit::new(ExitKind::ReadinessTimedOut { deadline }, true),
+            ),
+            (
+                "earlier abort evidence wins a tie",
+                Some(RecordedOutcome::Aborted { after_grace: false }),
+                Some(RecordedOutcome::Aborted { after_grace: true }),
+                Exit::new(ExitKind::Aborted { after_grace: false }, true),
+            ),
+        ];
+
+        for (case, recorded, forced, expected) in cases {
+            let reconciled = reconcile_recorded_outcomes(recorded, forced);
+            assert_eq!(
+                classify_exit(
+                    reconciled,
+                    JoinVerdict::Cancelled { after_grace: true },
+                    true
+                ),
+                expected,
+                "{case}"
+            );
+        }
     }
 
     #[derive(Debug, thiserror::Error)]

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -7,7 +7,38 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{ChildId, Membership};
+use crate::{identity::Membership, policy::ChildId};
+
+/// The terminal reason for a scope incarnation or root system.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum StopReason {
+    /// A non-empty ordered workload completed naturally.
+    Finished,
+    /// Shutdown was explicitly requested.
+    ShutdownRequested,
+    /// The scope exceeded its restart budget.
+    IntensityTripped(IntensityTrip),
+    /// A nested scope could not complete startup.
+    StartupFailed(StartupFailure),
+    /// The membership terminalized without an incarnation.
+    NeverStarted,
+}
+
+/// Failure of the root startup barrier.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum StartupError {
+    /// A child or nested lowering failed terminally during startup.
+    #[error("tree startup failed")]
+    StartupFailed(StartupFailure),
+    /// Restart intensity tripped during startup.
+    #[error("restart intensity tripped during startup")]
+    IntensityTripped(IntensityTrip),
+    /// Shutdown began before startup completed.
+    #[error("shutdown was requested during startup")]
+    ShutdownRequested,
+}
 
 /// The exact result returned by restartable tasks and actor callbacks.
 pub type ExitResult = Result<(), ExitError>;

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -176,37 +176,6 @@ pub struct StartupFailure {
     pub cause: StartupFailureCause,
 }
 
-/// The terminal reason for a scope incarnation or root system.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum StopReason {
-    /// A non-empty ordered workload completed naturally.
-    Finished,
-    /// Shutdown was explicitly requested.
-    ShutdownRequested,
-    /// The scope exceeded its restart budget.
-    IntensityTripped(IntensityTrip),
-    /// A nested scope could not complete startup.
-    StartupFailed(StartupFailure),
-    /// The membership terminalized without an incarnation.
-    NeverStarted,
-}
-
-/// Failure of the root startup barrier.
-#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
-#[non_exhaustive]
-pub enum StartupError {
-    /// A child or nested lowering failed terminally during startup.
-    #[error("tree startup failed")]
-    StartupFailed(StartupFailure),
-    /// Restart intensity tripped during startup.
-    #[error("restart intensity tripped during startup")]
-    IntensityTripped(IntensityTrip),
-    /// Shutdown began before startup completed.
-    #[error("shutdown was requested during startup")]
-    ShutdownRequested,
-}
-
 /// The cause of a nested-scope startup failure.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -199,6 +199,8 @@ pub enum StartupFailureCause {
         /// Child whose stable membership could not be minted.
         id: ChildId,
     },
+    /// A produced subtree contained an invalid public policy literal.
+    InvalidPolicy(crate::policy::InvalidPolicy),
 }
 
 #[derive(Debug)]
@@ -219,6 +221,7 @@ impl fmt::Display for StructuredStartupFailure {
                     "membership identity space is exhausted for child `{id}`"
                 )
             }
+            StartupFailureCause::InvalidPolicy(invalid) => invalid.fmt(formatter),
         }
     }
 }

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -41,7 +41,7 @@ impl Membership {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Incarnation {
     membership: Membership,
-    generation: Fence,
+    generation: Generation,
 }
 
 impl Incarnation {
@@ -61,19 +61,41 @@ impl Incarnation {
     }
 }
 
-/// The one ordered fencing value used for membership and incarnation checks.
+/// An ordered generation within one identity lineage.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct Generation(u64);
+
+impl Generation {
+    const POISON: Self = Self(u64::MAX);
+
+    fn new(value: u64) -> Option<Self> {
+        (value != Self::POISON.0).then_some(Self(value))
+    }
+
+    fn get(self) -> u64 {
+        self.0
+    }
+
+    fn supersedes(self, other: Self) -> bool {
+        self != Self::POISON && other != Self::POISON && self.0 > other.0
+    }
+
+    #[cfg(test)]
+    fn fixture(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// A complete membership fence: its lineage and ordered generation.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct Fence {
     lineage: u64,
-    generation: u64,
+    generation: Generation,
 }
 
 impl Fence {
     fn supersedes(self, other: Self) -> bool {
-        self.lineage == other.lineage
-            && self.generation != u64::MAX
-            && other.generation != u64::MAX
-            && self.generation > other.generation
+        self.lineage == other.lineage && self.generation.supersedes(other.generation)
     }
 }
 
@@ -105,14 +127,14 @@ impl FenceCounter {
 
     fn mint(&mut self) -> Option<Fence> {
         let next = self.current.checked_add(1)?;
-        if next == u64::MAX {
+        let Some(generation) = Generation::new(next) else {
             self.current = u64::MAX;
             return None;
-        }
+        };
         self.current = next;
         Some(Fence {
             lineage: self.lineage,
-            generation: next,
+            generation,
         })
     }
 
@@ -121,7 +143,7 @@ impl FenceCounter {
     /// Observation uses the same saturating, poison-never-minted primitive as
     /// membership and incarnation fencing.
     pub(crate) fn mint_sequence(&mut self) -> Option<u64> {
-        self.mint().map(|fence| fence.generation)
+        self.mint().map(|fence| fence.generation.get())
     }
 }
 
@@ -132,14 +154,14 @@ pub(crate) struct ScopeIdentity {
 }
 
 impl ScopeIdentity {
-    pub(crate) fn new() -> Option<Self> {
+    pub(crate) fn new() -> Self {
         #[cfg(test)]
         CURRENT_THREAD_SCOPE_CREATIONS.with(|creations| {
             creations.set(creations.get().saturating_add(1));
         });
-        Some(Self {
+        Self {
             memberships: HashMap::new(),
-        })
+        }
     }
 
     fn fresh_counter() -> Option<FenceCounter> {
@@ -191,35 +213,29 @@ impl ScopeIdentity {
         match self.memberships.entry(id.clone()) {
             Entry::Occupied(mut entry) => entry.get_mut().mint().map(Membership),
             Entry::Vacant(entry) => {
-                debug_assert_ne!(provisional.0.generation, u64::MAX);
+                debug_assert_ne!(provisional.0.generation, Generation::POISON);
                 entry.insert(FenceCounter {
                     lineage: provisional.0.lineage,
-                    current: provisional.0.generation,
+                    current: provisional.0.generation.get(),
                 });
                 Some(provisional)
             }
         }
     }
 
-    pub(crate) fn incarnation_counter(&self, membership: Membership) -> FenceCounter {
-        // The membership's complete fence is compressed into a unique local
-        // lineage. The membership scope lineage remains part of the mixing, so
-        // matching child ids in different scopes cannot compare equal.
-        //
-        // A nested builder mints its public handles before it is attached to
-        // the parent scope. Deriving from the membership itself keeps those
-        // handles valid after lowering under the parent's runtime cell.
-        let lineage = membership.0.lineage.rotate_left(17) ^ membership.0.generation;
-        FenceCounter::new(lineage)
+    pub(crate) fn incarnation_counter(&self, _membership: Membership) -> FenceCounter {
+        // Membership already supplies the complete incarnation lineage. The
+        // per-membership counter therefore needs only an ordered generation.
+        FenceCounter::new(0)
     }
 
     pub(crate) fn mint_incarnation(
         membership: Membership,
         counter: &mut FenceCounter,
     ) -> Option<Incarnation> {
-        counter.mint().map(|generation| Incarnation {
+        counter.mint().map(|fence| Incarnation {
             membership,
-            generation,
+            generation: fence.generation,
         })
     }
 }
@@ -228,12 +244,12 @@ impl ScopeIdentity {
 mod tests {
     use crate::ChildId;
 
-    use super::{FenceCounter, ScopeIdentity};
+    use super::{FenceCounter, Generation, ScopeIdentity};
 
     #[test]
     fn cross_scope_tokens_fail_closed() {
-        let mut left = ScopeIdentity::new().expect("scope identity available");
-        let mut right = ScopeIdentity::new().expect("scope identity available");
+        let mut left = ScopeIdentity::new();
+        let mut right = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let left_member = left.mint_membership(&id).expect("membership available");
         let right_member = right.mint_membership(&id).expect("membership available");
@@ -245,7 +261,7 @@ mod tests {
 
     #[test]
     fn membership_and_incarnation_order_is_scoped_by_owner_and_id() {
-        let mut scope = ScopeIdentity::new().expect("scope identity available");
+        let mut scope = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let first = scope.mint_membership(&id).expect("membership available");
         let second = scope.mint_membership(&id).expect("membership available");
@@ -277,19 +293,19 @@ mod tests {
     fn stable_scope_adopts_the_first_declaration_then_orders_rebuilds() {
         let id = ChildId::from("worker");
         let other_id = ChildId::from("other");
-        let mut first_builder = ScopeIdentity::new().expect("builder identity available");
+        let mut first_builder = ScopeIdentity::new();
         let first = first_builder
             .mint_membership(&id)
             .expect("first provisional membership available");
         let other = first_builder
             .mint_membership(&other_id)
             .expect("other provisional membership available");
-        let mut rebuilt_builder = ScopeIdentity::new().expect("builder identity available");
+        let mut rebuilt_builder = ScopeIdentity::new();
         let rebuilt = rebuilt_builder
             .mint_membership(&id)
             .expect("rebuilt provisional membership available");
 
-        let mut stable = ScopeIdentity::new().expect("stable identity available");
+        let mut stable = ScopeIdentity::new();
         assert_eq!(
             stable.adopt_or_mint_membership(&id, first),
             Some(first),
@@ -314,8 +330,11 @@ mod tests {
 
     #[test]
     fn exhaustion_never_mints_the_poison_value_or_a_duplicate() {
+        const TEST_LINEAGE: u64 = u64::MAX;
         let id = ChildId::from("worker");
-        let counter = FenceCounter::near_exhaustion(7);
+        // The production allocator never mints the poison lineage, so this
+        // fixture cannot collide with an unrelated identity created below.
+        let counter = FenceCounter::near_exhaustion(TEST_LINEAGE);
         let mut scope = ScopeIdentity::with_counter(id.clone(), counter);
         let last = scope
             .mint_membership(&id)
@@ -323,7 +342,7 @@ mod tests {
         assert!(scope.mint_membership(&id).is_none());
         assert!(scope.mint_membership(&id).is_none());
 
-        let other = MembershipFixture::at(7, u64::MAX);
+        let other = MembershipFixture::at(TEST_LINEAGE, u64::MAX);
         assert_ne!(last, other);
         assert!(!last.supersedes(other));
         assert!(!other.supersedes(last));
@@ -342,7 +361,7 @@ mod tests {
         stable
             .mint_membership(&id)
             .expect("last usable stable membership is minted");
-        let mut builder = ScopeIdentity::new().expect("builder identity available");
+        let mut builder = ScopeIdentity::new();
         let provisional = builder
             .mint_membership(&id)
             .expect("provisional membership available");
@@ -357,7 +376,7 @@ mod tests {
 
     #[test]
     fn incarnation_exhaustion_also_mints_nothing() {
-        let mut scope = ScopeIdentity::new().expect("scope identity available");
+        let mut scope = ScopeIdentity::new();
         let membership = scope
             .mint_membership(&ChildId::from("worker"))
             .expect("membership available");
@@ -369,13 +388,27 @@ mod tests {
         assert_eq!(last.membership(), membership);
     }
 
+    #[test]
+    fn generation_ordering_is_typed_and_poison_fails_closed() {
+        let first = Generation::fixture(1);
+        let second = Generation::fixture(2);
+
+        assert!(second.supersedes(first));
+        assert!(!first.supersedes(second));
+        assert!(!Generation::POISON.supersedes(second));
+        assert!(!second.supersedes(Generation::POISON));
+
+        let mut sequence = FenceCounter::new(0);
+        assert_eq!(sequence.mint_sequence(), Some(1));
+    }
+
     struct MembershipFixture;
 
     impl MembershipFixture {
         fn at(lineage: u64, generation: u64) -> super::Membership {
             super::Membership(super::Fence {
                 lineage,
-                generation,
+                generation: super::Generation::fixture(generation),
             })
         }
     }

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -332,8 +332,8 @@ mod tests {
     fn exhaustion_never_mints_the_poison_value_or_a_duplicate() {
         const TEST_LINEAGE: u64 = u64::MAX;
         let id = ChildId::from("worker");
-        // The production allocator never mints the poison lineage, so this
-        // fixture cannot collide with an unrelated identity created below.
+        // A fixture lineage this test does not otherwise allocate, so it
+        // cannot collide with an unrelated identity created below.
         let counter = FenceCounter::near_exhaustion(TEST_LINEAGE);
         let mut scope = ScopeIdentity::with_counter(id.clone(), counter);
         let last = scope

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -2,6 +2,8 @@
 
 //! Structured supervision and actors for asynchronous Rust systems.
 
+#[macro_use]
+mod definition;
 mod actor;
 mod cells;
 mod deadline;

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -37,9 +37,9 @@ pub use observe::{
 };
 pub use plan::{NotAdmittingCause, RemoveOutcome, ReserveError};
 pub use policy::{
-    Backoff, BackoffFactor, ChildId, DefaultsInheritance, Intensity, Jitter, Mailbox,
-    MailboxShutdown, PolicyError, Readiness, ReadinessDeadline, RestartCondition, RestartPolicy,
-    Retention, ScopeDefaults, Shutdown, Strategy,
+    Backoff, BackoffFactor, ChildId, DefaultsInheritance, Intensity, InvalidPolicy, Jitter,
+    Mailbox, MailboxShutdown, PolicyError, PolicyField, Readiness, ReadinessDeadline,
+    RestartCondition, RestartPolicy, Retention, ScopeDefaults, Shutdown, Strategy,
 };
 pub use raw::{
     Blocking, DeadlineElapsed, Guard, RawActor, RawContext, RawDef, RawOnceDef, Rejected,

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -3,6 +3,7 @@
 //! Structured supervision and actors for asynchronous Rust systems.
 
 mod actor;
+mod cells;
 mod deadline;
 mod driver;
 mod engine;
@@ -19,7 +20,7 @@ mod tree;
 pub use actor::{Actor, ActorDef, ActorOnceDef, Context, Handler, StopContext};
 pub use exit::{
     Exit, ExitError, ExitKind, ExitResult, IntensityTrip, ShutdownStraggler, ShutdownTimeout,
-    StartupFailure, StartupFailureCause,
+    StartupError, StartupFailure, StartupFailureCause, StopReason,
 };
 pub use identity::{Incarnation, Membership};
 pub use mailbox::{
@@ -43,8 +44,8 @@ pub use task::{CancellationToken, OneShotTaskRef, TaskContext, TaskDef, TaskOnce
 pub use tree::{
     ActorSlot, Admission, AdmissionReceipt, BuildError, DynamicActorSlot, DynamicScopeRef,
     DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, NotAdmittingCause, Removal, RemoveOutcome,
-    ReserveError, ScopeRef, StartOrShutdownError, StartupError, StopReason, Subtree, SubtreeDef,
-    SubtreeOnceDef, SubtreeSlot, System, TaskSlot, Tree,
+    ReserveError, ScopeRef, StartOrShutdownError, Subtree, SubtreeDef, SubtreeOnceDef, SubtreeSlot,
+    System, TaskSlot, Tree,
 };
 
 // Keep the repository-facing examples in the same rustdoc compilation lane as

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -11,6 +11,7 @@ mod exit;
 mod identity;
 mod mailbox;
 mod observe;
+mod plan;
 mod policy;
 mod raw;
 mod runtime;
@@ -32,6 +33,7 @@ pub use observe::{
     LifecycleEvents, LifecycleItem, LifecycleTryRecvError, MembershipStatus, ScopeKind,
     ScopeSnapshot, ScopeState, SnapshotClosed, SnapshotReceiver, WaitError,
 };
+pub use plan::{NotAdmittingCause, RemoveOutcome, ReserveError};
 pub use policy::{
     Backoff, BackoffFactor, ChildId, DefaultsInheritance, Intensity, Jitter, Mailbox,
     MailboxShutdown, PolicyError, Readiness, ReadinessDeadline, RestartCondition, RestartPolicy,
@@ -43,9 +45,8 @@ pub use raw::{
 pub use task::{CancellationToken, OneShotTaskRef, TaskContext, TaskDef, TaskOnceDef, TaskRef};
 pub use tree::{
     ActorSlot, Admission, AdmissionReceipt, BuildError, DynamicActorSlot, DynamicScopeRef,
-    DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, NotAdmittingCause, Removal, RemoveOutcome,
-    ReserveError, ScopeRef, StartOrShutdownError, Subtree, SubtreeDef, SubtreeOnceDef, SubtreeSlot,
-    System, TaskSlot, Tree,
+    DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, Removal, ScopeRef, StartOrShutdownError,
+    Subtree, SubtreeDef, SubtreeOnceDef, SubtreeSlot, System, TaskSlot, Tree,
 };
 
 // Keep the repository-facing examples in the same rustdoc compilation lane as

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -15,7 +15,8 @@ use std::{
 
 use crate::{
     ChildId, Incarnation, Mailbox, Membership,
-    driver::{MemberCell, Signal, SignalWatcher},
+    driver::MemberCell,
+    runtime::{Signal, SignalWatcher},
 };
 
 /// The kind of a failed actor send.
@@ -326,7 +327,7 @@ impl<T> Drop for ReplyReceiver<T> {
 pub struct ReplyReceive<T> {
     shared: Option<Arc<ReplyShared<T>>>,
     deadline: Duration,
-    timer: Option<crate::driver::DriverSleep>,
+    timer: Option<crate::runtime::BoxedSleep>,
     started: bool,
     done: bool,
 }
@@ -347,7 +348,7 @@ impl<T: Send + 'static> Future for ReplyReceive<T> {
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
         if !self.started {
             self.started = true;
-            let budget = crate::driver::deadline(self.deadline);
+            let budget = crate::runtime::deadline(self.deadline);
             if self.deadline.is_zero() {
                 self.done = true;
                 if let Some(shared) = &self.shared {
@@ -355,7 +356,7 @@ impl<T: Send + 'static> Future for ReplyReceive<T> {
                 }
                 return Poll::Ready(Err(ReplyError::Timeout));
             }
-            self.timer = Some(crate::driver::sleep_deadline(budget));
+            self.timer = Some(crate::runtime::sleep_deadline(budget));
         }
         let shared = Arc::clone(
             self.shared
@@ -1518,7 +1519,7 @@ impl<M> Drop for SendFuture<M> {
 pub struct SendTimeout<M> {
     send: Option<SendFuture<M>>,
     deadline: Duration,
-    timer: Option<crate::driver::DriverSleep>,
+    timer: Option<crate::runtime::BoxedSleep>,
     started: bool,
     done: bool,
 }
@@ -1539,7 +1540,7 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
         if !self.started {
             self.started = true;
-            let budget = crate::driver::deadline(self.deadline);
+            let budget = crate::runtime::deadline(self.deadline);
             if self.deadline.is_zero() {
                 let actor_id = self
                     .send
@@ -1571,7 +1572,7 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
                     kind: SendErrorKind::TimedOut,
                 }));
             }
-            self.timer = Some(crate::driver::sleep_deadline(budget));
+            self.timer = Some(crate::runtime::sleep_deadline(budget));
         }
         let send = self.send.as_mut().expect("pending timed send retains send");
         if let Poll::Ready(result) = Pin::new(send).poll(context) {
@@ -1624,7 +1625,7 @@ pub struct CallFuture<M, T> {
     actor: ActorRef<M>,
     make_msg: Option<Box<dyn FnOnce(Reply<T>) -> M + Send + 'static>>,
     deadline: Duration,
-    timer: Option<crate::driver::DriverSleep>,
+    timer: Option<crate::runtime::BoxedSleep>,
     send: Option<SendFuture<M>>,
     reply: Option<Arc<ReplyShared<T>>>,
     accepted: Option<Incarnation>,
@@ -1683,7 +1684,7 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
             self.started = true;
             // Capture the one overall budget before invoking user code. A
             // slow message constructor consumes acceptance/response time.
-            let budget = crate::driver::deadline(self.deadline);
+            let budget = crate::runtime::deadline(self.deadline);
             if self.deadline.is_zero() {
                 self.done = true;
                 return Poll::Ready(Err(CallError {
@@ -1701,7 +1702,7 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
             // at the exact deadline win. Construction is different: no send
             // existed before it completed, so do not start one after the
             // captured budget is strictly in the past.
-            if budget.is_overdue(crate::driver::now()) {
+            if budget.is_overdue(crate::runtime::now()) {
                 self.done = true;
                 return Poll::Ready(Err(CallError {
                     actor_id: self.actor.id().clone(),
@@ -1711,7 +1712,7 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
             }
             self.reply = receiver.shared.take();
             self.send = Some(self.actor.send(message));
-            self.timer = Some(crate::driver::sleep_deadline(budget));
+            self.timer = Some(crate::runtime::sleep_deadline(budget));
         }
 
         if self.accepted.is_none() {

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1,7 +1,7 @@
 //! Membership-owned actor mailboxes and request/reply capabilities.
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{BTreeMap, VecDeque},
     fmt,
     future::Future,
     hash::{Hash, Hasher},
@@ -16,7 +16,7 @@ use std::{
 use crate::{
     ChildId, Incarnation, Mailbox, Membership,
     cells::{MailboxControl, MailboxDisposal, MailboxStats, MailboxTermination, MemberCell},
-    runtime::{Signal, SignalWatcher},
+    runtime::{OneShotReceiver, OneShotSender, Signal, SignalWatcher},
 };
 
 /// The kind of a failed actor send.
@@ -168,54 +168,95 @@ impl fmt::Display for ReplyError {
 
 impl std::error::Error for ReplyError {}
 
-enum ReplyOutcome<T> {
-    Pending,
-    Value(T),
-    Dropped,
+trait DeadlineOperation {
+    type Output;
+
+    /// Polls the operation before or after the shared deadline transition.
+    ///
+    /// An elapsed poll must resolve. It is a second operation poll after the
+    /// timer becomes ready so completion or acceptance at the exact boundary
+    /// wins before operation-specific timeout cleanup runs.
+    fn poll_deadlined(
+        &mut self,
+        context: &mut Context<'_>,
+        budget: crate::deadline::Deadline,
+        elapsed: bool,
+    ) -> Poll<Self::Output>;
 }
 
-struct ReplyState<T> {
-    outcome: ReplyOutcome<T>,
-    receiver_alive: bool,
-    waker: Option<Waker>,
+/// First-poll deadline capture shared by every public mailbox deadline future.
+struct Deadlined<F> {
+    operation: F,
+    duration: Duration,
+    budget: Option<crate::deadline::Deadline>,
+    timer: Option<crate::runtime::BoxedSleep>,
+    started: bool,
+    done: bool,
 }
 
-struct ReplyShared<T> {
-    state: Mutex<ReplyState<T>>,
-}
-
-impl<T> ReplyShared<T> {
-    fn poll(&self, context: &mut Context<'_>) -> Poll<Result<T, ReplyError>> {
-        let mut state = self.state.lock().expect("reply mutex poisoned");
-        match std::mem::replace(&mut state.outcome, ReplyOutcome::Pending) {
-            ReplyOutcome::Value(value) => {
-                state.receiver_alive = false;
-                Poll::Ready(Ok(value))
-            }
-            ReplyOutcome::Dropped => {
-                state.receiver_alive = false;
-                Poll::Ready(Err(ReplyError::Dropped))
-            }
-            ReplyOutcome::Pending => {
-                state.waker = Some(context.waker().clone());
-                Poll::Pending
-            }
+impl<F> Deadlined<F> {
+    fn new(operation: F, duration: Duration) -> Self {
+        Self {
+            operation,
+            duration,
+            budget: None,
+            timer: None,
+            started: false,
+            done: false,
         }
     }
+}
 
-    fn close_receiver(&self) {
-        let mut state = self.state.lock().expect("reply mutex poisoned");
-        state.receiver_alive = false;
-        state.waker = None;
-        if matches!(state.outcome, ReplyOutcome::Value(_)) {
-            state.outcome = ReplyOutcome::Pending;
+impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
+    type Output = F::Output;
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.as_mut().get_mut();
+        if !this.started {
+            this.started = true;
+            let budget = crate::runtime::deadline(this.duration);
+            this.budget = Some(budget);
+            if !this.duration.is_zero() {
+                this.timer = Some(crate::runtime::sleep_deadline(budget));
+            }
         }
+        let budget = this
+            .budget
+            .expect("a started deadline future retains its captured budget");
+        if this.duration.is_zero() {
+            let result = this.operation.poll_deadlined(context, budget, true);
+            debug_assert!(result.is_ready(), "an elapsed operation must resolve");
+            this.done = result.is_ready();
+            return result;
+        }
+        if let Poll::Ready(result) = this.operation.poll_deadlined(context, budget, false) {
+            this.done = true;
+            return Poll::Ready(result);
+        }
+        if this
+            .timer
+            .as_mut()
+            .expect("a non-zero deadline future retains its timer")
+            .as_mut()
+            .poll(context)
+            .is_pending()
+        {
+            return Poll::Pending;
+        }
+        let result = this.operation.poll_deadlined(context, budget, true);
+        debug_assert!(result.is_ready(), "an elapsed operation must resolve");
+        this.done = result.is_ready();
+        result
     }
 }
 
 /// A consuming, infallible reply capability.
+///
+/// Dropping an unanswered capability is completion: its receiver observes
+/// [`ReplyError::Dropped`]. Dropping or timing out the receiver instead closes
+/// the channel, so a late [`Reply::send`] safely discards its value.
 pub struct Reply<T> {
-    shared: Arc<ReplyShared<T>>,
+    sender: Option<OneShotSender<T>>,
     answered: bool,
 }
 
@@ -232,20 +273,14 @@ impl<T: Send + 'static> Reply<T> {
     /// Creates a reply capability and its single owned receiver.
     #[must_use]
     pub fn channel() -> (Self, ReplyReceiver<T>) {
-        let shared = Arc::new(ReplyShared {
-            state: Mutex::new(ReplyState {
-                outcome: ReplyOutcome::Pending,
-                receiver_alive: true,
-                waker: None,
-            }),
-        });
+        let (sender, receiver) = crate::runtime::oneshot();
         (
             Self {
-                shared: Arc::clone(&shared),
+                sender: Some(sender),
                 answered: false,
             },
             ReplyReceiver {
-                shared: Some(shared),
+                receiver: Some(receiver),
             },
         )
     }
@@ -253,44 +288,17 @@ impl<T: Send + 'static> Reply<T> {
     /// Consumes the capability and delivers or discards the reply.
     pub fn send(mut self, value: T) {
         self.answered = true;
-        let wake = {
-            let mut state = self.shared.state.lock().expect("reply mutex poisoned");
-            if state.receiver_alive && matches!(state.outcome, ReplyOutcome::Pending) {
-                state.outcome = ReplyOutcome::Value(value);
-                state.waker.take()
-            } else {
-                None
-            }
-        };
-        if let Some(waker) = wake {
-            waker.wake();
-        }
-    }
-}
-
-impl<T> Drop for Reply<T> {
-    fn drop(&mut self) {
-        if self.answered {
-            return;
-        }
-        let wake = {
-            let mut state = self.shared.state.lock().expect("reply mutex poisoned");
-            if matches!(state.outcome, ReplyOutcome::Pending) {
-                state.outcome = ReplyOutcome::Dropped;
-                state.waker.take()
-            } else {
-                None
-            }
-        };
-        if let Some(waker) = wake {
-            waker.wake();
-        }
+        let sender = self
+            .sender
+            .take()
+            .expect("an unanswered reply retains its sender");
+        let _ = sender.send(value);
     }
 }
 
 /// The owned, non-cloneable receive half of [`Reply::channel`].
 pub struct ReplyReceiver<T> {
-    shared: Option<Arc<ReplyShared<T>>>,
+    receiver: Option<OneShotReceiver<T>>,
 }
 
 impl<T> fmt::Debug for ReplyReceiver<T> {
@@ -305,19 +313,38 @@ impl<T: Send + 'static> ReplyReceiver<T> {
     /// Consumes the receiver and waits within one response-only budget.
     pub fn recv(mut self, deadline: Duration) -> ReplyReceive<T> {
         ReplyReceive {
-            shared: self.shared.take(),
-            deadline,
-            timer: None,
-            started: false,
-            done: false,
+            deadlined: Deadlined::new(
+                ReplyOperation {
+                    receiver: self.receiver.take().expect("unused reply receiver is live"),
+                },
+                deadline,
+            ),
         }
     }
 }
 
-impl<T> Drop for ReplyReceiver<T> {
-    fn drop(&mut self) {
-        if let Some(shared) = &self.shared {
-            shared.close_receiver();
+struct ReplyOperation<T> {
+    receiver: OneShotReceiver<T>,
+}
+
+impl<T> DeadlineOperation for ReplyOperation<T> {
+    type Output = Result<T, ReplyError>;
+
+    fn poll_deadlined(
+        &mut self,
+        context: &mut Context<'_>,
+        _budget: crate::deadline::Deadline,
+        elapsed: bool,
+    ) -> Poll<Self::Output> {
+        match self.receiver.poll_receive(context) {
+            Poll::Ready(Some(value)) => Poll::Ready(Ok(value)),
+            Poll::Ready(None) => Poll::Ready(Err(ReplyError::Dropped)),
+            Poll::Pending if elapsed => Poll::Ready(
+                self.receiver
+                    .close_and_try_receive()
+                    .ok_or(ReplyError::Timeout),
+            ),
+            Poll::Pending => Poll::Pending,
         }
     }
 }
@@ -325,19 +352,15 @@ impl<T> Drop for ReplyReceiver<T> {
 /// Future returned by [`ReplyReceiver::recv`].
 #[must_use]
 pub struct ReplyReceive<T> {
-    shared: Option<Arc<ReplyShared<T>>>,
-    deadline: Duration,
-    timer: Option<crate::runtime::BoxedSleep>,
-    started: bool,
-    done: bool,
+    deadlined: Deadlined<ReplyOperation<T>>,
 }
 
 impl<T> fmt::Debug for ReplyReceive<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("ReplyReceive")
-            .field("started", &self.started)
-            .field("done", &self.done)
+            .field("started", &self.deadlined.started)
+            .field("done", &self.deadlined.done)
             .finish_non_exhaustive()
     }
 }
@@ -346,50 +369,7 @@ impl<T: Send + 'static> Future for ReplyReceive<T> {
     type Output = Result<T, ReplyError>;
 
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
-        if !self.started {
-            self.started = true;
-            let budget = crate::runtime::deadline(self.deadline);
-            if self.deadline.is_zero() {
-                self.done = true;
-                if let Some(shared) = &self.shared {
-                    shared.close_receiver();
-                }
-                return Poll::Ready(Err(ReplyError::Timeout));
-            }
-            self.timer = Some(crate::runtime::sleep_deadline(budget));
-        }
-        let shared = Arc::clone(
-            self.shared
-                .as_ref()
-                .expect("pending reply receive must retain its shared state"),
-        );
-        if let Poll::Ready(result) = shared.poll(context) {
-            self.done = true;
-            return Poll::Ready(result);
-        }
-        if self
-            .timer
-            .as_mut()
-            .expect("started reply receive must have a timer")
-            .as_mut()
-            .poll(context)
-            .is_ready()
-        {
-            shared.close_receiver();
-            self.done = true;
-            return Poll::Ready(Err(ReplyError::Timeout));
-        }
-        Poll::Pending
-    }
-}
-
-impl<T> Drop for ReplyReceive<T> {
-    fn drop(&mut self) {
-        if !self.done
-            && let Some(shared) = &self.shared
-        {
-            shared.close_receiver();
-        }
+        Pin::new(&mut self.deadlined).poll(context)
     }
 }
 
@@ -434,6 +414,12 @@ struct OperationState<M> {
 struct SendOperation<M> {
     state: Mutex<OperationState<M>>,
 }
+
+// Lock order is mailbox state, then send-operation state. Code that starts
+// from an operation lock must release it before entering the mailbox. Paths
+// that take only the operation lock (polling, detached teardown) never reach
+// back into mailbox state. This keeps acceptance, withdrawal, and waiter
+// registration on one acyclic ordering.
 
 impl<M> SendOperation<M> {
     fn new(message: M) -> Arc<Self> {
@@ -522,25 +508,17 @@ struct MailboxState<M> {
     sends_rejected: u64,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct WaiterId(u64);
 
-struct WaiterEntry<M> {
-    operation: Arc<SendOperation<M>>,
-    previous: Option<WaiterId>,
-    next: Option<WaiterId>,
-}
-
-/// FIFO registrations with constant-time removal by a send operation.
+/// FIFO registrations with direct removal by a send operation.
 ///
-/// The mailbox mutex serializes every mutation, so a compact intrusive list
-/// can use monotonic local ids without another synchronization layer. The ids
-/// are never reused, which also prevents a stale cancellation from unlinking
-/// a later operation.
+/// Monotonic keys are insertion order, so the first map entry is the oldest
+/// waiter. Keys are never reused, making stale cancellation ids harmless.
+/// `u64::MAX` is a poison key and is never minted; exhaustion remains poisoned
+/// instead of wrapping back into the live id domain.
 struct WaiterQueue<M> {
-    entries: HashMap<WaiterId, WaiterEntry<M>>,
-    head: Option<WaiterId>,
-    tail: Option<WaiterId>,
+    entries: BTreeMap<WaiterId, Arc<SendOperation<M>>>,
     next_id: u64,
     #[cfg(test)]
     direct_removals: usize,
@@ -549,9 +527,7 @@ struct WaiterQueue<M> {
 impl<M> Default for WaiterQueue<M> {
     fn default() -> Self {
         Self {
-            entries: HashMap::new(),
-            head: None,
-            tail: None,
+            entries: BTreeMap::new(),
             next_id: 0,
             #[cfg(test)]
             direct_removals: 0,
@@ -570,30 +546,17 @@ impl<M> WaiterQueue<M> {
     }
 
     fn push_back(&mut self, operation: Arc<SendOperation<M>>) -> WaiterId {
-        let id = WaiterId(self.next_id);
-        self.next_id = self
-            .next_id
-            .checked_add(1)
-            .expect("mailbox waiter identity space exhausted");
-        let previous = self.tail;
-        let replaced = self.entries.insert(
-            id,
-            WaiterEntry {
-                operation,
-                previous,
-                next: None,
-            },
-        );
-        debug_assert!(replaced.is_none());
-        if let Some(previous) = previous {
-            self.entries
-                .get_mut(&previous)
-                .expect("tail registration must be live")
-                .next = Some(id);
-        } else {
-            self.head = Some(id);
+        let Some(next) = self.next_id.checked_add(1) else {
+            panic!("mailbox waiter identity space exhausted");
+        };
+        if next == u64::MAX {
+            self.next_id = u64::MAX;
+            panic!("mailbox waiter identity space exhausted");
         }
-        self.tail = Some(id);
+        self.next_id = next;
+        let id = WaiterId(next);
+        let replaced = self.entries.insert(id, operation);
+        debug_assert!(replaced.is_none());
         id
     }
 
@@ -603,39 +566,27 @@ impl<M> WaiterQueue<M> {
     }
 
     fn observe_all(&self, incarnation: Incarnation) {
-        for entry in self.entries.values() {
-            entry.operation.observe(incarnation);
+        for operation in self.entries.values() {
+            operation.observe(incarnation);
         }
     }
 
     fn pop_front(&mut self) -> Option<(WaiterId, Arc<SendOperation<M>>)> {
-        let id = self.head?;
-        self.remove(id).map(|operation| (id, operation))
+        let entry = self.entries.pop_first();
+        #[cfg(test)]
+        if entry.is_some() {
+            self.direct_removals = self.direct_removals.saturating_add(1);
+        }
+        entry
     }
 
     fn remove(&mut self, id: WaiterId) -> Option<Arc<SendOperation<M>>> {
-        let entry = self.entries.remove(&id)?;
+        let operation = self.entries.remove(&id)?;
         #[cfg(test)]
         {
             self.direct_removals = self.direct_removals.saturating_add(1);
         }
-        if let Some(previous) = entry.previous {
-            self.entries
-                .get_mut(&previous)
-                .expect("previous registration must be live")
-                .next = entry.next;
-        } else {
-            self.head = entry.next;
-        }
-        if let Some(next) = entry.next {
-            self.entries
-                .get_mut(&next)
-                .expect("next registration must be live")
-                .previous = entry.previous;
-        } else {
-            self.tail = entry.previous;
-        }
-        Some(entry.operation)
+        Some(operation)
     }
 }
 
@@ -1075,6 +1026,12 @@ impl<M: Send + 'static> MailboxCell<M> {
 impl<M> MailboxCell<M> {
     fn withdraw(&self, operation: &Arc<SendOperation<M>>) -> Withdrawal<M> {
         let mut mailbox = self.state.lock().expect("mailbox mutex poisoned");
+        let current_observation = match mailbox.status {
+            BindingStatus::Bound(incarnation) | BindingStatus::Frozen(incarnation) => {
+                Some(incarnation)
+            }
+            BindingStatus::Unbound | BindingStatus::Terminal(_) => None,
+        };
         let (result, registration) = {
             let mut state = operation
                 .state
@@ -1088,7 +1045,12 @@ impl<M> MailboxCell<M> {
                     let message = message
                         .take()
                         .expect("a waiting operation must retain its message");
-                    let observed = *newest_observed;
+                    // The mailbox lock makes this one evidence snapshot: a
+                    // binding either precedes withdrawal and contributes its
+                    // incarnation, or follows the completed withdrawal. This
+                    // also covers an operation first submitted by an elapsed
+                    // (including zero-duration) deadline poll.
+                    let observed = (*newest_observed).or(current_observation);
                     state.outcome = OperationOutcome::Withdrawn;
                     state.waker = None;
                     (
@@ -1330,11 +1292,12 @@ impl<M: Send + 'static> ActorRef<M> {
     /// Sends within one acceptance budget, recovering an unaccepted message.
     pub fn send_timeout(&self, message: M, deadline: Duration) -> SendTimeout<M> {
         SendTimeout {
-            send: Some(self.send(message)),
-            deadline,
-            timer: None,
-            started: false,
-            done: false,
+            deadlined: Deadlined::new(
+                TimedSend {
+                    send: self.send(message),
+                },
+                deadline,
+            ),
         }
     }
 
@@ -1359,15 +1322,16 @@ impl<M: Send + 'static> ActorRef<M> {
         deadline: Duration,
     ) -> CallFuture<M, T> {
         CallFuture {
-            actor: self.clone(),
-            make_msg: Some(Box::new(make_msg)),
-            deadline,
-            timer: None,
-            send: None,
-            reply: None,
-            accepted: None,
-            started: false,
-            done: false,
+            deadlined: Deadlined::new(
+                CallOperation {
+                    actor: self.clone(),
+                    make_msg: Some(Box::new(make_msg)),
+                    send: None,
+                    reply: None,
+                    accepted: None,
+                },
+                deadline,
+            ),
         }
     }
 }
@@ -1499,20 +1463,59 @@ impl<M> Drop for SendFuture<M> {
 /// Cancellation-safe future returned by [`ActorRef::send_timeout`].
 #[must_use]
 pub struct SendTimeout<M> {
-    send: Option<SendFuture<M>>,
-    deadline: Duration,
-    timer: Option<crate::runtime::BoxedSleep>,
-    started: bool,
-    done: bool,
+    deadlined: Deadlined<TimedSend<M>>,
+}
+
+struct TimedSend<M> {
+    send: SendFuture<M>,
 }
 
 impl<M> fmt::Debug for SendTimeout<M> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("SendTimeout")
-            .field("started", &self.started)
-            .field("done", &self.done)
+            .field("started", &self.deadlined.started)
+            .field("done", &self.deadlined.done)
             .finish_non_exhaustive()
+    }
+}
+
+fn withdraw_send<M: Send + 'static>(send: &mut SendFuture<M>) -> Result<Incarnation, SendError<M>> {
+    let actor_id = send.actor.id().clone();
+    match send.withdraw() {
+        Withdrawal::Withdrawn { message, observed } => Err(SendError {
+            actor_id,
+            incarnation_observed: observed,
+            message,
+            kind: SendErrorKind::TimedOut,
+        }),
+        Withdrawal::Accepted(incarnation) => Ok(incarnation),
+        Withdrawal::Terminated { message, observed } => Err(SendError {
+            actor_id,
+            incarnation_observed: observed,
+            message,
+            kind: SendErrorKind::Terminated,
+        }),
+    }
+}
+
+impl<M: Send + 'static> DeadlineOperation for TimedSend<M> {
+    type Output = Result<Incarnation, SendError<M>>;
+
+    fn poll_deadlined(
+        &mut self,
+        context: &mut Context<'_>,
+        _budget: crate::deadline::Deadline,
+        elapsed: bool,
+    ) -> Poll<Self::Output> {
+        if let Poll::Ready(result) = Pin::new(&mut self.send).poll(context) {
+            return Poll::Ready(result);
+        }
+        if !elapsed {
+            Poll::Pending
+        } else {
+            Poll::Ready(withdraw_send(&mut self.send))
+        }
     }
 }
 
@@ -1520,161 +1523,95 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
     type Output = Result<Incarnation, SendError<M>>;
 
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
-        if !self.started {
-            self.started = true;
-            let budget = crate::runtime::deadline(self.deadline);
-            if self.deadline.is_zero() {
-                let actor_id = self
-                    .send
-                    .as_ref()
-                    .expect("pending timed send retains send")
-                    .actor
-                    .id()
-                    .clone();
-                let current = self
-                    .send
-                    .as_ref()
-                    .expect("pending timed send retains send")
-                    .actor
-                    .mailbox
-                    .current_observation();
-                let withdrawal = self
-                    .send
-                    .as_mut()
-                    .expect("pending timed send retains send")
-                    .withdraw();
-                let Withdrawal::Withdrawn { message, observed } = withdrawal else {
-                    unreachable!("an unpolled send cannot already be accepted")
-                };
-                self.done = true;
-                return Poll::Ready(Err(SendError {
-                    actor_id,
-                    incarnation_observed: observed.or(current),
-                    message,
-                    kind: SendErrorKind::TimedOut,
-                }));
-            }
-            self.timer = Some(crate::runtime::sleep_deadline(budget));
-        }
-        let send = self.send.as_mut().expect("pending timed send retains send");
-        if let Poll::Ready(result) = Pin::new(send).poll(context) {
-            self.done = true;
-            return Poll::Ready(result);
-        }
-        if self
-            .timer
-            .as_mut()
-            .expect("started timed send has a timer")
-            .as_mut()
-            .poll(context)
-            .is_ready()
-        {
-            let send = self.send.as_mut().expect("pending timed send retains send");
-            let actor_id = send.actor.id().clone();
-            match send.withdraw() {
-                Withdrawal::Withdrawn { message, observed } => {
-                    self.done = true;
-                    Poll::Ready(Err(SendError {
-                        actor_id,
-                        incarnation_observed: observed,
-                        message,
-                        kind: SendErrorKind::TimedOut,
-                    }))
-                }
-                Withdrawal::Accepted(incarnation) => {
-                    self.done = true;
-                    Poll::Ready(Ok(incarnation))
-                }
-                Withdrawal::Terminated { message, observed } => {
-                    self.done = true;
-                    Poll::Ready(Err(SendError {
-                        actor_id,
-                        incarnation_observed: observed,
-                        message,
-                        kind: SendErrorKind::Terminated,
-                    }))
-                }
-            }
-        } else {
-            Poll::Pending
-        }
+        Pin::new(&mut self.deadlined).poll(context)
     }
 }
 
 /// Cancellation-safe future returned by [`ActorRef::call`].
 #[must_use]
 pub struct CallFuture<M, T> {
+    deadlined: Deadlined<CallOperation<M, T>>,
+}
+
+struct CallOperation<M, T> {
     actor: ActorRef<M>,
     make_msg: Option<Box<dyn FnOnce(Reply<T>) -> M + Send + 'static>>,
-    deadline: Duration,
-    timer: Option<crate::runtime::BoxedSleep>,
     send: Option<SendFuture<M>>,
-    reply: Option<Arc<ReplyShared<T>>>,
+    reply: Option<OneShotReceiver<T>>,
     accepted: Option<Incarnation>,
-    started: bool,
-    done: bool,
 }
 
 impl<M, T> fmt::Debug for CallFuture<M, T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("CallFuture")
-            .field("started", &self.started)
-            .field("accepted", &self.accepted)
-            .field("done", &self.done)
+            .field("started", &self.deadlined.started)
+            .field("accepted", &self.deadlined.operation.accepted)
+            .field("done", &self.deadlined.done)
             .finish_non_exhaustive()
     }
 }
 
-impl<M, T> CallFuture<M, T> {
+impl<M, T> CallOperation<M, T> {
     fn poll_reply(
-        &self,
+        &mut self,
         context: &mut Context<'_>,
         incarnation: Incarnation,
         deadline_elapsed: bool,
     ) -> Poll<Result<Replied<T>, CallError>> {
         let reply = self
             .reply
-            .as_ref()
+            .as_mut()
             .expect("accepted call retains reply state");
-        match reply.poll(context) {
-            Poll::Ready(Ok(value)) => Poll::Ready(Ok(Replied { value, incarnation })),
-            Poll::Ready(Err(ReplyError::Dropped)) => Poll::Ready(Err(CallError {
+        match reply.poll_receive(context) {
+            Poll::Ready(Some(value)) => Poll::Ready(Ok(Replied { value, incarnation })),
+            Poll::Ready(None) => Poll::Ready(Err(CallError {
                 actor_id: self.actor.id().clone(),
                 incarnation_observed: Some(incarnation),
                 kind: CallErrorKind::ReplyDropped,
             })),
-            Poll::Ready(Err(ReplyError::Timeout)) => unreachable!(),
             Poll::Pending if deadline_elapsed => {
-                reply.close_receiver();
-                Poll::Ready(Err(CallError {
-                    actor_id: self.actor.id().clone(),
-                    incarnation_observed: Some(incarnation),
-                    kind: CallErrorKind::ResponseTimedOut,
-                }))
+                if let Some(value) = reply.close_and_try_receive() {
+                    Poll::Ready(Ok(Replied { value, incarnation }))
+                } else {
+                    Poll::Ready(Err(CallError {
+                        actor_id: self.actor.id().clone(),
+                        incarnation_observed: Some(incarnation),
+                        kind: CallErrorKind::ResponseTimedOut,
+                    }))
+                }
             }
             Poll::Pending => Poll::Pending,
         }
     }
+
+    fn close_reply(&mut self) {
+        if let Some(reply) = &mut self.reply {
+            let _ = reply.close_and_try_receive();
+        }
+    }
 }
 
-impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
+impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M, T> {
     type Output = Result<Replied<T>, CallError>;
 
-    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
-        if !self.started {
-            self.started = true;
-            // Capture the one overall budget before invoking user code. A
-            // slow message constructor consumes acceptance/response time.
-            let budget = crate::runtime::deadline(self.deadline);
-            if self.deadline.is_zero() {
-                self.done = true;
+    fn poll_deadlined(
+        &mut self,
+        context: &mut Context<'_>,
+        budget: crate::deadline::Deadline,
+        elapsed: bool,
+    ) -> Poll<Self::Output> {
+        if self.make_msg.is_some() {
+            if elapsed {
                 return Poll::Ready(Err(CallError {
                     actor_id: self.actor.id().clone(),
                     incarnation_observed: self.actor.mailbox.current_observation(),
                     kind: CallErrorKind::AcceptanceTimedOut,
                 }));
             }
+            // Capture the one overall budget before invoking user code. A
+            // slow message constructor consumes acceptance/response time. The
+            // shared scaffold captured `budget` before this callback runs.
             let (reply, mut receiver) = Reply::channel();
             let message =
                 self.make_msg
@@ -1685,16 +1622,14 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
             // existed before it completed, so do not start one after the
             // captured budget is strictly in the past.
             if budget.is_overdue(crate::runtime::now()) {
-                self.done = true;
                 return Poll::Ready(Err(CallError {
                     actor_id: self.actor.id().clone(),
                     incarnation_observed: self.actor.mailbox.current_observation(),
                     kind: CallErrorKind::AcceptanceTimedOut,
                 }));
             }
-            self.reply = receiver.shared.take();
+            self.reply = receiver.receiver.take();
             self.send = Some(self.actor.send(message));
-            self.timer = Some(crate::runtime::sleep_deadline(budget));
         }
 
         if self.accepted.is_none() {
@@ -1708,10 +1643,7 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
                     self.send = None;
                 }
                 Poll::Ready(Err(error)) => {
-                    if let Some(reply) = &self.reply {
-                        reply.close_receiver();
-                    }
-                    self.done = true;
+                    self.close_reply();
                     return Poll::Ready(Err(CallError {
                         actor_id: error.actor_id,
                         incarnation_observed: error.incarnation_observed,
@@ -1723,66 +1655,49 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
         }
 
         if let Some(accepted) = self.accepted
-            && let Poll::Ready(result) = self.poll_reply(context, accepted, false)
+            && let Poll::Ready(result) = self.poll_reply(context, accepted, elapsed)
         {
-            self.done = true;
             return Poll::Ready(result);
         }
 
-        if self
-            .timer
-            .as_mut()
-            .expect("started call has a timer")
-            .as_mut()
-            .poll(context)
-            .is_pending()
-        {
+        if !elapsed {
             return Poll::Pending;
         }
 
-        if let Some(accepted) = self.accepted {
-            let result = self.poll_reply(context, accepted, true);
-            self.done = true;
-            result
-        } else {
-            let actor_id = self.actor.id().clone();
-            let send = self
-                .send
+        let result = withdraw_send(
+            self.send
                 .as_mut()
-                .expect("unaccepted call retains send future");
-            let result = match send.withdraw() {
-                Withdrawal::Withdrawn { observed, .. } => CallError {
-                    actor_id,
-                    incarnation_observed: observed,
-                    kind: CallErrorKind::AcceptanceTimedOut,
-                },
-                Withdrawal::Accepted(incarnation) => {
-                    let result = self.poll_reply(context, incarnation, true);
-                    self.done = true;
-                    return result;
-                }
-                Withdrawal::Terminated { observed, .. } => CallError {
-                    actor_id,
-                    incarnation_observed: observed,
-                    kind: CallErrorKind::Terminated,
-                },
-            };
-            if let Some(reply) = &self.reply {
-                reply.close_receiver();
+                .expect("an unaccepted call retains its send future"),
+        );
+        self.send = None;
+        match result {
+            Ok(incarnation) => {
+                self.accepted = Some(incarnation);
+                self.poll_reply(context, incarnation, true)
             }
-            self.done = true;
-            Poll::Ready(Err(result))
+            Err(error) => {
+                self.close_reply();
+                Poll::Ready(Err(CallError {
+                    actor_id: error.actor_id,
+                    incarnation_observed: error.incarnation_observed,
+                    kind: match error.kind {
+                        SendErrorKind::TimedOut => CallErrorKind::AcceptanceTimedOut,
+                        SendErrorKind::Terminated => CallErrorKind::Terminated,
+                        SendErrorKind::NotRunning | SendErrorKind::Full => {
+                            unreachable!("withdrawal returns only timed-out or terminal errors")
+                        }
+                    },
+                }))
+            }
         }
     }
 }
 
-impl<M, T> Drop for CallFuture<M, T> {
-    fn drop(&mut self) {
-        if !self.done
-            && let Some(reply) = &self.reply
-        {
-            reply.close_receiver();
-        }
+impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
+    type Output = Result<Replied<T>, CallError>;
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.deadlined).poll(context)
     }
 }
 
@@ -2058,5 +1973,55 @@ mod tests {
         assert!(Arc::ptr_eq(&removed, &second));
         removed.clear_registration(second_id);
         assert!(waiters.is_empty());
+    }
+
+    #[test]
+    fn waiter_queue_preserves_fifo_across_removal() {
+        let mut waiters = super::WaiterQueue::default();
+        let first = super::SendOperation::new(1_u8);
+        let second = super::SendOperation::new(2_u8);
+        let third = super::SendOperation::new(3_u8);
+        let first_id = waiters.push_back(Arc::clone(&first));
+        let second_id = waiters.push_back(Arc::clone(&second));
+        let third_id = waiters.push_back(Arc::clone(&third));
+
+        assert!(Arc::ptr_eq(
+            &waiters.remove(second_id).expect("middle waiter is live"),
+            &second
+        ));
+        let (popped_first, operation) = waiters.pop_front().expect("head remains live");
+        assert_eq!(popped_first, first_id);
+        assert!(Arc::ptr_eq(&operation, &first));
+        let (popped_third, operation) = waiters.pop_front().expect("tail remains live");
+        assert_eq!(popped_third, third_id);
+        assert!(Arc::ptr_eq(&operation, &third));
+        assert!(waiters.is_empty());
+    }
+
+    #[test]
+    fn waiter_identity_exhaustion_poison_is_never_minted() {
+        let mut waiters = super::WaiterQueue {
+            next_id: u64::MAX - 2,
+            ..super::WaiterQueue::default()
+        };
+        let last = waiters.push_back(super::SendOperation::new(1_u8));
+        assert_eq!(last, super::WaiterId(u64::MAX - 1));
+
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                waiters.push_back(super::SendOperation::new(2_u8));
+            }))
+            .is_err(),
+            "the poison key is never minted"
+        );
+        assert_eq!(waiters.next_id, u64::MAX);
+        assert!(!waiters.entries.contains_key(&super::WaiterId(u64::MAX)));
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                waiters.push_back(super::SendOperation::new(3_u8));
+            }))
+            .is_err(),
+            "the exhausted domain stays poisoned"
+        );
     }
 }

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -15,7 +15,7 @@ use std::{
 
 use crate::{
     ChildId, Incarnation, Mailbox, Membership,
-    driver::MemberCell,
+    cells::{MailboxControl, MailboxDisposal, MailboxStats, MailboxTermination, MemberCell},
     runtime::{Signal, SignalWatcher},
 };
 
@@ -639,16 +639,6 @@ impl<M> WaiterQueue<M> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(crate) struct MailboxStats {
-    pub(crate) accepted: u64,
-    pub(crate) delivered: u64,
-    pub(crate) conflated: u64,
-    pub(crate) sends_rejected: u64,
-    pub(crate) depth: usize,
-    pub(crate) capacity: usize,
-}
-
 struct Promotion<M: Send + 'static> {
     displaced: Vec<Envelope<M>>,
     wakers: Vec<Waker>,
@@ -731,8 +721,6 @@ impl<M> Termination<M> {
     }
 }
 
-pub(crate) trait MailboxDisposal: Send {}
-
 struct MailboxPayload<M> {
     queue: Option<VecDeque<Envelope<M>>>,
     latest: Option<Envelope<M>>,
@@ -772,10 +760,6 @@ impl<M> Drop for MailboxPayload<M> {
 }
 
 impl<M: Send> MailboxDisposal for MailboxPayload<M> {}
-
-pub(crate) trait MailboxTermination: Send {
-    fn finish(self: Box<Self>) -> Option<Box<dyn MailboxDisposal>>;
-}
 
 struct MailboxTeardown<M: Send + 'static> {
     changed: Option<Signal>,
@@ -829,16 +813,6 @@ impl<M: Send + 'static> Drop for MailboxTeardown<M> {
             resume_unwind(panic);
         }
     }
-}
-
-/// Type-erased control used by the supervision driver.
-pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
-    fn configure(&self, mailbox: Mailbox);
-    fn bind(&self, incarnation: Incarnation);
-    fn freeze(&self, incarnation: Incarnation);
-    fn close(&self, incarnation: Incarnation) -> Option<Box<dyn MailboxDisposal>>;
-    fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>>;
-    fn stats(&self) -> MailboxStats;
 }
 
 pub(crate) struct MailboxCell<M> {
@@ -1854,7 +1828,7 @@ mod tests {
         task::{Context, Poll, Wake, Waker},
     };
 
-    use crate::{ChildId, Mailbox, SendErrorKind, driver::MemberCell, identity::ScopeIdentity};
+    use crate::{ChildId, Mailbox, SendErrorKind, cells::MemberCell, identity::ScopeIdentity};
 
     use super::{ActorRef, MailboxCell, MailboxControl};
 

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1150,6 +1150,14 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         if matches!(state.status, BindingStatus::Terminal(_)) {
             return;
         }
+        debug_assert!(
+            state.kind.is_some(),
+            "mailbox must be configured before its first bind"
+        );
+        debug_assert!(
+            matches!(state.status, BindingStatus::Unbound),
+            "mailbox must close the prior incarnation before rebinding"
+        );
         state.status = BindingStatus::Bound(incarnation);
         state.last_bound = Some(incarnation);
         // Binding is an observation edge for every operation that remained
@@ -1863,6 +1871,22 @@ mod tests {
     fn park_with(future: &mut std::pin::Pin<Box<super::SendFuture<u8>>>, waker: &Waker) {
         let mut context = Context::from_waker(waker);
         assert!(future.as_mut().poll(&mut context).is_pending());
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "mailbox must be configured before its first bind")]
+    fn binding_before_configuration_trips_the_driver_contract() {
+        let (mailbox, _) = actor();
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let membership = identity
+            .mint_membership(&ChildId::from("actor"))
+            .expect("membership available");
+        let mut incarnations = identity.incarnation_counter(membership);
+        let incarnation = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
+            .expect("incarnation available");
+
+        MailboxControl::bind(&*mailbox, incarnation);
     }
 
     #[test]

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -16,7 +16,7 @@ use std::{
 use crate::{
     ChildId, Incarnation, Mailbox, Membership,
     cells::{MailboxControl, MailboxDisposal, MailboxStats, MailboxTermination, MemberCell},
-    runtime::{OneShotReceiver, OneShotSender, Signal, SignalWatcher},
+    runtime::{OneShotClose, OneShotReceiver, OneShotSender, Signal, SignalWatcher},
 };
 
 /// The kind of a failed actor send.
@@ -173,9 +173,11 @@ trait DeadlineOperation {
 
     /// Polls the operation before or after the shared deadline transition.
     ///
-    /// An elapsed poll must resolve. It is a second operation poll after the
-    /// timer becomes ready so completion or acceptance at the exact boundary
-    /// wins before operation-specific timeout cleanup runs.
+    /// This is a second operation poll after the timer becomes ready so
+    /// completion or acceptance at the exact boundary wins before
+    /// operation-specific timeout cleanup runs. It may remain pending only
+    /// when an atomic completion transition won but has not published its
+    /// payload yet; that transition must wake the registered operation waker.
     fn poll_deadlined(
         &mut self,
         context: &mut Context<'_>,
@@ -225,7 +227,6 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             .expect("a started deadline future retains its captured budget");
         if this.duration.is_zero() {
             let result = this.operation.poll_deadlined(context, budget, true);
-            debug_assert!(result.is_ready(), "an elapsed operation must resolve");
             this.done = result.is_ready();
             return result;
         }
@@ -244,7 +245,6 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             return Poll::Pending;
         }
         let result = this.operation.poll_deadlined(context, budget, true);
-        debug_assert!(result.is_ready(), "an elapsed operation must resolve");
         this.done = result.is_ready();
         result
     }
@@ -339,11 +339,12 @@ impl<T> DeadlineOperation for ReplyOperation<T> {
         match self.receiver.poll_receive(context) {
             Poll::Ready(Some(value)) => Poll::Ready(Ok(value)),
             Poll::Ready(None) => Poll::Ready(Err(ReplyError::Dropped)),
-            Poll::Pending if elapsed => Poll::Ready(
-                self.receiver
-                    .close_and_try_receive()
-                    .ok_or(ReplyError::Timeout),
-            ),
+            Poll::Pending if elapsed => match self.receiver.close_and_poll_receive(context) {
+                OneShotClose::Value(value) => Poll::Ready(Ok(value)),
+                OneShotClose::SenderClosed => Poll::Ready(Err(ReplyError::Dropped)),
+                OneShotClose::Empty => Poll::Ready(Err(ReplyError::Timeout)),
+                OneShotClose::Pending => Poll::Pending,
+            },
             Poll::Pending => Poll::Pending,
         }
     }
@@ -1570,24 +1571,27 @@ impl<M, T> CallOperation<M, T> {
                 incarnation_observed: Some(incarnation),
                 kind: CallErrorKind::ReplyDropped,
             })),
-            Poll::Pending if deadline_elapsed => {
-                if let Some(value) = reply.close_and_try_receive() {
-                    Poll::Ready(Ok(Replied { value, incarnation }))
-                } else {
-                    Poll::Ready(Err(CallError {
-                        actor_id: self.actor.id().clone(),
-                        incarnation_observed: Some(incarnation),
-                        kind: CallErrorKind::ResponseTimedOut,
-                    }))
-                }
-            }
+            Poll::Pending if deadline_elapsed => match reply.close_and_poll_receive(context) {
+                OneShotClose::Value(value) => Poll::Ready(Ok(Replied { value, incarnation })),
+                OneShotClose::SenderClosed => Poll::Ready(Err(CallError {
+                    actor_id: self.actor.id().clone(),
+                    incarnation_observed: Some(incarnation),
+                    kind: CallErrorKind::ReplyDropped,
+                })),
+                OneShotClose::Empty => Poll::Ready(Err(CallError {
+                    actor_id: self.actor.id().clone(),
+                    incarnation_observed: Some(incarnation),
+                    kind: CallErrorKind::ResponseTimedOut,
+                })),
+                OneShotClose::Pending => Poll::Pending,
+            },
             Poll::Pending => Poll::Pending,
         }
     }
 
     fn close_reply(&mut self) {
         if let Some(reply) = &mut self.reply {
-            let _ = reply.close_and_try_receive();
+            reply.close();
         }
     }
 }

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1812,7 +1812,7 @@ mod tests {
     }
 
     fn actor() -> (Arc<MailboxCell<u8>>, ActorRef<u8>) {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("actor");
         let member = MemberCell::new(
             id.clone(),
@@ -1833,7 +1833,7 @@ mod tests {
     #[should_panic(expected = "mailbox must be configured before its first bind")]
     fn binding_before_configuration_trips_the_driver_contract() {
         let (mailbox, _) = actor();
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let membership = identity
             .mint_membership(&ChildId::from("actor"))
             .expect("membership available");
@@ -1903,7 +1903,7 @@ mod tests {
         park_with(&mut third, &counting);
         MailboxControl::configure(&*mailbox, Mailbox::default());
         let mut generations = {
-            let mut identity = ScopeIdentity::new().expect("scope identity available");
+            let mut identity = ScopeIdentity::new();
             let membership = identity
                 .mint_membership(&ChildId::from("actor"))
                 .expect("membership available");

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -184,6 +184,13 @@ trait DeadlineOperation {
         budget: crate::deadline::Deadline,
         elapsed: bool,
     ) -> Poll<Self::Output>;
+
+    /// Resolves a zero-width budget without ever attempting the operation.
+    ///
+    /// A zero budget is a short-circuit, not a raced deadline: nothing is
+    /// submitted and no completion is observed, so this reports the
+    /// operation's timeout outcome and performs only its own cleanup.
+    fn short_circuit(&mut self) -> Self::Output;
 }
 
 /// First-poll deadline capture shared by every public mailbox deadline future.
@@ -193,6 +200,7 @@ struct Deadlined<F> {
     budget: Option<crate::deadline::Deadline>,
     timer: Option<crate::runtime::BoxedSleep>,
     started: bool,
+    elapsed: bool,
     done: bool,
 }
 
@@ -204,6 +212,7 @@ impl<F> Deadlined<F> {
             budget: None,
             timer: None,
             started: false,
+            elapsed: false,
             done: false,
         }
     }
@@ -222,27 +231,37 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
                 this.timer = Some(crate::runtime::sleep_deadline(budget));
             }
         }
+        // A zero budget short-circuits: the operation is never attempted, so
+        // nothing is submitted and no completion is observed. The expiry
+        // boundary below governs only non-zero budgets, and the two rules
+        // therefore never compete.
+        if this.duration.is_zero() {
+            this.done = true;
+            return Poll::Ready(this.operation.short_circuit());
+        }
         let budget = this
             .budget
             .expect("a started deadline future retains its captured budget");
-        if this.duration.is_zero() {
-            let result = this.operation.poll_deadlined(context, budget, true);
-            this.done = result.is_ready();
-            return result;
-        }
         if let Poll::Ready(result) = this.operation.poll_deadlined(context, budget, false) {
             this.done = true;
             return Poll::Ready(result);
         }
-        if this
-            .timer
-            .as_mut()
-            .expect("a non-zero deadline future retains its timer")
-            .as_mut()
-            .poll(context)
-            .is_pending()
-        {
-            return Poll::Pending;
+        if !this.elapsed {
+            if this
+                .timer
+                .as_mut()
+                .expect("an unelapsed deadline future retains its timer")
+                .as_mut()
+                .poll(context)
+                .is_pending()
+            {
+                return Poll::Pending;
+            }
+            // The timer is a one-shot future: polling it again after it
+            // resolves panics. Latch the transition and release it, so an
+            // elapsed poll that stays pending re-polls only the operation.
+            this.elapsed = true;
+            this.timer = None;
         }
         let result = this.operation.poll_deadlined(context, budget, true);
         this.done = result.is_ready();
@@ -347,6 +366,11 @@ impl<T> DeadlineOperation for ReplyOperation<T> {
             },
             Poll::Pending => Poll::Pending,
         }
+    }
+
+    fn short_circuit(&mut self) -> Self::Output {
+        self.receiver.close();
+        Err(ReplyError::Timeout)
     }
 }
 
@@ -1518,6 +1542,13 @@ impl<M: Send + 'static> DeadlineOperation for TimedSend<M> {
             Poll::Ready(withdraw_send(&mut self.send))
         }
     }
+
+    fn short_circuit(&mut self) -> Self::Output {
+        // The send was never polled, so it was never submitted: withdrawal
+        // recovers the message and reports the mailbox's current binding as
+        // the newest incarnation observed during the attempt.
+        withdraw_send(&mut self.send)
+    }
 }
 
 impl<M: Send + 'static> Future for SendTimeout<M> {
@@ -1607,11 +1638,7 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
     ) -> Poll<Self::Output> {
         if self.make_msg.is_some() {
             if elapsed {
-                return Poll::Ready(Err(CallError {
-                    actor_id: self.actor.id().clone(),
-                    incarnation_observed: self.actor.mailbox.current_observation(),
-                    kind: CallErrorKind::AcceptanceTimedOut,
-                }));
+                return Poll::Ready(self.short_circuit());
             }
             // Capture the one overall budget before invoking user code. A
             // slow message constructor consumes acceptance/response time. The
@@ -1626,11 +1653,7 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
             // existed before it completed, so do not start one after the
             // captured budget is strictly in the past.
             if budget.is_overdue(crate::runtime::now()) {
-                return Poll::Ready(Err(CallError {
-                    actor_id: self.actor.id().clone(),
-                    incarnation_observed: self.actor.mailbox.current_observation(),
-                    kind: CallErrorKind::AcceptanceTimedOut,
-                }));
+                return Poll::Ready(self.short_circuit());
             }
             self.reply = receiver.receiver.take();
             self.send = Some(self.actor.send(message));
@@ -1658,10 +1681,13 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
             }
         }
 
-        if let Some(accepted) = self.accepted
-            && let Poll::Ready(result) = self.poll_reply(context, accepted, elapsed)
-        {
-            return Poll::Ready(result);
+        // Acceptance released the send future, so the reply is the only
+        // remaining source of an outcome. An elapsed reply poll may still be
+        // pending when a completion transition won without publishing its
+        // payload yet; that transition wakes the registered waker, so waiting
+        // is the answer rather than reaching for a send that no longer exists.
+        if let Some(accepted) = self.accepted {
+            return self.poll_reply(context, accepted, elapsed);
         }
 
         if !elapsed {
@@ -1694,6 +1720,16 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
                 }))
             }
         }
+    }
+
+    fn short_circuit(&mut self) -> Self::Output {
+        // No message was ever constructed, so there is nothing to withdraw
+        // and no accepting incarnation to report.
+        Err(CallError {
+            actor_id: self.actor.id().clone(),
+            incarnation_observed: self.actor.mailbox.current_observation(),
+            kind: CallErrorKind::AcceptanceTimedOut,
+        })
     }
 }
 
@@ -2026,6 +2062,73 @@ mod tests {
             }))
             .is_err(),
             "the exhausted domain stays poisoned"
+        );
+    }
+
+    /// Stays pending on its first elapsed poll, modelling an atomic
+    /// completion transition that won without publishing its payload yet.
+    #[derive(Default)]
+    struct PendingOnFirstExpiry {
+        elapsed_polls: usize,
+    }
+
+    impl super::DeadlineOperation for PendingOnFirstExpiry {
+        type Output = usize;
+
+        fn poll_deadlined(
+            &mut self,
+            _context: &mut Context<'_>,
+            _budget: crate::deadline::Deadline,
+            elapsed: bool,
+        ) -> Poll<usize> {
+            if !elapsed {
+                return Poll::Pending;
+            }
+            self.elapsed_polls += 1;
+            if self.elapsed_polls < 2 {
+                Poll::Pending
+            } else {
+                Poll::Ready(self.elapsed_polls)
+            }
+        }
+
+        fn short_circuit(&mut self) -> usize {
+            0
+        }
+    }
+
+    #[crate::runtime::test(start_paused = true)]
+    async fn an_expired_deadline_future_never_repolls_its_resolved_timer() {
+        let width = std::time::Duration::from_secs(1);
+        let mut future = Box::pin(super::Deadlined::new(
+            PendingOnFirstExpiry::default(),
+            width,
+        ));
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+
+        assert!(future.as_mut().poll(&mut context).is_pending());
+        crate::runtime::advance(width * 2).await;
+        // The timer resolves here and the operation stays pending, so the
+        // scaffold must latch the expiry rather than poll the timer again.
+        assert!(future.as_mut().poll(&mut context).is_pending());
+
+        assert!(matches!(future.as_mut().poll(&mut context), Poll::Ready(2)));
+    }
+
+    #[test]
+    fn a_zero_budget_short_circuits_without_polling_the_operation() {
+        let mut future = Box::pin(super::Deadlined::new(
+            PendingOnFirstExpiry::default(),
+            std::time::Duration::ZERO,
+        ));
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+
+        assert!(matches!(future.as_mut().poll(&mut context), Poll::Ready(0)));
+        assert_eq!(
+            future.operation.elapsed_polls, 0,
+            "a zero budget never attempts the operation"
         );
     }
 }

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -6,7 +6,6 @@ use std::{
     future::Future,
     hash::{Hash, Hasher},
     num::NonZeroUsize,
-    panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll, Waker},
@@ -15,8 +14,11 @@ use std::{
 
 use crate::{
     ChildId, Incarnation, Mailbox, Membership,
-    cells::{MailboxControl, MailboxDisposal, MailboxStats, MailboxTermination, MemberCell},
-    runtime::{OneShotClose, OneShotReceiver, OneShotSender, Signal, SignalWatcher},
+    cells::{MailboxControl, MailboxDisposal, MailboxTermination, MemberCell},
+    runtime::{
+        OneShotClose, OneShotReceiver, OneShotSender, PanicAccumulator, PanicPayload, Signal,
+        SignalWatcher, resume_panic,
+    },
 };
 
 /// The kind of a failed actor send.
@@ -528,9 +530,6 @@ struct MailboxState<M> {
     latest: Option<Envelope<M>>,
     waiters: WaiterQueue<M>,
     accepted: u64,
-    delivered: u64,
-    conflated: u64,
-    sends_rejected: u64,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -630,6 +629,9 @@ impl<M: Send + 'static> Default for Promotion<M> {
 }
 
 impl<M: Send + 'static> Promotion<M> {
+    // Drop is the completion path on every ownership edge. `finish` only
+    // names the intentional consume point; its Drop still wakes all accepted
+    // senders and isolates every displaced-message destructor.
     fn finish(self) {}
 
     fn finish_isolated(mut self) {
@@ -647,24 +649,12 @@ impl<M: Send + 'static> Promotion<M> {
 
 impl<M: Send + 'static> Drop for Promotion<M> {
     fn drop(&mut self) {
-        let already_panicking = std::thread::panicking();
-        let mut first_panic = None;
+        let mut panics = PanicAccumulator::default();
         for waker in self.wakers.drain(..) {
-            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| waker.wake()))
-                && first_panic.is_none()
-            {
-                first_panic = Some(payload);
-            }
+            panics.run(|| waker.wake());
         }
         for displaced in self.displaced.drain(..) {
-            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| drop(displaced)))
-                && first_panic.is_none()
-            {
-                first_panic = Some(payload);
-            }
-        }
-        if !already_panicking && let Some(payload) = first_panic {
-            resume_unwind(payload);
+            panics.run(|| drop(displaced));
         }
     }
 }
@@ -675,25 +665,19 @@ struct Termination<M> {
 }
 
 impl<M> Termination<M> {
-    fn finish(
-        &mut self,
-        retired: &mut Vec<Arc<SendOperation<M>>>,
-    ) -> Option<Box<dyn std::any::Any + Send + 'static>> {
-        let mut first_panic = None;
+    fn finish(&mut self, retired: &mut Vec<Arc<SendOperation<M>>>) -> Option<PanicPayload> {
+        let mut panics = PanicAccumulator::default();
         let final_incarnation = self.final_incarnation;
         while let Some((registration, waiter)) = self.waiters.pop_front() {
             waiter.clear_registration(registration);
-            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| {
+            panics.run(|| {
                 waiter.terminate(final_incarnation);
-            })) && first_panic.is_none()
-            {
-                first_panic = Some(payload);
-            }
+            });
             // A withdrawn sender may leave this as the final operation owner,
             // so retain it for the same isolated path as unread messages.
             retired.push(waiter);
         }
-        first_panic
+        panics.take()
     }
 }
 
@@ -705,37 +689,20 @@ struct MailboxPayload<M> {
 
 impl<M> Drop for MailboxPayload<M> {
     fn drop(&mut self) {
-        let already_panicking = std::thread::panicking();
-        let mut first_panic = None;
+        let mut panics = PanicAccumulator::default();
         if let Some(mut queue) = self.queue.take() {
             while let Some(envelope) = queue.pop_front() {
-                if let Err(payload) = catch_unwind(AssertUnwindSafe(|| drop(envelope)))
-                    && first_panic.is_none()
-                {
-                    first_panic = Some(payload);
-                }
+                panics.run(|| drop(envelope));
             }
         }
-        if let Some(latest) = self.latest.take()
-            && let Err(payload) = catch_unwind(AssertUnwindSafe(|| drop(latest)))
-            && first_panic.is_none()
-        {
-            first_panic = Some(payload);
+        if let Some(latest) = self.latest.take() {
+            panics.run(|| drop(latest));
         }
         for waiter in self.retired.drain(..) {
-            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| drop(waiter)))
-                && first_panic.is_none()
-            {
-                first_panic = Some(payload);
-            }
-        }
-        if !already_panicking && let Some(payload) = first_panic {
-            resume_unwind(payload);
+            panics.run(|| drop(waiter));
         }
     }
 }
-
-impl<M: Send> MailboxDisposal for MailboxPayload<M> {}
 
 struct MailboxTeardown<M: Send + 'static> {
     changed: Option<Signal>,
@@ -744,35 +711,30 @@ struct MailboxTeardown<M: Send + 'static> {
 }
 
 impl<M: Send + 'static> MailboxTeardown<M> {
-    fn finish_framework(&mut self) -> Option<Box<dyn std::any::Any + Send + 'static>> {
-        let mut first_panic = None;
-        if let Some(changed) = self.changed.take()
-            && let Err(payload) = catch_unwind(AssertUnwindSafe(|| changed.pulse()))
-        {
-            first_panic = Some(payload);
+    fn finish_framework(&mut self) -> Option<PanicPayload> {
+        let mut panics = PanicAccumulator::default();
+        if let Some(changed) = self.changed.take() {
+            panics.run(|| changed.pulse());
         }
         if let Some(mut termination) = self.termination.take() {
-            let panic = termination.finish(&mut self.payload.get_mut().retired);
-            if first_panic.is_none() {
-                first_panic = panic;
-            }
+            panics.record(termination.finish(&mut self.payload.get_mut().retired));
         }
-        first_panic
+        panics.take()
     }
 }
 
 impl<M: Send + 'static> MailboxTermination for MailboxTeardown<M> {
-    fn finish(mut self: Box<Self>) -> Option<Box<dyn MailboxDisposal>> {
+    fn finish(mut self: Box<Self>) -> Option<MailboxDisposal> {
         let panic = self.finish_framework();
         let payload = self
             .payload
             .take()
-            .map(|payload| Box::new(payload) as Box<dyn MailboxDisposal>);
+            .map(|payload| Box::new(payload) as MailboxDisposal);
         if let Some(panic) = panic {
             if let Some(payload) = payload {
                 crate::runtime::dispose_detached(payload);
             }
-            resume_unwind(panic);
+            resume_panic(panic);
         }
         payload
     }
@@ -780,13 +742,10 @@ impl<M: Send + 'static> MailboxTermination for MailboxTeardown<M> {
 
 impl<M: Send + 'static> Drop for MailboxTeardown<M> {
     fn drop(&mut self) {
-        let already_panicking = std::thread::panicking();
-        let panic = self.finish_framework();
+        let mut panics = PanicAccumulator::default();
+        panics.record(self.finish_framework());
         if let Some(payload) = self.payload.take() {
             crate::runtime::dispose_detached(payload);
-        }
-        if !already_panicking && let Some(panic) = panic {
-            resume_unwind(panic);
         }
     }
 }
@@ -818,9 +777,6 @@ impl<M: Send + 'static> MailboxCell<M> {
                 latest: None,
                 waiters: WaiterQueue::default(),
                 accepted: 0,
-                delivered: 0,
-                conflated: 0,
-                sends_rejected: 0,
             }),
             changed: Signal::default(),
         })
@@ -856,16 +812,10 @@ impl<M: Send + 'static> MailboxCell<M> {
                             });
                             None
                         }
-                        Some(MailboxKind::Latest) => {
-                            let displaced = state.latest.replace(Envelope {
-                                message,
-                                accepted_sequence,
-                            });
-                            state.conflated = state
-                                .conflated
-                                .saturating_add(u64::from(displaced.is_some()));
-                            displaced
-                        }
+                        Some(MailboxKind::Latest) => state.latest.replace(Envelope {
+                            message,
+                            accepted_sequence,
+                        }),
                         None => unreachable!(),
                     };
                     drop(state);
@@ -889,38 +839,28 @@ impl<M: Send + 'static> MailboxCell<M> {
     fn try_send(&self, message: M) -> Result<Incarnation, SendError<M>> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         match state.status {
-            BindingStatus::Terminal(final_incarnation) => {
-                state.sends_rejected = state.sends_rejected.saturating_add(1);
-                Err(SendError {
-                    actor_id: self.actor_id.clone(),
-                    incarnation_observed: final_incarnation,
-                    message,
-                    kind: SendErrorKind::Terminated,
-                })
-            }
-            BindingStatus::Unbound => {
-                state.sends_rejected = state.sends_rejected.saturating_add(1);
-                Err(SendError {
-                    actor_id: self.actor_id.clone(),
-                    incarnation_observed: None,
-                    message,
-                    kind: SendErrorKind::NotRunning,
-                })
-            }
-            BindingStatus::Frozen(incarnation) => {
-                state.sends_rejected = state.sends_rejected.saturating_add(1);
-                Err(SendError {
-                    actor_id: self.actor_id.clone(),
-                    incarnation_observed: Some(incarnation),
-                    message,
-                    kind: SendErrorKind::NotRunning,
-                })
-            }
+            BindingStatus::Terminal(final_incarnation) => Err(SendError {
+                actor_id: self.actor_id.clone(),
+                incarnation_observed: final_incarnation,
+                message,
+                kind: SendErrorKind::Terminated,
+            }),
+            BindingStatus::Unbound => Err(SendError {
+                actor_id: self.actor_id.clone(),
+                incarnation_observed: None,
+                message,
+                kind: SendErrorKind::NotRunning,
+            }),
+            BindingStatus::Frozen(incarnation) => Err(SendError {
+                actor_id: self.actor_id.clone(),
+                incarnation_observed: Some(incarnation),
+                message,
+                kind: SendErrorKind::NotRunning,
+            }),
             BindingStatus::Bound(incarnation) => match state.kind {
                 Some(MailboxKind::Queue(capacity))
                     if !state.waiters.is_empty() || state.queue.len() >= capacity.get() =>
                 {
-                    state.sends_rejected = state.sends_rejected.saturating_add(1);
                     Err(SendError {
                         actor_id: self.actor_id.clone(),
                         incarnation_observed: Some(incarnation),
@@ -946,23 +886,17 @@ impl<M: Send + 'static> MailboxCell<M> {
                         message,
                         accepted_sequence,
                     });
-                    state.conflated = state
-                        .conflated
-                        .saturating_add(u64::from(displaced.is_some()));
                     drop(state);
                     self.changed.pulse();
                     drop(displaced);
                     Ok(incarnation)
                 }
-                None => {
-                    state.sends_rejected = state.sends_rejected.saturating_add(1);
-                    Err(SendError {
-                        actor_id: self.actor_id.clone(),
-                        incarnation_observed: None,
-                        message,
-                        kind: SendErrorKind::NotRunning,
-                    })
-                }
+                None => Err(SendError {
+                    actor_id: self.actor_id.clone(),
+                    incarnation_observed: None,
+                    message,
+                    kind: SendErrorKind::NotRunning,
+                }),
             },
         }
     }
@@ -1008,7 +942,6 @@ impl<M: Send + 'static> MailboxCell<M> {
         } else {
             Promotion::default()
         };
-        state.delivered = state.delivered.saturating_add(u64::from(message.is_some()));
         drop(state);
         if message.is_some() {
             self.changed.pulse();
@@ -1030,21 +963,8 @@ impl<M: Send + 'static> MailboxCell<M> {
         self.changed.watcher()
     }
 
-    pub(crate) fn stats(&self) -> MailboxStats {
-        let state = self.state.lock().expect("mailbox mutex poisoned");
-        let (depth, capacity) = match state.kind {
-            Some(MailboxKind::Queue(capacity)) => (state.queue.len(), capacity.get()),
-            Some(MailboxKind::Latest) => (usize::from(state.latest.is_some()), 1),
-            None => (0, 0),
-        };
-        MailboxStats {
-            accepted: state.accepted,
-            delivered: state.delivered,
-            conflated: state.conflated,
-            sends_rejected: state.sends_rejected,
-            depth,
-            capacity,
-        }
+    fn accepted_sequence(&self) -> u64 {
+        self.state.lock().expect("mailbox mutex poisoned").accepted
     }
 }
 
@@ -1168,7 +1088,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         }
     }
 
-    fn close(&self, incarnation: Incarnation) -> Option<Box<dyn MailboxDisposal>> {
+    fn close(&self, incarnation: Incarnation) -> Option<MailboxDisposal> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         if !matches!(
             state.status,
@@ -1186,7 +1106,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             queue: Some(queue),
             latest,
             retired: Vec::new(),
-        }))
+        }) as MailboxDisposal)
     }
 
     fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>> {
@@ -1215,8 +1135,14 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         }))
     }
 
-    fn stats(&self) -> MailboxStats {
-        self.stats()
+    #[cfg(debug_assertions)]
+    fn bind_order_valid(&self) -> bool {
+        let state = self.state.lock().expect("mailbox mutex poisoned");
+        state.kind.is_some()
+            && matches!(
+                state.status,
+                BindingStatus::Unbound | BindingStatus::Terminal(_)
+            )
     }
 }
 
@@ -1257,7 +1183,6 @@ fn promote_waiters<M: Send + 'static>(state: &mut MailboxState<M>) -> Promotion<
                     message,
                     accepted_sequence,
                 }) {
-                    state.conflated = state.conflated.saturating_add(1);
                     promotion.displaced.push(displaced);
                 }
             }
@@ -1771,7 +1696,7 @@ impl<M: Send + 'static> MailboxReceiver<M> {
     }
 
     pub(crate) fn accepted_sequence(&self) -> u64 {
-        self.mailbox.stats().accepted
+        self.mailbox.accepted_sequence()
     }
 
     pub(crate) async fn changed(&mut self) {
@@ -1842,6 +1767,26 @@ mod tests {
             .expect("incarnation available");
 
         MailboxControl::bind(&*mailbox, incarnation);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "mailbox must close the prior incarnation before rebinding")]
+    fn rebinding_before_close_trips_the_driver_contract() {
+        let (mailbox, _) = actor();
+        MailboxControl::configure(&*mailbox, Mailbox::default());
+        let mut identity = ScopeIdentity::new();
+        let membership = identity
+            .mint_membership(&ChildId::from("actor"))
+            .expect("membership available");
+        let mut incarnations = identity.incarnation_counter(membership);
+        let first = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
+            .expect("first incarnation available");
+        let second = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
+            .expect("second incarnation available");
+
+        MailboxControl::bind(&*mailbox, first);
+        MailboxControl::bind(&*mailbox, second);
     }
 
     #[test]

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -14,6 +14,11 @@ use crate::{
 /// Number of lifecycle events retained independently for each subscriber.
 pub const LIFECYCLE_EVENT_CAPACITY: usize = 128;
 
+// Tokio rounds broadcast capacity up to a power of two. `try_recv` compares
+// receiver length with this requested capacity and therefore requires the
+// requested and effective capacities to remain equal.
+const _: () = assert!(LIFECYCLE_EVENT_CAPACITY.is_power_of_two());
+
 /// One item read from a lifecycle subscription.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use crate::{
-    ChildId, Exit, Incarnation, Intensity, Membership, RestartPolicy, Retention, StopReason,
-    Strategy, runtime,
+    ChildId, Exit, Incarnation, Intensity, Membership, RestartPolicy, Retention, Strategy,
+    exit::StopReason, runtime,
 };
 
 /// Number of lifecycle events retained independently for each subscriber.

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -607,7 +607,7 @@ mod tests {
 
     #[test]
     fn a_retained_event_after_explicit_lag_remains_subject_to_later_overflow() {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let membership = identity
             .mint_membership(&crate::ChildId::from("scope"))
             .expect("membership available");

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -355,7 +355,13 @@ impl BuilderCore {
         }
         root.set_observation_config(self.config.strategy, self.config.intensity);
         let mut children = Vec::with_capacity(self.slots.len());
+        debug_assert_eq!(
+            self.slots.len(),
+            resolved.len(),
+            "policy resolution is one entry per slot, in slot order"
+        );
         for (slot, resolved) in self.slots.iter().zip(resolved) {
+            let resolved = resolved.expect("validated slot must have resolved options");
             let definition = slot
                 .take_definition()
                 .expect("validated slot must have a definition");
@@ -378,17 +384,18 @@ impl BuilderCore {
     fn validate_policies(
         &self,
         inherited: &ResolvedDefaults,
-    ) -> Result<(ResolvedDefaults, Vec<ResolvedCommonOptions>), InvalidPolicy> {
+    ) -> Result<(ResolvedDefaults, Vec<Option<ResolvedCommonOptions>>), InvalidPolicy> {
         self.config
             .intensity
             .validate()
             .map_err(|error| InvalidPolicy::new(PolicyField::Intensity, error))?;
         let defaults = inherited.overlay(&self.config.defaults)?;
+        // One entry per slot, in slot order. An undefined slot resolves to
+        // `None` rather than being skipped, so this vector can never shift a
+        // later child onto another child's options.
         let mut resolved = Vec::with_capacity(self.slots.len());
         for slot in &self.slots {
-            if let Some(options) = slot.resolve_policy(&defaults)? {
-                resolved.push(options);
-            }
+            resolved.push(slot.resolve_policy(&defaults)?);
         }
         Ok((defaults, resolved))
     }

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -19,10 +19,13 @@ use crate::{
     task::{OnceTask, TaskDef},
 };
 
-/// A declaration-time reservation error.
+/// A child reservation or dynamic admission error.
 #[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
 #[non_exhaustive]
 pub enum ReserveError {
+    /// No ambient supported async runtime exists.
+    #[error("no ambient Tokio runtime is available")]
+    NoRuntime,
     /// The child id was empty.
     #[error("child id must not be empty")]
     EmptyId,

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -162,6 +162,25 @@ impl SlotCell {
             DefinitionState::Lowered => None,
         }
     }
+
+    /// Publishes the canonical never-started terminal state for this slot.
+    ///
+    /// Member terminality closes any mailbox before the nested scope closes
+    /// its observation surfaces. Every static and dynamic path uses this
+    /// method so those edges cannot drift independently.
+    pub(crate) fn terminalize_never_started(&self) {
+        self.member.terminalize(Exit::never_started());
+        if let Some(scope) = &self.scope {
+            scope.terminalize_never_started();
+        }
+    }
+
+    /// Claims an unlowered definition and publishes never-started terminality.
+    pub(crate) fn take_never_started(&self) -> Option<Isolated<ChildConstruction>> {
+        let definition = self.take_defined();
+        self.terminalize_never_started();
+        definition
+    }
 }
 
 /// Erased declaration storage before inherited defaults and identities are lowered.
@@ -277,10 +296,7 @@ impl BuilderCore {
 
     fn terminalize(&self) {
         for slot in &self.slots {
-            slot.member.terminalize(Exit::never_started());
-            if let Some(scope) = &slot.scope {
-                scope.terminalize_never_started();
-            }
+            slot.terminalize_never_started();
         }
         self.root.terminalize_never_started();
     }
@@ -309,10 +325,7 @@ impl Drop for ScopePlan {
             return;
         }
         for child in &self.children {
-            child.slot.member.terminalize(Exit::never_started());
-            if let Some(scope) = &child.slot.scope {
-                scope.terminalize_never_started();
-            }
+            child.slot.terminalize_never_started();
         }
         // Lowering can publish the planned children before ScopeRuntime takes
         // ownership. If construction then unwinds, the plan fallback also

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -147,7 +147,6 @@ impl SlotCell {
 /// Erased declaration storage before inherited defaults and identities are lowered.
 pub(crate) struct BuilderCore {
     pub(crate) root: Arc<ScopeCell>,
-    pub(crate) flavor: ScopeFlavor,
     pub(crate) config: ScopeConfig,
     pub(crate) slots: Vec<Arc<SlotCell>>,
     ids: HashMap<ChildId, Arc<SlotCell>>,
@@ -177,7 +176,6 @@ impl BuilderCore {
         let root = ScopeCell::new(member, flavor, child_identity);
         Self {
             root,
-            flavor,
             config: ScopeConfig::default(),
             slots: Vec::new(),
             ids: HashMap::new(),
@@ -276,7 +274,6 @@ impl BuilderCore {
         self.armed = false;
         Ok(ScopePlan {
             root,
-            flavor: self.flavor,
             config: self.config.clone(),
             defaults,
             children,
@@ -306,7 +303,6 @@ impl Drop for BuilderCore {
 /// Fully lowered scope plan whose construction payloads still have one owner.
 pub(crate) struct ScopePlan {
     pub(crate) root: Arc<ScopeCell>,
-    pub(crate) flavor: ScopeFlavor,
     pub(crate) config: ScopeConfig,
     pub(crate) defaults: ResolvedDefaults,
     pub(crate) children: Vec<ChildPlan>,

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -11,8 +11,8 @@ use crate::{
     definition::DefinitionSource,
     identity::ScopeIdentity,
     policy::{
-        CommonOptions, IdError, ResolvedCommonOptions, ResolvedDefaults, ScopeFlavor,
-        resolve_common,
+        CommonOptions, IdError, InvalidPolicy, PolicyField, ResolvedCommonOptions,
+        ResolvedDefaults, ScopeFlavor, resolve_common,
     },
     raw::RawConstruction,
     runtime::{self, Isolated, Latch},
@@ -41,6 +41,9 @@ pub enum ReserveError {
     /// The scope can mint no further membership identities.
     #[error("membership identity space is exhausted")]
     IdentityExhausted,
+    /// A public policy representation contained an invalid literal value.
+    #[error(transparent)]
+    InvalidPolicy(InvalidPolicy),
 }
 
 /// Exact reason an admission operation could not proceed.
@@ -184,6 +187,72 @@ impl SlotCell {
         self.terminalize_never_started();
         definition
     }
+
+    pub(crate) fn resolve_policy(
+        &self,
+        defaults: &ResolvedDefaults,
+    ) -> Result<Option<ResolvedCommonOptions>, InvalidPolicy> {
+        let state = self.definition.lock().expect("definition mutex poisoned");
+        let DefinitionState::Defined(definition) = &*state else {
+            return Ok(None);
+        };
+        self.resolve_defined_policy(definition, defaults).map(Some)
+    }
+
+    /// Resolves policy and claims the matching construction under one
+    /// definition lock. Dynamic removal can therefore observe either the
+    /// unclaimed definition or the completed claim, never the gap between
+    /// those operations.
+    pub(crate) fn resolve_and_take_defined(
+        &self,
+        defaults: &ResolvedDefaults,
+    ) -> Result<Option<(Isolated<ChildConstruction>, ResolvedCommonOptions)>, InvalidPolicy> {
+        self.resolve_and_take_defined_with(defaults, || {})
+    }
+
+    fn resolve_and_take_defined_with(
+        &self,
+        defaults: &ResolvedDefaults,
+        before_claim: impl FnOnce(),
+    ) -> Result<Option<(Isolated<ChildConstruction>, ResolvedCommonOptions)>, InvalidPolicy> {
+        let mut state = self.definition.lock().expect("definition mutex poisoned");
+        let DefinitionState::Defined(definition) = &*state else {
+            return Ok(None);
+        };
+        let resolved = self.resolve_defined_policy(definition, defaults)?;
+        before_claim();
+        let DefinitionState::Defined(definition) =
+            std::mem::replace(&mut *state, DefinitionState::Lowered)
+        else {
+            unreachable!("the definition lock keeps resolution and claim atomic")
+        };
+        Ok(Some((definition, resolved)))
+    }
+
+    fn resolve_defined_policy(
+        &self,
+        definition: &Isolated<ChildConstruction>,
+        defaults: &ResolvedDefaults,
+    ) -> Result<ResolvedCommonOptions, InvalidPolicy> {
+        let (options, one_shot) = match definition.get() {
+            ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
+            ChildConstruction::Task(definition) => (&definition.options, false),
+            ChildConstruction::TaskOnce(definition) => (&definition.options, true),
+            ChildConstruction::Scope(definition) => {
+                if let DefinitionSource::OneShot(tree) = &definition.source {
+                    let inherited = match definition.defaults {
+                        DefaultsInheritance::Inherit => defaults.clone(),
+                        DefaultsInheritance::Reset => ResolvedDefaults::default(),
+                    };
+                    tree.validate_policies(&inherited)
+                        .map_err(|invalid| invalid.prepend(self.member.id()))?;
+                }
+                (&definition.options, definition.one_shot())
+            }
+        };
+        resolve_common(options, defaults, one_shot, Readiness::Immediate)
+            .map_err(|invalid| invalid.prepend(self.member.id()))
+    }
 }
 
 /// Erased declaration storage before inherited defaults and identities are lowered.
@@ -258,6 +327,13 @@ impl BuilderCore {
                 disposal,
             });
         }
+        let (defaults, resolved) = match self.validate_policies(&inherited) {
+            Ok(resolved) => resolved,
+            Err(invalid) => {
+                let disposal = self.begin_failed_disposal();
+                return Err(LowerError::InvalidPolicy { invalid, disposal });
+            }
+        };
         if !Arc::ptr_eq(&root, &self.root) {
             let mut identity = root
                 .child_identity
@@ -278,13 +354,16 @@ impl BuilderCore {
             }
         }
         root.set_observation_config(self.config.strategy, self.config.intensity);
-        let defaults = inherited.overlay(&self.config.defaults);
         let mut children = Vec::with_capacity(self.slots.len());
-        for slot in &self.slots {
+        for (slot, resolved) in self.slots.iter().zip(resolved) {
             let definition = slot
                 .take_definition()
                 .expect("validated slot must have a definition");
-            children.push(ChildPlan::resolve(Arc::clone(slot), definition, &defaults));
+            children.push(ChildPlan::with_options(
+                Arc::clone(slot),
+                definition,
+                resolved,
+            ));
         }
         self.armed = false;
         Ok(ScopePlan {
@@ -294,6 +373,24 @@ impl BuilderCore {
             children,
             armed: true,
         })
+    }
+
+    fn validate_policies(
+        &self,
+        inherited: &ResolvedDefaults,
+    ) -> Result<(ResolvedDefaults, Vec<ResolvedCommonOptions>), InvalidPolicy> {
+        self.config
+            .intensity
+            .validate()
+            .map_err(|error| InvalidPolicy::new(PolicyField::Intensity, error))?;
+        let defaults = inherited.overlay(&self.config.defaults)?;
+        let mut resolved = Vec::with_capacity(self.slots.len());
+        for slot in &self.slots {
+            if let Some(options) = slot.resolve_policy(&defaults)? {
+                resolved.push(options);
+            }
+        }
+        Ok((defaults, resolved))
     }
 
     fn terminalize(&self) {
@@ -344,18 +441,11 @@ pub(crate) struct ChildPlan {
 }
 
 impl ChildPlan {
-    pub(crate) fn resolve(
+    pub(crate) fn with_options(
         slot: Arc<SlotCell>,
         construction: Isolated<ChildConstruction>,
-        defaults: &ResolvedDefaults,
+        options: ResolvedCommonOptions,
     ) -> Self {
-        let (options, one_shot) = match construction.get() {
-            ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
-            ChildConstruction::Task(definition) => (&definition.options, false),
-            ChildConstruction::TaskOnce(definition) => (&definition.options, true),
-            ChildConstruction::Scope(definition) => (&definition.options, definition.one_shot()),
-        };
-        let options = resolve_common(options, defaults, one_shot, Readiness::Immediate);
         slot.member.set_options(options.clone());
         Self {
             slot,
@@ -373,6 +463,10 @@ pub(crate) enum LowerError {
     },
     IdentityExhausted {
         id: ChildId,
+        disposal: Latch,
+    },
+    InvalidPolicy {
+        invalid: InvalidPolicy,
         disposal: Latch,
     },
 }
@@ -410,7 +504,7 @@ pub(crate) fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError
 mod tests {
     use std::{
         sync::{
-            Arc,
+            Arc, Barrier,
             atomic::{AtomicBool, Ordering},
         },
         time::Duration,
@@ -420,7 +514,7 @@ mod tests {
         Backoff, ExitError, Readiness, RestartCondition, RestartPolicy, Retention, Shutdown,
         TaskOnceDef,
         policy::{ResolvedDefaults, ScopeFlavor},
-        runtime::{self, Isolated, Timeout},
+        runtime::{self, Timeout},
         task::TaskDef,
     };
 
@@ -454,13 +548,54 @@ mod tests {
         let dynamic_slot = admission
             .reserve("dynamic", None)
             .expect("dynamic reservation succeeds");
-        let dynamic_plan = ChildPlan::resolve(
-            dynamic_slot,
-            Isolated::new(ChildConstruction::Task(configured_task())),
-            &defaults,
-        );
+        dynamic_slot.define(ChildConstruction::Task(configured_task()));
+        let dynamic_options = dynamic_slot
+            .resolve_policy(&defaults)
+            .expect("dynamic policy is valid")
+            .expect("dynamic slot is defined");
+        let dynamic_definition = dynamic_slot
+            .take_definition()
+            .expect("dynamic slot remains claimable");
+        let dynamic_plan =
+            ChildPlan::with_options(dynamic_slot, dynamic_definition, dynamic_options);
 
         assert_eq!(static_plan.children[0].options, dynamic_plan.options);
+    }
+
+    #[test]
+    fn dynamic_policy_resolution_and_definition_claim_are_atomic() {
+        let defaults = ResolvedDefaults::default();
+        let mut declaration = BuilderCore::new(ScopeFlavor::Dynamic);
+        let slot = declaration
+            .reserve("dynamic", None)
+            .expect("dynamic reservation succeeds");
+        slot.define(ChildConstruction::Task(configured_task()));
+
+        let race = Arc::new(Barrier::new(2));
+        let competing_slot = Arc::clone(&slot);
+        let competing_race = Arc::clone(&race);
+        let competing_claim = std::thread::spawn(move || {
+            competing_race.wait();
+            competing_slot.take_defined()
+        });
+
+        let claim = slot
+            .resolve_and_take_defined_with(&defaults, || {
+                // The competing remover is released only after resolution,
+                // while this method still owns the definition lock.
+                race.wait();
+                std::thread::yield_now();
+            })
+            .expect("dynamic policy is valid")
+            .expect("admission claims the defined construction");
+        assert!(
+            competing_claim
+                .join()
+                .expect("competing claim thread does not panic")
+                .is_none(),
+            "removal cannot claim between policy resolution and admission"
+        );
+        drop(claim);
     }
 
     struct DropFlag(Arc<AtomicBool>);
@@ -485,12 +620,16 @@ mod tests {
         let slot = declaration
             .reserve("one-shot", None)
             .expect("reservation succeeds");
-
-        let plan = ChildPlan::resolve(
-            slot,
-            Isolated::new(ChildConstruction::TaskOnce(construction)),
-            &ResolvedDefaults::default(),
-        );
+        slot.define(ChildConstruction::TaskOnce(construction));
+        let defaults = ResolvedDefaults::default();
+        let options = slot
+            .resolve_policy(&defaults)
+            .expect("one-shot policy is valid")
+            .expect("one-shot slot is defined");
+        let construction = slot
+            .take_definition()
+            .expect("one-shot slot remains claimable");
+        let plan = ChildPlan::with_options(slot, construction, options);
         assert!(plan.options.restart.is_never());
         assert_eq!(plan.options.retention, Retention::Remove);
         assert!(!dropped.load(Ordering::SeqCst));

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -110,6 +110,9 @@ enum DefinitionState {
     Lowered,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct DefinitionAlreadyLowered;
+
 /// Stable declaration slot joining identity, observation, and owned construction.
 pub(crate) struct SlotCell {
     pub(crate) member: Arc<MemberCell>,
@@ -145,27 +148,17 @@ impl SlotCell {
         )
     }
 
-    pub(crate) fn take_definition(&self) -> Option<Isolated<ChildConstruction>> {
+    pub(crate) fn take_definition(
+        &self,
+    ) -> Result<Option<Isolated<ChildConstruction>>, DefinitionAlreadyLowered> {
         let mut state = self.definition.lock().expect("definition mutex poisoned");
         match std::mem::replace(&mut *state, DefinitionState::Lowered) {
-            DefinitionState::Defined(definition) => Some(definition),
+            DefinitionState::Defined(definition) => Ok(Some(definition)),
             DefinitionState::Undefined => {
                 *state = DefinitionState::Undefined;
-                None
+                Ok(None)
             }
-            DefinitionState::Lowered => panic!("a tree was lowered more than once"),
-        }
-    }
-
-    pub(crate) fn take_defined(&self) -> Option<Isolated<ChildConstruction>> {
-        let mut state = self.definition.lock().expect("definition mutex poisoned");
-        match std::mem::replace(&mut *state, DefinitionState::Lowered) {
-            DefinitionState::Defined(definition) => Some(definition),
-            DefinitionState::Undefined => {
-                *state = DefinitionState::Undefined;
-                None
-            }
-            DefinitionState::Lowered => None,
+            DefinitionState::Lowered => Err(DefinitionAlreadyLowered),
         }
     }
 
@@ -183,7 +176,7 @@ impl SlotCell {
 
     /// Claims an unlowered definition and publishes never-started terminality.
     pub(crate) fn take_never_started(&self) -> Option<Isolated<ChildConstruction>> {
-        let definition = self.take_defined();
+        let definition = self.take_definition().ok().flatten();
         self.terminalize_never_started();
         definition
     }
@@ -269,7 +262,7 @@ impl BuilderCore {
         let definitions = self
             .slots
             .iter()
-            .filter_map(|slot| slot.take_defined())
+            .filter_map(|slot| slot.take_definition().ok().flatten())
             .filter_map(|mut definition| definition.take())
             .collect();
         runtime::dispose_all(definitions)
@@ -364,6 +357,7 @@ impl BuilderCore {
             let resolved = resolved.expect("validated slot must have resolved options");
             let definition = slot
                 .take_definition()
+                .expect("a tree must be lowered at most once")
                 .expect("validated slot must have a definition");
             children.push(ChildPlan::with_options(
                 Arc::clone(slot),
@@ -562,6 +556,7 @@ mod tests {
             .expect("dynamic slot is defined");
         let dynamic_definition = dynamic_slot
             .take_definition()
+            .expect("dynamic slot must not already be lowered")
             .expect("dynamic slot remains claimable");
         let dynamic_plan =
             ChildPlan::with_options(dynamic_slot, dynamic_definition, dynamic_options);
@@ -583,7 +578,7 @@ mod tests {
         let competing_race = Arc::clone(&race);
         let competing_claim = std::thread::spawn(move || {
             competing_race.wait();
-            competing_slot.take_defined()
+            competing_slot.take_definition().ok().flatten()
         });
 
         let claim = slot
@@ -635,6 +630,7 @@ mod tests {
             .expect("one-shot slot is defined");
         let construction = slot
             .take_definition()
+            .expect("one-shot slot must not already be lowered")
             .expect("one-shot slot remains claimable");
         let plan = ChildPlan::with_options(slot, construction, options);
         assert!(plan.options.restart.is_never());

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -8,6 +8,7 @@ use std::{
 use crate::{
     ChildId, DefaultsInheritance, Exit, Intensity, Readiness, ScopeDefaults, Strategy,
     cells::{MemberCell, ScopeCell},
+    definition::DefinitionSource,
     identity::ScopeIdentity,
     policy::{
         CommonOptions, IdError, ResolvedCommonOptions, ResolvedDefaults, ScopeFlavor,
@@ -347,7 +348,7 @@ pub(crate) enum LowerError {
 }
 
 pub(crate) struct ScopeConstruction {
-    pub(crate) source: ScopeSource,
+    pub(crate) source: DefinitionSource<ScopeFactory, Box<BuilderCore>>,
     pub(crate) options: CommonOptions,
     pub(crate) defaults: DefaultsInheritance,
 }
@@ -356,14 +357,16 @@ pub(crate) type ScopeFactory = Arc<dyn Fn() -> BuilderCore + Send + Sync + 'stat
 
 impl ScopeConstruction {
     pub(crate) fn one_shot(&self) -> bool {
-        matches!(self.source, ScopeSource::OneShot(_) | ScopeSource::Spent)
+        self.source.is_one_shot()
     }
-}
 
-pub(crate) enum ScopeSource {
-    Restartable(ScopeFactory),
-    OneShot(Box<BuilderCore>),
-    Spent,
+    pub(crate) fn restartable(&self) -> Option<&ScopeFactory> {
+        self.source.restartable()
+    }
+
+    pub(crate) fn take_one_shot(&mut self) -> Option<Box<BuilderCore>> {
+        self.source.take_one_shot()
+    }
 }
 
 pub(crate) fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError> {

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -1,0 +1,378 @@
+//! Declaration lowering and its owned construction plan.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use crate::{
+    ChildId, DefaultsInheritance, Exit, Intensity, Readiness, ScopeDefaults, Strategy,
+    cells::{MemberCell, ScopeCell},
+    identity::ScopeIdentity,
+    policy::{
+        CommonOptions, IdError, ResolvedCommonOptions, ResolvedDefaults, ScopeFlavor,
+        resolve_common,
+    },
+    raw::RawConstruction,
+    runtime::{self, Isolated, Latch},
+    task::{OnceTask, TaskDef},
+};
+
+/// A declaration-time reservation error.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ReserveError {
+    /// The child id was empty.
+    #[error("child id must not be empty")]
+    EmptyId,
+    /// A resident membership already occupies the id.
+    #[error("child id `{0}` is already resident")]
+    DuplicateId(ChildId),
+    /// A same-id membership is currently being removed.
+    #[error("child id `{0}` is being removed")]
+    RemovalInProgress(ChildId),
+    /// The target dynamic scope is not admitting.
+    #[error("scope is not admitting: {0:?}")]
+    NotAdmitting(NotAdmittingCause),
+    /// The scope can mint no further membership identities.
+    #[error("membership identity space is exhausted")]
+    IdentityExhausted,
+}
+
+/// Exact reason an admission operation could not proceed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum NotAdmittingCause {
+    /// The scope membership is terminal.
+    Terminal,
+    /// The live scope incarnation is draining.
+    Draining,
+    /// The dynamic root is parked after startup failure.
+    StartupFailed,
+    /// No scope incarnation is currently live.
+    NoLiveIncarnation,
+    /// This operation's reservation ended before admission.
+    ReservationEnded,
+}
+
+/// Outcome of an idempotent dynamic removal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RemoveOutcome {
+    /// A reservation or resident membership was removed.
+    Removed,
+    /// No matching membership remained to remove.
+    AlreadyAbsent,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ScopeConfig {
+    pub(crate) strategy: Strategy,
+    pub(crate) intensity: Intensity,
+    pub(crate) defaults: ScopeDefaults,
+}
+
+pub(crate) enum ChildConstruction {
+    Raw(RawConstruction),
+    Task(TaskDef),
+    TaskOnce(OnceTask),
+    Scope(Box<ScopeConstruction>),
+}
+
+enum DefinitionState {
+    Undefined,
+    Defined(Isolated<ChildConstruction>),
+    Lowered,
+}
+
+/// Stable declaration slot joining identity, observation, and owned construction.
+pub(crate) struct SlotCell {
+    pub(crate) member: Arc<MemberCell>,
+    pub(crate) scope: Option<Arc<ScopeCell>>,
+    definition: Mutex<DefinitionState>,
+}
+
+impl SlotCell {
+    pub(crate) fn new(member: Arc<MemberCell>, scope: Option<Arc<ScopeCell>>) -> Arc<Self> {
+        Arc::new(Self {
+            member,
+            scope,
+            definition: Mutex::new(DefinitionState::Undefined),
+        })
+    }
+
+    pub(crate) fn define(&self, definition: ChildConstruction) {
+        let mut state = self.definition.lock().expect("definition mutex poisoned");
+        match *state {
+            DefinitionState::Undefined => {
+                *state = DefinitionState::Defined(Isolated::new(definition));
+            }
+            DefinitionState::Defined(_) | DefinitionState::Lowered => {
+                panic!("a child slot was defined more than once")
+            }
+        }
+    }
+
+    pub(crate) fn is_undefined(&self) -> bool {
+        matches!(
+            *self.definition.lock().expect("definition mutex poisoned"),
+            DefinitionState::Undefined
+        )
+    }
+
+    pub(crate) fn take_definition(&self) -> Option<Isolated<ChildConstruction>> {
+        let mut state = self.definition.lock().expect("definition mutex poisoned");
+        match std::mem::replace(&mut *state, DefinitionState::Lowered) {
+            DefinitionState::Defined(definition) => Some(definition),
+            DefinitionState::Undefined => {
+                *state = DefinitionState::Undefined;
+                None
+            }
+            DefinitionState::Lowered => panic!("a tree was lowered more than once"),
+        }
+    }
+
+    pub(crate) fn take_defined(&self) -> Option<Isolated<ChildConstruction>> {
+        let mut state = self.definition.lock().expect("definition mutex poisoned");
+        match std::mem::replace(&mut *state, DefinitionState::Lowered) {
+            DefinitionState::Defined(definition) => Some(definition),
+            DefinitionState::Undefined => {
+                *state = DefinitionState::Undefined;
+                None
+            }
+            DefinitionState::Lowered => None,
+        }
+    }
+}
+
+/// Erased declaration storage before inherited defaults and identities are lowered.
+pub(crate) struct BuilderCore {
+    pub(crate) root: Arc<ScopeCell>,
+    pub(crate) flavor: ScopeFlavor,
+    pub(crate) config: ScopeConfig,
+    pub(crate) slots: Vec<Arc<SlotCell>>,
+    ids: HashMap<ChildId, Arc<SlotCell>>,
+    armed: bool,
+}
+
+impl BuilderCore {
+    fn begin_failed_disposal(&self) -> Latch {
+        let definitions = self
+            .slots
+            .iter()
+            .filter_map(|slot| slot.take_defined())
+            .filter_map(|mut definition| definition.take())
+            .collect();
+        runtime::dispose_all(definitions)
+    }
+
+    pub(crate) fn new(flavor: ScopeFlavor) -> Self {
+        let root_id = ChildId::from("$root");
+        let mut root_identity =
+            ScopeIdentity::new().expect("global scope identity space exhausted");
+        let membership = root_identity
+            .mint_membership(&root_id)
+            .expect("fresh scope identity must mint its root membership");
+        let member = MemberCell::new(root_id, membership);
+        let child_identity = ScopeIdentity::new().expect("global scope identity space exhausted");
+        let root = ScopeCell::new(member, flavor, child_identity);
+        Self {
+            root,
+            flavor,
+            config: ScopeConfig::default(),
+            slots: Vec::new(),
+            ids: HashMap::new(),
+            armed: true,
+        }
+    }
+
+    pub(crate) fn reserve(
+        &mut self,
+        id: impl Into<ChildId>,
+        scope: Option<ScopeFlavor>,
+    ) -> Result<Arc<SlotCell>, ReserveError> {
+        let id = checked_id(id)?;
+        if self.ids.contains_key(&id) {
+            return Err(ReserveError::DuplicateId(id));
+        }
+        let membership = self
+            .root
+            .child_identity
+            .lock()
+            .expect("scope identity mutex poisoned")
+            .mint_membership(&id)
+            .ok_or(ReserveError::IdentityExhausted)?;
+        let member = MemberCell::new(id.clone(), membership);
+        let scope = scope.map(|flavor| {
+            let identity = ScopeIdentity::new().expect("global scope identity space exhausted");
+            ScopeCell::new(Arc::clone(&member), flavor, identity)
+        });
+        let slot = SlotCell::new(member, scope);
+        self.ids.insert(id, Arc::clone(&slot));
+        self.slots.push(Arc::clone(&slot));
+        Ok(slot)
+    }
+
+    pub(crate) fn lower(
+        mut self,
+        inherited: ResolvedDefaults,
+        root_override: Option<Arc<ScopeCell>>,
+    ) -> Result<ScopePlan, LowerError> {
+        let root = root_override.unwrap_or_else(|| Arc::clone(&self.root));
+        let undefined: Vec<_> = self
+            .slots
+            .iter()
+            .filter(|slot| slot.is_undefined())
+            .map(|slot| vec![slot.member.id().clone()])
+            .collect();
+        if !undefined.is_empty() {
+            let disposal = self.begin_failed_disposal();
+            return Err(LowerError::Undefined {
+                paths: undefined,
+                disposal,
+            });
+        }
+        if !Arc::ptr_eq(&root, &self.root) {
+            let mut identity = root
+                .child_identity
+                .lock()
+                .expect("scope identity mutex poisoned");
+            for slot in &self.slots {
+                let Some(membership) =
+                    identity.adopt_or_mint_membership(slot.member.id(), slot.member.membership())
+                else {
+                    let id = slot.member.id().clone();
+                    drop(identity);
+                    let disposal = self.begin_failed_disposal();
+                    return Err(LowerError::IdentityExhausted { id, disposal });
+                };
+                if membership != slot.member.membership() {
+                    slot.member.rebase_membership(membership);
+                }
+            }
+        }
+        root.set_observation_config(self.config.strategy, self.config.intensity);
+        let defaults = inherited.overlay(&self.config.defaults);
+        let mut children = Vec::with_capacity(self.slots.len());
+        for slot in &self.slots {
+            let definition = slot
+                .take_definition()
+                .expect("validated slot must have a definition");
+            let (options, one_shot) = match definition.get() {
+                ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
+                ChildConstruction::Task(definition) => (&definition.options, false),
+                ChildConstruction::TaskOnce(definition) => (&definition.options, true),
+                ChildConstruction::Scope(definition) => {
+                    (&definition.options, definition.one_shot())
+                }
+            };
+            let resolved = resolve_common(options, &defaults, one_shot, Readiness::Immediate);
+            slot.member.set_options(resolved.clone());
+            children.push(ChildPlan {
+                slot: Arc::clone(slot),
+                construction: definition,
+                options: resolved,
+            });
+        }
+        self.armed = false;
+        Ok(ScopePlan {
+            root,
+            flavor: self.flavor,
+            config: self.config.clone(),
+            defaults,
+            children,
+            armed: true,
+        })
+    }
+
+    fn terminalize(&self) {
+        for slot in &self.slots {
+            slot.member.terminalize(Exit::never_started());
+            if let Some(scope) = &slot.scope {
+                scope.terminalize_never_started();
+            }
+        }
+        self.root.terminalize_never_started();
+    }
+}
+
+impl Drop for BuilderCore {
+    fn drop(&mut self) {
+        if self.armed {
+            self.terminalize();
+        }
+    }
+}
+
+/// Fully lowered scope plan whose construction payloads still have one owner.
+pub(crate) struct ScopePlan {
+    pub(crate) root: Arc<ScopeCell>,
+    pub(crate) flavor: ScopeFlavor,
+    pub(crate) config: ScopeConfig,
+    pub(crate) defaults: ResolvedDefaults,
+    pub(crate) children: Vec<ChildPlan>,
+    pub(crate) armed: bool,
+}
+
+impl Drop for ScopePlan {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        for child in &self.children {
+            child.slot.member.terminalize(Exit::never_started());
+            if let Some(scope) = &child.slot.scope {
+                scope.terminalize_never_started();
+            }
+        }
+        // Lowering can publish the planned children before ScopeRuntime takes
+        // ownership. If construction then unwinds, the plan fallback also
+        // owns those residencies and their matching Removed edges.
+        self.root.clear_residents();
+        self.root.terminalize_never_started();
+    }
+}
+
+pub(crate) struct ChildPlan {
+    pub(crate) slot: Arc<SlotCell>,
+    pub(crate) construction: Isolated<ChildConstruction>,
+    pub(crate) options: ResolvedCommonOptions,
+}
+
+#[derive(Debug)]
+pub(crate) enum LowerError {
+    Undefined {
+        paths: Vec<Vec<ChildId>>,
+        disposal: Latch,
+    },
+    IdentityExhausted {
+        id: ChildId,
+        disposal: Latch,
+    },
+}
+
+pub(crate) struct ScopeConstruction {
+    pub(crate) source: ScopeSource,
+    pub(crate) options: CommonOptions,
+    pub(crate) defaults: DefaultsInheritance,
+}
+
+pub(crate) type ScopeFactory = Arc<dyn Fn() -> BuilderCore + Send + Sync + 'static>;
+
+impl ScopeConstruction {
+    pub(crate) fn one_shot(&self) -> bool {
+        matches!(self.source, ScopeSource::OneShot(_) | ScopeSource::Spent)
+    }
+}
+
+pub(crate) enum ScopeSource {
+    Restartable(ScopeFactory),
+    OneShot(Box<BuilderCore>),
+    Spent,
+}
+
+pub(crate) fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError> {
+    let id = id.into();
+    ChildId::validate(id.as_str().to_owned()).map_err(|error| match error {
+        IdError::Empty => ReserveError::EmptyId,
+    })
+}

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -79,6 +79,25 @@ pub(crate) enum ChildConstruction {
     Scope(Box<ScopeConstruction>),
 }
 
+pub(crate) fn mint_reserved_slot(
+    parent: &ScopeCell,
+    id: &ChildId,
+    child_scope: Option<ScopeFlavor>,
+) -> Result<Arc<SlotCell>, ReserveError> {
+    let membership = parent
+        .child_identity
+        .lock()
+        .expect("scope identity mutex poisoned")
+        .mint_membership(id)
+        .ok_or(ReserveError::IdentityExhausted)?;
+    let member = MemberCell::new(id.clone(), membership);
+    let scope = child_scope.map(|flavor| {
+        let identity = ScopeIdentity::new().expect("global scope identity space exhausted");
+        ScopeCell::new(Arc::clone(&member), flavor, identity)
+    });
+    Ok(SlotCell::new(member, scope))
+}
+
 enum DefinitionState {
     Undefined,
     Defined(Isolated<ChildConstruction>),
@@ -193,19 +212,7 @@ impl BuilderCore {
         if self.ids.contains_key(&id) {
             return Err(ReserveError::DuplicateId(id));
         }
-        let membership = self
-            .root
-            .child_identity
-            .lock()
-            .expect("scope identity mutex poisoned")
-            .mint_membership(&id)
-            .ok_or(ReserveError::IdentityExhausted)?;
-        let member = MemberCell::new(id.clone(), membership);
-        let scope = scope.map(|flavor| {
-            let identity = ScopeIdentity::new().expect("global scope identity space exhausted");
-            ScopeCell::new(Arc::clone(&member), flavor, identity)
-        });
-        let slot = SlotCell::new(member, scope);
+        let slot = mint_reserved_slot(&self.root, &id, scope)?;
         self.ids.insert(id, Arc::clone(&slot));
         self.slots.push(Arc::clone(&slot));
         Ok(slot)
@@ -256,21 +263,7 @@ impl BuilderCore {
             let definition = slot
                 .take_definition()
                 .expect("validated slot must have a definition");
-            let (options, one_shot) = match definition.get() {
-                ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
-                ChildConstruction::Task(definition) => (&definition.options, false),
-                ChildConstruction::TaskOnce(definition) => (&definition.options, true),
-                ChildConstruction::Scope(definition) => {
-                    (&definition.options, definition.one_shot())
-                }
-            };
-            let resolved = resolve_common(options, &defaults, one_shot, Readiness::Immediate);
-            slot.member.set_options(resolved.clone());
-            children.push(ChildPlan {
-                slot: Arc::clone(slot),
-                construction: definition,
-                options: resolved,
-            });
+            children.push(ChildPlan::resolve(Arc::clone(slot), definition, &defaults));
         }
         self.armed = false;
         Ok(ScopePlan {
@@ -335,6 +328,28 @@ pub(crate) struct ChildPlan {
     pub(crate) options: ResolvedCommonOptions,
 }
 
+impl ChildPlan {
+    pub(crate) fn resolve(
+        slot: Arc<SlotCell>,
+        construction: Isolated<ChildConstruction>,
+        defaults: &ResolvedDefaults,
+    ) -> Self {
+        let (options, one_shot) = match construction.get() {
+            ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
+            ChildConstruction::Task(definition) => (&definition.options, false),
+            ChildConstruction::TaskOnce(definition) => (&definition.options, true),
+            ChildConstruction::Scope(definition) => (&definition.options, definition.one_shot()),
+        };
+        let options = resolve_common(options, defaults, one_shot, Readiness::Immediate);
+        slot.member.set_options(options.clone());
+        Self {
+            slot,
+            construction,
+            options,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) enum LowerError {
     Undefined {
@@ -374,4 +389,104 @@ pub(crate) fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError
     ChildId::validate(id.as_str().to_owned()).map_err(|error| match error {
         IdError::Empty => ReserveError::EmptyId,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Duration,
+    };
+
+    use crate::{
+        Backoff, ExitError, Readiness, RestartCondition, RestartPolicy, Retention, Shutdown,
+        TaskOnceDef,
+        policy::{ResolvedDefaults, ScopeFlavor},
+        runtime::{self, Isolated, Timeout},
+        task::TaskDef,
+    };
+
+    use super::{BuilderCore, ChildConstruction, ChildPlan};
+
+    fn configured_task() -> TaskDef {
+        TaskDef::new(|_| async { Ok(()) })
+            .restart(RestartPolicy::new(
+                RestartCondition::Always,
+                Backoff::Immediate,
+            ))
+            .shutdown(Shutdown::Abort)
+            .readiness(Readiness::Manual)
+            .expect("manual task readiness is valid")
+            .retention(Retention::Remove)
+    }
+
+    #[test]
+    fn static_and_dynamic_constructions_share_option_resolution() {
+        let defaults = ResolvedDefaults::default();
+        let mut declaration = BuilderCore::new(ScopeFlavor::Ordered);
+        let static_slot = declaration
+            .reserve("static", None)
+            .expect("static reservation succeeds");
+        static_slot.define(ChildConstruction::Task(configured_task()));
+        let static_plan = declaration
+            .lower(defaults.clone(), None)
+            .expect("defined declaration lowers");
+
+        let mut admission = BuilderCore::new(ScopeFlavor::Dynamic);
+        let dynamic_slot = admission
+            .reserve("dynamic", None)
+            .expect("dynamic reservation succeeds");
+        let dynamic_plan = ChildPlan::resolve(
+            dynamic_slot,
+            Isolated::new(ChildConstruction::Task(configured_task())),
+            &defaults,
+        );
+
+        assert_eq!(static_plan.children[0].options, dynamic_plan.options);
+    }
+
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[crate::runtime::test]
+    async fn resolving_one_shot_construction_preserves_owned_drop() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let capture = DropFlag(Arc::clone(&dropped));
+        let (completion, _claim) = runtime::oneshot();
+        let construction = TaskOnceDef::new(move |_| {
+            let _ = &capture;
+            async { Ok::<_, ExitError>(()) }
+        })
+        .erase(completion);
+        let mut declaration = BuilderCore::new(ScopeFlavor::Dynamic);
+        let slot = declaration
+            .reserve("one-shot", None)
+            .expect("reservation succeeds");
+
+        let plan = ChildPlan::resolve(
+            slot,
+            Isolated::new(ChildConstruction::TaskOnce(construction)),
+            &ResolvedDefaults::default(),
+        );
+        assert!(plan.options.restart.is_never());
+        assert_eq!(plan.options.retention, Retention::Remove);
+        assert!(!dropped.load(Ordering::SeqCst));
+
+        drop(plan);
+        let disposed = runtime::timeout(Duration::from_secs(1), async {
+            while !dropped.load(Ordering::SeqCst) {
+                runtime::yield_now().await;
+            }
+        })
+        .await;
+        assert!(matches!(disposed, Timeout::Completed(())));
+    }
 }

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -92,7 +92,7 @@ pub(crate) fn mint_reserved_slot(
         .ok_or(ReserveError::IdentityExhausted)?;
     let member = MemberCell::new(id.clone(), membership);
     let scope = child_scope.map(|flavor| {
-        let identity = ScopeIdentity::new().expect("global scope identity space exhausted");
+        let identity = ScopeIdentity::new();
         ScopeCell::new(Arc::clone(&member), flavor, identity)
     });
     Ok(SlotCell::new(member, scope))
@@ -205,13 +205,12 @@ impl BuilderCore {
 
     pub(crate) fn new(flavor: ScopeFlavor) -> Self {
         let root_id = ChildId::from("$root");
-        let mut root_identity =
-            ScopeIdentity::new().expect("global scope identity space exhausted");
+        let mut root_identity = ScopeIdentity::new();
         let membership = root_identity
             .mint_membership(&root_id)
             .expect("fresh scope identity must mint its root membership");
         let member = MemberCell::new(root_id, membership);
-        let child_identity = ScopeIdentity::new().expect("global scope identity space exhausted");
+        let child_identity = ScopeIdentity::new();
         let root = ScopeCell::new(member, flavor, child_identity);
         Self {
             root,

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -2,6 +2,13 @@
 
 use std::{fmt, num::NonZeroUsize, time::Duration};
 
+/// Whether a scope has fixed ordered membership or runtime-dynamic membership.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ScopeFlavor {
+    Ordered,
+    Dynamic,
+}
+
 /// The default bounded FIFO mailbox capacity.
 pub const DEFAULT_MAILBOX_CAPACITY: usize = 64;
 /// The default child shutdown grace.

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -823,6 +823,13 @@ mod tests {
     }
 
     #[test]
+    fn restart_policy_is_never_matches_only_the_never_condition() {
+        assert!(RestartPolicy::new(RestartCondition::Never, Backoff::Immediate).is_never());
+        assert!(!RestartPolicy::new(RestartCondition::OnFailure, Backoff::Immediate).is_never());
+        assert!(!RestartPolicy::new(RestartCondition::Always, Backoff::Immediate).is_never());
+    }
+
+    #[test]
     fn defaults_overlay_as_one_value_and_mailbox_capacity_resolves_by_kind() {
         let library = ResolvedDefaults::default();
         let latest = library

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -732,13 +732,49 @@ pub(crate) fn resolve_common(
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{num::NonZeroUsize, time::Duration};
 
     use super::{
         Backoff, BackoffFactor, Intensity, InvalidPolicy, Jitter, Mailbox, PolicyError,
         PolicyField, ReadinessDeadline, ResolvedDefaults, RestartCondition, RestartPolicy,
-        ScopeDefaults,
+        ScopeDefaults, Shutdown, tidy_abort_beat,
     };
+
+    #[test]
+    fn shipped_defaults_match_the_normative_policy() {
+        assert_eq!(Mailbox::default(), Mailbox::Queue(NonZeroUsize::new(64)));
+        assert_eq!(
+            Shutdown::default(),
+            Shutdown::Graceful {
+                grace: Duration::from_secs(5),
+            }
+        );
+        assert_eq!(
+            ResolvedDefaults::default().readiness_deadline,
+            ReadinessDeadline::Bounded(Duration::from_secs(30))
+        );
+        assert_eq!(
+            Intensity::default(),
+            Intensity {
+                max_restarts: 5,
+                within: Duration::from_secs(30),
+            }
+        );
+
+        assert_eq!(tidy_abort_beat(Duration::ZERO), Duration::from_millis(1));
+        assert_eq!(
+            tidy_abort_beat(Duration::from_millis(50)),
+            Duration::from_millis(5)
+        );
+        assert_eq!(
+            tidy_abort_beat(Duration::from_millis(100)),
+            Duration::from_millis(10)
+        );
+        assert_eq!(
+            tidy_abort_beat(Duration::from_secs(5)),
+            Duration::from_millis(10)
+        );
+    }
 
     #[test]
     fn backoff_progression_and_jitter_are_pure_math() {

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -16,6 +16,13 @@ pub const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 /// The default gated-readiness deadline.
 pub const DEFAULT_READINESS_DEADLINE: Duration = Duration::from_secs(30);
 
+/// Whether a scope has fixed ordered membership or runtime-dynamic membership.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ScopeFlavor {
+    Ordered,
+    Dynamic,
+}
+
 /// A child identifier within one scope.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ChildId(String);

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -16,13 +16,6 @@ pub const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 /// The default gated-readiness deadline.
 pub const DEFAULT_READINESS_DEADLINE: Duration = Duration::from_secs(30);
 
-/// Whether a scope has fixed ordered membership or runtime-dynamic membership.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum ScopeFlavor {
-    Ordered,
-    Dynamic,
-}
-
 /// A child identifier within one scope.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ChildId(String);

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -97,6 +97,14 @@ impl BackoffFactor {
     fn get(self) -> f64 {
         self.0
     }
+
+    fn validate(self) -> Result<(), PolicyError> {
+        if self.0.is_finite() && self.0 >= 1.0 {
+            Ok(())
+        } else {
+            Err(PolicyError::InvalidBackoffFactor)
+        }
+    }
 }
 
 impl fmt::Debug for BackoffFactor {
@@ -213,6 +221,26 @@ impl Backoff {
         // with exact Duration ordering after every conversion and jitter.
         delay.min(maximum)
     }
+
+    fn validate(self) -> Result<(), PolicyError> {
+        match self {
+            Self::Immediate => Ok(()),
+            Self::Fixed { delay, .. } if delay.is_zero() => Err(PolicyError::ZeroDuration),
+            Self::Fixed { .. } => Ok(()),
+            Self::Exponential {
+                base, factor, max, ..
+            } => {
+                if base.is_zero() || max.is_zero() {
+                    return Err(PolicyError::ZeroDuration);
+                }
+                factor.validate()?;
+                if max < base {
+                    return Err(PolicyError::BackoffMaximumBeforeBase);
+                }
+                Ok(())
+            }
+        }
+    }
 }
 
 fn duration_nanos(duration: Duration) -> f64 {
@@ -262,6 +290,10 @@ impl RestartPolicy {
     #[must_use]
     pub const fn is_never(self) -> bool {
         matches!(self.condition, RestartCondition::Never)
+    }
+
+    fn validate(self) -> Result<(), PolicyError> {
+        self.backoff.validate()
     }
 
     pub(crate) fn should_restart(self, failure: bool) -> bool {
@@ -331,6 +363,20 @@ impl ReadinessDeadline {
             Ok(Self::Bounded(duration))
         }
     }
+
+    fn validate_declared(self) -> Result<(), PolicyError> {
+        match self {
+            Self::Bounded(duration) if duration.is_zero() => Err(PolicyError::ZeroDuration),
+            Self::Inherit | Self::Bounded(_) | Self::Unbounded => Ok(()),
+        }
+    }
+
+    fn validate_resolved(self) -> Result<(), PolicyError> {
+        match self {
+            Self::Inherit => Err(PolicyError::UnresolvedReadinessDeadline),
+            value => value.validate_declared(),
+        }
+    }
 }
 
 /// The scope-wide restart budget.
@@ -352,6 +398,14 @@ impl Intensity {
                 max_restarts,
                 within,
             })
+        }
+    }
+
+    pub(crate) fn validate(self) -> Result<(), PolicyError> {
+        if self.within.is_zero() {
+            Err(PolicyError::ZeroDuration)
+        } else {
+            Ok(())
         }
     }
 }
@@ -471,9 +525,62 @@ pub enum PolicyError {
     /// An exponential maximum preceded its base delay.
     #[error("backoff maximum must not be shorter than its base")]
     BackoffMaximumBeforeBase,
+    /// An inherited readiness deadline remained unresolved at execution.
+    #[error("readiness deadline must be resolved before execution")]
+    UnresolvedReadinessDeadline,
     /// A readiness mode is not meaningful for this child kind.
     #[error("readiness mode is not supported by this child kind")]
     UnsupportedReadiness,
+}
+
+/// Policy field rejected at a trusted lowering or admission boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum PolicyField {
+    /// A scope restart-intensity window.
+    Intensity,
+    /// A default or child restart backoff.
+    RestartBackoff,
+    /// A default or child readiness deadline.
+    ReadinessDeadline,
+}
+
+impl fmt::Display for PolicyField {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Intensity => formatter.write_str("restart intensity"),
+            Self::RestartBackoff => formatter.write_str("restart backoff"),
+            Self::ReadinessDeadline => formatter.write_str("readiness deadline"),
+        }
+    }
+}
+
+/// Structured evidence for a policy value rejected during lowering.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("invalid {field} at child path {path:?}: {error}")]
+#[non_exhaustive]
+pub struct InvalidPolicy {
+    /// Child-id path relative to the scope being lowered; empty for scope policy.
+    pub path: Vec<ChildId>,
+    /// Policy field whose public representation bypassed validation.
+    pub field: PolicyField,
+    /// Exact validation failure.
+    pub error: PolicyError,
+}
+
+impl InvalidPolicy {
+    pub(crate) fn new(field: PolicyField, error: PolicyError) -> Self {
+        Self {
+            path: Vec::new(),
+            field,
+            error,
+        }
+    }
+
+    pub(crate) fn prepend(mut self, id: &ChildId) -> Self {
+        self.path.insert(0, id.clone());
+        self
+    }
 }
 
 pub(crate) fn tidy_abort_beat(grace: Duration) -> Duration {
@@ -513,8 +620,19 @@ impl Default for ResolvedDefaults {
 }
 
 impl ResolvedDefaults {
-    pub(crate) fn overlay(&self, values: &ScopeDefaults) -> Self {
-        Self {
+    pub(crate) fn overlay(&self, values: &ScopeDefaults) -> Result<Self, InvalidPolicy> {
+        self.validate()?;
+        if let Some(restart) = values.child_restart {
+            restart
+                .validate()
+                .map_err(|error| InvalidPolicy::new(PolicyField::RestartBackoff, error))?;
+        }
+        if let Some(deadline) = values.readiness_deadline {
+            deadline
+                .validate_declared()
+                .map_err(|error| InvalidPolicy::new(PolicyField::ReadinessDeadline, error))?;
+        }
+        let resolved = Self {
             child_restart: values.child_restart.unwrap_or(self.child_restart),
             child_shutdown: values.child_shutdown.unwrap_or(self.child_shutdown),
             mailbox: resolve_default_mailbox(values.mailbox, self.mailbox),
@@ -523,7 +641,18 @@ impl ResolvedDefaults {
                 ReadinessDeadline::Inherit => self.readiness_deadline,
                 value => value,
             },
-        }
+        };
+        resolved.validate()?;
+        Ok(resolved)
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), InvalidPolicy> {
+        self.child_restart
+            .validate()
+            .map_err(|error| InvalidPolicy::new(PolicyField::RestartBackoff, error))?;
+        self.readiness_deadline
+            .validate_resolved()
+            .map_err(|error| InvalidPolicy::new(PolicyField::ReadinessDeadline, error))
     }
 }
 
@@ -555,12 +684,22 @@ pub(crate) fn resolve_common(
     defaults: &ResolvedDefaults,
     one_shot: bool,
     default_readiness: Readiness,
-) -> ResolvedCommonOptions {
+) -> Result<ResolvedCommonOptions, InvalidPolicy> {
+    defaults.validate()?;
+    if let Some(restart) = options.restart {
+        restart
+            .validate()
+            .map_err(|error| InvalidPolicy::new(PolicyField::RestartBackoff, error))?;
+    }
+    options
+        .readiness_deadline
+        .validate_declared()
+        .map_err(|error| InvalidPolicy::new(PolicyField::ReadinessDeadline, error))?;
     let readiness_deadline = match options.readiness_deadline {
         ReadinessDeadline::Inherit => defaults.readiness_deadline,
         value => value,
     };
-    ResolvedCommonOptions {
+    let resolved = ResolvedCommonOptions {
         restart: if one_shot {
             RestartPolicy::new(RestartCondition::Never, Backoff::Immediate)
         } else {
@@ -579,7 +718,16 @@ pub(crate) fn resolve_common(
         } else {
             Retention::Retain
         }),
-    }
+    };
+    resolved
+        .restart
+        .validate()
+        .map_err(|error| InvalidPolicy::new(PolicyField::RestartBackoff, error))?;
+    resolved
+        .readiness_deadline
+        .validate_resolved()
+        .map_err(|error| InvalidPolicy::new(PolicyField::ReadinessDeadline, error))?;
+    Ok(resolved)
 }
 
 #[cfg(test)]
@@ -587,8 +735,9 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        Backoff, BackoffFactor, Intensity, Jitter, Mailbox, PolicyError, ReadinessDeadline,
-        ResolvedDefaults, ScopeDefaults,
+        Backoff, BackoffFactor, Intensity, InvalidPolicy, Jitter, Mailbox, PolicyError,
+        PolicyField, ReadinessDeadline, ResolvedDefaults, RestartCondition, RestartPolicy,
+        ScopeDefaults,
     };
 
     #[test]
@@ -676,18 +825,146 @@ mod tests {
     #[test]
     fn defaults_overlay_as_one_value_and_mailbox_capacity_resolves_by_kind() {
         let library = ResolvedDefaults::default();
-        let latest = library.overlay(&ScopeDefaults {
-            mailbox: Some(Mailbox::latest()),
-            ..ScopeDefaults::default()
-        });
+        let latest = library
+            .overlay(&ScopeDefaults {
+                mailbox: Some(Mailbox::latest()),
+                ..ScopeDefaults::default()
+            })
+            .expect("valid defaults");
         assert_eq!(latest.mailbox, Mailbox::Latest);
 
-        let deferred_queue = latest.overlay(&ScopeDefaults {
-            mailbox: Some(Mailbox::queue_inherit()),
-            ..ScopeDefaults::default()
-        });
+        let deferred_queue = latest
+            .overlay(&ScopeDefaults {
+                mailbox: Some(Mailbox::queue_inherit()),
+                ..ScopeDefaults::default()
+            })
+            .expect("valid defaults");
         assert_eq!(deferred_queue.mailbox, Mailbox::default());
         assert_eq!(deferred_queue.child_restart, latest.child_restart);
         assert_eq!(deferred_queue.child_shutdown, latest.child_shutdown);
+    }
+
+    #[test]
+    fn public_literal_representations_are_revalidated() {
+        assert_eq!(
+            Backoff::Fixed {
+                delay: Duration::ZERO,
+                jitter: Jitter::None,
+            }
+            .validate(),
+            Err(PolicyError::ZeroDuration)
+        );
+        assert_eq!(
+            Backoff::Exponential {
+                base: Duration::ZERO,
+                factor: BackoffFactor(2.0),
+                max: Duration::from_secs(1),
+                jitter: Jitter::None,
+            }
+            .validate(),
+            Err(PolicyError::ZeroDuration)
+        );
+        assert_eq!(
+            Backoff::Exponential {
+                base: Duration::from_secs(1),
+                factor: BackoffFactor(f64::NAN),
+                max: Duration::from_secs(2),
+                jitter: Jitter::None,
+            }
+            .validate(),
+            Err(PolicyError::InvalidBackoffFactor)
+        );
+        assert_eq!(
+            Backoff::Exponential {
+                base: Duration::from_secs(2),
+                factor: BackoffFactor(2.0),
+                max: Duration::from_secs(1),
+                jitter: Jitter::None,
+            }
+            .validate(),
+            Err(PolicyError::BackoffMaximumBeforeBase)
+        );
+        assert_eq!(
+            ReadinessDeadline::Bounded(Duration::ZERO).validate_declared(),
+            Err(PolicyError::ZeroDuration)
+        );
+        assert_eq!(
+            Intensity {
+                max_restarts: 0,
+                within: Duration::ZERO,
+            }
+            .validate(),
+            Err(PolicyError::ZeroDuration)
+        );
+    }
+
+    #[test]
+    fn inherited_and_resolved_policy_values_are_revalidated() {
+        let invalid_restart = ResolvedDefaults {
+            child_restart: RestartPolicy::new(
+                RestartCondition::Always,
+                Backoff::Fixed {
+                    delay: Duration::ZERO,
+                    jitter: Jitter::None,
+                },
+            ),
+            ..ResolvedDefaults::default()
+        };
+        assert_eq!(
+            invalid_restart.overlay(&ScopeDefaults {
+                child_restart: Some(RestartPolicy::default()),
+                ..ScopeDefaults::default()
+            }),
+            Err(InvalidPolicy::new(
+                PolicyField::RestartBackoff,
+                PolicyError::ZeroDuration
+            ))
+        );
+
+        let unresolved = ResolvedDefaults {
+            readiness_deadline: ReadinessDeadline::Inherit,
+            ..ResolvedDefaults::default()
+        };
+        assert_eq!(
+            unresolved.overlay(&ScopeDefaults::default()),
+            Err(InvalidPolicy::new(
+                PolicyField::ReadinessDeadline,
+                PolicyError::UnresolvedReadinessDeadline
+            ))
+        );
+    }
+
+    #[test]
+    fn minimum_valid_literal_edges_are_accepted() {
+        assert_eq!(
+            Backoff::Fixed {
+                delay: Duration::from_nanos(1),
+                jitter: Jitter::None,
+            }
+            .validate(),
+            Ok(())
+        );
+        assert_eq!(
+            Backoff::Exponential {
+                base: Duration::from_nanos(1),
+                factor: BackoffFactor(1.0),
+                max: Duration::from_nanos(1),
+                jitter: Jitter::Equal,
+            }
+            .validate(),
+            Ok(())
+        );
+        assert_eq!(
+            ReadinessDeadline::Bounded(Duration::from_nanos(1)).validate_resolved(),
+            Ok(())
+        );
+        assert_eq!(
+            Intensity {
+                max_restarts: 0,
+                within: Duration::from_nanos(1),
+            }
+            .validate(),
+            Ok(())
+        );
     }
 }

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -22,6 +22,7 @@ use crate::{
     runtime::{
         self, ActorWork, Latch, PanicAccumulator, PanicPayload, Signal, SignalWatcher, catch_panic,
         discard_panic, keep_first_panic, resume_preferred_panic,
+        resume_preferred_panic_outside_unwind,
     },
 };
 
@@ -729,7 +730,10 @@ impl<M> RawResources<M> {
     }
 
     fn resume_pending_panic(&self) {
-        resume_preferred_panic(self.panic.take(), None);
+        // Reached from the actor's own receive path, never from cleanup. The
+        // take is destructive, so containment here would drop the retained
+        // offload diagnostic and let the loop keep running.
+        resume_preferred_panic_outside_unwind(self.panic.take(), None);
     }
 
     async fn join_offloads(&mut self) {
@@ -1590,8 +1594,12 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
             let actor_drop = catch_panic(|| owner.drop_actor()).err();
             keep_first_panic(&mut cleanup_panic, actor_drop);
             // Once actor execution has panicked, teardown is secondary: never
-            // replace the actor's original diagnostic.
-            resume_preferred_panic(owner.take_primary_panic(), cleanup_panic);
+            // replace the actor's original diagnostic. This is the incarnation
+            // body's normal return path, so the resume must be unconditional:
+            // containing the primary payload here would strand `result` at
+            // `None` and report the actor's panic as the framework expect
+            // below.
+            resume_preferred_panic_outside_unwind(owner.take_primary_panic(), cleanup_panic);
             result.expect("an incarnation without a primary panic returns a result")
         })
     }
@@ -1665,7 +1673,9 @@ mod tests {
         EventQueue, OffloadResource, PanicSlot, QueuedEvent, RawResources, SharedOffloadFuture,
         SharedOffloadState,
     };
-    use crate::runtime::{Latch, PanicPayload, Signal, resume_preferred_panic};
+    use crate::runtime::{
+        Latch, PanicPayload, Signal, resume_preferred_panic, resume_preferred_panic_outside_unwind,
+    };
 
     fn marker(value: usize) -> QueuedEvent<usize> {
         QueuedEvent {
@@ -1695,6 +1705,23 @@ mod tests {
         }))
         .expect_err("the primary panic is resumed");
         assert_eq!(panic_message(&payload), Some("primary actor panic"));
+    }
+
+    #[test]
+    fn the_incarnation_return_path_resumes_a_primary_panic_it_solely_owns() {
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            resume_preferred_panic_outside_unwind(Some(Box::new("primary actor panic")), None);
+        }))
+        .expect_err("a sole-owned primary panic is never contained");
+        assert_eq!(panic_message(&payload), Some("primary actor panic"));
+
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            resume_preferred_panic_outside_unwind(None, Some(Box::new("cleanup panic")));
+        }))
+        .expect_err("cleanup stands in when there is no primary panic");
+        assert_eq!(panic_message(&payload), Some("cleanup panic"));
+
+        resume_preferred_panic_outside_unwind(None, None);
     }
 
     struct BlockingPollDrop {

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -16,10 +16,9 @@ use std::{
 use crate::{
     ActorRef, CancellationToken, ChildId, ExitResult, Incarnation, Mailbox, MailboxShutdown,
     PolicyError, Readiness, ReadinessDeadline, RestartPolicy, Retention, ScopeRef, Shutdown,
-    driver::{ActorWork, Signal, SignalWatcher},
     mailbox::{MailboxCell, MailboxControl, MailboxReceiver},
     policy::CommonOptions,
-    runtime::Latch,
+    runtime::{self, ActorWork, Latch, Signal, SignalWatcher},
 };
 
 type PanicPayload = Box<dyn Any + Send + 'static>;
@@ -1048,7 +1047,7 @@ impl<M: Send + 'static> RawContext<M> {
     {
         let cancellation = Latch::default();
         let token = self.shutdown.child(cancellation.clone());
-        let work = crate::driver::spawn_blocking_work(move || operation(token));
+        let work = runtime::spawn_blocking_work(move || operation(token));
         Blocking {
             future: Box::pin(async move { work.join().await }),
             cancellation,
@@ -1095,7 +1094,7 @@ impl<M: Send + 'static> RawContext<M> {
         K: Hash + Eq + Send + 'static,
     {
         self.resources.next_timer_order = self.resources.next_timer_order.saturating_add(1);
-        let now = crate::driver::now();
+        let now = runtime::now();
         let deadline = crate::deadline::Deadline::after(now, after).instant();
         self.resources.timers.replace(
             key,
@@ -1154,31 +1153,30 @@ impl<M: Send + 'static> RawContext<M> {
         }
 
         let token = self.shutdown.child(cancellation.clone());
-        let started_at = crate::driver::now();
+        let started_at = runtime::now();
         let expires_at = crate::deadline::Deadline::after(started_at, deadline).instant();
         let event_cancellation = cancellation.clone();
         let operation = async move {
             let completion = async move {
                 let work = CatchUnwindFuture::new(work);
                 if let Some(expires_at) = expires_at {
-                    match crate::driver::select(work, crate::driver::sleep_until(expires_at)).await
-                    {
-                        crate::driver::Selected::First(result) => result.map(Ok),
-                        crate::driver::Selected::Second(()) => Ok(Err(DeadlineElapsed)),
+                    match runtime::select_two(work, runtime::sleep_until(expires_at)).await {
+                        runtime::Either::Left(result) => result.map(Ok),
+                        runtime::Either::Right(()) => Ok(Err(DeadlineElapsed)),
                     }
                 } else {
                     work.await.map(Ok)
                 }
             };
-            match crate::driver::select(token.cancelled(), completion).await {
-                crate::driver::Selected::First(()) => {}
-                crate::driver::Selected::Second(Ok(result)) => {
+            match runtime::select_two(token.cancelled(), completion).await {
+                runtime::Either::Left(()) => {}
+                runtime::Either::Right(Ok(result)) => {
                     events.push(QueuedEvent::Deliver {
                         cancellation: event_cancellation,
                         make_message: Box::new(move || continuation(result)),
                     });
                 }
-                crate::driver::Selected::Second(Err(payload)) => {
+                runtime::Either::Right(Err(payload)) => {
                     panic.record(payload);
                     events.signal.pulse();
                 }
@@ -1190,7 +1188,7 @@ impl<M: Send + 'static> RawContext<M> {
             self.resources.events.signal.clone(),
             finished.clone(),
         );
-        let task = crate::driver::spawn_actor_work(SharedOffloadFuture(Arc::clone(&state)));
+        let task = runtime::spawn_actor_work(SharedOffloadFuture(Arc::clone(&state)));
         self.resources.offloads.push(OffloadResource {
             cancellation,
             finished,
@@ -1310,7 +1308,7 @@ impl<M: Send + 'static> RawContext<M> {
         if self.resources.fired_batch.is_some() || self.resources.timers.is_empty() {
             return;
         }
-        let now = crate::driver::now();
+        let now = runtime::now();
         let armings = self.resources.timers.take_due(now);
         if armings.is_empty() {
             return;
@@ -1328,7 +1326,7 @@ impl<M: Send + 'static> RawContext<M> {
     fn deliver_timer(&mut self, arming: u64) -> Option<M> {
         let entry = self.resources.timers.entry_mut(arming)?;
         if let Some(period) = entry.period {
-            let deadline = crate::deadline::Deadline::after(crate::driver::now(), period).instant();
+            let deadline = crate::deadline::Deadline::after(runtime::now(), period).instant();
             entry.deadline = deadline;
             let TimerMessage::Interval(make_message) = &entry.message else {
                 unreachable!("an interval timer must own a message factory")
@@ -1355,23 +1353,23 @@ impl<M: Send + 'static> RawContext<M> {
 
     async fn wait_for_event(&mut self) {
         let sleep = self.next_timer_deadline().map_or_else(
-            || Box::pin(std::future::pending()) as crate::driver::DriverSleep,
-            crate::driver::sleep_until,
+            || Box::pin(std::future::pending()) as runtime::BoxedSleep,
+            runtime::sleep_until,
         );
         let shutdown = self.shutdown.clone();
         let local_stop = self.local_stop.clone();
         let mailbox = &mut self.receiver;
         let event_watcher = &mut self.resources.event_watcher;
         let delivery = async move {
-            let _ = crate::driver::select(
+            let _ = runtime::select_two(
                 mailbox.changed(),
-                crate::driver::select(event_watcher.changed(), sleep),
+                runtime::select_two(event_watcher.changed(), sleep),
             )
             .await;
         };
-        let _ = crate::driver::select(
+        let _ = runtime::select_two(
             shutdown.cancelled(),
-            crate::driver::select(local_stop.fired(), delivery),
+            runtime::select_two(local_stop.fired(), delivery),
         )
         .await;
     }
@@ -1776,7 +1774,7 @@ mod tests {
         EventQueue, OffloadResource, PanicPayload, PanicSlot, QueuedEvent, RawResources,
         SharedOffloadFuture, SharedOffloadState, resume_preferred_panic,
     };
-    use crate::{driver::Signal, runtime::Latch};
+    use crate::runtime::{Latch, Signal};
 
     fn marker(value: usize) -> QueuedEvent<usize> {
         QueuedEvent::Deliver {

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -17,6 +17,7 @@ use crate::{
     ActorRef, CancellationToken, ChildId, ExitResult, Incarnation, Mailbox, MailboxShutdown,
     PolicyError, Readiness, ReadinessDeadline, RestartPolicy, Retention, ScopeRef, Shutdown,
     cells::{MailboxControl, MemberCell},
+    definition::DefinitionSource,
     mailbox::{MailboxCell, MailboxReceiver},
     policy::CommonOptions,
     runtime::{self, ActorWork, Latch, Signal, SignalWatcher},
@@ -1426,61 +1427,20 @@ impl<R: RawActor> RawDef<R> {
         }
     }
 
-    /// Overrides the restart policy.
-    #[must_use]
-    pub fn restart(mut self, restart: RestartPolicy) -> Self {
-        self.options.restart = Some(restart);
-        self
-    }
-
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor mailbox kind and capacity.
-    #[must_use]
-    pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
-        self.options.mailbox = Some(mailbox);
-        self
-    }
-
-    /// Overrides frozen-prefix drain versus discard behavior.
-    #[must_use]
-    pub fn mailbox_shutdown(mut self, shutdown: MailboxShutdown) -> Self {
-        self.options.mailbox_shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor's declared readiness mode.
-    pub fn readiness(mut self, readiness: Readiness) -> Result<Self, PolicyError> {
-        if readiness == Readiness::AfterInit {
-            return Err(PolicyError::UnsupportedReadiness);
-        }
-        self.options.readiness = Some(readiness);
-        Ok(self)
-    }
-
-    /// Overrides the structural readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(
+        restart,
+        shutdown,
+        mailbox,
+        mailbox_shutdown,
+        raw_readiness,
+        structural_readiness_deadline,
+        retention,
+    );
 
     pub(crate) fn erase(self, mailbox: Arc<MailboxCell<R::Msg>>) -> RawConstruction {
         let factory = self.factory;
         RawConstruction {
-            source: RawSource::Restartable(Arc::new(move || {
+            source: DefinitionSource::Restartable(Arc::new(move || {
                 let actor = factory();
                 Box::new(RawInstance {
                     actor,
@@ -1517,56 +1477,21 @@ impl<R: RawActor> RawOnceDef<R> {
         }
     }
 
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor mailbox kind and capacity.
-    #[must_use]
-    pub fn mailbox(mut self, mailbox: Mailbox) -> Self {
-        self.options.mailbox = Some(mailbox);
-        self
-    }
-
-    /// Overrides frozen-prefix drain versus discard behavior.
-    #[must_use]
-    pub fn mailbox_shutdown(mut self, shutdown: MailboxShutdown) -> Self {
-        self.options.mailbox_shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the actor's declared readiness mode.
-    pub fn readiness(mut self, readiness: Readiness) -> Result<Self, PolicyError> {
-        if readiness == Readiness::AfterInit {
-            return Err(PolicyError::UnsupportedReadiness);
-        }
-        self.options.readiness = Some(readiness);
-        Ok(self)
-    }
-
-    /// Overrides the structural readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(
+        shutdown,
+        mailbox,
+        mailbox_shutdown,
+        raw_readiness,
+        structural_readiness_deadline,
+        retention,
+    );
 
     pub(crate) fn erase(self, mailbox: Arc<MailboxCell<R::Msg>>) -> RawConstruction {
         RawConstruction {
-            source: RawSource::OneShot(Some(Box::new(RawInstance {
+            source: DefinitionSource::OneShot(Box::new(RawInstance {
                 actor: self.actor,
                 mailbox,
-            }))),
+            })),
             options: self.options,
         }
     }
@@ -1700,26 +1625,24 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
 }
 
 pub(crate) struct RawConstruction {
-    pub(crate) source: RawSource,
+    pub(crate) source: DefinitionSource<RawFactory, Box<dyn ErasedRawInstance>>,
     pub(crate) options: CommonOptions,
 }
 
 impl RawConstruction {
     pub(crate) fn one_shot(&self) -> bool {
-        matches!(self.source, RawSource::OneShot(_) | RawSource::Spent)
+        self.source.is_one_shot()
     }
 
     pub(crate) fn take_spawn(&mut self) -> RawSpawn {
-        match &mut self.source {
-            RawSource::Restartable(factory) => RawSpawn::Restartable(Arc::clone(factory)),
-            RawSource::OneShot(instance) => {
-                let instance = instance
-                    .take()
-                    .expect("one-shot raw actor construction invoked more than once");
-                self.source = RawSource::Spent;
-                RawSpawn::OneShot(instance)
-            }
-            RawSource::Spent => panic!("one-shot raw actor construction invoked more than once"),
+        if let Some(factory) = self.source.restartable() {
+            RawSpawn::Restartable(Arc::clone(factory))
+        } else {
+            RawSpawn::OneShot(
+                self.source
+                    .take_one_shot()
+                    .expect("one-shot raw actor construction invoked more than once"),
+            )
         }
     }
 }
@@ -1736,12 +1659,6 @@ impl RawSpawn {
             Self::OneShot(instance) => instance,
         }
     }
-}
-
-pub(crate) enum RawSource {
-    Restartable(RawFactory),
-    OneShot(Option<Box<dyn ErasedRawInstance>>),
-    Spent,
 }
 
 pub(crate) struct RawRunContext {

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -16,7 +16,8 @@ use std::{
 use crate::{
     ActorRef, CancellationToken, ChildId, ExitResult, Incarnation, Mailbox, MailboxShutdown,
     PolicyError, Readiness, ReadinessDeadline, RestartPolicy, Retention, ScopeRef, Shutdown,
-    mailbox::{MailboxCell, MailboxControl, MailboxReceiver},
+    cells::{MailboxControl, MemberCell},
+    mailbox::{MailboxCell, MailboxReceiver},
     policy::CommonOptions,
     runtime::{self, ActorWork, Latch, Signal, SignalWatcher},
 };
@@ -1746,7 +1747,7 @@ pub(crate) enum RawSource {
 pub(crate) struct RawRunContext {
     pub(crate) id: ChildId,
     pub(crate) incarnation: Incarnation,
-    pub(crate) member: Arc<crate::driver::MemberCell>,
+    pub(crate) member: Arc<MemberCell>,
     pub(crate) scope: ScopeRef,
     pub(crate) shutdown: Latch,
     pub(crate) abort: Latch,

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -6,7 +6,6 @@ use std::{
     fmt,
     future::Future,
     hash::{BuildHasher, Hash},
-    panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context as TaskPollContext, Poll},
@@ -20,37 +19,15 @@ use crate::{
     definition::DefinitionSource,
     mailbox::{MailboxCell, MailboxReceiver},
     policy::CommonOptions,
-    runtime::{self, ActorWork, Latch, Signal, SignalWatcher},
+    runtime::{
+        self, ActorWork, Latch, PanicAccumulator, PanicPayload, Signal, SignalWatcher, catch_panic,
+        discard_panic, keep_first_panic, resume_preferred_panic,
+    },
 };
 
-type PanicPayload = Box<dyn Any + Send + 'static>;
 type DeferredMessage<M> = Box<dyn FnOnce() -> M + Send + 'static>;
 type OffloadFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 type SharedWork = Arc<SharedOffloadState>;
-
-fn discard_panic(payload: Option<PanicPayload>) {
-    if let Some(payload) = payload {
-        let _ = catch_unwind(AssertUnwindSafe(|| drop(payload)));
-    }
-}
-
-fn keep_first_panic(first: &mut Option<PanicPayload>, candidate: Option<PanicPayload>) {
-    if first.is_none() {
-        *first = candidate;
-    } else {
-        discard_panic(candidate);
-    }
-}
-
-fn resume_preferred_panic(primary: Option<PanicPayload>, cleanup: Option<PanicPayload>) {
-    if let Some(payload) = primary {
-        discard_panic(cleanup);
-        resume_unwind(payload);
-    }
-    if let Some(payload) = cleanup {
-        resume_unwind(payload);
-    }
-}
 
 /// Marker returned to an offload continuation when its one deadline expires.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
@@ -202,17 +179,17 @@ impl<F: Future> Future for CatchUnwindFuture<F> {
 
     fn poll(self: Pin<&mut Self>, context: &mut TaskPollContext<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
-        let polled = catch_unwind(AssertUnwindSafe(|| {
+        let polled = catch_panic(|| {
             this.future
                 .as_mut()
                 .expect("a completed panic boundary was polled again")
                 .as_mut()
                 .poll(context)
-        }));
+        });
         match polled {
             Ok(Poll::Ready(value)) => {
                 let future = this.future.take();
-                match catch_unwind(AssertUnwindSafe(|| drop(future))) {
+                match catch_panic(|| drop(future)) {
                     Ok(()) => Poll::Ready(Ok(value)),
                     Err(payload) => Poll::Ready(Err(payload)),
                 }
@@ -220,7 +197,7 @@ impl<F: Future> Future for CatchUnwindFuture<F> {
             Ok(Poll::Pending) => Poll::Pending,
             Err(payload) => {
                 let future = this.future.take();
-                let _ = catch_unwind(AssertUnwindSafe(|| drop(future)));
+                discard_panic(catch_panic(|| drop(future)).err());
                 Poll::Ready(Err(payload))
             }
         }
@@ -229,20 +206,15 @@ impl<F: Future> Future for CatchUnwindFuture<F> {
 
 impl<F> Drop for CatchUnwindFuture<F> {
     fn drop(&mut self) {
-        let already_panicking = std::thread::panicking();
         let future = self.future.take();
-        let panic = catch_unwind(AssertUnwindSafe(|| drop(future))).err();
-        if !already_panicking && let Some(payload) = panic {
-            resume_unwind(payload);
-        }
+        let mut panics = PanicAccumulator::default();
+        panics.run(|| drop(future));
     }
 }
 
-enum QueuedEvent<M> {
-    Deliver {
-        cancellation: Latch,
-        make_message: DeferredMessage<M>,
-    },
+struct QueuedEvent<M> {
+    cancellation: Latch,
+    make_message: DeferredMessage<M>,
 }
 
 #[derive(Default)]
@@ -372,7 +344,7 @@ impl<K: Send + 'static> ErasedTimerKey for StoredTimerKey<K> {
 }
 
 enum TimerMessage<M> {
-    Once(Option<M>),
+    Once(M),
     Interval(Box<dyn Fn() -> M + Send + 'static>),
 }
 
@@ -622,7 +594,7 @@ impl SharedOffloadState {
 
     fn dispose(&self, future: Option<OffloadFuture>) {
         if let Some(future) = future {
-            match catch_unwind(AssertUnwindSafe(|| drop(future))) {
+            match catch_panic(|| drop(future)) {
                 Ok(()) => {}
                 Err(payload) => self.record(payload),
             }
@@ -653,7 +625,7 @@ impl Future for SharedOffloadFuture {
         let Some(mut future) = self.0.take_for_poll() else {
             return Poll::Ready(());
         };
-        let polled = catch_unwind(AssertUnwindSafe(|| future.as_mut().poll(context)));
+        let polled = catch_panic(|| future.as_mut().poll(context));
         match polled {
             Ok(Poll::Pending) => {
                 let dispose = self.0.finish_poll(future, true);
@@ -705,6 +677,9 @@ impl OffloadResource {
 struct RawResources<M> {
     accepting: bool,
     continuations: VecDeque<M>,
+    // Set after returning a continuation and cleared after an external
+    // mailbox/offload/timer item. `next_ready` uses it to prohibit two local
+    // continuations from leading while an external source remains eligible.
     continuation_needs_external: bool,
     timers: TimerStore<M>,
     next_timer_order: u64,
@@ -754,9 +729,7 @@ impl<M> RawResources<M> {
     }
 
     fn resume_pending_panic(&self) {
-        if let Some(payload) = self.panic.take() {
-            resume_unwind(payload);
-        }
+        resume_preferred_panic(self.panic.take(), None);
     }
 
     async fn join_offloads(&mut self) {
@@ -772,17 +745,16 @@ impl<M> RawResources<M> {
 
 impl<M> Drop for RawResources<M> {
     fn drop(&mut self) {
-        let freeze_panic = catch_unwind(AssertUnwindSafe(|| {
+        let freeze_panic = catch_panic(|| {
             let _ = self.freeze();
-        }))
+        })
         .err();
-        let mut cleanup_panic = self.panic.take();
-        keep_first_panic(&mut cleanup_panic, freeze_panic);
-        if std::thread::panicking() {
-            discard_panic(cleanup_panic);
-        } else if let Some(payload) = cleanup_panic {
-            resume_unwind(payload);
-        }
+        let mut panics = PanicAccumulator::default();
+        // `freeze` can transfer a destructor panic into the shared slot. Take
+        // that retained application diagnostic after cleanup and preserve it
+        // ahead of a direct framework-cleanup panic.
+        panics.record(self.panic.take());
+        panics.record(freeze_panic);
     }
 }
 
@@ -930,10 +902,12 @@ impl<M: Send + 'static> RawContext<M> {
     ///
     /// External intake freezes at this call — the drained set is exactly the
     /// already-accepted prefix (§5.1's close point) — queued continuations
-    /// and timers are discarded, and `recv` begins yielding the frozen
-    /// prefix followed by `None`. Idempotent. This is the primitive the
-    /// blanket handler loop's `Context::stop` is built on (§1 principle 5);
-    /// the child's configured §10 ladder bounds the stop.
+    /// and timers are discarded, and [`recv`](Self::recv) returns `None`.
+    /// A raw loop honoring [`MailboxShutdown::Drain`] must then consume the
+    /// frozen prefix with [`try_recv`](Self::try_recv); `recv` never drains a
+    /// frozen mailbox. Idempotent. This is the primitive the blanket handler
+    /// loop's `Context::stop` is built on (§1 principle 5); the child's
+    /// configured §10 ladder bounds the stop.
     pub fn stop(&mut self) {
         self.mailbox.freeze(self.incarnation);
         self.freeze_and_report();
@@ -966,7 +940,7 @@ impl<M: Send + 'static> RawContext<M> {
         if self.is_stopping() || !self.resources.accepting {
             return Err(Rejected::new((key, message)));
         }
-        self.replace_timer(key, TimerMessage::Once(Some(message)), after, None);
+        self.replace_timer(key, TimerMessage::Once(message), after, None);
         Ok(())
     }
 
@@ -1069,7 +1043,7 @@ impl<M: Send + 'static> RawContext<M> {
                 self.freeze_and_report();
                 return None;
             }
-            if let Some(message) = self.next_ready(false) {
+            if let Some(message) = self.next_ready() {
                 return Some(message);
             }
             self.wait_for_event().await;
@@ -1082,7 +1056,7 @@ impl<M: Send + 'static> RawContext<M> {
             self.freeze_and_report();
             self.receiver.try_recv()
         } else {
-            self.next_ready(false)
+            self.next_ready()
         }
     }
 
@@ -1140,7 +1114,7 @@ impl<M: Send + 'static> RawContext<M> {
         let panic = Arc::clone(&self.resources.panic);
         if deadline.is_zero() {
             drop(work);
-            events.push(QueuedEvent::Deliver {
+            events.push(QueuedEvent {
                 cancellation: cancellation.clone(),
                 make_message: Box::new(move || continuation(Err(DeadlineElapsed))),
             });
@@ -1173,7 +1147,7 @@ impl<M: Send + 'static> RawContext<M> {
             match runtime::select_two(token.cancelled(), completion).await {
                 runtime::Either::Left(()) => {}
                 runtime::Either::Right(Ok(result)) => {
-                    events.push(QueuedEvent::Deliver {
+                    events.push(QueuedEvent {
                         cancellation: event_cancellation,
                         make_message: Box::new(move || continuation(result)),
                     });
@@ -1200,7 +1174,24 @@ impl<M: Send + 'static> RawContext<M> {
         Ok(guard)
     }
 
-    fn next_ready(&mut self, allow_frozen_mailbox: bool) -> Option<M> {
+    /// Selects one live-incarnation input without awaiting.
+    ///
+    /// A due timer snapshots continuations, accepted live-mailbox messages,
+    /// queued offload completions, and timer armings before any timer message
+    /// is emitted. Stage priority is: at most one fairness continuation,
+    /// mailbox prefix, offload prefix, remaining snapshotted continuations,
+    /// then timer armings. Each external delivery permits one continuation to
+    /// lead the next call, so continuations can interleave with the mailbox and
+    /// offload stages without repeatedly cutting ahead of them. Once those
+    /// external prefixes are exhausted, the captured continuation remainder
+    /// drains before timers; arrivals after any watermark cannot jump the due
+    /// timers. This prevents both an always-readable mailbox and a self-feeding
+    /// continuation queue from starving the other.
+    ///
+    /// Frozen mailbox input is deliberately absent. Once stopping begins,
+    /// [`try_recv`](Self::try_recv) bypasses this selector and drains the
+    /// accepted prefix directly according to the caller's shutdown policy.
+    fn next_ready(&mut self) -> Option<M> {
         loop {
             self.resources.resume_pending_panic();
             self.begin_fired_batch();
@@ -1216,11 +1207,7 @@ impl<M: Send + 'static> RawContext<M> {
                 }
 
                 if !batch.mailbox_complete {
-                    let message = if allow_frozen_mailbox {
-                        self.receiver.try_recv()
-                    } else {
-                        self.receiver.try_recv_live_through(batch.mailbox_through)
-                    };
+                    let message = self.receiver.try_recv_live_through(batch.mailbox_through);
                     if let Some(message) = message {
                         self.resources.continuation_needs_external = false;
                         self.resources.fired_batch = Some(batch);
@@ -1272,11 +1259,7 @@ impl<M: Send + 'static> RawContext<M> {
                 return Some(message);
             }
 
-            let mailbox = if allow_frozen_mailbox {
-                self.receiver.try_recv()
-            } else {
-                self.receiver.try_recv_live()
-            };
+            let mailbox = self.receiver.try_recv_live();
             if let Some(message) = mailbox {
                 self.resources.continuation_needs_external = false;
                 return Some(message);
@@ -1298,12 +1281,7 @@ impl<M: Send + 'static> RawContext<M> {
     }
 
     fn materialize_event(event: QueuedEvent<M>) -> Option<M> {
-        match event {
-            QueuedEvent::Deliver {
-                cancellation,
-                make_message,
-            } => (!cancellation.is_fired()).then(make_message),
-        }
+        (!event.cancellation.is_fired()).then(event.make_message)
     }
 
     fn begin_fired_batch(&mut self) {
@@ -1346,7 +1324,7 @@ impl<M: Send + 'static> RawContext<M> {
         let TimerMessage::Once(message) = entry.message else {
             unreachable!("a non-interval timer must own a one-shot message")
         };
-        message
+        Some(message)
     }
 
     fn next_timer_deadline(&self) -> Option<Instant> {
@@ -1561,15 +1539,10 @@ impl<R: RawActor> Drop for RawIncarnationOwner<R> {
         // process. The resource panic is primary: it may be an owned offload
         // panic that completed before cancellation was requested.
         let primary_panic = self.take_primary_panic();
-        let mut cleanup_panic = catch_unwind(AssertUnwindSafe(|| self.drop_raw())).err();
-        let actor_panic = catch_unwind(AssertUnwindSafe(|| self.drop_actor())).err();
-        keep_first_panic(&mut cleanup_panic, actor_panic);
-        if std::thread::panicking() {
-            discard_panic(primary_panic);
-            discard_panic(cleanup_panic);
-        } else {
-            resume_preferred_panic(primary_panic, cleanup_panic);
-        }
+        let mut cleanup = PanicAccumulator::default();
+        cleanup.run(|| self.drop_raw());
+        cleanup.run(|| self.drop_actor());
+        resume_preferred_panic(primary_panic, cleanup.take());
     }
 }
 
@@ -1599,10 +1572,10 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
                     None
                 }
             };
-            let freeze_panic = catch_unwind(AssertUnwindSafe(|| {
+            let freeze_panic = catch_panic(|| {
                 mailbox.freeze(incarnation);
                 owner.raw().freeze_resources();
-            }))
+            })
             .err();
             let mut cleanup_panic = owner.raw().take_resource_panic();
             keep_first_panic(&mut cleanup_panic, freeze_panic);
@@ -1611,10 +1584,10 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
             keep_first_panic(&mut cleanup_panic, joined.err());
             let pending = owner.raw().take_resource_panic();
             keep_first_panic(&mut cleanup_panic, pending);
-            let raw_drop = catch_unwind(AssertUnwindSafe(|| owner.drop_raw())).err();
+            let raw_drop = catch_panic(|| owner.drop_raw()).err();
             keep_first_panic(&mut cleanup_panic, raw_drop);
 
-            let actor_drop = catch_unwind(AssertUnwindSafe(|| owner.drop_actor())).err();
+            let actor_drop = catch_panic(|| owner.drop_actor()).err();
             keep_first_panic(&mut cleanup_panic, actor_drop);
             // Once actor execution has panicked, teardown is secondary: never
             // replace the actor's original diagnostic.
@@ -1689,22 +1662,20 @@ mod tests {
     };
 
     use super::{
-        EventQueue, OffloadResource, PanicPayload, PanicSlot, QueuedEvent, RawResources,
-        SharedOffloadFuture, SharedOffloadState, resume_preferred_panic,
+        EventQueue, OffloadResource, PanicSlot, QueuedEvent, RawResources, SharedOffloadFuture,
+        SharedOffloadState,
     };
-    use crate::runtime::{Latch, Signal};
+    use crate::runtime::{Latch, PanicPayload, Signal, resume_preferred_panic};
 
     fn marker(value: usize) -> QueuedEvent<usize> {
-        QueuedEvent::Deliver {
+        QueuedEvent {
             cancellation: Latch::default(),
             make_message: Box::new(move || value),
         }
     }
 
     fn value(event: QueuedEvent<usize>) -> usize {
-        match event {
-            QueuedEvent::Deliver { make_message, .. } => make_message(),
-        }
+        (event.make_message)()
     }
 
     fn panic_message(payload: &PanicPayload) -> Option<&str> {
@@ -2002,7 +1973,7 @@ mod timer_store_tests {
     }
 
     fn once(entry: super::TimerEntry<&'static str>) -> &'static str {
-        let TimerMessage::Once(Some(message)) = entry.message else {
+        let TimerMessage::Once(message) = entry.message else {
             panic!("expected a live one-shot timer")
         };
         message
@@ -2016,21 +1987,21 @@ mod timer_store_tests {
             7_u8,
             Some(start + Duration::from_secs(3)),
             1,
-            TimerMessage::Once(Some("old-u8")),
+            TimerMessage::Once("old-u8"),
             None,
         );
         timers.replace(
             7_u16,
             Some(start + Duration::from_secs(1)),
             2,
-            TimerMessage::Once(Some("u16")),
+            TimerMessage::Once("u16"),
             None,
         );
         timers.replace(
             7_u8,
             Some(start + Duration::from_secs(2)),
             3,
-            TimerMessage::Once(Some("new-u8")),
+            TimerMessage::Once("new-u8"),
             None,
         );
 
@@ -2054,25 +2025,13 @@ mod timer_store_tests {
     #[test]
     fn hash_collision_uses_exact_erased_key_equality() {
         let mut timers = TimerStore::default();
-        timers.replace(
-            CollidingKey(1),
-            None,
-            1,
-            TimerMessage::Once(Some("first")),
-            None,
-        );
-        timers.replace(
-            CollidingKey(2),
-            None,
-            2,
-            TimerMessage::Once(Some("second")),
-            None,
-        );
+        timers.replace(CollidingKey(1), None, 1, TimerMessage::Once("first"), None);
+        timers.replace(CollidingKey(2), None, 2, TimerMessage::Once("second"), None);
         timers.replace(
             CollidingKey(1),
             None,
             3,
-            TimerMessage::Once(Some("replacement")),
+            TimerMessage::Once("replacement"),
             None,
         );
 
@@ -2117,7 +2076,7 @@ mod timer_store_tests {
                 key,
                 Some(start + Duration::from_secs((TIMERS - index) as u64)),
                 index as u64,
-                TimerMessage::Once(Some(())),
+                TimerMessage::Once(()),
                 None,
             );
         }

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -57,7 +57,7 @@ pub(crate) fn sleep_until(deadline: std::time::Instant) -> BoxedSleep {
 }
 
 pub(crate) struct ActorWork {
-    handle: Option<JoinHandle<(), ()>>,
+    handle: Option<JoinHandle<()>>,
     abort: AbortHandle,
 }
 
@@ -81,7 +81,7 @@ impl Drop for ActorWork {
 }
 
 pub(crate) fn spawn_actor_work(future: impl Future<Output = ()> + Send + 'static) -> ActorWork {
-    let handle = spawn((), future);
+    let handle = spawn(future);
     let abort = handle.abort_handle();
     ActorWork {
         handle: Some(handle),
@@ -90,7 +90,7 @@ pub(crate) fn spawn_actor_work(future: impl Future<Output = ()> + Send + 'static
 }
 
 pub(crate) struct BlockingWork<T> {
-    handle: Option<JoinHandle<(), T>>,
+    handle: Option<JoinHandle<T>>,
 }
 
 impl<T: Send + 'static> BlockingWork<T> {
@@ -99,7 +99,7 @@ impl<T: Send + 'static> BlockingWork<T> {
             .handle
             .take()
             .expect("blocking operation was joined more than once");
-        join_resuming(handle).await.1
+        join_resuming(handle).await
     }
 }
 
@@ -107,7 +107,7 @@ pub(crate) fn spawn_blocking_work<T: Send + 'static>(
     operation: impl FnOnce() -> T + Send + 'static,
 ) -> BlockingWork<T> {
     BlockingWork {
-        handle: Some(spawn_blocking((), operation)),
+        handle: Some(spawn_blocking(operation)),
     }
 }
 
@@ -718,9 +718,8 @@ impl<T> fmt::Debug for BroadcastReceiver<T> {
     }
 }
 
-/// A spawned operation whose identity is retained through joining.
-pub(crate) struct JoinHandle<I, T> {
-    id: I,
+/// A spawned operation owned by the library.
+pub(crate) struct JoinHandle<T> {
     inner: task::JoinHandle<T>,
 }
 
@@ -733,7 +732,7 @@ impl AbortHandle {
     }
 }
 
-impl<I, T> JoinHandle<I, T> {
+impl<T> JoinHandle<T> {
     pub(crate) fn abort_handle(&self) -> AbortHandle {
         AbortHandle(self.inner.abort_handle())
     }
@@ -765,30 +764,28 @@ pub(crate) enum JoinOutcome<T> {
     Cancelled,
 }
 
-pub(crate) fn spawn<I, F>(id: I, future: F) -> JoinHandle<I, F::Output>
+pub(crate) fn spawn<F>(future: F) -> JoinHandle<F::Output>
 where
     F: Future + Send + 'static,
     F::Output: Send + 'static,
 {
     JoinHandle {
-        id,
         inner: task::spawn(future),
     }
 }
 
-pub(crate) fn spawn_blocking<I, F, T>(id: I, operation: F) -> JoinHandle<I, T>
+pub(crate) fn spawn_blocking<F, T>(operation: F) -> JoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
     JoinHandle {
-        id,
         inner: task::spawn_blocking(operation),
     }
 }
 
-pub(crate) async fn join<I, T>(handle: JoinHandle<I, T>) -> JoinOutcome<T> {
-    let JoinHandle { inner, .. } = handle;
+pub(crate) async fn join<T>(handle: JoinHandle<T>) -> JoinOutcome<T> {
+    let JoinHandle { inner } = handle;
     match inner.await {
         Ok(value) => JoinOutcome::Ok { value },
         Err(error) if error.is_panic() => JoinOutcome::Panic {
@@ -801,10 +798,10 @@ pub(crate) async fn join<I, T>(handle: JoinHandle<I, T>) -> JoinOutcome<T> {
     }
 }
 
-pub(crate) async fn join_resuming<I, T>(handle: JoinHandle<I, T>) -> (I, T) {
-    let JoinHandle { id, inner } = handle;
+pub(crate) async fn join_resuming<T>(handle: JoinHandle<T>) -> T {
+    let JoinHandle { inner } = handle;
     match inner.await {
-        Ok(value) => (id, value),
+        Ok(value) => value,
         Err(error) if error.is_panic() => std::panic::resume_unwind(error.into_panic()),
         Err(error) => {
             debug_assert!(error.is_cancelled());
@@ -1018,7 +1015,7 @@ mod tests {
         for _ in 0..FIRERS {
             let latch = latch.clone();
             let ready = Arc::clone(&ready);
-            firers.push(spawn((), async move {
+            firers.push(spawn(async move {
                 ready.fetch_add(1, Ordering::AcqRel);
                 while ready.load(Ordering::Acquire) != FIRERS {
                     yield_now().await;
@@ -1050,7 +1047,7 @@ mod tests {
         for _ in 0..WAITERS {
             let latch = latch.clone();
             let parked = Arc::clone(&parked);
-            waiters.push(spawn((), async move {
+            waiters.push(spawn(async move {
                 let mut fired = Box::pin(latch.fired());
                 let first_poll =
                     std::future::poll_fn(|context| Poll::Ready(fired.as_mut().poll(context))).await;

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -1,10 +1,11 @@
 //! The only boundary between the library and its async runtime.
 
 use std::{
+    any::Any,
     fmt,
     future::Future,
     ops::RangeBounds,
-    panic::{AssertUnwindSafe, catch_unwind},
+    panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     pin::Pin,
     sync::{
         Arc, Mutex,
@@ -27,6 +28,84 @@ pub(crate) use tokio::test;
 #[cfg(test)]
 pub(crate) async fn advance(duration: Duration) {
     time::advance(duration).await;
+}
+
+/// Runtime-owned spelling for an unwind payload crossing a framework boundary.
+pub(crate) type PanicPayload = Box<dyn Any + Send + 'static>;
+
+/// Catches application code without requiring every caller to repeat the
+/// `AssertUnwindSafe` boundary vocabulary.
+pub(crate) fn catch_panic<T>(operation: impl FnOnce() -> T) -> Result<T, PanicPayload> {
+    catch_unwind(AssertUnwindSafe(operation))
+}
+
+/// Discards an optional panic payload without trusting its destructor.
+pub(crate) fn discard_panic(payload: Option<PanicPayload>) {
+    if let Some(payload) = payload
+        && let Err(hostile_payload) = catch_panic(|| drop(payload))
+    {
+        // A payload whose own destructor panics cannot be dropped safely:
+        // dropping the replacement payload would merely recurse outside the
+        // boundary. Leak only this already-panicking diagnostic.
+        std::mem::forget(hostile_payload);
+    }
+}
+
+/// Resumes one captured panic payload at the framework boundary.
+pub(crate) fn resume_panic(payload: PanicPayload) -> ! {
+    resume_unwind(payload)
+}
+
+/// Retains the first panic and safely discards a later cleanup panic.
+pub(crate) fn keep_first_panic(first: &mut Option<PanicPayload>, candidate: Option<PanicPayload>) {
+    if first.is_none() {
+        *first = candidate;
+    } else {
+        discard_panic(candidate);
+    }
+}
+
+/// Resumes the primary panic, or the cleanup panic when there is no primary.
+/// During an existing unwind both are contained to prevent a double panic.
+pub(crate) fn resume_preferred_panic(primary: Option<PanicPayload>, cleanup: Option<PanicPayload>) {
+    if std::thread::panicking() {
+        discard_panic(primary);
+        discard_panic(cleanup);
+    } else if let Some(payload) = primary {
+        discard_panic(cleanup);
+        resume_panic(payload);
+    } else if let Some(payload) = cleanup {
+        resume_panic(payload);
+    }
+}
+
+/// Collects independent cleanup panics while allowing every cleanup step to
+/// run. Dropping the accumulator resumes the first panic unless another unwind
+/// is already in progress; callers that need to defer that decision can
+/// [`take`](Self::take) the payload.
+#[derive(Default)]
+pub(crate) struct PanicAccumulator {
+    first: Option<PanicPayload>,
+}
+
+impl PanicAccumulator {
+    pub(crate) fn run(&mut self, operation: impl FnOnce()) {
+        self.record(catch_panic(operation).err());
+    }
+
+    pub(crate) fn record(&mut self, candidate: Option<PanicPayload>) {
+        keep_first_panic(&mut self.first, candidate);
+    }
+
+    pub(crate) fn take(&mut self) -> Option<PanicPayload> {
+        self.first.take()
+    }
+}
+
+impl Drop for PanicAccumulator {
+    fn drop(&mut self) {
+        resume_preferred_panic(None, self.first.take());
+    }
 }
 
 pub(crate) fn now() -> std::time::Instant {
@@ -229,13 +308,11 @@ where
         else {
             return;
         };
-        let panic = catch_unwind(AssertUnwindSafe(|| drop(value)))
-            .err()
-            .map(contain_panic_payload);
+        let panic = catch_panic(|| drop(value)).err().map(contain_panic_payload);
         // Completion is framework bookkeeping. Contain it as well so a
         // hostile waker or a runtime teardown race cannot unwind a blocking
         // worker or double-panic while the job is being dropped.
-        let _ = catch_unwind(AssertUnwindSafe(|| completion(panic)));
+        discard_panic(catch_panic(|| completion(panic)).err());
     }
 }
 
@@ -256,11 +333,12 @@ where
 {
     if is_available() {
         let worker = Arc::clone(&job);
-        if let Ok(handle) = catch_unwind(AssertUnwindSafe(|| {
-            task::spawn_blocking(move || worker.finish())
-        })) {
-            drop(handle);
-            return;
+        match catch_panic(|| task::spawn_blocking(move || worker.finish())) {
+            Ok(handle) => {
+                drop(handle);
+                return;
+            }
+            Err(payload) => discard_panic(Some(payload)),
         }
     }
 
@@ -802,7 +880,7 @@ pub(crate) async fn join_resuming<T>(handle: JoinHandle<T>) -> T {
     let JoinHandle { inner } = handle;
     match inner.await {
         Ok(value) => value,
-        Err(error) if error.is_panic() => std::panic::resume_unwind(error.into_panic()),
+        Err(error) if error.is_panic() => resume_unwind(error.into_panic()),
         Err(error) => {
             debug_assert!(error.is_cancelled());
             panic!("library-owned operation task was unexpectedly cancelled")
@@ -810,17 +888,21 @@ pub(crate) async fn join_resuming<T>(handle: JoinHandle<T>) -> T {
     }
 }
 
-fn contain_panic_payload(payload: Box<dyn std::any::Any + Send + 'static>) -> Option<String> {
-    let message = catch_unwind(AssertUnwindSafe(|| panic_message(payload.as_ref())))
-        .ok()
-        .flatten();
+fn contain_panic_payload(payload: PanicPayload) -> Option<String> {
+    let message = match catch_panic(|| panic_message(payload.as_ref())) {
+        Ok(message) => message,
+        Err(inspection_panic) => {
+            discard_panic(Some(inspection_panic));
+            None
+        }
+    };
     // A custom panic payload is user-owned too. Its destructor may panic, so
     // discard it under a fresh unwind boundary before publishing completion.
-    let _ = catch_unwind(AssertUnwindSafe(|| drop(payload)));
+    discard_panic(Some(payload));
     message
 }
 
-fn panic_message(payload: &(dyn std::any::Any + Send + 'static)) -> Option<String> {
+fn panic_message(payload: &(dyn Any + Send + 'static)) -> Option<String> {
     if let Some(message) = payload.downcast_ref::<&str>() {
         Some((*message).to_owned())
     } else {
@@ -945,9 +1027,22 @@ mod tests {
     };
 
     use super::{
-        DisposalJob, JoinOutcome, Latch, OneShotClose, Signal, Timeout, join, oneshot, spawn,
-        timeout, yield_now,
+        DisposalJob, JoinOutcome, Latch, OneShotClose, Signal, Timeout, discard_panic, join,
+        oneshot, spawn, timeout, yield_now,
     };
+
+    struct RecursivelyPanickingPayload;
+
+    impl Drop for RecursivelyPanickingPayload {
+        fn drop(&mut self) {
+            std::panic::panic_any(RecursivelyPanickingPayload);
+        }
+    }
+
+    #[test]
+    fn discarding_a_recursively_hostile_panic_payload_is_contained() {
+        discard_panic(Some(Box::new(RecursivelyPanickingPayload)));
+    }
 
     struct PanickingDrop(Arc<AtomicUsize>);
 

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -67,11 +67,40 @@ pub(crate) fn keep_first_panic(first: &mut Option<PanicPayload>, candidate: Opti
 
 /// Resumes the primary panic, or the cleanup panic when there is no primary.
 /// During an existing unwind both are contained to prevent a double panic.
+///
+/// Containment is only correct where losing the diagnostic is the lesser
+/// outcome, which is true in a destructor and false on a normal return path.
+/// Callers that own the sole surviving copy of an authoritative panic must use
+/// [`resume_preferred_panic_outside_unwind`] instead.
 pub(crate) fn resume_preferred_panic(primary: Option<PanicPayload>, cleanup: Option<PanicPayload>) {
     if std::thread::panicking() {
         discard_panic(primary);
         discard_panic(cleanup);
     } else if let Some(payload) = primary {
+        discard_panic(cleanup);
+        resume_panic(payload);
+    } else if let Some(payload) = cleanup {
+        resume_panic(payload);
+    }
+}
+
+/// Resumes exactly as [`resume_preferred_panic`], but never contains the
+/// payload.
+///
+/// This is the variant for call sites that are not destructors and have
+/// already taken sole ownership of the panic. Silently discarding there would
+/// erase the authoritative diagnostic and let the caller continue past a
+/// failure it believes it re-raised, so the caller's non-unwinding precondition
+/// is asserted rather than absorbed.
+pub(crate) fn resume_preferred_panic_outside_unwind(
+    primary: Option<PanicPayload>,
+    cleanup: Option<PanicPayload>,
+) {
+    debug_assert!(
+        !std::thread::panicking(),
+        "an unwinding caller must contain its payloads with resume_preferred_panic"
+    );
+    if let Some(payload) = primary {
         discard_panic(cleanup);
         resume_panic(payload);
     } else if let Some(payload) = cleanup {

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -23,6 +23,12 @@ use crate::deadline::Deadline;
 #[cfg(test)]
 pub(crate) use tokio::test;
 
+/// Advances a paused test clock, keeping timer control in this module.
+#[cfg(test)]
+pub(crate) async fn advance(duration: Duration) {
+    time::advance(duration).await;
+}
+
 pub(crate) fn now() -> std::time::Instant {
     time::Instant::now().into_std()
 }

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -853,9 +853,15 @@ where
 
 pub(crate) type MpscSender<T> = mpsc::Sender<T>;
 pub(crate) type MpscReceiver<T> = mpsc::Receiver<T>;
+pub(crate) type UnboundedMpscSender<T> = mpsc::UnboundedSender<T>;
+pub(crate) type UnboundedMpscReceiver<T> = mpsc::UnboundedReceiver<T>;
 
 pub(crate) fn bounded_mpsc<T>(capacity: usize) -> (MpscSender<T>, MpscReceiver<T>) {
     mpsc::channel(capacity)
+}
+
+pub(crate) fn unbounded_mpsc<T>() -> (UnboundedMpscSender<T>, UnboundedMpscReceiver<T>) {
+    mpsc::unbounded_channel()
 }
 
 pub(crate) async fn mpsc_send<T>(sender: &MpscSender<T>, value: T) -> Result<(), T> {
@@ -863,6 +869,14 @@ pub(crate) async fn mpsc_send<T>(sender: &MpscSender<T>, value: T) -> Result<(),
 }
 
 pub(crate) fn mpsc_try_recv<T>(receiver: &mut MpscReceiver<T>) -> Option<T> {
+    receiver.try_recv().ok()
+}
+
+pub(crate) fn unbounded_mpsc_send<T>(sender: &UnboundedMpscSender<T>, value: T) -> Result<(), T> {
+    sender.send(value).map_err(|error| error.0)
+}
+
+pub(crate) fn unbounded_mpsc_try_recv<T>(receiver: &mut UnboundedMpscReceiver<T>) -> Option<T> {
     receiver.try_recv().ok()
 }
 

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -8,7 +8,7 @@ use std::{
     pin::Pin,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -373,24 +373,96 @@ impl Latch {
     }
 }
 
+const ONESHOT_OPEN: u8 = 0;
+const ONESHOT_SENDING: u8 = 1;
+const ONESHOT_SENT: u8 = 2;
+const ONESHOT_SENDER_CLOSED: u8 = 3;
+const ONESHOT_RECEIVER_CLOSED: u8 = 4;
+
 /// Sending half of a runtime-backed single-delivery channel.
-pub(crate) struct OneShotSender<T>(oneshot::Sender<T>);
+pub(crate) struct OneShotSender<T> {
+    channel: Option<oneshot::Sender<T>>,
+    state: Arc<AtomicU8>,
+}
 
 /// Receiving half of a runtime-backed single-delivery channel.
-pub(crate) struct OneShotReceiver<T>(oneshot::Receiver<T>);
+pub(crate) struct OneShotReceiver<T> {
+    channel: oneshot::Receiver<T>,
+    state: Arc<AtomicU8>,
+}
+
+/// Outcome after atomically closing a single-delivery receive side.
+pub(crate) enum OneShotClose<T> {
+    /// A value was sent before the receiver closed.
+    Value(T),
+    /// The sender was dropped before the receiver closed.
+    SenderClosed,
+    /// The receiver closed while the sender was still live and empty.
+    Empty,
+    /// The send transition won but has not published its value yet.
+    Pending,
+}
 
 pub(crate) fn oneshot<T>() -> (OneShotSender<T>, OneShotReceiver<T>) {
-    let (sender, receiver) = oneshot::channel();
-    (OneShotSender(sender), OneShotReceiver(receiver))
+    let (channel_sender, channel_receiver) = oneshot::channel();
+    let state = Arc::new(AtomicU8::new(ONESHOT_OPEN));
+    (
+        OneShotSender {
+            channel: Some(channel_sender),
+            state: Arc::clone(&state),
+        },
+        OneShotReceiver {
+            channel: channel_receiver,
+            state,
+        },
+    )
 }
 
 impl<T> OneShotSender<T> {
-    pub(crate) fn send(self, value: T) -> Result<(), T> {
-        self.0.send(value)
+    pub(crate) fn send(mut self, value: T) -> Result<(), T> {
+        if self
+            .state
+            .compare_exchange(
+                ONESHOT_OPEN,
+                ONESHOT_SENDING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return Err(value);
+        }
+        let sender = self
+            .channel
+            .take()
+            .expect("a live one-shot sender retains its channel");
+        match sender.send(value) {
+            Ok(()) => {
+                self.state.store(ONESHOT_SENT, Ordering::Release);
+                Ok(())
+            }
+            Err(value) => {
+                self.state.store(ONESHOT_RECEIVER_CLOSED, Ordering::Release);
+                Err(value)
+            }
+        }
     }
 
     pub(crate) fn is_closed(&self) -> bool {
-        self.0.is_closed()
+        self.channel.as_ref().is_none_or(oneshot::Sender::is_closed)
+    }
+}
+
+impl<T> Drop for OneShotSender<T> {
+    fn drop(&mut self) {
+        if self.channel.is_some() {
+            let _ = self.state.compare_exchange(
+                ONESHOT_OPEN,
+                ONESHOT_SENDER_CLOSED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            );
+        }
     }
 }
 
@@ -399,26 +471,59 @@ impl<T> OneShotReceiver<T> {
         &mut self,
         context: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<T>> {
-        Pin::new(&mut self.0).poll(context).map(Result::ok)
+        Pin::new(&mut self.channel).poll(context).map(Result::ok)
     }
 
-    /// Closes the receive side and returns a value whose send won the race.
+    /// Closes the receive side unless send or sender-drop won first.
     ///
-    /// `tokio::sync::oneshot` makes `close` atomic with `send`; checking the
-    /// slot after closing therefore gives deadline users one transition point
-    /// at which an already-completed delivery wins and every later send loses.
-    pub(crate) fn close_and_try_receive(&mut self) -> Option<T> {
-        self.0.close();
-        self.0.try_recv().ok()
+    /// The shared transition word distinguishes sender-drop from receiver
+    /// close, which Tokio's post-close `try_recv` result alone cannot do. A
+    /// send that wins but is preempted before publishing returns `Pending`;
+    /// the preceding channel poll registered the wake for its completion.
+    pub(crate) fn close_and_poll_receive(
+        &mut self,
+        context: &mut std::task::Context<'_>,
+    ) -> OneShotClose<T> {
+        match self.state.compare_exchange(
+            ONESHOT_OPEN,
+            ONESHOT_RECEIVER_CLOSED,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => {
+                self.channel.close();
+                OneShotClose::Empty
+            }
+            Err(ONESHOT_SENDER_CLOSED) => OneShotClose::SenderClosed,
+            Err(ONESHOT_SENDING) | Err(ONESHOT_SENT) => {
+                match Pin::new(&mut self.channel).poll(context) {
+                    std::task::Poll::Ready(Ok(value)) => OneShotClose::Value(value),
+                    std::task::Poll::Ready(Err(_)) => OneShotClose::SenderClosed,
+                    std::task::Poll::Pending => OneShotClose::Pending,
+                }
+            }
+            Err(ONESHOT_RECEIVER_CLOSED) => OneShotClose::Empty,
+            Err(other) => unreachable!("unknown one-shot transition state {other}"),
+        }
+    }
+
+    pub(crate) fn close(&mut self) {
+        let _ = self.state.compare_exchange(
+            ONESHOT_OPEN,
+            ONESHOT_RECEIVER_CLOSED,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+        self.channel.close();
     }
 
     pub(crate) async fn receive(self) -> Option<T> {
-        self.0.await.ok()
+        self.channel.await.ok()
     }
 
     #[cfg(test)]
     pub(crate) fn try_receive(&mut self) -> Option<T> {
-        self.0.try_recv().ok()
+        self.channel.try_recv().ok()
     }
 }
 
@@ -823,7 +928,8 @@ mod tests {
     };
 
     use super::{
-        DisposalJob, JoinOutcome, Latch, Signal, Timeout, join, spawn, timeout, yield_now,
+        DisposalJob, JoinOutcome, Latch, OneShotClose, Signal, Timeout, join, oneshot, spawn,
+        timeout, yield_now,
     };
 
     struct PanickingDrop(Arc<AtomicUsize>);
@@ -854,6 +960,31 @@ mod tests {
             diagnostic.as_ref(),
             Some(Some(Some(message))) if message == "cancelled disposal job payload"
         ));
+    }
+
+    #[test]
+    fn closing_oneshot_distinguishes_value_sender_drop_and_receiver_win() {
+        let mut context = Context::from_waker(Waker::noop());
+        let (sender, mut receiver) = oneshot();
+        sender.send(1_u8).expect("receiver is live");
+        assert!(matches!(
+            receiver.close_and_poll_receive(&mut context),
+            OneShotClose::Value(1)
+        ));
+
+        let (sender, mut receiver) = oneshot::<u8>();
+        drop(sender);
+        assert!(matches!(
+            receiver.close_and_poll_receive(&mut context),
+            OneShotClose::SenderClosed
+        ));
+
+        let (sender, mut receiver) = oneshot::<u8>();
+        assert!(matches!(
+            receiver.close_and_poll_receive(&mut context),
+            OneShotClose::Empty
+        ));
+        assert_eq!(sender.send(1), Err(1));
     }
 
     #[test]

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -5,6 +5,7 @@ use std::{
     future::Future,
     ops::RangeBounds,
     panic::{AssertUnwindSafe, catch_unwind},
+    pin::Pin,
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -17,6 +18,8 @@ use tokio::{
     task, time,
 };
 
+use crate::deadline::Deadline;
+
 #[cfg(test)]
 pub(crate) use tokio::test;
 
@@ -26,6 +29,130 @@ pub(crate) fn now() -> std::time::Instant {
 
 pub(crate) fn is_available() -> bool {
     tokio::runtime::Handle::try_current().is_ok()
+}
+
+pub(crate) type BoxedSleep = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+pub(crate) fn deadline(duration: Duration) -> Deadline {
+    Deadline::after(now(), duration)
+}
+
+pub(crate) fn sleep_deadline(deadline: Deadline) -> BoxedSleep {
+    Box::pin(async move {
+        match deadline.instant() {
+            Some(deadline) => sleep_until_std(deadline).await,
+            None => std::future::pending().await,
+        }
+    })
+}
+
+pub(crate) fn sleep_until(deadline: std::time::Instant) -> BoxedSleep {
+    Box::pin(sleep_until_std(deadline))
+}
+
+pub(crate) struct ActorWork {
+    handle: Option<JoinHandle<(), ()>>,
+    abort: AbortHandle,
+}
+
+impl ActorWork {
+    pub(crate) fn abort(&self) {
+        self.abort.abort();
+    }
+
+    pub(crate) async fn join(mut self) {
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+        let _ = join(handle).await;
+    }
+}
+
+impl Drop for ActorWork {
+    fn drop(&mut self) {
+        self.abort.abort();
+    }
+}
+
+pub(crate) fn spawn_actor_work(future: impl Future<Output = ()> + Send + 'static) -> ActorWork {
+    let handle = spawn((), future);
+    let abort = handle.abort_handle();
+    ActorWork {
+        handle: Some(handle),
+        abort,
+    }
+}
+
+pub(crate) struct BlockingWork<T> {
+    handle: Option<JoinHandle<(), T>>,
+}
+
+impl<T: Send + 'static> BlockingWork<T> {
+    pub(crate) async fn join(mut self) -> T {
+        let handle = self
+            .handle
+            .take()
+            .expect("blocking operation was joined more than once");
+        join_resuming(handle).await.1
+    }
+}
+
+pub(crate) fn spawn_blocking_work<T: Send + 'static>(
+    operation: impl FnOnce() -> T + Send + 'static,
+) -> BlockingWork<T> {
+    BlockingWork {
+        handle: Some(spawn_blocking((), operation)),
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Signal {
+    inner: WatchSender<()>,
+}
+
+impl Default for Signal {
+    fn default() -> Self {
+        Self { inner: watch(()).0 }
+    }
+}
+
+impl Clone for Signal {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl Signal {
+    pub(crate) fn pulse(&self) {
+        self.inner.pulse();
+    }
+
+    pub(crate) fn watcher(&self) -> SignalWatcher {
+        SignalWatcher {
+            inner: self.inner.watcher(),
+            _signal: self.clone(),
+        }
+    }
+
+    #[cfg(test)]
+    fn watcher_count(&self) -> usize {
+        self.inner.receiver_count()
+    }
+}
+
+pub(crate) struct SignalWatcher {
+    inner: WatchReceiver<()>,
+    // Retain the source through every watcher so channel closure cannot turn
+    // into a spurious pulse.
+    _signal: Signal,
+}
+
+impl SignalWatcher {
+    pub(crate) async fn changed(&mut self) {
+        self.inner.changed().await;
+    }
 }
 
 /// Ownership wrapper for user values retained by framework state.
@@ -674,11 +801,13 @@ mod tests {
             Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
         },
-        task::Poll,
+        task::{Context, Poll, Waker},
         time::Duration,
     };
 
-    use super::{DisposalJob, JoinOutcome, Latch, Timeout, join, spawn, timeout, yield_now};
+    use super::{
+        DisposalJob, JoinOutcome, Latch, Signal, Timeout, join, spawn, timeout, yield_now,
+    };
 
     struct PanickingDrop(Arc<AtomicUsize>);
 
@@ -708,6 +837,21 @@ mod tests {
             diagnostic.as_ref(),
             Some(Some(Some(message))) if message == "cancelled disposal job payload"
         ));
+    }
+
+    #[test]
+    fn quiet_signal_wait_cancellation_keeps_one_watch_registration() {
+        let signal = Signal::default();
+        let mut watcher = signal.watcher();
+        assert_eq!(signal.watcher_count(), 1);
+
+        for _ in 0..10_000 {
+            let mut changed = Box::pin(watcher.changed());
+            let mut context = Context::from_waker(Waker::noop());
+            assert!(changed.as_mut().poll(&mut context).is_pending());
+            drop(changed);
+            assert_eq!(signal.watcher_count(), 1);
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -395,6 +395,23 @@ impl<T> OneShotSender<T> {
 }
 
 impl<T> OneShotReceiver<T> {
+    pub(crate) fn poll_receive(
+        &mut self,
+        context: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<T>> {
+        Pin::new(&mut self.0).poll(context).map(Result::ok)
+    }
+
+    /// Closes the receive side and returns a value whose send won the race.
+    ///
+    /// `tokio::sync::oneshot` makes `close` atomic with `send`; checking the
+    /// slot after closing therefore gives deadline users one transition point
+    /// at which an already-completed delivery wins and every later send loses.
+    pub(crate) fn close_and_try_receive(&mut self) -> Option<T> {
+        self.0.close();
+        self.0.try_recv().ok()
+    }
+
     pub(crate) async fn receive(self) -> Option<T> {
         self.0.await.ok()
     }

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -360,7 +360,7 @@ mod tests {
 
     fn task_context() -> (TaskContext, Latch, Latch, Latch) {
         let id = ChildId::from("task");
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let membership = identity.mint_membership(&id).expect("membership available");
         let mut incarnations = identity.incarnation_counter(membership);
         let incarnation = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
@@ -419,7 +419,7 @@ mod tests {
         OneShotTaskRef<T>,
         std::sync::Arc<MemberCell>,
     ) {
-        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("task");
         let membership = identity.mint_membership(&id).expect("membership available");
         let member = MemberCell::new(id, membership);
@@ -503,15 +503,15 @@ mod tests {
             let primary = Latch::default();
             let local = Latch::default();
             let operation = CancellationToken::from_latch(primary.clone()).child(local.clone());
-            let waiter = runtime::spawn((), async move {
+            let waiter = runtime::spawn(async move {
                 operation.cancelled().await;
             });
 
-            let primary_firer = runtime::spawn((), async move {
+            let primary_firer = runtime::spawn(async move {
                 runtime::yield_now().await;
                 primary.fire()
             });
-            let local_firer = runtime::spawn((), async move {
+            let local_firer = runtime::spawn(async move {
                 runtime::yield_now().await;
                 local.fire()
             });

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -11,7 +11,7 @@ use std::{
 use crate::{
     ChildId, Exit, ExitError, ExitResult, Incarnation, Membership, PolicyError, Readiness,
     ReadinessDeadline, RestartPolicy, Retention, Shutdown,
-    driver::MemberCell,
+    cells::MemberCell,
     policy::CommonOptions,
     runtime::{self, Latch},
 };
@@ -380,7 +380,7 @@ mod tests {
 
     use crate::{
         ChildId, Exit, ExitKind,
-        driver::MemberCell,
+        cells::MemberCell,
         identity::ScopeIdentity,
         runtime::{self, JoinOutcome, Latch, Timeout},
     };

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -115,7 +115,13 @@ impl TaskContext {
 
     /// Releases manual readiness. Repeated calls are no-ops.
     pub fn mark_ready(&self) {
-        self.ready.fire();
+        if !self.is_stopping() {
+            self.ready.fire();
+        }
+    }
+
+    pub(crate) fn is_stopping(&self) -> bool {
+        self.shutdown.is_cancelled() || self.abort.is_cancelled()
     }
 }
 
@@ -385,7 +391,63 @@ mod tests {
         runtime::{self, JoinOutcome, Latch, Timeout},
     };
 
-    use super::{CancellationToken, OneShotTaskRef, TaskRef};
+    use super::{CancellationToken, OneShotTaskRef, TaskContext, TaskRef};
+
+    fn task_context() -> (TaskContext, Latch, Latch, Latch) {
+        let id = ChildId::from("task");
+        let mut identity = ScopeIdentity::new().expect("scope identity available");
+        let membership = identity.mint_membership(&id).expect("membership available");
+        let mut incarnations = identity.incarnation_counter(membership);
+        let incarnation = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
+            .expect("incarnation available");
+        let shutdown = Latch::default();
+        let abort = Latch::default();
+        let ready = Latch::default();
+        let context = TaskContext::new(
+            id,
+            incarnation,
+            shutdown.clone(),
+            abort.clone(),
+            ready.clone(),
+        );
+        (context, shutdown, abort, ready)
+    }
+
+    #[test]
+    fn live_task_context_can_publish_readiness() {
+        let (context, shutdown, abort, ready) = task_context();
+
+        assert!(!context.is_stopping());
+        context.mark_ready();
+
+        assert!(ready.is_fired());
+        assert!(!shutdown.is_fired());
+        assert!(!abort.is_fired());
+    }
+
+    #[test]
+    fn shutdown_first_prevents_task_readiness_publication() {
+        let (context, shutdown, abort, ready) = task_context();
+
+        assert!(shutdown.fire());
+        assert!(context.is_stopping());
+        context.mark_ready();
+
+        assert!(!ready.is_fired());
+        assert!(!abort.is_fired());
+    }
+
+    #[test]
+    fn abort_first_prevents_task_readiness_publication() {
+        let (context, shutdown, abort, ready) = task_context();
+
+        assert!(abort.fire());
+        assert!(context.is_stopping());
+        context.mark_ready();
+
+        assert!(!ready.is_fired());
+        assert!(!shutdown.is_fired());
+    }
 
     fn one_shot_claim<T>() -> (
         runtime::OneShotSender<T>,

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -1,6 +1,7 @@
 //! Supervised task definitions, contexts, and handles.
 
 use std::{
+    convert::Infallible,
     fmt,
     future::Future,
     hash::{Hash, Hasher},
@@ -12,6 +13,7 @@ use crate::{
     ChildId, Exit, ExitError, ExitResult, Incarnation, Membership, PolicyError, Readiness,
     ReadinessDeadline, RestartPolicy, Retention, Shutdown,
     cells::MemberCell,
+    definition::DefinitionSource,
     policy::CommonOptions,
     runtime::{self, Latch},
 };
@@ -157,42 +159,13 @@ impl TaskDef {
         }
     }
 
-    /// Overrides the restart policy.
-    #[must_use]
-    pub fn restart(mut self, restart: RestartPolicy) -> Self {
-        self.options.restart = Some(restart);
-        self
-    }
-
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides task readiness (`Immediate` or `Manual`).
-    pub fn readiness(mut self, readiness: Readiness) -> Result<Self, PolicyError> {
-        if readiness == Readiness::AfterInit {
-            return Err(PolicyError::UnsupportedReadiness);
-        }
-        self.options.readiness = Some(readiness);
-        Ok(self)
-    }
-
-    /// Overrides the readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(
+        restart,
+        shutdown,
+        task_readiness,
+        task_readiness_deadline,
+        retention,
+    );
 }
 
 type OnceTaskFuture<T> = Pin<Box<dyn Future<Output = Result<T, ExitError>> + Send + 'static>>;
@@ -228,40 +201,12 @@ impl<T: Send + 'static> TaskOnceDef<T> {
         }
     }
 
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides task readiness (`Immediate` or `Manual`).
-    pub fn readiness(mut self, readiness: Readiness) -> Result<Self, PolicyError> {
-        if readiness == Readiness::AfterInit {
-            return Err(PolicyError::UnsupportedReadiness);
-        }
-        self.options.readiness = Some(readiness);
-        Ok(self)
-    }
-
-    /// Overrides the readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(shutdown, task_readiness, task_readiness_deadline, retention,);
 
     pub(crate) fn erase(self, completion: runtime::OneShotSender<T>) -> OnceTask {
         let body = self.body;
         OnceTask {
-            body: OnceTaskBody::Available(Box::new(move |context| {
+            source: DefinitionSource::OneShot(Box::new(move |context| {
                 Box::pin(async move {
                     match body(context).await {
                         Ok(value) => {
@@ -278,13 +223,18 @@ impl<T: Send + 'static> TaskOnceDef<T> {
 }
 
 pub(crate) struct OnceTask {
-    pub(crate) body: OnceTaskBody,
+    source: DefinitionSource<Infallible, OnceTaskFactory>,
     pub(crate) options: CommonOptions,
 }
 
-pub(crate) enum OnceTaskBody {
-    Available(Box<dyn FnOnce(TaskContext) -> TaskFuture + Send + 'static>),
-    Spent,
+type OnceTaskFactory = Box<dyn FnOnce(TaskContext) -> TaskFuture + Send + 'static>;
+
+impl OnceTask {
+    pub(crate) fn take_body(&mut self) -> OnceTaskFactory {
+        self.source
+            .take_one_shot()
+            .expect("one-shot task construction invoked more than once")
+    }
 }
 
 /// A cheap membership-addressed task handle.

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -326,7 +326,14 @@ impl<T> OneShotTaskRef<T> {
         if !matches!(exit.kind(), crate::ExitKind::Completed) {
             return Err(exit);
         }
-        completion.receive().await.ok_or(exit)
+        // The erased one-shot body sends before returning success, and this
+        // receiver is the sole completion claim. A published Completed verdict
+        // with a closed, empty channel is therefore a framework invariant
+        // violation, not an application exit that can be reported as `Err`.
+        Ok(completion
+            .receive()
+            .await
+            .expect("completed one-shot task must publish its typed value"))
     }
 }
 
@@ -440,6 +447,16 @@ mod tests {
         assert!(matches!(waiting.as_mut().poll(&mut context), Poll::Pending));
         member.terminalize(exit.clone());
         assert_eq!(waiting.await, Err(exit));
+    }
+
+    #[crate::runtime::test]
+    #[should_panic(expected = "completed one-shot task must publish its typed value")]
+    async fn completed_terminal_publication_requires_a_typed_value() {
+        let (sender, claim, member) = one_shot_claim::<u8>();
+        drop(sender);
+        member.terminalize(Exit::new(ExitKind::Completed, false));
+
+        let _ = claim.wait().await;
     }
 
     #[crate::runtime::test]

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -319,7 +319,11 @@ impl<T> OneShotTaskRef<T> {
     /// The typed value is released only when terminal publication classifies
     /// the membership as [`crate::ExitKind::Completed`]. Any competing
     /// failure, panic, abort, readiness timeout, or never-started verdict wins
-    /// even if the task body produced a value first.
+    /// even if the task body produced a value first. That precedence is
+    /// deliberately asymmetric: a body that returned `Err` keeps its
+    /// [`crate::ExitKind::Failed`] verdict through a racing forced abort,
+    /// while a body that returned `Ok` does not — the value is dropped and
+    /// the claim resolves `Err` with the abort verdict.
     pub async fn wait(self) -> Result<T, Exit> {
         let Self { completion, task } = self;
         let exit = task.wait().await;

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -114,6 +114,10 @@ impl TaskContext {
     }
 
     /// Releases manual readiness. Repeated calls are no-ops.
+    ///
+    /// Once cooperative shutdown or escalation has begun this incarnation is
+    /// already stopping, so readiness can no longer be published and the call
+    /// is a no-op as well.
     pub fn mark_ready(&self) {
         if !self.is_stopping() {
             self.ready.fire();

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -55,7 +55,7 @@ impl CancellationToken {
     /// Waits until cancellation is requested.
     pub async fn cancelled(&self) {
         if let Some(secondary) = &self.secondary {
-            let _ = crate::driver::select(self.primary.fired(), secondary.fired()).await;
+            let _ = runtime::select_two(self.primary.fired(), secondary.fired()).await;
         } else {
             self.primary.fired().await;
         }

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -13,56 +13,22 @@ use std::{
 };
 
 use crate::{
-    ActorDef, ActorOnceDef, ActorRef, ChildId, DefaultsInheritance, Exit, Intensity, IntensityTrip,
+    ActorDef, ActorOnceDef, ActorRef, ChildId, DefaultsInheritance, Exit, Intensity,
     LifecycleEvents, Membership, ReadinessDeadline, RestartPolicy, Retention, ScopeDefaults,
-    ScopeSnapshot, Shutdown, ShutdownTimeout, SnapshotReceiver, StartupFailure, Strategy,
-    WaitError,
-    driver::{DynamicReservation, MemberCell, ScopeCell},
+    ScopeSnapshot, Shutdown, ShutdownTimeout, SnapshotReceiver, Strategy, WaitError,
+    cells::{MemberCell, MemberStage, ScopeCell},
+    driver::DynamicReservation,
+    exit::{StartupError, StopReason},
     identity::ScopeIdentity,
     mailbox::MailboxCell,
-    policy::{CommonOptions, IdError, ResolvedCommonOptions, ResolvedDefaults, resolve_common},
+    policy::{
+        CommonOptions, IdError, ResolvedCommonOptions, ResolvedDefaults, ScopeFlavor,
+        resolve_common,
+    },
     raw::{RawConstruction, RawDef, RawOnceDef},
     runtime::{self, Latch},
     task::{OnceTask, OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
 };
-
-/// Whether a scope has fixed ordered membership or runtime-dynamic membership.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum ScopeFlavor {
-    Ordered,
-    Dynamic,
-}
-
-/// The terminal reason for a scope incarnation or root system.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum StopReason {
-    /// A non-empty ordered workload completed naturally.
-    Finished,
-    /// Shutdown was explicitly requested.
-    ShutdownRequested,
-    /// The scope exceeded its restart budget.
-    IntensityTripped(IntensityTrip),
-    /// A nested scope could not complete startup.
-    StartupFailed(StartupFailure),
-    /// The membership terminalized without an incarnation.
-    NeverStarted,
-}
-
-/// Failure of the root startup barrier.
-#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
-#[non_exhaustive]
-pub enum StartupError {
-    /// A child or nested lowering failed terminally during startup.
-    #[error("tree startup failed")]
-    StartupFailed(StartupFailure),
-    /// Restart intensity tripped during startup.
-    #[error("restart intensity tripped during startup")]
-    IntensityTripped(IntensityTrip),
-    /// Shutdown began before startup completed.
-    #[error("shutdown was requested during startup")]
-    ShutdownRequested,
-}
 
 /// Startup failure paired with any rollback timeout report.
 #[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
@@ -331,7 +297,7 @@ impl BuilderCore {
                 }
             }
         }
-        root.set_config(self.config.clone());
+        root.set_observation_config(self.config.strategy, self.config.intensity);
         let defaults = inherited.overlay(&self.config.defaults);
         let mut children = Vec::with_capacity(self.slots.len());
         for slot in &self.slots {
@@ -1742,10 +1708,7 @@ impl ScopeRef {
             if expires.is_due(crate::runtime::now()) {
                 return Err(WaitError::TimedOut);
             }
-            if matches!(
-                self.cell.member.record().stage,
-                crate::driver::MemberStage::Terminal(_)
-            ) {
+            if matches!(self.cell.member.record().stage, MemberStage::Terminal(_)) {
                 return Err(WaitError::ScopeTerminated {
                     state: snapshot.state.clone(),
                 });

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -16,12 +16,13 @@ use crate::{
     Membership, ReadinessDeadline, RestartPolicy, Retention, ScopeDefaults, ScopeSnapshot,
     Shutdown, ShutdownTimeout, SnapshotReceiver, Strategy, WaitError,
     cells::{MemberStage, ScopeCell},
+    definition::DefinitionSource,
     driver::DynamicReservation,
     exit::{StartupError, StopReason},
     mailbox::MailboxCell,
     plan::{
         BuilderCore, ChildConstruction, LowerError, RemoveOutcome, ReserveError, ScopeConstruction,
-        ScopeSource, SlotCell, checked_id,
+        SlotCell, checked_id,
     },
     policy::{CommonOptions, ResolvedDefaults, ScopeFlavor},
     raw::{RawDef, RawOnceDef},
@@ -1041,33 +1042,7 @@ impl<T: Subtree> SubtreeDef<T> {
         }
     }
 
-    /// Overrides the restart policy.
-    #[must_use]
-    pub fn restart(mut self, restart: RestartPolicy) -> Self {
-        self.options.restart = Some(restart);
-        self
-    }
-
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the structural readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(restart, shutdown, structural_readiness_deadline, retention,);
 
     /// Selects inheritance or reset for unset nested defaults.
     #[must_use]
@@ -1079,7 +1054,7 @@ impl<T: Subtree> SubtreeDef<T> {
     fn erase(self) -> ScopeConstruction {
         let factory = self.factory;
         ScopeConstruction {
-            source: ScopeSource::Restartable(Arc::new(move || {
+            source: DefinitionSource::Restartable(Arc::new(move || {
                 <T as sealed::Sealed>::into_core(factory())
             })),
             options: self.options,
@@ -1117,26 +1092,7 @@ impl<T: Subtree> SubtreeOnceDef<T> {
         }
     }
 
-    /// Overrides the shutdown policy.
-    #[must_use]
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.options.shutdown = Some(shutdown);
-        self
-    }
-
-    /// Overrides the structural readiness deadline.
-    #[must_use]
-    pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-        self.options.readiness_deadline = deadline;
-        self
-    }
-
-    /// Overrides terminal-membership retention.
-    #[must_use]
-    pub fn retention(mut self, retention: Retention) -> Self {
-        self.options.retention = Some(retention);
-        self
-    }
+    common_options_setters!(shutdown, structural_readiness_deadline, retention,);
 
     /// Selects inheritance or reset for unset nested defaults.
     #[must_use]
@@ -1147,7 +1103,9 @@ impl<T: Subtree> SubtreeOnceDef<T> {
 
     fn erase(self) -> ScopeConstruction {
         ScopeConstruction {
-            source: ScopeSource::OneShot(Box::new(<T as sealed::Sealed>::into_core(self.tree))),
+            source: DefinitionSource::OneShot(Box::new(<T as sealed::Sealed>::into_core(
+                self.tree,
+            ))),
             options: self.options,
             defaults: self.defaults,
         }

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -746,7 +746,7 @@ fn spawn_builder<R>(
     core: BuilderCore,
     make_ref: impl FnOnce(ScopeRef) -> R,
 ) -> Result<System<R>, BuildError> {
-    if !crate::driver::runtime_available() {
+    if !runtime::is_available() {
         return Err(BuildError::NoRuntime);
     }
     let root = Arc::clone(&core.root);

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -1,33 +1,32 @@
 //! Tree declarations, scope handles, and the owning system façade.
 
 use std::{
-    collections::HashMap,
     fmt,
     future::Future,
     hash::{Hash, Hasher},
     marker::PhantomData,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::Arc,
     task::{Context, Poll},
     time::Duration,
 };
 
 use crate::{
-    ActorDef, ActorOnceDef, ActorRef, ChildId, DefaultsInheritance, Exit, Intensity,
-    LifecycleEvents, Membership, ReadinessDeadline, RestartPolicy, Retention, ScopeDefaults,
-    ScopeSnapshot, Shutdown, ShutdownTimeout, SnapshotReceiver, Strategy, WaitError,
-    cells::{MemberCell, MemberStage, ScopeCell},
+    ActorDef, ActorOnceDef, ActorRef, ChildId, DefaultsInheritance, Intensity, LifecycleEvents,
+    Membership, ReadinessDeadline, RestartPolicy, Retention, ScopeDefaults, ScopeSnapshot,
+    Shutdown, ShutdownTimeout, SnapshotReceiver, Strategy, WaitError,
+    cells::{MemberStage, ScopeCell},
     driver::DynamicReservation,
     exit::{StartupError, StopReason},
-    identity::ScopeIdentity,
     mailbox::MailboxCell,
-    policy::{
-        CommonOptions, IdError, ResolvedCommonOptions, ResolvedDefaults, ScopeFlavor,
-        resolve_common,
+    plan::{
+        BuilderCore, ChildConstruction, LowerError, RemoveOutcome, ReserveError, ScopeConstruction,
+        ScopeSource, SlotCell, checked_id,
     },
-    raw::{RawConstruction, RawDef, RawOnceDef},
+    policy::{CommonOptions, ResolvedDefaults, ScopeFlavor},
+    raw::{RawDef, RawOnceDef},
     runtime::{self, Latch},
-    task::{OnceTask, OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
+    task::{OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
 };
 
 /// Startup failure paired with any rollback timeout report.
@@ -38,43 +37,6 @@ pub struct StartOrShutdownError {
     pub startup: StartupError,
     /// Stragglers forced down after the rollback bound, if any.
     pub rollback_timeout: Option<ShutdownTimeout>,
-}
-
-/// A declaration-time reservation error.
-#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
-#[non_exhaustive]
-pub enum ReserveError {
-    /// The child id was empty.
-    #[error("child id must not be empty")]
-    EmptyId,
-    /// A resident membership already occupies the id.
-    #[error("child id `{0}` is already resident")]
-    DuplicateId(ChildId),
-    /// A same-id membership is currently being removed.
-    #[error("child id `{0}` is being removed")]
-    RemovalInProgress(ChildId),
-    /// The target dynamic scope is not admitting.
-    #[error("scope is not admitting: {0:?}")]
-    NotAdmitting(NotAdmittingCause),
-    /// The scope can mint no further membership identities.
-    #[error("membership identity space is exhausted")]
-    IdentityExhausted,
-}
-
-/// Exact reason an admission operation could not proceed.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum NotAdmittingCause {
-    /// The scope membership is terminal.
-    Terminal,
-    /// The live scope incarnation is draining.
-    Draining,
-    /// The dynamic root is parked after startup failure.
-    StartupFailed,
-    /// No scope incarnation is currently live.
-    NoLiveIncarnation,
-    /// This operation's reservation ended before admission.
-    ReservationEnded,
 }
 
 /// A root lowering error.
@@ -90,306 +52,6 @@ pub enum BuildError {
         /// Child-id paths of every undefined reservation.
         paths: Vec<Vec<ChildId>>,
     },
-}
-
-#[derive(Debug)]
-pub(crate) enum LowerError {
-    Undefined {
-        paths: Vec<Vec<ChildId>>,
-        disposal: crate::runtime::Latch,
-    },
-    IdentityExhausted {
-        id: ChildId,
-        disposal: crate::runtime::Latch,
-    },
-}
-
-/// Outcome of an idempotent dynamic removal.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum RemoveOutcome {
-    /// A reservation or resident membership was removed.
-    Removed,
-    /// No matching membership remained to remove.
-    AlreadyAbsent,
-}
-
-#[derive(Clone, Debug, Default)]
-pub(crate) struct ScopeConfig {
-    pub(crate) strategy: Strategy,
-    pub(crate) intensity: Intensity,
-    pub(crate) defaults: ScopeDefaults,
-}
-
-pub(crate) enum ChildConstruction {
-    Raw(RawConstruction),
-    Task(TaskDef),
-    TaskOnce(OnceTask),
-    Scope(Box<ScopeConstruction>),
-}
-
-enum DefinitionState {
-    Undefined,
-    Defined(crate::runtime::Isolated<ChildConstruction>),
-    Lowered,
-}
-
-pub(crate) struct SlotCell {
-    pub(crate) member: Arc<MemberCell>,
-    pub(crate) scope: Option<Arc<ScopeCell>>,
-    definition: Mutex<DefinitionState>,
-}
-
-impl SlotCell {
-    pub(crate) fn new(member: Arc<MemberCell>, scope: Option<Arc<ScopeCell>>) -> Arc<Self> {
-        Arc::new(Self {
-            member,
-            scope,
-            definition: Mutex::new(DefinitionState::Undefined),
-        })
-    }
-
-    pub(crate) fn define(&self, definition: ChildConstruction) {
-        let mut state = self.definition.lock().expect("definition mutex poisoned");
-        match *state {
-            DefinitionState::Undefined => {
-                *state = DefinitionState::Defined(crate::runtime::Isolated::new(definition));
-            }
-            DefinitionState::Defined(_) | DefinitionState::Lowered => {
-                panic!("a child slot was defined more than once")
-            }
-        }
-    }
-
-    pub(crate) fn is_undefined(&self) -> bool {
-        matches!(
-            *self.definition.lock().expect("definition mutex poisoned"),
-            DefinitionState::Undefined
-        )
-    }
-
-    pub(crate) fn take_definition(&self) -> Option<crate::runtime::Isolated<ChildConstruction>> {
-        let mut state = self.definition.lock().expect("definition mutex poisoned");
-        match std::mem::replace(&mut *state, DefinitionState::Lowered) {
-            DefinitionState::Defined(definition) => Some(definition),
-            DefinitionState::Undefined => {
-                *state = DefinitionState::Undefined;
-                None
-            }
-            DefinitionState::Lowered => panic!("a tree was lowered more than once"),
-        }
-    }
-
-    pub(crate) fn take_defined(&self) -> Option<crate::runtime::Isolated<ChildConstruction>> {
-        let mut state = self.definition.lock().expect("definition mutex poisoned");
-        match std::mem::replace(&mut *state, DefinitionState::Lowered) {
-            DefinitionState::Defined(definition) => Some(definition),
-            DefinitionState::Undefined => {
-                *state = DefinitionState::Undefined;
-                None
-            }
-            DefinitionState::Lowered => None,
-        }
-    }
-}
-
-pub(crate) struct BuilderCore {
-    root: Arc<ScopeCell>,
-    flavor: ScopeFlavor,
-    config: ScopeConfig,
-    slots: Vec<Arc<SlotCell>>,
-    ids: HashMap<ChildId, Arc<SlotCell>>,
-    armed: bool,
-}
-
-impl BuilderCore {
-    fn begin_failed_disposal(&self) -> crate::runtime::Latch {
-        let definitions = self
-            .slots
-            .iter()
-            .filter_map(|slot| slot.take_defined())
-            .filter_map(|mut definition| definition.take())
-            .collect();
-        crate::runtime::dispose_all(definitions)
-    }
-
-    fn new(flavor: ScopeFlavor) -> Self {
-        let root_id = ChildId::from("$root");
-        let mut root_identity =
-            ScopeIdentity::new().expect("global scope identity space exhausted");
-        let membership = root_identity
-            .mint_membership(&root_id)
-            .expect("fresh scope identity must mint its root membership");
-        let member = MemberCell::new(root_id, membership);
-        let child_identity = ScopeIdentity::new().expect("global scope identity space exhausted");
-        let root = ScopeCell::new(member, flavor, child_identity);
-        Self {
-            root,
-            flavor,
-            config: ScopeConfig::default(),
-            slots: Vec::new(),
-            ids: HashMap::new(),
-            armed: true,
-        }
-    }
-
-    fn reserve(
-        &mut self,
-        id: impl Into<ChildId>,
-        scope: Option<ScopeFlavor>,
-    ) -> Result<Arc<SlotCell>, ReserveError> {
-        let id = checked_id(id)?;
-        if self.ids.contains_key(&id) {
-            return Err(ReserveError::DuplicateId(id));
-        }
-        let membership = self
-            .root
-            .child_identity
-            .lock()
-            .expect("scope identity mutex poisoned")
-            .mint_membership(&id)
-            .ok_or(ReserveError::IdentityExhausted)?;
-        let member = MemberCell::new(id.clone(), membership);
-        let scope = scope.map(|flavor| {
-            let identity = ScopeIdentity::new().expect("global scope identity space exhausted");
-            ScopeCell::new(Arc::clone(&member), flavor, identity)
-        });
-        let slot = SlotCell::new(member, scope);
-        self.ids.insert(id, Arc::clone(&slot));
-        self.slots.push(Arc::clone(&slot));
-        Ok(slot)
-    }
-
-    pub(crate) fn lower(
-        mut self,
-        inherited: ResolvedDefaults,
-        root_override: Option<Arc<ScopeCell>>,
-    ) -> Result<ScopePlan, LowerError> {
-        let root = root_override.unwrap_or_else(|| Arc::clone(&self.root));
-        let undefined: Vec<_> = self
-            .slots
-            .iter()
-            .filter(|slot| slot.is_undefined())
-            .map(|slot| vec![slot.member.id().clone()])
-            .collect();
-        if !undefined.is_empty() {
-            let disposal = self.begin_failed_disposal();
-            return Err(LowerError::Undefined {
-                paths: undefined,
-                disposal,
-            });
-        }
-        if !Arc::ptr_eq(&root, &self.root) {
-            let mut identity = root
-                .child_identity
-                .lock()
-                .expect("scope identity mutex poisoned");
-            for slot in &self.slots {
-                let Some(membership) =
-                    identity.adopt_or_mint_membership(slot.member.id(), slot.member.membership())
-                else {
-                    let id = slot.member.id().clone();
-                    drop(identity);
-                    let disposal = self.begin_failed_disposal();
-                    return Err(LowerError::IdentityExhausted { id, disposal });
-                };
-                if membership != slot.member.membership() {
-                    slot.member.rebase_membership(membership);
-                }
-            }
-        }
-        root.set_observation_config(self.config.strategy, self.config.intensity);
-        let defaults = inherited.overlay(&self.config.defaults);
-        let mut children = Vec::with_capacity(self.slots.len());
-        for slot in &self.slots {
-            let definition = slot
-                .take_definition()
-                .expect("validated slot must have a definition");
-            let (options, one_shot) = match definition.get() {
-                ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
-                ChildConstruction::Task(definition) => (&definition.options, false),
-                ChildConstruction::TaskOnce(definition) => (&definition.options, true),
-                ChildConstruction::Scope(definition) => {
-                    (&definition.options, definition.one_shot())
-                }
-            };
-            let resolved =
-                resolve_common(options, &defaults, one_shot, crate::Readiness::Immediate);
-            slot.member.set_options(resolved.clone());
-            children.push(ChildPlan {
-                slot: Arc::clone(slot),
-                construction: definition,
-                options: resolved,
-            });
-        }
-        self.armed = false;
-        Ok(ScopePlan {
-            root,
-            flavor: self.flavor,
-            config: self.config.clone(),
-            defaults,
-            children,
-            armed: true,
-        })
-    }
-
-    fn terminalize(&self) {
-        for slot in &self.slots {
-            slot.member.terminalize(Exit::never_started());
-            if let Some(scope) = &slot.scope {
-                scope.terminalize_never_started();
-            }
-        }
-        self.root.terminalize_never_started();
-    }
-}
-
-impl Drop for BuilderCore {
-    fn drop(&mut self) {
-        if self.armed {
-            self.terminalize();
-        }
-    }
-}
-
-pub(crate) struct ScopePlan {
-    pub(crate) root: Arc<ScopeCell>,
-    pub(crate) flavor: ScopeFlavor,
-    pub(crate) config: ScopeConfig,
-    pub(crate) defaults: ResolvedDefaults,
-    pub(crate) children: Vec<ChildPlan>,
-    pub(crate) armed: bool,
-}
-
-impl Drop for ScopePlan {
-    fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-        for child in &self.children {
-            child.slot.member.terminalize(Exit::never_started());
-            if let Some(scope) = &child.slot.scope {
-                scope.terminalize_never_started();
-            }
-        }
-        // Lowering can publish the planned children before ScopeRuntime takes
-        // ownership. If construction then unwinds, the plan fallback also
-        // owns those residencies and their matching Removed edges.
-        self.root.clear_residents();
-        self.root.terminalize_never_started();
-    }
-}
-
-pub(crate) struct ChildPlan {
-    pub(crate) slot: Arc<SlotCell>,
-    pub(crate) construction: crate::runtime::Isolated<ChildConstruction>,
-    pub(crate) options: ResolvedCommonOptions,
-}
-
-fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError> {
-    let id = id.into();
-    ChildId::validate(id.as_str().to_owned()).map_err(|error| match error {
-        IdError::Empty => ReserveError::EmptyId,
-    })
 }
 
 fn attach_actor_slot<M: Send + 'static>(slot: Arc<SlotCell>) -> ActorSlot<M> {
@@ -734,7 +396,7 @@ fn spawn_builder<R>(
 }
 
 #[cfg(test)]
-pub(crate) fn lower_tree_for_test(tree: Tree) -> ScopePlan {
+pub(crate) fn lower_tree_for_test(tree: Tree) -> crate::plan::ScopePlan {
     tree.core
         .lower(ResolvedDefaults::default(), None)
         .expect("test tree must be fully defined")
@@ -1489,26 +1151,6 @@ impl<T: Subtree> SubtreeOnceDef<T> {
             defaults: self.defaults,
         }
     }
-}
-
-pub(crate) struct ScopeConstruction {
-    pub(crate) source: ScopeSource,
-    pub(crate) options: CommonOptions,
-    pub(crate) defaults: DefaultsInheritance,
-}
-
-pub(crate) type ScopeFactory = Arc<dyn Fn() -> BuilderCore + Send + Sync + 'static>;
-
-impl ScopeConstruction {
-    pub(crate) fn one_shot(&self) -> bool {
-        matches!(self.source, ScopeSource::OneShot(_) | ScopeSource::Spent)
-    }
-}
-
-pub(crate) enum ScopeSource {
-    Restartable(ScopeFactory),
-    OneShot(Box<BuilderCore>),
-    Spent,
 }
 
 /// A typed pre-spawn subtree slot.

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -24,7 +24,7 @@ use crate::{
         BuilderCore, ChildConstruction, LowerError, RemoveOutcome, ReserveError, ScopeConstruction,
         SlotCell,
     },
-    policy::{CommonOptions, ResolvedDefaults, ScopeFlavor},
+    policy::{CommonOptions, InvalidPolicy, ResolvedDefaults, ScopeFlavor},
     raw::{RawDef, RawOnceDef},
     runtime::{self, Latch},
     task::{OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
@@ -53,6 +53,9 @@ pub enum BuildError {
         /// Child-id paths of every undefined reservation.
         paths: Vec<Vec<ChildId>>,
     },
+    /// A public policy representation contained an invalid literal value.
+    #[error(transparent)]
+    InvalidPolicy(InvalidPolicy),
 }
 
 #[derive(Clone, Copy)]
@@ -533,6 +536,7 @@ fn spawn_builder<R>(
             LowerError::IdentityExhausted { .. } => {
                 unreachable!("root lowering does not mint memberships")
             }
+            LowerError::InvalidPolicy { invalid, .. } => BuildError::InvalidPolicy(invalid),
         })?;
     let scope_ref = ScopeRef { cell: root };
     let run = crate::driver::spawn_system(plan);

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -1232,7 +1232,7 @@ impl ScopeRef {
 
     /// Requests shutdown without waiting.
     pub fn request_shutdown(&self) {
-        self.cell.request_shutdown();
+        let _ = self.cell.request_shutdown();
     }
 
     /// Waits for terminal membership state.

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -396,15 +396,16 @@ fn spawn_builder<R>(
 }
 
 #[cfg(test)]
-pub(crate) fn lower_tree_for_test(tree: Tree) -> crate::plan::ScopePlan {
-    tree.core
-        .lower(ResolvedDefaults::default(), None)
-        .expect("test tree must be fully defined")
-}
+impl Tree {
+    pub(crate) fn lower_for_test(self) -> crate::plan::ScopePlan {
+        self.core
+            .lower(ResolvedDefaults::default(), None)
+            .expect("test tree must be fully defined")
+    }
 
-#[cfg(test)]
-pub(crate) fn into_core_for_test(tree: Tree) -> BuilderCore {
-    tree.core
+    pub(crate) fn into_core_for_test(self) -> BuilderCore {
+        self.core
+    }
 }
 
 /// An owned pre-spawn actor slot with a stable mailbox binding.

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -664,27 +664,94 @@ impl<H> AdmissionReceipt<H> {
     }
 }
 
-/// An admission future. Fused additions abort on drop; split definitions
-/// detach after their first poll.
+/// An admission future.
+///
+/// Fused additions abort on drop; split definitions detach after their first
+/// poll starts admission. Reservation and that first poll require an ambient
+/// Tokio runtime. A first poll outside one returns [`ReserveError::NoRuntime`]
+/// and releases the reservation. Like a fused future, it remains pending if
+/// polled again after completion.
 #[must_use]
 pub struct Admission<H> {
-    reservation: Option<DynamicReservation>,
-    receipt: Option<AdmissionReceipt<H>>,
-    fused_cancel: Option<Latch>,
-    inner: Option<AdmissionWait>,
-    immediate: Option<ReserveError>,
-    polled: bool,
-    done: bool,
+    state: AdmissionState<H>,
 }
 
 type AdmissionWait = Pin<Box<dyn Future<Output = Result<(), ReserveError>> + Send + 'static>>;
+
+struct PendingAdmission<H> {
+    reservation: DynamicReservation,
+    receipt: AdmissionReceipt<H>,
+    fused_cancel: Option<Latch>,
+}
+
+impl<H> PendingAdmission<H> {
+    fn start(&self) -> Result<AdmissionWait, ReserveError> {
+        let response = crate::driver::start_admission(
+            Arc::clone(&self.reservation.control),
+            Arc::clone(&self.reservation.slot),
+            self.fused_cancel.clone(),
+        )?;
+        Ok(Box::pin(async move {
+            response
+                .receive()
+                .await
+                .unwrap_or(Err(ReserveError::NotAdmitting(
+                    crate::NotAdmittingCause::Terminal,
+                )))
+        }))
+    }
+
+    fn cancel_reservation(&self) {
+        crate::driver::cancel_dynamic_reservation(
+            &self.reservation.control,
+            &self.reservation.slot,
+        );
+    }
+}
+
+enum AdmissionState<H> {
+    Immediate(ReserveError),
+    Unpolled(PendingAdmission<H>),
+    InFlight {
+        pending: PendingAdmission<H>,
+        wait: AdmissionWait,
+    },
+    Done,
+}
+
+impl<H> AdmissionState<H> {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Immediate(_) => "Immediate",
+            Self::Unpolled(_) => "Unpolled",
+            Self::InFlight { .. } => "InFlight",
+            Self::Done => "Done",
+        }
+    }
+
+    fn begin(self, wait: AdmissionWait) -> Self {
+        match self {
+            Self::Unpolled(pending) => Self::InFlight { pending, wait },
+            other => other,
+        }
+    }
+
+    fn complete(
+        self,
+        result: Result<(), ReserveError>,
+    ) -> (Self, Option<Result<AdmissionReceipt<H>, ReserveError>>) {
+        match self {
+            Self::InFlight { pending, .. } => (Self::Done, Some(result.map(|()| pending.receipt))),
+            other => (other, None),
+        }
+    }
+}
 
 impl<H> fmt::Debug for Admission<H> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("Admission")
-            .field("polled", &self.polled)
-            .field("done", &self.done)
+            .field("state", &self.state.name())
             .finish_non_exhaustive()
     }
 }
@@ -692,29 +759,21 @@ impl<H> fmt::Debug for Admission<H> {
 impl<H> Admission<H> {
     fn error(error: ReserveError) -> Self {
         Self {
-            reservation: None,
-            receipt: None,
-            fused_cancel: None,
-            inner: None,
-            immediate: Some(error),
-            polled: false,
-            done: false,
+            state: AdmissionState::Immediate(error),
         }
     }
 
     fn new(reservation: DynamicReservation, handles: H, fused: bool) -> Self {
         let membership = reservation.slot.member.membership();
         Self {
-            reservation: Some(reservation),
-            receipt: Some(AdmissionReceipt {
-                membership,
-                handles,
+            state: AdmissionState::Unpolled(PendingAdmission {
+                reservation,
+                receipt: AdmissionReceipt {
+                    membership,
+                    handles,
+                },
+                fused_cancel: fused.then(Latch::default),
             }),
-            fused_cancel: fused.then(Latch::default),
-            inner: None,
-            immediate: None,
-            polled: false,
-            done: false,
         }
     }
 }
@@ -723,64 +782,54 @@ impl<H: Unpin> Future for Admission<H> {
     type Output = Result<AdmissionReceipt<H>, ReserveError>;
 
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
-        if let Some(error) = self.immediate.take() {
-            self.done = true;
-            return Poll::Ready(Err(error));
-        }
-        if !self.polled {
-            self.polled = true;
-            let reservation = self
-                .reservation
-                .as_ref()
-                .expect("pending admission must carry its reservation");
-            let response = crate::driver::start_admission(
-                Arc::clone(&reservation.control),
-                Arc::clone(&reservation.slot),
-                self.fused_cancel.clone(),
-            );
-            self.inner = Some(Box::pin(async move {
-                response
-                    .receive()
-                    .await
-                    .expect("admission response obligation must complete")
-            }));
-        }
-        let poll = self
-            .inner
-            .as_mut()
-            .expect("polled admission must carry its response future")
-            .as_mut()
-            .poll(context);
-        match poll {
-            Poll::Ready(Ok(())) => {
-                self.done = true;
-                Poll::Ready(Ok(self
-                    .receipt
-                    .take()
-                    .expect("successful admission must carry a receipt")))
+        let this = self.as_mut().get_mut();
+        loop {
+            match &mut this.state {
+                AdmissionState::Immediate(error) => {
+                    let error = error.clone();
+                    this.state = AdmissionState::Done;
+                    return Poll::Ready(Err(error));
+                }
+                AdmissionState::Unpolled(pending) => {
+                    let wait = match pending.start() {
+                        Ok(wait) => wait,
+                        Err(error) => {
+                            pending.cancel_reservation();
+                            this.state = AdmissionState::Done;
+                            return Poll::Ready(Err(error));
+                        }
+                    };
+                    let previous = std::mem::replace(&mut this.state, AdmissionState::Done);
+                    this.state = previous.begin(wait);
+                }
+                AdmissionState::InFlight { wait, .. } => match wait.as_mut().poll(context) {
+                    Poll::Ready(result) => {
+                        let previous = std::mem::replace(&mut this.state, AdmissionState::Done);
+                        let (state, output) = previous.complete(result);
+                        this.state = state;
+                        if let Some(output) = output {
+                            return Poll::Ready(output);
+                        }
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
+                AdmissionState::Done => return Poll::Pending,
             }
-            Poll::Ready(Err(error)) => {
-                self.done = true;
-                Poll::Ready(Err(error))
-            }
-            Poll::Pending => Poll::Pending,
         }
     }
 }
 
 impl<H> Drop for Admission<H> {
     fn drop(&mut self) {
-        if self.done {
-            return;
-        }
-        let Some(reservation) = &self.reservation else {
-            return;
-        };
-        if let Some(cancel) = &self.fused_cancel {
-            crate::driver::signal_fused_cancel(&reservation.control, cancel);
-            crate::driver::cancel_dynamic_reservation(&reservation.control, &reservation.slot);
-        } else if !self.polled {
-            crate::driver::cancel_dynamic_reservation(&reservation.control, &reservation.slot);
+        match &self.state {
+            AdmissionState::Unpolled(pending) => pending.cancel_reservation(),
+            AdmissionState::InFlight { pending, .. } => {
+                if let Some(cancel) = &pending.fused_cancel {
+                    crate::driver::signal_fused_cancel(&pending.reservation.control, cancel);
+                    pending.cancel_reservation();
+                }
+            }
+            AdmissionState::Immediate(_) | AdmissionState::Done => {}
         }
     }
 }
@@ -1364,6 +1413,8 @@ impl DynamicScopeRef {
     }
 
     /// Reserves an actor id synchronously and exposes its exact handle.
+    ///
+    /// Returns [`ReserveError::NoRuntime`] outside an ambient Tokio runtime.
     pub fn reserve_actor<M: Send + 'static>(
         &self,
         id: impl Into<ChildId>,
@@ -1432,6 +1483,8 @@ impl DynamicScopeRef {
     }
 
     /// Reserves a task id synchronously and exposes its exact handle.
+    ///
+    /// Returns [`ReserveError::NoRuntime`] outside an ambient Tokio runtime.
     pub fn reserve_task(&self, id: impl Into<ChildId>) -> Result<DynamicTaskSlot, ReserveError> {
         crate::driver::reserve_dynamic(&self.0.cell, id.into(), None).map(|reservation| {
             DynamicTaskSlot {
@@ -1461,6 +1514,8 @@ impl DynamicScopeRef {
     }
 
     /// Reserves a typed subtree id synchronously.
+    ///
+    /// Returns [`ReserveError::NoRuntime`] outside an ambient Tokio runtime.
     pub fn reserve_subtree<T: Subtree>(
         &self,
         id: impl Into<ChildId>,

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -61,6 +61,138 @@ fn attach_actor_slot<M: Send + 'static>(slot: Arc<SlotCell>) -> ActorSlot<M> {
     ActorSlot { slot, mailbox }
 }
 
+macro_rules! impl_common_builder_surface {
+    (
+        reserve_actor: $reserve_actor_doc:literal,
+        add_actor: $add_actor_doc:literal,
+        add_actor_once: $add_actor_once_doc:literal,
+        add_raw: $add_raw_doc:literal,
+        add_raw_once: $add_raw_once_doc:literal,
+        reserve_task: $reserve_task_doc:literal,
+        add_task: $add_task_doc:literal,
+        add_task_once: $add_task_once_doc:literal,
+        reserve_subtree: $reserve_subtree_doc:literal,
+        add_subtree: $add_subtree_doc:literal,
+        add_subtree_once: $add_subtree_once_doc:literal $(,)?
+    ) => {
+        /// Sets the scope restart-intensity budget.
+        pub fn intensity(&mut self, intensity: Intensity) -> &mut Self {
+            self.core.config.intensity = intensity;
+            self
+        }
+
+        /// Sets child policy defaults for this scope.
+        pub fn defaults(&mut self, defaults: ScopeDefaults) -> &mut Self {
+            self.core.config.defaults = defaults;
+            self
+        }
+
+        #[doc = $reserve_actor_doc]
+        pub fn reserve_actor<M: Send + 'static>(
+            &mut self,
+            id: impl Into<ChildId>,
+        ) -> Result<ActorSlot<M>, ReserveError> {
+            self.core.reserve(id, None).map(attach_actor_slot)
+        }
+
+        #[doc = $add_actor_doc]
+        pub fn add_actor<A: crate::Actor>(
+            &mut self,
+            id: impl Into<ChildId>,
+            definition: ActorDef<A>,
+        ) -> Result<ActorRef<A::Msg>, ReserveError> {
+            self.reserve_actor(id).map(|slot| slot.define(definition))
+        }
+
+        #[doc = $add_actor_once_doc]
+        pub fn add_actor_once<A: crate::Actor>(
+            &mut self,
+            id: impl Into<ChildId>,
+            definition: ActorOnceDef<A>,
+        ) -> Result<ActorRef<A::Msg>, ReserveError> {
+            self.reserve_actor(id)
+                .map(|slot| slot.define_once(definition))
+        }
+
+        #[doc = $add_raw_doc]
+        pub fn add_raw<R: crate::RawActor>(
+            &mut self,
+            id: impl Into<ChildId>,
+            definition: RawDef<R>,
+        ) -> Result<ActorRef<R::Msg>, ReserveError> {
+            self.reserve_actor(id)
+                .map(|slot| slot.define_raw(definition))
+        }
+
+        #[doc = $add_raw_once_doc]
+        pub fn add_raw_once<R: crate::RawActor>(
+            &mut self,
+            id: impl Into<ChildId>,
+            definition: RawOnceDef<R>,
+        ) -> Result<ActorRef<R::Msg>, ReserveError> {
+            self.reserve_actor(id)
+                .map(|slot| slot.define_once_raw(definition))
+        }
+
+        #[doc = $reserve_task_doc]
+        pub fn reserve_task(&mut self, id: impl Into<ChildId>) -> Result<TaskSlot, ReserveError> {
+            self.core.reserve(id, None).map(|slot| TaskSlot { slot })
+        }
+
+        #[doc = $add_task_doc]
+        pub fn add_task(
+            &mut self,
+            id: impl Into<ChildId>,
+            definition: TaskDef,
+        ) -> Result<TaskRef, ReserveError> {
+            self.reserve_task(id).map(|slot| slot.define(definition))
+        }
+
+        #[doc = $add_task_once_doc]
+        pub fn add_task_once<T: Send + 'static>(
+            &mut self,
+            id: impl Into<ChildId>,
+            definition: TaskOnceDef<T>,
+        ) -> Result<(TaskRef, OneShotTaskRef<T>), ReserveError> {
+            self.reserve_task(id)
+                .map(|slot| slot.define_once(definition))
+        }
+
+        #[doc = $reserve_subtree_doc]
+        pub fn reserve_subtree<T: Subtree>(
+            &mut self,
+            id: impl Into<ChildId>,
+        ) -> Result<SubtreeSlot<T>, ReserveError> {
+            self.core
+                .reserve(id, Some(<T as sealed::Sealed>::FLAVOR))
+                .map(|slot| SubtreeSlot {
+                    slot,
+                    marker: PhantomData,
+                })
+        }
+
+        #[doc = $add_subtree_doc]
+        pub fn add_subtree<T: Subtree>(
+            &mut self,
+            id: impl Into<ChildId>,
+            definition: SubtreeDef<T>,
+        ) -> Result<T::Ref, ReserveError> {
+            self.reserve_subtree::<T>(id)
+                .map(|slot| slot.define(definition))
+        }
+
+        #[doc = $add_subtree_once_doc]
+        pub fn add_subtree_once<T: Subtree>(
+            &mut self,
+            id: impl Into<ChildId>,
+            definition: SubtreeOnceDef<T>,
+        ) -> Result<T::Ref, ReserveError> {
+            self.reserve_subtree::<T>(id)
+                .map(|slot| slot.define_once(definition))
+        }
+    };
+}
+
 /// A fixed-membership, readiness-ordered tree declaration.
 pub struct Tree {
     core: BuilderCore,
@@ -97,120 +229,18 @@ impl Tree {
         self
     }
 
-    /// Sets the scope restart-intensity budget.
-    pub fn intensity(&mut self, intensity: Intensity) -> &mut Self {
-        self.core.config.intensity = intensity;
-        self
-    }
-
-    /// Sets child policy defaults for this scope.
-    pub fn defaults(&mut self, defaults: ScopeDefaults) -> &mut Self {
-        self.core.config.defaults = defaults;
-        self
-    }
-
-    /// Reserves an actor membership and returns its pre-spawn handle slot.
-    pub fn reserve_actor<M: Send + 'static>(
-        &mut self,
-        id: impl Into<ChildId>,
-    ) -> Result<ActorSlot<M>, ReserveError> {
-        self.core.reserve(id, None).map(attach_actor_slot)
-    }
-
-    /// Adds a restartable callback-oriented actor.
-    pub fn add_actor<A: crate::Actor>(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: ActorDef<A>,
-    ) -> Result<ActorRef<A::Msg>, ReserveError> {
-        self.reserve_actor(id).map(|slot| slot.define(definition))
-    }
-
-    /// Adds a consuming one-shot callback-oriented actor.
-    pub fn add_actor_once<A: crate::Actor>(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: ActorOnceDef<A>,
-    ) -> Result<ActorRef<A::Msg>, ReserveError> {
-        self.reserve_actor(id)
-            .map(|slot| slot.define_once(definition))
-    }
-
-    /// Adds a restartable raw actor.
-    pub fn add_raw<R: crate::RawActor>(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: RawDef<R>,
-    ) -> Result<ActorRef<R::Msg>, ReserveError> {
-        self.reserve_actor(id)
-            .map(|slot| slot.define_raw(definition))
-    }
-
-    /// Adds a consuming one-shot raw actor.
-    pub fn add_raw_once<R: crate::RawActor>(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: RawOnceDef<R>,
-    ) -> Result<ActorRef<R::Msg>, ReserveError> {
-        self.reserve_actor(id)
-            .map(|slot| slot.define_once_raw(definition))
-    }
-
-    /// Reserves a task membership and returns its pre-spawn handle slot.
-    pub fn reserve_task(&mut self, id: impl Into<ChildId>) -> Result<TaskSlot, ReserveError> {
-        self.core.reserve(id, None).map(|slot| TaskSlot { slot })
-    }
-
-    /// Adds a restartable task.
-    pub fn add_task(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: TaskDef,
-    ) -> Result<TaskRef, ReserveError> {
-        self.reserve_task(id).map(|slot| slot.define(definition))
-    }
-
-    /// Adds a consuming one-shot task and its typed completion claim.
-    pub fn add_task_once<T: Send + 'static>(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: TaskOnceDef<T>,
-    ) -> Result<(TaskRef, OneShotTaskRef<T>), ReserveError> {
-        self.reserve_task(id)
-            .map(|slot| slot.define_once(definition))
-    }
-
-    /// Reserves a typed subtree membership.
-    pub fn reserve_subtree<T: Subtree>(
-        &mut self,
-        id: impl Into<ChildId>,
-    ) -> Result<SubtreeSlot<T>, ReserveError> {
-        self.core
-            .reserve(id, Some(<T as sealed::Sealed>::FLAVOR))
-            .map(|slot| SubtreeSlot {
-                slot,
-                marker: PhantomData,
-            })
-    }
-
-    /// Adds a restartable subtree.
-    pub fn add_subtree<T: Subtree>(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: SubtreeDef<T>,
-    ) -> Result<T::Ref, ReserveError> {
-        self.reserve_subtree::<T>(id)
-            .map(|slot| slot.define(definition))
-    }
-
-    /// Adds a consuming one-shot subtree.
-    pub fn add_subtree_once<T: Subtree>(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: SubtreeOnceDef<T>,
-    ) -> Result<T::Ref, ReserveError> {
-        self.reserve_subtree::<T>(id)
-            .map(|slot| slot.define_once(definition))
+    impl_common_builder_surface! {
+        reserve_actor: "Reserves an actor membership and returns its pre-spawn handle slot.",
+        add_actor: "Adds a restartable callback-oriented actor.",
+        add_actor_once: "Adds a consuming one-shot callback-oriented actor.",
+        add_raw: "Adds a restartable raw actor.",
+        add_raw_once: "Adds a consuming one-shot raw actor.",
+        reserve_task: "Reserves a task membership and returns its pre-spawn handle slot.",
+        add_task: "Adds a restartable task.",
+        add_task_once: "Adds a consuming one-shot task and its typed completion claim.",
+        reserve_subtree: "Reserves a typed subtree membership.",
+        add_subtree: "Adds a restartable subtree.",
+        add_subtree_once: "Adds a consuming one-shot subtree.",
     }
 
     /// Lowers and starts this tree synchronously.
@@ -249,120 +279,18 @@ impl DynamicTree {
         }
     }
 
-    /// Sets the scope restart-intensity budget.
-    pub fn intensity(&mut self, intensity: Intensity) -> &mut Self {
-        self.core.config.intensity = intensity;
-        self
-    }
-
-    /// Sets child policy defaults for this scope.
-    pub fn defaults(&mut self, defaults: ScopeDefaults) -> &mut Self {
-        self.core.config.defaults = defaults;
-        self
-    }
-
-    /// Reserves an initial actor membership.
-    pub fn reserve_actor<M: Send + 'static>(
-        &mut self,
-        id: impl Into<ChildId>,
-    ) -> Result<ActorSlot<M>, ReserveError> {
-        self.core.reserve(id, None).map(attach_actor_slot)
-    }
-
-    /// Adds an initial restartable callback-oriented actor.
-    pub fn add_actor<A: crate::Actor>(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: ActorDef<A>,
-    ) -> Result<ActorRef<A::Msg>, ReserveError> {
-        self.reserve_actor(id).map(|slot| slot.define(definition))
-    }
-
-    /// Adds an initial consuming one-shot callback-oriented actor.
-    pub fn add_actor_once<A: crate::Actor>(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: ActorOnceDef<A>,
-    ) -> Result<ActorRef<A::Msg>, ReserveError> {
-        self.reserve_actor(id)
-            .map(|slot| slot.define_once(definition))
-    }
-
-    /// Adds an initial restartable raw actor.
-    pub fn add_raw<R: crate::RawActor>(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: RawDef<R>,
-    ) -> Result<ActorRef<R::Msg>, ReserveError> {
-        self.reserve_actor(id)
-            .map(|slot| slot.define_raw(definition))
-    }
-
-    /// Adds an initial consuming one-shot raw actor.
-    pub fn add_raw_once<R: crate::RawActor>(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: RawOnceDef<R>,
-    ) -> Result<ActorRef<R::Msg>, ReserveError> {
-        self.reserve_actor(id)
-            .map(|slot| slot.define_once_raw(definition))
-    }
-
-    /// Reserves an initial task membership.
-    pub fn reserve_task(&mut self, id: impl Into<ChildId>) -> Result<TaskSlot, ReserveError> {
-        self.core.reserve(id, None).map(|slot| TaskSlot { slot })
-    }
-
-    /// Adds an initial restartable task.
-    pub fn add_task(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: TaskDef,
-    ) -> Result<TaskRef, ReserveError> {
-        self.reserve_task(id).map(|slot| slot.define(definition))
-    }
-
-    /// Adds an initial one-shot task.
-    pub fn add_task_once<T: Send + 'static>(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: TaskOnceDef<T>,
-    ) -> Result<(TaskRef, OneShotTaskRef<T>), ReserveError> {
-        self.reserve_task(id)
-            .map(|slot| slot.define_once(definition))
-    }
-
-    /// Reserves an initial typed subtree membership.
-    pub fn reserve_subtree<T: Subtree>(
-        &mut self,
-        id: impl Into<ChildId>,
-    ) -> Result<SubtreeSlot<T>, ReserveError> {
-        self.core
-            .reserve(id, Some(<T as sealed::Sealed>::FLAVOR))
-            .map(|slot| SubtreeSlot {
-                slot,
-                marker: PhantomData,
-            })
-    }
-
-    /// Adds an initial restartable subtree.
-    pub fn add_subtree<T: Subtree>(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: SubtreeDef<T>,
-    ) -> Result<T::Ref, ReserveError> {
-        self.reserve_subtree::<T>(id)
-            .map(|slot| slot.define(definition))
-    }
-
-    /// Adds an initial one-shot subtree.
-    pub fn add_subtree_once<T: Subtree>(
-        &mut self,
-        id: impl Into<ChildId>,
-        definition: SubtreeOnceDef<T>,
-    ) -> Result<T::Ref, ReserveError> {
-        self.reserve_subtree::<T>(id)
-            .map(|slot| slot.define_once(definition))
+    impl_common_builder_surface! {
+        reserve_actor: "Reserves an initial actor membership.",
+        add_actor: "Adds an initial restartable callback-oriented actor.",
+        add_actor_once: "Adds an initial consuming one-shot callback-oriented actor.",
+        add_raw: "Adds an initial restartable raw actor.",
+        add_raw_once: "Adds an initial consuming one-shot raw actor.",
+        reserve_task: "Reserves an initial task membership.",
+        add_task: "Adds an initial restartable task.",
+        add_task_once: "Adds an initial one-shot task.",
+        reserve_subtree: "Reserves an initial typed subtree membership.",
+        add_subtree: "Adds an initial restartable subtree.",
+        add_subtree_once: "Adds an initial one-shot subtree.",
     }
 
     /// Lowers and starts this tree synchronously.

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -692,12 +692,17 @@ impl<H> PendingAdmission<H> {
             self.fused_cancel.clone(),
         )?;
         Ok(Box::pin(async move {
-            response
-                .receive()
-                .await
-                .unwrap_or(Err(ReserveError::NotAdmitting(
+            response.receive().await.unwrap_or_else(|| {
+                // The driver's admission `Obligation` publishes an outcome on
+                // every path, including its drop fallback. Treat a missing
+                // response as the scope having gone terminal so a caller is
+                // never stranded, but fail loudly in debug builds: silence
+                // here would mask an obligation regression.
+                debug_assert!(false, "admission response obligation must complete");
+                Err(ReserveError::NotAdmitting(
                     crate::NotAdmittingCause::Terminal,
-                )))
+                ))
+            })
         }))
     }
 
@@ -822,7 +827,16 @@ impl<H: Unpin> Future for Admission<H> {
 impl<H> Drop for Admission<H> {
     fn drop(&mut self) {
         match &self.state {
-            AdmissionState::Unpolled(pending) => pending.cancel_reservation(),
+            AdmissionState::Unpolled(pending) => {
+                // A fused admission annuls its reservation on every drop edge,
+                // polled or not. Firing the latch before cancelling keeps the
+                // scope's control-plane wake and the cancellation evidence in
+                // the same order the in-flight path uses.
+                if let Some(cancel) = &pending.fused_cancel {
+                    crate::driver::signal_fused_cancel(&pending.reservation.control, cancel);
+                }
+                pending.cancel_reservation();
+            }
             AdmissionState::InFlight { pending, .. } => {
                 if let Some(cancel) = &pending.fused_cancel {
                     crate::driver::signal_fused_cancel(&pending.reservation.control, cancel);

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -22,7 +22,7 @@ use crate::{
     mailbox::MailboxCell,
     plan::{
         BuilderCore, ChildConstruction, LowerError, RemoveOutcome, ReserveError, ScopeConstruction,
-        SlotCell, checked_id,
+        SlotCell,
     },
     policy::{CommonOptions, ResolvedDefaults, ScopeFlavor},
     raw::{RawDef, RawOnceDef},
@@ -1368,8 +1368,7 @@ impl DynamicScopeRef {
         &self,
         id: impl Into<ChildId>,
     ) -> Result<DynamicActorSlot<M>, ReserveError> {
-        let id = checked_id(id)?;
-        crate::driver::reserve_dynamic(&self.0.cell, id, None).map(|reservation| {
+        crate::driver::reserve_dynamic(&self.0.cell, id.into(), None).map(|reservation| {
             let mailbox = MailboxCell::new(reservation.slot.member.id().clone());
             reservation.slot.member.attach_mailbox(mailbox.clone());
             DynamicActorSlot {
@@ -1434,9 +1433,10 @@ impl DynamicScopeRef {
 
     /// Reserves a task id synchronously and exposes its exact handle.
     pub fn reserve_task(&self, id: impl Into<ChildId>) -> Result<DynamicTaskSlot, ReserveError> {
-        let id = checked_id(id)?;
-        crate::driver::reserve_dynamic(&self.0.cell, id, None).map(|reservation| DynamicTaskSlot {
-            core: TaskSlotCore::new(DynamicSlotEndpoint(Some(reservation))),
+        crate::driver::reserve_dynamic(&self.0.cell, id.into(), None).map(|reservation| {
+            DynamicTaskSlot {
+                core: TaskSlotCore::new(DynamicSlotEndpoint(Some(reservation))),
+            }
         })
     }
 
@@ -1465,12 +1465,10 @@ impl DynamicScopeRef {
         &self,
         id: impl Into<ChildId>,
     ) -> Result<DynamicSubtreeSlot<T>, ReserveError> {
-        let id = checked_id(id)?;
-        crate::driver::reserve_dynamic(&self.0.cell, id, Some(<T as sealed::Sealed>::FLAVOR)).map(
-            |reservation| DynamicSubtreeSlot {
+        crate::driver::reserve_dynamic(&self.0.cell, id.into(), Some(<T as sealed::Sealed>::FLAVOR))
+            .map(|reservation| DynamicSubtreeSlot {
                 core: SubtreeSlotCore::new(DynamicSlotEndpoint(Some(reservation))),
-            },
-        )
+            })
     }
 
     /// Adds a restartable subtree, resolving at admission.

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -55,10 +55,228 @@ pub enum BuildError {
     },
 }
 
+#[derive(Clone, Copy)]
+enum AdmissionOwnership {
+    Split,
+    Fused,
+}
+
+impl AdmissionOwnership {
+    fn is_fused(self) -> bool {
+        matches!(self, Self::Fused)
+    }
+}
+
+trait SlotEndpoint: Sized {
+    type Output<H>;
+
+    fn slot(&self) -> &SlotCell;
+
+    fn define<H>(
+        self,
+        handles: H,
+        construction: ChildConstruction,
+        ownership: AdmissionOwnership,
+    ) -> Self::Output<H>;
+}
+
+struct StaticSlotEndpoint(Arc<SlotCell>);
+
+impl SlotEndpoint for StaticSlotEndpoint {
+    type Output<H> = H;
+
+    fn slot(&self) -> &SlotCell {
+        &self.0
+    }
+
+    fn define<H>(self, handles: H, construction: ChildConstruction, _: AdmissionOwnership) -> H {
+        self.0.define(construction);
+        handles
+    }
+}
+
+struct DynamicSlotEndpoint(Option<DynamicReservation>);
+
+impl DynamicSlotEndpoint {
+    fn reservation(&self) -> &DynamicReservation {
+        self.0
+            .as_ref()
+            .expect("dynamic slot reservation was already consumed")
+    }
+}
+
+impl SlotEndpoint for DynamicSlotEndpoint {
+    type Output<H> = Admission<H>;
+
+    fn slot(&self) -> &SlotCell {
+        &self.reservation().slot
+    }
+
+    fn define<H>(
+        mut self,
+        handles: H,
+        construction: ChildConstruction,
+        ownership: AdmissionOwnership,
+    ) -> Admission<H> {
+        let reservation = self
+            .0
+            .take()
+            .expect("dynamic slot reservation was already consumed");
+        reservation.slot.define(construction);
+        Admission::new(reservation, handles, ownership.is_fused())
+    }
+}
+
+impl Drop for DynamicSlotEndpoint {
+    fn drop(&mut self) {
+        if let Some(reservation) = &self.0 {
+            crate::driver::cancel_dynamic_reservation(&reservation.control, &reservation.slot);
+        }
+    }
+}
+
+struct ActorSlotCore<E, M> {
+    endpoint: E,
+    mailbox: Arc<MailboxCell<M>>,
+}
+
+macro_rules! impl_actor_core_definition {
+    ($method:ident, $definition:ident) => {
+        fn $method<R>(
+            self,
+            definition: $definition<R>,
+            ownership: AdmissionOwnership,
+        ) -> E::Output<ActorRef<M>>
+        where
+            R: crate::RawActor<Msg = M>,
+        {
+            let actor = self.actor_ref();
+            let Self { endpoint, mailbox } = self;
+            endpoint.define(
+                actor,
+                ChildConstruction::Raw(definition.erase(mailbox)),
+                ownership,
+            )
+        }
+    };
+}
+
+impl<E: SlotEndpoint, M: Send + 'static> ActorSlotCore<E, M> {
+    fn new(endpoint: E, mailbox: Arc<MailboxCell<M>>) -> Self {
+        Self { endpoint, mailbox }
+    }
+
+    fn actor_ref(&self) -> ActorRef<M> {
+        ActorRef::new(
+            Arc::clone(&self.endpoint.slot().member),
+            Arc::clone(&self.mailbox),
+        )
+    }
+
+    impl_actor_core_definition!(define_raw, RawDef);
+    impl_actor_core_definition!(define_once_raw, RawOnceDef);
+}
+
+struct TaskSlotCore<E> {
+    endpoint: E,
+}
+
+impl<E: SlotEndpoint> TaskSlotCore<E> {
+    fn new(endpoint: E) -> Self {
+        Self { endpoint }
+    }
+
+    fn task_ref(&self) -> TaskRef {
+        TaskRef::new(Arc::clone(&self.endpoint.slot().member))
+    }
+
+    fn define(self, definition: TaskDef, ownership: AdmissionOwnership) -> E::Output<TaskRef> {
+        let task = self.task_ref();
+        self.endpoint
+            .define(task, ChildConstruction::Task(definition), ownership)
+    }
+
+    fn define_once<T: Send + 'static>(
+        self,
+        definition: TaskOnceDef<T>,
+        ownership: AdmissionOwnership,
+    ) -> E::Output<(TaskRef, OneShotTaskRef<T>)> {
+        let task = self.task_ref();
+        let (completion, receiver) = runtime::oneshot();
+        let claim = OneShotTaskRef::new(receiver, task.clone());
+        self.endpoint.define(
+            (task, claim),
+            ChildConstruction::TaskOnce(definition.erase(completion)),
+            ownership,
+        )
+    }
+}
+
+struct SubtreeSlotCore<E, T: Subtree> {
+    endpoint: E,
+    marker: PhantomData<fn() -> T>,
+}
+
+macro_rules! impl_subtree_core_definition {
+    ($method:ident, $definition:ident) => {
+        fn $method(
+            self,
+            definition: $definition<T>,
+            ownership: AdmissionOwnership,
+        ) -> E::Output<T::Ref> {
+            let scope = self.scope_ref();
+            self.endpoint.define(
+                scope,
+                ChildConstruction::Scope(Box::new(definition.erase())),
+                ownership,
+            )
+        }
+    };
+}
+
+impl<E: SlotEndpoint, T: Subtree> SubtreeSlotCore<E, T> {
+    fn new(endpoint: E) -> Self {
+        Self {
+            endpoint,
+            marker: PhantomData,
+        }
+    }
+
+    fn scope_ref(&self) -> T::Ref {
+        <T as sealed::Sealed>::make_ref(ScopeRef {
+            cell: Arc::clone(
+                self.endpoint
+                    .slot()
+                    .scope
+                    .as_ref()
+                    .expect("subtree slot must carry a scope cell"),
+            ),
+        })
+    }
+
+    impl_subtree_core_definition!(define, SubtreeDef);
+    impl_subtree_core_definition!(define_once, SubtreeOnceDef);
+}
+
+macro_rules! impl_slot_debug {
+    ($slot:ident $(<$generic:ident $(: $bound:path)?>)?, $label:literal) => {
+        impl$(<$generic $(: $bound)?>)? fmt::Debug for $slot$(<$generic>)? {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter
+                    .debug_struct($label)
+                    .field("id", self.core.endpoint.slot().member.id())
+                    .finish_non_exhaustive()
+            }
+        }
+    };
+}
+
 fn attach_actor_slot<M: Send + 'static>(slot: Arc<SlotCell>) -> ActorSlot<M> {
     let mailbox = MailboxCell::new(slot.member.id().clone());
     slot.member.attach_mailbox(mailbox.clone());
-    ActorSlot { slot, mailbox }
+    ActorSlot {
+        core: ActorSlotCore::new(StaticSlotEndpoint(slot), mailbox),
+    }
 }
 
 macro_rules! impl_common_builder_surface {
@@ -136,7 +354,9 @@ macro_rules! impl_common_builder_surface {
 
         #[doc = $reserve_task_doc]
         pub fn reserve_task(&mut self, id: impl Into<ChildId>) -> Result<TaskSlot, ReserveError> {
-            self.core.reserve(id, None).map(|slot| TaskSlot { slot })
+            self.core.reserve(id, None).map(|slot| TaskSlot {
+                core: TaskSlotCore::new(StaticSlotEndpoint(slot)),
+            })
         }
 
         #[doc = $add_task_doc]
@@ -166,8 +386,7 @@ macro_rules! impl_common_builder_surface {
             self.core
                 .reserve(id, Some(<T as sealed::Sealed>::FLAVOR))
                 .map(|slot| SubtreeSlot {
-                    slot,
-                    marker: PhantomData,
+                    core: SubtreeSlotCore::new(StaticSlotEndpoint(slot)),
                 })
         }
 
@@ -339,24 +558,16 @@ impl Tree {
 
 /// An owned pre-spawn actor slot with a stable mailbox binding.
 pub struct ActorSlot<M> {
-    slot: Arc<SlotCell>,
-    mailbox: Arc<MailboxCell<M>>,
+    core: ActorSlotCore<StaticSlotEndpoint, M>,
 }
 
-impl<M> fmt::Debug for ActorSlot<M> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("ActorSlot")
-            .field("id", self.slot.member.id())
-            .finish_non_exhaustive()
-    }
-}
+impl_slot_debug!(ActorSlot<M>, "ActorSlot");
 
 impl<M: Send + 'static> ActorSlot<M> {
     /// Returns the membership-addressed handle before definition or spawn.
     #[must_use]
     pub fn actor_ref(&self) -> ActorRef<M> {
-        ActorRef::new(Arc::clone(&self.slot.member), Arc::clone(&self.mailbox))
+        self.core.actor_ref()
     }
 
     /// Defines a restartable callback-oriented actor and consumes the slot.
@@ -383,10 +594,7 @@ impl<M: Send + 'static> ActorSlot<M> {
     where
         R: crate::RawActor<Msg = M>,
     {
-        let actor = self.actor_ref();
-        self.slot
-            .define(ChildConstruction::Raw(definition.erase(self.mailbox)));
-        actor
+        self.core.define_raw(definition, AdmissionOwnership::Split)
     }
 
     /// Defines a consuming one-shot raw actor and consumes the slot.
@@ -395,40 +603,29 @@ impl<M: Send + 'static> ActorSlot<M> {
     where
         R: crate::RawActor<Msg = M>,
     {
-        let actor = self.actor_ref();
-        self.slot
-            .define(ChildConstruction::Raw(definition.erase(self.mailbox)));
-        actor
+        self.core
+            .define_once_raw(definition, AdmissionOwnership::Split)
     }
 }
 
 /// An owned pre-spawn task slot.
 pub struct TaskSlot {
-    slot: Arc<SlotCell>,
+    core: TaskSlotCore<StaticSlotEndpoint>,
 }
 
-impl fmt::Debug for TaskSlot {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("TaskSlot")
-            .field("id", self.slot.member.id())
-            .finish_non_exhaustive()
-    }
-}
+impl_slot_debug!(TaskSlot, "TaskSlot");
 
 impl TaskSlot {
     /// Returns the membership handle before definition or spawn.
     #[must_use]
     pub fn task_ref(&self) -> TaskRef {
-        TaskRef::new(Arc::clone(&self.slot.member))
+        self.core.task_ref()
     }
 
     /// Defines a restartable task and consumes the slot.
     #[must_use]
     pub fn define(self, definition: TaskDef) -> TaskRef {
-        let task = self.task_ref();
-        self.slot.define(ChildConstruction::Task(definition));
-        task
+        self.core.define(definition, AdmissionOwnership::Split)
     }
 
     /// Defines a one-shot task and consumes the slot.
@@ -436,12 +633,7 @@ impl TaskSlot {
         self,
         definition: TaskOnceDef<T>,
     ) -> (TaskRef, OneShotTaskRef<T>) {
-        let task = self.task_ref();
-        let (completion, receiver) = runtime::oneshot();
-        let claim = OneShotTaskRef::new(receiver, task.clone());
-        self.slot
-            .define(ChildConstruction::TaskOnce(definition.erase(completion)));
-        (task, claim)
+        self.core.define_once(definition, AdmissionOwnership::Split)
     }
 }
 
@@ -595,47 +787,16 @@ impl<H> Drop for Admission<H> {
 
 /// A split dynamic actor reservation with a stable mailbox binding.
 pub struct DynamicActorSlot<M> {
-    reservation: Option<DynamicReservation>,
-    mailbox: Arc<MailboxCell<M>>,
+    core: ActorSlotCore<DynamicSlotEndpoint, M>,
 }
 
-impl<M> fmt::Debug for DynamicActorSlot<M> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("DynamicActorSlot")
-            .field(
-                "id",
-                self.reservation
-                    .as_ref()
-                    .expect("dynamic actor slot reservation was already consumed")
-                    .slot
-                    .member
-                    .id(),
-            )
-            .finish_non_exhaustive()
-    }
-}
+impl_slot_debug!(DynamicActorSlot<M>, "DynamicActorSlot");
 
 impl<M: Send + 'static> DynamicActorSlot<M> {
-    fn reservation(&self) -> &DynamicReservation {
-        self.reservation
-            .as_ref()
-            .expect("dynamic actor slot reservation was already consumed")
-    }
-
-    fn take_reservation(&mut self) -> DynamicReservation {
-        self.reservation
-            .take()
-            .expect("dynamic actor slot reservation was already consumed")
-    }
-
     /// Returns the exact actor handle before admission.
     #[must_use]
     pub fn actor_ref(&self) -> ActorRef<M> {
-        ActorRef::new(
-            Arc::clone(&self.reservation().slot.member),
-            Arc::clone(&self.mailbox),
-        )
+        self.core.actor_ref()
     }
 
     /// Defines a restartable callback-oriented actor; dropping after first poll detaches.
@@ -646,13 +807,6 @@ impl<M: Send + 'static> DynamicActorSlot<M> {
         self.define_raw(definition.into_raw())
     }
 
-    fn define_fused<A>(self, definition: ActorDef<A>) -> Admission<ActorRef<M>>
-    where
-        A: crate::Actor<Msg = M>,
-    {
-        self.define_raw_fused(definition.into_raw())
-    }
-
     /// Defines a one-shot callback-oriented actor; dropping after first poll detaches.
     pub fn define_once<A>(self, definition: ActorOnceDef<A>) -> Admission<ActorRef<M>>
     where
@@ -661,252 +815,74 @@ impl<M: Send + 'static> DynamicActorSlot<M> {
         self.define_once_raw(definition.into_raw())
     }
 
-    fn define_once_fused<A>(self, definition: ActorOnceDef<A>) -> Admission<ActorRef<M>>
-    where
-        A: crate::Actor<Msg = M>,
-    {
-        self.define_once_raw_fused(definition.into_raw())
-    }
-
     /// Defines a restartable raw actor; dropping after first poll detaches.
-    pub fn define_raw<R>(mut self, definition: RawDef<R>) -> Admission<ActorRef<M>>
+    pub fn define_raw<R>(self, definition: RawDef<R>) -> Admission<ActorRef<M>>
     where
         R: crate::RawActor<Msg = M>,
     {
-        self.define_raw_with(definition, false)
-    }
-
-    fn define_raw_fused<R>(mut self, definition: RawDef<R>) -> Admission<ActorRef<M>>
-    where
-        R: crate::RawActor<Msg = M>,
-    {
-        self.define_raw_with(definition, true)
-    }
-
-    fn define_raw_with<R>(&mut self, definition: RawDef<R>, fused: bool) -> Admission<ActorRef<M>>
-    where
-        R: crate::RawActor<Msg = M>,
-    {
-        let actor = self.actor_ref();
-        let reservation = self.take_reservation();
-        reservation.slot.define(ChildConstruction::Raw(
-            definition.erase(Arc::clone(&self.mailbox)),
-        ));
-        Admission::new(reservation, actor, fused)
+        self.core.define_raw(definition, AdmissionOwnership::Split)
     }
 
     /// Defines a one-shot raw actor; dropping after first poll detaches.
-    pub fn define_once_raw<R>(mut self, definition: RawOnceDef<R>) -> Admission<ActorRef<M>>
+    pub fn define_once_raw<R>(self, definition: RawOnceDef<R>) -> Admission<ActorRef<M>>
     where
         R: crate::RawActor<Msg = M>,
     {
-        self.define_once_raw_with(definition, false)
-    }
-
-    fn define_once_raw_fused<R>(mut self, definition: RawOnceDef<R>) -> Admission<ActorRef<M>>
-    where
-        R: crate::RawActor<Msg = M>,
-    {
-        self.define_once_raw_with(definition, true)
-    }
-
-    fn define_once_raw_with<R>(
-        &mut self,
-        definition: RawOnceDef<R>,
-        fused: bool,
-    ) -> Admission<ActorRef<M>>
-    where
-        R: crate::RawActor<Msg = M>,
-    {
-        let actor = self.actor_ref();
-        let reservation = self.take_reservation();
-        reservation.slot.define(ChildConstruction::Raw(
-            definition.erase(Arc::clone(&self.mailbox)),
-        ));
-        Admission::new(reservation, actor, fused)
-    }
-}
-
-impl<M> Drop for DynamicActorSlot<M> {
-    fn drop(&mut self) {
-        if let Some(reservation) = &self.reservation {
-            crate::driver::cancel_dynamic_reservation(&reservation.control, &reservation.slot);
-        }
+        self.core
+            .define_once_raw(definition, AdmissionOwnership::Split)
     }
 }
 
 /// A split dynamic task reservation.
 pub struct DynamicTaskSlot {
-    reservation: Option<DynamicReservation>,
+    core: TaskSlotCore<DynamicSlotEndpoint>,
 }
 
-impl fmt::Debug for DynamicTaskSlot {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("DynamicTaskSlot")
-            .field("id", self.reservation().slot.member.id())
-            .finish_non_exhaustive()
-    }
-}
+impl_slot_debug!(DynamicTaskSlot, "DynamicTaskSlot");
 
 impl DynamicTaskSlot {
-    fn reservation(&self) -> &DynamicReservation {
-        self.reservation
-            .as_ref()
-            .expect("dynamic task slot reservation was already consumed")
-    }
-
-    fn take_reservation(&mut self) -> DynamicReservation {
-        self.reservation
-            .take()
-            .expect("dynamic task slot reservation was already consumed")
-    }
-
     /// Returns the exact task handle before admission.
     #[must_use]
     pub fn task_ref(&self) -> TaskRef {
-        TaskRef::new(Arc::clone(&self.reservation().slot.member))
+        self.core.task_ref()
     }
 
     /// Defines a restartable task; dropping after first poll detaches admission.
-    pub fn define(mut self, definition: TaskDef) -> Admission<TaskRef> {
-        let task = self.task_ref();
-        let reservation = self.take_reservation();
-        reservation.slot.define(ChildConstruction::Task(definition));
-        Admission::new(reservation, task, false)
-    }
-
-    fn define_fused(mut self, definition: TaskDef) -> Admission<TaskRef> {
-        let task = self.task_ref();
-        let reservation = self.take_reservation();
-        reservation.slot.define(ChildConstruction::Task(definition));
-        Admission::new(reservation, task, true)
+    pub fn define(self, definition: TaskDef) -> Admission<TaskRef> {
+        self.core.define(definition, AdmissionOwnership::Split)
     }
 
     /// Defines a one-shot task; dropping after first poll detaches admission.
     pub fn define_once<T: Send + 'static>(
-        mut self,
+        self,
         definition: TaskOnceDef<T>,
     ) -> Admission<(TaskRef, OneShotTaskRef<T>)> {
-        let task = self.task_ref();
-        let (completion, receiver) = runtime::oneshot();
-        let reservation = self.take_reservation();
-        let claim = OneShotTaskRef::new(receiver, task.clone());
-        reservation
-            .slot
-            .define(ChildConstruction::TaskOnce(definition.erase(completion)));
-        Admission::new(reservation, (task, claim), false)
-    }
-
-    fn define_once_fused<T: Send + 'static>(
-        mut self,
-        definition: TaskOnceDef<T>,
-    ) -> Admission<(TaskRef, OneShotTaskRef<T>)> {
-        let task = self.task_ref();
-        let (completion, receiver) = runtime::oneshot();
-        let reservation = self.take_reservation();
-        let claim = OneShotTaskRef::new(receiver, task.clone());
-        reservation
-            .slot
-            .define(ChildConstruction::TaskOnce(definition.erase(completion)));
-        Admission::new(reservation, (task, claim), true)
-    }
-}
-
-impl Drop for DynamicTaskSlot {
-    fn drop(&mut self) {
-        if let Some(reservation) = &self.reservation {
-            crate::driver::cancel_dynamic_reservation(&reservation.control, &reservation.slot);
-        }
+        self.core.define_once(definition, AdmissionOwnership::Split)
     }
 }
 
 /// A split dynamic subtree reservation.
 pub struct DynamicSubtreeSlot<T: Subtree> {
-    reservation: Option<DynamicReservation>,
-    marker: PhantomData<fn() -> T>,
+    core: SubtreeSlotCore<DynamicSlotEndpoint, T>,
 }
 
-impl<T: Subtree> fmt::Debug for DynamicSubtreeSlot<T> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("DynamicSubtreeSlot")
-            .field("id", self.reservation().slot.member.id())
-            .finish_non_exhaustive()
-    }
-}
+impl_slot_debug!(DynamicSubtreeSlot<T: Subtree>, "DynamicSubtreeSlot");
 
 impl<T: Subtree> DynamicSubtreeSlot<T> {
-    fn reservation(&self) -> &DynamicReservation {
-        self.reservation
-            .as_ref()
-            .expect("dynamic subtree slot reservation was already consumed")
-    }
-
-    fn take_reservation(&mut self) -> DynamicReservation {
-        self.reservation
-            .take()
-            .expect("dynamic subtree slot reservation was already consumed")
-    }
-
     /// Returns the typed exact scope handle before admission.
     #[must_use]
     pub fn scope_ref(&self) -> T::Ref {
-        <T as sealed::Sealed>::make_ref(ScopeRef {
-            cell: Arc::clone(
-                self.reservation()
-                    .slot
-                    .scope
-                    .as_ref()
-                    .expect("subtree reservation needs a scope cell"),
-            ),
-        })
+        self.core.scope_ref()
     }
 
     /// Defines a restartable subtree; dropping after first poll detaches.
-    pub fn define(mut self, definition: SubtreeDef<T>) -> Admission<T::Ref> {
-        let scope = self.scope_ref();
-        let reservation = self.take_reservation();
-        reservation
-            .slot
-            .define(ChildConstruction::Scope(Box::new(definition.erase())));
-        Admission::new(reservation, scope, false)
-    }
-
-    fn define_fused(mut self, definition: SubtreeDef<T>) -> Admission<T::Ref> {
-        let scope = self.scope_ref();
-        let reservation = self.take_reservation();
-        reservation
-            .slot
-            .define(ChildConstruction::Scope(Box::new(definition.erase())));
-        Admission::new(reservation, scope, true)
+    pub fn define(self, definition: SubtreeDef<T>) -> Admission<T::Ref> {
+        self.core.define(definition, AdmissionOwnership::Split)
     }
 
     /// Defines a one-shot subtree; dropping after first poll detaches.
-    pub fn define_once(mut self, definition: SubtreeOnceDef<T>) -> Admission<T::Ref> {
-        let scope = self.scope_ref();
-        let reservation = self.take_reservation();
-        reservation
-            .slot
-            .define(ChildConstruction::Scope(Box::new(definition.erase())));
-        Admission::new(reservation, scope, false)
-    }
-
-    fn define_once_fused(mut self, definition: SubtreeOnceDef<T>) -> Admission<T::Ref> {
-        let scope = self.scope_ref();
-        let reservation = self.take_reservation();
-        reservation
-            .slot
-            .define(ChildConstruction::Scope(Box::new(definition.erase())));
-        Admission::new(reservation, scope, true)
-    }
-}
-
-impl<T: Subtree> Drop for DynamicSubtreeSlot<T> {
-    fn drop(&mut self) {
-        if let Some(reservation) = &self.reservation {
-            crate::driver::cancel_dynamic_reservation(&reservation.control, &reservation.slot);
-        }
+    pub fn define_once(self, definition: SubtreeOnceDef<T>) -> Admission<T::Ref> {
+        self.core.define_once(definition, AdmissionOwnership::Split)
     }
 }
 
@@ -1042,49 +1018,28 @@ impl<T: Subtree> SubtreeOnceDef<T> {
 
 /// A typed pre-spawn subtree slot.
 pub struct SubtreeSlot<T: Subtree> {
-    slot: Arc<SlotCell>,
-    marker: PhantomData<fn() -> T>,
+    core: SubtreeSlotCore<StaticSlotEndpoint, T>,
 }
 
-impl<T: Subtree> fmt::Debug for SubtreeSlot<T> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("SubtreeSlot")
-            .field("id", self.slot.member.id())
-            .finish_non_exhaustive()
-    }
-}
+impl_slot_debug!(SubtreeSlot<T: Subtree>, "SubtreeSlot");
 
 impl<T: Subtree> SubtreeSlot<T> {
     /// Returns the typed scope handle before definition or spawn.
     #[must_use]
     pub fn scope_ref(&self) -> T::Ref {
-        <T as sealed::Sealed>::make_ref(ScopeRef {
-            cell: Arc::clone(
-                self.slot
-                    .scope
-                    .as_ref()
-                    .expect("subtree slot must carry a scope cell"),
-            ),
-        })
+        self.core.scope_ref()
     }
 
     /// Defines a restartable subtree and consumes the slot.
     #[must_use]
     pub fn define(self, definition: SubtreeDef<T>) -> T::Ref {
-        let scope = self.scope_ref();
-        self.slot
-            .define(ChildConstruction::Scope(Box::new(definition.erase())));
-        scope
+        self.core.define(definition, AdmissionOwnership::Split)
     }
 
     /// Defines a one-shot subtree and consumes the slot.
     #[must_use]
     pub fn define_once(self, definition: SubtreeOnceDef<T>) -> T::Ref {
-        let scope = self.scope_ref();
-        self.slot
-            .define(ChildConstruction::Scope(Box::new(definition.erase())));
-        scope
+        self.core.define_once(definition, AdmissionOwnership::Split)
     }
 }
 
@@ -1418,8 +1373,7 @@ impl DynamicScopeRef {
             let mailbox = MailboxCell::new(reservation.slot.member.id().clone());
             reservation.slot.member.attach_mailbox(mailbox.clone());
             DynamicActorSlot {
-                reservation: Some(reservation),
-                mailbox,
+                core: ActorSlotCore::new(DynamicSlotEndpoint(Some(reservation)), mailbox),
             }
         })
     }
@@ -1431,7 +1385,9 @@ impl DynamicScopeRef {
         definition: ActorDef<A>,
     ) -> Admission<ActorRef<A::Msg>> {
         match self.reserve_actor(id) {
-            Ok(slot) => slot.define_fused(definition),
+            Ok(slot) => slot
+                .core
+                .define_raw(definition.into_raw(), AdmissionOwnership::Fused),
             Err(error) => Admission::error(error),
         }
     }
@@ -1443,7 +1399,9 @@ impl DynamicScopeRef {
         definition: ActorOnceDef<A>,
     ) -> Admission<ActorRef<A::Msg>> {
         match self.reserve_actor(id) {
-            Ok(slot) => slot.define_once_fused(definition),
+            Ok(slot) => slot
+                .core
+                .define_once_raw(definition.into_raw(), AdmissionOwnership::Fused),
             Err(error) => Admission::error(error),
         }
     }
@@ -1455,7 +1413,7 @@ impl DynamicScopeRef {
         definition: RawDef<R>,
     ) -> Admission<ActorRef<R::Msg>> {
         match self.reserve_actor(id) {
-            Ok(slot) => slot.define_raw_fused(definition),
+            Ok(slot) => slot.core.define_raw(definition, AdmissionOwnership::Fused),
             Err(error) => Admission::error(error),
         }
     }
@@ -1467,7 +1425,9 @@ impl DynamicScopeRef {
         definition: RawOnceDef<R>,
     ) -> Admission<ActorRef<R::Msg>> {
         match self.reserve_actor(id) {
-            Ok(slot) => slot.define_once_raw_fused(definition),
+            Ok(slot) => slot
+                .core
+                .define_once_raw(definition, AdmissionOwnership::Fused),
             Err(error) => Admission::error(error),
         }
     }
@@ -1476,14 +1436,14 @@ impl DynamicScopeRef {
     pub fn reserve_task(&self, id: impl Into<ChildId>) -> Result<DynamicTaskSlot, ReserveError> {
         let id = checked_id(id)?;
         crate::driver::reserve_dynamic(&self.0.cell, id, None).map(|reservation| DynamicTaskSlot {
-            reservation: Some(reservation),
+            core: TaskSlotCore::new(DynamicSlotEndpoint(Some(reservation))),
         })
     }
 
     /// Adds a restartable task, resolving at admission rather than startup.
     pub fn add_task(&self, id: impl Into<ChildId>, definition: TaskDef) -> Admission<TaskRef> {
         match self.reserve_task(id) {
-            Ok(slot) => slot.define_fused(definition),
+            Ok(slot) => slot.core.define(definition, AdmissionOwnership::Fused),
             Err(error) => Admission::error(error),
         }
     }
@@ -1495,7 +1455,7 @@ impl DynamicScopeRef {
         definition: TaskOnceDef<T>,
     ) -> Admission<(TaskRef, OneShotTaskRef<T>)> {
         match self.reserve_task(id) {
-            Ok(slot) => slot.define_once_fused(definition),
+            Ok(slot) => slot.core.define_once(definition, AdmissionOwnership::Fused),
             Err(error) => Admission::error(error),
         }
     }
@@ -1508,8 +1468,7 @@ impl DynamicScopeRef {
         let id = checked_id(id)?;
         crate::driver::reserve_dynamic(&self.0.cell, id, Some(<T as sealed::Sealed>::FLAVOR)).map(
             |reservation| DynamicSubtreeSlot {
-                reservation: Some(reservation),
-                marker: PhantomData,
+                core: SubtreeSlotCore::new(DynamicSlotEndpoint(Some(reservation))),
             },
         )
     }
@@ -1521,7 +1480,7 @@ impl DynamicScopeRef {
         definition: SubtreeDef<T>,
     ) -> Admission<T::Ref> {
         match self.reserve_subtree::<T>(id) {
-            Ok(slot) => slot.define_fused(definition),
+            Ok(slot) => slot.core.define(definition, AdmissionOwnership::Fused),
             Err(error) => Admission::error(error),
         }
     }
@@ -1533,7 +1492,7 @@ impl DynamicScopeRef {
         definition: SubtreeOnceDef<T>,
     ) -> Admission<T::Ref> {
         match self.reserve_subtree::<T>(id) {
-            Ok(slot) => slot.define_once_fused(definition),
+            Ok(slot) => slot.core.define_once(definition, AdmissionOwnership::Fused),
             Err(error) => Admission::error(error),
         }
     }

--- a/crates/shelterwood/tests/acceptance/assistant.rs
+++ b/crates/shelterwood/tests/acceptance/assistant.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, poll_until};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, ChildState, Context, DeadlineElapsed, DynamicScopeRef,
     DynamicTree, ExitError, ExitResult, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
@@ -420,7 +420,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
     let mut lifecycle = root.subscribe_lifecycle();
 
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             gateway_scope
                 .snapshot()
                 .child("bridge")
@@ -456,7 +456,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
     let session_membership = session.membership();
 
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             session
                 .snapshot()
                 .child("stream")
@@ -477,14 +477,14 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .await
         .expect("session aggregate readiness completes");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             *stream_values.lock().expect("stream values mutex poisoned") == [3]
         })
         .await,
         "latest mailbox keeps the newest accepted streaming update"
     );
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             rehydrated.load(Ordering::SeqCst) >= 1
         })
         .await
@@ -521,7 +521,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .await
         .expect("control panic request accepted");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             session.snapshot().child("control").is_some_and(|child| {
                 matches!(child.state, ChildState::Running)
                     && child.restart_count == 1
@@ -559,7 +559,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .await
         .expect("tool panic request accepted");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             tools
                 .snapshot()
                 .child("temporary-tool")
@@ -578,7 +578,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .await
         .expect("offload request accepted");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             tool_args.completions.load(Ordering::SeqCst) == 1
         })
         .await,
@@ -612,7 +612,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .expect("redelivery of the same journal id is acknowledged");
     assert_eq!(transport.processed.load(Ordering::SeqCst), 1);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             transport.duplicate_notices.load(Ordering::SeqCst) == 1
         })
         .await
@@ -633,7 +633,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
 
     let removal = sessions.remove_scope(&session);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             stop_entered.load(Ordering::SeqCst)
         })
         .await
@@ -778,7 +778,7 @@ async fn assistant_sessions_idle_evict_on_timers_and_streams_cancel_mid_flight()
     // Mid-life streaming works and the idle timer is armed from init.
     stream.send(5).await.expect("stream accepts mid-life value");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             stream_values
                 .lock()
                 .expect("stream values mutex poisoned")
@@ -794,7 +794,7 @@ async fn assistant_sessions_idle_evict_on_timers_and_streams_cancel_mid_flight()
         .await
         .expect("live session accepts activity");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             activities.load(Ordering::SeqCst) == 1
         })
         .await,

--- a/crates/shelterwood/tests/acceptance/sidecar.rs
+++ b/crates/shelterwood/tests/acceptance/sidecar.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, policy::never, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, policy::never, poll_until};
 use shelterwood::{
     Actor, ActorOnceDef, ChildState, Context, ExitError, ExitKind, ExitResult, Readiness,
     ReadinessDeadline, Shutdown, StartOrShutdownError, StopContext, SubtreeOnceDef, TaskDef,
@@ -209,7 +209,7 @@ async fn sidecar_runs_two_host_owned_cycles_with_readiness_and_policy_exact_shut
         let system = fixture.tree.spawn().expect("runtime is available");
         let scope = system.scope();
         assert!(
-            poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
                 fixture.config_started.load(Ordering::SeqCst)
             })
             .await
@@ -336,7 +336,7 @@ async fn sidecar_startup_failure_leaves_prefix_supervised_until_host_rolls_it_ba
     let system = fixture.tree.spawn().expect("runtime is available");
     let scope = system.scope();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             fixture.prefix_one.load(Ordering::SeqCst)
         })
         .await

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -6,10 +6,11 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, assert_quiet, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until};
 use shelterwood::{
-    Actor, ActorDef, ActorOnceDef, Context, DynamicTree, ExitError, ExitResult, Handler, RawActor,
-    RawContext, RawOnceDef, Readiness, StopContext, TaskDef, Tree,
+    Actor, ActorDef, ActorOnceDef, ActorRef, Context, DynamicTree, ExitError, ExitResult, Handler,
+    Mailbox, RawActor, RawContext, RawOnceDef, Readiness, ScopeRef, SendErrorKind, StopContext,
+    TaskDef, Tree,
 };
 
 #[derive(Clone)]
@@ -330,7 +331,7 @@ async fn restartable_and_dynamic_actor_definition_surfaces_work() {
         .expect("dynamic actor admitted")
         .into_handles();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             dynamic_events
                 .lock()
                 .expect("events mutex poisoned")
@@ -396,4 +397,119 @@ async fn manual_readiness_override_on_a_wrapped_handler_stays_gated() {
         .shutdown(Duration::from_secs(1))
         .await
         .expect("tree shuts down");
+}
+
+enum ContextSurfaceMessage {
+    Enter,
+    Queued,
+    SelfSent,
+}
+
+struct ContextSurfaceActor {
+    entered: ReleaseGate,
+    release: ReleaseGate,
+    observed: Option<tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>>,
+    stopped: Option<tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>>,
+}
+
+impl Actor for ContextSurfaceActor {
+    type Msg = ContextSurfaceMessage;
+    type Args = (
+        ReleaseGate,
+        ReleaseGate,
+        tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>,
+        tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>,
+    );
+
+    async fn init(
+        (entered, release, observed, stopped): Self::Args,
+        _: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        Ok(Self {
+            entered,
+            release,
+            observed: Some(observed),
+            stopped: Some(stopped),
+        })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            ContextSurfaceMessage::Enter => {
+                self.entered.release();
+                self.release.wait().await;
+
+                let myself: ActorRef<ContextSurfaceMessage> = context.myself();
+                let scope: ScopeRef = context.scope();
+                let error = myself
+                    .try_send(ContextSurfaceMessage::SelfSent)
+                    .expect_err("the one-slot mailbox is already full");
+                assert_eq!(error.kind, SendErrorKind::Full);
+                assert!(matches!(error.message, ContextSurfaceMessage::SelfSent));
+                self.observed
+                    .take()
+                    .expect("surface observation is sent once")
+                    .send((myself, scope))
+                    .expect("test still awaits typed context handles");
+            }
+            ContextSurfaceMessage::Queued => context.stop(),
+            ContextSurfaceMessage::SelfSent => {
+                panic!("a self-send rejected from the full mailbox must not be delivered")
+            }
+        }
+        Ok(())
+    }
+
+    async fn on_stop(&mut self, context: &mut StopContext<'_, Self>) {
+        let myself: ActorRef<ContextSurfaceMessage> = context.myself();
+        let scope: ScopeRef = context.scope();
+        self.stopped
+            .take()
+            .expect("stop-context observation is sent once")
+            .send((myself, scope))
+            .expect("test still awaits typed stop-context handles");
+    }
+}
+
+#[tokio::test]
+async fn typed_context_handles_preserve_identity_and_self_send_capacity() {
+    let entered = ReleaseGate::default();
+    let release = ReleaseGate::default();
+    let (observed, observation) = tokio::sync::oneshot::channel();
+    let (stopped, stop_observation) = tokio::sync::oneshot::channel();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "context-surface",
+            ActorOnceDef::<ContextSurfaceActor>::new((
+                entered.clone(),
+                release.clone(),
+                observed,
+                stopped,
+            ))
+            .mailbox(Mailbox::queue(1).expect("non-zero capacity")),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+
+    actor
+        .send(ContextSurfaceMessage::Enter)
+        .await
+        .expect("actor enters handler");
+    entered.wait().await;
+    actor
+        .try_send(ContextSurfaceMessage::Queued)
+        .expect("the sole pending slot is filled");
+    release.release();
+
+    let (myself, scope) = observation.await.expect("actor reports its handles");
+    assert_eq!(myself, actor);
+    assert_eq!(scope, system.scope());
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    let (stopping_myself, stopping_scope) = stop_observation
+        .await
+        .expect("actor reports stop-context handles");
+    assert_eq!(stopping_myself, actor);
+    assert_eq!(stopping_scope, scope);
 }

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -2,12 +2,14 @@ use std::{cell::Cell, error::Error, hash::Hash, time::Duration};
 
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, ActorSlot, Admission, Blocking, CallError, CallFuture,
-    CancellationToken, Context, DeadlineElapsed, DynamicActorSlot, DynamicScopeRef,
-    DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, ExitError, ExitResult, Guard, Handler,
-    Incarnation, LifecycleEvents, LifecycleTryRecvError, Membership, OneShotTaskRef, RawActor,
-    RawContext, RawDef, RawOnceDef, Removal, Reply, ReplyReceive, ReplyReceiver, ScopeRef,
-    SendError, SendFuture, SendTimeout, SnapshotClosed, SnapshotReceiver, StopContext, SubtreeDef,
-    SubtreeOnceDef, SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, Tree, WaitError,
+    CancellationToken, Context, DeadlineElapsed, DefaultsInheritance, DynamicActorSlot,
+    DynamicScopeRef, DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, ExitError, ExitResult,
+    Guard, Handler, Incarnation, LifecycleEvents, LifecycleTryRecvError, Mailbox, MailboxShutdown,
+    Membership, OneShotTaskRef, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
+    ReadinessDeadline, Removal, Reply, ReplyReceive, ReplyReceiver, RestartPolicy, Retention,
+    ScopeRef, SendError, SendFuture, SendTimeout, Shutdown, SnapshotClosed, SnapshotReceiver,
+    StopContext, SubtreeDef, SubtreeOnceDef, SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef,
+    TaskSlot, Tree, WaitError,
 };
 
 fn assert_error<T: Error>() {}
@@ -193,6 +195,77 @@ fn raw_types_obey_error_and_future_trait_contracts() {
     let (reply, receiver) = Reply::<Cell<()>>::channel();
     assert_send(reply);
     assert_send(receiver);
+}
+
+#[test]
+fn all_definition_option_setters_compile() {
+    let _ = RawDef::<OpaqueRaw>::factory(|| OpaqueRaw {
+        _not_sync: Cell::new(()),
+    })
+    .restart(RestartPolicy::default())
+    .shutdown(Shutdown::default())
+    .mailbox(Mailbox::default())
+    .mailbox_shutdown(MailboxShutdown::default())
+    .readiness(Readiness::Immediate)
+    .expect("immediate raw readiness is supported")
+    .readiness_deadline(ReadinessDeadline::Inherit)
+    .retention(Retention::Retain);
+
+    let _ = RawOnceDef::new(OpaqueRaw {
+        _not_sync: Cell::new(()),
+    })
+    .shutdown(Shutdown::default())
+    .mailbox(Mailbox::default())
+    .mailbox_shutdown(MailboxShutdown::default())
+    .readiness(Readiness::Manual)
+    .expect("manual raw readiness is supported")
+    .readiness_deadline(ReadinessDeadline::Inherit)
+    .retention(Retention::Retain);
+
+    let _ = ActorDef::<OpaqueActor>::factory(|| Cell::new(()))
+        .restart(RestartPolicy::default())
+        .shutdown(Shutdown::default())
+        .mailbox(Mailbox::default())
+        .mailbox_shutdown(MailboxShutdown::default())
+        .readiness(Readiness::AfterInit)
+        .readiness_deadline(ReadinessDeadline::Inherit)
+        .retention(Retention::Retain);
+
+    let _ = ActorOnceDef::<OpaqueActor>::new(Cell::new(()))
+        .shutdown(Shutdown::default())
+        .mailbox(Mailbox::default())
+        .mailbox_shutdown(MailboxShutdown::default())
+        .readiness(Readiness::AfterInit)
+        .readiness_deadline(ReadinessDeadline::Inherit)
+        .retention(Retention::Retain);
+
+    let _ = TaskDef::new(|_| async { Ok(()) })
+        .restart(RestartPolicy::default())
+        .shutdown(Shutdown::default())
+        .readiness(Readiness::Immediate)
+        .expect("immediate task readiness is supported")
+        .readiness_deadline(ReadinessDeadline::Inherit)
+        .retention(Retention::Retain);
+
+    let _ = TaskOnceDef::new(|_| async { Ok::<_, ExitError>(()) })
+        .shutdown(Shutdown::default())
+        .readiness(Readiness::Manual)
+        .expect("manual task readiness is supported")
+        .readiness_deadline(ReadinessDeadline::Inherit)
+        .retention(Retention::Retain);
+
+    let _ = SubtreeDef::factory(Tree::new)
+        .restart(RestartPolicy::default())
+        .shutdown(Shutdown::default())
+        .readiness_deadline(ReadinessDeadline::Inherit)
+        .retention(Retention::Retain)
+        .defaults(DefaultsInheritance::Inherit);
+
+    let _ = SubtreeOnceDef::new(Tree::new())
+        .shutdown(Shutdown::default())
+        .readiness_deadline(ReadinessDeadline::Inherit)
+        .retention(Retention::Retain)
+        .defaults(DefaultsInheritance::Reset);
 }
 
 #[test]

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -6,7 +6,7 @@ use shelterwood::{
     DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, ExitError, ExitResult, Guard, Handler,
     Incarnation, LifecycleEvents, LifecycleTryRecvError, Membership, OneShotTaskRef, RawActor,
     RawContext, RawDef, RawOnceDef, Removal, Reply, ReplyReceive, ReplyReceiver, ScopeRef,
-    SendError, SendFuture, SendTimeout, SnapshotClosed, SnapshotReceiver, SubtreeDef,
+    SendError, SendFuture, SendTimeout, SnapshotClosed, SnapshotReceiver, StopContext, SubtreeDef,
     SubtreeOnceDef, SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, Tree, WaitError,
 };
 
@@ -123,6 +123,8 @@ impl Actor for ClonedActor {
 fn actor_types_obey_resource_and_payload_trait_contracts() {
     assert_error::<DeadlineElapsed>();
     assert_raw::<Handler<OpaqueActor>>();
+    assert_send_type::<Context<'static, OpaqueActor>>();
+    assert_send_type::<StopContext<'static, OpaqueActor>>();
     assert_send_type::<Blocking<Cell<()>>>();
     assert_static::<Blocking<Cell<()>>>();
     assert_send_type::<Guard>();

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -1,15 +1,15 @@
 use std::{cell::Cell, error::Error, hash::Hash, time::Duration};
 
 use shelterwood::{
-    Actor, ActorDef, ActorOnceDef, ActorRef, ActorSlot, Admission, Blocking, CallError, CallFuture,
-    CancellationToken, Context, DeadlineElapsed, DefaultsInheritance, DynamicActorSlot,
+    Actor, ActorDef, ActorOnceDef, ActorRef, ActorSlot, Admission, Blocking, BuildError, CallError,
+    CallFuture, CancellationToken, Context, DeadlineElapsed, DefaultsInheritance, DynamicActorSlot,
     DynamicScopeRef, DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, ExitError, ExitResult,
-    Guard, Handler, Incarnation, LifecycleEvents, LifecycleTryRecvError, Mailbox, MailboxShutdown,
-    Membership, OneShotTaskRef, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
-    ReadinessDeadline, Removal, Reply, ReplyReceive, ReplyReceiver, RestartPolicy, Retention,
-    ScopeRef, SendError, SendFuture, SendTimeout, Shutdown, SnapshotClosed, SnapshotReceiver,
-    StopContext, SubtreeDef, SubtreeOnceDef, SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef,
-    TaskSlot, Tree, WaitError,
+    Guard, Handler, Incarnation, Intensity, LifecycleEvents, LifecycleTryRecvError, Mailbox,
+    MailboxShutdown, Membership, OneShotTaskRef, RawActor, RawContext, RawDef, RawOnceDef,
+    Readiness, ReadinessDeadline, Removal, Reply, ReplyReceive, ReplyReceiver, ReserveError,
+    RestartPolicy, Retention, ScopeDefaults, ScopeRef, SendError, SendFuture, SendTimeout,
+    Shutdown, SnapshotClosed, SnapshotReceiver, StopContext, Strategy, SubtreeDef, SubtreeOnceDef,
+    SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, Tree, WaitError,
 };
 
 fn assert_error<T: Error>() {}
@@ -161,6 +161,81 @@ impl RawActor for OpaqueRaw {
     async fn run(&mut self, _context: &mut RawContext<Self::Msg>) -> ExitResult {
         Ok(())
     }
+}
+
+#[test]
+fn ordered_and_dynamic_builders_expose_the_parallel_typed_surface() {
+    let mut ordered = Tree::new();
+    let _: &mut Tree = ordered.strategy(Strategy::default());
+    let _: &mut Tree = ordered.intensity(Intensity::default());
+    let _: &mut Tree = ordered.defaults(ScopeDefaults::default());
+    let _: Result<ActorSlot<Cell<()>>, ReserveError> = ordered.reserve_actor("ordered-actor-slot");
+    let _: Result<ActorRef<()>, ReserveError> =
+        ordered.add_actor("ordered-actor", ActorDef::<ClonedActor>::cloned(()));
+    let _: Result<ActorRef<()>, ReserveError> =
+        ordered.add_actor_once("ordered-actor-once", ActorOnceDef::<ClonedActor>::new(()));
+    let _: Result<ActorRef<Cell<()>>, ReserveError> = ordered.add_raw(
+        "ordered-raw",
+        RawDef::<OpaqueRaw>::factory(|| OpaqueRaw {
+            _not_sync: Cell::new(()),
+        }),
+    );
+    let _: Result<ActorRef<Cell<()>>, ReserveError> = ordered.add_raw_once(
+        "ordered-raw-once",
+        RawOnceDef::new(OpaqueRaw {
+            _not_sync: Cell::new(()),
+        }),
+    );
+    let _: Result<TaskSlot, ReserveError> = ordered.reserve_task("ordered-task-slot");
+    let _: Result<TaskRef, ReserveError> =
+        ordered.add_task("ordered-task", TaskDef::new(|_| async { Ok(()) }));
+    let _: Result<(TaskRef, OneShotTaskRef<()>), ReserveError> = ordered.add_task_once(
+        "ordered-task-once",
+        TaskOnceDef::new(|_| async { Ok::<_, ExitError>(()) }),
+    );
+    let _: Result<SubtreeSlot<Tree>, ReserveError> =
+        ordered.reserve_subtree("ordered-subtree-slot");
+    let _: Result<ScopeRef, ReserveError> =
+        ordered.add_subtree("ordered-subtree", SubtreeDef::factory(Tree::new));
+    let _: Result<ScopeRef, ReserveError> =
+        ordered.add_subtree_once("ordered-subtree-once", SubtreeOnceDef::new(Tree::new()));
+
+    let mut dynamic = DynamicTree::new();
+    let _: &mut DynamicTree = dynamic.intensity(Intensity::default());
+    let _: &mut DynamicTree = dynamic.defaults(ScopeDefaults::default());
+    let _: Result<ActorSlot<Cell<()>>, ReserveError> = dynamic.reserve_actor("dynamic-actor-slot");
+    let _: Result<ActorRef<()>, ReserveError> =
+        dynamic.add_actor("dynamic-actor", ActorDef::<ClonedActor>::cloned(()));
+    let _: Result<ActorRef<()>, ReserveError> =
+        dynamic.add_actor_once("dynamic-actor-once", ActorOnceDef::<ClonedActor>::new(()));
+    let _: Result<ActorRef<Cell<()>>, ReserveError> = dynamic.add_raw(
+        "dynamic-raw",
+        RawDef::<OpaqueRaw>::factory(|| OpaqueRaw {
+            _not_sync: Cell::new(()),
+        }),
+    );
+    let _: Result<ActorRef<Cell<()>>, ReserveError> = dynamic.add_raw_once(
+        "dynamic-raw-once",
+        RawOnceDef::new(OpaqueRaw {
+            _not_sync: Cell::new(()),
+        }),
+    );
+    let _: Result<TaskSlot, ReserveError> = dynamic.reserve_task("dynamic-task-slot");
+    let _: Result<TaskRef, ReserveError> =
+        dynamic.add_task("dynamic-task", TaskDef::new(|_| async { Ok(()) }));
+    let _: Result<(TaskRef, OneShotTaskRef<()>), ReserveError> = dynamic.add_task_once(
+        "dynamic-task-once",
+        TaskOnceDef::new(|_| async { Ok::<_, ExitError>(()) }),
+    );
+    let _: Result<SubtreeSlot<Tree>, ReserveError> =
+        dynamic.reserve_subtree("dynamic-subtree-slot");
+    let _: Result<ScopeRef, ReserveError> =
+        dynamic.add_subtree("dynamic-subtree", SubtreeDef::factory(Tree::new));
+    let _: Result<ScopeRef, ReserveError> =
+        dynamic.add_subtree_once("dynamic-subtree-once", SubtreeOnceDef::new(Tree::new()));
+
+    let _: fn(Tree) -> Result<System<ScopeRef>, BuildError> = Tree::spawn;
+    let _: fn(DynamicTree) -> Result<System<DynamicScopeRef>, BuildError> = DynamicTree::spawn;
 }
 
 #[test]

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -151,6 +151,53 @@ fn actor_types_obey_resource_and_payload_trait_contracts() {
     let _ = SubtreeOnceDef::new(Tree::new());
 }
 
+#[test]
+#[allow(clippy::type_complexity)]
+fn slot_method_signatures_remain_nominal_and_parallel() {
+    let _: fn(&ActorSlot<Cell<()>>) -> ActorRef<Cell<()>> = ActorSlot::actor_ref;
+    let _: fn(ActorSlot<Cell<()>>, ActorDef<OpaqueActor>) -> ActorRef<Cell<()>> = ActorSlot::define;
+    let _: fn(ActorSlot<Cell<()>>, ActorOnceDef<OpaqueActor>) -> ActorRef<Cell<()>> =
+        ActorSlot::define_once;
+    let _: fn(ActorSlot<Cell<()>>, RawDef<OpaqueRaw>) -> ActorRef<Cell<()>> = ActorSlot::define_raw;
+    let _: fn(ActorSlot<Cell<()>>, RawOnceDef<OpaqueRaw>) -> ActorRef<Cell<()>> =
+        ActorSlot::define_once_raw;
+
+    let _: fn(&TaskSlot) -> TaskRef = TaskSlot::task_ref;
+    let _: fn(TaskSlot, TaskDef) -> TaskRef = TaskSlot::define;
+    let _: fn(TaskSlot, TaskOnceDef<Cell<()>>) -> (TaskRef, OneShotTaskRef<Cell<()>>) =
+        TaskSlot::define_once;
+
+    let _: fn(&SubtreeSlot<Tree>) -> ScopeRef = SubtreeSlot::<Tree>::scope_ref;
+    let _: fn(SubtreeSlot<Tree>, SubtreeDef<Tree>) -> ScopeRef = SubtreeSlot::<Tree>::define;
+    let _: fn(SubtreeSlot<Tree>, SubtreeOnceDef<Tree>) -> ScopeRef =
+        SubtreeSlot::<Tree>::define_once;
+
+    let _: fn(&DynamicActorSlot<Cell<()>>) -> ActorRef<Cell<()>> = DynamicActorSlot::actor_ref;
+    let _: fn(DynamicActorSlot<Cell<()>>, ActorDef<OpaqueActor>) -> Admission<ActorRef<Cell<()>>> =
+        DynamicActorSlot::define;
+    let _: fn(
+        DynamicActorSlot<Cell<()>>,
+        ActorOnceDef<OpaqueActor>,
+    ) -> Admission<ActorRef<Cell<()>>> = DynamicActorSlot::define_once;
+    let _: fn(DynamicActorSlot<Cell<()>>, RawDef<OpaqueRaw>) -> Admission<ActorRef<Cell<()>>> =
+        DynamicActorSlot::define_raw;
+    let _: fn(DynamicActorSlot<Cell<()>>, RawOnceDef<OpaqueRaw>) -> Admission<ActorRef<Cell<()>>> =
+        DynamicActorSlot::define_once_raw;
+
+    let _: fn(&DynamicTaskSlot) -> TaskRef = DynamicTaskSlot::task_ref;
+    let _: fn(DynamicTaskSlot, TaskDef) -> Admission<TaskRef> = DynamicTaskSlot::define;
+    let _: fn(
+        DynamicTaskSlot,
+        TaskOnceDef<Cell<()>>,
+    ) -> Admission<(TaskRef, OneShotTaskRef<Cell<()>>)> = DynamicTaskSlot::define_once;
+
+    let _: fn(&DynamicSubtreeSlot<Tree>) -> ScopeRef = DynamicSubtreeSlot::<Tree>::scope_ref;
+    let _: fn(DynamicSubtreeSlot<Tree>, SubtreeDef<Tree>) -> Admission<ScopeRef> =
+        DynamicSubtreeSlot::<Tree>::define;
+    let _: fn(DynamicSubtreeSlot<Tree>, SubtreeOnceDef<Tree>) -> Admission<ScopeRef> =
+        DynamicSubtreeSlot::<Tree>::define_once;
+}
+
 struct OpaqueRaw {
     _not_sync: Cell<()>,
 }

--- a/crates/shelterwood/tests/common/mod.rs
+++ b/crates/shelterwood/tests/common/mod.rs
@@ -6,4 +6,4 @@ pub(crate) mod waiting;
 
 pub(crate) use gates::{DestructorBlocker, DestructorGate, ReleaseGate};
 pub(crate) use ownership::{ConsumeCount, ConsumeGuard, LiveFlag, PanicOnDrop};
-pub(crate) use timing::{advance_time, assert_quiet, poll_once, poll_until};
+pub(crate) use timing::{POLL_TIMEOUT, advance_time, assert_quiet, poll_once, poll_until};

--- a/crates/shelterwood/tests/common/timing.rs
+++ b/crates/shelterwood/tests/common/timing.rs
@@ -5,6 +5,9 @@ use std::{
     time::Duration,
 };
 
+/// Shared wall-clock budget for eventually-consistent test observations.
+pub(crate) const POLL_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Polls a pinned future once with a no-op waker.
 pub(crate) fn poll_once<F: Future>(future: Pin<&mut F>) -> Poll<F::Output> {
     let mut context = Context::from_waker(Waker::noop());

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -216,7 +216,7 @@ async fn call_promotion_winning_the_deadline_race_reports_response_timeout() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction() {
+async fn zero_deadline_accepts_ready_send_but_does_not_construct_a_call() {
     let gate = ReleaseGate::default();
     let values = Arc::new(Mutex::new(Vec::new()));
     let calls = Arc::new(AtomicUsize::new(0));
@@ -235,10 +235,15 @@ async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction
         .try_send(Message::Value(1))
         .expect("identity probe accepts");
 
-    let timed = actor
+    let accepted_at_zero = actor
         .send_timeout(Message::Value(2), Duration::ZERO)
         .await
-        .expect_err("zero send deadline short-circuits");
+        .expect("immediate acceptance wins a zero send deadline");
+    assert_eq!(accepted_at_zero, accepting);
+    let timed = actor
+        .send_timeout(Message::Value(3), Duration::ZERO)
+        .await
+        .expect_err("a full mailbox cannot accept at the zero deadline");
     assert_eq!(timed.kind, SendErrorKind::TimedOut);
     assert_eq!(timed.incarnation_observed, Some(accepting));
     let constructed_in_call = Arc::clone(&constructed);
@@ -251,7 +256,7 @@ async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction
             Duration::ZERO,
         )
         .await
-        .expect_err("zero call deadline short-circuits");
+        .expect_err("a zero call deadline short-circuits user construction");
     assert_eq!(call.kind, CallErrorKind::AcceptanceTimedOut);
     assert_eq!(call.incarnation_observed, Some(accepting));
     assert!(!constructed.load(Ordering::SeqCst));
@@ -259,16 +264,16 @@ async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction
     gate.release();
     assert!(
         poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
-            values.lock().expect("values mutex poisoned").as_slice() == [1]
+            values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
         })
         .await
     );
     assert_quiet(Duration::from_millis(20), || {
-        values.lock().expect("values mutex poisoned").contains(&2)
+        values.lock().expect("values mutex poisoned").contains(&3)
             || calls.load(Ordering::SeqCst) != 0
     })
     .await;
-    assert!(matches!(timed.message, Message::Value(2)));
+    assert!(matches!(timed.message, Message::Value(3)));
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -578,4 +583,24 @@ async fn reply_receiver_reports_drop_and_is_safe_to_abandon() {
     let (reply, receiver) = Reply::<usize>::channel();
     drop(receiver);
     reply.send(1);
+
+    let (reply, receiver) = Reply::channel();
+    reply.send(2);
+    assert_eq!(
+        receiver.recv(Duration::ZERO).await,
+        Ok(2),
+        "a completed reply wins at a zero-width boundary"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn reply_completion_wins_at_the_exact_deadline() {
+    let width = Duration::from_secs(10);
+    let (reply, receiver) = Reply::channel();
+    let mut receive = Box::pin(receiver.recv(width));
+    assert!(poll_once(receive.as_mut()).is_pending());
+
+    advance_time(width).await;
+    reply.send(7);
+    assert_eq!(receive.await, Ok(7));
 }

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -216,7 +216,7 @@ async fn call_promotion_winning_the_deadline_race_reports_response_timeout() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn zero_deadline_accepts_ready_send_but_does_not_construct_a_call() {
+async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction() {
     let gate = ReleaseGate::default();
     let values = Arc::new(Mutex::new(Vec::new()));
     let calls = Arc::new(AtomicUsize::new(0));
@@ -235,15 +235,12 @@ async fn zero_deadline_accepts_ready_send_but_does_not_construct_a_call() {
         .try_send(Message::Value(1))
         .expect("identity probe accepts");
 
-    let accepted_at_zero = actor
+    // The mailbox has room, so only the zero-budget short-circuit keeps this
+    // send from being attempted at all.
+    let timed = actor
         .send_timeout(Message::Value(2), Duration::ZERO)
         .await
-        .expect("immediate acceptance wins a zero send deadline");
-    assert_eq!(accepted_at_zero, accepting);
-    let timed = actor
-        .send_timeout(Message::Value(3), Duration::ZERO)
-        .await
-        .expect_err("a full mailbox cannot accept at the zero deadline");
+        .expect_err("zero send deadline short-circuits");
     assert_eq!(timed.kind, SendErrorKind::TimedOut);
     assert_eq!(timed.incarnation_observed, Some(accepting));
     let constructed_in_call = Arc::clone(&constructed);
@@ -256,7 +253,7 @@ async fn zero_deadline_accepts_ready_send_but_does_not_construct_a_call() {
             Duration::ZERO,
         )
         .await
-        .expect_err("a zero call deadline short-circuits user construction");
+        .expect_err("zero call deadline short-circuits");
     assert_eq!(call.kind, CallErrorKind::AcceptanceTimedOut);
     assert_eq!(call.incarnation_observed, Some(accepting));
     assert!(!constructed.load(Ordering::SeqCst));
@@ -264,16 +261,16 @@ async fn zero_deadline_accepts_ready_send_but_does_not_construct_a_call() {
     gate.release();
     assert!(
         poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
-            values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
+            values.lock().expect("values mutex poisoned").as_slice() == [1]
         })
         .await
     );
     assert_quiet(Duration::from_millis(20), || {
-        values.lock().expect("values mutex poisoned").contains(&3)
+        values.lock().expect("values mutex poisoned").contains(&2)
             || calls.load(Ordering::SeqCst) != 0
     })
     .await;
-    assert!(matches!(timed.message, Message::Value(3)));
+    assert!(matches!(timed.message, Message::Value(2)));
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -588,8 +585,8 @@ async fn reply_receiver_reports_drop_and_is_safe_to_abandon() {
     reply.send(2);
     assert_eq!(
         receiver.recv(Duration::ZERO).await,
-        Ok(2),
-        "a completed reply wins at a zero-width boundary"
+        Err(ReplyError::Timeout),
+        "a zero budget short-circuits instead of observing a completed reply"
     );
 }
 

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
 use shelterwood::{
     Backoff, CallErrorKind, ChildState, ExitError, ExitResult, Jitter, Mailbox, RawActor,
     RawContext, RawOnceDef, Readiness, ReadinessDeadline, Reply, ReplyError, RestartCondition,
@@ -155,7 +155,7 @@ async fn acceptance_winning_the_deadline_withdrawal_race_succeeds() {
     advance_time(deadline).await;
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values.lock().expect("values mutex poisoned").contains(&1)
         })
         .await
@@ -165,7 +165,7 @@ async fn acceptance_winning_the_deadline_withdrawal_race_succeeds() {
         "acceptance is checked before successful withdrawal at the boundary"
     );
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
         })
         .await
@@ -199,7 +199,7 @@ async fn call_promotion_winning_the_deadline_race_reports_response_timeout() {
     advance_time(deadline).await;
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             calls.load(Ordering::SeqCst) == 1
         })
         .await
@@ -260,7 +260,7 @@ async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction
 
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values.lock().expect("values mutex poisoned").as_slice() == [1]
         })
         .await
@@ -519,7 +519,7 @@ async fn overflowing_restart_delay_never_restarts_immediately() {
     release_failure.release();
 
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             system.scope().child("restart").is_some_and(|child| {
                 matches!(child.state, ChildState::Restarting) && child.restart_at.is_none()
             })

--- a/crates/shelterwood/tests/defaults.rs
+++ b/crates/shelterwood/tests/defaults.rs
@@ -1,0 +1,211 @@
+//! Pins SPEC Appendix A's shipped defaults behaviorally: every other test
+//! sets policy explicitly, so without these a default regression passes the
+//! whole suite.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
+use shelterwood::{
+    Actor, ActorDef, Context, ExitError, ExitKind, ExitResult, Readiness, SendErrorKind,
+    StartupError, StopReason, TaskDef, Tree,
+};
+
+enum CapacityMessage {
+    Block,
+    Fill,
+}
+
+struct CapacityActor {
+    release: ReleaseGate,
+    entered: ReleaseGate,
+}
+
+impl Actor for CapacityActor {
+    type Msg = CapacityMessage;
+    type Args = (ReleaseGate, ReleaseGate);
+
+    async fn init(
+        (entered, release): Self::Args,
+        _: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        Ok(Self { release, entered })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+        if let CapacityMessage::Block = message {
+            self.entered.release();
+            self.release.wait().await;
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn default_mailbox_is_a_queue_of_sixty_four_messages() {
+    let entered = ReleaseGate::default();
+    let release = ReleaseGate::default();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor(
+            "unconfigured",
+            ActorDef::<CapacityActor>::cloned((entered.clone(), release.clone())),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    actor
+        .send(CapacityMessage::Block)
+        .await
+        .expect("the blocking message is accepted");
+    entered.wait().await;
+
+    let mut accepted = 0usize;
+    let full = loop {
+        match actor.try_send(CapacityMessage::Fill) {
+            Ok(_) => accepted += 1,
+            Err(error) => break error,
+        }
+        assert!(accepted <= 128, "unbounded acceptance is not a queue");
+    };
+    assert_eq!(
+        accepted, 64,
+        "Appendix A ships a bounded queue of 64 messages"
+    );
+    assert_eq!(full.kind, SendErrorKind::Full);
+
+    release.release();
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("drained actor shuts down");
+}
+
+#[tokio::test(start_paused = true)]
+async fn default_child_shutdown_grace_is_five_seconds() {
+    let mut tree = Tree::new();
+    let task = tree
+        .add_task("stubborn", TaskDef::new(|_| std::future::pending()))
+        .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("immediate task readiness");
+
+    let mut shutdown = Box::pin(system.shutdown(Duration::from_secs(60)));
+    assert_quiet(Duration::from_millis(50), || {
+        poll_once(shutdown.as_mut()).is_ready()
+    })
+    .await;
+    advance_time(Duration::from_millis(4500)).await;
+    // ~4.55s elapsed: still inside the shipped 5s grace.
+    assert_quiet(Duration::from_millis(50), || {
+        poll_once(shutdown.as_mut()).is_ready()
+    })
+    .await;
+    advance_time(Duration::from_millis(600)).await;
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            poll_once(shutdown.as_mut()).is_ready()
+        })
+        .await,
+        "grace elapses at 5s and the abort ladder completes"
+    );
+    drop(shutdown);
+
+    let exit = task.wait().await;
+    assert!(
+        matches!(exit.kind(), ExitKind::Aborted { after_grace: true }),
+        "an uncooperative task is aborted after the default grace: {exit:?}"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn default_readiness_deadline_is_thirty_seconds() {
+    // The driver arms the deadline from the paused virtual clock, so the
+    // baseline must come from the same clock: the real clock has already
+    // drifted past virtual t0 by the time the test body runs.
+    let before = tokio::time::Instant::now().into_std();
+    let mut tree = Tree::new();
+    let task = tree
+        .add_task(
+            "gated",
+            TaskDef::new(|_| std::future::pending())
+                .restart(crate::common::policy::never())
+                .readiness(Readiness::Manual)
+                .expect("manual readiness"),
+        )
+        .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+
+    let mut started = Box::pin(system.wait_started());
+    assert_quiet(Duration::from_millis(50), || {
+        poll_once(started.as_mut()).is_ready()
+    })
+    .await;
+    advance_time(Duration::from_secs(29)).await;
+    // ~29.1s elapsed: still inside the shipped 30s readiness deadline.
+    assert_quiet(Duration::from_millis(50), || {
+        poll_once(started.as_mut()).is_ready()
+    })
+    .await;
+    drop(started);
+    advance_time(Duration::from_millis(1500)).await;
+
+    let startup = system
+        .wait_started()
+        .await
+        .expect_err("unsignalled manual readiness times out at the shipped 30s deadline");
+    assert!(matches!(startup, StartupError::StartupFailed(_)));
+    let exit = task.wait().await;
+    let ExitKind::ReadinessTimedOut { deadline } = exit.kind() else {
+        panic!("expected a typed readiness timeout, got {exit:?}");
+    };
+    assert!(*deadline >= before + Duration::from_secs(30));
+    system
+        .shutdown(Duration::ZERO)
+        .await
+        .expect("terminal child leaves no straggler");
+}
+
+#[tokio::test]
+async fn default_intensity_allows_five_restarts_before_tripping() {
+    let runs = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    tree.add_task(
+        "failing",
+        TaskDef::new({
+            let runs = Arc::clone(&runs);
+            move |_| {
+                let runs = Arc::clone(&runs);
+                async move {
+                    runs.fetch_add(1, Ordering::SeqCst);
+                    Err(ExitError::message("deliberate failure"))
+                }
+            }
+        }),
+    )
+    .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+
+    // Immediate task readiness means startup may complete before the failures
+    // accumulate, so the trip is asserted on the scope's stop reason rather
+    // than the startup result.
+    let StopReason::IntensityTripped(trip) = system.wait().await else {
+        panic!("repeated failure trips the shipped budget");
+    };
+    assert_eq!(
+        trip.observed_restarts, 6,
+        "the shipped budget admits 5 restarts and trips on the 6th"
+    );
+    assert_eq!(
+        runs.load(Ordering::SeqCst),
+        6,
+        "initial run plus 5 restarts spawn; the tripping restart never does"
+    );
+}

--- a/crates/shelterwood/tests/delivery.rs
+++ b/crates/shelterwood/tests/delivery.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, assert_quiet, poll_once, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_once, poll_until};
 use shelterwood::{
     CallErrorKind, ExitError, ExitResult, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Reply,
     SendErrorKind, Shutdown, SubtreeOnceDef, Tree,
@@ -71,7 +71,7 @@ async fn accepted_but_undelivered_prefix_never_crosses_an_incarnation() {
     actor.try_send(3).expect("remainder accepts");
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             generation.load(Ordering::SeqCst) == 2
         })
         .await
@@ -81,7 +81,7 @@ async fn accepted_but_undelivered_prefix_never_crosses_an_incarnation() {
         .await
         .expect("fresh message reaches replacement");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             log.lock().expect("prefix log mutex poisoned").as_slice() == [(1, 1), (2, 4)]
         })
         .await
@@ -242,7 +242,7 @@ async fn queue_preserves_per_sender_fifo_under_interleaved_senders() {
     sender_b.await.expect("sender b joins");
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             log.lock().expect("order log mutex poisoned").len() == 4
         })
         .await
@@ -356,7 +356,7 @@ async fn send_cancellation_withdraws_before_acceptance_but_not_after() {
     drop(before);
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             log.lock().expect("send log mutex poisoned").as_slice() == [(2, 1)]
         })
         .await
@@ -365,7 +365,7 @@ async fn send_cancellation_withdraws_before_acceptance_but_not_after() {
     assert!(matches!(poll_once(after.as_mut()), Poll::Ready(Ok(_))));
     drop(after);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             log.lock().expect("send log mutex poisoned").as_slice() == [(2, 1), (2, 3)]
         })
         .await
@@ -417,7 +417,7 @@ async fn call_cancellation_withdraws_before_acceptance_but_processes_after() {
         let expected = usize::from(accepted_before_drop);
         if accepted_before_drop {
             assert!(
-                poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+                poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
                     calls.load(Ordering::SeqCst) == expected
                 })
                 .await

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -500,6 +500,68 @@ async fn unadmitted_removal_completes_after_blocking_definition_disposal() {
         .expect("dynamic root shuts down");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn restart_window_removal_joins_factory_disposal_before_terminality() {
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = DynamicTree::new();
+    let task = tree
+        .add_task(
+            "restarting",
+            TaskDef::new({
+                let capture = BlockingDropProbe::new(&gate, dropped);
+                move |_| {
+                    let _ = &capture;
+                    async { Err(ExitError::message("restart me")) }
+                }
+            })
+            .restart(RestartPolicy::new(
+                RestartCondition::OnFailure,
+                Backoff::fixed(Duration::from_secs(60), Jitter::None).expect("fixed backoff"),
+            )),
+        )
+        .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+    let scope = system.scope();
+    system
+        .wait_started()
+        .await
+        .expect("first incarnation starts");
+    scope
+        .wait_for_child(
+            "restarting",
+            |child| matches!(child.state, ChildState::Restarting),
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("task enters restart backoff");
+
+    let mut removal = Box::pin(scope.remove_task(&task));
+    poll_pending(&mut removal).await;
+    wait_for_destructor(&gate).await;
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("factory disposal reports its thread"),
+        thread::current().id()
+    );
+    poll_pending(&mut removal).await;
+    let mut terminal = Box::pin(task.wait());
+    poll_pending(&mut terminal).await;
+
+    gate.release();
+    assert!(matches!(
+        terminal.await.kind(),
+        ExitKind::Failed(error) if error.to_string() == "restart me"
+    ));
+    assert_eq!(removal.await, RemoveOutcome::Removed);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root shuts down");
+}
+
 #[tokio::test]
 async fn unadmitted_removal_completes_when_the_panic_payload_destructor_panics() {
     let tree = DynamicTree::new();
@@ -687,6 +749,58 @@ async fn startup_rollback_detaches_never_started_one_shot_state_after_escalation
     assert!(matches!(
         completion
             .wait()
+            .await
+            .expect_err("the ordered suffix never ran")
+            .kind(),
+        ExitKind::NeverStarted
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn startup_rollback_joins_never_started_disposal_before_terminality() {
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    tree.add_task(
+        "fails",
+        TaskDef::new(|_| async { Err(ExitError::message("startup failure")) })
+            .restart(never())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness"),
+    )
+    .expect("valid failing task");
+    let (_never_started, completion) = tree
+        .add_task_once(
+            "never-started",
+            TaskOnceDef::new({
+                let state = BlockingDropProbe::new(&gate, dropped);
+                move |_| {
+                    let _ = &state;
+                    async { Ok::<_, ExitError>(()) }
+                }
+            }),
+        )
+        .expect("valid one-shot suffix");
+
+    let system = tree.spawn().expect("runtime is available");
+    let mut rollback = Box::pin(system.start_or_shutdown(Duration::from_secs(5)));
+    poll_pending(&mut rollback).await;
+    wait_for_destructor(&gate).await;
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("one-shot state reports its thread"),
+        thread::current().id()
+    );
+    poll_pending(&mut rollback).await;
+    let mut terminal = Box::pin(completion.wait());
+    poll_pending(&mut terminal).await;
+
+    gate.release();
+    assert!(rollback.await.is_err(), "startup failure is preserved");
+    assert!(matches!(
+        terminal
             .await
             .expect_err("the ordered suffix never ran")
             .kind(),

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -11,7 +11,8 @@ use std::{
 };
 
 use crate::common::{
-    DestructorBlocker, DestructorGate, PanicOnDrop, ReleaseGate, policy::never, poll_until,
+    DestructorBlocker, DestructorGate, POLL_TIMEOUT, PanicOnDrop, ReleaseGate, policy::never,
+    poll_until,
 };
 use shelterwood::{
     Backoff, ChildState, DynamicTree, ExitError, ExitKind, ExitResult, Jitter, LifecycleEventKind,
@@ -225,7 +226,7 @@ async fn panicking_unread_messages_are_all_disposed_without_reclassifying_the_ac
         .await
         .expect("payload panics do not unwind the scope driver");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             drops.load(Ordering::SeqCst) == 2
         })
         .await,

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, assert_quiet, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until};
 use shelterwood::{
     Actor, ActorOnceDef, Context, Exit, ExitError, ExitKind, ExitResult, LifecycleEventKind,
     LifecycleEvents, LifecycleItem, Mailbox, MailboxShutdown, SendErrorKind, Shutdown, StopContext,
@@ -114,7 +114,7 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
 
     actor.send(Message::Stop).await.expect("stop accepted");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             stop_entered.load(Ordering::SeqCst)
         })
         .await
@@ -130,7 +130,7 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
     allow_stop.release();
 
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             drain_entered.load(Ordering::SeqCst)
         })
         .await

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -588,6 +588,140 @@ async fn reserved_cell_removal_wins_a_queued_split_definition() {
         .expect("root stops");
 }
 
+#[test]
+fn admission_runtime_guards_leave_reservation_ids_reusable() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("test runtime");
+    let (system, scope, task, mut admission) = runtime.block_on(async {
+        let system = DynamicTree::new().spawn().expect("runtime is available");
+        system.wait_started().await.expect("root starts");
+        let scope = system.scope();
+        let slot = scope
+            .reserve_task("poll-outside")
+            .expect("reservation starts inside the runtime");
+        let task = slot.task_ref();
+        let admission = Box::pin(slot.define(waiting_task()));
+        (system, scope, task, admission)
+    });
+
+    assert!(matches!(scope.reserve_task(""), Err(ReserveError::EmptyId)));
+    assert!(matches!(
+        scope.reserve_task("poll-outside"),
+        Err(ReserveError::NoRuntime)
+    ));
+    assert!(matches!(
+        scope.reserve_task("reserve-outside"),
+        Err(ReserveError::NoRuntime)
+    ));
+    let mut immediate = Box::pin(scope.add_task("add-outside", waiting_task()));
+    assert!(matches!(
+        poll_once(immediate.as_mut()),
+        std::task::Poll::Ready(Err(ReserveError::NoRuntime))
+    ));
+    assert!(matches!(
+        poll_once(admission.as_mut()),
+        std::task::Poll::Ready(Err(ReserveError::NoRuntime))
+    ));
+    assert!(poll_once(admission.as_mut()).is_pending());
+
+    runtime.block_on(async {
+        assert!(matches!(task.wait().await.kind(), ExitKind::NeverStarted));
+        for id in ["reserve-outside", "add-outside", "poll-outside"] {
+            let task = scope
+                .add_task(id, waiting_task())
+                .await
+                .unwrap_or_else(|error| panic!("id `{id}` remains reusable: {error:?}"))
+                .into_handles();
+            assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
+        }
+        system
+            .shutdown(Duration::from_secs(1))
+            .await
+            .expect("root stops");
+    });
+    assert!(matches!(
+        scope.reserve_task("stopped-outside"),
+        Err(ReserveError::NoRuntime)
+    ));
+}
+
+#[tokio::test]
+async fn select_and_timeout_preserve_fused_and_split_admission_ownership() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+
+    let mut fused = Box::pin(scope.add_task("fused-select", waiting_task()));
+    assert!(poll_once(fused.as_mut()).is_pending());
+    tokio::select! {
+        biased;
+        () = std::future::ready(()) => {}
+        result = fused => panic!("ready branch must win over admission: {result:?}"),
+    }
+    let reused = scope
+        .add_task("fused-select", waiting_task())
+        .await
+        .expect("select dropping a fused admission frees its id")
+        .into_handles();
+    assert_eq!(scope.remove_task(&reused).await, RemoveOutcome::Removed);
+
+    let split_started = Arc::new(AtomicBool::new(false));
+    let split_cancelled = Arc::new(AtomicBool::new(false));
+    let slot = scope
+        .reserve_task("split-timeout")
+        .expect("split reservation");
+    let task = slot.task_ref();
+    let mut split = Box::pin(slot.define(TaskDef::new({
+        let split_started = Arc::clone(&split_started);
+        let split_cancelled = Arc::clone(&split_cancelled);
+        move |context| {
+            let split_started = Arc::clone(&split_started);
+            let split_cancelled = Arc::clone(&split_cancelled);
+            async move {
+                split_started.store(true, Ordering::SeqCst);
+                context.shutdown_token().cancelled().await;
+                split_cancelled.store(true, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+    })));
+    assert!(poll_once(split.as_mut()).is_pending());
+    let timed_admission = async move {
+        let _split = split;
+        std::future::pending::<()>().await;
+    };
+    assert!(
+        tokio::time::timeout(Duration::ZERO, timed_admission)
+            .await
+            .is_err()
+    );
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            split_started.load(Ordering::SeqCst)
+        })
+        .await,
+        "timing out a polled split admission detaches the running child"
+    );
+    assert!(matches!(
+        scope.reserve_task("split-timeout"),
+        Err(ReserveError::DuplicateId(_))
+    ));
+    assert_quiet(Duration::from_millis(20), || {
+        split_cancelled.load(Ordering::SeqCst)
+    })
+    .await;
+    assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
+    assert!(split_cancelled.load(Ordering::SeqCst));
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
 #[tokio::test]
 async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
     let system = DynamicTree::new().spawn().expect("runtime is available");

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -13,12 +13,35 @@ use crate::common::{
     waiting::{task as waiting_task, tree as waiting_tree},
 };
 use shelterwood::{
-    Actor, ActorOnceDef, Backoff, ChildState, Context as ActorContext, DynamicTree, ExitError,
-    ExitKind, ExitResult, NotAdmittingCause, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
-    RemoveOutcome, ReserveError, RestartCondition, RestartPolicy, Retention, ScopeRef,
-    SendErrorKind, Shutdown, StopReason, SubtreeDef, SubtreeOnceDef, System, TaskDef, TaskOnceDef,
-    Tree,
+    Actor, ActorOnceDef, Backoff, ChildState, Context as ActorContext, DynamicScopeRef,
+    DynamicTree, ExitError, ExitKind, ExitResult, NotAdmittingCause, RawActor, RawContext, RawDef,
+    RawOnceDef, Readiness, RemoveOutcome, ReserveError, RestartCondition, RestartPolicy, Retention,
+    ScopeRef, SendErrorKind, Shutdown, StopReason, SubtreeDef, SubtreeOnceDef, System, TaskDef,
+    TaskOnceDef, Tree,
 };
+
+/// Waits until a fused drop has finished releasing its id.
+///
+/// Dropping a polled fused `Admission` only fires the fused-cancel latch.
+/// The driver then marks the membership `removing` and runs the stop ladder,
+/// so a flag stored from inside the child's own shutdown handler is raised
+/// *within* the removal window, while the dynamic entry is still held.
+/// Reusing the id off that flag alone therefore races the only producer of
+/// `ReserveError::RemovalInProgress`: a surviving entry whose member is
+/// already `removing`.
+///
+/// Removal completion releases the entry before it withdraws residency, so
+/// an absent resident is a sound — slightly conservative — signal that the
+/// id is free again.
+async fn wait_for_id_release(scope: &DynamicScopeRef, id: &str) {
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            scope.child(id).is_none()
+        })
+        .await,
+        "removal of {id} did not release its id"
+    );
+}
 
 struct DropProbe(Arc<AtomicBool>);
 
@@ -612,6 +635,7 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
         })
         .await
     );
+    wait_for_id_release(&scope, "fused-after-admission").await;
     let reused = scope
         .add_task("fused-after-admission", waiting_task())
         .await
@@ -726,6 +750,7 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
         })
         .await
     );
+    wait_for_id_release(&scope, "fused-actor").await;
     let actor = scope
         .add_raw("fused-actor", RawDef::factory(|| WaitingRaw))
         .await
@@ -756,6 +781,7 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
         })
         .await
     );
+    wait_for_id_release(&scope, "fused-subtree").await;
     let subtree = scope
         .add_subtree_once("fused-subtree", SubtreeOnceDef::new(waiting_tree()))
         .await

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -78,6 +78,39 @@ impl RawActor for WaitingRaw {
     }
 }
 
+struct SignalledWaitingRaw {
+    started: Arc<AtomicBool>,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl RawActor for SignalledWaitingRaw {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        self.started.store(true, Ordering::SeqCst);
+        context.shutdown_token().cancelled().await;
+        self.cancelled.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+fn signalled_waiting_tree(started: Arc<AtomicBool>, cancelled: Arc<AtomicBool>) -> Tree {
+    let mut tree = Tree::new();
+    let (_, completion) = tree
+        .add_task_once(
+            "worker",
+            TaskOnceDef::new(move |context| async move {
+                started.store(true, Ordering::SeqCst);
+                context.shutdown_token().cancelled().await;
+                cancelled.store(true, Ordering::SeqCst);
+                Ok::<_, ExitError>(())
+            }),
+        )
+        .expect("valid signalled task");
+    drop(completion);
+    tree
+}
+
 #[tokio::test]
 async fn restartable_dynamic_surfaces_are_parallel_across_all_three_child_kinds() {
     let system = DynamicTree::new().spawn().expect("runtime is available");
@@ -661,6 +694,131 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
 }
 
 #[tokio::test]
+async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+
+    let actor_started = Arc::new(AtomicBool::new(false));
+    let actor_cancelled = Arc::new(AtomicBool::new(false));
+    let mut fused_actor = Box::pin(scope.add_raw(
+        "fused-actor",
+        RawDef::factory({
+            let actor_started = Arc::clone(&actor_started);
+            let actor_cancelled = Arc::clone(&actor_cancelled);
+            move || SignalledWaitingRaw {
+                started: Arc::clone(&actor_started),
+                cancelled: Arc::clone(&actor_cancelled),
+            }
+        }),
+    ));
+    assert!(poll_once(fused_actor.as_mut()).is_pending());
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            actor_started.load(Ordering::SeqCst)
+        })
+        .await
+    );
+    drop(fused_actor);
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            actor_cancelled.load(Ordering::SeqCst)
+        })
+        .await
+    );
+    let actor = scope
+        .add_raw("fused-actor", RawDef::factory(|| WaitingRaw))
+        .await
+        .expect("fused actor drop frees its id")
+        .into_handles();
+    assert_eq!(scope.remove_actor(&actor).await, RemoveOutcome::Removed);
+
+    let subtree_started = Arc::new(AtomicBool::new(false));
+    let subtree_cancelled = Arc::new(AtomicBool::new(false));
+    let mut fused_subtree = Box::pin(scope.add_subtree_once(
+        "fused-subtree",
+        SubtreeOnceDef::new(signalled_waiting_tree(
+            Arc::clone(&subtree_started),
+            Arc::clone(&subtree_cancelled),
+        )),
+    ));
+    assert!(poll_once(fused_subtree.as_mut()).is_pending());
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            subtree_started.load(Ordering::SeqCst)
+        })
+        .await
+    );
+    drop(fused_subtree);
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            subtree_cancelled.load(Ordering::SeqCst)
+        })
+        .await
+    );
+    let subtree = scope
+        .add_subtree_once("fused-subtree", SubtreeOnceDef::new(waiting_tree()))
+        .await
+        .expect("fused subtree drop frees its id")
+        .into_handles();
+    assert_eq!(scope.remove_scope(&subtree).await, RemoveOutcome::Removed);
+
+    let actor_started = Arc::new(AtomicBool::new(false));
+    let actor_cancelled = Arc::new(AtomicBool::new(false));
+    let slot = scope
+        .reserve_actor("split-actor")
+        .expect("actor reservation succeeds");
+    let actor = slot.actor_ref();
+    let mut split_actor = Box::pin(slot.define_once_raw(RawOnceDef::new(SignalledWaitingRaw {
+        started: Arc::clone(&actor_started),
+        cancelled: Arc::clone(&actor_cancelled),
+    })));
+    assert!(poll_once(split_actor.as_mut()).is_pending());
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            actor_started.load(Ordering::SeqCst)
+        })
+        .await
+    );
+    drop(split_actor);
+    assert_quiet(Duration::from_millis(20), || {
+        actor_cancelled.load(Ordering::SeqCst)
+    })
+    .await;
+    assert_eq!(scope.remove_actor(&actor).await, RemoveOutcome::Removed);
+    assert!(actor_cancelled.load(Ordering::SeqCst));
+
+    let subtree_started = Arc::new(AtomicBool::new(false));
+    let subtree_cancelled = Arc::new(AtomicBool::new(false));
+    let slot = scope
+        .reserve_subtree::<Tree>("split-subtree")
+        .expect("subtree reservation succeeds");
+    let subtree = slot.scope_ref();
+    let mut split_subtree = Box::pin(slot.define_once(SubtreeOnceDef::new(
+        signalled_waiting_tree(Arc::clone(&subtree_started), Arc::clone(&subtree_cancelled)),
+    )));
+    assert!(poll_once(split_subtree.as_mut()).is_pending());
+    assert!(
+        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            subtree_started.load(Ordering::SeqCst)
+        })
+        .await
+    );
+    drop(split_subtree);
+    assert_quiet(Duration::from_millis(20), || {
+        subtree_cancelled.load(Ordering::SeqCst)
+    })
+    .await;
+    assert_eq!(scope.remove_scope(&subtree).await, RemoveOutcome::Removed);
+    assert!(subtree_cancelled.load(Ordering::SeqCst));
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[tokio::test]
 async fn removing_a_member_releases_its_factory_before_scope_shutdown() {
     let started = Arc::new(AtomicBool::new(false));
     let factory_dropped = Arc::new(AtomicBool::new(false));
@@ -788,6 +946,20 @@ async fn dropping_undefined_dynamic_slots_terminalizes_cells_and_frees_ids() {
     system.wait_started().await.expect("root starts");
     let scope = system.scope();
 
+    let actor_slot = scope
+        .reserve_actor::<()>("actor")
+        .expect("actor reservation");
+    let abandoned_actor = actor_slot.actor_ref();
+    drop(actor_slot);
+    assert_eq!(
+        abandoned_actor
+            .send(())
+            .await
+            .expect_err("abandoned actor is terminal")
+            .kind,
+        SendErrorKind::Terminated
+    );
+
     let task_slot = scope.reserve_task("worker").expect("task reservation");
     let abandoned_task = task_slot.task_ref();
     drop(task_slot);
@@ -812,6 +984,12 @@ async fn dropping_undefined_dynamic_slots_terminalizes_cells_and_frees_ids() {
         .expect("task id was released")
         .into_handles();
     assert_eq!(scope.remove_task(&worker).await, RemoveOutcome::Removed);
+    let actor = scope
+        .add_raw("actor", RawDef::factory(|| WaitingRaw))
+        .await
+        .expect("actor id was released")
+        .into_handles();
+    assert_eq!(scope.remove_actor(&actor).await, RemoveOutcome::Removed);
     let nested = scope
         .add_subtree_once("nested", SubtreeOnceDef::new(waiting_tree()))
         .await

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::common::{
-    ReleaseGate, advance_time, assert_quiet,
+    POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet,
     policy::never,
     poll_once, poll_until,
     waiting::{task as waiting_task, tree as waiting_tree},
@@ -35,7 +35,7 @@ use shelterwood::{
 /// id is free again.
 async fn wait_for_id_release(scope: &DynamicScopeRef, id: &str) {
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             scope.child(id).is_none()
         })
         .await,
@@ -132,6 +132,38 @@ fn signalled_waiting_tree(started: Arc<AtomicBool>, cancelled: Arc<AtomicBool>) 
         .expect("valid signalled task");
     drop(completion);
     tree
+}
+
+#[tokio::test]
+async fn scope_dynamic_conversion_and_exact_dynamic_scope_removal_are_publicly_usable() {
+    let ordered = Tree::new().spawn().expect("runtime is available");
+    let ordered_scope: ScopeRef = ordered.scope();
+    assert!(ordered_scope.dynamic().is_none());
+    ordered
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("ordered root stops");
+
+    let dynamic = DynamicTree::new().spawn().expect("runtime is available");
+    dynamic.wait_started().await.expect("dynamic root starts");
+    let dynamic_scope = dynamic.scope();
+    let erased: &ScopeRef = dynamic_scope.as_scope();
+    let recovered = erased.dynamic().expect("dynamic capability is recoverable");
+    assert_eq!(recovered.as_scope(), erased);
+
+    let nested = dynamic_scope
+        .add_subtree_once("nested-dynamic", SubtreeOnceDef::new(DynamicTree::new()))
+        .await
+        .expect("dynamic subtree is admitted")
+        .into_handles();
+    assert_eq!(
+        dynamic_scope.remove_dynamic_scope(&nested).await,
+        RemoveOutcome::Removed
+    );
+    dynamic
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root stops");
 }
 
 #[tokio::test]
@@ -512,7 +544,7 @@ async fn removal_is_synchronous_detached_and_shared() {
     ));
     drop(first);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             cancelled.load(Ordering::SeqCst)
         })
         .await
@@ -699,7 +731,7 @@ async fn select_and_timeout_preserve_fused_and_split_admission_ownership() {
             .is_err()
     );
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             split_started.load(Ordering::SeqCst)
         })
         .await,
@@ -757,14 +789,14 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
     ));
     assert!(poll_once(fused.as_mut()).is_pending());
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             fused_started.load(Ordering::SeqCst)
         })
         .await
     );
     drop(fused);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             fused_cancelled.load(Ordering::SeqCst)
         })
         .await
@@ -798,7 +830,7 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
     assert!(poll_once(split.as_mut()).is_pending());
     drop(split);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             split_started.load(Ordering::SeqCst)
         })
         .await
@@ -831,7 +863,7 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
     })));
     assert!(poll_once(split_after.as_mut()).is_pending());
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             split_after_started.load(Ordering::SeqCst)
         })
         .await
@@ -872,14 +904,14 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
     ));
     assert!(poll_once(fused_actor.as_mut()).is_pending());
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             actor_started.load(Ordering::SeqCst)
         })
         .await
     );
     drop(fused_actor);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             actor_cancelled.load(Ordering::SeqCst)
         })
         .await
@@ -903,14 +935,14 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
     ));
     assert!(poll_once(fused_subtree.as_mut()).is_pending());
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             subtree_started.load(Ordering::SeqCst)
         })
         .await
     );
     drop(fused_subtree);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             subtree_cancelled.load(Ordering::SeqCst)
         })
         .await
@@ -935,7 +967,7 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
     })));
     assert!(poll_once(split_actor.as_mut()).is_pending());
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             actor_started.load(Ordering::SeqCst)
         })
         .await
@@ -959,7 +991,7 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
     )));
     assert!(poll_once(split_subtree.as_mut()).is_pending());
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             subtree_started.load(Ordering::SeqCst)
         })
         .await
@@ -1005,7 +1037,7 @@ async fn removing_a_member_releases_its_factory_before_scope_shutdown() {
         .expect("task admitted")
         .into_handles();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             started.load(Ordering::SeqCst)
         })
         .await
@@ -1203,7 +1235,7 @@ async fn dynamic_scope_rejects_reservations_between_incarnations() {
     let system = root.spawn().expect("runtime is available");
 
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             first_started.load(Ordering::SeqCst)
         })
         .await
@@ -1296,7 +1328,7 @@ fn pending_restart_subtree(
 
 async fn await_first_restart_window(root: &ScopeRef, starts: &Arc<AtomicUsize>) {
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             starts.load(Ordering::SeqCst) == 1
         })
         .await
@@ -1495,7 +1527,7 @@ async fn draining_scopes_reject_admission_and_treat_removal_as_absent() {
     let scope = system.scope();
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(2)));
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             cancelled.load(Ordering::SeqCst)
         })
         .await

--- a/crates/shelterwood/tests/lifecycle.rs
+++ b/crates/shelterwood/tests/lifecycle.rs
@@ -7,7 +7,9 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{PanicOnDrop, ReleaseGate, assert_quiet, policy::never, poll_until};
+use crate::common::{
+    POLL_TIMEOUT, PanicOnDrop, ReleaseGate, assert_quiet, policy::never, poll_until,
+};
 use shelterwood::{
     Actor, ActorOnceDef, Context, DynamicTree, ExitError, ExitKind, ExitResult, Intensity,
     LifecycleEventKind, LifecycleItem, Readiness, Retention, ScopeState, Shutdown, StartupError,
@@ -258,7 +260,7 @@ async fn replacement_starts_only_after_the_old_future_is_destroyed() {
         .await
         .expect("initial incarnation starts");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             starts.load(Ordering::SeqCst) >= 2
         })
         .await
@@ -304,7 +306,7 @@ async fn ordered_teardown_is_reverse_and_joins_before_advancing() {
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(2)));
 
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             order.lock().expect("order mutex poisoned").as_slice() == [2]
         })
         .await
@@ -315,14 +317,14 @@ async fn ordered_teardown_is_reverse_and_joins_before_advancing() {
     .await;
     gates[2].release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             order.lock().expect("order mutex poisoned").as_slice() == [2, 1]
         })
         .await
     );
     gates[1].release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             order.lock().expect("order mutex poisoned").as_slice() == [2, 1, 0]
         })
         .await
@@ -363,7 +365,7 @@ async fn dynamic_teardown_cancels_children_concurrently() {
     system.wait_started().await.expect("tree starts");
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(2)));
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             cancelled.iter().all(|flag| flag.load(Ordering::SeqCst))
         })
         .await

--- a/crates/shelterwood/tests/lifecycle.rs
+++ b/crates/shelterwood/tests/lifecycle.rs
@@ -10,8 +10,8 @@ use std::{
 use crate::common::{PanicOnDrop, ReleaseGate, assert_quiet, policy::never, poll_until};
 use shelterwood::{
     Actor, ActorOnceDef, Context, DynamicTree, ExitError, ExitKind, ExitResult, Intensity,
-    Readiness, Retention, Shutdown, StartupError, StartupFailureCause, StopReason, SubtreeOnceDef,
-    TaskDef, TaskOnceDef, Tree,
+    LifecycleEventKind, LifecycleItem, Readiness, Retention, ScopeState, Shutdown, StartupError,
+    StartupFailureCause, StopReason, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
 };
 
 #[tokio::test]
@@ -374,6 +374,77 @@ async fn dynamic_teardown_cancels_children_concurrently() {
         .await
         .expect("shutdown task joins")
         .expect("clean shutdown");
+}
+
+#[tokio::test]
+async fn concurrent_initial_failures_publish_one_startup_failed_scope_edge() {
+    let release = Arc::new(tokio::sync::Barrier::new(3));
+    let mut tree = DynamicTree::new();
+    for index in 0..2 {
+        tree.add_task(
+            format!("child-{index}"),
+            TaskDef::new({
+                let release = Arc::clone(&release);
+                move |_| {
+                    let release = Arc::clone(&release);
+                    async move {
+                        release.wait().await;
+                        Err(ExitError::message(format!("failure-{index}")))
+                    }
+                }
+            })
+            .restart(never())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness"),
+        )
+        .expect("valid task");
+    }
+
+    let system = tree.spawn().expect("runtime is available");
+    let mut lifecycle = system.scope().subscribe_lifecycle();
+    release.wait().await;
+
+    let mut exits = 0;
+    let mut startup_failed_edges = 0;
+    while exits < 2 {
+        let item = tokio::time::timeout(Duration::from_secs(2), lifecycle.recv())
+            .await
+            .expect("both concurrent exits are bounded")
+            .expect("the root lifecycle remains open");
+        let LifecycleItem::Event(event) = item else {
+            panic!("the small fixture cannot lag");
+        };
+        match event.kind {
+            LifecycleEventKind::Exited { .. } => exits += 1,
+            LifecycleEventKind::ScopeState {
+                state: ScopeState::StartupFailed,
+            } => startup_failed_edges += 1,
+            _ => {}
+        }
+    }
+    while let Ok(item) = lifecycle.try_recv() {
+        if matches!(
+            item,
+            LifecycleItem::Event(shelterwood::LifecycleEvent {
+                kind: LifecycleEventKind::ScopeState {
+                    state: ScopeState::StartupFailed,
+                },
+                ..
+            })
+        ) {
+            startup_failed_edges += 1;
+        }
+    }
+
+    assert_eq!(
+        startup_failed_edges, 1,
+        "the first initial failure owns the root startup transition"
+    );
+    assert!(system.wait_started().await.is_err());
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed dynamic root shuts down");
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/mailbox.rs
+++ b/crates/shelterwood/tests/mailbox.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
 use shelterwood::{
     CallErrorKind, ExitResult, Mailbox, MailboxShutdown, RawActor, RawContext, RawDef, Reply,
     ReplyError, SendErrorKind, Tree,
@@ -143,7 +143,7 @@ async fn queue_backpressure_and_send_error_identity_are_exact() {
         accepting
     );
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
         })
         .await
@@ -187,7 +187,7 @@ async fn latest_mailbox_keeps_only_the_newest_accepted_value() {
     actor.try_send(Message::Value(3)).expect("replace two");
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values.lock().expect("values mutex poisoned").as_slice() == [3]
         })
         .await
@@ -237,7 +237,7 @@ async fn timed_send_withdraws_and_recovers_the_message() {
     drop(cancelled);
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values.lock().expect("values mutex poisoned").as_slice() == [1]
         })
         .await
@@ -247,7 +247,7 @@ async fn timed_send_withdraws_and_recovers_the_message() {
         .await
         .expect("recovered message is safe to resend");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
         })
         .await
@@ -290,7 +290,7 @@ async fn call_distinguishes_success_drop_and_response_timeout() {
                 async move { call_actor.call(|reply| Message::Ask(7, reply), width).await },
             );
         assert!(
-            poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
                 asks.load(Ordering::SeqCst) == 1
             })
             .await

--- a/crates/shelterwood/tests/mod.rs
+++ b/crates/shelterwood/tests/mod.rs
@@ -15,6 +15,7 @@ mod mailbox;
 mod observation;
 mod offloads;
 mod one_shot_resource_ownership;
+mod policy_validation;
 mod raw;
 mod readiness;
 mod rebind;

--- a/crates/shelterwood/tests/mod.rs
+++ b/crates/shelterwood/tests/mod.rs
@@ -5,6 +5,7 @@ mod actor;
 mod api_trait_conformance;
 mod common;
 mod deadlines;
+mod defaults;
 mod delivery;
 mod disposal;
 mod drain;

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -987,6 +987,14 @@ async fn never_ran_members_stop_rather_than_report_startup_abort() {
         .wait_started()
         .await
         .expect_err("pre-ready terminal exit aborts startup");
+    scope
+        .wait_for_child(
+            "never-ran",
+            |child| matches!(child.state, ChildState::Stopped { .. }),
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("joined suffix disposal publishes terminality");
     let snapshot = scope.snapshot();
     assert!(matches!(
         snapshot

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -8,14 +8,14 @@ use std::{
 };
 
 use crate::common::{
-    ReleaseGate, assert_quiet, poll_once, poll_until,
+    POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_once, poll_until,
     waiting::{task as waiting_task, tree as waiting_tree},
 };
 use shelterwood::{
-    Backoff, ChildState, DynamicScopeRef, DynamicTree, Jitter, LifecycleEvent, LifecycleEventKind,
-    LifecycleEvents, LifecycleItem, LifecycleTryRecvError, RemoveOutcome, RestartCondition,
-    RestartPolicy, Retention, ScopeRef, ScopeState, StopReason, SubtreeDef, SubtreeOnceDef,
-    TaskDef, TaskOnceDef, TaskRef, Tree, WaitError,
+    Backoff, ChildState, DynamicScopeRef, DynamicTree, Jitter, LIFECYCLE_EVENT_CAPACITY,
+    LifecycleEvent, LifecycleEventKind, LifecycleEvents, LifecycleItem, LifecycleTryRecvError,
+    RemoveOutcome, RestartCondition, RestartPolicy, Retention, ScopeRef, ScopeState, StopReason,
+    SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef, TaskRef, Tree, WaitError,
 };
 
 async fn next_item(events: &mut LifecycleEvents) -> LifecycleItem {
@@ -139,14 +139,20 @@ async fn drain_added_started_ready(events: &mut LifecycleEvents) {
 
 #[tokio::test]
 async fn lifecycle_lag_is_exact_coalesced_per_episode_and_subscribers_are_isolated() {
+    const EVENTS_PER_ADMISSION: usize = 3;
+
     let system = DynamicTree::new().spawn().expect("runtime is available");
     system.wait_started().await.expect("root starts");
     let scope = system.scope();
     let mut slow = scope.subscribe_lifecycle();
     let mut fast = scope.subscribe_lifecycle();
 
+    let admissions_per_episode = LIFECYCLE_EVENT_CAPACITY.div_ceil(EVENTS_PER_ADMISSION) + 1;
+    let emitted_per_episode = admissions_per_episode * EVENTS_PER_ADMISSION;
+    let dropped_per_episode = emitted_per_episode - LIFECYCLE_EVENT_CAPACITY;
+
     for episode in 0..2 {
-        for index in 0..50 {
+        for index in 0..admissions_per_episode {
             admit_waiter(&scope, format!("worker-{episode}-{index}")).await;
             drain_added_started_ready(&mut fast).await;
         }
@@ -154,10 +160,12 @@ async fn lifecycle_lag_is_exact_coalesced_per_episode_and_subscribers_are_isolat
         let watermark = scope.snapshot().lifecycle_seq;
         assert_eq!(
             next_item(&mut slow).await,
-            LifecycleItem::Lagged { dropped: 22 },
-            "150 events in a 128-event queue drop exactly 22"
+            LifecycleItem::Lagged {
+                dropped: dropped_per_episode as u64,
+            },
+            "each overflow episode reports its capacity-derived exact drop count"
         );
-        for _ in 0..128 {
+        for _ in 0..LIFECYCLE_EVENT_CAPACITY {
             let LifecycleItem::Event(event) = next_item(&mut slow).await else {
                 panic!("one coalesced marker must lead each overflow episode");
             };
@@ -190,7 +198,7 @@ async fn catch_up_watermarks_dedupe_initial_events_discard_stale_scopes_and_intr
         .expect("subtree admitted")
         .into_handles();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             root.snapshot()
                 .child("nested")
                 .is_some_and(|child| matches!(child.state, ChildState::Running))
@@ -287,7 +295,7 @@ async fn removed_is_the_pruning_edge_not_the_retained_terminal_edge() {
     let membership = task.membership();
     task.wait().await;
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             root.snapshot()
                 .child("retained")
                 .is_some_and(|child| child.state.is_terminal())
@@ -358,7 +366,7 @@ async fn removed_is_the_pruning_edge_not_the_retained_terminal_edge() {
     let teardown_membership = teardown_task.membership();
     teardown_task.wait().await;
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             root.snapshot()
                 .child("teardown-tombstone")
                 .is_some_and(|child| child.state.is_terminal())
@@ -570,7 +578,7 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
     };
 
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             root.snapshot()
                 .child("nested")
                 .is_some_and(|child| matches!(child.state, ChildState::Restarting))
@@ -620,7 +628,7 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
     assert_eq!(nested.snapshot().total_restarts, 0);
     assert!(nested.snapshot().lifecycle_seq >= starting.seq);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             root.snapshot().child("nested").is_some_and(|child| {
                 matches!(child.state, ChildState::Running) && child.restart_at.is_none()
             })
@@ -1132,7 +1140,7 @@ async fn snapshot_subscriptions_conflate_unobserved_transitions_to_the_latest_va
         .into_handles();
     task.wait().await;
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             scope.child("ephemeral").is_none()
         })
         .await,

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{assert_quiet, poll_until};
+use crate::common::{POLL_TIMEOUT, assert_quiet, poll_until};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
     Guard, LifecycleEventKind, LifecycleItem, Readiness, Shutdown, StartupError,
@@ -138,7 +138,7 @@ async fn timers_and_offload_completions_never_cross_an_incarnation_boundary() {
         .await
         .expect("actor live");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             generations.load(Ordering::SeqCst) >= 2
         })
         .await
@@ -227,7 +227,7 @@ async fn offload_completion_wins_at_the_exact_deadline() {
         .await
         .expect("actor live");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             armed.load(Ordering::SeqCst) && offload_started.load(Ordering::SeqCst)
         })
         .await,
@@ -300,7 +300,7 @@ async fn dropping_scoped_guard_suppresses_the_continuation() {
     system.wait_started().await.expect("actor starts");
     actor.send(GuardMessage::Start).await.expect("actor live");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             guard_dropped.load(Ordering::SeqCst)
         })
         .await,
@@ -313,6 +313,51 @@ async fn dropping_scoped_guard_suppresses_the_continuation() {
     actor.send(GuardMessage::Stop).await.expect("actor live");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert_eq!(deliveries.load(Ordering::SeqCst), 0);
+}
+
+struct ExportGuardActor;
+
+impl Actor for ExportGuardActor {
+    type Msg = ();
+    type Args = tokio::sync::oneshot::Sender<Guard>;
+
+    async fn init(
+        guard_sender: Self::Args,
+        context: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        let guard = context
+            .offload_scoped(std::future::pending::<()>(), |_| (), Duration::MAX)
+            .expect("scoped offload accepted");
+        guard_sender
+            .send(guard)
+            .expect("test still awaits cancellation guard");
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): (), _: &mut Context<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn guard_reports_incarnation_cancellation() {
+    let (guard_sender, guard_receiver) = tokio::sync::oneshot::channel();
+    let mut tree = Tree::new();
+    tree.add_actor_once(
+        "guard-exporter",
+        ActorOnceDef::<ExportGuardActor>::new(guard_sender),
+    )
+    .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    let guard = guard_receiver.await.expect("actor exports guard");
+    assert!(!guard.is_cancelled());
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("actor stops");
+    assert!(guard.is_cancelled());
 }
 
 struct DropLog {
@@ -499,7 +544,7 @@ async fn dropping_run_blocking_future_cancels_and_detaches_its_thread() {
         .expect("actor live");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             cancelled.load(Ordering::SeqCst)
         })
         .await
@@ -981,7 +1026,7 @@ async fn queued_offload_panic_survives_hard_abort() {
         .await
         .expect("mailbox accepts before readiness");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             queued.load(Ordering::SeqCst)
         })
         .await,
@@ -1057,7 +1102,7 @@ async fn hard_abort_preserves_owned_offload_panic_over_handler_destructor() {
     system.wait_started().await.expect("actor starts");
     actor.send(()).await.expect("actor accepts trigger");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             queued.load(Ordering::SeqCst)
         })
         .await,
@@ -1161,7 +1206,7 @@ async fn incarnation_offloads_are_destroyed_before_actor_state_on_panic() {
         .await
         .expect("actor live");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             log.lock().expect("drop log mutex poisoned").len() == 2
         })
         .await
@@ -1241,7 +1286,7 @@ async fn incarnation_offloads_are_destroyed_before_actor_state_on_error() {
         .await
         .expect("actor live");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             log.lock().expect("drop log mutex poisoned").len() == 2
         })
         .await

--- a/crates/shelterwood/tests/policy_validation.rs
+++ b/crates/shelterwood/tests/policy_validation.rs
@@ -1,0 +1,406 @@
+use std::time::Duration;
+
+use shelterwood::{
+    Actor, ActorDef, Backoff, BackoffFactor, BuildError, ChildId, Context, DynamicTree, ExitError,
+    ExitKind, ExitResult, Intensity, InvalidPolicy, Jitter, PolicyError, PolicyField, RawActor,
+    RawContext, RawDef, Readiness, ReadinessDeadline, ReserveError, RestartCondition,
+    RestartPolicy, ScopeDefaults, StartupError, StartupFailureCause, SubtreeDef, SubtreeOnceDef,
+    TaskDef, Tree,
+};
+
+struct InertActor;
+
+impl Actor for InertActor {
+    type Msg = ();
+    type Args = ();
+
+    async fn init((): (), _context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): (), _context: &mut Context<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+}
+
+struct InertRaw;
+
+impl RawActor for InertRaw {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        context.shutdown_token().cancelled().await;
+        Ok(())
+    }
+}
+
+fn zero_fixed_restart() -> RestartPolicy {
+    RestartPolicy::new(
+        RestartCondition::Always,
+        Backoff::Fixed {
+            delay: Duration::ZERO,
+            jitter: Jitter::None,
+        },
+    )
+}
+
+fn reversed_exponential_restart() -> RestartPolicy {
+    RestartPolicy::new(
+        RestartCondition::Always,
+        Backoff::Exponential {
+            base: Duration::from_secs(2),
+            factor: BackoffFactor::new(2.0).expect("valid factor"),
+            max: Duration::from_secs(1),
+            jitter: Jitter::None,
+        },
+    )
+}
+
+fn assert_invalid(invalid: InvalidPolicy, path: &[&str], field: PolicyField, error: PolicyError) {
+    assert_eq!(
+        invalid.path,
+        path.iter().copied().map(ChildId::from).collect::<Vec<_>>()
+    );
+    assert_eq!(invalid.field, field);
+    assert_eq!(invalid.error, error);
+}
+
+fn build_invalid(tree: Tree) -> InvalidPolicy {
+    match tree.spawn() {
+        Err(BuildError::InvalidPolicy(invalid)) => invalid,
+        Err(other) => panic!("expected invalid policy, got {other:?}"),
+        Ok(_) => panic!("invalid policy unexpectedly built"),
+    }
+}
+
+fn admission_invalid(error: ReserveError) -> InvalidPolicy {
+    match error {
+        ReserveError::InvalidPolicy(invalid) => invalid,
+        other => panic!("expected invalid policy, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn static_build_revalidates_actor_task_raw_and_subtree_literals() {
+    let mut actor = Tree::new();
+    actor
+        .add_actor(
+            "actor",
+            ActorDef::<InertActor>::cloned(())
+                .readiness_deadline(ReadinessDeadline::Bounded(Duration::ZERO)),
+        )
+        .expect("valid id");
+    assert_invalid(
+        build_invalid(actor),
+        &["actor"],
+        PolicyField::ReadinessDeadline,
+        PolicyError::ZeroDuration,
+    );
+
+    let mut task = Tree::new();
+    task.add_task(
+        "task",
+        TaskDef::new(|_| async { Ok(()) }).restart(zero_fixed_restart()),
+    )
+    .expect("valid id");
+    assert_invalid(
+        build_invalid(task),
+        &["task"],
+        PolicyField::RestartBackoff,
+        PolicyError::ZeroDuration,
+    );
+
+    let mut raw = Tree::new();
+    raw.add_raw(
+        "raw",
+        RawDef::factory(|| InertRaw).restart(reversed_exponential_restart()),
+    )
+    .expect("valid id");
+    assert_invalid(
+        build_invalid(raw),
+        &["raw"],
+        PolicyField::RestartBackoff,
+        PolicyError::BackoffMaximumBeforeBase,
+    );
+
+    let mut subtree = Tree::new();
+    subtree
+        .add_subtree(
+            "subtree",
+            SubtreeDef::factory(Tree::new)
+                .readiness_deadline(ReadinessDeadline::Bounded(Duration::ZERO)),
+        )
+        .expect("valid id");
+    assert_invalid(
+        build_invalid(subtree),
+        &["subtree"],
+        PolicyField::ReadinessDeadline,
+        PolicyError::ZeroDuration,
+    );
+}
+
+#[tokio::test]
+async fn static_build_revalidates_scope_defaults_and_owned_nested_policy() {
+    let mut intensity = Tree::new();
+    intensity.intensity(Intensity {
+        max_restarts: 1,
+        within: Duration::ZERO,
+    });
+    assert_invalid(
+        build_invalid(intensity),
+        &[],
+        PolicyField::Intensity,
+        PolicyError::ZeroDuration,
+    );
+
+    let mut defaults = Tree::new();
+    defaults.defaults(ScopeDefaults {
+        child_restart: Some(zero_fixed_restart()),
+        ..ScopeDefaults::default()
+    });
+    assert_invalid(
+        build_invalid(defaults),
+        &[],
+        PolicyField::RestartBackoff,
+        PolicyError::ZeroDuration,
+    );
+
+    let mut nested = Tree::new();
+    nested.intensity(Intensity {
+        max_restarts: 1,
+        within: Duration::ZERO,
+    });
+    let mut root = Tree::new();
+    root.add_subtree_once("nested", SubtreeOnceDef::new(nested))
+        .expect("valid id");
+    assert_invalid(
+        build_invalid(root),
+        &["nested"],
+        PolicyField::Intensity,
+        PolicyError::ZeroDuration,
+    );
+}
+
+#[tokio::test]
+async fn dynamic_admission_revalidates_actor_task_raw_and_subtree_literals() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+
+    let actor = scope
+        .add_actor(
+            "actor",
+            ActorDef::<InertActor>::cloned(())
+                .readiness_deadline(ReadinessDeadline::Bounded(Duration::ZERO)),
+        )
+        .await
+        .expect_err("zero actor deadline is rejected");
+    assert_invalid(
+        admission_invalid(actor),
+        &["actor"],
+        PolicyField::ReadinessDeadline,
+        PolicyError::ZeroDuration,
+    );
+
+    let task = scope
+        .add_task(
+            "task",
+            TaskDef::new(|_| async { Ok(()) }).restart(zero_fixed_restart()),
+        )
+        .await
+        .expect_err("zero task backoff is rejected");
+    assert_invalid(
+        admission_invalid(task),
+        &["task"],
+        PolicyField::RestartBackoff,
+        PolicyError::ZeroDuration,
+    );
+
+    let raw = scope
+        .add_raw(
+            "raw",
+            RawDef::factory(|| InertRaw).restart(reversed_exponential_restart()),
+        )
+        .await
+        .expect_err("reversed raw backoff is rejected");
+    assert_invalid(
+        admission_invalid(raw),
+        &["raw"],
+        PolicyField::RestartBackoff,
+        PolicyError::BackoffMaximumBeforeBase,
+    );
+
+    let subtree = scope
+        .add_subtree(
+            "subtree",
+            SubtreeDef::factory(Tree::new)
+                .readiness_deadline(ReadinessDeadline::Bounded(Duration::ZERO)),
+        )
+        .await
+        .expect_err("zero subtree deadline is rejected");
+    assert_invalid(
+        admission_invalid(subtree),
+        &["subtree"],
+        PolicyField::ReadinessDeadline,
+        PolicyError::ZeroDuration,
+    );
+
+    let split = scope.reserve_task("split").expect("valid reservation");
+    let split = split
+        .define(TaskDef::new(|_| async { Ok(()) }).restart(zero_fixed_restart()))
+        .await
+        .expect_err("split definition validates at admission");
+    assert_invalid(
+        admission_invalid(split),
+        &["split"],
+        PolicyField::RestartBackoff,
+        PolicyError::ZeroDuration,
+    );
+
+    scope
+        .reserve_task("split")
+        .expect("rejected admission releases the id");
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[tokio::test]
+async fn dynamic_owned_subtree_policy_is_rejected_before_incarnation_start() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+    let mut nested = Tree::new();
+    nested.intensity(Intensity {
+        max_restarts: 0,
+        within: Duration::ZERO,
+    });
+
+    let error = scope
+        .add_subtree_once("nested", SubtreeOnceDef::new(nested))
+        .await
+        .expect_err("owned invalid subtree is rejected at admission");
+    assert_invalid(
+        admission_invalid(error),
+        &["nested"],
+        PolicyField::Intensity,
+        PolicyError::ZeroDuration,
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[tokio::test]
+async fn restartable_subtree_factory_output_reports_structured_policy_failure() {
+    let mut root = Tree::new();
+    root.add_subtree(
+        "nested",
+        SubtreeDef::factory(|| {
+            let mut nested = Tree::new();
+            nested.intensity(Intensity {
+                max_restarts: 1,
+                within: Duration::ZERO,
+            });
+            nested
+        })
+        .restart(RestartPolicy::new(
+            RestartCondition::Never,
+            Backoff::Immediate,
+        )),
+    )
+    .expect("valid subtree edge");
+    let system = root
+        .spawn()
+        .expect("factory output is produced after root lowering");
+    let StartupError::StartupFailed(failure) = system
+        .wait_started()
+        .await
+        .expect_err("factory output fails policy validation")
+    else {
+        panic!("expected structured startup failure");
+    };
+    let StartupFailureCause::Child { id, exit, .. } = failure.cause else {
+        panic!("root failure must name its nested child");
+    };
+    assert_eq!(id.as_str(), "nested");
+    let ExitKind::Failed(error) = exit.kind() else {
+        panic!("nested lowering is a child failure");
+    };
+    let nested = error
+        .startup_failure()
+        .expect("framework provenance is retained");
+    let StartupFailureCause::InvalidPolicy(invalid) = &nested.cause else {
+        panic!("nested failure must retain invalid-policy evidence");
+    };
+    assert_invalid(
+        invalid.clone(),
+        &[],
+        PolicyField::Intensity,
+        PolicyError::ZeroDuration,
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed root rolls back");
+}
+
+#[tokio::test]
+async fn minimum_valid_policy_literals_survive_lowering_and_admission() {
+    let factor = BackoffFactor::new(1.0).expect("minimum factor is valid");
+    let valid_restart = RestartPolicy::new(
+        RestartCondition::Always,
+        Backoff::Exponential {
+            base: Duration::from_nanos(1),
+            factor,
+            max: Duration::from_nanos(1),
+            jitter: Jitter::None,
+        },
+    );
+    let mut tree = DynamicTree::new();
+    tree.intensity(Intensity {
+        max_restarts: 0,
+        within: Duration::from_nanos(1),
+    });
+    tree.defaults(ScopeDefaults {
+        child_restart: Some(valid_restart),
+        readiness_deadline: Some(ReadinessDeadline::Inherit),
+        ..ScopeDefaults::default()
+    });
+    tree.add_actor(
+        "actor",
+        ActorDef::<InertActor>::cloned(())
+            .readiness(Readiness::Immediate)
+            .readiness_deadline(ReadinessDeadline::Bounded(Duration::from_nanos(1))),
+    )
+    .expect("minimum bounded deadline is valid");
+    tree.add_raw("raw", RawDef::factory(|| InertRaw).restart(valid_restart))
+        .expect("minimum exponential backoff is valid");
+    tree.add_task(
+        "task",
+        TaskDef::new(|context| async move {
+            context.shutdown_token().cancelled().await;
+            Ok(())
+        })
+        .restart(RestartPolicy::new(
+            RestartCondition::Always,
+            Backoff::Fixed {
+                delay: Duration::from_nanos(1),
+                jitter: Jitter::Equal,
+            },
+        )),
+    )
+    .expect("minimum fixed backoff is valid");
+
+    let system = tree.spawn().expect("valid edge policies lower");
+    system
+        .wait_started()
+        .await
+        .expect("valid edge policies start");
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, assert_quiet, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until};
 use shelterwood::{
     DynamicTree, ExitError, ExitResult, Mailbox, MailboxShutdown, PolicyError, RawActor,
     RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline, RemoveOutcome, ScopeDefaults,
@@ -262,7 +262,7 @@ async fn raw_manual_readiness_gates_ordered_startup_but_not_mailbox_acceptance()
         .expect("valid sibling");
     let system = tree.spawn().expect("runtime is available");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             entered.load(Ordering::SeqCst)
         })
         .await
@@ -279,7 +279,7 @@ async fn raw_manual_readiness_gates_ordered_startup_but_not_mailbox_acceptance()
     system.wait_started().await.expect("manual gate releases");
     assert!(sibling_started.load(Ordering::SeqCst));
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values
                 .lock()
                 .expect("manual values mutex poisoned")
@@ -348,7 +348,7 @@ async fn raw_recv_is_shutdown_biased_and_try_recv_controls_drain_vs_discard() {
         actor.try_send(2).expect("two accepts");
         let shutdown = tokio::spawn(async move { system.shutdown(Duration::from_secs(1)).await });
         assert!(
-            poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+            poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
                 matches!(
                     actor.try_send(3),
                     Err(ref error)
@@ -410,7 +410,7 @@ async fn dynamic_scope_admits_uses_and_exactly_removes_a_raw_actor() {
     let actor = receipt.into_handles();
     actor.send(9).await.expect("dynamic actor accepts");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values
                 .lock()
                 .expect("dynamic values mutex poisoned")
@@ -455,7 +455,7 @@ async fn deferred_queue_capacity_ignores_a_latest_scope_default() {
         .expect("second value proves queue capacity did not become latest");
     gate.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             values
                 .lock()
                 .expect("default values mutex poisoned")
@@ -565,7 +565,7 @@ async fn hard_abort_offload_panic_with_panicking_raw_destructor_is_contained() {
     let mut events = system.scope().subscribe_lifecycle();
     system.wait_started().await.expect("actor starts");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             queued.load(Ordering::SeqCst)
         })
         .await,

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -6,7 +6,9 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, advance_time, assert_quiet, policy::never, poll_until};
+use crate::common::{
+    POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, policy::never, poll_until,
+};
 use shelterwood::{
     ChildState, DynamicTree, ExitError, ExitKind, Readiness, ReadinessDeadline, ScopeState,
     Shutdown, StartupError, StartupFailureCause, SubtreeOnceDef, TaskDef, Tree,
@@ -57,7 +59,7 @@ async fn ordered_startup_waits_for_manual_readiness() {
 
     let system = tree.spawn().expect("runtime is available");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             order.lock().expect("order mutex poisoned").as_slice() == ["gated"]
         })
         .await
@@ -198,7 +200,7 @@ async fn ready_at_deadline_wins_and_shutdown_disarms_the_gate() {
         .expect("valid task");
     let ready_system = ready_tree.spawn().expect("runtime is available");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             ready_started.load(Ordering::SeqCst)
         })
         .await
@@ -302,14 +304,14 @@ async fn restart_before_aggregate_readiness_rearms_the_gate() {
     .expect("valid task");
     let system = tree.spawn().expect("runtime is available");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             later_started.load(Ordering::SeqCst)
         })
         .await
     );
     fail_first.release();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             incarnation.load(Ordering::SeqCst) == 2
         })
         .await
@@ -474,7 +476,7 @@ async fn runtime_dynamic_additions_never_join_aggregate_readiness() {
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             initial_started.load(Ordering::SeqCst)
         })
         .await

--- a/crates/shelterwood/tests/rebind.rs
+++ b/crates/shelterwood/tests/rebind.rs
@@ -7,7 +7,8 @@ use std::{
 };
 
 use crate::common::{
-    DestructorBlocker, DestructorGate, ReleaseGate, policy::never, poll_once, poll_until,
+    DestructorBlocker, DestructorGate, POLL_TIMEOUT, ReleaseGate, policy::never, poll_once,
+    poll_until,
 };
 use shelterwood::{
     Backoff, CallErrorKind, ExitError, ExitResult, Jitter, Mailbox, RawActor, RawContext, RawDef,
@@ -151,7 +152,7 @@ async fn rebind_refreshes_all_overflow_waiter_incarnation_evidence() {
     fail_first.release();
     let mut replacement = None;
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             if let std::task::Poll::Ready(result) = poll_once(promoted.as_mut()) {
                 replacement = Some(result.expect("first waiter enters replacement capacity"));
                 true
@@ -225,7 +226,7 @@ async fn send_rides_the_frozen_destructor_and_rebind_window() {
     let accepting = parked.await.expect("send rides into replacement");
     assert!(accepting.supersedes(first));
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             deliveries
                 .lock()
                 .expect("deliveries mutex poisoned")
@@ -314,7 +315,7 @@ async fn timed_send_withdraws_while_replacement_is_in_backoff() {
     fail_first.release();
     let mut observed_rebind = None;
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             match actor.try_send(0) {
                 Err(error) if error.kind == SendErrorKind::NotRunning => {
                     observed_rebind = Some(error.incarnation_observed);
@@ -375,7 +376,7 @@ async fn dropping_a_parked_send_in_the_rebind_window_withdraws_it() {
     parked.await.expect("the retained send rides the window");
     actor.send(44).await.expect("replacement accepts");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             deliveries
                 .lock()
                 .expect("deliveries mutex poisoned")

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
 use shelterwood::{
     Actor, ActorOnceDef, Backoff, ChildState, Context, DefaultsInheritance, DynamicTree, ExitError,
     ExitKind, ExitResult, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError,
@@ -225,14 +225,14 @@ async fn intensity_window_ages_out_between_restart_schedules() {
     system.wait_started().await.expect("root starts");
     advance_time(Duration::from_secs(11)).await;
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             starts.load(Ordering::SeqCst) >= 2
         })
         .await
     );
     advance_time(Duration::from_secs(11)).await;
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             starts.load(Ordering::SeqCst) >= 3
         })
         .await
@@ -417,7 +417,7 @@ async fn dynamic_and_always_members_do_not_finish_naturally() {
     let ordered = ordered.spawn().expect("runtime is available");
     ordered.wait_started().await.expect("ordered starts");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             starts.load(Ordering::SeqCst) >= 2
         })
         .await
@@ -514,7 +514,7 @@ async fn owning_shutdown_joins_recursively_aborted_scope_drivers() {
     let system = root.spawn().expect("runtime is available");
     system.wait_started().await.expect("tree starts");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             started.load(Ordering::Acquire)
         })
         .await,
@@ -651,7 +651,7 @@ async fn locally_requested_subtree_shutdown_reads_cancelled() {
         .expect("valid subtree");
     let system = root.spawn().expect("runtime is available");
     assert!(
-        poll_until(Duration::from_secs(1), Duration::from_millis(1), || {
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             started.load(Ordering::SeqCst)
         })
         .await

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -136,6 +136,30 @@ async fn one_shot_completion_finishes_an_ordered_root() {
 }
 
 #[tokio::test]
+async fn large_ordered_immediate_startup_is_iterative() {
+    const CHILDREN: usize = 4_096;
+
+    let mut tree = Tree::new();
+    for index in 0..CHILDREN {
+        let (_task, _completion) = tree
+            .add_task_once(
+                format!("immediate-{index}"),
+                TaskOnceDef::new(|_| async { Ok::<(), ExitError>(()) })
+                    .readiness(Readiness::Immediate)
+                    .expect("immediate task readiness is valid"),
+            )
+            .expect("unique child declaration");
+    }
+
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("all immediate children start without recursive re-entry");
+    assert_eq!(system.wait().await, StopReason::Finished);
+}
+
+#[tokio::test]
 async fn one_shot_completion_reports_failure_and_panic_verdicts() {
     let mut failed_tree = Tree::new();
     let (_task, failed) = failed_tree

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use crate::common::LiveFlag;
 use shelterwood::{
     BuildError, DynamicTree, ExitError, ExitKind, Readiness, ReadinessDeadline, RemoveOutcome,
-    Shutdown, StopReason, TaskDef, TaskOnceDef, Tree,
+    ReserveError, Shutdown, StopReason, TaskDef, TaskOnceDef, Tree,
 };
 
 #[test]
@@ -36,6 +36,25 @@ fn declaration_errors_are_eager_and_root_lowering_is_the_only_other_build_error(
         ));
         assert!(matches!(task.wait().await.kind(), ExitKind::NeverStarted));
     });
+}
+
+#[tokio::test]
+async fn dynamic_reservation_validates_ids_at_the_driver_boundary() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+
+    assert!(matches!(scope.reserve_task(""), Err(ReserveError::EmptyId)));
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root stops");
+
+    assert!(matches!(scope.reserve_task(""), Err(ReserveError::EmptyId)));
+    assert!(matches!(
+        scope.reserve_task("worker"),
+        Err(ReserveError::NotAdmitting(_))
+    ));
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -2,9 +2,33 @@ use std::time::Duration;
 
 use crate::common::LiveFlag;
 use shelterwood::{
-    BuildError, DynamicTree, ExitError, ExitKind, Readiness, ReadinessDeadline, RemoveOutcome,
-    ReserveError, Shutdown, StopReason, TaskDef, TaskOnceDef, Tree,
+    BuildError, DynamicTree, Exit, ExitError, ExitKind, Readiness, ReadinessDeadline,
+    RemoveOutcome, ReserveError, Shutdown, StopReason, TaskDef, TaskOnceDef, Tree,
 };
+
+#[test]
+fn public_exit_constructor_preserves_evidence_and_classifies_failures() {
+    let completed = Exit::new(ExitKind::Completed, true);
+    assert!(completed.cancelled());
+    assert!(matches!(completed.kind(), ExitKind::Completed));
+    assert!(!completed.is_failure());
+
+    for kind in [
+        ExitKind::Failed(ExitError::message("failed")),
+        ExitKind::Panicked {
+            message: Some("panicked".to_owned()),
+        },
+        ExitKind::ReadinessTimedOut {
+            deadline: std::time::Instant::now(),
+        },
+        ExitKind::Aborted { after_grace: true },
+        ExitKind::NeverStarted,
+    ] {
+        let exit = Exit::new(kind, false);
+        assert!(!exit.cancelled());
+        assert!(exit.is_failure(), "non-completed exit: {:?}", exit.kind());
+    }
+}
 
 #[test]
 fn spawn_without_runtime_is_a_build_error() {

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,7 @@
                   target/doc/shelterwood.json
                 ${pkgs.bash}/bin/bash ./tools/check-runtime-paths.sh
                 ${pkgs.bash}/bin/bash ./tools/check-exit-paths.sh
+                ${pkgs.bash}/bin/bash ./tools/check-layering-paths.sh
                 ${pkgs.bash}/bin/bash ./tools/sync-packaged-docs.sh --check
                 ${pkgs.bash}/bin/bash ./tools/check-packaged-crate.sh
               '';

--- a/justfile
+++ b/justfile
@@ -34,6 +34,9 @@ runtime-path-check:
 exit-path-check:
     ./tools/check-exit-paths.sh
 
+layering-path-check:
+    ./tools/check-layering-paths.sh
+
 packaged-docs-sync:
     ./tools/sync-packaged-docs.sh --write
 
@@ -48,7 +51,7 @@ nixfmt-check:
 
 # Fast local CI mirror — reuses the local cargo cache and incremental builds.
 # The clean Nix lane retains the explicit all-target build for non-test codegen coverage.
-ci: fmt lint test doc-check runtime-api-check runtime-path-check exit-path-check packaged-docs-check package-check nixfmt-check
+ci: fmt lint test doc-check runtime-api-check runtime-path-check exit-path-check layering-path-check packaged-docs-check package-check nixfmt-check
 
 # Full clean Nix CI lane; use before pushing or when touching Nix files.
 ci-nix:

--- a/tools/api-reachability/src/main.rs
+++ b/tools/api-reachability/src/main.rs
@@ -9,6 +9,7 @@ use std::{
 use serde_json::Value;
 
 const FORBIDDEN_ROOTS: &[&str] = &["tokio", "tokio_util"];
+const SUPPORTED_FORMAT_VERSION: u64 = 61;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let path = env::args_os()
@@ -31,6 +32,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 fn find_leaks(document: &Value) -> Result<BTreeSet<String>, Box<dyn Error>> {
+    validate_format_version(document)?;
     let index = object_field(document, "index")?;
     let paths = object_field(document, "paths")?;
 
@@ -81,6 +83,22 @@ fn find_leaks(document: &Value) -> Result<BTreeSet<String>, Box<dyn Error>> {
     }
 
     Ok(leaks)
+}
+
+fn validate_format_version(document: &Value) -> Result<(), Box<dyn Error>> {
+    let version = document
+        .get("format_version")
+        .and_then(Value::as_u64)
+        .ok_or("rustdoc JSON has no integer field `format_version`")?;
+
+    if version == SUPPORTED_FORMAT_VERSION {
+        return Ok(());
+    }
+
+    Err(format!(
+        "unsupported rustdoc JSON format version {version}; expected {SUPPORTED_FORMAT_VERSION}"
+    )
+    .into())
 }
 
 fn is_blanket_impl(item: &Value) -> bool {
@@ -176,6 +194,7 @@ mod tests {
     #[test]
     fn follows_public_type_ids_without_treating_every_number_as_an_id() {
         let document = json!({
+            "format_version": 61,
             "index": {
                 "0": {
                     "id": 0,
@@ -217,6 +236,7 @@ mod tests {
     #[test]
     fn ignores_materialized_blanket_impls_but_follows_explicit_impls() {
         let document = json!({
+            "format_version": 61,
             "index": {
                 "0": {
                     "id": 0,
@@ -267,6 +287,35 @@ mod tests {
                 "shelterwood::Explicit -> tokio_util::future::FutureExt".to_owned(),
                 "shelterwood::impl-explicit -> tokio_util::future::FutureExt".to_owned(),
             ])
+        );
+    }
+
+    #[test]
+    fn accepts_supported_format_version() {
+        let document = json!({
+            "format_version": 61,
+            "index": {},
+            "paths": {}
+        });
+
+        assert_eq!(
+            find_leaks(&document).expect("format version 61 must remain supported"),
+            BTreeSet::new()
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_format_version() {
+        let document = json!({
+            "format_version": 60,
+            "index": {},
+            "paths": {}
+        });
+
+        let error = find_leaks(&document).expect_err("older schemas must be rejected");
+        assert_eq!(
+            error.to_string(),
+            "unsupported rustdoc JSON format version 60; expected 61"
         );
     }
 }

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -18,6 +18,7 @@ readonly below_driver_layers=(
   crates/shelterwood/src/task.rs
 )
 readonly driver_path="crates/shelterwood/src/driver.rs"
+readonly tree_path="crates/shelterwood/src/tree.rs"
 
 check_forbidden() {
   local message="$1"
@@ -54,5 +55,15 @@ check_forbidden \
   "upward tree references found in the driver layer:" \
   '\btree::' \
   "$driver_path"
+
+check_forbidden \
+  "child option resolution escaped the shared plan funnel:" \
+  '\bresolve_common\b' \
+  "$driver_path"
+
+check_forbidden \
+  "dynamic child-id validation escaped the reservation boundary:" \
+  '\bchecked_id\b' \
+  "$tree_path"
 
 echo "supervision layering restrictions: clean"

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly lower_layers=(
+  crates/shelterwood/src/mailbox.rs
+  crates/shelterwood/src/raw.rs
+  crates/shelterwood/src/task.rs
+)
+readonly cells_path="crates/shelterwood/src/cells.rs"
+
+check_forbidden() {
+  local message="$1"
+  local forbidden="$2"
+  shift 2
+
+  local matches
+  local status
+  set +e
+  matches="$({ rg --line-number "$forbidden" "$@"; } 2>&1)"
+  status=$?
+  set -e
+
+  case "$status" in
+    0)
+      echo "$message" >&2
+      echo "$matches" >&2
+      exit 1
+      ;;
+    1) ;;
+    *)
+      echo "$matches" >&2
+      exit "$status"
+      ;;
+  esac
+}
+
+check_forbidden \
+  "upward driver references found below the driver layer:" \
+  '\bdriver::' \
+  "${lower_layers[@]}"
+
+check_forbidden \
+  "upward driver or tree references found in the shared cells layer:" \
+  '\b(driver|tree)::' \
+  "$cells_path"
+
+echo "shared-cell layering restrictions: clean"

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-readonly lower_layers=(
+readonly below_driver_layers=(
+  crates/shelterwood/src/actor.rs
+  crates/shelterwood/src/cells.rs
+  crates/shelterwood/src/deadline.rs
+  crates/shelterwood/src/engine.rs
+  crates/shelterwood/src/exit.rs
+  crates/shelterwood/src/identity.rs
   crates/shelterwood/src/mailbox.rs
+  crates/shelterwood/src/observe.rs
+  crates/shelterwood/src/plan.rs
+  crates/shelterwood/src/policy.rs
   crates/shelterwood/src/raw.rs
+  crates/shelterwood/src/runtime.rs
   crates/shelterwood/src/task.rs
 )
-readonly cells_path="crates/shelterwood/src/cells.rs"
 readonly driver_path="crates/shelterwood/src/driver.rs"
 
 check_forbidden() {
@@ -36,18 +45,13 @@ check_forbidden() {
 }
 
 check_forbidden \
-  "upward driver references found below the driver layer:" \
-  '\bdriver::' \
-  "${lower_layers[@]}"
-
-check_forbidden \
-  "upward driver or tree references found in the shared cells layer:" \
+  "upward driver or tree references found below the driver layer:" \
   '\b(driver|tree)::' \
-  "$cells_path"
+  "${below_driver_layers[@]}"
 
 check_forbidden \
   "upward tree references found in the driver layer:" \
   '\btree::' \
   "$driver_path"
 
-echo "shared-cell layering restrictions: clean"
+echo "supervision layering restrictions: clean"

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -5,6 +5,7 @@ readonly below_driver_layers=(
   crates/shelterwood/src/actor.rs
   crates/shelterwood/src/cells.rs
   crates/shelterwood/src/deadline.rs
+  crates/shelterwood/src/definition.rs
   crates/shelterwood/src/engine.rs
   crates/shelterwood/src/exit.rs
   crates/shelterwood/src/identity.rs

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -7,6 +7,7 @@ readonly lower_layers=(
   crates/shelterwood/src/task.rs
 )
 readonly cells_path="crates/shelterwood/src/cells.rs"
+readonly driver_path="crates/shelterwood/src/driver.rs"
 
 check_forbidden() {
   local message="$1"
@@ -43,5 +44,10 @@ check_forbidden \
   "upward driver or tree references found in the shared cells layer:" \
   '\b(driver|tree)::' \
   "$cells_path"
+
+check_forbidden \
+  "upward tree references found in the driver layer:" \
+  '\btree::' \
+  "$driver_path"
 
 echo "shared-cell layering restrictions: clean"


### PR DESCRIPTION
PRs 59-78 were stack-merged into their parent branches in ascending order, so each parent had already been merged upward before its child's content arrived — only #58 actually reached main. This lands the stack tip (the exact reviewed, CI-green head of #78) on main in one merge. No new content beyond what #59-#78 already carried.