### PR TITLE
Extract shared cancellation token

### DIFF
--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -3,10 +3,10 @@
 use std::{fmt, future::Future, hash::Hash, marker::PhantomData, sync::Arc, time::Duration};
 
 use crate::{
-    ActorRef, Blocking, CancellationToken, ChildId, DeadlineElapsed, ExitError, ExitResult, Guard,
-    Incarnation, Mailbox, MailboxShutdown, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
+    ActorRef, Blocking, ChildId, DeadlineElapsed, ExitError, ExitResult, Guard, Incarnation,
+    Mailbox, MailboxShutdown, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
     ReadinessDeadline, Rejected, RestartPolicy, Retention, ScopeRef, Shutdown,
-    policy::CommonOptions,
+    cancellation::CancellationToken, policy::CommonOptions,
 };
 
 /// Callback-oriented actor contract.

--- a/crates/shelterwood/src/admission.rs
+++ b/crates/shelterwood/src/admission.rs
@@ -1,6 +1,6 @@
 //! Dynamic membership admission errors and removal outcomes.
 
-use crate::policy::{ChildId, InvalidPolicy};
+use crate::{identity::ChildId, policy::InvalidPolicy};
 
 /// A child reservation or dynamic admission error.
 #[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]

--- a/crates/shelterwood/src/cancellation.rs
+++ b/crates/shelterwood/src/cancellation.rs
@@ -1,0 +1,123 @@
+//! Read-only cancellation capabilities shared by supervised children and work.
+
+use crate::runtime::{self, Latch};
+
+/// A library-owned cancellation token.
+#[derive(Clone, Debug, Default)]
+pub struct CancellationToken {
+    primary: Latch,
+    secondary: Option<Latch>,
+}
+
+impl CancellationToken {
+    pub(crate) fn from_latch(latch: Latch) -> Self {
+        Self {
+            primary: latch,
+            secondary: None,
+        }
+    }
+
+    pub(crate) fn from_latches(primary: Latch, secondary: Latch) -> Self {
+        Self {
+            primary,
+            secondary: Some(secondary),
+        }
+    }
+
+    pub(crate) fn child(&self, cancellation: Latch) -> Self {
+        debug_assert!(self.secondary.is_none());
+        Self::from_latches(self.primary.clone(), cancellation)
+    }
+
+    /// Reports whether cancellation has been requested.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.primary.is_fired() || self.secondary.as_ref().is_some_and(Latch::is_fired)
+    }
+
+    /// Waits until cancellation is requested.
+    pub async fn cancelled(&self) {
+        if let Some(secondary) = &self.secondary {
+            let _ = runtime::select_two(self.primary.fired(), secondary.fired()).await;
+        } else {
+            self.primary.fired().await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::runtime::{self, JoinOutcome, Latch, Timeout};
+
+    use super::CancellationToken;
+
+    #[crate::runtime::test]
+    async fn local_cancellation_cancels_only_the_derived_token() {
+        let primary = Latch::default();
+        let local = Latch::default();
+        let supervisor = CancellationToken::from_latch(primary.clone());
+        let operation = supervisor.child(local.clone());
+
+        assert!(local.fire());
+        assert!(matches!(
+            runtime::timeout(Duration::from_secs(1), operation.cancelled()).await,
+            Timeout::Completed(())
+        ));
+        assert!(operation.is_cancelled());
+        assert!(!supervisor.is_cancelled());
+        assert!(!primary.is_fired());
+    }
+
+    #[crate::runtime::test]
+    async fn supervisor_cancellation_cancels_the_derived_token() {
+        let primary = Latch::default();
+        let local = Latch::default();
+        let supervisor = CancellationToken::from_latch(primary.clone());
+        let operation = supervisor.child(local.clone());
+
+        assert!(primary.fire());
+        assert!(matches!(
+            runtime::timeout(Duration::from_secs(1), operation.cancelled()).await,
+            Timeout::Completed(())
+        ));
+        assert!(supervisor.is_cancelled());
+        assert!(operation.is_cancelled());
+        assert!(!local.is_fired());
+    }
+
+    #[crate::runtime::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn simultaneous_supervisor_and_local_cancellation_wake_the_operation() {
+        for _ in 0..128 {
+            let primary = Latch::default();
+            let local = Latch::default();
+            let operation = CancellationToken::from_latch(primary.clone()).child(local.clone());
+            let waiter = runtime::spawn(async move {
+                operation.cancelled().await;
+            });
+
+            let primary_firer = runtime::spawn(async move {
+                runtime::yield_now().await;
+                primary.fire()
+            });
+            let local_firer = runtime::spawn(async move {
+                runtime::yield_now().await;
+                local.fire()
+            });
+
+            assert!(matches!(
+                runtime::join(primary_firer).await,
+                JoinOutcome::Ok { value: true }
+            ));
+            assert!(matches!(
+                runtime::join(local_firer).await,
+                JoinOutcome::Ok { value: true }
+            ));
+            assert!(matches!(
+                runtime::timeout(Duration::from_secs(1), runtime::join(waiter)).await,
+                Timeout::Completed(JoinOutcome::Ok { value: () })
+            ));
+        }
+    }
+}

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -6,6 +6,7 @@
 mod definition;
 mod actor;
 mod admission;
+mod cancellation;
 mod cells;
 mod deadline;
 mod driver;
@@ -23,6 +24,7 @@ mod tree;
 
 pub use actor::{Actor, ActorDef, ActorOnceDef, Context, Handler, StopContext};
 pub use admission::{NotAdmittingCause, RemoveOutcome, ReserveError};
+pub use cancellation::CancellationToken;
 pub use exit::{
     Exit, ExitError, ExitKind, ExitResult, IntensityTrip, ShutdownStraggler, ShutdownTimeout,
     StartupError, StartupFailure, StartupFailureCause, StopReason,
@@ -45,7 +47,7 @@ pub use policy::{
 pub use raw::{
     Blocking, DeadlineElapsed, Guard, RawActor, RawContext, RawDef, RawOnceDef, Rejected,
 };
-pub use task::{CancellationToken, OneShotTaskRef, TaskContext, TaskDef, TaskOnceDef, TaskRef};
+pub use task::{OneShotTaskRef, TaskContext, TaskDef, TaskOnceDef, TaskRef};
 pub use tree::{
     ActorSlot, Admission, AdmissionReceipt, BuildError, DynamicActorSlot, DynamicScopeRef,
     DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, Removal, ScopeRef, StartOrShutdownError,

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -13,8 +13,9 @@ use std::{
 };
 
 use crate::{
-    ActorRef, CancellationToken, ChildId, ExitResult, Incarnation, Mailbox, MailboxShutdown,
-    PolicyError, Readiness, ReadinessDeadline, RestartPolicy, Retention, ScopeRef, Shutdown,
+    ActorRef, ChildId, ExitResult, Incarnation, Mailbox, MailboxShutdown, PolicyError, Readiness,
+    ReadinessDeadline, RestartPolicy, Retention, ScopeRef, Shutdown,
+    cancellation::CancellationToken,
     cells::{MailboxControl, MemberCell},
     definition::DefinitionSource,
     mailbox::{MailboxCell, MailboxReceiver},

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -12,6 +12,7 @@ use std::{
 use crate::{
     ChildId, Exit, ExitError, ExitResult, Incarnation, Membership, PolicyError, Readiness,
     ReadinessDeadline, RestartPolicy, Retention, Shutdown,
+    cancellation::CancellationToken,
     cells::MemberCell,
     definition::DefinitionSource,
     policy::CommonOptions,
@@ -20,49 +21,6 @@ use crate::{
 
 pub(crate) type TaskFuture = Pin<Box<dyn Future<Output = ExitResult> + Send + 'static>>;
 pub(crate) type TaskFactory = Arc<dyn Fn(TaskContext) -> TaskFuture + Send + Sync + 'static>;
-
-/// A library-owned cancellation token.
-#[derive(Clone, Debug, Default)]
-pub struct CancellationToken {
-    primary: Latch,
-    secondary: Option<Latch>,
-}
-
-impl CancellationToken {
-    pub(crate) fn from_latch(latch: Latch) -> Self {
-        Self {
-            primary: latch,
-            secondary: None,
-        }
-    }
-
-    pub(crate) fn from_latches(primary: Latch, secondary: Latch) -> Self {
-        Self {
-            primary,
-            secondary: Some(secondary),
-        }
-    }
-
-    pub(crate) fn child(&self, cancellation: Latch) -> Self {
-        debug_assert!(self.secondary.is_none());
-        Self::from_latches(self.primary.clone(), cancellation)
-    }
-
-    /// Reports whether cancellation has been requested.
-    #[must_use]
-    pub fn is_cancelled(&self) -> bool {
-        self.primary.is_fired() || self.secondary.as_ref().is_some_and(Latch::is_fired)
-    }
-
-    /// Waits until cancellation is requested.
-    pub async fn cancelled(&self) {
-        if let Some(secondary) = &self.secondary {
-            let _ = runtime::select_two(self.primary.fired(), secondary.fired()).await;
-        } else {
-            self.primary.fired().await;
-        }
-    }
-}
 
 /// Per-incarnation capabilities supplied to a supervised task.
 #[derive(Clone, Debug)]
@@ -359,17 +317,16 @@ mod tests {
     use std::{
         future::Future,
         task::{Context, Poll, Waker},
-        time::Duration,
     };
 
     use crate::{
         ChildId, Exit, ExitKind,
         cells::MemberCell,
         identity::ScopeIdentity,
-        runtime::{self, JoinOutcome, Latch, Timeout},
+        runtime::{self, Latch},
     };
 
-    use super::{CancellationToken, OneShotTaskRef, TaskContext, TaskRef};
+    use super::{OneShotTaskRef, TaskContext, TaskRef};
 
     fn task_context() -> (TaskContext, Latch, Latch, Latch) {
         let id = ChildId::from("task");
@@ -474,73 +431,5 @@ mod tests {
         member.terminalize(Exit::new(ExitKind::Completed, false));
 
         let _ = claim.wait().await;
-    }
-
-    #[crate::runtime::test]
-    async fn local_cancellation_cancels_only_the_derived_token() {
-        let primary = Latch::default();
-        let local = Latch::default();
-        let supervisor = CancellationToken::from_latch(primary.clone());
-        let operation = supervisor.child(local.clone());
-
-        assert!(local.fire());
-        assert!(matches!(
-            runtime::timeout(Duration::from_secs(1), operation.cancelled()).await,
-            Timeout::Completed(())
-        ));
-        assert!(operation.is_cancelled());
-        assert!(!supervisor.is_cancelled());
-        assert!(!primary.is_fired());
-    }
-
-    #[crate::runtime::test]
-    async fn supervisor_cancellation_cancels_the_derived_token() {
-        let primary = Latch::default();
-        let local = Latch::default();
-        let supervisor = CancellationToken::from_latch(primary.clone());
-        let operation = supervisor.child(local.clone());
-
-        assert!(primary.fire());
-        assert!(matches!(
-            runtime::timeout(Duration::from_secs(1), operation.cancelled()).await,
-            Timeout::Completed(())
-        ));
-        assert!(supervisor.is_cancelled());
-        assert!(operation.is_cancelled());
-        assert!(!local.is_fired());
-    }
-
-    #[crate::runtime::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn simultaneous_supervisor_and_local_cancellation_wake_the_operation() {
-        for _ in 0..128 {
-            let primary = Latch::default();
-            let local = Latch::default();
-            let operation = CancellationToken::from_latch(primary.clone()).child(local.clone());
-            let waiter = runtime::spawn(async move {
-                operation.cancelled().await;
-            });
-
-            let primary_firer = runtime::spawn(async move {
-                runtime::yield_now().await;
-                primary.fire()
-            });
-            let local_firer = runtime::spawn(async move {
-                runtime::yield_now().await;
-                local.fire()
-            });
-
-            assert!(matches!(
-                runtime::join(primary_firer).await,
-                JoinOutcome::Ok { value: true }
-            ));
-            assert!(matches!(
-                runtime::join(local_firer).await,
-                JoinOutcome::Ok { value: true }
-            ));
-            assert!(matches!(
-                runtime::timeout(Duration::from_secs(1), runtime::join(waiter)).await,
-                Timeout::Completed(JoinOutcome::Ok { value: () })
-            ));
-        }
     }
 }

--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -81,6 +81,8 @@ expect_case exit-downcast-mut check-exit-paths.sh \
   "runtime type recovery found on the exit path:"
 expect_case layering-driver-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
+expect_case layering-cancellation-driver-below check-layering-paths.sh \
+  "upward driver or tree references found below the driver layer:"
 expect_case layering-tree-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-tree-in-driver check-layering-paths.sh \

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -8,6 +8,7 @@ cd "${SHELTERWOOD_ENFORCEMENT_ROOT:-.}"
 readonly below_driver_layers=(
   crates/shelterwood/src/admission.rs
   crates/shelterwood/src/actor.rs
+  crates/shelterwood/src/cancellation.rs
   crates/shelterwood/src/cells.rs
   crates/shelterwood/src/deadline.rs
   crates/shelterwood/src/definition.rs

--- a/tools/enforcement-fixtures/overlays/layering-cancellation-driver-below/crates/shelterwood/src/cancellation.rs
+++ b/tools/enforcement-fixtures/overlays/layering-cancellation-driver-below/crates/shelterwood/src/cancellation.rs
@@ -1,0 +1,5 @@
+// Known-bad fixture: the shared cancellation layer must not reference the
+// driver above it.
+pub fn request_stop() {
+    crate::driver::request_stop();
+}

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/cancellation.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/cancellation.rs
@@ -1,0 +1,2 @@
+// Placeholder mirroring crates/shelterwood/src/cancellation.rs so every path the
+// enforcement scripts scan exists in the fixture tree.


### PR DESCRIPTION
## Summary

- move `CancellationToken` from the task implementation into a dedicated shared cancellation module
- import the token directly from that module in task, raw-actor, and callback-actor code
- move the cancellation-specific unit tests with the implementation
- keep the layering scanner and its fixture tree comprehensive for the new module

## Why

`CancellationToken` is a read-only cancellation capability shared across supervised tasks, raw actors, callback actors, and actor-owned blocking work. Defining it in `task.rs` implied task ownership that the runtime architecture does not have. The original location was historical: tasks introduced the type before actors reused it.

The public API remains `shelterwood::CancellationToken`; this is an internal source-layout reorganization with no behavioral change.

## Validation

- `./scripts/dev just ci`