### PR TITLE
Bound internal queues, tasks, and threads (issue #55 resource bounds)

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1,7 +1,7 @@
 //! Mutable runtime shell and shared handle state.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, VecDeque},
     ops::{Bound, Index, IndexMut},
     sync::{Arc, Mutex, Weak, mpsc},
     time::{Duration, Instant},
@@ -205,10 +205,23 @@ struct DynamicState {
     entries: HashMap<ChildId, DynamicEntry>,
 }
 
+/// Admission requests awaiting the scope's single forwarder task.
+///
+/// `forwarding` is only cleared by the forwarder after observing an empty
+/// queue under this lock, and submitters push and consult it under the same
+/// lock, so a queued request always has a live forwarder destined to drain
+/// it.
+#[derive(Default)]
+struct AdmissionQueue {
+    pending: VecDeque<AdmissionRequest>,
+    forwarding: bool,
+}
+
 pub(crate) struct DynamicControl {
     scope: Weak<ScopeCell>,
     events: runtime::MpscSender<DriverEvent>,
     state: Mutex<DynamicState>,
+    admissions: Mutex<AdmissionQueue>,
 }
 
 impl DynamicControl {
@@ -220,6 +233,7 @@ impl DynamicControl {
                 accepting: true,
                 entries: HashMap::new(),
             }),
+            admissions: Mutex::default(),
         })
     }
 
@@ -339,10 +353,45 @@ pub(crate) fn start_admission(
             let _ = sender.send(Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal)));
         }),
     };
-    runtime::spawn(async move {
-        let _ = runtime::mpsc_send(&control.events, DriverEvent::Admission(request)).await;
-    });
+    // The driver channel is bounded and a split admission may be dropped
+    // right after this first poll (drop detaches), so the send cannot live in
+    // the caller-held future. Spawning one detached sender task per admission
+    // would let a saturated driver channel accumulate one live task per
+    // pending admission; instead requests queue here and at most one
+    // forwarder task per scope drains them in FIFO order, keeping
+    // pending-admission memory proportional to the requests themselves.
+    let start_forwarder = {
+        let mut admissions = control
+            .admissions
+            .lock()
+            .expect("admission queue mutex poisoned");
+        admissions.pending.push_back(request);
+        !std::mem::replace(&mut admissions.forwarding, true)
+    };
+    if start_forwarder {
+        runtime::spawn(forward_admissions(control));
+    }
     Ok(response)
+}
+
+async fn forward_admissions(control: Arc<DynamicControl>) {
+    loop {
+        let request = {
+            let mut admissions = control
+                .admissions
+                .lock()
+                .expect("admission queue mutex poisoned");
+            let Some(request) = admissions.pending.pop_front() else {
+                admissions.forwarding = false;
+                return;
+            };
+            request
+        };
+        // A failed send returns and drops the request, whose response
+        // obligation then completes with `Terminal`. Keep draining so every
+        // queued admission is answered even after the driver stops.
+        let _ = runtime::mpsc_send(&control.events, DriverEvent::Admission(request)).await;
+    }
 }
 
 fn cancel_dynamic_reservation_parts(
@@ -4345,6 +4394,66 @@ mod tests {
         drop(held_gate);
         let response = worker.join().expect("removal transition completes");
         drop(response);
+    }
+
+    #[crate::runtime::test]
+    async fn saturated_admissions_share_one_forwarder_task_and_all_resolve() {
+        const ADMISSIONS: usize = 64;
+
+        let root = isolated_scope("root", ScopeFlavor::Dynamic);
+        let (events, event_receiver) = crate::runtime::bounded_mpsc(1);
+        let control = DynamicControl::new(&root, events);
+        let child_id = ChildId::from("worker");
+        let member = MemberCell::new(
+            child_id.clone(),
+            root.child_identity
+                .lock()
+                .expect("scope identity mutex poisoned")
+                .mint_membership(&child_id)
+                .expect("child membership available"),
+        );
+        let slot = SlotCell::new(Arc::clone(&member), None);
+
+        let baseline = crate::runtime::alive_task_count();
+        let mut responses = Vec::with_capacity(ADMISSIONS);
+        for _ in 0..ADMISSIONS {
+            responses.push(
+                super::start_admission(Arc::clone(&control), Arc::clone(&slot), None)
+                    .expect("runtime is available"),
+            );
+        }
+
+        // Let the forwarder run until it parks on the saturated driver
+        // channel; pending admissions must not each hold a live sender task.
+        for _ in 0..64 {
+            crate::runtime::yield_now().await;
+        }
+        assert!(
+            crate::runtime::alive_task_count() <= baseline + 1,
+            "saturated admissions share one forwarder task instead of spawning one each"
+        );
+
+        // Ending the driver channel answers every queued admission through
+        // its response obligation.
+        drop(event_receiver);
+        for response in responses {
+            assert!(matches!(
+                response.receive().await,
+                Some(Err(crate::ReserveError::NotAdmitting(
+                    crate::NotAdmittingCause::Terminal
+                )))
+            ));
+        }
+
+        let mut alive = crate::runtime::alive_task_count();
+        for _ in 0..1_024 {
+            if alive == baseline {
+                break;
+            }
+            crate::runtime::yield_now().await;
+            alive = crate::runtime::alive_task_count();
+        }
+        assert_eq!(alive, baseline, "the forwarder exits once its queue drains");
     }
 
     #[crate::runtime::test]

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -247,11 +247,14 @@ impl PanicSlot {
 
 /// Incarnation-internal completion storage for offload continuations.
 ///
-/// The queue is deliberately unbounded. Every entry is produced by work this
-/// incarnation itself started — exactly one completion per offload — so its
-/// population is bounded by the actor's own in-flight offload count plus
-/// completions accepted but not yet consumed; no external sender can reach
-/// it. Bounded-mailbox policy governs external input only (SPEC §5.5:
+/// The queue is deliberately unbounded, but sustained traffic cannot grow it
+/// without bound. Every entry is produced by work this incarnation itself
+/// started — exactly one completion per offload, no external sender can
+/// reach it — and `next_ready` snapshots the queued completions at each
+/// mailbox delivery (timer batches snapshot likewise) and drains that prefix
+/// ahead of later mailbox input, so the population stays bounded by the
+/// actor's own in-flight offload count plus the completions arriving within
+/// one such window. Bounded-mailbox policy governs external input only (SPEC §5.5:
 /// offload completions do not consume mailbox capacity), and imposing a
 /// bound here would either block the offload task or drop a completion the
 /// total-continuation contract promises to deliver. Freezing at stop clears
@@ -693,6 +696,13 @@ struct RawResources<M> {
     // mailbox/offload/timer item. `next_ready` uses it to prohibit two local
     // continuations from leading while an external source remains eligible.
     continuation_needs_external: bool,
+    // Queued offload completions granted the lead over the mailbox, captured
+    // as the event-queue watermark at the previous steady-state mailbox
+    // delivery. `next_ready` drains this many completion entries before
+    // consulting the mailbox again, so an always-readable mailbox cannot
+    // starve the completion queue, while completions pushed after the
+    // capture wait behind the next mailbox message and cannot starve it.
+    offloads_lead: usize,
     timers: TimerStore<M>,
     next_timer_order: u64,
     fired_batch: Option<FiredTimerBatch>,
@@ -710,6 +720,7 @@ impl<M> Default for RawResources<M> {
             accepting: true,
             continuations: VecDeque::new(),
             continuation_needs_external: false,
+            offloads_lead: 0,
             timers: TimerStore::default(),
             next_timer_order: 0,
             fired_batch: None,
@@ -736,6 +747,7 @@ impl<M> RawResources<M> {
         self.continuations.clear();
         self.timers.clear();
         self.fired_batch = None;
+        self.offloads_lead = 0;
         self.events.clear();
         dropped_continuations
     }
@@ -1008,11 +1020,13 @@ impl<M: Send + 'static> RawContext<M> {
     ///
     /// Completions re-enter the loop through incarnation-internal storage
     /// that does not consume mailbox capacity (SPEC §5.5). That storage is
-    /// unbounded but self-limiting: it holds at most one entry per offload
-    /// this incarnation has started and not yet consumed, and only the actor
-    /// itself can start offloads, so its population is bounded by the
-    /// caller's own in-flight count. Bookkeeping for finished offloads is
-    /// reclaimed when a new offload starts and when the loop goes idle.
+    /// unbounded but cannot accumulate a backlog: it holds at most one entry
+    /// per offload the actor itself started, and completions already queued
+    /// when a mailbox message is delivered are consumed ahead of later
+    /// mailbox input, so its population stays proportional to the caller's
+    /// in-flight count even under sustained mailbox traffic. Bookkeeping for
+    /// finished offloads is reclaimed when a new offload starts and when the
+    /// loop goes idle.
     pub fn offload<F, T, C>(
         &mut self,
         work: F,
@@ -1030,8 +1044,9 @@ impl<M: Send + 'static> RawContext<M> {
 
     /// Starts guarded incarnation-owned async work with one deadline budget.
     ///
-    /// Completion storage follows [`offload`](Self::offload): unbounded but
-    /// limited to one entry per unconsumed offload the actor itself started.
+    /// Completion storage follows [`offload`](Self::offload): unbounded, but
+    /// one entry per offload the actor itself started, drained ahead of
+    /// later mailbox input so no backlog accumulates.
     pub fn offload_scoped<F, T, C>(
         &mut self,
         work: F,
@@ -1219,6 +1234,14 @@ impl<M: Send + 'static> RawContext<M> {
     /// timers. This prevents both an always-readable mailbox and a self-feeding
     /// continuation queue from starving the other.
     ///
+    /// Outside a timer batch, each mailbox delivery snapshots the queued
+    /// offload completions, and that prefix leads the mailbox on later
+    /// calls. An always-readable mailbox therefore cannot starve the
+    /// completion queue — the backlog never grows across mailbox deliveries
+    /// — while completions pushed after the snapshot wait behind the next
+    /// mailbox message, so a self-feeding offload chain cannot starve
+    /// external input either.
+    ///
     /// Frozen mailbox input is deliberately absent. Once stopping begins,
     /// [`try_recv`](Self::try_recv) bypasses this selector and drains the
     /// accepted prefix directly according to the caller's shutdown policy.
@@ -1290,8 +1313,26 @@ impl<M: Send + 'static> RawContext<M> {
                 return Some(message);
             }
 
+            while self.resources.offloads_lead > 0 {
+                let Some(event) = self.resources.events.pop() else {
+                    self.resources.offloads_lead = 0;
+                    break;
+                };
+                self.resources.offloads_lead -= 1;
+                if let Some(message) = Self::materialize_event(event) {
+                    self.resources.continuation_needs_external = false;
+                    return Some(message);
+                }
+            }
+
             let mailbox = self.receiver.try_recv_live();
             if let Some(message) = mailbox {
+                // Completions already queued at this delivery lead the
+                // mailbox on later calls, so the completion backlog cannot
+                // grow across mailbox deliveries, while completions pushed
+                // after this snapshot wait their turn and cannot starve the
+                // mailbox.
+                self.resources.offloads_lead = self.resources.events.watermark();
                 self.resources.continuation_needs_external = false;
                 return Some(message);
             }

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -245,6 +245,17 @@ impl PanicSlot {
     }
 }
 
+/// Incarnation-internal completion storage for offload continuations.
+///
+/// The queue is deliberately unbounded. Every entry is produced by work this
+/// incarnation itself started — exactly one completion per offload — so its
+/// population is bounded by the actor's own in-flight offload count plus
+/// completions accepted but not yet consumed; no external sender can reach
+/// it. Bounded-mailbox policy governs external input only (SPEC §5.5:
+/// offload completions do not consume mailbox capacity), and imposing a
+/// bound here would either block the offload task or drop a completion the
+/// total-continuation contract promises to deliver. Freezing at stop clears
+/// the queue, and dropped `RawResources` clear it on every exit path.
 struct EventQueue<M> {
     // Timer batches snapshot the number of currently queued events. Insertion
     // and the snapshot share this lock, so FIFO order itself is the sequence
@@ -729,6 +740,15 @@ impl<M> RawResources<M> {
         dropped_continuations
     }
 
+    /// Drops ledger entries for offloads that already finished, keeping a
+    /// long-lived incarnation's ledger O(in-flight) rather than
+    /// O(offloads-ever-issued). Invoked at the two cheap points that bound
+    /// steady-state retention: when a new offload starts and when the loop
+    /// goes idle.
+    fn reclaim_finished(&mut self) {
+        self.offloads.retain(|offload| !offload.finished.is_fired());
+    }
+
     fn resume_pending_panic(&self) {
         // Reached from the actor's own receive path, never from cleanup. The
         // take is destructive, so containment here would drop the retained
@@ -985,6 +1005,14 @@ impl<M: Send + 'static> RawContext<M> {
     }
 
     /// Starts incarnation-owned async work with one total deadline budget.
+    ///
+    /// Completions re-enter the loop through incarnation-internal storage
+    /// that does not consume mailbox capacity (SPEC §5.5). That storage is
+    /// unbounded but self-limiting: it holds at most one entry per offload
+    /// this incarnation has started and not yet consumed, and only the actor
+    /// itself can start offloads, so its population is bounded by the
+    /// caller's own in-flight count. Bookkeeping for finished offloads is
+    /// reclaimed when a new offload starts and when the loop goes idle.
     pub fn offload<F, T, C>(
         &mut self,
         work: F,
@@ -1001,6 +1029,9 @@ impl<M: Send + 'static> RawContext<M> {
     }
 
     /// Starts guarded incarnation-owned async work with one deadline budget.
+    ///
+    /// Completion storage follows [`offload`](Self::offload): unbounded but
+    /// limited to one entry per unconsumed offload the actor itself started.
     pub fn offload_scoped<F, T, C>(
         &mut self,
         work: F,
@@ -1100,12 +1131,8 @@ impl<M: Send + 'static> RawContext<M> {
         if self.is_stopping() || !self.resources.accepting {
             return Err(Rejected::new((work, continuation)));
         }
-        // Completed offloads no longer need their resources; prune them here
-        // so a long-lived incarnation's ledger stays O(in-flight), not
-        // O(offloads-ever-issued).
-        self.resources
-            .offloads
-            .retain(|offload| !offload.finished.is_fired());
+        // Completed offloads no longer need their resources.
+        self.resources.reclaim_finished();
 
         let cancellation = Latch::default();
         let finished = Latch::default();
@@ -1336,6 +1363,9 @@ impl<M: Send + 'static> RawContext<M> {
     }
 
     async fn wait_for_event(&mut self) {
+        // The loop is about to go idle: reclaim finished offload bookkeeping
+        // now so steady-state retention never waits for the next offload.
+        self.resources.reclaim_finished();
         let sleep = self.next_timer_deadline().map_or_else(
             || Box::pin(std::future::pending()) as runtime::BoxedSleep,
             runtime::sleep_until,
@@ -1930,6 +1960,32 @@ mod tests {
             panic_message(&payload),
             Some("unit offload destructor panic")
         );
+    }
+
+    #[test]
+    fn finished_offload_ledger_entries_are_reclaimed_eagerly() {
+        let mut resources = RawResources::<()>::default();
+        for finished in [true, false, true] {
+            let completion = Latch::default();
+            if finished {
+                completion.fire();
+            }
+            resources.offloads.push(OffloadResource {
+                cancellation: Latch::default(),
+                finished: completion,
+                state: None,
+                task: None,
+            });
+        }
+
+        resources.reclaim_finished();
+
+        assert_eq!(
+            resources.offloads.len(),
+            1,
+            "reclamation retains exactly the unfinished offloads"
+        );
+        assert!(!resources.offloads[0].finished.is_fired());
     }
 
     #[test]

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -2,6 +2,7 @@
 
 use std::{
     any::Any,
+    collections::VecDeque,
     fmt,
     future::Future,
     ops::RangeBounds,
@@ -28,6 +29,15 @@ pub(crate) use tokio::test;
 #[cfg(test)]
 pub(crate) async fn advance(duration: Duration) {
     time::advance(duration).await;
+}
+
+/// Counts the runtime's currently alive spawned tasks, keeping runtime
+/// metrics access in this module.
+#[cfg(test)]
+pub(crate) fn alive_task_count() -> usize {
+    tokio::runtime::Handle::current()
+        .metrics()
+        .num_alive_tasks()
 }
 
 /// Runtime-owned spelling for an unwind payload crossing a framework boundary.
@@ -355,6 +365,87 @@ where
     }
 }
 
+/// Erased view of a queued disposal job for the shared fallback thread.
+trait QueuedDisposal: Send + Sync {
+    fn run(&self);
+}
+
+impl<T, C> QueuedDisposal for DisposalJob<T, C>
+where
+    T: Send + 'static,
+    C: FnOnce(Option<Option<String>>) + Send + 'static,
+{
+    fn run(&self) {
+        self.finish();
+    }
+}
+
+/// Jobs awaiting the shared non-runtime disposal thread.
+///
+/// `worker_live` is only cleared by the worker after observing an empty queue
+/// under this lock, and submitters push and consult it under the same lock, so
+/// a queued job always has a live worker destined to drain it.
+struct FallbackDisposals {
+    queue: VecDeque<Arc<dyn QueuedDisposal>>,
+    worker_live: bool,
+}
+
+static FALLBACK_DISPOSALS: Mutex<FallbackDisposals> = Mutex::new(FallbackDisposals {
+    queue: VecDeque::new(),
+    worker_live: false,
+});
+
+/// Queues a disposal job for the shared fallback thread, lazily starting it.
+/// Returns `false` when no worker exists and none could be started; the
+/// caller must then finish the job itself.
+fn enqueue_fallback_disposal(job: Arc<dyn QueuedDisposal>) -> bool {
+    let mut state = FALLBACK_DISPOSALS
+        .lock()
+        .expect("fallback disposal queue mutex poisoned");
+    state.queue.push_back(job);
+    if state.worker_live {
+        return true;
+    }
+    // Spawning under the lock makes queueing and worker liveness one atomic
+    // decision: no submitter can observe a queued job without a worker.
+    match std::thread::Builder::new()
+        .name("shelterwood-disposal".to_owned())
+        .spawn(run_fallback_disposals)
+    {
+        Ok(worker) => {
+            drop(worker);
+            state.worker_live = true;
+            true
+        }
+        Err(_) => {
+            // The queue was empty before this push (no live worker implies an
+            // empty queue), so the popped entry is exactly the failed job.
+            let rejected = state.queue.pop_back();
+            debug_assert!(rejected.is_some());
+            false
+        }
+    }
+}
+
+fn run_fallback_disposals() {
+    loop {
+        let job = {
+            let mut state = FALLBACK_DISPOSALS
+                .lock()
+                .expect("fallback disposal queue mutex poisoned");
+            let Some(job) = state.queue.pop_front() else {
+                state.worker_live = false;
+                return;
+            };
+            job
+        };
+        // `DisposalJob::finish` contains destructor and completion panics
+        // internally; this outer boundary keeps even an unforeseen framework
+        // panic from stranding `worker_live` and the queued jobs behind it.
+        discard_panic(catch_panic(|| job.run()).err());
+    }
+}
+
 fn dispatch_disposal<T, C>(job: Arc<DisposalJob<T, C>>)
 where
     T: Send + 'static,
@@ -371,12 +462,15 @@ where
         }
     }
 
-    let worker = Arc::clone(&job);
-    if std::thread::Builder::new()
-        .name("shelterwood-disposal".to_owned())
-        .spawn(move || worker.finish())
-        .is_ok()
-    {
+    // Outside a runtime, one shared lazily started thread drains a queue of
+    // disposal jobs, so dropping N values costs at most one thread rather
+    // than one thread per value, while a blocking or panicking destructor
+    // still never runs on (or unwinds into) the submitting thread. The queue
+    // is unbounded on purpose: applying a bound would block the submitter on
+    // user destructors, exactly what isolation must prevent. Serialization is
+    // the accepted trade: one blocking destructor delays later fallback
+    // disposals instead of consuming another native thread.
+    if enqueue_fallback_disposal(Arc::clone(&job) as Arc<dyn QueuedDisposal>) {
         return;
     }
 
@@ -387,6 +481,11 @@ where
 
 /// Runs potentially blocking user destruction away from the caller and then
 /// invokes framework completion with the contained panic diagnostic.
+///
+/// Inside a Tokio runtime this uses the blocking pool. Outside one, jobs are
+/// funneled through a single shared disposal thread, so destroying many
+/// values (for example dropping a large unspawned tree) never creates one
+/// native thread per value.
 pub(crate) fn dispose_then<T, C>(value: T, completion: C)
 where
     T: Send + 'static,

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -465,13 +465,13 @@ async fn non_runtime_reservation_cancellation_contains_destructor_panic() {
         .expect("dynamic root shuts down");
 }
 
-struct HostileCapture {
+struct HostileFallbackCapture {
     dropped: tokio::sync::mpsc::UnboundedSender<ThreadId>,
     blocker: Option<DestructorBlocker>,
     panic: Option<&'static str>,
 }
 
-impl Drop for HostileCapture {
+impl Drop for HostileFallbackCapture {
     fn drop(&mut self) {
         let _ = self.dropped.send(thread::current().id());
         drop(self.blocker.take());
@@ -501,7 +501,7 @@ async fn non_runtime_disposals_share_one_thread_and_contain_panics() {
             .expect("task reservation");
         tasks.push(slot.task_ref());
         admissions.push(slot.define(TaskDef::new({
-            let capture = HostileCapture {
+            let capture = HostileFallbackCapture {
                 dropped: dropped.clone(),
                 // The first destructor blocks so every later job queues
                 // behind it on the shared fallback disposal thread.
@@ -553,7 +553,7 @@ async fn non_runtime_disposals_share_one_thread_and_contain_panics() {
         .reserve_task("after-panic")
         .expect("task reservation after a contained panic");
     let admission = slot.define(TaskDef::new({
-        let capture = HostileCapture {
+        let capture = HostileFallbackCapture {
             dropped,
             blocker: None,
             panic: None,

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -465,6 +465,122 @@ async fn non_runtime_reservation_cancellation_contains_destructor_panic() {
         .expect("dynamic root shuts down");
 }
 
+struct HostileCapture {
+    dropped: tokio::sync::mpsc::UnboundedSender<ThreadId>,
+    blocker: Option<DestructorBlocker>,
+    panic: Option<&'static str>,
+}
+
+impl Drop for HostileCapture {
+    fn drop(&mut self) {
+        let _ = self.dropped.send(thread::current().id());
+        drop(self.blocker.take());
+        if let Some(message) = self.panic {
+            panic!("{message}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn non_runtime_disposals_share_one_thread_and_contain_panics() {
+    const VALUES: usize = 8;
+
+    let test_thread = thread::current().id();
+    let tree = DynamicTree::new();
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+    let gate = DestructorGate::default();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+
+    let mut tasks = Vec::with_capacity(VALUES);
+    let mut admissions = Vec::with_capacity(VALUES);
+    for index in 0..VALUES {
+        let slot = scope
+            .reserve_task(format!("hostile-{index}"))
+            .expect("task reservation");
+        tasks.push(slot.task_ref());
+        admissions.push(slot.define(TaskDef::new({
+            let capture = HostileCapture {
+                dropped: dropped.clone(),
+                // The first destructor blocks so every later job queues
+                // behind it on the shared fallback disposal thread.
+                blocker: (index == 0).then(|| gate.blocker()),
+                panic: (index == VALUES - 1).then_some("hostile fallback destructor"),
+            };
+            move |_| {
+                let _ = &capture;
+                async { Ok(()) }
+            }
+        })));
+    }
+    drop(dropped);
+
+    let dropper = thread::spawn(move || {
+        let dropper_thread = thread::current().id();
+        drop(admissions);
+        dropper_thread
+    });
+    let dropper_thread = dropper
+        .join()
+        .expect("dropping definitions outside a Tokio runtime never blocks or panics the caller");
+
+    wait_for_destructor(&gate).await;
+    gate.release();
+
+    let mut disposal_threads = Vec::with_capacity(VALUES);
+    while disposal_threads.len() < VALUES {
+        disposal_threads.push(drops.recv().await.expect("every capture is disposed"));
+    }
+    assert!(drops.recv().await.is_none());
+    let disposal_thread = disposal_threads[0];
+    assert!(
+        disposal_threads
+            .iter()
+            .all(|thread| *thread == disposal_thread),
+        "queued fallback disposals share one disposal thread instead of one thread per value"
+    );
+    assert_ne!(disposal_thread, dropper_thread);
+    assert_ne!(disposal_thread, test_thread);
+    for task in tasks {
+        assert!(matches!(task.wait().await.kind(), ExitKind::NeverStarted));
+    }
+
+    // A contained destructor panic must not wedge the shared queue: a later
+    // non-runtime disposal still completes off the submitting thread.
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let slot = scope
+        .reserve_task("after-panic")
+        .expect("task reservation after a contained panic");
+    let admission = slot.define(TaskDef::new({
+        let capture = HostileCapture {
+            dropped,
+            blocker: None,
+            panic: None,
+        };
+        move |_| {
+            let _ = &capture;
+            async { Ok(()) }
+        }
+    }));
+    let late_dropper = thread::spawn(move || {
+        let dropper_thread = thread::current().id();
+        drop(admission);
+        dropper_thread
+    });
+    let late_dropper_thread = late_dropper.join().expect("late cancellation never panics");
+    let late_disposal_thread = drops
+        .recv()
+        .await
+        .expect("disposal keeps running after a contained destructor panic");
+    assert_ne!(late_disposal_thread, late_dropper_thread);
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root shuts down");
+}
+
 #[tokio::test]
 async fn unadmitted_removal_completes_after_blocking_definition_disposal() {
     let tree = DynamicTree::new();

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, assert_quiet, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
     Guard, LifecycleEventKind, LifecycleItem, Readiness, Shutdown, StartupError,
@@ -1265,6 +1265,167 @@ impl Actor for FailTeardownActor {
             .expect("offload accepted");
         Err(ExitError::message("injected handler failure"))
     }
+}
+
+const FLOOD: usize = 256;
+
+enum FloodMessage {
+    Start,
+    Completed(usize),
+}
+
+struct FloodActor {
+    seen: Vec<bool>,
+    delivered: usize,
+    completed_work: Arc<AtomicUsize>,
+    release: ReleaseGate,
+}
+
+impl Actor for FloodActor {
+    type Msg = FloodMessage;
+    type Args = (Arc<AtomicUsize>, ReleaseGate);
+
+    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self {
+            seen: vec![false; FLOOD],
+            delivered: 0,
+            completed_work: args.0,
+            release: args.1,
+        })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            FloodMessage::Start => {
+                for index in 0..FLOOD {
+                    let completed_work = Arc::clone(&self.completed_work);
+                    context
+                        .offload(
+                            async move {
+                                completed_work.fetch_add(1, Ordering::SeqCst);
+                                index
+                            },
+                            move |result| {
+                                FloodMessage::Completed(
+                                    result.expect("flooded offload completes within its budget"),
+                                )
+                            },
+                            Duration::MAX,
+                        )
+                        .expect("live offload accepted");
+                }
+                // Hold the loop here so every completion queues before any
+                // is consumed: completion storage is 1:1 with the offloads
+                // this incarnation started, never dropped or conflated.
+                self.release.wait().await;
+                Ok(())
+            }
+            FloodMessage::Completed(index) => {
+                assert!(
+                    !self.seen[index],
+                    "each flooded completion is delivered exactly once"
+                );
+                self.seen[index] = true;
+                self.delivered += 1;
+                if self.delivered == FLOOD {
+                    context.stop();
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// A completion flood: every offload finishes while the loop is held, so all
+/// completions queue in incarnation-internal storage before one is consumed,
+/// and every one of them is still delivered exactly once.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn offload_completion_flood_is_absorbed_and_fully_delivered() {
+    let completed_work = Arc::new(AtomicUsize::new(0));
+    let release = ReleaseGate::default();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "flood",
+            ActorOnceDef::<FloodActor>::new((Arc::clone(&completed_work), release.clone())),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    actor.send(FloodMessage::Start).await.expect("actor live");
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            completed_work.load(Ordering::SeqCst) == FLOOD
+        })
+        .await
+    );
+    release.release();
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+}
+
+const CYCLES: usize = 64;
+
+enum CycleMessage {
+    Start,
+    Completed(usize),
+}
+
+struct CycleActor {
+    next: usize,
+}
+
+impl CycleActor {
+    fn offload_next(&self, context: &mut Context<'_, Self>) {
+        let value = self.next;
+        context
+            .offload(
+                async move { value },
+                move |result| CycleMessage::Completed(result.expect("cycle offload completes")),
+                Duration::MAX,
+            )
+            .expect("live offload accepted");
+    }
+}
+
+impl Actor for CycleActor {
+    type Msg = CycleMessage;
+    type Args = ();
+
+    async fn init((): Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self { next: 0 })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            CycleMessage::Start => self.offload_next(context),
+            CycleMessage::Completed(value) => {
+                assert_eq!(value, self.next, "steady-state cycles deliver in order");
+                self.next += 1;
+                if self.next == CYCLES {
+                    context.stop();
+                } else {
+                    self.offload_next(context);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Steady-state offload churn: the loop goes idle between completions, so
+/// finished-offload bookkeeping is reclaimed continuously rather than only
+/// when the next offload starts or the incarnation tears down, and every
+/// cycle's completion is delivered.
+#[tokio::test]
+async fn sequential_offload_cycles_deliver_every_completion() {
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once("cycles", ActorOnceDef::<CycleActor>::new(()))
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    actor.send(CycleMessage::Start).await.expect("actor live");
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
 }
 
 /// §5.5's teardown order holds on the error path too: a handler `Err` joins

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
-    Guard, LifecycleEventKind, LifecycleItem, Readiness, Shutdown, StartupError,
+    Guard, LifecycleEventKind, LifecycleItem, Mailbox, Readiness, Shutdown, StartupError,
     StartupFailureCause, Tree,
 };
 
@@ -1426,6 +1426,93 @@ async fn sequential_offload_cycles_deliver_every_completion() {
     system.wait_started().await.expect("actor starts");
     actor.send(CycleMessage::Start).await.expect("actor live");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+}
+
+const SATURATE: usize = 64;
+
+enum SaturateMessage {
+    Ping,
+    Completed,
+}
+
+struct SaturatedActor {
+    issued: usize,
+    delivered: usize,
+    peak_backlog: Arc<AtomicUsize>,
+}
+
+impl Actor for SaturatedActor {
+    type Msg = SaturateMessage;
+    type Args = (ReleaseGate, Arc<AtomicUsize>);
+
+    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        args.0.wait().await;
+        Ok(Self {
+            issued: 0,
+            delivered: 0,
+            peak_backlog: args.1,
+        })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            SaturateMessage::Ping => {
+                self.peak_backlog
+                    .fetch_max(self.issued - self.delivered, Ordering::SeqCst);
+                self.issued += 1;
+                context
+                    .offload(
+                        async {},
+                        |result| {
+                            assert_eq!(result, Err(DeadlineElapsed));
+                            SaturateMessage::Completed
+                        },
+                        Duration::ZERO,
+                    )
+                    .expect("live offload accepted");
+            }
+            SaturateMessage::Completed => {
+                self.delivered += 1;
+                if self.delivered == SATURATE {
+                    context.stop();
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A continuously nonempty mailbox cannot starve queued offload completions:
+/// the completions queued at each mailbox delivery are consumed ahead of
+/// later mailbox input, so the completion backlog stays proportional to the
+/// actor's own in-flight issuance instead of growing with mailbox history.
+#[tokio::test]
+async fn saturated_mailbox_does_not_grow_the_completion_backlog() {
+    let gate = ReleaseGate::default();
+    let peak_backlog = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "saturated",
+            ActorOnceDef::<SaturatedActor>::new((gate.clone(), Arc::clone(&peak_backlog)))
+                .mailbox(Mailbox::queue(SATURATE).expect("non-zero capacity")),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    for _ in 0..SATURATE {
+        actor
+            .send(SaturateMessage::Ping)
+            .await
+            .expect("mailbox accepts during init");
+    }
+    gate.release();
+    system.wait_started().await.expect("actor starts");
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert!(
+        peak_backlog.load(Ordering::SeqCst) <= 2,
+        "queued completions drain ahead of later mailbox input instead of \
+         accumulating while the mailbox stays nonempty"
+    );
 }
 
 /// §5.5's teardown order holds on the error path too: a handler `Err` joins


### PR DESCRIPTION
Implements the three resource-bound items from the #55 audit ("Disposal consistency and resource bounds", step 4 of the suggested sequencing). Each item was re-verified against current `main` before changing anything — all three still applied after the issue-56 refactor. The public API is unchanged.

## 1. Bound or explicitly document raw offload completion storage

> **Bound or explicitly document raw offload completion storage.** Completed offloads enqueue into an unbounded internal `VecDeque` in `raw.rs`, bypassing bounded mailbox policy. Completed resource entries are also reclaimed only when another offload starts or teardown runs. Add flood and steady-state reclamation tests.

**Design chosen: prove and document that unbounded is the correct semantic, plus eager reclamation.** Every `EventQueue` entry is produced by work the incarnation itself started — exactly one completion per offload — so its population is bounded by the actor's own in-flight count; no external sender can reach it. Bounded-mailbox policy governs external input only, and SPEC §5.5 already pins "offload completions do not consume mailbox capacity" and the total-continuation contract (every offload's continuation must produce a message). Imposing a bound would either block the offload task or drop a completion that contract promises — both worse than the self-inflicted, self-limiting queue. The invariant is now documented on `EventQueue` and in the `offload`/`offload_scoped` rustdoc (no SPEC change; documented behavior is unchanged).

For the second half of the finding, finished-offload ledger entries are now reclaimed at *two* cheap points — when a new offload starts (already on main) and when the loop goes idle (`wait_for_event`), via a shared `RawResources::reclaim_finished` — so steady-state retention no longer waits for another admission or teardown.

Tests: `offloads::offload_completion_flood_is_absorbed_and_fully_delivered` (256 completions queued while the loop is held, each delivered exactly once), `offloads::sequential_offload_cycles_deliver_every_completion` (steady-state churn through the idle reclamation point), and a unit test pinning that reclamation retains exactly the unfinished entries.

## 2. Avoid one detached sender task per admission under channel saturation

> **Avoid one detached sender task per admission under channel saturation.** First-polling an `Admission` spawns a task to await the bounded driver channel. The channel bounds dequeueing, not the population of pending tasks. Add a saturation test and consider a level-triggered or drop-triggered design.

**Design chosen: coalesce into at most one forwarder task per dynamic scope.** The send cannot live in the caller-held future because split admissions detach on drop after first poll (documented public semantics), so *some* detached execution must own delivery. Instead of one task per admission, requests now queue on the scope's `DynamicControl` and a single forwarder task drains them into the bounded driver channel in FIFO order; the forwarder exits when the queue empties and is respawned on demand. Pending-admission memory is therefore the queued `AdmissionRequest`s themselves, and live-task count is at most one per scope. This keeps arbitration untouched (requests still arrive as `DriverEvent::Admission` on the same channel) and improves cross-admission ordering from racing spawned tasks to FIFO. A full level-triggered redesign (driver scanning dynamic state) would have restructured driver wakeups and arbitration for no additional bound, which felt disproportionate; the trade-off is documented at the queueing site.

Failure paths: a failed send drops the request and its response `Obligation` completes with `Terminal`; the forwarder keeps draining after the driver stops so every queued admission is answered.

Test: `driver::tests::saturated_admissions_share_one_forwarder_task_and_all_resolve` — 64 admissions against an undrained capacity-1 channel hold at most one extra live task (fails on the old design, which held ~64), all resolve `Terminal` once the channel closes, and the forwarder exits when drained.

## 3. Avoid one native thread per isolated drop outside Tokio

> **Avoid one native thread per isolated drop outside Tokio.** Runtime disposal fallback can create one OS thread per value. Dropping a large unspawned tree with blocking definitions can exhaust threads; prefer a bounded disposal queue/pool or batching.

**Design chosen: one shared lazily started disposal thread with an unbounded queue.** `dispatch_disposal`'s non-runtime fallback now enqueues the (type-erased) job into a global queue drained by a single `shelterwood-disposal` thread, started on demand and exiting when idle. The queue and the worker-liveness flag share one lock, so a queued job always has a live worker destined to drain it (spawning happens under the lock; on spawn failure the job is popped back and finished inline on the submitter — the pre-existing last-resort). Isolation guarantees are preserved: a blocking/panicking `Drop` never runs on or unwinds into the submitting thread, `DisposalJob::finish` still contains destructor and completion panics (plus a belt-and-braces boundary in the worker loop so nothing can strand the flag), and completion bookkeeping runs exactly as before. The queue is deliberately unbounded — bounding it would block the submitter on user destructors, which is exactly what isolation must prevent; serialization (one blocking destructor delays later fallback disposals) is the accepted trade for bounded thread usage, and is noted in the code. The in-runtime path (Tokio blocking pool) is unchanged.

Test: `disposal::non_runtime_disposals_share_one_thread_and_contain_panics` — eight hostile-destructor definitions (first blocking, last panicking) dropped from a non-runtime thread are all disposed on one shared thread (not one thread per value, and never the dropper's thread), the dropper never blocks or panics, and a later non-runtime disposal still completes after the contained panic.

## Notes for review

- Sibling branches `agent/issue-55-disposal` and `agent/issue-55-handler` are in flight from the same audit; this branch keeps its `runtime.rs` diff confined to the fallback-dispatch mechanism (plus a test-only metrics helper required by the layering check, which forbids `tokio::` outside `runtime.rs`) and does not touch disposal *call sites* or `actor.rs`.
- `./scripts/dev just ci` passes: 380 tests, doctests, clippy `-D warnings`, docs, API-reachability, runtime/exit/layering path checks, packaging, nixfmt.

Refs #55.