### PR TITLE
Clamp timer arming below the Instant clock limit

### DIFF
--- a/crates/shelterwood/src/deadline.rs
+++ b/crates/shelterwood/src/deadline.rs
@@ -11,8 +11,19 @@ pub(crate) struct Deadline(Option<Instant>);
 
 impl Deadline {
     /// Captures a duration budget relative to `started_at`.
+    ///
+    /// A deadline the timer could not arm — one within
+    /// [`Self::ARMING_HEADROOM`] of the clock limit — is treated exactly
+    /// like one the clock cannot represent: it never arrives. Filtering
+    /// here keeps every stored deadline identical to the instant that
+    /// would be armed for it, so due-ness checks and timer wakes can
+    /// never disagree at the clock boundary.
     pub(crate) fn after(started_at: Instant, duration: Duration) -> Self {
-        Self(started_at.checked_add(duration))
+        Self(
+            started_at
+                .checked_add(duration)
+                .filter(|deadline| deadline.checked_add(Self::ARMING_HEADROOM).is_some()),
+        )
     }
 
     /// Returns the representable absolute deadline, if there is one.
@@ -24,10 +35,11 @@ impl Deadline {
     ///
     /// Arming a deadline is itself clock arithmetic — tokio rounds a
     /// sleep deadline up to the next whole millisecond by adding to it
-    /// before tick conversion — so a clamp flush against `Instant`'s
-    /// limit would panic at arming time. One second comfortably covers
-    /// that sub-millisecond round-up without measurably loosening the
-    /// clamp.
+    /// before tick conversion, and a paused test clock advances its base
+    /// past the armed tick by another whole millisecond — so a deadline
+    /// flush against `Instant`'s limit would panic at arming or advance
+    /// time. One second comfortably covers both additions without
+    /// measurably loosening the clamp.
     pub(crate) const ARMING_HEADROOM: Duration = Duration::from_secs(1);
 
     /// Captures a duration budget as an absolute instant, saturating to
@@ -72,7 +84,10 @@ impl Deadline {
     /// clock limit would still panic inside the timer's millisecond
     /// round-up, so the arming boundary pulls it back just far enough to
     /// fit. Deadlines that already leave the headroom pass through
-    /// unchanged.
+    /// unchanged — including everything [`Deadline::after`] produces,
+    /// which withholds unarmable deadlines at computation time; this
+    /// clamp is the last line of defense for instants that reach the
+    /// runtime boundary by any other route.
     pub(crate) fn clamp_armable(deadline: Instant) -> Instant {
         if deadline.checked_add(Self::ARMING_HEADROOM).is_some() {
             return deadline;
@@ -140,6 +155,31 @@ mod tests {
     }
 
     #[test]
+    fn unarmable_but_representable_budgets_never_arrive() {
+        let now = Instant::now();
+        // The largest armable budget: its deadline sits exactly one
+        // headroom below the clock limit, so one more headroom on top of
+        // it lands flush against the limit — representable, but a panic
+        // to arm.
+        let armable = Deadline::saturating_after(now, Duration::MAX) - now;
+        let unarmable = armable + Deadline::ARMING_HEADROOM;
+
+        assert_eq!(
+            Deadline::after(now, armable).instant(),
+            Some(now + armable),
+            "a budget that leaves the arming headroom is a real deadline"
+        );
+        let flush = Deadline::after(now, unarmable);
+        assert_eq!(
+            flush.instant(),
+            None,
+            "a budget the timer could not arm never arrives"
+        );
+        assert!(!flush.is_due(now + armable));
+        assert!(!flush.is_overdue(now + armable));
+    }
+
+    #[test]
     fn clamp_armable_passes_ordinary_deadlines_through_unchanged() {
         let now = Instant::now();
         let deadline = now + Duration::from_secs(1);
@@ -154,7 +194,7 @@ mod tests {
         // limit: representable, but a panic to arm.
         let flush = Deadline::saturating_after(now, Duration::MAX) + Deadline::ARMING_HEADROOM;
         let clamped = Deadline::clamp_armable(flush);
-        assert!(clamped <= flush, "the clamp never arms later than asked");
+        assert!(clamped < flush, "the clamp never arms later than asked");
         assert!(
             clamped.checked_add(Deadline::ARMING_HEADROOM).is_some(),
             "the clamp leaves the timer's arming headroom below the clock limit"

--- a/crates/shelterwood/src/deadline.rs
+++ b/crates/shelterwood/src/deadline.rs
@@ -66,6 +66,21 @@ impl Deadline {
         started_at + low
     }
 
+    /// Clamps an absolute deadline to the largest armable instant.
+    ///
+    /// A representable deadline within [`Self::ARMING_HEADROOM`] of the
+    /// clock limit would still panic inside the timer's millisecond
+    /// round-up, so the arming boundary pulls it back just far enough to
+    /// fit. Deadlines that already leave the headroom pass through
+    /// unchanged.
+    pub(crate) fn clamp_armable(deadline: Instant) -> Instant {
+        if deadline.checked_add(Self::ARMING_HEADROOM).is_some() {
+            return deadline;
+        }
+        let now = Instant::now();
+        Self::saturating_after(now, deadline.saturating_duration_since(now))
+    }
+
     /// Reports whether a representable deadline has elapsed.
     pub(crate) fn is_due(self, now: Instant) -> bool {
         self.0.is_some_and(|deadline| now >= deadline)
@@ -122,6 +137,30 @@ mod tests {
             "the clamp saturates to the clock limit less the arming headroom, \
              not to a halved budget"
         );
+    }
+
+    #[test]
+    fn clamp_armable_passes_ordinary_deadlines_through_unchanged() {
+        let now = Instant::now();
+        let deadline = now + Duration::from_secs(1);
+        assert_eq!(Deadline::clamp_armable(deadline), deadline);
+    }
+
+    #[test]
+    fn clamp_armable_pulls_a_near_limit_deadline_below_the_headroom() {
+        let now = Instant::now();
+        // The far-future clamp saturates to the clock limit less the
+        // headroom, so adding the headroom back lands flush against the
+        // limit: representable, but a panic to arm.
+        let flush = Deadline::saturating_after(now, Duration::MAX) + Deadline::ARMING_HEADROOM;
+        let clamped = Deadline::clamp_armable(flush);
+        assert!(clamped <= flush, "the clamp never arms later than asked");
+        assert!(
+            clamped.checked_add(Deadline::ARMING_HEADROOM).is_some(),
+            "the clamp leaves the timer's arming headroom below the clock limit"
+        );
+        let century = Duration::from_secs(60 * 60 * 24 * 365 * 100);
+        assert!(clamped > now + century, "the clamp stays far future");
     }
 
     #[test]

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -1083,6 +1083,12 @@ pub(crate) async fn yield_now() {
 }
 
 pub(crate) async fn sleep_until_std(deadline: std::time::Instant) {
+    // Every absolute-deadline arming funnels through here, so this is the
+    // one place the arming clamp has to hold: tokio rounds the deadline up
+    // to the next whole millisecond with a panicking add before tick
+    // conversion, and a deadline flush against the clock limit would
+    // panic at arming time rather than when it was computed.
+    let deadline = Deadline::clamp_armable(deadline);
     time::sleep_until(time::Instant::from_std(deadline)).await;
 }
 
@@ -1195,9 +1201,20 @@ mod tests {
     };
 
     use super::{
-        DisposalJob, JoinOutcome, Latch, OneShotClose, Signal, Timeout, discard_panic, join,
-        oneshot, spawn, timeout, yield_now,
+        Deadline, DisposalJob, JoinOutcome, Latch, OneShotClose, Signal, Timeout, discard_panic,
+        join, oneshot, spawn, timeout, yield_now,
     };
+
+    #[tokio::test(start_paused = true)]
+    async fn arming_a_deadline_flush_against_the_clock_limit_stays_pending() {
+        let now = std::time::Instant::now();
+        let flush = Deadline::saturating_after(now, Duration::MAX) + Deadline::ARMING_HEADROOM;
+        let mut sleep = std::pin::pin!(super::sleep_until_std(flush));
+        let mut context = Context::from_waker(Waker::noop());
+        // The timer registers on first poll: without the arming clamp this
+        // panicked inside tokio's millisecond round-up rather than parking.
+        assert!(sleep.as_mut().poll(&mut context).is_pending());
+    }
 
     struct RecursivelyPanickingPayload;
 

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -1083,11 +1083,13 @@ pub(crate) async fn yield_now() {
 }
 
 pub(crate) async fn sleep_until_std(deadline: std::time::Instant) {
-    // Every absolute-deadline arming funnels through here, so this is the
-    // one place the arming clamp has to hold: tokio rounds the deadline up
-    // to the next whole millisecond with a panicking add before tick
-    // conversion, and a deadline flush against the clock limit would
-    // panic at arming time rather than when it was computed.
+    // Every absolute-deadline arming crosses the runtime boundary here:
+    // tokio rounds the deadline up to the next whole millisecond with a
+    // panicking add before tick conversion, so a deadline flush against
+    // the clock limit would panic at arming time rather than when it was
+    // computed. Deadline::after already withholds such deadlines, making
+    // this clamp a pass-through for them; it guards instants that arrive
+    // by any other route.
     let deadline = Deadline::clamp_armable(deadline);
     time::sleep_until(time::Instant::from_std(deadline)).await;
 }
@@ -1101,6 +1103,14 @@ pub(crate) async fn timeout<F>(duration: Duration, future: F) -> Timeout<F::Outp
 where
     F: Future,
 {
+    // tokio's timeout only falls back to its internal far future when the
+    // deadline addition overflows outright; a representable deadline flush
+    // against the clock limit would still panic at arming. Route the
+    // budget through Deadline so an unarmable timeout never elapses,
+    // matching sleep_deadline's overflow semantics.
+    if deadline(duration).instant().is_none() {
+        return Timeout::Completed(future.await);
+    }
     match time::timeout(duration, future).await {
         Ok(value) => Timeout::Completed(value),
         Err(_) => Timeout::Elapsed,
@@ -1214,6 +1224,20 @@ mod tests {
         // The timer registers on first poll: without the arming clamp this
         // panicked inside tokio's millisecond round-up rather than parking.
         assert!(sleep.as_mut().poll(&mut context).is_pending());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timeout_with_an_unarmable_budget_never_elapses() {
+        let now = super::now();
+        let flush = Deadline::saturating_after(now, Duration::MAX) + Deadline::ARMING_HEADROOM;
+        // The paused clock is frozen, so the budget reconstructs the flush
+        // deadline exactly and the unarmable-budget guard must engage.
+        let budget = flush - now;
+        let mut timeout = std::pin::pin!(timeout(budget, std::future::pending::<()>()));
+        let mut context = Context::from_waker(Waker::noop());
+        // Without the guard, tokio's timeout armed this representable
+        // deadline and panicked inside the millisecond round-up.
+        assert!(timeout.as_mut().poll(&mut context).is_pending());
     }
 
     struct RecursivelyPanickingPayload;


### PR DESCRIPTION
Closes #86.

Tokio's timer rounds a sleep deadline up to the next whole millisecond by adding to it with a panicking `Add` before tick conversion (`TimeSource::deadline_to_tick`, tokio 1.53.1 `src/runtime/time/source.rs:19`), so any representable deadline within that round-up of the `Instant` clock limit panics at arming time, not when it was computed.

The fix works at three layers:

1. **`Deadline::after` withholds unarmable deadlines at computation time.** A deadline within `ARMING_HEADROOM` of the clock limit is treated exactly like one the clock cannot represent: it never arrives (`None`). This keeps every stored deadline identical to the instant that would be armed for it, so due-ness checks and timer wakes cannot disagree at the clock boundary — a near-limit deadline cannot wake early and re-arm.
2. **`runtime::timeout` gates its budget through the same policy.** Tokio's `timeout` only falls back to its internal far future when the deadline addition overflows outright; a representable near-limit deadline still panicked at arming, reachable from the public shutdown APIs (`shutdown_and_wait(timeout)`, `Supervisor::shutdown(timeout)`). An unarmable budget now never elapses, matching `sleep_deadline`'s overflow semantics.
3. **`Deadline::clamp_armable` in `runtime::sleep_until_std` is the last line of defense.** Everything `Deadline::after` produces passes through unchanged (one `checked_add` on the hot path); it guards instants that reach the runtime boundary by any other route, pulling a flush deadline back to the largest armable instant via the existing `saturating_after` saturation.

An adversarial review pass (two independent reviewers attacking the clamp math, tokio internals, funnel completeness, and consumer semantics) produced layers 1 and 2: the original single-clamp version missed the `runtime::timeout` path and let stored due times diverge from armed wake times. The review also audited the vendored tokio timer and confirmed the round-up add is the only panicking `Instant` arithmetic on the arming path, with the 1s headroom also covering the paused-clock auto-advance addition.

Both regression tests were verified to reproduce the exact upstream panic (`overflow when adding duration to instant`) with their respective guards temporarily disabled.

Upstream, this remains a one-line tokio bug (the round-up add is the only non-saturating step left in tick conversion — siblings fixed in tokio-rs/tokio#4495 / tokio-rs/tokio#5183; still present on master). Left alone for now per discussion; if fixed upstream, `clamp_armable` and `ARMING_HEADROOM` become removable.

`./scripts/dev just ci` is green (418 tests, fmt, clippy `-D warnings`, doctests, nixfmt).