### PR TITLE
Test coverage follow-ups from the issue #55 audit

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -438,6 +438,24 @@ pub(crate) struct ScopeCell {
     observation_closed: AtomicBool,
     #[cfg(test)]
     runtime_storage: Mutex<RuntimeStorage>,
+    #[cfg(test)]
+    gate_capture_probe: Mutex<Option<std::sync::mpsc::Sender<GateCapture>>>,
+}
+
+/// One observation-gate capture reported to a test probe.
+///
+/// A capture is reported after a thread has cloned the gate it is about to
+/// acquire and before it blocks on that acquisition. Unit tests use these
+/// reports as explicit barriers in place of scheduler or strong-count
+/// polling: receiving a capture proves the reporting thread committed to the
+/// gate that was current at that instant.
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum GateCapture {
+    /// [`ScopeCell::with_observation_gate`] captured its current gate.
+    Observation,
+    /// Gate adoption captured an obsolete gate it must acquire to hand off.
+    Adoption,
 }
 
 #[cfg(test)]
@@ -481,6 +499,8 @@ impl ScopeCell {
             observation_closed: AtomicBool::new(false),
             #[cfg(test)]
             runtime_storage: Mutex::new(RuntimeStorage::default()),
+            #[cfg(test)]
+            gate_capture_probe: Mutex::new(None),
         })
     }
 
@@ -523,6 +543,30 @@ impl ScopeCell {
         self.current_observation_gate()
     }
 
+    /// Installs a probe reporting every gate capture made through this scope.
+    #[cfg(test)]
+    pub(crate) fn probe_gate_captures(&self) -> std::sync::mpsc::Receiver<GateCapture> {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        *self
+            .gate_capture_probe
+            .lock()
+            .expect("gate capture probe mutex poisoned") = Some(sender);
+        receiver
+    }
+
+    #[cfg(test)]
+    fn report_gate_capture(&self, capture: GateCapture) {
+        if let Some(probe) = &*self
+            .gate_capture_probe
+            .lock()
+            .expect("gate capture probe mutex poisoned")
+        {
+            // The probe channel is unbounded, so reporting never blocks and
+            // cannot reorder the acquisition it announces.
+            let _ = probe.send(capture);
+        }
+    }
+
     fn current_observation_gate(&self) -> Arc<Mutex<()>> {
         Arc::clone(
             &self
@@ -538,6 +582,9 @@ impl ScopeCell {
             if Arc::ptr_eq(&current, gate) {
                 return;
             }
+
+            #[cfg(test)]
+            self.report_gate_capture(GateCapture::Adoption);
 
             // An operation that passed `with_observation_gate`'s pointer
             // check may finish its complete edge before handoff. An operation
@@ -601,6 +648,8 @@ impl ScopeCell {
         let mut operation = Some(operation);
         loop {
             let gate = self.current_observation_gate();
+            #[cfg(test)]
+            self.report_gate_capture(GateCapture::Observation);
             let guard = gate
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2973,6 +2973,12 @@ mod tests {
         resident_projection, restart_shutdown_work, run_nested_tree, run_scope_incarnation,
     };
 
+    /// Bounds every gate-capture probe wait. The probe sender lives inside
+    /// the scope cell for the whole test, so the channel can never
+    /// disconnect: a regression that keeps a thread from reaching its gate
+    /// must time out with a diagnostic rather than hang the test on `recv`.
+    const CAPTURE_PROBE_WAIT: Duration = Duration::from_secs(10);
+
     fn isolated_scope(id: &'static str, flavor: ScopeFlavor) -> Arc<ScopeCell> {
         let mut identity = ScopeIdentity::new();
         let id = ChildId::from(id);
@@ -3160,7 +3166,9 @@ mod tests {
         // The capture report proves the observer committed to the
         // pre-admission gate, which the held guard keeps it from acquiring.
         assert_eq!(
-            captures.recv().expect("the observer reports its capture"),
+            captures
+                .recv_timeout(CAPTURE_PROBE_WAIT)
+                .expect("the observer reports its capture within the bound"),
             GateCapture::Observation
         );
 
@@ -3172,7 +3180,9 @@ mod tests {
         worker.join().expect("observer follows the gate handoff");
 
         assert_eq!(
-            captures.recv().expect("the observer reports its retry"),
+            captures
+                .recv_timeout(CAPTURE_PROBE_WAIT)
+                .expect("the observer reports its retry within the bound"),
             GateCapture::Observation,
             "the handoff forces one retry capture on the root gate"
         );
@@ -3472,8 +3482,8 @@ mod tests {
             .expect("observer enters the pre-admission edge");
         assert_eq!(
             captures
-                .recv()
-                .expect("the observation edge reports its capture"),
+                .recv_timeout(CAPTURE_PROBE_WAIT)
+                .expect("the observation edge reports its capture within the bound"),
             GateCapture::Observation
         );
 
@@ -3489,7 +3499,9 @@ mod tests {
         // is blocked behind the complete observation edge rather than
         // replacing it concurrently, so adoption cannot yet have completed.
         assert_eq!(
-            captures.recv().expect("adoption reports its capture"),
+            captures
+                .recv_timeout(CAPTURE_PROBE_WAIT)
+                .expect("adoption reports its capture within the bound"),
             GateCapture::Adoption
         );
         assert!(matches!(
@@ -4370,7 +4382,9 @@ mod tests {
         // until that gate is released, so a single acquisition attempt decides
         // whether removal reached the gate while still holding the state.
         assert_eq!(
-            captures.recv().expect("removal reports its gate capture"),
+            captures
+                .recv_timeout(CAPTURE_PROBE_WAIT)
+                .expect("removal reports its gate capture within the bound"),
             GateCapture::Observation
         );
         drop(

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 
 #[cfg(test)]
-use crate::cells::{MemberCell, RuntimeStorage};
+use crate::cells::{GateCapture, MemberCell, RuntimeStorage};
 
 /// An exactly-once synchronous completion.
 ///
@@ -2967,10 +2967,10 @@ mod tests {
 
     use super::{
         ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
-        MemberCell, MemberStage, Obligation, Pending, RemovalResponses, RuntimeStorage, ScopeCell,
-        ScopeEpochGuard, ScopeFlavor, ScopeRuntime, complete_removals, driver_event_class,
-        dynamic_control, mint_child_incarnation, report_channel, resident_projection,
-        restart_shutdown_work, run_nested_tree, run_scope_incarnation,
+        GateCapture, MemberCell, MemberStage, Obligation, Pending, RemovalResponses,
+        RuntimeStorage, ScopeCell, ScopeEpochGuard, ScopeFlavor, ScopeRuntime, complete_removals,
+        driver_event_class, dynamic_control, mint_child_incarnation, report_channel,
+        resident_projection, restart_shutdown_work, run_nested_tree, run_scope_incarnation,
     };
 
     fn isolated_scope(id: &'static str, flavor: ScopeFlavor) -> Arc<ScopeCell> {
@@ -3149,6 +3149,7 @@ mod tests {
     fn pre_admission_observer_retries_after_gate_handoff() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
         let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
+        let captures = nested.probe_gate_captures();
         let prior_gate = nested.observation_gate();
         let held = prior_gate
             .lock()
@@ -3156,15 +3157,11 @@ mod tests {
         let observer = Arc::clone(&nested);
         let worker = std::thread::spawn(move || observer.set_state(ScopeState::Starting));
 
-        for _ in 0..100_000 {
-            if Arc::strong_count(&prior_gate) >= 3 {
-                break;
-            }
-            std::thread::yield_now();
-        }
-        assert!(
-            Arc::strong_count(&prior_gate) >= 3,
-            "observer must be waiting on the pre-admission gate"
+        // The capture report proves the observer committed to the
+        // pre-admission gate, which the held guard keeps it from acquiring.
+        assert_eq!(
+            captures.recv().expect("the observer reports its capture"),
+            GateCapture::Observation
         );
 
         // Model the instant at which adoption owns the old gate and publishes
@@ -3174,6 +3171,11 @@ mod tests {
         drop(held);
         worker.join().expect("observer follows the gate handoff");
 
+        assert_eq!(
+            captures.recv().expect("the observer reports its retry"),
+            GateCapture::Observation,
+            "the handoff forces one retry capture on the root gate"
+        );
         assert_eq!(nested.record().state, ScopeState::Starting);
         assert!(Arc::ptr_eq(
             &root.observation_gate(),
@@ -3453,7 +3455,7 @@ mod tests {
     fn gate_handoff_waits_for_an_in_flight_observation_edge() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
         let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
-        let prior_gate = nested.observation_gate();
+        let captures = nested.probe_gate_captures();
         let (entered, entered_receiver) = std::sync::mpsc::sync_channel(0);
         let (release, release_receiver) = std::sync::mpsc::sync_channel(0);
         let observer = Arc::clone(&nested);
@@ -3468,6 +3470,12 @@ mod tests {
         entered_receiver
             .recv()
             .expect("observer enters the pre-admission edge");
+        assert_eq!(
+            captures
+                .recv()
+                .expect("the observation edge reports its capture"),
+            GateCapture::Observation
+        );
 
         let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
         let adopting_root = Arc::clone(&root);
@@ -3477,19 +3485,12 @@ mod tests {
             adopted.send(()).expect("test receiver remains available");
         });
 
-        // The field, this test, and the active observation own three gate
-        // references. A fourth proves adoption reached the old gate and is
-        // blocked behind the complete observation edge rather than replacing
-        // it concurrently.
-        for _ in 0..100_000 {
-            if Arc::strong_count(&prior_gate) >= 4 {
-                break;
-            }
-            std::thread::yield_now();
-        }
-        assert!(
-            Arc::strong_count(&prior_gate) >= 4,
-            "adoption must synchronize through the prior observation gate"
+        // The adoption capture proves handoff committed to the prior gate and
+        // is blocked behind the complete observation edge rather than
+        // replacing it concurrently, so adoption cannot yet have completed.
+        assert_eq!(
+            captures.recv().expect("adoption reports its capture"),
+            GateCapture::Adoption
         );
         assert!(matches!(
             adopted_receiver.try_recv(),
@@ -4356,40 +4357,28 @@ mod tests {
             );
         root.set_dynamic_route(Some(super::DynamicRoute::new(Arc::clone(&control))));
 
+        let captures = root.probe_gate_captures();
         let gate = root.observation_gate();
         let held_gate = gate.lock().expect("observation gate starts healthy");
-        let baseline_member_owners = Arc::strong_count(&member);
         let removal_root = Arc::clone(&root);
         let removal_id = child_id.clone();
         let worker =
             std::thread::spawn(move || super::remove_dynamic(&removal_root, &removal_id, None));
 
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
-        while Arc::strong_count(&member) == baseline_member_owners {
-            assert!(
-                std::time::Instant::now() < deadline,
-                "removal reaches its observation transition"
-            );
-            std::thread::yield_now();
-        }
-        loop {
-            match control.state.try_lock() {
-                Ok(state) => {
-                    drop(state);
-                    break;
-                }
-                Err(std::sync::TryLockError::WouldBlock) => {
-                    assert!(
-                        std::time::Instant::now() < deadline,
-                        "a removal blocked on observation must release dynamic state"
-                    );
-                    std::thread::yield_now();
-                }
-                Err(std::sync::TryLockError::Poisoned(_)) => {
-                    panic!("dynamic-state mutex poisoned")
-                }
-            }
-        }
+        // The capture report proves removal committed to the held observation
+        // gate for its removing transition. Dynamic state cannot change again
+        // until that gate is released, so a single acquisition attempt decides
+        // whether removal reached the gate while still holding the state.
+        assert_eq!(
+            captures.recv().expect("removal reports its gate capture"),
+            GateCapture::Observation
+        );
+        drop(
+            control
+                .state
+                .try_lock()
+                .expect("a removal waiting on observation must release dynamic state"),
+        );
 
         drop(held_gate);
         let response = worker.join().expect("removal transition completes");

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -626,3 +626,92 @@ async fn typed_context_handles_preserve_identity_and_self_send_capacity() {
     assert_eq!(stopping_myself, actor);
     assert_eq!(stopping_scope, scope);
 }
+
+struct HandlerScopeQuitter;
+
+impl Actor for HandlerScopeQuitter {
+    type Msg = ();
+    type Args = ();
+
+    async fn init((): (), _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): (), context: &mut Context<'_, Self>) -> ExitResult {
+        context.request_scope_shutdown();
+        Ok(())
+    }
+}
+
+/// `Context::request_scope_shutdown` from a live handler drains the
+/// supervising scope as `ShutdownRequested`. The parked sibling only exits
+/// under the shutdown token, so the recorded stop reason proves the
+/// request — not natural completion — ended the tree.
+#[tokio::test]
+async fn handler_context_scope_shutdown_request_stops_the_tree() {
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once("quitter", ActorOnceDef::<HandlerScopeQuitter>::new(()))
+        .expect("valid actor");
+    tree.add_task(
+        "parked",
+        TaskDef::new(|context| async move {
+            context.shutdown_token().cancelled().await;
+            Ok(())
+        }),
+    )
+    .expect("valid parked task");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("tree starts");
+    actor.send(()).await.expect("quitter is live");
+    assert_eq!(
+        system.wait().await,
+        shelterwood::StopReason::ShutdownRequested
+    );
+}
+
+struct StopEscalatingActor;
+
+impl Actor for StopEscalatingActor {
+    type Msg = ();
+    type Args = ();
+
+    async fn init((): (), _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): (), context: &mut Context<'_, Self>) -> ExitResult {
+        context.stop();
+        Ok(())
+    }
+
+    async fn on_stop(&mut self, context: &mut StopContext<'_, Self>) {
+        context.request_scope_shutdown();
+    }
+}
+
+/// `StopContext::request_scope_shutdown` still reaches the supervising
+/// scope: a clean local stop escalates from teardown into a whole-scope
+/// shutdown that also releases the parked sibling.
+#[tokio::test]
+async fn stop_context_scope_shutdown_request_escalates_a_local_stop() {
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once("escalating", ActorOnceDef::<StopEscalatingActor>::new(()))
+        .expect("valid actor");
+    tree.add_task(
+        "parked",
+        TaskDef::new(|context| async move {
+            context.shutdown_token().cancelled().await;
+            Ok(())
+        }),
+    )
+    .expect("valid parked task");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("tree starts");
+    actor.send(()).await.expect("escalating actor is live");
+    assert_eq!(
+        system.wait().await,
+        shelterwood::StopReason::ShutdownRequested
+    );
+}

--- a/crates/shelterwood/tests/delivery.rs
+++ b/crates/shelterwood/tests/delivery.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_once, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, poll_once, poll_until};
 use shelterwood::{
     CallErrorKind, ExitError, ExitResult, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Reply,
     SendErrorKind, Shutdown, SubtreeOnceDef, Tree,
@@ -86,17 +86,19 @@ async fn accepted_but_undelivered_prefix_never_crosses_an_incarnation() {
         })
         .await
     );
-    assert_quiet(Duration::from_millis(20), || {
-        log.lock()
-            .expect("prefix log mutex poisoned")
-            .iter()
-            .any(|(_, value)| *value == 2 || *value == 3)
-    })
-    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await
         .expect("actor stops");
+    // The final history is authoritative: after synchronized shutdown no
+    // later delivery can occur, so the accepted-but-undelivered prefix
+    // (2 and 3) is proven absent rather than merely unseen for a quiet
+    // window.
+    assert_eq!(
+        *log.lock().expect("prefix log mutex poisoned"),
+        [(1, 1), (2, 4)],
+        "the undelivered prefix must never reach any incarnation"
+    );
 }
 
 #[derive(Debug)]
@@ -321,14 +323,17 @@ async fn latest_conflation_drops_replaced_call_and_keeps_newest_value() {
     assert_eq!(error.kind, CallErrorKind::ReplyDropped);
     assert_eq!(error.incarnation_observed, Some(accepting));
     gate.release();
-    assert_quiet(Duration::from_millis(20), || {
-        calls.load(Ordering::SeqCst) != 0
-    })
-    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await
         .expect("actor stops");
+    // The replaced call envelope was destroyed at conflation time — the
+    // complete post-shutdown history proves the handler never saw it.
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "a conflated-away call must never be delivered"
+    );
 }
 
 #[tokio::test]
@@ -370,17 +375,17 @@ async fn send_cancellation_withdraws_before_acceptance_but_not_after() {
         })
         .await
     );
-    assert_quiet(Duration::from_millis(20), || {
-        log.lock()
-            .expect("send log mutex poisoned")
-            .iter()
-            .any(|(_, value)| *value == 2)
-    })
-    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await
         .expect("actor stops");
+    // The complete post-shutdown history proves the pre-acceptance
+    // cancellation withdrew message 2 outright.
+    assert_eq!(
+        *log.lock().expect("send log mutex poisoned"),
+        [(2, 1), (2, 3)],
+        "a send cancelled before acceptance must never be delivered"
+    );
 }
 
 #[tokio::test]
@@ -422,16 +427,18 @@ async fn call_cancellation_withdraws_before_acceptance_but_processes_after() {
                 })
                 .await
             );
-        } else {
-            assert_quiet(Duration::from_millis(20), || {
-                calls.load(Ordering::SeqCst) != expected
-            })
-            .await;
         }
         system
             .shutdown(Duration::from_secs(1))
             .await
             .expect("actor stops");
+        // The complete post-shutdown history is exact in both directions:
+        // an accepted call is processed once, a withdrawn call never.
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            expected,
+            "cancellation before acceptance withdraws the call outright"
+        );
     }
 }
 

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -64,6 +64,17 @@ impl Actor for DrainActor {
                         .expect_err("drain rejects timers");
                     assert!(matches!(timer.into_inner().1, Message::Timer));
 
+                    let interval = context
+                        .set_interval("interval", Message::Timer, Duration::from_secs(1))
+                        .expect_err("drain rejects intervals");
+                    let (interval_key, interval_message) = interval.into_inner();
+                    assert_eq!(interval_key, "interval");
+                    assert!(matches!(interval_message, Message::Timer));
+
+                    context
+                        .clear_timer(&"timer")
+                        .expect_err("drain rejects timer retraction");
+
                     let ran = Arc::clone(&self.0.deferred_ran);
                     let offload = context
                         .offload(
@@ -75,6 +86,24 @@ impl Actor for DrainActor {
                         )
                         .expect_err("drain rejects offloads");
                     drop(offload);
+
+                    let scoped_ran = Arc::clone(&self.0.deferred_ran);
+                    let scoped = context
+                        .offload_scoped(
+                            async move {
+                                scoped_ran.store(true, Ordering::SeqCst);
+                            },
+                            |_| Message::Offload,
+                            Duration::from_secs(1),
+                        )
+                        .expect_err("drain rejects scoped offloads");
+                    // The rejected payload is recovered whole: the work
+                    // future is discarded without running and the
+                    // continuation still produces its message.
+                    let (scoped_work, scoped_continuation) = scoped.into_inner();
+                    drop(scoped_work);
+                    assert!(matches!(scoped_continuation(Ok(())), Message::Offload));
+
                     self.0.allow_drain.wait().await;
                 }
             }

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -16,8 +16,8 @@ use shelterwood::{
     Actor, ActorOnceDef, Backoff, ChildState, Context as ActorContext, DynamicScopeRef,
     DynamicTree, ExitError, ExitKind, ExitResult, NotAdmittingCause, RawActor, RawContext, RawDef,
     RawOnceDef, Readiness, RemoveOutcome, ReserveError, RestartCondition, RestartPolicy, Retention,
-    ScopeRef, SendErrorKind, Shutdown, StopReason, SubtreeDef, SubtreeOnceDef, System, TaskDef,
-    TaskOnceDef, Tree,
+    ScopeRef, ScopeState, SendErrorKind, Shutdown, StopReason, SubtreeDef, SubtreeOnceDef, System,
+    TaskDef, TaskOnceDef, Tree,
 };
 
 /// Waits until a fused drop has finished releasing its id.
@@ -1680,5 +1680,97 @@ async fn ancestor_hard_abort_disposes_a_queued_admission_and_midflight_removal()
     assert!(matches!(
         queued.wait().await.kind(),
         ExitKind::Aborted { .. } | ExitKind::NeverStarted
+    ));
+}
+
+#[tokio::test]
+async fn admission_receipts_expose_membership_and_borrowed_handles() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+
+    let receipt = scope
+        .add_task("worker", waiting_task())
+        .await
+        .expect("task is admitted");
+    let membership = receipt.membership();
+    assert_eq!(receipt.handles().membership(), membership);
+    assert_eq!(receipt.handles().id().as_str(), "worker");
+    let task = receipt.into_handles();
+    assert_eq!(task.membership(), membership);
+
+    assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+/// A root whose initial child fails before its readiness edge publishes
+/// `StartupFailed` and keeps the started prefix supervised (§6); reservation
+/// and admission on that scope both surface the dedicated cause.
+#[tokio::test]
+async fn startup_failed_roots_reject_reservation_and_admission_with_startup_failed() {
+    let mut tree = DynamicTree::new();
+    tree.add_task(
+        "failing-readiness",
+        TaskDef::new(|_| async { Err(ExitError::message("fails before ready")) })
+            .readiness(Readiness::Manual)
+            .expect("manual readiness")
+            .restart(never()),
+    )
+    .expect("valid failing task");
+    tree.add_task("survivor", waiting_task())
+        .expect("valid surviving task");
+    let system = tree.spawn().expect("runtime is available");
+    let scope = system.scope();
+    system
+        .wait_started()
+        .await
+        .expect_err("pre-ready terminal exit aborts startup");
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            matches!(scope.snapshot().state, ScopeState::StartupFailed)
+        })
+        .await,
+        "the root publishes StartupFailed while the started prefix remains supervised"
+    );
+
+    assert!(matches!(
+        scope.reserve_task("late"),
+        Err(ReserveError::NotAdmitting(NotAdmittingCause::StartupFailed))
+    ));
+    assert!(matches!(
+        scope.add_task("late", waiting_task()).await,
+        Err(ReserveError::NotAdmitting(NotAdmittingCause::StartupFailed))
+    ));
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed startup rolls back");
+}
+
+/// After the owner completes shutdown the scope membership is terminal;
+/// reservation and admission both surface `Terminal` rather than a
+/// live-incarnation cause.
+#[tokio::test]
+async fn terminal_scopes_reject_reservation_and_admission_with_terminal() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+    assert_eq!(scope.wait_stopped().await, StopReason::ShutdownRequested);
+
+    assert!(matches!(
+        scope.reserve_task("late"),
+        Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal))
+    ));
+    assert!(matches!(
+        scope.add_task("late", waiting_task()).await,
+        Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal))
     ));
 }

--- a/crates/shelterwood/tests/events.rs
+++ b/crates/shelterwood/tests/events.rs
@@ -363,6 +363,106 @@ async fn intervals_start_after_one_period_and_skip_missed_ticks() {
     assert_eq!(ticks.load(Ordering::SeqCst), 2);
 }
 
+#[derive(Clone, Copy, Debug)]
+enum ClearedIntervalMessage {
+    Arm,
+    Tick,
+    Probe,
+}
+
+struct ClearedIntervalActor {
+    ticks: Arc<AtomicUsize>,
+    armed: ReleaseGate,
+}
+
+impl Actor for ClearedIntervalActor {
+    type Msg = ClearedIntervalMessage;
+    type Args = (Arc<AtomicUsize>, ReleaseGate);
+
+    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self {
+            ticks: args.0,
+            armed: args.1,
+        })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            ClearedIntervalMessage::Arm => {
+                assert_eq!(
+                    context.clear_timer(&"interval"),
+                    Ok(false),
+                    "a never-armed key has nothing to retract"
+                );
+                context
+                    .set_interval(
+                        "interval",
+                        ClearedIntervalMessage::Tick,
+                        Duration::from_secs(10),
+                    )
+                    .expect("interval accepted");
+                self.armed.release();
+            }
+            ClearedIntervalMessage::Tick => {
+                self.ticks.fetch_add(1, Ordering::SeqCst);
+                context
+                    .set_interval("interval", ClearedIntervalMessage::Tick, Duration::ZERO)
+                    .expect("a zero period clears the key");
+                assert_eq!(
+                    context.clear_timer(&"interval"),
+                    Ok(false),
+                    "the zero-period arm already cleared the key"
+                );
+                // The probe fires long after every deadline the cleared
+                // interval would have had, so a surviving interval must
+                // deliver again before the probe stops the actor.
+                context
+                    .set_timeout(
+                        "probe",
+                        ClearedIntervalMessage::Probe,
+                        Duration::from_secs(120),
+                    )
+                    .expect("probe timeout accepted");
+            }
+            ClearedIntervalMessage::Probe => context.stop(),
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_zero_period_interval_arming_clears_the_key_and_stops_ticks() {
+    let ticks = Arc::new(AtomicUsize::new(0));
+    let armed = ReleaseGate::default();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "cleared-interval",
+            ActorOnceDef::<ClearedIntervalActor>::new((Arc::clone(&ticks), armed.clone())),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    actor
+        .send(ClearedIntervalMessage::Arm)
+        .await
+        .expect("actor live");
+    armed.wait().await;
+
+    tokio::time::advance(Duration::from_secs(10)).await;
+    // A surviving interval would tick again inside this window, strictly
+    // before the probe deadline arrives.
+    tokio::time::advance(Duration::from_secs(30)).await;
+    tokio::time::advance(Duration::from_secs(100)).await;
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    // The complete post-stop history is exact: one tick, then silence.
+    assert_eq!(
+        ticks.load(Ordering::SeqCst),
+        1,
+        "a cleared interval must never tick again"
+    );
+}
+
 #[derive(Clone)]
 enum OverflowMessage {
     Fired,
@@ -421,5 +521,12 @@ async fn overflowing_timer_deadlines_never_fire() {
             .shutdown(Duration::from_secs(1))
             .await
             .expect("tree shuts down");
+        // The complete post-shutdown history seals the negative: the
+        // overflowed deadline never fired at all.
+        assert_eq!(
+            fired.load(Ordering::SeqCst),
+            0,
+            "an overflowed timer deadline must never fire"
+        );
     }
 }

--- a/crates/shelterwood/tests/mailbox.rs
+++ b/crates/shelterwood/tests/mailbox.rs
@@ -192,14 +192,17 @@ async fn latest_mailbox_keeps_only_the_newest_accepted_value() {
         })
         .await
     );
-    assert_quiet(Duration::from_millis(20), || {
-        values.lock().expect("values mutex poisoned").len() > 1
-    })
-    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await
         .expect("actor stops");
+    // The complete post-shutdown history proves conflation destroyed the
+    // replaced values rather than merely delaying them.
+    assert_eq!(
+        *values.lock().expect("values mutex poisoned"),
+        [3],
+        "only the newest accepted value survives conflation"
+    );
 }
 
 #[tokio::test(start_paused = true)]
@@ -252,14 +255,17 @@ async fn timed_send_withdraws_and_recovers_the_message() {
         })
         .await
     );
-    assert_quiet(Duration::from_millis(20), || {
-        values.lock().expect("values mutex poisoned").contains(&3)
-    })
-    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await
         .expect("actor stops");
+    // The complete post-shutdown history proves the cancelled send was
+    // withdrawn before acceptance while the recovered message arrived.
+    assert_eq!(
+        *values.lock().expect("values mutex poisoned"),
+        [1, 2],
+        "a send cancelled before acceptance must never be delivered"
+    );
 }
 
 #[tokio::test(start_paused = true)]

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -12,10 +12,11 @@ use crate::common::{
     waiting::{task as waiting_task, tree as waiting_tree},
 };
 use shelterwood::{
-    Backoff, ChildState, DynamicScopeRef, DynamicTree, Jitter, LIFECYCLE_EVENT_CAPACITY,
+    Backoff, ChildState, DynamicScopeRef, DynamicTree, Intensity, Jitter, LIFECYCLE_EVENT_CAPACITY,
     LifecycleEvent, LifecycleEventKind, LifecycleEvents, LifecycleItem, LifecycleTryRecvError,
-    RemoveOutcome, RestartCondition, RestartPolicy, Retention, ScopeRef, ScopeState, StopReason,
-    SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef, TaskRef, Tree, WaitError,
+    MembershipStatus, RemoveOutcome, RestartCondition, RestartPolicy, Retention, ScopeKind,
+    ScopeRef, ScopeState, StopReason, Strategy, SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef,
+    TaskRef, Tree, WaitError,
 };
 
 async fn next_item(events: &mut LifecycleEvents) -> LifecycleItem {
@@ -597,6 +598,17 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
     assert_eq!(restart_window.total_restarts, 1);
     assert_eq!(child.scope_seq, Some(stopped_seq));
     assert_eq!(nested.snapshot().total_restarts, 1);
+    assert_eq!(
+        restart_window
+            .descendant(["nested"])
+            .map(|child| child.id.as_str()),
+        Some("nested"),
+        "a path may end at a scope child inside its restart window"
+    );
+    assert!(
+        restart_window.descendant(["nested", "worker"]).is_none(),
+        "a restart window has no nested snapshot to advance past"
+    );
 
     tokio::time::advance(Duration::from_secs(10)).await;
     let starting = loop {
@@ -1199,4 +1211,226 @@ async fn lifecycle_subscriptions_start_now_without_replaying_prior_history() {
         .shutdown(Duration::from_secs(1))
         .await
         .expect("root stops");
+}
+
+/// One representative tree exercises the full projected snapshot shape at
+/// once: dynamic and ordered scope kinds, strategy, intensity budgets,
+/// per-child restart policy and retention, active versus removing membership,
+/// a child held mid-stop, and recursive scope rows with their watermarks.
+#[tokio::test]
+async fn end_to_end_snapshot_projects_kinds_policies_membership_status_and_stopping() {
+    let worker_policy = RestartPolicy::new(
+        RestartCondition::Always,
+        Backoff::fixed(Duration::from_secs(5), Jitter::None).expect("valid backoff"),
+    );
+    let mut nested = Tree::new();
+    nested.strategy(Strategy::OneForOne);
+    nested.intensity(Intensity::new(3, Duration::from_secs(45)).expect("valid intensity"));
+    nested
+        .add_task(
+            "worker",
+            waiting_task()
+                .restart(worker_policy)
+                .retention(Retention::Retain),
+        )
+        .expect("valid nested task");
+    let mut root = DynamicTree::new();
+    root.intensity(Intensity::new(7, Duration::from_secs(90)).expect("valid intensity"));
+    let nested_scope = root
+        .add_subtree_once(
+            "nested",
+            SubtreeOnceDef::new(nested).retention(Retention::Retain),
+        )
+        .expect("valid subtree");
+    let system = root.spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+
+    let stop_entered = ReleaseGate::default();
+    let release_stop = ReleaseGate::default();
+    let departing = scope
+        .add_task(
+            "departing",
+            TaskDef::new({
+                let stop_entered = stop_entered.clone();
+                let release_stop = release_stop.clone();
+                move |context| {
+                    let stop_entered = stop_entered.clone();
+                    let release_stop = release_stop.clone();
+                    async move {
+                        context.shutdown_token().cancelled().await;
+                        stop_entered.release();
+                        release_stop.wait().await;
+                        Ok(())
+                    }
+                }
+            })
+            .restart(RestartPolicy::new(
+                RestartCondition::Never,
+                Backoff::Immediate,
+            ))
+            .retention(Retention::Remove)
+            .shutdown(shelterwood::Shutdown::Graceful {
+                grace: Duration::from_secs(30),
+            }),
+        )
+        .await
+        .expect("departing task is admitted")
+        .into_handles();
+    scope
+        .wait_for_child(
+            "departing",
+            |child| matches!(child.state, ChildState::Running),
+            POLL_TIMEOUT,
+        )
+        .await
+        .expect("departing child runs");
+
+    let running = scope.snapshot();
+    assert_eq!(running.state, ScopeState::Running);
+    assert_eq!(running.kind, ScopeKind::Dynamic);
+    assert_eq!(
+        running.strategy, None,
+        "dynamic scopes have no fate-sharing strategy"
+    );
+    assert_eq!(
+        running.intensity,
+        Intensity::new(7, Duration::from_secs(90)).expect("valid intensity")
+    );
+    assert_eq!(running.total_restarts, 0);
+    assert_eq!(
+        running
+            .children
+            .iter()
+            .map(|child| child.id.as_str())
+            .collect::<Vec<_>>(),
+        ["nested", "departing"],
+        "children project in admission order"
+    );
+
+    let nested_row = running.child("nested").expect("nested scope is resident");
+    assert_eq!(nested_row.membership, nested_scope.membership());
+    assert!(nested_row.incarnation.is_some());
+    assert!(matches!(nested_row.state, ChildState::Running));
+    assert_eq!(nested_row.last_exit, None);
+    assert_eq!(nested_row.membership_status, MembershipStatus::Active);
+    assert_eq!(nested_row.restart_count, 0);
+    assert!(
+        nested_row.restart_policy.is_never(),
+        "a one-shot subtree cannot restart"
+    );
+    assert_eq!(nested_row.retention, Retention::Retain);
+    assert_eq!(nested_row.restart_at, None);
+
+    let recursive = nested_row.nested.as_ref().expect("nested scope is live");
+    assert_eq!(nested_row.scope_seq, Some(recursive.lifecycle_seq));
+    assert_eq!(recursive.state, ScopeState::Running);
+    assert_eq!(recursive.kind, ScopeKind::Ordered);
+    assert_eq!(recursive.strategy, Some(Strategy::OneForOne));
+    assert_eq!(
+        recursive.intensity,
+        Intensity::new(3, Duration::from_secs(45)).expect("valid intensity")
+    );
+    let worker_row = running
+        .descendant(["nested", "worker"])
+        .expect("recursion reaches the nested worker");
+    assert_eq!(worker_row.restart_policy, worker_policy);
+    assert_eq!(worker_row.retention, Retention::Retain);
+    assert_eq!(worker_row.membership_status, MembershipStatus::Active);
+
+    let departing_row = running
+        .child("departing")
+        .expect("departing task is resident");
+    assert_eq!(departing_row.membership, departing.membership());
+    assert!(matches!(departing_row.state, ChildState::Running));
+    assert_eq!(
+        departing_row.restart_policy,
+        RestartPolicy::new(RestartCondition::Never, Backoff::Immediate)
+    );
+    assert_eq!(departing_row.retention, Retention::Remove);
+    assert_eq!(departing_row.membership_status, MembershipStatus::Active);
+    assert!(departing_row.nested.is_none());
+    assert!(departing_row.scope_seq.is_none());
+
+    let removal = scope.remove_task(&departing);
+    stop_entered.wait().await;
+    let removing = scope
+        .wait_for_child(
+            "departing",
+            |child| {
+                child.membership_status == MembershipStatus::Removing
+                    && matches!(child.state, ChildState::Stopping)
+            },
+            POLL_TIMEOUT,
+        )
+        .await
+        .expect("planned removal projects a removing, stopping child");
+    assert_eq!(removing.membership_status, MembershipStatus::Removing);
+    assert!(matches!(removing.state, ChildState::Stopping));
+    assert!(
+        removing.incarnation.is_some(),
+        "a stopping child still has its live incarnation"
+    );
+
+    release_stop.release();
+    assert_eq!(removal.await, RemoveOutcome::Removed);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+    assert!(nested_scope.snapshot().state.is_stopped());
+}
+
+/// `ScopeState::is_stopped` and `ChildState::is_terminal` are true exactly
+/// for terminal projections, across unstarted, running, and stopped values.
+#[tokio::test]
+async fn state_predicates_hold_only_for_terminal_projections() {
+    let mut declaration = Tree::new();
+    let unstarted = declaration
+        .add_subtree_once("nested", SubtreeOnceDef::new(Tree::new()))
+        .expect("valid subtree");
+    assert_eq!(unstarted.snapshot().state, ScopeState::Unstarted);
+    assert!(!unstarted.snapshot().state.is_stopped());
+    drop(declaration);
+    assert_eq!(unstarted.wait_stopped().await, StopReason::NeverStarted);
+    assert!(unstarted.snapshot().state.is_stopped());
+
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+    assert!(!scope.snapshot().state.is_stopped());
+
+    let runner = scope
+        .add_task("runner", waiting_task())
+        .await
+        .expect("waiting task admitted")
+        .into_handles();
+    let (done, completion) = scope
+        .add_task_once(
+            "done",
+            TaskOnceDef::new(|_| async { Ok(()) }).retention(Retention::Retain),
+        )
+        .await
+        .expect("one-shot task admitted")
+        .into_handles();
+    drop(completion);
+    done.wait().await;
+    let terminal = scope
+        .wait_for_child("done", |child| child.state.is_terminal(), POLL_TIMEOUT)
+        .await
+        .expect("finished child projects terminal state");
+    assert!(matches!(terminal.state, ChildState::Stopped { .. }));
+
+    let running = scope.child("runner").expect("waiting child is resident");
+    assert!(matches!(running.state, ChildState::Running));
+    assert!(!running.state.is_terminal());
+
+    assert_eq!(scope.remove_task(&runner).await, RemoveOutcome::Removed);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+    let stopped = scope.snapshot().state.clone();
+    assert!(matches!(stopped, ScopeState::Stopped { .. }));
+    assert!(stopped.is_stopped());
 }

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -6,11 +6,13 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until};
+use crate::common::{
+    POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until, waiting::task as waiting_task,
+};
 use shelterwood::{
     DynamicTree, ExitError, ExitResult, Mailbox, MailboxShutdown, PolicyError, RawActor,
     RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline, RemoveOutcome, ScopeDefaults,
-    SendErrorKind, Shutdown, Tree,
+    SendErrorKind, Shutdown, SubtreeOnceDef, Tree,
 };
 
 struct FactoryTaskActor {
@@ -589,4 +591,141 @@ async fn hard_abort_offload_panic_with_panicking_raw_destructor_is_contained() {
         }
     }
     assert_eq!(panic_message.as_deref(), Some("injected offload panic"));
+}
+
+struct ScopeQuitterRaw;
+
+impl RawActor for ScopeQuitterRaw {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        context
+            .recv()
+            .await
+            .expect("quit trigger arrives before shutdown");
+        context.request_scope_shutdown();
+        assert!(
+            context.recv().await.is_none(),
+            "the requested scope shutdown reaches the requester's own token"
+        );
+        Ok(())
+    }
+}
+
+/// `RawContext::request_scope_shutdown` targets the supervising scope
+/// (§7): the nested scope drains as `ShutdownRequested` while the parent
+/// and its other children keep running.
+#[tokio::test]
+async fn raw_context_scope_shutdown_request_stops_only_the_supervising_scope() {
+    let mut nested = Tree::new();
+    let quitter = nested
+        .add_raw_once("quitter", RawOnceDef::new(ScopeQuitterRaw))
+        .expect("valid raw actor");
+    let mut root = Tree::new();
+    root.add_task("outer-parked", waiting_task())
+        .expect("valid parked task");
+    let sub = root
+        .add_subtree_once("nested", SubtreeOnceDef::new(nested))
+        .expect("valid subtree");
+    let system = root.spawn().expect("runtime is available");
+    system.wait_started().await.expect("tree starts");
+
+    quitter.send(()).await.expect("quitter is live");
+    assert_eq!(
+        sub.wait_stopped().await,
+        shelterwood::StopReason::ShutdownRequested
+    );
+    // The parent scope survives its child's requested shutdown: the parked
+    // sibling is still supervised, and the root still answers its own
+    // shutdown cleanly.
+    assert!(matches!(
+        system
+            .scope()
+            .snapshot()
+            .child("outer-parked")
+            .map(|child| child.state.clone()),
+        Some(shelterwood::ChildState::Running)
+    ));
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root shuts down after the nested scope stopped");
+}
+
+struct StoppingRejectionRaw {
+    checked: Arc<AtomicBool>,
+}
+
+impl RawActor for StoppingRejectionRaw {
+    type Msg = u8;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        // Live edge cases first: an absent key has nothing to retract, an
+        // armed interval is retractable, and a zero-period arm clears its
+        // key outright.
+        assert!(
+            !context.clear_timer(&"absent"),
+            "a never-armed key reports no retraction"
+        );
+        context
+            .set_interval("interval", 7u8, Duration::from_secs(600))
+            .expect("live interval arms");
+        assert!(
+            context.clear_timer(&"interval"),
+            "an armed interval is retractable"
+        );
+        context
+            .set_interval("cleared-by-zero", 8u8, Duration::from_secs(600))
+            .expect("live interval arms");
+        context
+            .set_interval("cleared-by-zero", 9u8, Duration::ZERO)
+            .expect("a zero period clears the key");
+        assert!(
+            !context.clear_timer(&"cleared-by-zero"),
+            "the zero-period arm already cleared the key"
+        );
+
+        context.stop();
+
+        // A stopping incarnation rejects new local work and returns every
+        // payload whole.
+        let timer = context
+            .set_timeout("timeout", 1u8, Duration::from_secs(1))
+            .expect_err("a stopping context rejects timers");
+        assert_eq!(timer.into_inner(), ("timeout", 1u8));
+        let interval = context
+            .set_interval("interval", 2u8, Duration::from_secs(1))
+            .expect_err("a stopping context rejects intervals");
+        assert_eq!(interval.into_inner(), ("interval", 2u8));
+        let offload = context
+            .offload_scoped(
+                async { 3u8 },
+                |result| result.expect("recovered continuation sees its value"),
+                Duration::from_secs(1),
+            )
+            .expect_err("a stopping context rejects scoped offloads");
+        // Recovery is total: the caller still owns the work future and the
+        // continuation, and both remain usable outside the offload path.
+        let (work, continuation) = offload.into_inner();
+        assert_eq!(continuation(Ok(work.await)), 3);
+
+        self.checked.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn stopping_raw_context_rejects_timers_and_offloads_with_payload_recovery() {
+    let checked = Arc::new(AtomicBool::new(false));
+    let mut tree = Tree::new();
+    tree.add_raw_once(
+        "stopping-surface",
+        RawOnceDef::new(StoppingRejectionRaw {
+            checked: Arc::clone(&checked),
+        }),
+    )
+    .expect("valid raw actor");
+    let system = tree.spawn().expect("runtime is available");
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert!(checked.load(Ordering::SeqCst));
 }

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,7 @@
                 ${pkgs.bash}/bin/bash ./tools/check-runtime-paths.sh
                 ${pkgs.bash}/bin/bash ./tools/check-exit-paths.sh
                 ${pkgs.bash}/bin/bash ./tools/check-layering-paths.sh
+                ${pkgs.bash}/bin/bash ./tools/check-enforcement-fixtures.sh
                 ${pkgs.bash}/bin/bash ./tools/sync-packaged-docs.sh --check
                 ${pkgs.bash}/bin/bash ./tools/check-packaged-crate.sh
               '';

--- a/justfile
+++ b/justfile
@@ -37,6 +37,9 @@ exit-path-check:
 layering-path-check:
     ./tools/check-layering-paths.sh
 
+enforcement-fixture-check:
+    ./tools/check-enforcement-fixtures.sh
+
 packaged-docs-sync:
     ./tools/sync-packaged-docs.sh --write
 
@@ -51,7 +54,7 @@ nixfmt-check:
 
 # Fast local CI mirror — reuses the local cargo cache and incremental builds.
 # The clean Nix lane retains the explicit all-target build for non-test codegen coverage.
-ci: fmt lint test doc-check runtime-api-check runtime-path-check exit-path-check layering-path-check packaged-docs-check package-check nixfmt-check
+ci: fmt lint test doc-check runtime-api-check runtime-path-check exit-path-check layering-path-check enforcement-fixture-check packaged-docs-check package-check nixfmt-check
 
 # Full clean Nix CI lane; use before pushing or when touching Nix files.
 ci-nix:

--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Exercises the regex enforcement scripts against known-good and known-bad
+# fixture trees so a pattern regression can neither stop flagging a forbidden
+# construct nor start flagging a near-miss identifier.
+#
+# Each case stages the skeleton tree (whose files are the known-good
+# near-misses) into a scratch directory, overlays at most one seeded
+# violation, and runs every enforcement script against the staged tree via
+# SHELTERWOOD_ENFORCEMENT_ROOT. The script named by the case must fail with
+# its own diagnostic; every other script must stay clean.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly repo_root
+readonly fixtures_root="$repo_root/tools/enforcement-fixtures"
+readonly scripts=(
+  check-runtime-paths.sh
+  check-exit-paths.sh
+  check-layering-paths.sh
+)
+
+workspace="$(mktemp -d)"
+readonly workspace
+trap 'rm -rf "$workspace"' EXIT
+
+failures=0
+
+run_check() {
+  local script="$1"
+  local root="$2"
+  set +e
+  check_output="$(SHELTERWOOD_ENFORCEMENT_ROOT="$root" bash "$repo_root/tools/$script" 2>&1)"
+  check_status=$?
+  set -e
+}
+
+expect_case() {
+  local case_name="$1"
+  local flagged_script="${2:-}"
+  local diagnostic="${3:-}"
+
+  local root="$workspace/$case_name"
+  cp -R "$fixtures_root/skeleton" "$root"
+  if [[ -n "$flagged_script" ]]; then
+    cp -R "$fixtures_root/overlays/$case_name/." "$root/"
+  fi
+
+  local script
+  for script in "${scripts[@]}"; do
+    run_check "$script" "$root"
+    if [[ "$script" == "$flagged_script" ]]; then
+      if [[ "$check_status" -eq 0 ]]; then
+        echo "fixture case '$case_name': $script must flag the seeded violation" >&2
+        failures=1
+      elif [[ "$check_output" != *"$diagnostic"* ]]; then
+        echo "fixture case '$case_name': $script reported an unexpected diagnostic:" >&2
+        echo "$check_output" >&2
+        failures=1
+      fi
+    elif [[ "$check_status" -ne 0 ]]; then
+      echo "fixture case '$case_name': $script must pass but reported:" >&2
+      echo "$check_output" >&2
+      failures=1
+    fi
+  done
+}
+
+expect_case clean
+expect_case runtime-tokio check-runtime-paths.sh \
+  "runtime or randomness paths found outside the runtime module:"
+expect_case runtime-tokio-util check-runtime-paths.sh \
+  "runtime or randomness paths found outside the runtime module:"
+expect_case runtime-fastrand check-runtime-paths.sh \
+  "runtime or randomness paths found outside the runtime module:"
+expect_case exit-downcast check-exit-paths.sh \
+  "runtime type recovery found on the exit path:"
+expect_case exit-downcast-ref check-exit-paths.sh \
+  "runtime type recovery found on the exit path:"
+expect_case exit-downcast-mut check-exit-paths.sh \
+  "runtime type recovery found on the exit path:"
+expect_case layering-driver-below check-layering-paths.sh \
+  "upward driver or tree references found below the driver layer:"
+expect_case layering-tree-below check-layering-paths.sh \
+  "upward driver or tree references found below the driver layer:"
+expect_case layering-tree-in-driver check-layering-paths.sh \
+  "upward tree references found in the driver layer:"
+expect_case layering-resolve-common check-layering-paths.sh \
+  "child option resolution escaped the shared plan funnel:"
+expect_case layering-checked-id check-layering-paths.sh \
+  "dynamic child-id validation escaped the reservation boundary:"
+
+if [[ "$failures" -ne 0 ]]; then
+  echo "enforcement fixture check failed" >&2
+  exit 1
+fi
+
+echo "enforcement fixture coverage: clean"

--- a/tools/check-exit-paths.sh
+++ b/tools/check-exit-paths.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# The fixture harness re-points this scan at a mirrored source tree; the
+# default scans the repository from the invoking directory as before.
+cd "${SHELTERWOOD_ENFORCEMENT_ROOT:-.}"
+
 readonly forbidden='[.]downcast(_ref|_mut)?([[:space:]]*)?(::)?[<(]'
 readonly exit_path=(
   crates/shelterwood/src/driver.rs

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# The fixture harness re-points this scan at a mirrored source tree; the
+# default scans the repository from the invoking directory as before.
+cd "${SHELTERWOOD_ENFORCEMENT_ROOT:-.}"
+
 readonly below_driver_layers=(
   crates/shelterwood/src/actor.rs
   crates/shelterwood/src/cells.rs

--- a/tools/check-runtime-paths.sh
+++ b/tools/check-runtime-paths.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# The fixture harness re-points this scan at a mirrored source tree; the
+# default scans the repository from the invoking directory as before.
+cd "${SHELTERWOOD_ENFORCEMENT_ROOT:-.}"
+
 readonly source_root="crates/shelterwood/src"
 readonly forbidden='\b(tokio|tokio_util|fastrand)::'
 
 set +e
 matches="$({
+  # The exemption globs are anchored to the exact module path: rg matches
+  # globs against the path as searched, so the bare forms `runtime.rs` and
+  # `runtime/**` would respectively exempt any same-named file anywhere and
+  # exempt nothing at all.
   rg --line-number \
     --glob '*.rs' \
-    --glob '!runtime.rs' \
-    --glob '!runtime/**' \
+    --glob "!$source_root/runtime.rs" \
+    --glob "!$source_root/runtime/**" \
     "$forbidden" \
     "$source_root"
 } 2>&1)"

--- a/tools/enforcement-fixtures/overlays/exit-downcast-mut/crates/shelterwood/src/exit.rs
+++ b/tools/enforcement-fixtures/overlays/exit-downcast-mut/crates/shelterwood/src/exit.rs
@@ -1,0 +1,5 @@
+// Known-bad fixture: a mutable downcast on the exit path must be flagged by
+// the exit-path check, including the whitespace-split turbofish form.
+pub fn classify() {
+    let _failure = payload.downcast_mut ::<Failure>();
+}

--- a/tools/enforcement-fixtures/overlays/exit-downcast-ref/crates/shelterwood/src/engine.rs
+++ b/tools/enforcement-fixtures/overlays/exit-downcast-ref/crates/shelterwood/src/engine.rs
@@ -1,0 +1,5 @@
+// Known-bad fixture: a borrowing downcast on the exit path must be flagged
+// by the exit-path check, including the argument-inference form.
+pub fn tally() {
+    let _message = payload.downcast_ref(marker);
+}

--- a/tools/enforcement-fixtures/overlays/exit-downcast/crates/shelterwood/src/driver.rs
+++ b/tools/enforcement-fixtures/overlays/exit-downcast/crates/shelterwood/src/driver.rs
@@ -1,0 +1,5 @@
+// Known-bad fixture: a consuming downcast on the exit path must be flagged
+// by the exit-path check.
+pub fn shell() {
+    let _panic = payload.downcast::<Panic>();
+}

--- a/tools/enforcement-fixtures/overlays/layering-checked-id/crates/shelterwood/src/tree.rs
+++ b/tools/enforcement-fixtures/overlays/layering-checked-id/crates/shelterwood/src/tree.rs
@@ -1,0 +1,5 @@
+// Known-bad fixture: dynamic child-id validation escaping the reservation
+// boundary must be flagged by the layering check.
+pub fn reserve() {
+    checked_id(candidate);
+}

--- a/tools/enforcement-fixtures/overlays/layering-driver-below/crates/shelterwood/src/engine.rs
+++ b/tools/enforcement-fixtures/overlays/layering-driver-below/crates/shelterwood/src/engine.rs
@@ -1,0 +1,5 @@
+// Known-bad fixture: an upward driver reference below the driver layer must
+// be flagged by the layering check.
+pub fn tally() {
+    crate::driver::request_stop();
+}

--- a/tools/enforcement-fixtures/overlays/layering-resolve-common/crates/shelterwood/src/driver.rs
+++ b/tools/enforcement-fixtures/overlays/layering-resolve-common/crates/shelterwood/src/driver.rs
@@ -1,0 +1,5 @@
+// Known-bad fixture: child option resolution escaping the shared plan funnel
+// must be flagged by the layering check.
+pub fn shell() {
+    resolve_common(options);
+}

--- a/tools/enforcement-fixtures/overlays/layering-tree-below/crates/shelterwood/src/observe.rs
+++ b/tools/enforcement-fixtures/overlays/layering-tree-below/crates/shelterwood/src/observe.rs
@@ -1,0 +1,5 @@
+// Known-bad fixture: an upward tree reference below the driver layer must be
+// flagged by the layering check.
+pub fn graft() {
+    tree::Snapshot::project();
+}

--- a/tools/enforcement-fixtures/overlays/layering-tree-in-driver/crates/shelterwood/src/driver.rs
+++ b/tools/enforcement-fixtures/overlays/layering-tree-in-driver/crates/shelterwood/src/driver.rs
@@ -1,0 +1,5 @@
+// Known-bad fixture: an upward tree reference in the driver layer must be
+// flagged by the layering check.
+pub fn shell() {
+    tree::Lowered::admit();
+}

--- a/tools/enforcement-fixtures/overlays/runtime-fastrand/crates/shelterwood/src/policy.rs
+++ b/tools/enforcement-fixtures/overlays/runtime-fastrand/crates/shelterwood/src/policy.rs
@@ -1,0 +1,5 @@
+// Known-bad fixture: a direct fastrand reference outside the runtime module
+// must be flagged by the runtime-path check.
+pub fn sample() {
+    let _jitter = fastrand::u64(..);
+}

--- a/tools/enforcement-fixtures/overlays/runtime-tokio-util/crates/shelterwood/src/cells.rs
+++ b/tools/enforcement-fixtures/overlays/runtime-tokio-util/crates/shelterwood/src/cells.rs
@@ -1,0 +1,5 @@
+// Known-bad fixture: a direct tokio_util reference outside the runtime
+// module must be flagged by the runtime-path check.
+pub fn tighten() {
+    let _token = tokio_util::sync::CancellationToken::new();
+}

--- a/tools/enforcement-fixtures/overlays/runtime-tokio/crates/shelterwood/src/mailbox.rs
+++ b/tools/enforcement-fixtures/overlays/runtime-tokio/crates/shelterwood/src/mailbox.rs
@@ -1,0 +1,5 @@
+// Known-bad fixture: a direct tokio reference outside the runtime module
+// must be flagged by the runtime-path check.
+pub fn bind() {
+    tokio::spawn(async {});
+}

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/actor.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/actor.rs
@@ -1,0 +1,2 @@
+// Placeholder mirroring crates/shelterwood/src/actor.rs so every path the
+// enforcement scripts scan exists in the fixture tree.

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/cells.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/cells.rs
@@ -1,0 +1,5 @@
+// Known-good fixture: an identifier that merely ends in "driver" must not
+// match the word-bounded upward-layering pattern below the driver layer.
+pub fn tighten() {
+    screwdriver::torque();
+}

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/deadline.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/deadline.rs
@@ -1,0 +1,2 @@
+// Placeholder mirroring crates/shelterwood/src/deadline.rs so every path the
+// enforcement scripts scan exists in the fixture tree.

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/definition.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/definition.rs
@@ -1,0 +1,2 @@
+// Placeholder mirroring crates/shelterwood/src/definition.rs so every path the
+// enforcement scripts scan exists in the fixture tree.

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/driver.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/driver.rs
@@ -1,0 +1,13 @@
+// Known-good fixture for the driver layer: near-misses for every pattern the
+// exit-path and layering checks apply to this file.
+pub fn shell() {
+    // Method names that merely start with "downcast" are not runtime type
+    // recovery and must not match the exit-path pattern.
+    settings.downcast_settings(defaults);
+    // "subtree" merely ends in "tree" and must not match the word-bounded
+    // upward-reference pattern.
+    subtree::route();
+    // A name that merely extends the plan-funnel helper's name must not
+    // match its word-bounded pattern.
+    resolve_commonality();
+}

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/engine.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/engine.rs
@@ -1,0 +1,5 @@
+// Known-good fixture: a method name that merely starts with "downcast_ref"
+// must not match the exit-path pattern.
+pub fn tally() {
+    metrics.downcast_ref_count();
+}

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/exit.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/exit.rs
@@ -1,0 +1,7 @@
+// Known-good fixture: the word "downcast" without a method call must not
+// match the exit-path pattern, which requires a receiver and an argument
+// list or turbofish.
+pub fn classify() {
+    let downcast_hint = false;
+    let _ = downcast_hint;
+}

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/identity.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/identity.rs
@@ -1,0 +1,2 @@
+// Placeholder mirroring crates/shelterwood/src/identity.rs so every path the
+// enforcement scripts scan exists in the fixture tree.

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/mailbox.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/mailbox.rs
@@ -1,0 +1,5 @@
+// Known-good fixture: an identifier that merely ends in a forbidden crate
+// name must not match the word-bounded runtime-path pattern.
+pub fn bind() {
+    my_tokio::channel();
+}

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/observe.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/observe.rs
@@ -1,0 +1,5 @@
+// Known-good fixture: an identifier that merely ends in "tree" must not
+// match the word-bounded upward-layering pattern below the driver layer.
+pub fn graft() {
+    subtree::graft();
+}

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/plan.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/plan.rs
@@ -1,0 +1,2 @@
+// Placeholder mirroring crates/shelterwood/src/plan.rs so every path the
+// enforcement scripts scan exists in the fixture tree.

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/policy.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/policy.rs
@@ -1,0 +1,5 @@
+// Known-good fixture: an identifier that merely ends in a forbidden crate
+// name must not match the word-bounded runtime-path pattern.
+pub fn sample() {
+    not_fastrand::seed();
+}

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/raw.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/raw.rs
@@ -1,0 +1,2 @@
+// Placeholder mirroring crates/shelterwood/src/raw.rs so every path the
+// enforcement scripts scan exists in the fixture tree.

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/runtime.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/runtime.rs
@@ -1,0 +1,7 @@
+// Known-good fixture: runtime.rs is the one file allowed to name the runtime
+// and randomness crates, so these references must never be flagged.
+pub fn spawn_supervised() {
+    tokio::spawn(async {});
+    let _token = tokio_util::sync::CancellationToken::new();
+    let _seed = fastrand::u64(..);
+}

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/runtime/clock.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/runtime/clock.rs
@@ -1,0 +1,5 @@
+// Known-good fixture: files under runtime/ share runtime.rs's exemption, so
+// this reference must never be flagged.
+pub async fn pause() {
+    tokio::time::sleep(std::time::Duration::ZERO).await;
+}

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/task.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/task.rs
@@ -1,0 +1,2 @@
+// Placeholder mirroring crates/shelterwood/src/task.rs so every path the
+// enforcement scripts scan exists in the fixture tree.

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/tree.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/tree.rs
@@ -1,0 +1,5 @@
+// Known-good fixture: a name that merely extends the reservation-boundary
+// helper's name must not match its word-bounded pattern.
+pub fn reserve() {
+    unchecked_id();
+}


### PR DESCRIPTION
Tests-only PR (plus enforcement-script fixtures/harness) addressing the remaining pure test-coverage checkboxes from the audit in #55. No production behavior changes: the only `src/` edits are `#[cfg(test)]`-gated (a gate-capture probe in `cells.rs` and the reworked unit tests in `driver.rs`).

## Issue #55 checklist items addressed

> - [ ] Add an end-to-end snapshot projection test covering scope kind/strategy/intensity, child restart policy/retention, active/removing membership, and stopping state.

`observation.rs`: `end_to_end_snapshot_projects_kinds_policies_membership_status_and_stopping` builds a dynamic root (non-default intensity) containing an ordered subtree (explicit strategy/intensity) plus a dynamically added child, and asserts the full `ScopeSnapshot`/`ChildSnapshot` shape: kind, strategy (`None` for dynamic), intensity round-trip, admission order, verbatim restart-policy/retention projection, live incarnation, nested recursion with `scope_seq` watermark, then `MembershipStatus::Removing` + `ChildState::Stopping` with the stop gated mid-flight, and terminal state after shutdown.

> - [ ] Cover `RawContext::request_scope_shutdown`, `Context::request_scope_shutdown`, and `StopContext::request_scope_shutdown`.

`raw.rs`: `raw_context_scope_shutdown_request_stops_only_the_supervising_scope` (nested scope drains as `ShutdownRequested` while the parent and a parked sibling keep running). `actor.rs`: `handler_context_scope_shutdown_request_stops_the_tree` and `stop_context_scope_shutdown_request_escalates_a_local_stop` (a clean local stop escalates from `on_stop` into a whole-scope shutdown); parked siblings make `StopReason::ShutdownRequested` the only possible stop cause.

> - [ ] Replace negative-delivery tests that rely only on short quiet windows with synchronized shutdown plus final-history assertions.

Reworked in `delivery.rs` (`accepted_but_undelivered_prefix...`, `latest_conflation_drops_replaced_call...`, `send_cancellation_withdraws...`, `call_cancellation_withdraws...`) and `mailbox.rs` (`latest_mailbox_keeps_only_the_newest_accepted_value`, `timed_send_withdraws_and_recovers_the_message`): the 20ms wall-clock quiet windows are gone; each test now shuts down and asserts the exact complete recorded history. `events.rs::overflowing_timer_deadlines_never_fire` keeps its paused-clock (deterministic) window and gains the post-shutdown final seal. Judgment call: quiet windows asserting startup ordering, readiness gating, or natural non-completion (`actor.rs`, `readiness.rs`, `subtrees.rs`, `lifecycle.rs`, `dynamic.rs` split-detach) were left alone — they assert properties with no recorded history to seal, and several already pair the window with a synchronized positive assertion.

> - [ ] Cover interval clearing, absent timer keys, drain-time interval/scoped-offload rejection, and payload recovery.

`events.rs`: `a_zero_period_interval_arming_clears_the_key_and_stops_ticks` (absent-key `Ok(false)`, zero-period clearing, and a late probe timeout that makes any surviving tick observable deterministically). `drain.rs`: the drain fixture now also asserts drain-time rejection of `set_interval`, `clear_timer`, and `offload_scoped`, recovering the scoped payload whole (work discarded unrun, continuation still produces its message). `raw.rs`: `stopping_raw_context_rejects_timers_and_offloads_with_payload_recovery` covers the raw-level equivalents after `stop()`, including awaiting the recovered work future and feeding it through the recovered continuation.

> - [ ] Add direct coverage for snapshot/handle façade methods and `NotAdmittingCause::{StartupFailed, Terminal}`.

Survey found `AdmissionReceipt::handles()`, `ScopeState::is_stopped`, `ChildState::is_terminal`, and `descendant()` across a restart window uncovered; now tested in `dynamic.rs`/`observation.rs` (other façade accessors were verified already covered). `NotAdmittingCause::StartupFailed` is produced by a real dynamic root whose initial child fails before its readiness edge (root publishes `ScopeState::StartupFailed`); `Terminal` by reserving/adding after owner shutdown completes. Both `reserve_task` and `add_task` surfaces are asserted.

> - [ ] Add fixture-based bypass tests for the source/rustdoc enforcement scripts or replace regex checks with syntax-aware analysis.

Fixture approach: `tools/enforcement-fixtures/` holds a known-good skeleton tree plus one bad overlay per forbidden pattern class (tokio/tokio_util/fastrand outside runtime, exit-path `.downcast{,_ref,_mut}`, all four layering rules), and near-miss known-goods (`my_tokio::`, `downcast_settings(...)`, `runtime.rs`/`runtime/**` exemptions) the regexes must not flag. `tools/check-enforcement-fixtures.sh` asserts each bad overlay is flagged by the intended check's diagnostic and the skeleton passes all checks; wired into `just ci` (`enforcement-fixture-check`) and the `part0-enforcement` Nix check, keeping the two in sync. The scripts accept `SHELTERWOOD_ENFORCEMENT_ROOT` (default behavior unchanged). One deliberate script fix the fixtures surfaced: the runtime-path exemption globs are now anchored (`!crates/shelterwood/src/runtime.rs`, `.../runtime/**`) — the bare `!runtime.rs` exempted a same-named file anywhere and `!runtime/**` exempted nothing. No current-tree outcome changes. The rustdoc-side `api-reachability` tool was left without JSON fixtures: its input is the unstable rustdoc JSON format, so frozen fixtures would pin a rustc-version artifact rather than the tool's contract; the source-side scripts got the full fixture treatment instead.

> - [ ] Replace implementation-coupled scheduler/strong-count polling in observation-gate tests with explicit barriers.

The three driver unit tests (`pre_admission_observer_retries_after_gate_handoff`, `gate_handoff_waits_for_an_in_flight_observation_edge`, `dynamic_removal_releases_state_before_waiting_for_the_observation_gate`) no longer spin on `Arc::strong_count`/`yield_now` with wall-clock deadlines. A `#[cfg(test)]`-only probe in `ScopeCell` reports each gate capture (observation vs adoption) after the gate is cloned and before it is acquired — the same commit point the strong-count polling inferred — through an unbounded channel, so the tests block on explicit capture events and additionally assert the forced retry on the root gate. Verified stable across 30 repeat runs.

## Not included (in-flight sibling branches from the same audit)

Hostile-destructor disposal, offload flood/reclamation, and exact-backoff-value items are covered by `agent/issue-55-disposal`, `agent/issue-55-handler`, and `agent/issue-55-bounds`.

## Verification

`./scripts/dev just ci` passes end to end: 385 tests (up from 366 on main), 3 doctests, clippy `-D warnings`, nightly fmt, doc build, API reachability, all path restrictions, the new enforcement-fixture check, packaged-docs sync, package check, nixfmt. No real bugs were uncovered — every asserted behavior matched the specified contract.