### PR TITLE
Pause high-cycle storage test clock

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -3571,7 +3571,7 @@ mod tests {
         );
     }
 
-    #[crate::runtime::test]
+    #[crate::runtime::test(start_paused = true)]
     async fn dynamic_high_cycle_add_remove_keeps_only_live_runtime_storage() {
         const CYCLES: usize = 1_000;
 


### PR DESCRIPTION
## Summary

- run the dynamic high-cycle runtime-storage test with Tokio's clock paused
- preserve the shutdown ladder and storage-reclamation coverage while avoiding real-time timer waits

## Why

The test creates a permanently pending task with `Shutdown::Abort` and awaits its full removal 1,000 times in sequence. Each removal reaches the hard-abort path only after the minimum 1 ms tidy-abort deadline, and real timer scheduling makes those serialized waits account for almost all of the test's roughly 2.9-second runtime.

Tokio's paused test clock auto-advances through those deadlines while retaining the same cancellation, escalation, hard-abort, task-exit, and storage-reclamation transitions. The focused test completes in about 0.12 seconds after this change.

## Validation

- `./scripts/dev cargo test -p shelterwood driver::tests::dynamic_high_cycle_add_remove_keeps_only_live_runtime_storage -- --exact`
- `./scripts/dev just ci` (413 tests passed, plus formatting, Clippy, docs, API reachability, packaging, and repository policy checks)
