### PR TITLE
Terminate hung nextest tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.default]
+slow-timeout = { period = "60s", terminate-after = 2 }

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,12 @@
       # Repository docs and their packaged doctest copies are compared in the
       # clean build sandbox, so keep Markdown alongside Cargo sources.
       extraSourceFilter =
-        path: type: type == "regular" && builtins.match ".*\\.md" (toString path) != null;
+        path: type:
+        type == "regular"
+        && (
+          builtins.match ".*\\.md" (toString path) != null
+          || builtins.match ".*/\\.config/nextest\\.toml" (toString path) != null
+        );
       extraChecks =
         pkgs:
         let


### PR DESCRIPTION
## Summary

- configure nextest's default profile to report tests as slow after 60 seconds and terminate them after two periods
- retain `.config/nextest.toml` in the filtered source used by the authoritative Nix CI lane

## Why

Without a repository nextest configuration, slow tests only emit warnings. A hung test can therefore wedge CI until the workflow's six-hour limit. Terminating after the second 60-second period makes the run fail in roughly two minutes and preserves the test name in nextest's failure output.

## Impact

Normal tests keep the same behavior. Tests that run beyond roughly two minutes are terminated and reported as failures instead of leaving the CI job stuck.

## Validation

- `./scripts/dev just test` — 413 nextest tests and 3 doctests passed
- `./scripts/dev just ci-nix` — all authoritative clean Nix checks passed
- `./scripts/dev nixfmt --check flake.nix`
- `git diff --check`