### PR TITLE
Move child IDs into identity

### DIFF
--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{identity::Membership, policy::ChildId};
+use crate::identity::{ChildId, Membership};
 
 /// The terminal reason for a scope incarnation or root system.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -1,7 +1,8 @@
-//! Membership and incarnation identity.
+//! Child, membership, and incarnation identity.
 
 use std::{
     collections::{HashMap, hash_map::Entry},
+    fmt,
     hash::Hash,
     sync::atomic::{AtomicU64, Ordering},
 };
@@ -9,13 +10,55 @@ use std::{
 #[cfg(test)]
 use std::cell::Cell;
 
-use crate::ChildId;
-
 static NEXT_LINEAGE: AtomicU64 = AtomicU64::new(0);
 
 #[cfg(test)]
 thread_local! {
     static CURRENT_THREAD_SCOPE_CREATIONS: Cell<u64> = const { Cell::new(0) };
+}
+
+/// A child identifier within one scope.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ChildId(String);
+
+impl ChildId {
+    pub(crate) fn validate(value: impl Into<String>) -> Result<Self, IdError> {
+        let value = value.into();
+        if value.is_empty() {
+            Err(IdError::Empty)
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    /// Returns the identifier as text.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ChildId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl From<&str> for ChildId {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+impl From<String> for ChildId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum IdError {
+    Empty,
 }
 
 /// A child's identity within one supervising scope.

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -25,7 +25,7 @@ pub use exit::{
     Exit, ExitError, ExitKind, ExitResult, IntensityTrip, ShutdownStraggler, ShutdownTimeout,
     StartupError, StartupFailure, StartupFailureCause, StopReason,
 };
-pub use identity::{Incarnation, Membership};
+pub use identity::{ChildId, Incarnation, Membership};
 pub use mailbox::{
     ActorRef, CallError, CallErrorKind, CallFuture, Replied, Reply, ReplyError, ReplyReceive,
     ReplyReceiver, SendError, SendErrorKind, SendFuture, SendTimeout,
@@ -37,9 +37,9 @@ pub use observe::{
 };
 pub use plan::{NotAdmittingCause, RemoveOutcome, ReserveError};
 pub use policy::{
-    Backoff, BackoffFactor, ChildId, DefaultsInheritance, Intensity, InvalidPolicy, Jitter,
-    Mailbox, MailboxShutdown, PolicyError, PolicyField, Readiness, ReadinessDeadline,
-    RestartCondition, RestartPolicy, Retention, ScopeDefaults, Shutdown, Strategy,
+    Backoff, BackoffFactor, DefaultsInheritance, Intensity, InvalidPolicy, Jitter, Mailbox,
+    MailboxShutdown, PolicyError, PolicyField, Readiness, ReadinessDeadline, RestartCondition,
+    RestartPolicy, Retention, ScopeDefaults, Shutdown, Strategy,
 };
 pub use raw::{
     Blocking, DeadlineElapsed, Guard, RawActor, RawContext, RawDef, RawOnceDef, Rejected,

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -9,10 +9,10 @@ use crate::{
     ChildId, DefaultsInheritance, Exit, Intensity, Readiness, ScopeDefaults, Strategy,
     cells::{MemberCell, ScopeCell},
     definition::DefinitionSource,
-    identity::ScopeIdentity,
+    identity::{IdError, ScopeIdentity},
     policy::{
-        CommonOptions, IdError, InvalidPolicy, PolicyField, ResolvedCommonOptions,
-        ResolvedDefaults, ScopeFlavor, resolve_common,
+        CommonOptions, InvalidPolicy, PolicyField, ResolvedCommonOptions, ResolvedDefaults,
+        ScopeFlavor, resolve_common,
     },
     raw::RawConstruction,
     runtime::{self, Isolated, Latch},

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -2,6 +2,8 @@
 
 use std::{fmt, num::NonZeroUsize, time::Duration};
 
+use crate::identity::ChildId;
+
 /// Whether a scope has fixed ordered membership or runtime-dynamic membership.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ScopeFlavor {
@@ -15,50 +17,6 @@ pub const DEFAULT_MAILBOX_CAPACITY: usize = 64;
 pub const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 /// The default gated-readiness deadline.
 pub const DEFAULT_READINESS_DEADLINE: Duration = Duration::from_secs(30);
-
-/// A child identifier within one scope.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct ChildId(String);
-
-impl ChildId {
-    pub(crate) fn validate(value: impl Into<String>) -> Result<Self, IdError> {
-        let value = value.into();
-        if value.is_empty() {
-            Err(IdError::Empty)
-        } else {
-            Ok(Self(value))
-        }
-    }
-
-    /// Returns the identifier as text.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl fmt::Display for ChildId {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(formatter)
-    }
-}
-
-impl From<&str> for ChildId {
-    fn from(value: &str) -> Self {
-        Self(value.to_owned())
-    }
-}
-
-impl From<String> for ChildId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum IdError {
-    Empty,
-}
 
 /// The condition under which an exited child is restarted.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]


### PR DESCRIPTION
## Summary

- move `ChildId` and its internal validation error from policy into the identity module
- update lowering, policy, and exit internals to import the type from its domain owner
- keep the public crate-root path `shelterwood::ChildId` unchanged

## Why

`ChildId` is the stable textual identity used by child handles, mailboxes, observations, exits, and membership generation. Its previous location in `policy.rs` grouped an identity primitive with configuration data even though policy is only one consumer.

This is a source-layout reorganization with no behavioral or public API change.

## Validation

- `./scripts/dev just ci`