### PR TITLE
Introduce an Epoch newtype for scope incarnation epochs

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -17,7 +17,7 @@ use std::{
 
 use crate::{
     ChildId, Exit, Incarnation, Intensity, Mailbox, Membership, Readiness, ScopeState, Strategy,
-    engine::ScopeEpochs,
+    engine::{Epoch, RequestTarget, ScopeEpochs},
     exit::{StartupError, StopReason},
     identity::{FenceCounter, ScopeIdentity},
     observe::{
@@ -405,7 +405,7 @@ struct ScopeControl {
 
 #[derive(Clone, Copy, Debug)]
 struct ScopeRequest {
-    epoch: u64,
+    epoch: Epoch,
     consumed: bool,
 }
 
@@ -993,7 +993,7 @@ impl ScopeCell {
         }
     }
 
-    pub(crate) fn begin_incarnation(&self) -> Option<u64> {
+    pub(crate) fn begin_incarnation(&self) -> Option<Epoch> {
         self.with_observation_gate(|| {
             let mut control = self.control.lock().expect("scope control mutex poisoned");
             let epoch = control.epochs.begin()?;
@@ -1012,17 +1012,17 @@ impl ScopeCell {
         })
     }
 
-    pub(crate) fn finish_incarnation(&self, epoch: u64, reason: StopReason) {
+    pub(crate) fn finish_incarnation(&self, epoch: Epoch, reason: StopReason) {
         self.finish_incarnation_with_terminal(epoch, reason, None);
     }
 
-    pub(crate) fn finish_root_incarnation(&self, epoch: u64, reason: StopReason, exit: Exit) {
+    pub(crate) fn finish_root_incarnation(&self, epoch: Epoch, reason: StopReason, exit: Exit) {
         self.finish_incarnation_with_terminal(epoch, reason, Some(exit));
     }
 
     fn finish_incarnation_with_terminal(
         &self,
-        epoch: u64,
+        epoch: Epoch,
         reason: StopReason,
         terminal_exit: Option<Exit>,
     ) {
@@ -1104,9 +1104,12 @@ impl ScopeCell {
         }
     }
 
-    pub(crate) fn request_shutdown(&self) -> Option<u64> {
+    pub(crate) fn request_shutdown(&self) -> Option<Epoch> {
         let mut control = self.control.lock().expect("scope control mutex poisoned");
-        let (target, pending_incarnation) = control.epochs.request_target()?;
+        let RequestTarget {
+            epoch: target,
+            pending_incarnation,
+        } = control.epochs.request_target()?;
         if control
             .shutdown
             .is_none_or(|request| request.epoch < target)
@@ -1133,7 +1136,7 @@ impl ScopeCell {
         })
     }
 
-    pub(crate) fn has_stop_request(&self, epoch: u64) -> bool {
+    pub(crate) fn has_stop_request(&self, epoch: Epoch) -> bool {
         let control = self.control.lock().expect("scope control mutex poisoned");
         control
             .shutdown
@@ -1141,7 +1144,7 @@ impl ScopeCell {
             || control.force.is_some_and(|request| request.epoch == epoch)
     }
 
-    pub(crate) fn take_shutdown_request(&self, epoch: u64) -> bool {
+    pub(crate) fn take_shutdown_request(&self, epoch: Epoch) -> bool {
         let mut control = self.control.lock().expect("scope control mutex poisoned");
         match control.shutdown.as_mut() {
             Some(request) if request.epoch == epoch && !request.consumed => {
@@ -1152,7 +1155,7 @@ impl ScopeCell {
         }
     }
 
-    pub(crate) fn force_shutdown(&self, epoch: u64) {
+    pub(crate) fn force_shutdown(&self, epoch: Epoch) {
         let mut control = self.control.lock().expect("scope control mutex poisoned");
         if control.epochs.is_current(epoch) {
             control.force = Some(ScopeRequest {
@@ -1164,7 +1167,7 @@ impl ScopeCell {
         self.member.record.pulse();
     }
 
-    pub(crate) fn take_force_request(&self, epoch: u64) -> bool {
+    pub(crate) fn take_force_request(&self, epoch: Epoch) -> bool {
         let mut control = self.control.lock().expect("scope control mutex poisoned");
         match control.force.as_mut() {
             Some(request) if request.epoch == epoch && !request.consumed => {
@@ -1175,7 +1178,7 @@ impl ScopeCell {
         }
     }
 
-    pub(crate) fn incarnation_finished(&self, epoch: u64) -> bool {
+    pub(crate) fn incarnation_finished(&self, epoch: Epoch) -> bool {
         let control = self.control.lock().expect("scope control mutex poisoned");
         control.epochs.finished(epoch)
     }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -13,7 +13,7 @@ use crate::{
     cells::{DynamicRoute, MemberStage, ResidentProjection, ScopeCell},
     deadline::Deadline,
     engine::{
-        ArbitrationClass, DeadlineHandle, DeadlineQueue, ExitDispatch, IntensityState,
+        ArbitrationClass, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch, IntensityState,
         MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState,
         ScopeLifecycle, ScopeMode, StopAction, StopLadder, arbitrate, dispatch_exit,
         schedule_restart,
@@ -587,7 +587,7 @@ fn collect_stragglers(scope: &ScopeCell, prefix: &[ChildId], out: &mut Vec<Shutd
     }
 }
 
-async fn wait_for_incarnation(scope: &ScopeCell, epoch: u64) {
+async fn wait_for_incarnation(scope: &ScopeCell, epoch: Epoch) {
     let mut watcher = scope.signal().watcher();
     loop {
         if scope.incarnation_finished(epoch)
@@ -950,7 +950,7 @@ struct ScopeRuntime {
     is_root: bool,
     parent_ready: Option<Latch>,
     dynamic: Option<Arc<DynamicControl>>,
-    epoch: u64,
+    epoch: Epoch,
     ancestor_shutdown: Option<Latch>,
     ancestor_shutdown_seen: bool,
     ancestor_abort: Option<Latch>,
@@ -2500,7 +2500,7 @@ fn mint_child_incarnation(slot: &Arc<SlotCell>, counter: &mut FenceCounter) -> O
 /// identity exhaustion.
 struct ScopeEpochGuard {
     scope: Arc<ScopeCell>,
-    epoch: Option<u64>,
+    epoch: Option<Epoch>,
 }
 
 impl ScopeEpochGuard {
@@ -2520,7 +2520,7 @@ impl ScopeEpochGuard {
         self.scope.finish_incarnation(epoch, reason);
     }
 
-    fn transfer(mut self) -> u64 {
+    fn transfer(mut self) -> Epoch {
         self.epoch
             .take()
             .expect("an owned scope epoch transfers at most once")
@@ -2957,7 +2957,7 @@ mod tests {
         LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Readiness, ReadinessDeadline,
         RemoveOutcome, Retention, ScopeState, SendErrorKind, StartupError, StartupFailureCause,
         StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
-        engine::{ScopeLifecycle, StopLadder, arbitrate},
+        engine::{Epoch, ScopeLifecycle, StopLadder, arbitrate},
         exit::{JoinVerdict, RecordedOutcome},
         identity::{FenceCounter, ScopeIdentity},
         mailbox::MailboxCell,
@@ -3994,7 +3994,7 @@ mod tests {
 
     struct ObserveScopeOnStartupWake {
         scope: Arc<ScopeCell>,
-        epoch: Option<u64>,
+        epoch: Option<Epoch>,
         observed: Mutex<Option<(MemberStage, Option<bool>)>>,
     }
 

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -444,12 +444,30 @@ impl ReadinessGate {
     }
 }
 
+/// One scope incarnation's driver-ownership token.
+///
+/// Epochs are minted per scope in strictly increasing order and `u64::MAX` is
+/// never minted (it is reserved to poison [`ScopeEpochs`] exhaustion), so
+/// plain ordering is total over every minted epoch — unlike identity
+/// generations, no poison value can enter a comparison.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct Epoch(u64);
+
+/// The epoch a scope shutdown request lands on.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct RequestTarget {
+    pub(crate) epoch: Epoch,
+    /// The target incarnation has not begun: the request addresses the next
+    /// epoch a future driver will mint.
+    pub(crate) pending_incarnation: bool,
+}
+
 /// Cross-incarnation liveness encoded once as an epoch state, rather than an
 /// epoch pair plus an independently mutable `live` bit.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ScopeEpochs {
     Idle { last_stopped: u64 },
-    Live { current: u64, last_stopped: u64 },
+    Live { current: Epoch, last_stopped: u64 },
     Exhausted { last_stopped: u64 },
 }
 
@@ -460,7 +478,7 @@ impl Default for ScopeEpochs {
 }
 
 impl ScopeEpochs {
-    pub(crate) fn begin(&mut self) -> Option<u64> {
+    pub(crate) fn begin(&mut self) -> Option<Epoch> {
         let last_stopped = match *self {
             Self::Idle { last_stopped } => last_stopped,
             // One scope cell cannot own two simultaneous drivers. Rejecting
@@ -478,6 +496,7 @@ impl ScopeEpochs {
             *self = Self::Exhausted { last_stopped };
             return None;
         }
+        let current = Epoch(current);
         *self = Self::Live {
             current,
             last_stopped,
@@ -485,32 +504,38 @@ impl ScopeEpochs {
         Some(current)
     }
 
-    pub(crate) fn live_epoch(self) -> Option<u64> {
+    pub(crate) fn live_epoch(self) -> Option<Epoch> {
         match self {
             Self::Idle { .. } | Self::Exhausted { .. } => None,
             Self::Live { current, .. } => Some(current),
         }
     }
 
-    pub(crate) fn request_target(self) -> Option<(u64, bool)> {
+    pub(crate) fn request_target(self) -> Option<RequestTarget> {
         match self {
-            Self::Live { current, .. } => Some((current, false)),
+            Self::Live { current, .. } => Some(RequestTarget {
+                epoch: current,
+                pending_incarnation: false,
+            }),
             Self::Idle { last_stopped } => last_stopped
                 .checked_add(1)
                 .filter(|target| *target != u64::MAX)
-                .map(|target| (target, true)),
+                .map(|target| RequestTarget {
+                    epoch: Epoch(target),
+                    pending_incarnation: true,
+                }),
             Self::Exhausted { .. } => None,
         }
     }
 
-    pub(crate) fn finish(&mut self, epoch: u64) -> bool {
+    pub(crate) fn finish(&mut self, epoch: Epoch) -> bool {
         match *self {
             Self::Live {
                 current,
                 last_stopped,
             } if current == epoch => {
                 *self = Self::Idle {
-                    last_stopped: last_stopped.max(epoch),
+                    last_stopped: last_stopped.max(epoch.0),
                 };
                 true
             }
@@ -518,19 +543,19 @@ impl ScopeEpochs {
         }
     }
 
-    pub(crate) fn is_current(self, epoch: u64) -> bool {
+    pub(crate) fn is_current(self, epoch: Epoch) -> bool {
         self.live_epoch() == Some(epoch)
     }
 
-    pub(crate) fn request_is_pending(self, epoch: u64) -> bool {
-        matches!(self, Self::Idle { last_stopped } if epoch > last_stopped)
+    pub(crate) fn request_is_pending(self, epoch: Epoch) -> bool {
+        matches!(self, Self::Idle { last_stopped } if epoch.0 > last_stopped)
     }
 
-    pub(crate) fn finished(self, epoch: u64) -> bool {
+    pub(crate) fn finished(self, epoch: Epoch) -> bool {
         match self {
             Self::Idle { last_stopped }
             | Self::Live { last_stopped, .. }
-            | Self::Exhausted { last_stopped } => last_stopped >= epoch,
+            | Self::Exhausted { last_stopped } => last_stopped >= epoch.0,
         }
     }
 }
@@ -817,10 +842,10 @@ mod tests {
     };
 
     use super::{
-        ArbitrationClass, DeadlineHandle, DeadlineQueue, ExitDispatch, IntensityState,
-        MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState, ScopeEpochs,
-        ScopeLifecycle, ScopeMode, StopAction, StopLadder, arbitrate, dispatch_exit,
-        schedule_restart, tidy_abort_beat,
+        ArbitrationClass, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch, IntensityState,
+        MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RequestTarget,
+        RestartState, ScopeEpochs, ScopeLifecycle, ScopeMode, StopAction, StopLadder, arbitrate,
+        dispatch_exit, schedule_restart, tidy_abort_beat,
     };
 
     #[test]
@@ -1175,30 +1200,42 @@ mod tests {
     #[test]
     fn scope_epoch_exhaustion_is_poisoned_without_minting_or_reuse() {
         let mut epochs = ScopeEpochs::default();
-        assert_eq!(epochs.request_target(), Some((1, true)));
+        assert_eq!(
+            epochs.request_target(),
+            Some(RequestTarget {
+                epoch: Epoch(1),
+                pending_incarnation: true,
+            })
+        );
         let first = epochs.begin().expect("first epoch is available");
         assert_eq!(epochs.live_epoch(), Some(first));
-        assert_eq!(epochs.request_target(), Some((first, false)));
+        assert_eq!(
+            epochs.request_target(),
+            Some(RequestTarget {
+                epoch: first,
+                pending_incarnation: false,
+            })
+        );
         assert_eq!(epochs.begin(), None, "a live epoch cannot be replaced");
-        assert!(!epochs.finish(first + 1));
+        assert!(!epochs.finish(Epoch(first.0 + 1)));
         assert_eq!(epochs.live_epoch(), Some(first));
         assert!(epochs.finish(first));
         assert!(!epochs.finish(first), "a stopped epoch cannot finish twice");
         assert_eq!(epochs.live_epoch(), None);
         assert!(epochs.finished(first));
-        assert!(epochs.request_is_pending(first + 1));
+        assert!(epochs.request_is_pending(Epoch(first.0 + 1)));
 
         let mut exhausted = ScopeEpochs::Idle {
             last_stopped: u64::MAX - 2,
         };
         let last = exhausted.begin().expect("last non-poison epoch");
-        assert_eq!(last, u64::MAX - 1);
+        assert_eq!(last, Epoch(u64::MAX - 1));
         assert!(exhausted.finish(last));
         assert_eq!(exhausted.begin(), None, "MAX is reserved as poison");
         assert_eq!(exhausted.live_epoch(), None);
         assert_eq!(exhausted.request_target(), None);
         assert_eq!(exhausted.begin(), None, "poisoning is permanent");
-        assert!(!exhausted.finish(u64::MAX));
+        assert!(!exhausted.finish(Epoch(u64::MAX)));
     }
 
     #[test]

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -444,13 +444,18 @@ impl ReadinessGate {
     }
 }
 
-/// One scope incarnation's driver-ownership token.
+/// One scope incarnation's ownership token: minted for the driver that runs
+/// the incarnation, and also addressed forward by a shutdown request that
+/// targets the next incarnation before any driver has begun it.
 ///
 /// Epochs are minted per scope in strictly increasing order starting at
 /// [`Epoch::FIRST`], and `u64::MAX` is never minted ([`Epoch::successor`]
 /// reserves it to poison [`ScopeEpochs`] exhaustion). Plain ordering is
 /// therefore total over every minted epoch, so `Epoch` derives `Ord` where
 /// identity generations instead guard their in-band poison with `supersedes`.
+/// Unlike an incarnation identity, an epoch carries no scope tag, so ordering
+/// is meaningful only between epochs of one scope; every comparison site
+/// draws both operands from that scope's own control plane.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) struct Epoch(u64);
 
@@ -1251,6 +1256,11 @@ mod tests {
         let last = exhausted.begin().expect("last non-poison epoch");
         assert_eq!(last, Epoch(u64::MAX - 1));
         assert!(exhausted.finish(last));
+        assert_eq!(
+            exhausted.request_target(),
+            None,
+            "an idle request cannot address the reserved poison epoch"
+        );
         assert_eq!(exhausted.begin(), None, "MAX is reserved as poison");
         assert_eq!(exhausted.live_epoch(), None);
         assert_eq!(exhausted.request_target(), None);

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -446,12 +446,32 @@ impl ReadinessGate {
 
 /// One scope incarnation's driver-ownership token.
 ///
-/// Epochs are minted per scope in strictly increasing order and `u64::MAX` is
-/// never minted (it is reserved to poison [`ScopeEpochs`] exhaustion), so
-/// plain ordering is total over every minted epoch — unlike identity
-/// generations, no poison value can enter a comparison.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+/// Epochs are minted per scope in strictly increasing order starting at
+/// [`Epoch::FIRST`], and `u64::MAX` is never minted ([`Epoch::successor`]
+/// reserves it to poison [`ScopeEpochs`] exhaustion). Plain ordering is
+/// therefore total over every minted epoch, so `Epoch` derives `Ord` where
+/// identity generations instead guard their in-band poison with `supersedes`.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) struct Epoch(u64);
+
+impl Epoch {
+    /// The first epoch a scope can mint.
+    const FIRST: Self = Self(1);
+
+    /// The epoch minted after `previous`, or the first with no predecessor.
+    fn after(previous: Option<Self>) -> Option<Self> {
+        previous.map_or(Some(Self::FIRST), Self::successor)
+    }
+
+    /// The next mintable epoch. `None` reserves `u64::MAX` as the poison so
+    /// no observable epoch can alias permanent exhaustion.
+    fn successor(self) -> Option<Self> {
+        self.0
+            .checked_add(1)
+            .filter(|next| *next != u64::MAX)
+            .map(Self)
+    }
+}
 
 /// The epoch a scope shutdown request lands on.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -466,14 +486,21 @@ pub(crate) struct RequestTarget {
 /// epoch pair plus an independently mutable `live` bit.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ScopeEpochs {
-    Idle { last_stopped: u64 },
-    Live { current: Epoch, last_stopped: u64 },
-    Exhausted { last_stopped: u64 },
+    Idle {
+        last_stopped: Option<Epoch>,
+    },
+    Live {
+        current: Epoch,
+        last_stopped: Option<Epoch>,
+    },
+    Exhausted {
+        last_stopped: Option<Epoch>,
+    },
 }
 
 impl Default for ScopeEpochs {
     fn default() -> Self {
-        Self::Idle { last_stopped: 0 }
+        Self::Idle { last_stopped: None }
     }
 }
 
@@ -486,17 +513,10 @@ impl ScopeEpochs {
             // driver's epoch while trying to advance the counter.
             Self::Live { .. } | Self::Exhausted { .. } => return None,
         };
-        let Some(current) = last_stopped.checked_add(1) else {
+        let Some(current) = Epoch::after(last_stopped) else {
             *self = Self::Exhausted { last_stopped };
             return None;
         };
-        // Reserve MAX as poison so no observable epoch can alias the
-        // permanently exhausted state.
-        if current == u64::MAX {
-            *self = Self::Exhausted { last_stopped };
-            return None;
-        }
-        let current = Epoch(current);
         *self = Self::Live {
             current,
             last_stopped,
@@ -517,13 +537,10 @@ impl ScopeEpochs {
                 epoch: current,
                 pending_incarnation: false,
             }),
-            Self::Idle { last_stopped } => last_stopped
-                .checked_add(1)
-                .filter(|target| *target != u64::MAX)
-                .map(|target| RequestTarget {
-                    epoch: Epoch(target),
-                    pending_incarnation: true,
-                }),
+            Self::Idle { last_stopped } => Epoch::after(last_stopped).map(|epoch| RequestTarget {
+                epoch,
+                pending_incarnation: true,
+            }),
             Self::Exhausted { .. } => None,
         }
     }
@@ -535,7 +552,7 @@ impl ScopeEpochs {
                 last_stopped,
             } if current == epoch => {
                 *self = Self::Idle {
-                    last_stopped: last_stopped.max(epoch.0),
+                    last_stopped: last_stopped.max(Some(epoch)),
                 };
                 true
             }
@@ -548,14 +565,16 @@ impl ScopeEpochs {
     }
 
     pub(crate) fn request_is_pending(self, epoch: Epoch) -> bool {
-        matches!(self, Self::Idle { last_stopped } if epoch.0 > last_stopped)
+        matches!(self, Self::Idle { last_stopped } if Some(epoch) > last_stopped)
     }
 
     pub(crate) fn finished(self, epoch: Epoch) -> bool {
         match self {
             Self::Idle { last_stopped }
             | Self::Live { last_stopped, .. }
-            | Self::Exhausted { last_stopped } => last_stopped >= epoch.0,
+            | Self::Exhausted { last_stopped } => {
+                last_stopped.is_some_and(|last_stopped| last_stopped >= epoch)
+            }
         }
     }
 }
@@ -1217,16 +1236,17 @@ mod tests {
             })
         );
         assert_eq!(epochs.begin(), None, "a live epoch cannot be replaced");
-        assert!(!epochs.finish(Epoch(first.0 + 1)));
+        let unminted = first.successor().expect("a successor epoch is available");
+        assert!(!epochs.finish(unminted));
         assert_eq!(epochs.live_epoch(), Some(first));
         assert!(epochs.finish(first));
         assert!(!epochs.finish(first), "a stopped epoch cannot finish twice");
         assert_eq!(epochs.live_epoch(), None);
         assert!(epochs.finished(first));
-        assert!(epochs.request_is_pending(Epoch(first.0 + 1)));
+        assert!(epochs.request_is_pending(unminted));
 
         let mut exhausted = ScopeEpochs::Idle {
-            last_stopped: u64::MAX - 2,
+            last_stopped: Some(Epoch(u64::MAX - 2)),
         };
         let last = exhausted.begin().expect("last non-poison epoch");
         assert_eq!(last, Epoch(u64::MAX - 1));


### PR DESCRIPTION
## What

Wraps scope incarnation epochs in a crate-private `Epoch` newtype (engine.rs) and threads it through `ScopeEpochs`, `ScopeCell`'s incarnation/shutdown control surface (cells.rs), and `ScopeEpochGuard`/`ScopeRuntime` (driver.rs). Also replaces `ScopeEpochs::request_target`'s anonymous `(u64, bool)` return with a named `RequestTarget { epoch, pending_incarnation }` struct.

## Why

- cells.rs traffics in three unrelated `u64` planes (epochs, lifecycle sequence numbers, restart counts); the stale-driver guards in `finish_incarnation_with_terminal` and `request_shutdown` compare epochs with `<=`/`<`, exactly where a plane mix-up would be silent. The newtype makes that a type error.
- `ScopeEpochs` reserves `u64::MAX` as poison and never mints it — the same situation for which the identity layer already has the `Generation` newtype. `Epoch` documents that parallel: because the poison value is never minted, plain `Ord` is total over every observable epoch.
- The `(u64, bool)` tuple's flag was only decodable by reading `request_shutdown`; `RequestTarget.pending_incarnation` names it.

No behavior change; purely a type-level refactor. Public API is untouched (`Epoch` is `pub(crate)`).

## Scope note (issue #91)

This started as a four-part newtype pass over cells.rs, but three parts contend with the open #91 audit and are deliberately deferred until that work settles:
- `ObservationGate` wrapper for `Arc<Mutex<()>>` — contends with #91 item 9 (gate-handoff fast path) and the adoption directionality assert.
- `MemberMailbox` struct → enum — contends with #91's `Mutex<Option<_>>` take-once spec-conformance decision.
- Public `LifecycleSeq` newtype — threads through the observation hubs and `lifecycle_sequence`, which #91 items 3 and 5 rewrite.

Epochs appear nowhere in #91, and the driver lines touched here are disjoint from its mailbox-caching item, so this part proceeds alone.

## Testing

`just ci` (full local mirror: fmt, clippy, nextest, doc, runtime-api/path/layering/fixture/packaged-docs/package/nixfmt checks) passes clean.