### PR TITLE
Audit follow-ups: exact backoff, restart_at clamp, exit equality docs, package metadata (#55)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1695,11 +1695,16 @@ Two separated concerns:
   bit-equality of the underlying bits, sound because the invariant
   excludes NaN and required because `Backoff` is §1 plain data carrying
   the universal `Eq` bound; delay computation is pinned to nanosecond
-  precision: the base delay's whole-nanosecond count is multiplied as
-  `f64`, rounded to the nearest nanosecond, saturating (Appendix A's
-  far-future clamp — never an overflow panic); jitter maps a pre-drawn
-  `f64` sample in `[0, 1)` as `delay = d/2 + sample × d/2`, rounded the
-  same way. The attempt counter is per
+  precision: when the effective multiplier is exactly one — the first
+  attempt, a factor of `1.0`, or a fixed delay — the whole-nanosecond
+  count is used exactly, with no float round-trip; otherwise the base
+  delay's whole-nanosecond count is multiplied as `f64`, rounded to the
+  nearest nanosecond, and a product at or above `max` saturates to the
+  exact configured `max` (never an overflow panic); jitter maps a
+  pre-drawn `f64` sample in `[0, 1)` as `delay = d/2 + sample × d/2`,
+  rounded the same way — a zero sample yields the exact half,
+  half-nanosecond remainders rounding up with no float round-trip. The
+  attempt counter is per
   membership: `n = 1` on the first scheduled restart, incremented per
   scheduled restart — a restart scheduled and then cancelled by teardown
   still advanced it, mirroring the intensity charge below — and reset by

--- a/crates/shelterwood/Cargo.toml
+++ b/crates/shelterwood/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.97.1"
 license = "MIT OR Apache-2.0"
+description = "A structured-supervision and actor runtime for asynchronous Rust"
+documentation = "https://docs.rs/shelterwood"
+homepage = "https://github.com/ralexstokes/shelterwood"
+repository = "https://github.com/ralexstokes/shelterwood"
 autotests = false
 
 [dependencies]

--- a/crates/shelterwood/src/deadline.rs
+++ b/crates/shelterwood/src/deadline.rs
@@ -20,23 +20,50 @@ impl Deadline {
         self.0
     }
 
-    /// Captures a duration budget as an absolute instant, saturating to a
-    /// far-future point when the exact deadline overflows the clock.
+    /// Headroom the far-future clamp keeps below the clock limit.
+    ///
+    /// Arming a deadline is itself clock arithmetic — tokio rounds a
+    /// sleep deadline up to the next whole millisecond by adding to it
+    /// before tick conversion — so a clamp flush against `Instant`'s
+    /// limit would panic at arming time. One second comfortably covers
+    /// that sub-millisecond round-up without measurably loosening the
+    /// clamp.
+    pub(crate) const ARMING_HEADROOM: Duration = Duration::from_secs(1);
+
+    /// Captures a duration budget as an absolute instant, saturating to
+    /// the largest armable deadline when the exact one overflows the
+    /// clock (or its [`Self::ARMING_HEADROOM`]).
     ///
     /// This is the far-future clamp: callers that must surface a present
     /// absolute point — a `Restarting` snapshot's `restart_at` — use this
     /// instead of [`Deadline::after`]'s never-arrives `None`.
     pub(crate) fn saturating_after(started_at: Instant, duration: Duration) -> Instant {
-        let mut budget = duration;
-        loop {
-            if let Some(instant) = started_at.checked_add(budget) {
-                return instant;
-            }
-            // Halving converges, and the first representable budget after
-            // an overflowing one is at least half the clock's remaining
-            // range — still far future.
-            budget /= 2;
+        let armable = |budget: Duration| {
+            budget
+                .checked_add(Self::ARMING_HEADROOM)
+                .and_then(|padded| started_at.checked_add(padded))
+                .is_some()
+        };
+        if armable(duration) {
+            return started_at + duration;
         }
+        // The exact deadline overflows: saturate to the largest budget
+        // that still fits — the closest armable approximation — so a
+        // narrow clock never arms the deadline earlier than it must.
+        // Binary search on the nanosecond-granular budget: `low` always
+        // fits, `high` never does, and the gap halves every step,
+        // bounding the loop by the bit width of `Duration`.
+        let mut low = Duration::ZERO;
+        let mut high = duration;
+        while high - low > Duration::from_nanos(1) {
+            let mid = low + (high - low) / 2;
+            if armable(mid) {
+                low = mid;
+            } else {
+                high = mid;
+            }
+        }
+        started_at + low
     }
 
     /// Reports whether a representable deadline has elapsed.
@@ -79,10 +106,22 @@ mod tests {
     }
 
     #[test]
-    fn saturating_after_clamps_overflow_to_a_far_future_instant() {
+    fn saturating_after_clamps_overflow_to_the_largest_armable_instant() {
         let now = Instant::now();
+        let clamped = Deadline::saturating_after(now, Duration::MAX);
         let century = Duration::from_secs(60 * 60 * 24 * 365 * 100);
-        assert!(Deadline::saturating_after(now, Duration::MAX) > now + century);
+        assert!(clamped > now + century);
+        assert!(
+            clamped.checked_add(Deadline::ARMING_HEADROOM).is_some(),
+            "the clamp leaves the timer's arming headroom below the clock limit"
+        );
+        assert!(
+            clamped
+                .checked_add(Deadline::ARMING_HEADROOM + Duration::from_nanos(1))
+                .is_none(),
+            "the clamp saturates to the clock limit less the arming headroom, \
+             not to a halved budget"
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/deadline.rs
+++ b/crates/shelterwood/src/deadline.rs
@@ -20,6 +20,25 @@ impl Deadline {
         self.0
     }
 
+    /// Captures a duration budget as an absolute instant, saturating to a
+    /// far-future point when the exact deadline overflows the clock.
+    ///
+    /// This is the far-future clamp: callers that must surface a present
+    /// absolute point — a `Restarting` snapshot's `restart_at` — use this
+    /// instead of [`Deadline::after`]'s never-arrives `None`.
+    pub(crate) fn saturating_after(started_at: Instant, duration: Duration) -> Instant {
+        let mut budget = duration;
+        loop {
+            if let Some(instant) = started_at.checked_add(budget) {
+                return instant;
+            }
+            // Halving converges, and the first representable budget after
+            // an overflowing one is at least half the clock's remaining
+            // range — still far future.
+            budget /= 2;
+        }
+    }
+
     /// Reports whether a representable deadline has elapsed.
     pub(crate) fn is_due(self, now: Instant) -> bool {
         self.0.is_some_and(|deadline| now >= deadline)
@@ -48,6 +67,22 @@ mod tests {
         assert_eq!(deadline.instant(), None);
         assert!(!deadline.is_due(now));
         assert!(!deadline.is_overdue(now));
+    }
+
+    #[test]
+    fn saturating_after_matches_exact_addition_when_representable() {
+        let now = Instant::now();
+        assert_eq!(
+            Deadline::saturating_after(now, Duration::from_secs(1)),
+            now + Duration::from_secs(1)
+        );
+    }
+
+    #[test]
+    fn saturating_after_clamps_overflow_to_a_far_future_instant() {
+        let now = Instant::now();
+        let century = Duration::from_secs(60 * 60 * 24 * 365 * 100);
+        assert!(Deadline::saturating_after(now, Duration::MAX) > now + century);
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1951,9 +1951,10 @@ impl ScopeRuntime {
                         record.last_exit = Some(exit.clone());
                         record.restart_count = decision.restart_count;
                         // Publish the derived schedule even when intensity
-                        // prevents spawning it. `None` remains reserved for
-                        // an unrepresentable clock deadline.
-                        record.restart_at = decision.restart_at;
+                        // prevents spawning it. The engine clamps
+                        // unrepresentable deadlines far future, so
+                        // `restart_at` is present exactly while restarting.
+                        record.restart_at = Some(decision.restart_at);
                         record.stage = MemberStage::Restarting;
                     },
                     LifecycleEventKind::Exited {
@@ -1981,12 +1982,10 @@ impl ScopeRuntime {
                     }
                     self.begin_drain(StopReason::IntensityTripped(trip));
                 } else {
-                    if let Some(restart_at) = decision.restart_at {
-                        child.restart_deadline = Some(
-                            self.deadlines
-                                .push(restart_at, DeadlineKind::Restart { child: key }),
-                        );
-                    }
+                    child.restart_deadline = Some(
+                        self.deadlines
+                            .push(decision.restart_at, DeadlineKind::Restart { child: key }),
+                    );
                 }
             }
         }

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -294,7 +294,9 @@ pub(crate) struct RestartDecision {
     pub(crate) attempt: u64,
     pub(crate) restart_count: u64,
     pub(crate) delay: Duration,
-    pub(crate) restart_at: Option<Instant>,
+    /// Absolute backoff deadline; unrepresentable far-future points are
+    /// clamped (B.6: `restart_at` is present exactly in `Restarting`).
+    pub(crate) restart_at: Instant,
     pub(crate) charge: IntensityCharge,
 }
 
@@ -308,7 +310,7 @@ pub(crate) fn schedule_restart(
 ) -> RestartDecision {
     let (attempt, restart_count) = restarts.schedule();
     let delay = restart_policy.backoff().next_delay(attempt, jitter_sample);
-    let restart_at = Deadline::after(now, delay).instant();
+    let restart_at = Deadline::saturating_after(now, delay);
     let charge = intensity.charge(intensity_policy, now);
     RestartDecision {
         attempt,
@@ -1028,13 +1030,13 @@ mod tests {
         assert_eq!(decision.attempt, 1);
         assert_eq!(decision.restart_count, 1);
         assert_eq!(decision.delay, Duration::ZERO);
-        assert_eq!(decision.restart_at, Some(now));
+        assert_eq!(decision.restart_at, now);
         assert_eq!(decision.charge.total_restarts, 1);
         assert!(decision.charge.tripped);
     }
 
     #[test]
-    fn overflowing_restart_delay_has_no_immediate_spawn_deadline() {
+    fn overflowing_restart_delay_clamps_to_a_far_future_deadline() {
         let now = Instant::now();
         let intensity_policy = Intensity::new(5, Duration::from_secs(10)).expect("valid intensity");
         let restart_policy = RestartPolicy::new(
@@ -1052,7 +1054,12 @@ mod tests {
             0.5,
         );
 
-        assert_eq!(decision.restart_at, None);
+        assert_eq!(decision.delay, Duration::MAX);
+        let century = Duration::from_secs(60 * 60 * 24 * 365 * 100);
+        assert!(
+            decision.restart_at > now + century,
+            "an unrepresentable backoff deadline clamps far future, never near now"
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -230,6 +230,16 @@ impl Error for StructuredStartupFailure {}
 
 /// The structured result of one child incarnation or never-started
 /// membership.
+///
+/// # Equality
+///
+/// `Exit` equality is structural for every variant except
+/// [`ExitKind::Failed`], whose [`ExitError`] payload compares by
+/// **shared provenance** (the same erased error allocation), not by error
+/// content: an exit and its clones — including the copies the framework
+/// publishes through snapshots and lifecycle events — compare equal,
+/// while two independently constructed errors with identical messages do
+/// not. Compare failure content through [`ExitError::as_error`] instead.
 #[derive(Clone, Debug)]
 pub struct Exit {
     kind: ExitKind,
@@ -269,6 +279,10 @@ impl Exit {
     }
 }
 
+/// Equality per the type-level contract: structural on every variant,
+/// except that [`ExitKind::Failed`] payloads compare by shared provenance
+/// ([`Arc::ptr_eq`] on the erased error), because a type-erased error has
+/// no content equality to consult.
 impl PartialEq for Exit {
     fn eq(&self, other: &Self) -> bool {
         self.cancelled == other.cancelled && exit_kind_eq(&self.kind, &other.kind)
@@ -303,6 +317,9 @@ pub enum ExitKind {
     /// The incarnation returned successfully.
     Completed,
     /// User code returned an error.
+    ///
+    /// Under [`Exit`]'s `PartialEq`, this payload compares by shared
+    /// provenance, not by error content — see [`Exit`]'s equality docs.
     Failed(ExitError),
     /// User code or destruction panicked.
     Panicked {
@@ -571,6 +588,26 @@ mod tests {
         for (case, recorded, join, cancelled, expected) in cases {
             assert_eq!(classify_exit(recorded, join, cancelled), expected, "{case}");
         }
+    }
+
+    #[test]
+    fn failed_exit_equality_is_shared_provenance_not_content() {
+        let error = ExitError::message("boom");
+        let exit = Exit::new(ExitKind::Failed(error.clone()), false);
+
+        // Clones of one error — including framework-published copies —
+        // compare equal.
+        assert_eq!(exit, exit.clone());
+        assert_eq!(exit, Exit::new(ExitKind::Failed(error.clone()), false));
+
+        // Independently created errors with identical content do not.
+        assert_ne!(
+            exit,
+            Exit::new(ExitKind::Failed(ExitError::message("boom")), false)
+        );
+
+        // Cancellation remains structural even with shared provenance.
+        assert_ne!(exit, Exit::new(ExitKind::Failed(error), true));
     }
 
     #[test]

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -218,8 +218,9 @@ pub struct ChildSnapshot {
     pub restart_policy: RestartPolicy,
     /// Resolved terminal-retention policy.
     pub retention: Retention,
-    /// Absolute backoff deadline while restarting, or `None` when the delay
-    /// is too distant for the clock to represent.
+    /// Absolute backoff deadline, present exactly while the membership is
+    /// restarting; a delay too distant for the clock to represent is
+    /// clamped to a far-future instant.
     pub restart_at: Option<Instant>,
     /// Recursive state of a scope child when its incarnation is live or terminal.
     pub nested: Option<Arc<ScopeSnapshot>>,

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -199,10 +199,24 @@ impl Backoff {
                 max,
                 jitter,
             } => {
-                let exponent = i32::try_from(attempt.saturating_sub(1)).unwrap_or(i32::MAX);
-                let nanos = duration_nanos(base) * factor.get().powi(exponent);
-                let clamped = nanos.min(duration_nanos(max));
-                (duration_from_nanos(clamped), jitter, max)
+                let delay = if attempt == 1 || factor.get() == 1.0 {
+                    // The multiplier is exactly one, so the product is the
+                    // base itself. Skipping the float round-trip keeps the
+                    // delay exact above 2^53 nanoseconds.
+                    base
+                } else {
+                    let exponent = i32::try_from(attempt.saturating_sub(1)).unwrap_or(i32::MAX);
+                    let nanos = duration_nanos(base) * factor.get().powi(exponent);
+                    if nanos < duration_nanos(max) {
+                        duration_from_nanos(nanos)
+                    } else {
+                        // At or above the cap, saturate to the exact
+                        // configured maximum rather than to a float
+                        // round-trip of it.
+                        max
+                    }
+                };
+                (delay.min(max), jitter, max)
             }
         };
         let delay = match jitter {
@@ -213,7 +227,14 @@ impl Backoff {
                 } else {
                     0.0
                 };
-                duration_from_nanos(duration_nanos(delay) * (0.5 + sample * 0.5))
+                if sample == 0.0 {
+                    // The lower jitter edge is exactly half the delay,
+                    // rounded to the nearest nanosecond without a float
+                    // round-trip.
+                    half_duration(delay)
+                } else {
+                    duration_from_nanos(duration_nanos(delay) * (0.5 + sample * 0.5))
+                }
             }
         };
         // Floating-point duration conversion can round an extreme value a
@@ -245,6 +266,17 @@ impl Backoff {
 
 fn duration_nanos(duration: Duration) -> f64 {
     duration.as_nanos() as f64
+}
+
+/// Halves a delay exactly, rounding half a nanosecond up — the same
+/// direction the float path rounds an exact `.5` remainder.
+fn half_duration(duration: Duration) -> Duration {
+    let nanos = duration.as_nanos().div_ceil(2);
+    let seconds =
+        u64::try_from(nanos / 1_000_000_000).expect("a halved delay fits the duration range");
+    let subsecond =
+        u32::try_from(nanos % 1_000_000_000).expect("nanosecond remainder is below one billion");
+    Duration::new(seconds, subsecond)
 }
 
 fn duration_from_nanos(nanos: f64) -> Duration {
@@ -839,23 +871,129 @@ mod tests {
             Intensity::new(1, Duration::ZERO),
             Err(PolicyError::ZeroDuration)
         );
+        let factor = BackoffFactor::new(2.0).expect("valid factor");
+        assert_eq!(
+            Backoff::exponential(Duration::ZERO, factor, Duration::from_secs(1), Jitter::None),
+            Err(PolicyError::ZeroDuration)
+        );
+        assert_eq!(
+            Backoff::exponential(Duration::from_secs(1), factor, Duration::ZERO, Jitter::None),
+            Err(PolicyError::ZeroDuration)
+        );
         assert_eq!(
             Backoff::exponential(
                 Duration::from_secs(2),
-                BackoffFactor::new(2.0).expect("valid factor"),
+                factor,
                 Duration::from_secs(1),
                 Jitter::None,
             ),
             Err(PolicyError::BackoffMaximumBeforeBase)
         );
-        assert_eq!(
-            BackoffFactor::new(f64::NAN),
-            Err(PolicyError::InvalidBackoffFactor)
+        let just_below_one = f64::from_bits(1.0_f64.to_bits() - 1);
+        for invalid in [
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            just_below_one,
+            0.5,
+            0.0,
+            -1.0,
+        ] {
+            assert_eq!(
+                BackoffFactor::new(invalid),
+                Err(PolicyError::InvalidBackoffFactor),
+                "factor {invalid} must be rejected"
+            );
+        }
+        assert!(BackoffFactor::new(1.0).is_ok());
+        assert!(BackoffFactor::new(f64::MAX).is_ok());
+        assert!(Mailbox::queue(1).is_ok());
+        assert!(ReadinessDeadline::bounded(Duration::from_nanos(1)).is_ok());
+        assert!(Intensity::new(0, Duration::from_nanos(1)).is_ok());
+        assert!(Backoff::fixed(Duration::from_nanos(1), Jitter::Equal).is_ok());
+        assert!(
+            Backoff::exponential(
+                Duration::from_nanos(1),
+                BackoffFactor::new(1.0).expect("valid factor"),
+                Duration::from_nanos(1),
+                Jitter::Equal,
+            )
+            .is_ok(),
+            "an exponential maximum equal to its base is valid"
         );
-        assert_eq!(
-            BackoffFactor::new(0.5),
-            Err(PolicyError::InvalidBackoffFactor)
-        );
+    }
+
+    #[test]
+    fn unit_multiplier_backoff_delays_are_exact_beyond_float_precision() {
+        // 2^60 + 1 whole nanoseconds cannot survive an f64 round-trip.
+        let base = Duration::from_nanos((1 << 60) + 1);
+        let doubling = Backoff::exponential(
+            base,
+            BackoffFactor::new(2.0).expect("valid factor"),
+            Duration::MAX,
+            Jitter::None,
+        )
+        .expect("valid backoff");
+        assert_eq!(doubling.next_delay(1, 0.9), base);
+
+        let flat = Backoff::exponential(
+            base,
+            BackoffFactor::new(1.0).expect("valid factor"),
+            Duration::MAX,
+            Jitter::None,
+        )
+        .expect("valid backoff");
+        assert_eq!(flat.next_delay(1, 0.0), base);
+        assert_eq!(flat.next_delay(u64::MAX, 0.0), base);
+
+        let fixed = Backoff::fixed(base, Jitter::None).expect("valid backoff");
+        assert_eq!(fixed.next_delay(u64::MAX, 0.99), base);
+
+        let huge_fixed = Backoff::fixed(Duration::MAX, Jitter::None).expect("valid backoff");
+        assert_eq!(huge_fixed.next_delay(u64::MAX, 0.5), Duration::MAX);
+    }
+
+    #[test]
+    fn saturated_backoff_delays_land_exactly_on_the_configured_maximum() {
+        // One nanosecond below `Duration::MAX` does not survive an f64
+        // round-trip, so an exact saturation is observable.
+        let max = Duration::MAX - Duration::from_nanos(1);
+        let explosive = Backoff::exponential(
+            Duration::from_nanos(1),
+            BackoffFactor::new(f64::MAX).expect("finite factor"),
+            max,
+            Jitter::None,
+        )
+        .expect("valid backoff");
+        assert_eq!(explosive.next_delay(2, 0.0), max);
+        assert_eq!(explosive.next_delay(u64::MAX, 0.0), max);
+
+        let doubling = Backoff::exponential(
+            Duration::from_secs(1),
+            BackoffFactor::new(2.0).expect("valid factor"),
+            max,
+            Jitter::None,
+        )
+        .expect("valid backoff");
+        assert_eq!(doubling.next_delay(200, 0.0), max);
+    }
+
+    #[test]
+    fn zero_sample_equal_jitter_is_the_exact_half_delay() {
+        // Half of an odd nanosecond count rounds up by exactly half a
+        // nanosecond; the float path would land one nanosecond short.
+        let odd = Duration::from_nanos((1 << 60) + 1);
+        let fixed = Backoff::fixed(odd, Jitter::Equal).expect("valid backoff");
+        let exact_half = Duration::from_nanos((1 << 59) + 1);
+        assert_eq!(fixed.next_delay(1, 0.0), exact_half);
+        // Non-finite and negative samples clamp to the same exact edge.
+        for sample in [f64::NAN, f64::NEG_INFINITY, -3.0] {
+            assert_eq!(fixed.next_delay(1, sample), exact_half);
+        }
+
+        let even =
+            Backoff::fixed(Duration::from_nanos(1 << 60), Jitter::Equal).expect("valid backoff");
+        assert_eq!(even.next_delay(1, 0.0), Duration::from_nanos(1 << 59));
     }
 
     #[test]

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -483,7 +483,7 @@ async fn overflowing_shutdown_grace_does_not_escalate() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn overflowing_restart_delay_never_restarts_immediately() {
+async fn overflowing_restart_delay_clamps_far_future_and_never_restarts_immediately() {
     let release_failure = ReleaseGate::default();
     let starts = Arc::new(AtomicUsize::new(0));
     let mut tree = Tree::new();
@@ -518,10 +518,16 @@ async fn overflowing_restart_delay_never_restarts_immediately() {
         .expect("first incarnation starts");
     release_failure.release();
 
+    // SPEC B.6: `restart_at` is present exactly in `Restarting`; a delay
+    // too distant for the clock clamps to a far-future instant.
+    let century = Duration::from_secs(60 * 60 * 24 * 365 * 100);
     assert!(
         poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             system.scope().child("restart").is_some_and(|child| {
-                matches!(child.state, ChildState::Restarting) && child.restart_at.is_none()
+                matches!(child.state, ChildState::Restarting)
+                    && child
+                        .restart_at
+                        .is_some_and(|at| at > std::time::Instant::now() + century)
             })
         })
         .await

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -1414,13 +1414,14 @@ async fn assert_pending_restart_shutdown_is_expedited<R: Clone>(
         "shutdown must start exactly the pending incarnation without waiting for backoff"
     );
     if width == Duration::MAX {
-        // An unrepresentable deadline schedules no restart at all, so there is
-        // no later incarnation to reach. Only the quiet window applies.
+        // An unrepresentable deadline is clamped to a far-future instant
+        // that never arrives, so there is no later incarnation to reach.
+        // Only the quiet window applies.
         advance_time(Duration::from_secs(1)).await;
         assert_eq!(
             starts.load(Ordering::SeqCst),
             2,
-            "an unrepresentable deadline must not resurrect the stopped incarnation"
+            "a far-future-clamped deadline must not resurrect the stopped incarnation"
         );
         system.shutdown(Duration::ZERO).await.expect("root stops");
         return;


### PR DESCRIPTION
Implements the public-policy/observation and metadata group of audit follow-ups from #55 (review baseline `de197e6`; all items re-verified against current `main` before changing anything). Full local CI mirror (`just ci`) passes.

## Items addressed (quoting #55)

### 1. "Preserve exact backoff durations."
> `Backoff::next_delay` converts total nanoseconds through `f64`, losing precision above `2^53` nanoseconds even for attempt one with factor `1.0`. Preserve exact fast paths and use checked integer arithmetic where practical.

Still applied at current main. `next_delay` now computes exactly, in integer nanoseconds, every path whose effective multiplier is exactly one: the attempt-one and factor-`1.0` exponential cases, fixed delays, and the zero-sample equal-jitter edge (`d/2`, half-nanosecond remainders rounding up, matching the float path's rounding direction). A product at or above the cap saturates to the **exact** configured `max` rather than to an f64 round-trip of it (deterministic saturation). Genuinely fractional products and non-zero jitter samples keep the spec's f64 arithmetic. Since this changes normative behavior at the extremes, SPEC.md §9.2 moves with it and pins the exact paths.

### 2. "Resolve the overflowed `restart_at` contract mismatch."
> `schedule_restart` produces `restart_at = None` for unrepresentable delays, while the specification says `restart_at` is present exactly in `Restarting` and far-future points are clamped. Implement the clamp or update the normative contract and tests.

Still applied at current main; the SPEC (B.6 plus Appendix A's far-future clamp row) was not amended, so the clamp is implemented as the issue prefers. New `Deadline::saturating_after` clamps an overflowing `now + delay` to the farthest representable instant (halving the budget until representable — the first representable point is at least half the clock's remaining range, so it stays far future). `RestartDecision::restart_at` becomes a plain `Instant`, and the driver publishes and arms it unconditionally, so a `Restarting` snapshot always carries `restart_at`. Correctness does not depend on timer fidelity at that range: the deadline queue's `pop_due(now)` comparison gates the restart, so a clamped deadline can never fire early. Engine unit tests, `deadline.rs` unit tests, and the paused-time integration test (`tests/deadlines.rs`) now pin the clamped contract (present, far-future, and still no premature restart); a stale comment in `tests/dynamic.rs` was aligned.

### 3. "Document or remove failed-exit pointer-identity equality."
> `ExitKind::Failed` equality uses `Arc::ptr_eq`; clones compare equal but independently created equivalent errors do not.

Still applied at current main. Kept the semantics (the conservative choice — a type-erased error has no content equality to consult, and framework-published snapshot/event copies are clones, so shared-provenance equality is exactly what observation consumers need). Documented it in three places: an "Equality" section on `Exit`, a note on the `ExitKind::Failed` variant, and the `PartialEq` impl itself. Added `failed_exit_equality_is_shared_provenance_not_content` pinning clone-equal / equivalent-content-unequal / cancellation-still-structural.

### 4. "Complete package metadata."
> The package check passes but warns that the manifest lacks description, documentation, homepage, and repository fields.

Added `description` (one line derived from README.md), `documentation` (docs.rs), `homepage`, and `repository` (https://github.com/ralexstokes/shelterwood). The `package-check` lane in `just ci` now runs with no manifest warnings.

### 5. "Strengthen extreme backoff tests to assert exact values and every validation branch."

Paired with item 1. New unit tests in `policy.rs` assert **exact** `Duration` values (not ranges) for: a `2^60 + 1` ns base at attempt one and under factor `1.0` at `u64::MAX` attempts, fixed `Duration::MAX` delays, saturation landing exactly on a `Duration::MAX − 1 ns` cap (a value that does not survive an f64 round-trip, so exactness is observable), and the exact half-delay jitter edge for odd and even nanosecond counts including non-finite/negative sample clamping. `invalid_policy_data_is_rejected_eagerly` now covers every validation-error branch of the policy constructors: `Backoff::fixed` zero delay; `Backoff::exponential` zero base, zero max, and max-before-base; `BackoffFactor::new` NaN, ±infinity, next-below-1.0, and sub-one values (with the `1.0` and `f64::MAX` boundaries accepted); `Mailbox::queue(0)`; `ReadinessDeadline::bounded(ZERO)`; `Intensity::new(_, ZERO)`; plus the accepted minimum edges.

## Notes

- Public API unchanged except documentation; `RestartDecision` is crate-private.
- `ChildSnapshot::restart_at` stays `Option<Instant>` (`None` outside `Restarting`, per B.6); only its doc changed.
- CI: `./scripts/dev just ci` green on the final tree (fmt, clippy, nextest, doc, reachability/path checks, packaged-docs, package, nixfmt).