### PR TITLE
Optimize supervision hot paths

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -9,7 +9,7 @@ use std::{
     any::Any,
     fmt,
     sync::{
-        Arc, Mutex, Weak,
+        Arc, Mutex, OnceLock, RwLock, Weak,
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::Instant,
@@ -19,7 +19,7 @@ use crate::{
     ChildId, Exit, Incarnation, Intensity, Mailbox, Membership, Readiness, ScopeState, Strategy,
     engine::{Epoch, RequestTarget, ScopeEpochs},
     exit::{StartupError, StopReason},
-    identity::{FenceCounter, ScopeIdentity},
+    identity::ScopeIdentity,
     observe::{
         ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
         LifecycleHub, MembershipStatus, ScopeKind, ScopeSnapshot, SnapshotHub, SnapshotReceiver,
@@ -93,11 +93,12 @@ pub(crate) struct MemberRecord {
 #[derive(Debug)]
 pub(crate) struct MemberCell {
     id: ChildId,
-    membership: Mutex<Membership>,
+    membership: Membership,
+    rebased_membership: OnceLock<Membership>,
     record: runtime::WatchSender<MemberRecord>,
     terminal_disposal_pending: AtomicBool,
     mailbox: Mutex<MemberMailbox>,
-    options: Mutex<Option<ResolvedCommonOptions>>,
+    options: OnceLock<ResolvedCommonOptions>,
     pub(crate) removal: Latch,
 }
 
@@ -133,11 +134,12 @@ impl MemberCell {
         });
         Arc::new(Self {
             id,
-            membership: Mutex::new(membership),
+            membership,
+            rebased_membership: OnceLock::new(),
             record,
             terminal_disposal_pending: AtomicBool::new(false),
             mailbox: Mutex::new(MemberMailbox::default()),
-            options: Mutex::new(None),
+            options: OnceLock::new(),
             removal: Latch::default(),
         })
     }
@@ -147,10 +149,10 @@ impl MemberCell {
     }
 
     pub(crate) fn membership(&self) -> Membership {
-        *self
-            .membership
-            .lock()
-            .expect("member identity mutex poisoned")
+        self.rebased_membership
+            .get()
+            .copied()
+            .unwrap_or(self.membership)
     }
 
     pub(crate) fn rebase_membership(&self, membership: Membership) {
@@ -161,10 +163,9 @@ impl MemberCell {
                 && record.last_incarnation.is_none(),
             "only an unstarted reservation can be rebased"
         );
-        *self
-            .membership
-            .lock()
-            .expect("member identity mutex poisoned") = membership;
+        self.rebased_membership
+            .set(membership)
+            .expect("a reservation can be rebased at most once");
     }
 
     pub(crate) fn record(&self) -> MemberRecord {
@@ -206,23 +207,21 @@ impl MemberCell {
     }
 
     pub(crate) fn set_options(&self, options: ResolvedCommonOptions) {
-        *self.options.lock().expect("member options mutex poisoned") = Some(options);
+        self.options
+            .set(options)
+            .expect("member options are resolved exactly once");
     }
 
     fn options(&self) -> ResolvedCommonOptions {
-        self.options
-            .lock()
-            .expect("member options mutex poisoned")
-            .clone()
-            .unwrap_or_else(|| {
-                crate::policy::resolve_common(
-                    &crate::policy::CommonOptions::default(),
-                    &crate::policy::ResolvedDefaults::default(),
-                    false,
-                    Readiness::Immediate,
-                )
-                .expect("library defaults must be valid")
-            })
+        self.options.get().cloned().unwrap_or_else(|| {
+            crate::policy::resolve_common(
+                &crate::policy::CommonOptions::default(),
+                &crate::policy::ResolvedDefaults::default(),
+                false,
+                Readiness::Immediate,
+            )
+            .expect("library defaults must be valid")
+        })
     }
 
     pub(crate) fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
@@ -430,8 +429,7 @@ pub(crate) struct ScopeCell {
     dynamic_route: Mutex<Option<DynamicRoute>>,
     current_children: runtime::WatchSender<Vec<ResidentChild>>,
     parent: runtime::WatchSender<Option<Weak<ScopeCell>>>,
-    observation_gate: Mutex<Arc<Mutex<()>>>,
-    lifecycle_sequence: Mutex<FenceCounter>,
+    observation_gate: RwLock<Arc<Mutex<()>>>,
     lifecycle_seq: AtomicU64,
     lifecycle: LifecycleHub,
     snapshots: SnapshotHub,
@@ -491,8 +489,7 @@ impl ScopeCell {
             dynamic_route: Mutex::new(None),
             current_children,
             parent,
-            observation_gate: Mutex::new(Arc::new(Mutex::new(()))),
-            lifecycle_sequence: Mutex::new(FenceCounter::new(0)),
+            observation_gate: RwLock::new(Arc::new(Mutex::new(()))),
             lifecycle_seq: AtomicU64::new(0),
             lifecycle: LifecycleHub::default(),
             snapshots: SnapshotHub::default(),
@@ -571,7 +568,7 @@ impl ScopeCell {
         Arc::clone(
             &self
                 .observation_gate
-                .lock()
+                .read()
                 .expect("observation gate handoff mutex poisoned"),
         )
     }
@@ -595,7 +592,7 @@ impl ScopeCell {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             let mut installed = self
                 .observation_gate
-                .lock()
+                .write()
                 .expect("observation gate handoff mutex poisoned");
             if Arc::ptr_eq(&current, &installed) {
                 *installed = Arc::clone(gate);
@@ -626,7 +623,7 @@ impl ScopeCell {
         for descendant in descendants {
             let mut installed = descendant
                 .observation_gate
-                .lock()
+                .write()
                 .expect("observation gate handoff mutex poisoned");
             if Arc::ptr_eq(&installed, previous) {
                 *installed = Arc::clone(gate);
@@ -918,11 +915,14 @@ impl ScopeCell {
     }
 
     fn emit_locked(&self, kind: LifecycleEventKind) {
+        // The resident-tree observation gate serializes every mint. The
+        // atomic is the published watermark as well as the counter, avoiding
+        // a second, provably uncontended lock on every lifecycle edge.
         let seq = self
-            .lifecycle_sequence
-            .lock()
-            .expect("lifecycle sequence mutex poisoned")
-            .mint_sequence();
+            .lifecycle_seq
+            .load(Ordering::Relaxed)
+            .checked_add(1)
+            .filter(|seq| *seq != u64::MAX);
         let Some(seq) = seq else {
             self.lifecycle_seq.store(u64::MAX, Ordering::Release);
             self.publish_snapshot_chain_locked();
@@ -965,16 +965,13 @@ impl ScopeCell {
     pub(crate) fn replace_observation_gate(&self, gate: Arc<Mutex<()>>) {
         *self
             .observation_gate
-            .lock()
+            .write()
             .expect("observation gate handoff mutex remains healthy") = gate;
     }
 
     #[cfg(test)]
-    pub(crate) fn set_lifecycle_sequence(&self, counter: FenceCounter) {
-        *self
-            .lifecycle_sequence
-            .lock()
-            .expect("lifecycle sequence mutex poisoned") = counter;
+    pub(crate) fn set_lifecycle_sequence(&self, current: u64) {
+        self.lifecycle_seq.store(current, Ordering::Relaxed);
     }
 
     pub(crate) fn set_startup(&self, startup: Result<(), StartupError>) {

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -915,14 +915,18 @@ impl ScopeCell {
     }
 
     fn emit_locked(&self, kind: LifecycleEventKind) {
-        // The resident-tree observation gate serializes every mint. The
+        // The resident-tree observation gate serializes every mint; the
         // atomic is the published watermark as well as the counter, avoiding
-        // a second, provably uncontended lock on every lifecycle edge.
+        // a second, provably uncontended lock on every lifecycle edge. The
+        // mint is still a compare-and-swap so an emit that ever escaped the
+        // gate could reorder events but never duplicate a sequence value.
         let seq = self
             .lifecycle_seq
-            .load(Ordering::Relaxed)
-            .checked_add(1)
-            .filter(|seq| *seq != u64::MAX);
+            .try_update(Ordering::Release, Ordering::Relaxed, |current| {
+                current.checked_add(1).filter(|seq| *seq != u64::MAX)
+            })
+            .ok()
+            .map(|previous| previous.saturating_add(1));
         let Some(seq) = seq else {
             self.lifecycle_seq.store(u64::MAX, Ordering::Release);
             self.publish_snapshot_chain_locked();
@@ -932,7 +936,6 @@ impl ScopeCell {
             }
             return;
         };
-        self.lifecycle_seq.store(seq, Ordering::Release);
         self.publish_snapshot_chain_locked();
 
         let scope = self.member.membership();

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -209,12 +209,12 @@ struct DynamicState {
 pub(crate) struct DynamicControl {
     events: runtime::MpscSender<DriverEvent>,
     state: Mutex<DynamicState>,
-    admissions: runtime::UnboundedMpscSender<AdmissionRequest>,
+    requests: runtime::UnboundedMpscSender<DriverEvent>,
 }
 
 impl DynamicControl {
     fn new(events: runtime::MpscSender<DriverEvent>) -> Arc<Self> {
-        let (admissions, mut admission_receiver) = runtime::unbounded_mpsc();
+        let (requests, mut request_receiver) = runtime::unbounded_mpsc();
         let forward_events = events.clone();
         let control = Arc::new(Self {
             events,
@@ -222,19 +222,16 @@ impl DynamicControl {
                 accepting: true,
                 entries: HashMap::new(),
             }),
-            admissions,
+            requests,
         });
         if runtime::is_available() {
             runtime::spawn(async move {
-                while let Some(request) =
-                    runtime::unbounded_mpsc_recv(&mut admission_receiver).await
+                while let Some(request) = runtime::unbounded_mpsc_recv(&mut request_receiver).await
                 {
-                    // A failed send returns and drops the request, whose
-                    // response obligation then completes with `Terminal`.
-                    // Keep draining so every queued admission is answered
-                    // after the driver stops.
-                    let _ =
-                        runtime::mpsc_send(&forward_events, DriverEvent::Admission(request)).await;
+                    // A failed admission send drops its response obligation,
+                    // completing it with `Terminal`. Keep draining so every
+                    // queued request is discharged after the driver stops.
+                    let _ = runtime::mpsc_send(&forward_events, request).await;
                 }
             });
         }
@@ -362,7 +359,7 @@ pub(crate) fn start_admission(
     // the caller-held future. One persistent forwarder per scope drains this
     // unbounded FIFO, keeping pending-admission memory proportional to the
     // requests without a second mutex-protected channel implementation.
-    let _ = runtime::unbounded_mpsc_send(&control.admissions, request);
+    let _ = runtime::unbounded_mpsc_send(&control.requests, DriverEvent::Admission(request));
     Ok(response)
 }
 
@@ -401,7 +398,7 @@ pub(crate) fn signal_fused_cancel(
     latch: &Latch,
 ) {
     if latch.fire() {
-        queue_driver_event(&control.events, DriverEvent::Removal(membership));
+        queue_driver_event(control, DriverEvent::Removal(membership));
     }
 }
 
@@ -449,22 +446,20 @@ pub(crate) fn remove_dynamic(
     drop(state);
     scope.transition_child(&member, |record| record.removing = true, None);
     if member.removal.fire() {
-        queue_driver_event(&control.events, DriverEvent::Removal(membership));
+        queue_driver_event(&control, DriverEvent::Removal(membership));
     }
     response
 }
 
-fn queue_driver_event(events: &runtime::MpscSender<DriverEvent>, event: DriverEvent) {
-    let Err(event) = runtime::mpsc_try_send(events, event) else {
+fn queue_driver_event(control: &DynamicControl, event: DriverEvent) {
+    let Err(event) = runtime::mpsc_try_send(&control.events, event) else {
         return;
     };
-    if !runtime::is_available() {
-        return;
-    }
-    let events = events.clone();
-    runtime::spawn(async move {
-        let _ = runtime::mpsc_send(&events, event).await;
-    });
+    // The unbounded send is synchronous and runtime-independent, so a drop or
+    // removal from a foreign thread cannot lose the edge when the bounded
+    // driver lane is full. The per-scope forwarder applies backpressure only
+    // on that saturated fallback; the normal removal path stays allocation-free.
+    let _ = runtime::unbounded_mpsc_send(&control.requests, event);
 }
 
 struct AdmissionRequest {
@@ -4367,6 +4362,53 @@ mod tests {
         drop(held_gate);
         let response = worker.join().expect("removal transition completes");
         drop(response);
+    }
+
+    #[crate::runtime::test]
+    async fn saturated_removal_from_a_foreign_thread_reaches_the_driver() {
+        let mut identity = ScopeIdentity::new();
+        let first_id = ChildId::from("first");
+        let second_id = ChildId::from("second");
+        let first = identity
+            .mint_membership(&first_id)
+            .expect("first membership available");
+        let second = identity
+            .mint_membership(&second_id)
+            .expect("second membership available");
+        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(1);
+        assert!(
+            events.try_send(DriverEvent::Removal(first)).is_ok(),
+            "the fixture saturates the bounded driver lane"
+        );
+        let control = DynamicControl::new(events);
+        let foreign_control = Arc::clone(&control);
+        std::thread::spawn(move || {
+            assert!(
+                !crate::runtime::is_available(),
+                "Tokio context is not inherited by a foreign thread"
+            );
+            super::signal_fused_cancel(&foreign_control, second, &Latch::default());
+        })
+        .join()
+        .expect("foreign-thread removal signaling succeeds");
+
+        let Some(DriverEvent::Removal(observed_first)) = event_receiver.recv().await else {
+            panic!("the saturated event remains first");
+        };
+        assert_eq!(observed_first, first);
+        let second_event =
+            match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
+                crate::runtime::Timeout::Completed(event) => {
+                    event.expect("the control forwarder remains open")
+                }
+                crate::runtime::Timeout::Elapsed => {
+                    panic!("the off-runtime removal edge must not be lost")
+                }
+            };
+        let DriverEvent::Removal(observed_second) = second_event else {
+            panic!("the forwarded event is the requested removal");
+        };
+        assert_eq!(observed_second, second);
     }
 
     #[crate::runtime::test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1,7 +1,7 @@
 //! Mutable runtime shell and shared handle state.
 
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque},
+    collections::{BTreeMap, HashMap},
     ops::{Bound, Index, IndexMut},
     sync::{Arc, Mutex, Weak, mpsc},
     time::{Duration, Instant},
@@ -11,7 +11,7 @@ use crate::{
     ChildId, Exit, ExitKind, Incarnation, IntensityTrip, Membership, Readiness, ReadinessDeadline,
     ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure, StartupFailureCause,
     admission::{NotAdmittingCause, RemoveOutcome, ReserveError},
-    cells::{DynamicRoute, MemberStage, ResidentProjection, ScopeCell},
+    cells::{DynamicRoute, MailboxControl, MemberStage, ResidentProjection, ScopeCell},
     deadline::Deadline,
     engine::{
         ArbitrationClass, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch, IntensityState,
@@ -206,36 +206,39 @@ struct DynamicState {
     entries: HashMap<ChildId, DynamicEntry>,
 }
 
-/// Admission requests awaiting the scope's single forwarder task.
-///
-/// `forwarding` is only cleared by the forwarder after observing an empty
-/// queue under this lock, and submitters push and consult it under the same
-/// lock, so a queued request always has a live forwarder destined to drain
-/// it.
-#[derive(Default)]
-struct AdmissionQueue {
-    pending: VecDeque<AdmissionRequest>,
-    forwarding: bool,
-}
-
 pub(crate) struct DynamicControl {
-    scope: Weak<ScopeCell>,
     events: runtime::MpscSender<DriverEvent>,
     state: Mutex<DynamicState>,
-    admissions: Mutex<AdmissionQueue>,
+    admissions: runtime::UnboundedMpscSender<AdmissionRequest>,
 }
 
 impl DynamicControl {
-    fn new(scope: &Arc<ScopeCell>, events: runtime::MpscSender<DriverEvent>) -> Arc<Self> {
-        Arc::new(Self {
-            scope: Arc::downgrade(scope),
+    fn new(events: runtime::MpscSender<DriverEvent>) -> Arc<Self> {
+        let (admissions, mut admission_receiver) = runtime::unbounded_mpsc();
+        let forward_events = events.clone();
+        let control = Arc::new(Self {
             events,
             state: Mutex::new(DynamicState {
                 accepting: true,
                 entries: HashMap::new(),
             }),
-            admissions: Mutex::default(),
-        })
+            admissions,
+        });
+        if runtime::is_available() {
+            runtime::spawn(async move {
+                while let Some(request) =
+                    runtime::unbounded_mpsc_recv(&mut admission_receiver).await
+                {
+                    // A failed send returns and drops the request, whose
+                    // response obligation then completes with `Terminal`.
+                    // Keep draining so every queued admission is answered
+                    // after the driver stops.
+                    let _ =
+                        runtime::mpsc_send(&forward_events, DriverEvent::Admission(request)).await;
+                }
+            });
+        }
+        control
     }
 
     fn close(&self) -> HashMap<ChildId, DynamicEntry> {
@@ -356,43 +359,11 @@ pub(crate) fn start_admission(
     };
     // The driver channel is bounded and a split admission may be dropped
     // right after this first poll (drop detaches), so the send cannot live in
-    // the caller-held future. Spawning one detached sender task per admission
-    // would let a saturated driver channel accumulate one live task per
-    // pending admission; instead requests queue here and at most one
-    // forwarder task per scope drains them in FIFO order, keeping
-    // pending-admission memory proportional to the requests themselves.
-    let start_forwarder = {
-        let mut admissions = control
-            .admissions
-            .lock()
-            .expect("admission queue mutex poisoned");
-        admissions.pending.push_back(request);
-        !std::mem::replace(&mut admissions.forwarding, true)
-    };
-    if start_forwarder {
-        runtime::spawn(forward_admissions(control));
-    }
+    // the caller-held future. One persistent forwarder per scope drains this
+    // unbounded FIFO, keeping pending-admission memory proportional to the
+    // requests without a second mutex-protected channel implementation.
+    let _ = runtime::unbounded_mpsc_send(&control.admissions, request);
     Ok(response)
-}
-
-async fn forward_admissions(control: Arc<DynamicControl>) {
-    loop {
-        let request = {
-            let mut admissions = control
-                .admissions
-                .lock()
-                .expect("admission queue mutex poisoned");
-            let Some(request) = admissions.pending.pop_front() else {
-                admissions.forwarding = false;
-                return;
-            };
-            request
-        };
-        // A failed send returns and drops the request, whose response
-        // obligation then completes with `Terminal`. Keep draining so every
-        // queued admission is answered even after the driver stops.
-        let _ = runtime::mpsc_send(&control.events, DriverEvent::Admission(request)).await;
-    }
 }
 
 fn cancel_dynamic_reservation_parts(
@@ -424,10 +395,13 @@ pub(crate) fn cancel_dynamic_reservation(control: &Arc<DynamicControl>, slot: &A
     dispose_definition_then(definition, move || drop(removed));
 }
 
-pub(crate) fn signal_fused_cancel(control: &Arc<DynamicControl>, latch: &Latch) {
-    latch.fire();
-    if let Some(scope) = control.scope.upgrade() {
-        scope.signal().pulse();
+pub(crate) fn signal_fused_cancel(
+    control: &Arc<DynamicControl>,
+    membership: Membership,
+    latch: &Latch,
+) {
+    if latch.fire() {
+        queue_driver_event(&control.events, DriverEvent::Removal(membership));
     }
 }
 
@@ -464,6 +438,7 @@ pub(crate) fn remove_dynamic(
     // through the normal removal path, like live residents, so that
     // registration is reclaimed before the removal response completes.
     let member = Arc::clone(&entry.slot.member);
+    let membership = member.membership();
     // Dynamic-state protects admission/removal bookkeeping; the observation
     // gate protects the public projection. Release the former before entering
     // the latter. No path takes the two in the opposite order, so this is not
@@ -473,9 +448,23 @@ pub(crate) fn remove_dynamic(
     // stall every concurrent reservation, removal, and driver admission.
     drop(state);
     scope.transition_child(&member, |record| record.removing = true, None);
-    member.removal.fire();
-    scope.signal().pulse();
+    if member.removal.fire() {
+        queue_driver_event(&control.events, DriverEvent::Removal(membership));
+    }
     response
+}
+
+fn queue_driver_event(events: &runtime::MpscSender<DriverEvent>, event: DriverEvent) {
+    let Err(event) = runtime::mpsc_try_send(events, event) else {
+        return;
+    };
+    if !runtime::is_available() {
+        return;
+    }
+    let events = events.clone();
+    runtime::spawn(async move {
+        let _ = runtime::mpsc_send(&events, event).await;
+    });
 }
 
 struct AdmissionRequest {
@@ -525,6 +514,7 @@ fn dispose_definition_then(
 enum DriverEvent {
     Child(ChildEvent),
     Admission(AdmissionRequest),
+    Removal(Membership),
 }
 
 impl SystemRun {
@@ -756,6 +746,7 @@ fn discharge_child_terminality(completion: ChildTerminality) {
 
 struct ChildRuntime {
     slot: Arc<SlotCell>,
+    mailbox: Option<Arc<dyn MailboxControl>>,
     terminality: Obligation<ChildTerminality>,
     construction: runtime::Isolated<ChildConstruction>,
     pending_terminal: Option<PendingTerminal>,
@@ -797,12 +788,14 @@ impl ChildRuntime {
             .lock()
             .expect("scope identity mutex poisoned")
             .incarnation_counter(slot.member.membership());
-        if let Some(mailbox) = slot.member.mailbox() {
+        let mailbox = slot.member.mailbox();
+        if let Some(mailbox) = &mailbox {
             mailbox.configure(options.mailbox);
         }
         Self {
             terminality,
             slot,
+            mailbox,
             construction,
             pending_terminal: None,
             options,
@@ -977,7 +970,7 @@ impl Drop for ScopeRuntime {
         };
         for child in self.children.values_mut() {
             if let Some(active) = child.active.take() {
-                if let Some(mailbox) = child.slot.member.mailbox() {
+                if let Some(mailbox) = &child.mailbox {
                     mailbox.freeze(active.incarnation);
                     if let Some(teardown) = mailbox.close(active.incarnation) {
                         runtime::dispose_detached(teardown);
@@ -1467,7 +1460,7 @@ impl ScopeRuntime {
         } = dispatch_child_construction(child, &self.root, &self.defaults, incarnation, &latches);
         let now = runtime::now();
         child.spawned_once = true;
-        if let Some(mailbox) = child.slot.member.mailbox() {
+        if let Some(mailbox) = &child.mailbox {
             #[cfg(debug_assertions)]
             debug_assert!(
                 mailbox.bind_order_valid(),
@@ -1682,7 +1675,7 @@ impl ScopeRuntime {
                 |record| record.stage = MemberStage::Stopping,
                 None,
             );
-            if let Some(mailbox) = child.slot.member.mailbox() {
+            if let Some(mailbox) = &child.mailbox {
                 mailbox.freeze(active.incarnation);
             }
             active.forced_outcome = forced;
@@ -1940,7 +1933,7 @@ impl ScopeRuntime {
         if let Some(deadline) = active.stop_deadline.take() {
             self.deadlines.cancel(deadline);
         }
-        if let Some(mailbox) = child.slot.member.mailbox()
+        if let Some(mailbox) = &child.mailbox
             && let Some(teardown) = mailbox.close(incarnation)
         {
             runtime::dispose_detached(teardown);
@@ -2369,26 +2362,6 @@ impl ScopeRuntime {
         self.spawn_child(key);
     }
 
-    fn pending_removals(&self) -> Vec<Membership> {
-        let Some(control) = &self.dynamic else {
-            return Vec::new();
-        };
-        control
-            .state
-            .lock()
-            .expect("dynamic-state mutex poisoned")
-            .entries
-            .values()
-            .filter(|entry| {
-                entry.admitted
-                    && !entry.removal_started
-                    && (entry.slot.member.removal.is_fired()
-                        || entry.fused_cancel.as_ref().is_some_and(Latch::is_fired))
-            })
-            .map(|entry| entry.slot.member.membership())
-            .collect()
-    }
-
     fn handle_removal(&mut self, membership: Membership) {
         if let Some(control) = &self.dynamic {
             let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
@@ -2631,8 +2604,8 @@ async fn run_scope_incarnation(
     let capacity = plan.children.len().saturating_mul(3).max(64);
     let (events, mut event_receiver) = runtime::bounded_mpsc(capacity);
     let (disposal_events, mut disposal_event_receiver) = runtime::unbounded_mpsc();
-    let dynamic = (plan.root.flavor == ScopeFlavor::Dynamic)
-        .then(|| DynamicControl::new(&root, events.clone()));
+    let dynamic =
+        (plan.root.flavor == ScopeFlavor::Dynamic).then(|| DynamicControl::new(events.clone()));
     if let Some(control) = &dynamic {
         let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
         for child in &plan.children {
@@ -2740,12 +2713,6 @@ async fn run_scope_incarnation(
             // cannot publish Running after the stop boundary.
             pending.push((ArbitrationClass::ScopeShutdown, Pending::Force));
         }
-        for membership in scope.pending_removals() {
-            pending.push((
-                ArbitrationClass::MembershipRemoval,
-                Pending::Removal(membership),
-            ));
-        }
         while let Some(event) = runtime::mpsc_try_recv(&mut event_receiver) {
             let class = driver_event_class(&event);
             pending.push((class, Pending::Driver(event)));
@@ -2850,7 +2817,9 @@ async fn run_scope_incarnation(
                 Pending::Force => {
                     scope.force_all();
                 }
-                Pending::Removal(membership) => scope.handle_removal(membership),
+                Pending::Driver(DriverEvent::Removal(membership)) => {
+                    scope.handle_removal(membership)
+                }
                 Pending::Driver(DriverEvent::Admission(request)) => {
                     scope.handle_admission(request);
                 }
@@ -2914,7 +2883,6 @@ enum Pending {
     AncestorShutdown,
     AncestorAbort,
     Force,
-    Removal(Membership),
     Driver(DriverEvent),
     Deadline(DeadlineKind),
 }
@@ -2933,6 +2901,7 @@ fn restart_shutdown_work(child: ChildKey) -> (ArbitrationClass, Pending) {
 fn driver_event_class(event: &DriverEvent) -> ArbitrationClass {
     match event {
         DriverEvent::Child(ChildEvent::SelfStop { .. }) => ArbitrationClass::MembershipRemoval,
+        DriverEvent::Removal(_) => ArbitrationClass::MembershipRemoval,
         DriverEvent::Child(ChildEvent::Constructed { .. } | ChildEvent::Ready { .. }) => {
             ArbitrationClass::ReadinessSignal
         }
@@ -4292,7 +4261,7 @@ mod tests {
         let slot = SlotCell::new(Arc::clone(&member), None);
         root.set_admitted_children(vec![resident_projection(&slot)]);
         let (events, _receiver) = crate::runtime::bounded_mpsc(1);
-        let control = DynamicControl::new(&root, events);
+        let control = DynamicControl::new(events);
         let (sender, mut response) = crate::runtime::oneshot();
         let mut responses = RemovalResponses::default();
         responses.0.push(sender);
@@ -4352,7 +4321,7 @@ mod tests {
         let slot = SlotCell::new(Arc::clone(&member), None);
         root.set_admitted_children(vec![resident_projection(&slot)]);
         let (events, _receiver) = crate::runtime::bounded_mpsc(1);
-        let control = DynamicControl::new(&root, events);
+        let control = DynamicControl::new(events);
         control
             .state
             .lock()
@@ -4406,7 +4375,7 @@ mod tests {
 
         let root = isolated_scope("root", ScopeFlavor::Dynamic);
         let (events, event_receiver) = crate::runtime::bounded_mpsc(1);
-        let control = DynamicControl::new(&root, events);
+        let control = DynamicControl::new(events);
         let child_id = ChildId::from("worker");
         let member = MemberCell::new(
             child_id.clone(),
@@ -4895,7 +4864,7 @@ mod tests {
         let membership = identity.mint_membership(&id).expect("membership available");
         let member = MemberCell::new(id, membership);
         let scope = ScopeCell::new(member, ScopeFlavor::Ordered, ScopeIdentity::new());
-        scope.set_lifecycle_sequence(FenceCounter::near_exhaustion(0));
+        scope.set_lifecycle_sequence(u64::MAX - 2);
         let mut events = scope.subscribe_lifecycle();
 
         scope.emit(LifecycleEventKind::ScopeState {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -210,12 +210,21 @@ pub(crate) struct DynamicControl {
     events: runtime::MpscSender<DriverEvent>,
     state: Mutex<DynamicState>,
     requests: runtime::UnboundedMpscSender<DriverEvent>,
+    request_forwarder_close: Latch,
+    #[cfg(test)]
+    request_forwarder_ended: Latch,
 }
 
 impl DynamicControl {
     fn new(events: runtime::MpscSender<DriverEvent>) -> Arc<Self> {
         let (requests, mut request_receiver) = runtime::unbounded_mpsc();
         let forward_events = events.clone();
+        let request_forwarder_close = Latch::default();
+        let close_forwarder = request_forwarder_close.clone();
+        #[cfg(test)]
+        let request_forwarder_ended = Latch::default();
+        #[cfg(test)]
+        let forwarder_ended = request_forwarder_ended.clone();
         let control = Arc::new(Self {
             events,
             state: Mutex::new(DynamicState {
@@ -223,16 +232,38 @@ impl DynamicControl {
                 entries: HashMap::new(),
             }),
             requests,
+            request_forwarder_close,
+            #[cfg(test)]
+            request_forwarder_ended,
         });
         if runtime::is_available() {
             runtime::spawn(async move {
-                while let Some(request) = runtime::unbounded_mpsc_recv(&mut request_receiver).await
-                {
+                loop {
+                    let request = match runtime::select_two(
+                        close_forwarder.fired(),
+                        runtime::unbounded_mpsc_recv(&mut request_receiver),
+                    )
+                    .await
+                    {
+                        runtime::Either::Left(()) | runtime::Either::Right(None) => break,
+                        runtime::Either::Right(Some(request)) => request,
+                    };
                     // A failed admission send drops its response obligation,
-                    // completing it with `Terminal`. Keep draining so every
-                    // queued request is discharged after the driver stops.
-                    let _ = runtime::mpsc_send(&forward_events, request).await;
+                    // completing it with `Terminal`. Explicit closure drops
+                    // this request and the queued suffix for the same result.
+                    if matches!(
+                        runtime::select_two(
+                            close_forwarder.fired(),
+                            runtime::mpsc_send(&forward_events, request),
+                        )
+                        .await,
+                        runtime::Either::Left(())
+                    ) {
+                        break;
+                    }
                 }
+                #[cfg(test)]
+                forwarder_ended.fire();
             });
         }
         control
@@ -243,6 +274,10 @@ impl DynamicControl {
         state.accepting = false;
         let entries = std::mem::take(&mut state.entries);
         drop(state);
+        // Reservation handles may retain this control after scope teardown.
+        // Stop the sole per-scope forwarder explicitly instead of waiting for
+        // every clone of its unbounded sender to disappear.
+        self.request_forwarder_close.fire();
         let mut retained = HashMap::new();
         for (id, entry) in entries {
             if !entry.admitted {
@@ -4289,6 +4324,32 @@ mod tests {
         );
         drop(entries);
         assert_eq!(response.try_receive(), Some(RemoveOutcome::Removed));
+    }
+
+    #[crate::runtime::test]
+    async fn retained_unadmitted_slot_does_not_retain_the_request_forwarder() {
+        let system = DynamicTree::new().spawn().expect("runtime is available");
+        system.wait_started().await.expect("root starts");
+        let scope = system.scope();
+        let slot = scope
+            .reserve_task("retained")
+            .expect("unadmitted reservation is retained");
+        let control = dynamic_control(&scope.as_scope().cell)
+            .expect("the live dynamic scope exposes its control");
+        let forwarder_ended = control.request_forwarder_ended.clone();
+
+        system
+            .shutdown(Duration::from_secs(1))
+            .await
+            .expect("driver teardown completes");
+
+        assert!(control.request_forwarder_close.is_fired());
+        assert!(matches!(
+            crate::runtime::timeout(Duration::from_secs(1), forwarder_ended.fired()).await,
+            crate::runtime::Timeout::Completed(())
+        ));
+        drop(slot);
+        drop(control);
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -236,6 +236,10 @@ impl DynamicControl {
             #[cfg(test)]
             request_forwarder_ended,
         });
+        // Off-runtime construction (unit tests only) safely skips the
+        // forwarder: `reserve_dynamic`/`start_admission` fail closed with
+        // `NoRuntime` before anything can enqueue, and a live driver — the
+        // only other producer — exists only inside the runtime.
         if runtime::is_available() {
             runtime::spawn(async move {
                 loop {

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -185,6 +185,7 @@ impl FenceCounter {
     ///
     /// Observation uses the same saturating, poison-never-minted primitive as
     /// membership and incarnation fencing.
+    #[cfg(test)]
     pub(crate) fn mint_sequence(&mut self) -> Option<u64> {
         self.mint().map(|fence| fence.generation.get())
     }

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -4,7 +4,10 @@ use std::{
     collections::{HashMap, hash_map::Entry},
     fmt,
     hash::Hash,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 #[cfg(test)]
@@ -18,8 +21,10 @@ thread_local! {
 }
 
 /// A child identifier within one scope.
+// Shared text keeps error evidence allocation-free: every rejected send and
+// call clones the id, so a clone must be a refcount bump, not a heap copy.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct ChildId(String);
+pub struct ChildId(Arc<str>);
 
 impl ChildId {
     pub(crate) fn validate(value: impl Into<String>) -> Result<Self, IdError> {
@@ -27,7 +32,7 @@ impl ChildId {
         if value.is_empty() {
             Err(IdError::Empty)
         } else {
-            Ok(Self(value))
+            Ok(Self(Arc::from(value)))
         }
     }
 
@@ -46,13 +51,13 @@ impl fmt::Display for ChildId {
 
 impl From<&str> for ChildId {
     fn from(value: &str) -> Self {
-        Self(value.to_owned())
+        Self(Arc::from(value))
     }
 }
 
 impl From<String> for ChildId {
     fn from(value: String) -> Self {
-        Self(value)
+        Self(Arc::from(value))
     }
 }
 

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1368,6 +1368,10 @@ pub struct SendFuture<M> {
 enum SendFutureState<M> {
     Immediate(Option<M>),
     Parked(Arc<SendOperation<M>>),
+    // Acceptance is remembered so a completed send stays idempotently
+    // observable, matching the retained-operation behaviour this state
+    // machine replaced.
+    Sent(Incarnation),
     Done,
 }
 
@@ -1393,6 +1397,7 @@ impl<M: Send + 'static> SendFuture<M> {
                 observed: self.mailbox.current_observation(),
             },
             SendFutureState::Parked(operation) => self.mailbox.withdraw(&operation),
+            SendFutureState::Sent(incarnation) => Withdrawal::Accepted(incarnation),
             SendFutureState::Done => panic!("a completed send was withdrawn"),
         }
     }
@@ -1406,7 +1411,10 @@ impl<M> fmt::Debug for SendFuture<M> {
                 "submitted",
                 &!matches!(self.state, SendFutureState::Immediate(_)),
             )
-            .field("done", &matches!(self.state, SendFutureState::Done))
+            .field(
+                "done",
+                &matches!(self.state, SendFutureState::Sent(_) | SendFutureState::Done),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -1422,7 +1430,7 @@ impl<M: Send + 'static> Future for SendFuture<M> {
                 .expect("an unsubmitted send retains its message");
             match this.mailbox.submit(message) {
                 Submission::Accepted(incarnation) => {
-                    this.state = SendFutureState::Done;
+                    this.state = SendFutureState::Sent(incarnation);
                     return Poll::Ready(Ok(incarnation));
                 }
                 Submission::Parked(operation) => {
@@ -1443,6 +1451,9 @@ impl<M: Send + 'static> Future for SendFuture<M> {
             }
         }
 
+        if let SendFutureState::Sent(incarnation) = this.state {
+            return Poll::Ready(Ok(incarnation));
+        }
         let SendFutureState::Parked(operation) = &this.state else {
             panic!("a completed send future was polled")
         };
@@ -1454,7 +1465,7 @@ impl<M: Send + 'static> Future for SendFuture<M> {
             OperationOutcome::Accepted(incarnation) => {
                 let incarnation = *incarnation;
                 drop(operation_state);
-                this.state = SendFutureState::Done;
+                this.state = SendFutureState::Sent(incarnation);
                 Poll::Ready(Ok(incarnation))
             }
             OperationOutcome::Terminated {
@@ -1500,7 +1511,7 @@ impl<M> Drop for SendFuture<M> {
                 }
                 Withdrawal::Accepted(_) => {}
             },
-            SendFutureState::Done => {}
+            SendFutureState::Sent(_) | SendFutureState::Done => {}
         }
     }
 }
@@ -2197,5 +2208,67 @@ mod tests {
             future.operation.elapsed_polls, 0,
             "a zero budget never attempts the operation"
         );
+    }
+
+    #[test]
+    fn an_accepted_send_reports_acceptance_on_every_poll() {
+        let (mailbox, actor) = actor();
+        MailboxControl::configure(&*mailbox, Mailbox::default());
+        let mut identity = ScopeIdentity::new();
+        let membership = identity
+            .mint_membership(&ChildId::from("actor"))
+            .expect("membership available");
+        let mut incarnations = identity.incarnation_counter(membership);
+        let incarnation = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
+            .expect("incarnation available");
+        MailboxControl::bind(&*mailbox, incarnation);
+
+        let mut send = Box::pin(actor.send(1));
+        let mut context = Context::from_waker(Waker::noop());
+        let Poll::Ready(Ok(first)) = send.as_mut().poll(&mut context) else {
+            panic!("a bound, non-full mailbox accepts immediately")
+        };
+        let Poll::Ready(Ok(second)) = send.as_mut().poll(&mut context) else {
+            panic!("a completed send stays observable")
+        };
+        assert_eq!(first, second);
+        assert_eq!(first, incarnation);
+    }
+
+    struct CountedDrop(Arc<AtomicUsize>);
+
+    impl Drop for CountedDrop {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn dropping_a_never_polled_send_disposes_the_message_exactly_once() {
+        let mut identity = ScopeIdentity::new();
+        let id = ChildId::from("actor");
+        let member = MemberCell::new(
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
+        );
+        let mailbox: Arc<MailboxCell<CountedDrop>> = MailboxCell::new(member.id().clone());
+        member.attach_mailbox(mailbox.clone());
+        let actor = ActorRef::new(member, Arc::clone(&mailbox));
+        let drops = Arc::new(AtomicUsize::new(0));
+
+        drop(actor.send(CountedDrop(Arc::clone(&drops))));
+
+        // The never-submitted message routes through detached isolated
+        // disposal on another thread, so acknowledge it with a bounded wait.
+        for _ in 0..1_000 {
+            if drops.load(Ordering::SeqCst) == 1 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        let state = mailbox.state.lock().expect("mailbox mutex poisoned");
+        assert!(state.queue.is_empty());
+        assert!(state.waiters.is_empty());
     }
 }

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -7,7 +7,10 @@ use std::{
     hash::{Hash, Hasher},
     num::NonZeroUsize,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
     task::{Context, Poll, Waker},
     time::Duration,
 };
@@ -535,7 +538,15 @@ struct MailboxState<M> {
     queue: VecDeque<Envelope<M>>,
     latest: Option<Envelope<M>>,
     waiters: WaiterQueue<M>,
-    accepted: u64,
+}
+
+enum Submission<M> {
+    Accepted(Incarnation),
+    Parked(Arc<SendOperation<M>>),
+    Terminated {
+        message: M,
+        final_incarnation: Option<Incarnation>,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -759,6 +770,7 @@ impl<M: Send + 'static> Drop for MailboxTeardown<M> {
 pub(crate) struct MailboxCell<M> {
     actor_id: ChildId,
     state: Mutex<MailboxState<M>>,
+    accepted: AtomicU64,
     changed: Signal,
 }
 
@@ -782,21 +794,20 @@ impl<M: Send + 'static> MailboxCell<M> {
                 queue: VecDeque::new(),
                 latest: None,
                 waiters: WaiterQueue::default(),
-                accepted: 0,
             }),
+            accepted: AtomicU64::new(0),
             changed: Signal::default(),
         })
     }
 
-    fn submit(&self, operation: &Arc<SendOperation<M>>) {
+    fn submit(&self, message: M) -> Submission<M> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         match state.status {
-            BindingStatus::Terminal(final_incarnation) => {
-                drop(state);
-                operation.terminate(final_incarnation);
-            }
+            BindingStatus::Terminal(final_incarnation) => Submission::Terminated {
+                message,
+                final_incarnation,
+            },
             BindingStatus::Bound(incarnation) => {
-                operation.observe(incarnation);
                 let can_accept = match state.kind {
                     Some(MailboxKind::Queue(capacity)) => {
                         state.waiters.is_empty() && state.queue.len() < capacity.get()
@@ -805,11 +816,7 @@ impl<M: Send + 'static> MailboxCell<M> {
                     None => false,
                 };
                 if can_accept {
-                    let (message, wake) = operation
-                        .accept(incarnation)
-                        .expect("a newly submitted operation still owns its message");
-                    state.accepted = state.accepted.saturating_add(1);
-                    let accepted_sequence = state.accepted;
+                    let accepted_sequence = self.mint_accepted_sequence();
                     let displaced = match state.kind {
                         Some(MailboxKind::Queue(_)) => {
                             state.queue.push_back(Envelope {
@@ -826,20 +833,31 @@ impl<M: Send + 'static> MailboxCell<M> {
                     };
                     drop(state);
                     self.changed.pulse();
-                    if let Some(waker) = wake {
-                        waker.wake();
-                    }
                     drop(displaced);
+                    Submission::Accepted(incarnation)
                 } else {
-                    state.waiters.park(operation);
+                    let operation = SendOperation::new(message);
+                    operation.observe(incarnation);
+                    state.waiters.park(&operation);
+                    Submission::Parked(operation)
                 }
             }
             BindingStatus::Frozen(incarnation) => {
+                let operation = SendOperation::new(message);
                 operation.observe(incarnation);
-                state.waiters.park(operation);
+                state.waiters.park(&operation);
+                Submission::Parked(operation)
             }
-            BindingStatus::Unbound => state.waiters.park(operation),
+            BindingStatus::Unbound => {
+                let operation = SendOperation::new(message);
+                state.waiters.park(&operation);
+                Submission::Parked(operation)
+            }
         }
+    }
+
+    fn mint_accepted_sequence(&self) -> u64 {
+        mint_accepted_sequence(&self.accepted)
     }
 
     fn try_send(&self, message: M) -> Result<Incarnation, SendError<M>> {
@@ -875,8 +893,7 @@ impl<M: Send + 'static> MailboxCell<M> {
                     })
                 }
                 Some(MailboxKind::Queue(_)) => {
-                    state.accepted = state.accepted.saturating_add(1);
-                    let accepted_sequence = state.accepted;
+                    let accepted_sequence = self.mint_accepted_sequence();
                     state.queue.push_back(Envelope {
                         message,
                         accepted_sequence,
@@ -886,8 +903,7 @@ impl<M: Send + 'static> MailboxCell<M> {
                     Ok(incarnation)
                 }
                 Some(MailboxKind::Latest) => {
-                    state.accepted = state.accepted.saturating_add(1);
-                    let accepted_sequence = state.accepted;
+                    let accepted_sequence = self.mint_accepted_sequence();
                     let displaced = state.latest.replace(Envelope {
                         message,
                         accepted_sequence,
@@ -944,7 +960,7 @@ impl<M: Send + 'static> MailboxCell<M> {
             None => None,
         };
         let promotion = if message.is_some() && matches!(state.status, BindingStatus::Bound(_)) {
-            promote_waiters(&mut state)
+            promote_waiters(&mut state, &self.accepted)
         } else {
             Promotion::default()
         };
@@ -970,7 +986,7 @@ impl<M: Send + 'static> MailboxCell<M> {
     }
 
     fn accepted_sequence(&self) -> u64 {
-        self.state.lock().expect("mailbox mutex poisoned").accepted
+        self.accepted.load(Ordering::Acquire)
     }
 }
 
@@ -1079,7 +1095,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         // the operation lock, so a concurrent timeout sees either the prior
         // evidence or this incarnation consistently with which edge won.
         state.waiters.observe_all(incarnation);
-        let promotion = promote_waiters(&mut state);
+        let promotion = promote_waiters(&mut state, &self.accepted);
         drop(state);
         self.changed.pulse();
         promotion.finish_isolated();
@@ -1152,7 +1168,19 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
     }
 }
 
-fn promote_waiters<M: Send + 'static>(state: &mut MailboxState<M>) -> Promotion<M> {
+fn mint_accepted_sequence(accepted: &AtomicU64) -> u64 {
+    accepted
+        .try_update(Ordering::Release, Ordering::Relaxed, |accepted| {
+            Some(accepted.saturating_add(1))
+        })
+        .expect("accepted sequence updates never reject")
+        .saturating_add(1)
+}
+
+fn promote_waiters<M: Send + 'static>(
+    state: &mut MailboxState<M>,
+    accepted_sequence: &AtomicU64,
+) -> Promotion<M> {
     let mut promotion = Promotion::default();
     let Some(kind) = state.kind else {
         return promotion;
@@ -1177,8 +1205,7 @@ fn promote_waiters<M: Send + 'static>(state: &mut MailboxState<M>) -> Promotion<
         if let Some(waker) = wake {
             promotion.wakers.push(waker);
         }
-        state.accepted = state.accepted.saturating_add(1);
-        let accepted_sequence = state.accepted;
+        let accepted_sequence = mint_accepted_sequence(accepted_sequence);
         match kind {
             MailboxKind::Queue(_) => state.queue.push_back(Envelope {
                 message,
@@ -1237,7 +1264,7 @@ impl<M> ActorRef<M> {
 impl<M: Send + 'static> ActorRef<M> {
     /// Sends with backpressure and transparently waits through rebind windows.
     pub fn send(&self, message: M) -> SendFuture<M> {
-        SendFuture::new(self.clone(), message)
+        SendFuture::new(Arc::clone(&self.mailbox), message)
     }
 
     /// Attempts immediate acceptance without parking.
@@ -1331,30 +1358,43 @@ impl<M> Hash for ActorRef<M> {
 /// Cancellation-safe future returned by [`ActorRef::send`].
 #[must_use]
 pub struct SendFuture<M> {
-    actor: ActorRef<M>,
-    operation: Arc<SendOperation<M>>,
+    mailbox: Arc<MailboxCell<M>>,
+    state: SendFutureState<M>,
     // Captured where `M: Send + 'static` holds so the unbounded `Drop` impl
     // can route a withdrawn message through isolated disposal.
     dispose: fn(M),
-    submitted: bool,
-    done: bool,
 }
 
+enum SendFutureState<M> {
+    Immediate(Option<M>),
+    Parked(Arc<SendOperation<M>>),
+    Done,
+}
+
+// No field is structurally pinned. In particular, the immediate message may
+// move when first poll hands it to the mailbox.
+impl<M> Unpin for SendFuture<M> {}
+
 impl<M: Send + 'static> SendFuture<M> {
-    fn new(actor: ActorRef<M>, message: M) -> Self {
+    fn new(mailbox: Arc<MailboxCell<M>>, message: M) -> Self {
         Self {
-            actor,
-            operation: SendOperation::new(message),
+            mailbox,
+            state: SendFutureState::Immediate(Some(message)),
             dispose: dispose_detached::<M>,
-            submitted: false,
-            done: false,
         }
     }
 
     fn withdraw(&mut self) -> Withdrawal<M> {
-        let result = self.actor.mailbox.withdraw(&self.operation);
-        self.done = true;
-        result
+        match std::mem::replace(&mut self.state, SendFutureState::Done) {
+            SendFutureState::Immediate(mut message) => Withdrawal::Withdrawn {
+                message: message
+                    .take()
+                    .expect("an unsubmitted send retains its message"),
+                observed: self.mailbox.current_observation(),
+            },
+            SendFutureState::Parked(operation) => self.mailbox.withdraw(&operation),
+            SendFutureState::Done => panic!("a completed send was withdrawn"),
+        }
     }
 }
 
@@ -1362,8 +1402,11 @@ impl<M> fmt::Debug for SendFuture<M> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("SendFuture")
-            .field("submitted", &self.submitted)
-            .field("done", &self.done)
+            .field(
+                "submitted",
+                &!matches!(self.state, SendFutureState::Immediate(_)),
+            )
+            .field("done", &matches!(self.state, SendFutureState::Done))
             .finish_non_exhaustive()
     }
 }
@@ -1372,20 +1415,46 @@ impl<M: Send + 'static> Future for SendFuture<M> {
     type Output = Result<Incarnation, SendError<M>>;
 
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
-        if !self.submitted {
-            self.submitted = true;
-            self.actor.mailbox.submit(&self.operation);
+        let this = self.as_mut().get_mut();
+        if let SendFutureState::Immediate(message) = &mut this.state {
+            let message = message
+                .take()
+                .expect("an unsubmitted send retains its message");
+            match this.mailbox.submit(message) {
+                Submission::Accepted(incarnation) => {
+                    this.state = SendFutureState::Done;
+                    return Poll::Ready(Ok(incarnation));
+                }
+                Submission::Parked(operation) => {
+                    this.state = SendFutureState::Parked(operation);
+                }
+                Submission::Terminated {
+                    message,
+                    final_incarnation,
+                } => {
+                    this.state = SendFutureState::Done;
+                    return Poll::Ready(Err(SendError {
+                        actor_id: this.mailbox.actor_id.clone(),
+                        incarnation_observed: final_incarnation,
+                        message,
+                        kind: SendErrorKind::Terminated,
+                    }));
+                }
+            }
         }
-        let mut state = self
-            .operation
+
+        let SendFutureState::Parked(operation) = &this.state else {
+            panic!("a completed send future was polled")
+        };
+        let mut operation_state = operation
             .state
             .lock()
             .expect("send operation mutex poisoned");
-        match &mut state.outcome {
+        match &mut operation_state.outcome {
             OperationOutcome::Accepted(incarnation) => {
                 let incarnation = *incarnation;
-                drop(state);
-                self.done = true;
+                drop(operation_state);
+                this.state = SendFutureState::Done;
                 Poll::Ready(Ok(incarnation))
             }
             OperationOutcome::Terminated {
@@ -1393,19 +1462,19 @@ impl<M: Send + 'static> Future for SendFuture<M> {
                 final_incarnation,
             } => {
                 let error = SendError {
-                    actor_id: self.actor.id().clone(),
+                    actor_id: this.mailbox.actor_id.clone(),
                     incarnation_observed: *final_incarnation,
                     message: message
                         .take()
                         .expect("a terminal operation retains its message until observed"),
                     kind: SendErrorKind::Terminated,
                 };
-                drop(state);
-                self.done = true;
+                drop(operation_state);
+                this.state = SendFutureState::Done;
                 Poll::Ready(Err(error))
             }
             OperationOutcome::Waiting { .. } => {
-                state.waker = Some(context.waker().clone());
+                operation_state.waker = Some(context.waker().clone());
                 Poll::Pending
             }
             OperationOutcome::Withdrawn => panic!("a withdrawn send future was polled"),
@@ -1415,17 +1484,23 @@ impl<M: Send + 'static> Future for SendFuture<M> {
 
 impl<M> Drop for SendFuture<M> {
     fn drop(&mut self) {
-        if !self.done {
-            // Cancellation recovers the unaccepted message with no caller
-            // left to hand it to. Destroying it inline would run a possibly
-            // blocking or panicking user destructor in this drop glue, so
-            // route the payload through isolated disposal.
-            match self.actor.mailbox.withdraw(&self.operation) {
+        // Cancellation recovers the unaccepted message with no caller left to
+        // hand it to. Destroying it inline would run a possibly blocking or
+        // panicking user destructor in this drop glue, so route the payload
+        // through isolated disposal.
+        match std::mem::replace(&mut self.state, SendFutureState::Done) {
+            SendFutureState::Immediate(mut message) => {
+                if let Some(message) = message.take() {
+                    (self.dispose)(message);
+                }
+            }
+            SendFutureState::Parked(operation) => match self.mailbox.withdraw(&operation) {
                 Withdrawal::Withdrawn { message, .. } | Withdrawal::Terminated { message, .. } => {
                     (self.dispose)(message);
                 }
                 Withdrawal::Accepted(_) => {}
-            }
+            },
+            SendFutureState::Done => {}
         }
     }
 }
@@ -1451,7 +1526,7 @@ impl<M> fmt::Debug for SendTimeout<M> {
 }
 
 fn withdraw_send<M: Send + 'static>(send: &mut SendFuture<M>) -> Result<Incarnation, SendError<M>> {
-    let actor_id = send.actor.id().clone();
+    let actor_id = send.mailbox.actor_id.clone();
     match send.withdraw() {
         Withdrawal::Withdrawn { message, observed } => Err(SendError {
             actor_id,

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -380,7 +380,13 @@ impl SnapshotHub {
             })
             .0
         });
-        if sender.receiver_count() == 0 {
+        // `close` may win between the first atomic check and lazy sender
+        // initialization. Reconcile the channel state after initialization so
+        // that first subscriber still observes closure; once installed,
+        // `close` itself performs this publication and wakeup.
+        if self.closed.load(Ordering::Acquire) {
+            sender.send_modify(|state| state.closed = true);
+        } else if sender.receiver_count() == 0 {
             sender.send_modify(|state| {
                 state.snapshot = initial;
                 state.generation = state.generation.saturating_add(1);

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -408,9 +408,17 @@ impl SnapshotHub {
             return;
         };
         if sender.receiver_count() > 0 {
-            sender.send_modify(|state| {
+            sender.send_if_modified(|state| {
+                // `close` and publication serialize on the retained watch
+                // state. The atomic is the fast path; this check prevents a
+                // publisher that passed it just before closure from mutating
+                // the terminal value afterward.
+                if state.closed {
+                    return false;
+                }
                 state.snapshot = snapshot();
                 state.generation = state.generation.saturating_add(1);
+                true
             });
         }
     }
@@ -567,20 +575,34 @@ impl LifecycleHub {
             kind = ?event.kind,
             "scope lifecycle event"
         );
-        if !self.closed.load(Ordering::Acquire) {
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        self.channels.signal.send_if_modified(|signal| {
+            // Enqueue and activity notification share the same linearization
+            // point as closure. A publisher that passed the atomic fast-path
+            // check cannot append after receivers have observed `closed`.
+            if signal.closed {
+                return false;
+            }
             let _ = self.channels.events.send(event);
             // The watch version is also the no-loss activity notification for
             // async receivers. Its value changes only for explicit lag.
-            self.channels.signal.pulse();
-        }
+            true
+        });
     }
 
     pub(crate) fn publish_lagged(&self, dropped: u64) {
-        if !self.closed.load(Ordering::Acquire) {
-            self.channels.signal.send_modify(|signal| {
-                signal.explicit_lag = signal.explicit_lag.saturating_add(dropped);
-            });
+        if self.closed.load(Ordering::Acquire) {
+            return;
         }
+        self.channels.signal.send_if_modified(|signal| {
+            if signal.closed {
+                return false;
+            }
+            signal.explicit_lag = signal.explicit_lag.saturating_add(dropped);
+            true
+        });
     }
 
     pub(crate) fn close(&self) {
@@ -619,18 +641,104 @@ pub enum WaitError {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        sync::{Arc, atomic::Ordering},
+        thread,
+    };
+
     use crate::{
-        ScopeState,
+        Intensity, ScopeState,
         identity::ScopeIdentity,
-        observe::{LifecycleEvent, LifecycleEventKind, LifecycleItem},
+        observe::{
+            LifecycleEvent, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, ScopeKind,
+            ScopeSnapshot,
+        },
     };
 
     use super::{LIFECYCLE_EVENT_CAPACITY, LifecycleHub, SnapshotHub};
+
+    fn snapshot(state: ScopeState) -> Arc<ScopeSnapshot> {
+        Arc::new(ScopeSnapshot {
+            state,
+            kind: ScopeKind::Dynamic,
+            strategy: None,
+            intensity: Intensity::default(),
+            total_restarts: 0,
+            lifecycle_seq: 0,
+            children: Arc::from([]),
+        })
+    }
 
     #[test]
     fn snapshot_projection_is_skipped_without_subscribers() {
         let hub = SnapshotHub::default();
         hub.publish(|| panic!("projection must be lazy when no receiver exists"));
+    }
+
+    #[crate::runtime::test]
+    async fn snapshot_publication_that_linearizes_before_close_is_drained() {
+        let hub = Arc::new(SnapshotHub::default());
+        let mut snapshots = hub.subscribe(snapshot(ScopeState::Unstarted));
+        let (entered, wait_for_release) = std::sync::mpsc::channel();
+        let (release, released) = std::sync::mpsc::channel();
+
+        let publisher = {
+            let hub = Arc::clone(&hub);
+            thread::spawn(move || {
+                hub.publish(|| {
+                    entered.send(()).expect("test remains active");
+                    released.recv().expect("publisher is released");
+                    snapshot(ScopeState::Running)
+                });
+            })
+        };
+        wait_for_release
+            .recv()
+            .expect("publisher reaches the serialized channel update");
+        let closer = {
+            let hub = Arc::clone(&hub);
+            thread::spawn(move || hub.close())
+        };
+        while !hub.closed.load(Ordering::Acquire) {
+            thread::yield_now();
+        }
+        release.send(()).expect("publisher is still waiting");
+        publisher.join().expect("publisher does not panic");
+        closer.join().expect("closer does not panic");
+
+        assert_eq!(
+            snapshots
+                .changed()
+                .await
+                .expect("publication precedes close")
+                .state,
+            ScopeState::Running
+        );
+        assert!(snapshots.changed().await.is_err());
+        hub.publish(|| panic!("publication after close must remain lazy"));
+
+        let mut after_close = hub.subscribe(snapshot(ScopeState::Stopped {
+            reason: crate::StopReason::Finished,
+        }));
+        assert!(matches!(
+            after_close.borrow_latest().state,
+            ScopeState::Stopped {
+                reason: crate::StopReason::Finished
+            }
+        ));
+        assert!(after_close.changed().await.is_err());
+    }
+
+    #[crate::runtime::test]
+    async fn lifecycle_close_wakes_parked_receivers() {
+        let hub = Arc::new(LifecycleHub::default());
+        let mut events = hub.subscribe();
+        let waiter = crate::runtime::spawn(async move { events.recv().await });
+        crate::runtime::yield_now().await;
+
+        hub.close();
+
+        assert_eq!(crate::runtime::join_resuming(waiter).await, None);
     }
 
     #[test]
@@ -668,5 +776,38 @@ mod tests {
             panic!("expected the retained suffix");
         };
         assert_eq!(first_retained.seq, 3);
+    }
+
+    #[test]
+    fn lifecycle_close_drains_the_queued_prefix_and_rejects_late_publication() {
+        let mut identity = ScopeIdentity::new();
+        let membership = identity
+            .mint_membership(&crate::ChildId::from("scope"))
+            .expect("membership available");
+        let event = |seq| LifecycleEvent {
+            scope_path: Vec::new(),
+            scope: membership,
+            seq,
+            kind: LifecycleEventKind::ScopeState {
+                state: ScopeState::Running,
+            },
+        };
+        let hub = LifecycleHub::default();
+        let mut events = hub.subscribe();
+
+        hub.publish_lagged(2);
+        hub.publish(event(1));
+        hub.close();
+        hub.publish_lagged(3);
+        hub.publish(event(2));
+
+        assert_eq!(events.try_recv(), Ok(LifecycleItem::Lagged { dropped: 2 }));
+        assert_eq!(events.try_recv(), Ok(LifecycleItem::Event(event(1))));
+        assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Closed));
+        assert_eq!(
+            hub.subscribe().try_recv(),
+            Err(LifecycleTryRecvError::Closed),
+            "post-close subscribers start at the drained terminal edge"
+        );
     }
 }

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -2,7 +2,10 @@
 
 use std::{
     fmt,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -303,22 +306,32 @@ pub struct SnapshotClosed;
 /// Conflating receiver for recursive scope snapshots.
 #[derive(Clone)]
 pub struct SnapshotReceiver {
-    inner: runtime::WatchReceiver<Arc<ScopeSnapshot>>,
+    inner: runtime::WatchReceiver<SnapshotHubState>,
+    seen_generation: u64,
 }
 
 impl SnapshotReceiver {
     /// Borrows the newest snapshot without marking it observed.
     #[must_use]
     pub fn borrow_latest(&self) -> Arc<ScopeSnapshot> {
-        self.inner.borrow_cloned()
+        self.inner.borrow_cloned().snapshot
     }
 
     /// Waits for and returns a newer snapshot.
     pub async fn changed(&mut self) -> Result<Arc<ScopeSnapshot>, SnapshotClosed> {
-        if self.inner.changed_or_closed().await {
-            Ok(self.inner.borrow_and_update_cloned())
-        } else {
-            Err(SnapshotClosed)
+        loop {
+            let state = self.inner.borrow_cloned();
+            if state.generation != self.seen_generation {
+                let state = self.inner.borrow_and_update_cloned();
+                self.seen_generation = state.generation;
+                return Ok(state.snapshot);
+            }
+            if state.closed {
+                return Err(SnapshotClosed);
+            }
+            if !self.inner.changed_or_closed().await {
+                return Err(SnapshotClosed);
+            }
         }
     }
 }
@@ -334,67 +347,90 @@ impl fmt::Debug for SnapshotReceiver {
 
 #[derive(Default)]
 pub(crate) struct SnapshotHub {
-    state: Mutex<SnapshotHubState>,
+    sender: OnceLock<runtime::WatchSender<SnapshotHubState>>,
+    closed: AtomicBool,
 }
 
-#[derive(Default)]
+#[derive(Clone, Debug)]
 struct SnapshotHubState {
-    sender: Option<runtime::WatchSender<Arc<ScopeSnapshot>>>,
+    snapshot: Arc<ScopeSnapshot>,
+    generation: u64,
     closed: bool,
 }
 
 impl SnapshotHub {
     pub(crate) fn subscribe(&self, initial: Arc<ScopeSnapshot>) -> SnapshotReceiver {
-        let mut state = self.state.lock().expect("snapshot hub mutex poisoned");
-        if state.closed {
-            let (sender, inner) = runtime::watch(initial);
+        if self.closed.load(Ordering::Acquire) {
+            let (sender, inner) = runtime::watch(SnapshotHubState {
+                snapshot: initial,
+                generation: 0,
+                closed: true,
+            });
             drop(sender);
-            return SnapshotReceiver { inner };
-        }
-        if let Some(sender) = &state.sender
-            && sender.receiver_count() > 0
-        {
             return SnapshotReceiver {
-                inner: sender.watcher(),
+                inner,
+                seen_generation: 0,
             };
         }
-        let (sender, inner) = runtime::watch(initial);
-        state.sender = Some(sender);
-        SnapshotReceiver { inner }
+        let sender = self.sender.get_or_init(|| {
+            runtime::watch(SnapshotHubState {
+                snapshot: Arc::clone(&initial),
+                generation: 0,
+                closed: false,
+            })
+            .0
+        });
+        if sender.receiver_count() == 0 {
+            sender.send_modify(|state| {
+                state.snapshot = initial;
+                state.generation = state.generation.saturating_add(1);
+            });
+        }
+        let inner = sender.watcher();
+        let seen_generation = inner.borrow_cloned().generation;
+        SnapshotReceiver {
+            inner,
+            seen_generation,
+        }
     }
 
     pub(crate) fn publish(&self, snapshot: impl FnOnce() -> Arc<ScopeSnapshot>) {
-        let mut state = self.state.lock().expect("snapshot hub mutex poisoned");
-        let Some(sender) = &state.sender else {
-            return;
-        };
-        if sender.receiver_count() == 0 {
-            state.sender = None;
+        if self.closed.load(Ordering::Acquire) {
             return;
         }
-        sender.replace(snapshot());
+        let Some(sender) = self.sender.get() else {
+            return;
+        };
+        if sender.receiver_count() > 0 {
+            sender.send_modify(|state| {
+                state.snapshot = snapshot();
+                state.generation = state.generation.saturating_add(1);
+            });
+        }
     }
 
     pub(crate) fn close(&self) {
-        let mut state = self.state.lock().expect("snapshot hub mutex poisoned");
-        state.closed = true;
-        state.sender = None;
+        if self.closed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        if let Some(sender) = self.sender.get() {
+            sender.send_modify(|state| state.closed = true);
+        }
     }
 }
 
 impl fmt::Debug for SnapshotHub {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let state = self.state.lock().expect("snapshot hub mutex poisoned");
         formatter
             .debug_struct("SnapshotHub")
             .field(
                 "receivers",
-                &state
+                &self
                     .sender
-                    .as_ref()
+                    .get()
                     .map_or(0, |sender| sender.receiver_count()),
             )
-            .field("closed", &state.closed)
+            .field("closed", &self.closed.load(Ordering::Acquire))
             .finish()
     }
 }
@@ -414,7 +450,7 @@ pub enum LifecycleTryRecvError {
 /// One membership-owned lifecycle subscription.
 pub struct LifecycleEvents {
     events: runtime::BroadcastReceiver<LifecycleEvent>,
-    explicit_lag: runtime::WatchReceiver<u64>,
+    signal: runtime::WatchReceiver<LifecycleSignal>,
     seen_explicit_lag: u64,
 }
 
@@ -427,7 +463,7 @@ impl LifecycleEvents {
                 Err(LifecycleTryRecvError::Closed) => return None,
                 Err(LifecycleTryRecvError::Empty) => {}
             }
-            let _ = self.explicit_lag.changed_or_closed().await;
+            let _ = self.signal.changed_or_closed().await;
         }
     }
 
@@ -436,7 +472,8 @@ impl LifecycleEvents {
         // The marker leads the overflow episode deliberately. A consumer
         // snapshots here, then discards retained events at or below that
         // watermark before applying the newer suffix.
-        let current_explicit_lag = self.explicit_lag.borrow_cloned();
+        let signal = self.signal.borrow_cloned();
+        let current_explicit_lag = signal.explicit_lag;
         if current_explicit_lag != self.seen_explicit_lag {
             let mut dropped = current_explicit_lag.saturating_sub(self.seen_explicit_lag);
             self.seen_explicit_lag = current_explicit_lag;
@@ -462,6 +499,7 @@ impl LifecycleEvents {
         match self.events.try_receive() {
             runtime::BroadcastReceive::Item(event) => Ok(LifecycleItem::Event(event)),
             runtime::BroadcastReceive::Lagged(dropped) => Ok(LifecycleItem::Lagged { dropped }),
+            runtime::BroadcastReceive::Empty if signal.closed => Err(LifecycleTryRecvError::Closed),
             runtime::BroadcastReceive::Empty => Err(LifecycleTryRecvError::Empty),
             runtime::BroadcastReceive::Closed => Err(LifecycleTryRecvError::Closed),
         }
@@ -478,47 +516,40 @@ impl fmt::Debug for LifecycleEvents {
 }
 
 pub(crate) struct LifecycleHub {
-    channels: Mutex<Option<LifecycleChannels>>,
+    channels: LifecycleChannels,
+    closed: AtomicBool,
 }
 
 struct LifecycleChannels {
     events: runtime::BroadcastSender<LifecycleEvent>,
-    explicit_lag: runtime::WatchSender<u64>,
+    signal: runtime::WatchSender<LifecycleSignal>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct LifecycleSignal {
+    explicit_lag: u64,
+    closed: bool,
 }
 
 impl Default for LifecycleHub {
     fn default() -> Self {
         let (events, _) = runtime::broadcast(LIFECYCLE_EVENT_CAPACITY);
-        let (explicit_lag, _) = runtime::watch(0);
+        let (signal, _) = runtime::watch(LifecycleSignal::default());
         Self {
-            channels: Mutex::new(Some(LifecycleChannels {
-                events,
-                explicit_lag,
-            })),
+            channels: LifecycleChannels { events, signal },
+            closed: AtomicBool::new(false),
         }
     }
 }
 
 impl LifecycleHub {
     pub(crate) fn subscribe(&self) -> LifecycleEvents {
-        let channels = self.channels.lock().expect("lifecycle hub mutex poisoned");
-        if let Some(channels) = channels.as_ref() {
-            let explicit_lag = channels.explicit_lag.watcher();
-            let seen_explicit_lag = explicit_lag.borrow_cloned();
-            return LifecycleEvents {
-                events: channels.events.subscribe(),
-                explicit_lag,
-                seen_explicit_lag,
-            };
-        }
-        let (events_sender, events) = runtime::broadcast(LIFECYCLE_EVENT_CAPACITY);
-        let (lag_sender, explicit_lag) = runtime::watch(0);
-        drop(events_sender);
-        drop(lag_sender);
+        let signal = self.channels.signal.watcher();
+        let seen_explicit_lag = signal.borrow_cloned().explicit_lag;
         LifecycleEvents {
-            events,
-            explicit_lag,
-            seen_explicit_lag: 0,
+            events: self.channels.events.subscribe(),
+            signal,
+            seen_explicit_lag,
         }
     }
 
@@ -530,52 +561,37 @@ impl LifecycleHub {
             kind = ?event.kind,
             "scope lifecycle event"
         );
-        if let Some(channels) = self
-            .channels
-            .lock()
-            .expect("lifecycle hub mutex poisoned")
-            .as_ref()
-        {
-            let _ = channels.events.send(event);
+        if !self.closed.load(Ordering::Acquire) {
+            let _ = self.channels.events.send(event);
             // The watch version is also the no-loss activity notification for
             // async receivers. Its value changes only for explicit lag.
-            channels.explicit_lag.pulse();
+            self.channels.signal.pulse();
         }
     }
 
     pub(crate) fn publish_lagged(&self, dropped: u64) {
-        if let Some(channels) = self
-            .channels
-            .lock()
-            .expect("lifecycle hub mutex poisoned")
-            .as_ref()
-        {
-            channels
-                .explicit_lag
-                .send_modify(|total| *total = total.saturating_add(dropped));
+        if !self.closed.load(Ordering::Acquire) {
+            self.channels.signal.send_modify(|signal| {
+                signal.explicit_lag = signal.explicit_lag.saturating_add(dropped);
+            });
         }
     }
 
     pub(crate) fn close(&self) {
-        self.channels
-            .lock()
-            .expect("lifecycle hub mutex poisoned")
-            .take();
+        if !self.closed.swap(true, Ordering::AcqRel) {
+            self.channels
+                .signal
+                .send_modify(|signal| signal.closed = true);
+        }
     }
 }
 
 impl fmt::Debug for LifecycleHub {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let channels = self.channels.lock().expect("lifecycle hub mutex poisoned");
         formatter
             .debug_struct("LifecycleHub")
-            .field(
-                "receivers",
-                &channels
-                    .as_ref()
-                    .map_or(0, |channels| channels.events.receiver_count()),
-            )
-            .field("closed", &channels.is_none())
+            .field("receivers", &self.channels.events.receiver_count())
+            .field("closed", &self.closed.load(Ordering::Acquire))
             .finish()
     }
 }

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -578,6 +578,14 @@ impl LifecycleHub {
         if self.closed.load(Ordering::Acquire) {
             return;
         }
+        self.publish_past_fast_path(event);
+    }
+
+    /// The enqueue half of [`publish`](Self::publish), after the atomic
+    /// fast-path check. Split out so tests can pin the close race: calling
+    /// this on a closed hub is exactly a publisher that read `closed ==
+    /// false` and then lost the linearization race to `close`.
+    fn publish_past_fast_path(&self, event: LifecycleEvent) {
         self.channels.signal.send_if_modified(|signal| {
             // Enqueue and activity notification share the same linearization
             // point as closure. A publisher that passed the atomic fast-path
@@ -739,6 +747,33 @@ mod tests {
         hub.close();
 
         assert_eq!(crate::runtime::join_resuming(waiter).await, None);
+    }
+
+    #[test]
+    fn lifecycle_publication_that_lost_the_close_race_appends_nothing() {
+        let mut identity = ScopeIdentity::new();
+        let membership = identity
+            .mint_membership(&crate::ChildId::from("scope"))
+            .expect("membership available");
+        let hub = LifecycleHub::default();
+        let mut events = hub.subscribe();
+        hub.close();
+
+        // A publisher that read `closed == false` and then lost the
+        // linearization race to `close` must append nothing.
+        hub.publish_past_fast_path(LifecycleEvent {
+            scope_path: Vec::new(),
+            scope: membership,
+            seq: 1,
+            kind: LifecycleEventKind::ScopeState {
+                state: ScopeState::Running,
+            },
+        });
+
+        assert!(matches!(
+            events.try_recv(),
+            Err(LifecycleTryRecvError::Closed)
+        ));
     }
 
     #[test]

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -1134,12 +1134,20 @@ pub(crate) async fn mpsc_send<T>(sender: &MpscSender<T>, value: T) -> Result<(),
     sender.send(value).await.map_err(|error| error.0)
 }
 
+pub(crate) fn mpsc_try_send<T>(sender: &MpscSender<T>, value: T) -> Result<(), T> {
+    sender.try_send(value).map_err(|error| error.into_inner())
+}
+
 pub(crate) fn mpsc_try_recv<T>(receiver: &mut MpscReceiver<T>) -> Option<T> {
     receiver.try_recv().ok()
 }
 
 pub(crate) fn unbounded_mpsc_send<T>(sender: &UnboundedMpscSender<T>, value: T) -> Result<(), T> {
     sender.send(value).map_err(|error| error.0)
+}
+
+pub(crate) async fn unbounded_mpsc_recv<T>(receiver: &mut UnboundedMpscReceiver<T>) -> Option<T> {
+    receiver.recv().await
 }
 
 pub(crate) fn unbounded_mpsc_try_recv<T>(receiver: &mut UnboundedMpscReceiver<T>) -> Option<T> {

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -864,13 +864,21 @@ impl<H> Drop for Admission<H> {
                 // scope's control-plane wake and the cancellation evidence in
                 // the same order the in-flight path uses.
                 if let Some(cancel) = &pending.fused_cancel {
-                    crate::driver::signal_fused_cancel(&pending.reservation.control, cancel);
+                    crate::driver::signal_fused_cancel(
+                        &pending.reservation.control,
+                        pending.reservation.slot.member.membership(),
+                        cancel,
+                    );
                 }
                 pending.cancel_reservation();
             }
             AdmissionState::InFlight { pending, .. } => {
                 if let Some(cancel) = &pending.fused_cancel {
-                    crate::driver::signal_fused_cancel(&pending.reservation.control, cancel);
+                    crate::driver::signal_fused_cancel(
+                        &pending.reservation.control,
+                        pending.reservation.slot.member.membership(),
+                        cancel,
+                    );
                     pending.cancel_reservation();
                 }
             }


### PR DESCRIPTION
Addresses the nine hot-path findings in #91.

What changed:

- makes `SendFuture` allocate a parked send operation only when the mailbox actually applies backpressure, and retains only the mailbox handle
- moves the accepted-message watermark to an atomic while preserving its mailbox publication boundary
- stores `ChildId` text in `Arc<str>` so cloned error evidence is allocation-free
- removes per-publication hub locks while preserving lazy snapshots, exact lifecycle lag, final-value delivery, and terminal closure
- replaces write-once member membership/options locks and the gate-serialized lifecycle counter with cheaper storage
- uses a shared-read observation-gate handoff and caches each child runtime's mailbox control
- replaces the hand-rolled admission queue with the runtime unbounded MPSC and delivers removals as driver events instead of scanning every dynamic entry each loop

Why:

These are the targeted allocation, refcount, and lock reductions identified by the #91 audit. The driver’s single-owner decision core and all observable mailbox/observation semantics remain unchanged.

Validation:

- `./scripts/dev just ci`
- 418/418 nextest cases passed
- doctests, rustdoc warnings, API reachability, runtime/exit/layering enforcement, packaged-crate verification, and nixfmt all passed

Part 1 of the #91 implementation series.