### PR TITLE
Collapse Handler::run onto the raw incarnation boundary

### DIFF
--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -1,15 +1,12 @@
 //! Callback-oriented actors layered entirely on the public raw-actor surface.
 
-use std::{
-    fmt, future::Future, hash::Hash, marker::PhantomData, panic::resume_unwind, sync::Arc,
-    time::Duration,
-};
+use std::{fmt, future::Future, hash::Hash, marker::PhantomData, sync::Arc, time::Duration};
 
 use crate::{
     ActorRef, Blocking, CancellationToken, ChildId, DeadlineElapsed, ExitError, ExitResult, Guard,
     Incarnation, Mailbox, MailboxShutdown, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
     ReadinessDeadline, Rejected, RestartPolicy, Retention, ScopeRef, Shutdown,
-    policy::CommonOptions, raw::CatchUnwindFuture,
+    policy::CommonOptions,
 };
 
 /// Callback-oriented actor contract.
@@ -367,6 +364,13 @@ impl<A: Actor> RawActor for Handler<A> {
         self.readiness
     }
 
+    /// Runs one incarnation, leaning on the raw incarnation boundary for all
+    /// panic and teardown machinery: after this future returns or panics, the
+    /// raw runner freezes the mailbox and incarnation resources, joins them,
+    /// and only then drops this handler (§5.5's resource-before-actor order),
+    /// preserving a callback panic as the authoritative exit. Storing the
+    /// actor in `self` rather than a frame local is what keeps its drop after
+    /// that join on the `Err` and panic paths.
     async fn run(&mut self, raw: &mut RawContext<Self::Msg>) -> ExitResult {
         let args = self
             .args
@@ -376,99 +380,34 @@ impl<A: Actor> RawActor for Handler<A> {
             let mut context = Context::<A>::new(raw, false);
             A::init(args, &mut context).await?
         };
-        self.actor = Some(actor);
+        let actor = self.actor.insert(actor);
         if raw.readiness() == Readiness::AfterInit {
             raw.mark_ready();
         }
 
-        let live_failure = loop {
-            let received = CatchUnwindFuture::new(raw.recv()).await;
-            let message = match received {
-                Ok(Some(message)) => message,
-                Ok(None) => break None,
-                Err(payload) => resume_unwind(payload),
-            };
-            let actor = self
-                .actor
-                .as_mut()
-                .expect("initialized handler retains its actor");
-            if let Err(failure) = handle_message(actor, raw, message, false).await {
-                break Some(failure);
-            }
-        };
+        while let Some(message) = raw.recv().await {
+            let mut context = Context::<A>::new(raw, false);
+            actor.handle(message, &mut context).await?;
+        }
 
-        let failure = match (live_failure, raw.mailbox_shutdown()) {
-            (Some(failure), _) => Some(failure),
-            (None, MailboxShutdown::Drain) => {
-                let mut failure = None;
+        match raw.mailbox_shutdown() {
+            MailboxShutdown::Drain => {
                 while let Some(message) = raw.try_recv() {
-                    let actor = self
-                        .actor
-                        .as_mut()
-                        .expect("initialized handler retains its actor");
-                    if let Err(current) = handle_message(actor, raw, message, true).await {
-                        failure = Some(current);
-                        break;
-                    }
+                    let mut context = Context::<A>::new(raw, true);
+                    actor.handle(message, &mut context).await?;
                 }
-                failure
             }
-            (None, MailboxShutdown::Discard) => {
+            MailboxShutdown::Discard => {
                 while let Some(message) = raw.try_recv() {
                     drop(message);
                 }
-                None
             }
-        };
-
-        if let Some(failure) = failure {
-            return match failure {
-                HandlerFailure::Returned(error) => fail_after_teardown(raw, error).await,
-                HandlerFailure::Panicked(payload) => resume_unwind(payload),
-            };
         }
 
         let mut context = StopContext::<A>::new(raw);
-        let actor = self
-            .actor
-            .as_mut()
-            .expect("initialized handler retains its actor");
-        if let Err(payload) = CatchUnwindFuture::new(actor.on_stop(&mut context)).await {
-            resume_unwind(payload);
-        }
+        actor.on_stop(&mut context).await;
         Ok(())
     }
-}
-
-enum HandlerFailure {
-    Returned(ExitError),
-    Panicked(Box<dyn std::any::Any + Send + 'static>),
-}
-
-async fn handle_message<A: Actor>(
-    actor: &mut A,
-    raw: &mut RawContext<A::Msg>,
-    message: A::Msg,
-    draining: bool,
-) -> Result<(), HandlerFailure> {
-    let mut context = Context::<A>::new(raw, draining);
-    match CatchUnwindFuture::new(actor.handle(message, &mut context)).await {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(error)) => Err(HandlerFailure::Returned(error)),
-        Err(payload) => Err(HandlerFailure::Panicked(payload)),
-    }
-}
-
-/// Propagates a handler error after §5.5's orderly teardown order: incarnation-owned
-/// work is frozen, cancelled, and joined before actor state — which the
-/// caller still owns — is dropped at its frame's exit.
-async fn fail_after_teardown<M: Send + 'static>(
-    raw: &mut RawContext<M>,
-    error: ExitError,
-) -> ExitResult {
-    raw.freeze_resources();
-    raw.join_resources().await;
-    Err(error)
 }
 
 type ArgsFactory<A> = Arc<dyn Fn() -> <A as Actor>::Args + Send + Sync + 'static>;

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -364,37 +364,55 @@ impl<A: Actor> RawActor for Handler<A> {
         self.readiness
     }
 
-    /// Runs one incarnation, leaning on the raw incarnation boundary for all
-    /// panic and teardown machinery: after this future returns or panics, the
-    /// raw runner freezes the mailbox and incarnation resources, joins them,
-    /// and only then drops this handler (§5.5's resource-before-actor order),
-    /// preserving a callback panic as the authoritative exit. Storing the
-    /// actor in `self` rather than a frame local is what keeps its drop after
-    /// that join on the `Err` and panic paths.
+    /// Runs one incarnation, leaning on the raw incarnation boundary for the
+    /// panic machinery: a callback panic unwinds straight through this frame,
+    /// and the raw runner freezes the mailbox and incarnation resources,
+    /// joins them, and only then drops this handler (§5.5's
+    /// resource-before-actor order), preserving the panic as the
+    /// authoritative exit. Storing the actor in `self` rather than a frame
+    /// local is what keeps its drop after that join on the `Err` and panic
+    /// paths. Callback *errors* cannot lean on that boundary the same way:
+    /// this wrapper is the advertised raw-decorator composition point, so a
+    /// decorator — not the raw runner — may resume after this future
+    /// returns, and it must not observe still-live incarnation resources;
+    /// every error exit therefore freezes and joins them here first.
     async fn run(&mut self, raw: &mut RawContext<Self::Msg>) -> ExitResult {
         let args = self
             .args
             .take()
             .expect("handler actor initialization invoked more than once");
-        let actor = {
+        let initialized = {
             let mut context = Context::<A>::new(raw, false);
-            A::init(args, &mut context).await?
+            A::init(args, &mut context).await
         };
-        let actor = self.actor.insert(actor);
+        let actor = match initialized {
+            Ok(actor) => self.actor.insert(actor),
+            Err(error) => return fail_after_teardown(raw, error).await,
+        };
         if raw.readiness() == Readiness::AfterInit {
             raw.mark_ready();
         }
 
         while let Some(message) = raw.recv().await {
-            let mut context = Context::<A>::new(raw, false);
-            actor.handle(message, &mut context).await?;
+            let handled = {
+                let mut context = Context::<A>::new(raw, false);
+                actor.handle(message, &mut context).await
+            };
+            if let Err(error) = handled {
+                return fail_after_teardown(raw, error).await;
+            }
         }
 
         match raw.mailbox_shutdown() {
             MailboxShutdown::Drain => {
                 while let Some(message) = raw.try_recv() {
-                    let mut context = Context::<A>::new(raw, true);
-                    actor.handle(message, &mut context).await?;
+                    let handled = {
+                        let mut context = Context::<A>::new(raw, true);
+                        actor.handle(message, &mut context).await
+                    };
+                    if let Err(error) = handled {
+                        return fail_after_teardown(raw, error).await;
+                    }
                 }
             }
             MailboxShutdown::Discard => {
@@ -408,6 +426,19 @@ impl<A: Actor> RawActor for Handler<A> {
         actor.on_stop(&mut context).await;
         Ok(())
     }
+}
+
+/// Propagates a callback error after §5.5's orderly teardown: incarnation-owned
+/// work is frozen, cancelled, and joined before control returns to the caller,
+/// which at the advertised composition point may be a raw decorator rather
+/// than the raw incarnation boundary itself.
+async fn fail_after_teardown<M: Send + 'static>(
+    raw: &mut RawContext<M>,
+    error: ExitError,
+) -> ExitResult {
+    raw.freeze_resources();
+    raw.join_resources().await;
+    Err(error)
 }
 
 type ArgsFactory<A> = Arc<dyn Fn() -> <A as Actor>::Args + Send + Sync + 'static>;

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -349,6 +349,119 @@ async fn restartable_and_dynamic_actor_definition_surfaces_work() {
         .expect("tree shuts down");
 }
 
+struct ResumeProbeDecorator<R> {
+    inner: R,
+    log: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl<R: RawActor> RawActor for ResumeProbeDecorator<R> {
+    type Msg = R::Msg;
+
+    fn readiness(&self) -> Readiness {
+        self.inner.readiness()
+    }
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        let result = self.inner.run(context).await;
+        self.log
+            .lock()
+            .expect("teardown log mutex poisoned")
+            .push("decorator-resumed");
+        result
+    }
+}
+
+struct TeardownDropLog {
+    log: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl Drop for TeardownDropLog {
+    fn drop(&mut self) {
+        self.log
+            .lock()
+            .expect("teardown log mutex poisoned")
+            .push("offload-destroyed");
+    }
+}
+
+enum OffloadThenFailMessage {
+    Start,
+}
+
+struct OffloadThenFailActor {
+    log: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl Actor for OffloadThenFailActor {
+    type Msg = OffloadThenFailMessage;
+    type Args = Arc<Mutex<Vec<&'static str>>>;
+
+    async fn init(log: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self { log })
+    }
+
+    async fn handle(
+        &mut self,
+        OffloadThenFailMessage::Start: Self::Msg,
+        context: &mut Context<'_, Self>,
+    ) -> ExitResult {
+        let guard = TeardownDropLog {
+            log: Arc::clone(&self.log),
+        };
+        context
+            .offload(
+                async move {
+                    let _guard = guard;
+                    std::future::pending::<()>().await;
+                },
+                |_| OffloadThenFailMessage::Start,
+                Duration::MAX,
+            )
+            .expect("live offload accepted");
+        Err(ExitError::message("injected handler failure"))
+    }
+}
+
+/// `Handler` is the advertised raw-decorator composition point, so the raw
+/// incarnation boundary is not necessarily its immediate caller: a callback
+/// error must freeze and join incarnation-owned work inside `Handler::run`,
+/// before a decorator that resumes after delegating can observe still-live
+/// offloads.
+#[tokio::test]
+async fn handler_error_joins_offloads_before_returning_to_a_raw_decorator() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "erroring",
+            RawOnceDef::new(ResumeProbeDecorator {
+                inner: Handler::<OffloadThenFailActor>::new(Arc::clone(&log)),
+                log: Arc::clone(&log),
+            }),
+        )
+        .expect("valid decorated actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    actor
+        .send(OffloadThenFailMessage::Start)
+        .await
+        .expect("actor live");
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            log.lock().expect("teardown log mutex poisoned").len() == 2
+        })
+        .await
+    );
+    assert_eq!(
+        *log.lock().expect("teardown log mutex poisoned"),
+        ["offload-destroyed", "decorator-resumed"]
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("tree shuts down");
+}
+
 struct InertActor;
 
 impl Actor for InertActor {


### PR DESCRIPTION
## Issue #55 item

From the simplification section of #55 (baseline `de197e6`):

> **Remove duplicated handler panic/teardown machinery where the raw runner already supplies it.** [`Handler::run`](https://github.com/ralexstokes/shelterwood/blob/de197e6bb8db0c371cac8c445f0e741543b2955e/crates/shelterwood/src/actor.rs#L357-L458) adds local panic/error/freeze/join handling inside the raw incarnation boundary. Preserve callback semantics while collapsing redundant boundaries.

## What the duplication was

After the issue-56 stack, `RawInstance::run` (raw.rs) is a complete containment boundary around the incarnation future: it catches a panic as the primary diagnostic, freezes the mailbox and incarnation resources, joins them, and only then drops the context and the handler (and with it the actor state), re-raising with primary-over-cleanup preference — on return, `Err`, panic, and hard abort (`RawIncarnationOwner::drop`). `Handler::run` already relied on this for `A::init` panics and errors, which had no local wrapper at all.

The handler layer duplicated three pieces of that, all removed here:

- `CatchUnwindFuture` around `raw.recv()` and `on_stop` that only ever `resume_unwind`-ed the payload it caught — a pure passthrough to the raw boundary.
- `HandlerFailure`/`handle_message`, which latched a `handle` panic in a local enum only to resume it later; direct propagation reaches the same raw boundary with the same classification (payload preserved, panic hook fires once either way).
- `fail_after_teardown` (`freeze_resources` + `join_resources` on the `Err` path), which the raw boundary repeats unconditionally the moment `run` returns, before dropping the actor. Both operations are idempotent, and no user code runs between the handler's return and the raw boundary's freeze.

`Handler::run` now propagates callback errors with `?` and lets callback panics unwind directly.

## What was kept (the non-redundant part)

Storing the actor in `self.actor` rather than a frame local is load-bearing: it is what keeps the actor's drop *after* the resource join on the `Err` and panic paths (SPEC §5.5: "frozen, cancelled, and joined before actor state is dropped"). That stays, with a doc comment on `run` explaining the reliance on the raw boundary.

One incidental hardening: previously a panic out of `join_resources` during the handler-level `Err` teardown would unwind into the raw boundary as a *primary* (actor) panic, discarding the actor's `Err`. With the join deferred to the raw boundary it is classified as a cleanup panic, secondary to the actor's own diagnostic.

## Callback semantics preserved (unchanged)

- `init` error/panic → startup failure, no `on_stop` (path unchanged — was already unwrapped).
- Live or draining `handle` `Err`/panic → drain stops there, `on_stop` skipped, same exit classification.
- `Drain` delivers the frozen prefix with `is_draining()` contexts before `on_stop`; `Discard` drops it and still runs `on_stop`.
- `on_stop` panic supersedes the run outcome (`Panicked`).
- Resources frozen/joined before actor drop on return, error, and caught-panic paths; hard-abort ordering via `RawIncarnationOwner::drop` untouched.

Verified against the existing pins: `drain::handler_drain_errors_and_panics_keep_their_authoritative_exit`, `drain::handler_on_stop_panic_is_contained_and_classified`, `drain::handler_discard_skips_the_prefix_and_still_runs_on_stop`, `drain::handler_drain_and_on_stop_share_one_grace_budget`, `lifecycle::actor_destructor_panic_supersedes_the_completed_run_outcome`, plus the actor/raw/offload suites.

`./scripts/dev just ci` passes (371 tests + 3 doctests, clippy, fmt, docs, packaging, nixfmt).

Refs #55.