### PR TITLE
Route rejection- and cancellation-discarded user values through isolated disposal

### DIFF
--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -17,7 +17,7 @@ use crate::{
     cells::{MailboxControl, MailboxDisposal, MailboxTermination, MemberCell},
     runtime::{
         OneShotClose, OneShotReceiver, OneShotSender, PanicAccumulator, PanicPayload, Signal,
-        SignalWatcher, resume_panic,
+        SignalWatcher, dispose_detached, resume_panic,
     },
 };
 
@@ -271,11 +271,42 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
     }
 }
 
+/// Reply receive state that keeps user value destruction off framework and
+/// caller drop glue.
+///
+/// A reply value stored before the receive side is cancelled is user-owned:
+/// destroying it inline could block or panic whoever dropped the receiver.
+/// The disposal function is captured at construction, where the value type's
+/// `Send + 'static` bounds hold, so unbounded holders can still route an
+/// unclaimed stored value through isolated disposal on drop.
+struct ReplyState<T> {
+    inner: OneShotReceiver<T>,
+    dispose: fn(T),
+}
+
+impl<T: Send + 'static> ReplyState<T> {
+    fn new(inner: OneShotReceiver<T>) -> Self {
+        Self {
+            inner,
+            dispose: dispose_detached::<T>,
+        }
+    }
+}
+
+impl<T> Drop for ReplyState<T> {
+    fn drop(&mut self) {
+        if let Some(value) = self.inner.close_and_take() {
+            (self.dispose)(value);
+        }
+    }
+}
+
 /// A consuming, infallible reply capability.
 ///
 /// Dropping an unanswered capability is completion: its receiver observes
 /// [`ReplyError::Dropped`]. Dropping or timing out the receiver instead closes
-/// the channel, so a late [`Reply::send`] safely discards its value.
+/// the channel, so a late [`Reply::send`] safely discards its value through
+/// isolated disposal.
 pub struct Reply<T> {
     sender: Option<OneShotSender<T>>,
     answered: bool,
@@ -301,7 +332,7 @@ impl<T: Send + 'static> Reply<T> {
                 answered: false,
             },
             ReplyReceiver {
-                receiver: Some(receiver),
+                receiver: Some(ReplyState::new(receiver)),
             },
         )
     }
@@ -313,13 +344,18 @@ impl<T: Send + 'static> Reply<T> {
             .sender
             .take()
             .expect("an unanswered reply retains its sender");
-        let _ = sender.send(value);
+        // A cancelled receiver rejects the value. Destroying it inline would
+        // run a possibly blocking or panicking user destructor on the replying
+        // actor; route the discard through isolated disposal instead.
+        if let Err(unclaimed) = sender.send(value) {
+            dispose_detached(unclaimed);
+        }
     }
 }
 
 /// The owned, non-cloneable receive half of [`Reply::channel`].
 pub struct ReplyReceiver<T> {
-    receiver: Option<OneShotReceiver<T>>,
+    receiver: Option<ReplyState<T>>,
 }
 
 impl<T> fmt::Debug for ReplyReceiver<T> {
@@ -345,7 +381,7 @@ impl<T: Send + 'static> ReplyReceiver<T> {
 }
 
 struct ReplyOperation<T> {
-    receiver: OneShotReceiver<T>,
+    receiver: ReplyState<T>,
 }
 
 impl<T> DeadlineOperation for ReplyOperation<T> {
@@ -357,10 +393,10 @@ impl<T> DeadlineOperation for ReplyOperation<T> {
         _budget: crate::deadline::Deadline,
         elapsed: bool,
     ) -> Poll<Self::Output> {
-        match self.receiver.poll_receive(context) {
+        match self.receiver.inner.poll_receive(context) {
             Poll::Ready(Some(value)) => Poll::Ready(Ok(value)),
             Poll::Ready(None) => Poll::Ready(Err(ReplyError::Dropped)),
-            Poll::Pending if elapsed => match self.receiver.close_and_poll_receive(context) {
+            Poll::Pending if elapsed => match self.receiver.inner.close_and_poll_receive(context) {
                 OneShotClose::Value(value) => Poll::Ready(Ok(value)),
                 OneShotClose::SenderClosed => Poll::Ready(Err(ReplyError::Dropped)),
                 OneShotClose::Empty => Poll::Ready(Err(ReplyError::Timeout)),
@@ -371,7 +407,7 @@ impl<T> DeadlineOperation for ReplyOperation<T> {
     }
 
     fn short_circuit(&mut self) -> Self::Output {
-        self.receiver.close();
+        self.receiver.inner.close();
         Err(ReplyError::Timeout)
     }
 }
@@ -1326,6 +1362,9 @@ impl<M> Hash for ActorRef<M> {
 pub struct SendFuture<M> {
     actor: ActorRef<M>,
     operation: Arc<SendOperation<M>>,
+    // Captured where `M: Send + 'static` holds so the unbounded `Drop` impl
+    // can route a withdrawn message through isolated disposal.
+    dispose: fn(M),
     submitted: bool,
     done: bool,
 }
@@ -1335,6 +1374,7 @@ impl<M: Send + 'static> SendFuture<M> {
         Self {
             actor,
             operation: SendOperation::new(message),
+            dispose: dispose_detached::<M>,
             submitted: false,
             done: false,
         }
@@ -1405,7 +1445,16 @@ impl<M: Send + 'static> Future for SendFuture<M> {
 impl<M> Drop for SendFuture<M> {
     fn drop(&mut self) {
         if !self.done {
-            let _ = self.actor.mailbox.withdraw(&self.operation);
+            // Cancellation recovers the unaccepted message with no caller
+            // left to hand it to. Destroying it inline would run a possibly
+            // blocking or panicking user destructor in this drop glue, so
+            // route the payload through isolated disposal.
+            match self.actor.mailbox.withdraw(&self.operation) {
+                Withdrawal::Withdrawn { message, .. } | Withdrawal::Terminated { message, .. } => {
+                    (self.dispose)(message);
+                }
+                Withdrawal::Accepted(_) => {}
+            }
         }
     }
 }
@@ -1494,7 +1543,7 @@ struct CallOperation<M, T> {
     actor: ActorRef<M>,
     make_msg: Option<Box<dyn FnOnce(Reply<T>) -> M + Send + 'static>>,
     send: Option<SendFuture<M>>,
-    reply: Option<OneShotReceiver<T>>,
+    reply: Option<ReplyState<T>>,
     accepted: Option<Incarnation>,
 }
 
@@ -1520,34 +1569,36 @@ impl<M, T> CallOperation<M, T> {
             .reply
             .as_mut()
             .expect("accepted call retains reply state");
-        match reply.poll_receive(context) {
+        match reply.inner.poll_receive(context) {
             Poll::Ready(Some(value)) => Poll::Ready(Ok(Replied { value, incarnation })),
             Poll::Ready(None) => Poll::Ready(Err(CallError {
                 actor_id: self.actor.id().clone(),
                 incarnation_observed: Some(incarnation),
                 kind: CallErrorKind::ReplyDropped,
             })),
-            Poll::Pending if deadline_elapsed => match reply.close_and_poll_receive(context) {
-                OneShotClose::Value(value) => Poll::Ready(Ok(Replied { value, incarnation })),
-                OneShotClose::SenderClosed => Poll::Ready(Err(CallError {
-                    actor_id: self.actor.id().clone(),
-                    incarnation_observed: Some(incarnation),
-                    kind: CallErrorKind::ReplyDropped,
-                })),
-                OneShotClose::Empty => Poll::Ready(Err(CallError {
-                    actor_id: self.actor.id().clone(),
-                    incarnation_observed: Some(incarnation),
-                    kind: CallErrorKind::ResponseTimedOut,
-                })),
-                OneShotClose::Pending => Poll::Pending,
-            },
+            Poll::Pending if deadline_elapsed => {
+                match reply.inner.close_and_poll_receive(context) {
+                    OneShotClose::Value(value) => Poll::Ready(Ok(Replied { value, incarnation })),
+                    OneShotClose::SenderClosed => Poll::Ready(Err(CallError {
+                        actor_id: self.actor.id().clone(),
+                        incarnation_observed: Some(incarnation),
+                        kind: CallErrorKind::ReplyDropped,
+                    })),
+                    OneShotClose::Empty => Poll::Ready(Err(CallError {
+                        actor_id: self.actor.id().clone(),
+                        incarnation_observed: Some(incarnation),
+                        kind: CallErrorKind::ResponseTimedOut,
+                    })),
+                    OneShotClose::Pending => Poll::Pending,
+                }
+            }
             Poll::Pending => Poll::Pending,
         }
     }
 
     fn close_reply(&mut self) {
         if let Some(reply) = &mut self.reply {
-            reply.close();
+            reply.inner.close();
         }
     }
 }

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -16,7 +16,7 @@ use crate::{
     ChildId, Incarnation, Mailbox, Membership,
     cells::{MailboxControl, MailboxDisposal, MailboxTermination, MemberCell},
     runtime::{
-        OneShotClose, OneShotReceiver, OneShotSender, PanicAccumulator, PanicPayload, Signal,
+        DisposingReceiver, OneShotClose, OneShotSender, PanicAccumulator, PanicPayload, Signal,
         SignalWatcher, dispose_detached, resume_panic,
     },
 };
@@ -271,36 +271,6 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
     }
 }
 
-/// Reply receive state that keeps user value destruction off framework and
-/// caller drop glue.
-///
-/// A reply value stored before the receive side is cancelled is user-owned:
-/// destroying it inline could block or panic whoever dropped the receiver.
-/// The disposal function is captured at construction, where the value type's
-/// `Send + 'static` bounds hold, so unbounded holders can still route an
-/// unclaimed stored value through isolated disposal on drop.
-struct ReplyState<T> {
-    inner: OneShotReceiver<T>,
-    dispose: fn(T),
-}
-
-impl<T: Send + 'static> ReplyState<T> {
-    fn new(inner: OneShotReceiver<T>) -> Self {
-        Self {
-            inner,
-            dispose: dispose_detached::<T>,
-        }
-    }
-}
-
-impl<T> Drop for ReplyState<T> {
-    fn drop(&mut self) {
-        if let Some(value) = self.inner.close_and_take() {
-            (self.dispose)(value);
-        }
-    }
-}
-
 /// A consuming, infallible reply capability.
 ///
 /// Dropping an unanswered capability is completion: its receiver observes
@@ -332,7 +302,7 @@ impl<T: Send + 'static> Reply<T> {
                 answered: false,
             },
             ReplyReceiver {
-                receiver: Some(ReplyState::new(receiver)),
+                receiver: Some(DisposingReceiver::new(receiver)),
             },
         )
     }
@@ -355,7 +325,7 @@ impl<T: Send + 'static> Reply<T> {
 
 /// The owned, non-cloneable receive half of [`Reply::channel`].
 pub struct ReplyReceiver<T> {
-    receiver: Option<ReplyState<T>>,
+    receiver: Option<DisposingReceiver<T>>,
 }
 
 impl<T> fmt::Debug for ReplyReceiver<T> {
@@ -381,7 +351,7 @@ impl<T: Send + 'static> ReplyReceiver<T> {
 }
 
 struct ReplyOperation<T> {
-    receiver: ReplyState<T>,
+    receiver: DisposingReceiver<T>,
 }
 
 impl<T> DeadlineOperation for ReplyOperation<T> {
@@ -1315,6 +1285,7 @@ impl<M: Send + 'static> ActorRef<M> {
                     send: None,
                     reply: None,
                     accepted: None,
+                    dispose_constructor: dispose_detached::<MessageConstructor<M, T>>,
                 },
                 deadline,
             ),
@@ -1539,12 +1510,30 @@ pub struct CallFuture<M, T> {
     deadlined: Deadlined<CallOperation<M, T>>,
 }
 
+type MessageConstructor<M, T> = Box<dyn FnOnce(Reply<T>) -> M + Send + 'static>;
+
 struct CallOperation<M, T> {
     actor: ActorRef<M>,
-    make_msg: Option<Box<dyn FnOnce(Reply<T>) -> M + Send + 'static>>,
+    make_msg: Option<MessageConstructor<M, T>>,
     send: Option<SendFuture<M>>,
-    reply: Option<ReplyState<T>>,
+    reply: Option<DisposingReceiver<T>>,
     accepted: Option<Incarnation>,
+    // Captured where `M: Send + 'static` holds so the unbounded `Drop` impl
+    // can route an unused constructor and its captures through isolated
+    // disposal.
+    dispose_constructor: fn(MessageConstructor<M, T>),
+}
+
+impl<M, T> Drop for CallOperation<M, T> {
+    fn drop(&mut self) {
+        if let Some(make_msg) = self.make_msg.take() {
+            // An unstarted or short-circuited call discards its constructor
+            // without ever building a message. Destroying the captures inline
+            // would run possibly blocking or panicking user destructors in
+            // this drop glue, so route them through isolated disposal.
+            (self.dispose_constructor)(make_msg);
+        }
+    }
 }
 
 impl<M, T> fmt::Debug for CallFuture<M, T> {
@@ -1647,6 +1636,10 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
                 }
                 Poll::Ready(Err(error)) => {
                     self.close_reply();
+                    // The call surface has no way to hand the recovered
+                    // message back; route the discard through isolated
+                    // disposal.
+                    dispose_detached(error.message);
                     return Poll::Ready(Err(CallError {
                         actor_id: error.actor_id,
                         incarnation_observed: error.incarnation_observed,
@@ -1683,6 +1676,9 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
             }
             Err(error) => {
                 self.close_reply();
+                // The call surface has no way to hand the recovered message
+                // back; route the discard through isolated disposal.
+                dispose_detached(error.message);
                 Poll::Ready(Err(CallError {
                     actor_id: error.actor_id,
                     incarnation_observed: error.incarnation_observed,

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -650,6 +650,36 @@ impl<T> OneShotReceiver<T> {
     }
 }
 
+/// One-shot receive state that keeps user value destruction off framework and
+/// holder drop glue.
+///
+/// A value stored before the receive side is cancelled is user-owned:
+/// destroying it inline could block or panic whoever dropped the holder. The
+/// disposal function is captured at construction, where the value type's
+/// `Send + 'static` bounds hold, so unbounded holders can still route an
+/// unclaimed stored value through isolated disposal on drop.
+pub(crate) struct DisposingReceiver<T> {
+    pub(crate) inner: OneShotReceiver<T>,
+    dispose: fn(T),
+}
+
+impl<T: Send + 'static> DisposingReceiver<T> {
+    pub(crate) fn new(inner: OneShotReceiver<T>) -> Self {
+        Self {
+            inner,
+            dispose: dispose_detached::<T>,
+        }
+    }
+}
+
+impl<T> Drop for DisposingReceiver<T> {
+    fn drop(&mut self) {
+        if let Some(value) = self.inner.close_and_take() {
+            (self.dispose)(value);
+        }
+    }
+}
+
 /// Publishing half of a runtime-backed conflating state channel.
 pub(crate) struct WatchSender<T>(watch::Sender<T>);
 

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -630,6 +630,16 @@ impl<T> OneShotReceiver<T> {
         self.channel.close();
     }
 
+    /// Closes the receive side and recovers a value stored before the close.
+    ///
+    /// Tokio retains a value sent before `close`, so this is the cancellation
+    /// hook that lets callers route an unclaimed stored value through isolated
+    /// disposal instead of destroying it in their own drop glue.
+    pub(crate) fn close_and_take(&mut self) -> Option<T> {
+        self.close();
+        self.channel.try_recv().ok()
+    }
+
     pub(crate) async fn receive(self) -> Option<T> {
         self.channel.await.ok()
     }

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -303,7 +303,7 @@ impl Hash for TaskRef {
 /// The sole claim to a one-shot task's typed completion value.
 #[must_use]
 pub struct OneShotTaskRef<T> {
-    completion: runtime::OneShotReceiver<T>,
+    completion: runtime::DisposingReceiver<T>,
     task: TaskRef,
 }
 
@@ -316,9 +316,12 @@ impl<T> fmt::Debug for OneShotTaskRef<T> {
     }
 }
 
-impl<T> OneShotTaskRef<T> {
+impl<T: Send + 'static> OneShotTaskRef<T> {
     pub(crate) fn new(completion: runtime::OneShotReceiver<T>, task: TaskRef) -> Self {
-        Self { completion, task }
+        Self {
+            completion: runtime::DisposingReceiver::new(completion),
+            task,
+        }
     }
 
     /// Consumes the claim and waits for the authoritative terminal verdict.
@@ -329,11 +332,13 @@ impl<T> OneShotTaskRef<T> {
     /// even if the task body produced a value first. That precedence is
     /// deliberately asymmetric: a body that returned `Err` keeps its
     /// [`crate::ExitKind::Failed`] verdict through a racing forced abort,
-    /// while a body that returned `Ok` does not — the value is dropped and
-    /// the claim resolves `Err` with the abort verdict.
-    pub async fn wait(self) -> Result<T, Exit> {
-        let Self { completion, task } = self;
-        let exit = task.wait().await;
+    /// while a body that returned `Ok` does not — the value is discarded
+    /// through isolated disposal and the claim resolves `Err` with the abort
+    /// verdict. An unclaimed stored value is likewise disposed in isolation
+    /// when the claim is dropped, so a blocking or panicking destructor never
+    /// runs on the dropping thread.
+    pub async fn wait(mut self) -> Result<T, Exit> {
+        let exit = self.task.wait().await;
         if !matches!(exit.kind(), crate::ExitKind::Completed) {
             return Err(exit);
         }
@@ -341,10 +346,11 @@ impl<T> OneShotTaskRef<T> {
         // receiver is the sole completion claim. A published Completed verdict
         // with a closed, empty channel is therefore a framework invariant
         // violation, not an application exit that can be reported as `Err`.
-        Ok(completion
-            .receive()
-            .await
-            .expect("completed one-shot task must publish its typed value"))
+        Ok(
+            std::future::poll_fn(|context| self.completion.inner.poll_receive(context))
+                .await
+                .expect("completed one-shot task must publish its typed value"),
+        )
     }
 }
 
@@ -421,7 +427,7 @@ mod tests {
         assert!(!shutdown.is_fired());
     }
 
-    fn one_shot_claim<T>() -> (
+    fn one_shot_claim<T: Send + 'static>() -> (
         runtime::OneShotSender<T>,
         OneShotTaskRef<T>,
         std::sync::Arc<MemberCell>,

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -210,7 +210,14 @@ impl<T: Send + 'static> TaskOnceDef<T> {
                 Box::pin(async move {
                     match body(context).await {
                         Ok(value) => {
-                            let _ = completion.send(value);
+                            // A rejected send means the completion claim was
+                            // abandoned. Destroying the value here would run a
+                            // possibly blocking or panicking user destructor
+                            // inside the supervised task future, hanging it or
+                            // replacing a Completed verdict with Panicked.
+                            if let Err(abandoned) = completion.send(value) {
+                                runtime::dispose_detached(abandoned);
+                            }
                             Ok(())
                         }
                         Err(error) => Err(error),

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -274,6 +274,17 @@ macro_rules! impl_slot_debug {
     };
 }
 
+/// Routes a definition rejected before admission through isolated disposal.
+///
+/// A failed reservation returns before framework state owns the supplied
+/// definition, so dropping it inline would run a possibly blocking or
+/// panicking user destructor on the caller instead of producing an ordinary
+/// [`ReserveError`].
+fn dispose_rejected<D: Send + 'static>(definition: D, error: ReserveError) -> ReserveError {
+    runtime::dispose_detached(definition);
+    error
+}
+
 fn attach_actor_slot<M: Send + 'static>(slot: Arc<SlotCell>) -> ActorSlot<M> {
     let mailbox = MailboxCell::new(slot.member.id().clone());
     slot.member.attach_mailbox(mailbox.clone());
@@ -322,7 +333,10 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: ActorDef<A>,
         ) -> Result<ActorRef<A::Msg>, ReserveError> {
-            self.reserve_actor(id).map(|slot| slot.define(definition))
+            match self.reserve_actor(id) {
+                Ok(slot) => Ok(slot.define(definition)),
+                Err(error) => Err(dispose_rejected(definition, error)),
+            }
         }
 
         #[doc = $add_actor_once_doc]
@@ -331,8 +345,10 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: ActorOnceDef<A>,
         ) -> Result<ActorRef<A::Msg>, ReserveError> {
-            self.reserve_actor(id)
-                .map(|slot| slot.define_once(definition))
+            match self.reserve_actor(id) {
+                Ok(slot) => Ok(slot.define_once(definition)),
+                Err(error) => Err(dispose_rejected(definition, error)),
+            }
         }
 
         #[doc = $add_raw_doc]
@@ -341,8 +357,10 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: RawDef<R>,
         ) -> Result<ActorRef<R::Msg>, ReserveError> {
-            self.reserve_actor(id)
-                .map(|slot| slot.define_raw(definition))
+            match self.reserve_actor(id) {
+                Ok(slot) => Ok(slot.define_raw(definition)),
+                Err(error) => Err(dispose_rejected(definition, error)),
+            }
         }
 
         #[doc = $add_raw_once_doc]
@@ -351,8 +369,10 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: RawOnceDef<R>,
         ) -> Result<ActorRef<R::Msg>, ReserveError> {
-            self.reserve_actor(id)
-                .map(|slot| slot.define_once_raw(definition))
+            match self.reserve_actor(id) {
+                Ok(slot) => Ok(slot.define_once_raw(definition)),
+                Err(error) => Err(dispose_rejected(definition, error)),
+            }
         }
 
         #[doc = $reserve_task_doc]
@@ -368,7 +388,10 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: TaskDef,
         ) -> Result<TaskRef, ReserveError> {
-            self.reserve_task(id).map(|slot| slot.define(definition))
+            match self.reserve_task(id) {
+                Ok(slot) => Ok(slot.define(definition)),
+                Err(error) => Err(dispose_rejected(definition, error)),
+            }
         }
 
         #[doc = $add_task_once_doc]
@@ -377,8 +400,10 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: TaskOnceDef<T>,
         ) -> Result<(TaskRef, OneShotTaskRef<T>), ReserveError> {
-            self.reserve_task(id)
-                .map(|slot| slot.define_once(definition))
+            match self.reserve_task(id) {
+                Ok(slot) => Ok(slot.define_once(definition)),
+                Err(error) => Err(dispose_rejected(definition, error)),
+            }
         }
 
         #[doc = $reserve_subtree_doc]
@@ -399,8 +424,10 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: SubtreeDef<T>,
         ) -> Result<T::Ref, ReserveError> {
-            self.reserve_subtree::<T>(id)
-                .map(|slot| slot.define(definition))
+            match self.reserve_subtree::<T>(id) {
+                Ok(slot) => Ok(slot.define(definition)),
+                Err(error) => Err(dispose_rejected(definition, error)),
+            }
         }
 
         #[doc = $add_subtree_once_doc]
@@ -409,8 +436,10 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: SubtreeOnceDef<T>,
         ) -> Result<T::Ref, ReserveError> {
-            self.reserve_subtree::<T>(id)
-                .map(|slot| slot.define_once(definition))
+            match self.reserve_subtree::<T>(id) {
+                Ok(slot) => Ok(slot.define_once(definition)),
+                Err(error) => Err(dispose_rejected(definition, error)),
+            }
         }
     };
 }
@@ -1456,7 +1485,7 @@ impl DynamicScopeRef {
             Ok(slot) => slot
                 .core
                 .define_raw(definition.into_raw(), AdmissionOwnership::Fused),
-            Err(error) => Admission::error(error),
+            Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
 
@@ -1470,7 +1499,7 @@ impl DynamicScopeRef {
             Ok(slot) => slot
                 .core
                 .define_once_raw(definition.into_raw(), AdmissionOwnership::Fused),
-            Err(error) => Admission::error(error),
+            Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
 
@@ -1482,7 +1511,7 @@ impl DynamicScopeRef {
     ) -> Admission<ActorRef<R::Msg>> {
         match self.reserve_actor(id) {
             Ok(slot) => slot.core.define_raw(definition, AdmissionOwnership::Fused),
-            Err(error) => Admission::error(error),
+            Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
 
@@ -1496,7 +1525,7 @@ impl DynamicScopeRef {
             Ok(slot) => slot
                 .core
                 .define_once_raw(definition, AdmissionOwnership::Fused),
-            Err(error) => Admission::error(error),
+            Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
 
@@ -1515,7 +1544,7 @@ impl DynamicScopeRef {
     pub fn add_task(&self, id: impl Into<ChildId>, definition: TaskDef) -> Admission<TaskRef> {
         match self.reserve_task(id) {
             Ok(slot) => slot.core.define(definition, AdmissionOwnership::Fused),
-            Err(error) => Admission::error(error),
+            Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
 
@@ -1527,7 +1556,7 @@ impl DynamicScopeRef {
     ) -> Admission<(TaskRef, OneShotTaskRef<T>)> {
         match self.reserve_task(id) {
             Ok(slot) => slot.core.define_once(definition, AdmissionOwnership::Fused),
-            Err(error) => Admission::error(error),
+            Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
 
@@ -1552,7 +1581,7 @@ impl DynamicScopeRef {
     ) -> Admission<T::Ref> {
         match self.reserve_subtree::<T>(id) {
             Ok(slot) => slot.core.define(definition, AdmissionOwnership::Fused),
-            Err(error) => Admission::error(error),
+            Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
 
@@ -1564,7 +1593,7 @@ impl DynamicScopeRef {
     ) -> Admission<T::Ref> {
         match self.reserve_subtree::<T>(id) {
             Ok(slot) => slot.core.define_once(definition, AdmissionOwnership::Fused),
-            Err(error) => Admission::error(error),
+            Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
 

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -15,10 +15,10 @@ use crate::common::{
     poll_until,
 };
 use shelterwood::{
-    Backoff, ChildState, DynamicTree, ExitError, ExitKind, ExitResult, Jitter, LifecycleEventKind,
-    LifecycleItem, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline,
-    RemoveOutcome, Reply, ReserveError, RestartCondition, RestartPolicy, SubtreeOnceDef, TaskDef,
-    TaskOnceDef, Tree,
+    Backoff, CallErrorKind, ChildState, DynamicTree, ExitError, ExitKind, ExitResult, Jitter,
+    LifecycleEventKind, LifecycleItem, Mailbox, RawActor, RawContext, RawDef, RawOnceDef,
+    Readiness, ReadinessDeadline, RemoveOutcome, Reply, ReserveError, RestartCondition,
+    RestartPolicy, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
 };
 
 struct DropProbe {
@@ -1173,6 +1173,173 @@ async fn dropped_reply_receiver_disposes_stored_value_through_isolated_disposal(
             .recv()
             .await
             .expect("stored reply reports its disposal thread"),
+        thread::current().id()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unclaimed_completion_value_disposes_blocking_destructor_off_the_claim_holder() {
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let probe = BlockingDropProbe::new(&gate, dropped);
+    let (task, completion) = tree
+        .add_task_once(
+            "unclaimed",
+            TaskOnceDef::new(move |_| async move { Ok::<_, ExitError>(probe) }),
+        )
+        .expect("valid task");
+
+    let system = tree.spawn().expect("runtime is available");
+    let exit = task.wait().await;
+    assert!(matches!(exit.kind(), ExitKind::Completed));
+    drop(completion);
+    wait_for_destructor(&gate).await;
+    let disposal_thread = drops
+        .recv()
+        .await
+        .expect("unclaimed completion reports its disposal thread");
+    gate.release();
+    assert_ne!(disposal_thread, thread::current().id());
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+}
+
+#[tokio::test]
+async fn unclaimed_completion_value_contains_destructor_panic() {
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let probe = DropProbe::panicking(dropped, "unclaimed completion destructor");
+    let (task, completion) = tree
+        .add_task_once(
+            "unclaimed",
+            TaskOnceDef::new(move |_| async move { Ok::<_, ExitError>(probe) }),
+        )
+        .expect("valid task");
+
+    let system = tree.spawn().expect("runtime is available");
+    let exit = task.wait().await;
+    assert!(matches!(exit.kind(), ExitKind::Completed));
+    drop(completion);
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("unclaimed completion reports its disposal thread"),
+        thread::current().id()
+    );
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+}
+
+struct CompleteNow<M>(PhantomData<M>);
+
+impl<M> Default for CompleteNow<M> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<M: Send + 'static> RawActor for CompleteNow<M> {
+    type Msg = M;
+
+    async fn run(&mut self, _context: &mut RawContext<Self::Msg>) -> ExitResult {
+        Ok(())
+    }
+}
+
+struct ProbedCall<P> {
+    _reply: Reply<()>,
+    _probe: P,
+}
+
+#[tokio::test]
+async fn terminated_call_disposes_recovered_message_off_the_caller() {
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "done",
+            RawOnceDef::new(CompleteNow::<ProbedCall<DropProbe>>::default()),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+
+    let probe = DropProbe::panicking(dropped, "terminated call message destructor");
+    let error = actor
+        .call(
+            move |reply| ProbedCall {
+                _reply: reply,
+                _probe: probe,
+            },
+            Duration::from_secs(1),
+        )
+        .await
+        .expect_err("terminated actor rejects the call");
+    assert!(matches!(error.kind, CallErrorKind::Terminated));
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("recovered message reports its disposal thread"),
+        thread::current().id()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn acceptance_timed_out_call_disposes_recovered_message_off_the_caller() {
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "unread",
+            RawOnceDef::new(Unread::<ProbedCall<BlockingDropProbe>>::default()),
+        )
+        .expect("valid actor");
+
+    let probe = BlockingDropProbe::new(&gate, dropped);
+    let error = actor
+        .call(
+            move |reply| ProbedCall {
+                _reply: reply,
+                _probe: probe,
+            },
+            Duration::from_millis(50),
+        )
+        .await
+        .expect_err("unbound mailbox never accepts within the deadline");
+    assert!(matches!(error.kind, CallErrorKind::AcceptanceTimedOut));
+    wait_for_destructor(&gate).await;
+    let disposal_thread = drops
+        .recv()
+        .await
+        .expect("recovered message reports its disposal thread");
+    gate.release();
+    assert_ne!(disposal_thread, thread::current().id());
+    drop(tree);
+}
+
+#[tokio::test]
+async fn dropped_unstarted_call_disposes_constructor_off_the_caller() {
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once("unread", RawOnceDef::new(Unread::<()>::default()))
+        .expect("valid actor");
+
+    let capture = DropProbe::panicking(dropped, "unstarted call constructor destructor");
+    let call = actor.call(
+        move |_reply: Reply<()>| {
+            let _ = &capture;
+        },
+        Duration::from_secs(1),
+    );
+    drop(call);
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("unstarted constructor reports its disposal thread"),
         thread::current().id()
     );
 }

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -17,7 +17,8 @@ use crate::common::{
 use shelterwood::{
     Backoff, ChildState, DynamicTree, ExitError, ExitKind, ExitResult, Jitter, LifecycleEventKind,
     LifecycleItem, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline,
-    RemoveOutcome, RestartCondition, RestartPolicy, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
+    RemoveOutcome, Reply, ReserveError, RestartCondition, RestartPolicy, SubtreeOnceDef, TaskDef,
+    TaskOnceDef, Tree,
 };
 
 struct DropProbe {
@@ -898,6 +899,298 @@ async fn restart_window_cleanup_is_isolated_without_reclassifying_the_recorded_e
         task.wait().await.kind(),
         ExitKind::Failed(error) if error.to_string() == "restart me"
     ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn abandoned_one_shot_completion_disposes_blocking_value_off_the_task() {
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let probe = BlockingDropProbe::new(&gate, dropped);
+    let (task, completion) = tree
+        .add_task_once(
+            "abandoned",
+            TaskOnceDef::new(move |_| async move { Ok::<_, ExitError>(probe) }),
+        )
+        .expect("valid task");
+    drop(completion);
+
+    let system = tree.spawn().expect("runtime is available");
+    wait_for_destructor(&gate).await;
+    let bounded = tokio::time::timeout(Duration::from_secs(1), task.wait()).await;
+    gate.release();
+    let exit = bounded.expect("a blocked abandoned-claim disposal must not hang the task");
+    assert!(matches!(exit.kind(), ExitKind::Completed));
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("abandoned result reports its disposal thread"),
+        thread::current().id()
+    );
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn abandoned_one_shot_completion_keeps_completed_verdict_through_destructor_panic() {
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let probe = DropProbe::panicking(dropped, "abandoned completion destructor");
+    let (task, completion) = tree
+        .add_task_once(
+            "abandoned",
+            TaskOnceDef::new(move |_| async move { Ok::<_, ExitError>(probe) }),
+        )
+        .expect("valid task");
+    drop(completion);
+
+    let system = tree.spawn().expect("runtime is available");
+    let exit = task.wait().await;
+    assert!(
+        matches!(exit.kind(), ExitKind::Completed),
+        "an abandoned claim's destructor panic must not reclassify the task: {exit:?}"
+    );
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("abandoned result reports its disposal thread"),
+        thread::current().id()
+    );
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn duplicate_id_rejection_disposes_blocking_definition_off_the_caller() {
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    tree.add_task("dup", TaskDef::new(|_| async { Ok(()) }).restart(never()))
+        .expect("first definition");
+    let error = tree
+        .add_task(
+            "dup",
+            TaskDef::new({
+                let capture = BlockingDropProbe::new(&gate, dropped);
+                move |_| {
+                    let _ = &capture;
+                    async { Ok(()) }
+                }
+            }),
+        )
+        .expect_err("duplicate id is rejected");
+    assert!(matches!(error, ReserveError::DuplicateId(id) if id.as_str() == "dup"));
+
+    wait_for_destructor(&gate).await;
+    let disposal_thread = drops
+        .recv()
+        .await
+        .expect("rejected definition reports its disposal thread");
+    gate.release();
+    assert_ne!(disposal_thread, thread::current().id());
+}
+
+struct HostileCapture {
+    _probe: DropProbe,
+}
+
+impl RawActor for HostileCapture {
+    type Msg = ();
+
+    async fn run(&mut self, _context: &mut RawContext<Self::Msg>) -> ExitResult {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn duplicate_id_rejection_contains_definition_destructor_panic() {
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    tree.add_raw_once("dup", RawOnceDef::new(Unread::<()>::default()))
+        .expect("first definition");
+    let error = tree
+        .add_raw_once(
+            "dup",
+            RawOnceDef::new(HostileCapture {
+                _probe: DropProbe::panicking(dropped, "rejected definition destructor"),
+            }),
+        )
+        .expect_err("duplicate id is rejected without unwinding the caller");
+    assert!(matches!(error, ReserveError::DuplicateId(id) if id.as_str() == "dup"));
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("rejected definition reports its disposal thread"),
+        thread::current().id()
+    );
+}
+
+#[tokio::test]
+async fn dynamic_duplicate_rejection_disposes_definition_before_admission() {
+    let tree = DynamicTree::new();
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+    let _held = scope.reserve_task("dup").expect("task reservation");
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let admission = scope.add_task(
+        "dup",
+        TaskDef::new({
+            let capture = DropProbe::panicking(dropped, "rejected dynamic definition destructor");
+            move |_| {
+                let _ = &capture;
+                async { Ok(()) }
+            }
+        }),
+    );
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("rejected definition reports its disposal thread"),
+        thread::current().id()
+    );
+    let error = admission.await.expect_err("duplicate id is rejected");
+    assert!(matches!(error, ReserveError::DuplicateId(id) if id.as_str() == "dup"));
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root shuts down");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancelled_send_disposes_blocking_message_off_the_caller() {
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let tree = {
+        let mut tree = Tree::new();
+        let actor = tree
+            .add_raw_once(
+                "unread",
+                RawOnceDef::new(Unread::<BlockingDropProbe>::default()),
+            )
+            .expect("valid actor");
+        let mut pending = Box::pin(actor.send(BlockingDropProbe::new(&gate, dropped)));
+        poll_pending(&mut pending).await;
+        drop(pending);
+        tree
+    };
+
+    wait_for_destructor(&gate).await;
+    let disposal_thread = drops
+        .recv()
+        .await
+        .expect("withdrawn message reports its disposal thread");
+    gate.release();
+    assert_ne!(disposal_thread, thread::current().id());
+    drop(tree);
+}
+
+#[tokio::test]
+async fn cancelled_send_contains_message_destructor_panic() {
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once("unread", RawOnceDef::new(Unread::<DropProbe>::default()))
+        .expect("valid actor");
+    let mut pending =
+        Box::pin(actor.send(DropProbe::panicking(dropped, "cancelled send destructor")));
+    poll_pending(&mut pending).await;
+    drop(pending);
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("withdrawn message reports its disposal thread"),
+        thread::current().id()
+    );
+}
+
+struct ReplyThenPark {
+    gate: DestructorGate,
+    dropped: tokio::sync::mpsc::UnboundedSender<ThreadId>,
+    replied: ReleaseGate,
+}
+
+impl RawActor for ReplyThenPark {
+    type Msg = Reply<BlockingDropProbe>;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        if let Some(reply) = context.recv().await {
+            reply.send(BlockingDropProbe::new(&self.gate, self.dropped.clone()));
+            self.replied.release();
+        }
+        context.shutdown_token().cancelled().await;
+        Ok(())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancelled_call_disposes_stored_reply_off_the_caller() {
+    let gate = DestructorGate::default();
+    let replied = ReleaseGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "replier",
+            RawOnceDef::new(ReplyThenPark {
+                gate: gate.clone(),
+                dropped,
+                replied: replied.clone(),
+            }),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+
+    let mut call = Box::pin(actor.call(|reply| reply, Duration::from_secs(5)));
+    poll_pending(&mut call).await;
+    replied.wait().await;
+    drop(call);
+    wait_for_destructor(&gate).await;
+    let disposal_thread = drops
+        .recv()
+        .await
+        .expect("stored reply reports its disposal thread");
+    gate.release();
+    assert_ne!(disposal_thread, thread::current().id());
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("replier shuts down");
+}
+
+#[tokio::test]
+async fn dropped_reply_receiver_disposes_stored_value_through_isolated_disposal() {
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let (reply, receiver) = Reply::<DropProbe>::channel();
+    reply.send(DropProbe::panicking(dropped, "unclaimed reply destructor"));
+    drop(receiver);
+    assert_ne!(
+        drops
+            .recv()
+            .await
+            .expect("stored reply reports its disposal thread"),
+        thread::current().id()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn late_reply_send_disposes_unclaimed_value_off_the_sender() {
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let (reply, receiver) = Reply::<BlockingDropProbe>::channel();
+    drop(receiver);
+    reply.send(BlockingDropProbe::new(&gate, dropped));
+    wait_for_destructor(&gate).await;
+    let disposal_thread = drops
+        .recv()
+        .await
+        .expect("late reply reports its disposal thread");
+    gate.release();
+    assert_ne!(disposal_thread, thread::current().id());
 }
 
 struct OffloadPanic {


### PR DESCRIPTION
Implements three disposal-safety items from the #55 audit (verified still present at current `main` before changing anything). The crate's invariant is that framework code paths never run user destruction inline; these were the remaining paths where a blocking or panicking `Drop` on a user value could hang or reclassify framework behavior. All fixes reuse the existing detached isolated-disposal path (`runtime::dispose_detached`) — no new mechanism.

## Issue #55 items addressed

> **Do not let an abandoned one-shot completion claim alter the task verdict.** `TaskOnceDef::erase` ignores `Err(T)` from the completion send. If `OneShotTaskRef<T>` was dropped, a blocking or panicking `T::drop` runs inside the supervised task future and can hang it or turn an otherwise successful task into `Panicked`. Dispose rejected values through the isolated-disposal path and test blocking/panicking result values.

`TaskOnceDef::erase` now routes an `Err(value)` from the completion send through `dispose_detached` instead of dropping it inside the erased task future. Regressions: `abandoned_one_shot_completion_disposes_blocking_value_off_the_task` (task still reaches `Completed` within a bounded wait while the destructor is frozen) and `abandoned_one_shot_completion_keeps_completed_verdict_through_destructor_panic` (verdict stays `Completed`, not `Panicked`).

> **Isolate definitions rejected before admission.** Immediate `add_*` errors in `tree.rs`, and the analogous declaration-time builder methods, drop supplied definitions synchronously. A blocking or panicking destructor can block/panic the caller instead of producing `ReserveError`.

All eight declaration-time `add_*` methods (the shared `Tree`/`DynamicTree` builder surface) and all eight `DynamicScopeRef::add_*` admission methods now route the supplied definition through a new `dispose_rejected` helper on any reservation failure before returning/embedding the `ReserveError`. Regressions cover a blocking `TaskDef` and a panicking `RawOnceDef` on duplicate-id declaration, plus a panicking `TaskDef` on a dynamic duplicate-id admission (`Admission` still resolves to `Err(DuplicateId)`, caller not unwound, disposal observed off-thread).

> **Isolate payloads discarded by cancellation.** `SendFuture::drop` discards a withdrawn message synchronously; reply cancellation similarly destroys an already-stored value during `close_receiver`. Add hostile-payload cancellation coverage.

- `SendFuture::drop` now matches the withdrawal outcome and routes a recovered (`Withdrawn`/`Terminated`) message through isolated disposal. Because `Drop` cannot carry extra bounds, the disposal fn pointer is captured in `SendFuture::new` where `M: Send + 'static` holds.
- A new private `ReplyState<T>` wrapper (same fn-pointer technique) holds every reply receiver — `ReplyReceiver`, `ReplyOperation` (`ReplyReceiver::recv` timeout path), and `CallOperation` — and on drop recovers a stored-but-unclaimed reply via the new `OneShotReceiver::close_and_take` and disposes it detached. A late `Reply::send` against a cancelled receiver likewise disposes the rejected value instead of dropping it on the replying actor.
- Regressions: cancelled send with blocking and with panicking payloads, cancelled `CallFuture` after the actor deterministically stored a blocking reply, dropped `ReplyReceiver` holding a stored panicking value, and a late `Reply::send` with a blocking value.

## Notes and judgment calls

- Every new regression test was verified to fail against the unfixed implementation (5 representative fast-failing tests re-run with `src/` reverted: 5/5 failed, e.g. the abandoned-claim task exit read `Panicked { "abandoned completion destructor" }`).
- The fn-pointer capture (`dispose: fn(M)` on `SendFuture`, `fn(T)` on `ReplyState`) exists because `Drop` impls cannot add `Send + 'static` bounds; capturing `dispose_detached::<M>` at construction keeps the public struct signatures (`SendFuture<M>`, `CallFuture<M, T>`, `ReplyReceiver<T>`) unchanged.
- `Reply::send`'s rejected-value discard was folded into this item: it is the sender-side half of the same reply-cancellation window, and the old inline drop ran hostile destructors on the replying actor's thread.
- Public API surface unchanged apart from one doc sentence on `Reply` (late sends now "discard through isolated disposal"); the API-reachability check passes unchanged.

## Verification

- `./scripts/dev just fmt` clean (nightly rustfmt applied).
- `./scripts/dev just ci` (full local CI mirror) passes: 385 tests + 3 doctests, clippy `-D warnings`, docs, API reachability, runtime/exit/layering path checks, packaging, nixfmt.

Refs #55 (does not close it; other checklist items remain).