### PR TITLE
Remove redundant type erasure and allocations

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -3,10 +3,10 @@
 //! These cells are the neutral synchronization and observation projection
 //! layer shared by public handles, mailboxes, actor/task contexts, and the
 //! mutable supervision driver. In particular, this module does not depend on
-//! driver state or declaration-plan slots.
+//! mutable driver state. Its dynamic-route interface names declaration slots
+//! only as opaque capability payloads; their state remains owned elsewhere.
 
 use std::{
-    any::Any,
     fmt,
     sync::{
         Arc, Mutex, OnceLock, RwLock, Weak,
@@ -17,6 +17,7 @@ use std::{
 
 use crate::{
     ChildId, Exit, Incarnation, Intensity, Mailbox, Membership, Readiness, ScopeState, Strategy,
+    admission::{RemoveOutcome, ReserveError},
     engine::{Epoch, RequestTarget, ScopeEpochs},
     exit::{StartupError, StopReason},
     identity::ScopeIdentity,
@@ -24,6 +25,7 @@ use crate::{
         ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
         LifecycleHub, MembershipStatus, ScopeKind, ScopeSnapshot, SnapshotHub, SnapshotReceiver,
     },
+    plan::SlotCell,
     policy::{ResolvedCommonOptions, ScopeFlavor},
     runtime::{self, Latch},
 };
@@ -318,23 +320,33 @@ pub(crate) struct ScopeRecord {
     pub(crate) total_restarts: u64,
 }
 
-#[derive(Clone)]
-pub(crate) struct DynamicRoute(Arc<dyn Any + Send + Sync>);
+pub(crate) trait DynamicRoute: Send + Sync {
+    fn reserve(
+        &self,
+        scope: &Arc<ScopeCell>,
+        id: ChildId,
+        child_scope: Option<ScopeFlavor>,
+    ) -> Result<Arc<SlotCell>, ReserveError>;
 
-impl fmt::Debug for DynamicRoute {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.debug_tuple("DynamicRoute").finish()
-    }
-}
+    fn start_admission(
+        self: Arc<Self>,
+        slot: Arc<SlotCell>,
+        fused_cancel: Option<Latch>,
+    ) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError>;
 
-impl DynamicRoute {
-    pub(crate) fn new<T: Any + Send + Sync>(route: Arc<T>) -> Self {
-        Self(route)
-    }
+    fn cancel_reservation(&self, slot: &Arc<SlotCell>);
 
-    pub(crate) fn resolve<T: Any + Send + Sync>(self) -> Result<Arc<T>, Self> {
-        Arc::downcast(self.0).map_err(Self)
-    }
+    fn signal_fused_cancel(&self, membership: Membership, latch: &Latch);
+
+    fn remove(
+        &self,
+        scope: &Arc<ScopeCell>,
+        id: &ChildId,
+        exact: Option<Membership>,
+    ) -> runtime::OneShotReceiver<RemoveOutcome>;
+
+    #[cfg(test)]
+    fn request_forwarder_probe(&self) -> (Latch, Latch);
 }
 
 /// Driver-independent view of one declaration slot while its membership is
@@ -426,7 +438,7 @@ pub(crate) struct ScopeCell {
     config: runtime::WatchSender<ObservationConfig>,
     record: runtime::WatchSender<ScopeRecord>,
     control: Mutex<ScopeControl>,
-    dynamic_route: Mutex<Option<DynamicRoute>>,
+    dynamic_route: Mutex<Option<Arc<dyn DynamicRoute>>>,
     current_children: runtime::WatchSender<Vec<ResidentChild>>,
     parent: runtime::WatchSender<Option<Weak<ScopeCell>>>,
     observation_gate: RwLock<Arc<Mutex<()>>>,
@@ -1233,7 +1245,7 @@ impl ScopeCell {
         drop(residents);
     }
 
-    pub(crate) fn set_dynamic_route(&self, route: Option<DynamicRoute>) {
+    pub(crate) fn set_dynamic_route(&self, route: Option<Arc<dyn DynamicRoute>>) {
         *self
             .dynamic_route
             .lock()
@@ -1241,7 +1253,7 @@ impl ScopeCell {
         self.member.record.pulse();
     }
 
-    pub(crate) fn dynamic_route(&self) -> Option<DynamicRoute> {
+    pub(crate) fn dynamic_route(&self) -> Option<Arc<dyn DynamicRoute>> {
         self.dynamic_route
             .lock()
             .expect("scope dynamic-route mutex poisoned")

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -298,26 +298,13 @@ impl DynamicControl {
     }
 }
 
-fn dynamic_control(scope: &ScopeCell) -> Option<Arc<DynamicControl>> {
-    // The cells layer stores the route erased because it may not name a driver
-    // type. `set_dynamic_route` is the only writer, so a failed downcast is a
-    // driver bug, not an absent route: resolving it to `None` would fail open,
-    // reporting `NoLiveIncarnation` and `AlreadyAbsent` for a live scope.
-    Some(
-        scope
-            .dynamic_route()?
-            .resolve()
-            .unwrap_or_else(|_| panic!("the dynamic route is always a DynamicControl")),
-    )
-}
-
 fn resident_projection(slot: &SlotCell) -> ResidentProjection {
     ResidentProjection::new(Arc::clone(&slot.member), slot.scope.clone())
 }
 
 pub(crate) struct DynamicReservation {
     pub(crate) slot: Arc<SlotCell>,
-    pub(crate) control: Arc<DynamicControl>,
+    pub(crate) control: Arc<dyn DynamicRoute>,
 }
 
 pub(crate) fn reserve_dynamic(
@@ -332,7 +319,7 @@ pub(crate) fn reserve_dynamic(
     if matches!(scope.member.record().stage, MemberStage::Terminal(_)) {
         return Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal));
     }
-    let control = dynamic_control(scope).ok_or(ReserveError::NotAdmitting(
+    let control = scope.dynamic_route().ok_or(ReserveError::NotAdmitting(
         NotAdmittingCause::NoLiveIncarnation,
     ))?;
     match scope.record().state {
@@ -349,6 +336,16 @@ pub(crate) fn reserve_dynamic(
             ));
         }
     }
+    let slot = control.reserve(scope, id, child_scope)?;
+    Ok(DynamicReservation { slot, control })
+}
+
+fn reserve_dynamic_slot(
+    control: &DynamicControl,
+    scope: &Arc<ScopeCell>,
+    id: ChildId,
+    child_scope: Option<ScopeFlavor>,
+) -> Result<Arc<SlotCell>, ReserveError> {
     let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
     if !state.accepting {
         return Err(ReserveError::NotAdmitting(NotAdmittingCause::Draining));
@@ -370,13 +367,18 @@ pub(crate) fn reserve_dynamic(
             removal_started: false,
         },
     );
-    Ok(DynamicReservation {
-        slot,
-        control: Arc::clone(&control),
-    })
+    Ok(slot)
 }
 
 pub(crate) fn start_admission(
+    control: Arc<dyn DynamicRoute>,
+    slot: Arc<SlotCell>,
+    fused_cancel: Option<Latch>,
+) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError> {
+    control.start_admission(slot, fused_cancel)
+}
+
+fn start_dynamic_admission(
     control: Arc<DynamicControl>,
     slot: Arc<SlotCell>,
     fused_cancel: Option<Latch>,
@@ -385,8 +387,9 @@ pub(crate) fn start_admission(
         return Err(ReserveError::NoRuntime);
     }
     let (sender, response) = runtime::oneshot();
+    let route: Arc<dyn DynamicRoute> = control.clone();
     let request = AdmissionRequest {
-        control: Arc::downgrade(&control),
+        control: Arc::downgrade(&route),
         slot,
         fused_cancel,
         response: Obligation::new(sender, |sender| {
@@ -403,7 +406,7 @@ pub(crate) fn start_admission(
 }
 
 fn cancel_dynamic_reservation_parts(
-    control: &Arc<DynamicControl>,
+    control: &DynamicControl,
     slot: &Arc<SlotCell>,
 ) -> (
     Option<runtime::Isolated<ChildConstruction>>,
@@ -424,7 +427,11 @@ fn cancel_dynamic_reservation_parts(
     (definition, removed)
 }
 
-pub(crate) fn cancel_dynamic_reservation(control: &Arc<DynamicControl>, slot: &Arc<SlotCell>) {
+pub(crate) fn cancel_dynamic_reservation(control: &dyn DynamicRoute, slot: &Arc<SlotCell>) {
+    control.cancel_reservation(slot);
+}
+
+fn cancel_dynamic_reservation_impl(control: &DynamicControl, slot: &Arc<SlotCell>) {
     let (definition, removed) = cancel_dynamic_reservation_parts(control, slot);
     // The entry's drop completes its removal response; it must follow the
     // member's terminal publication and isolated definition disposal.
@@ -432,10 +439,14 @@ pub(crate) fn cancel_dynamic_reservation(control: &Arc<DynamicControl>, slot: &A
 }
 
 pub(crate) fn signal_fused_cancel(
-    control: &Arc<DynamicControl>,
+    control: &dyn DynamicRoute,
     membership: Membership,
     latch: &Latch,
 ) {
+    control.signal_fused_cancel(membership, latch);
+}
+
+fn signal_fused_cancel_impl(control: &DynamicControl, membership: Membership, latch: &Latch) {
     if latch.fire() {
         queue_driver_event(control, DriverEvent::Removal(membership));
     }
@@ -452,9 +463,18 @@ pub(crate) fn remove_dynamic(
     ) {
         return completed_removal(RemoveOutcome::AlreadyAbsent);
     }
-    let Some(control) = dynamic_control(scope) else {
+    let Some(control) = scope.dynamic_route() else {
         return completed_removal(RemoveOutcome::AlreadyAbsent);
     };
+    control.remove(scope, id, exact)
+}
+
+fn remove_dynamic_impl(
+    control: &DynamicControl,
+    scope: &Arc<ScopeCell>,
+    id: &ChildId,
+    exact: Option<Membership>,
+) -> RemovalResponse {
     let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
     let Some(entry) = state.entries.get_mut(id) else {
         return completed_removal(RemoveOutcome::AlreadyAbsent);
@@ -485,9 +505,53 @@ pub(crate) fn remove_dynamic(
     drop(state);
     scope.transition_child(&member, |record| record.removing = true, None);
     if member.removal.fire() {
-        queue_driver_event(&control, DriverEvent::Removal(membership));
+        queue_driver_event(control, DriverEvent::Removal(membership));
     }
     response
+}
+
+impl DynamicRoute for DynamicControl {
+    fn reserve(
+        &self,
+        scope: &Arc<ScopeCell>,
+        id: ChildId,
+        child_scope: Option<ScopeFlavor>,
+    ) -> Result<Arc<SlotCell>, ReserveError> {
+        reserve_dynamic_slot(self, scope, id, child_scope)
+    }
+
+    fn start_admission(
+        self: Arc<Self>,
+        slot: Arc<SlotCell>,
+        fused_cancel: Option<Latch>,
+    ) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError> {
+        start_dynamic_admission(self, slot, fused_cancel)
+    }
+
+    fn cancel_reservation(&self, slot: &Arc<SlotCell>) {
+        cancel_dynamic_reservation_impl(self, slot);
+    }
+
+    fn signal_fused_cancel(&self, membership: Membership, latch: &Latch) {
+        signal_fused_cancel_impl(self, membership, latch);
+    }
+
+    fn remove(
+        &self,
+        scope: &Arc<ScopeCell>,
+        id: &ChildId,
+        exact: Option<Membership>,
+    ) -> RemovalResponse {
+        remove_dynamic_impl(self, scope, id, exact)
+    }
+
+    #[cfg(test)]
+    fn request_forwarder_probe(&self) -> (Latch, Latch) {
+        (
+            self.request_forwarder_close.clone(),
+            self.request_forwarder_ended.clone(),
+        )
+    }
 }
 
 fn queue_driver_event(control: &DynamicControl, event: DriverEvent) {
@@ -502,7 +566,7 @@ fn queue_driver_event(control: &DynamicControl, event: DriverEvent) {
 }
 
 struct AdmissionRequest {
-    control: Weak<DynamicControl>,
+    control: Weak<dyn DynamicRoute>,
     slot: Arc<SlotCell>,
     fused_cancel: Option<Latch>,
     response: Obligation<runtime::OneShotSender<Result<(), ReserveError>>>,
@@ -2264,14 +2328,16 @@ impl ScopeRuntime {
     }
 
     fn handle_admission(&mut self, mut request: AdmissionRequest) {
-        let Some(control) = request.control.upgrade() else {
+        let Some(request_control) = request.control.upgrade() else {
             request.complete(Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal)));
             return;
         };
-        if self
-            .dynamic
-            .as_ref()
-            .is_none_or(|current| !Arc::ptr_eq(current, &control))
+        let Some(control) = self.dynamic.as_ref().cloned() else {
+            request.complete(Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal)));
+            return;
+        };
+        let current_route: Arc<dyn DynamicRoute> = control.clone();
+        if !Arc::ptr_eq(&current_route, &request_control)
             || self.lifecycle.is_draining()
             || self.lifecycle.startup_failed()
         {
@@ -2655,7 +2721,7 @@ async fn run_scope_incarnation(
             );
         }
         drop(state);
-        root.set_dynamic_route(Some(DynamicRoute::new(Arc::clone(control))));
+        root.set_dynamic_route(Some(control.clone()));
     }
     root.set_admitted_children(
         plan.children
@@ -2973,8 +3039,8 @@ mod tests {
         ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
         GateCapture, MemberCell, MemberStage, Obligation, Pending, RemovalResponses,
         RuntimeStorage, ScopeCell, ScopeEpochGuard, ScopeFlavor, ScopeRuntime, complete_removals,
-        driver_event_class, dynamic_control, mint_child_incarnation, report_channel,
-        resident_projection, restart_shutdown_work, run_nested_tree, run_scope_incarnation,
+        driver_event_class, mint_child_incarnation, report_channel, resident_projection,
+        restart_shutdown_work, run_nested_tree, run_scope_incarnation,
     };
 
     /// Bounds every gate-capture probe wait. The probe sender lives inside
@@ -4338,16 +4404,19 @@ mod tests {
         let slot = scope
             .reserve_task("retained")
             .expect("unadmitted reservation is retained");
-        let control = dynamic_control(&scope.as_scope().cell)
+        let control = scope
+            .as_scope()
+            .cell
+            .dynamic_route()
             .expect("the live dynamic scope exposes its control");
-        let forwarder_ended = control.request_forwarder_ended.clone();
+        let (forwarder_close, forwarder_ended) = control.request_forwarder_probe();
 
         system
             .shutdown(Duration::from_secs(1))
             .await
             .expect("driver teardown completes");
 
-        assert!(control.request_forwarder_close.is_fired());
+        assert!(forwarder_close.is_fired());
         assert!(matches!(
             crate::runtime::timeout(Duration::from_secs(1), forwarder_ended.fired()).await,
             crate::runtime::Timeout::Completed(())
@@ -4397,7 +4466,7 @@ mod tests {
                     removal_started: false,
                 },
             );
-        root.set_dynamic_route(Some(super::DynamicRoute::new(Arc::clone(&control))));
+        root.set_dynamic_route(Some(control.clone()));
 
         let captures = root.probe_gate_captures();
         let gate = root.observation_gate();
@@ -4452,7 +4521,7 @@ mod tests {
                 !crate::runtime::is_available(),
                 "Tokio context is not inherited by a foreign thread"
             );
-            super::signal_fused_cancel(&foreign_control, second, &Latch::default());
+            super::signal_fused_cancel(foreign_control.as_ref(), second, &Latch::default());
         })
         .join()
         .expect("foreign-thread removal signaling succeeds");
@@ -4498,7 +4567,7 @@ mod tests {
         let mut responses = Vec::with_capacity(ADMISSIONS);
         for _ in 0..ADMISSIONS {
             responses.push(
-                super::start_admission(Arc::clone(&control), Arc::clone(&slot), None)
+                super::start_admission(control.clone(), Arc::clone(&slot), None)
                     .expect("runtime is available"),
             );
         }
@@ -4541,8 +4610,11 @@ mod tests {
         let system = DynamicTree::new().spawn().expect("runtime is available");
         let root = system.scope();
         system.wait_started().await.expect("dynamic root starts");
-        let control =
-            dynamic_control(&root.as_scope().cell).expect("running dynamic root has a control");
+        let control = root
+            .as_scope()
+            .cell
+            .dynamic_route()
+            .expect("running dynamic root has a control");
         let weak = Arc::downgrade(&control);
         drop(control);
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -387,9 +387,8 @@ fn start_dynamic_admission(
         return Err(ReserveError::NoRuntime);
     }
     let (sender, response) = runtime::oneshot();
-    let route: Arc<dyn DynamicRoute> = control.clone();
     let request = AdmissionRequest {
-        control: Arc::downgrade(&route),
+        control: Arc::downgrade(&control),
         slot,
         fused_cancel,
         response: Obligation::new(sender, |sender| {
@@ -566,7 +565,9 @@ fn queue_driver_event(control: &DynamicControl, event: DriverEvent) {
 }
 
 struct AdmissionRequest {
-    control: Weak<dyn DynamicRoute>,
+    // Concrete so rejection can dispose the reservation through the very
+    // control that reserved it, even when it is no longer the live route.
+    control: Weak<DynamicControl>,
     slot: Arc<SlotCell>,
     fused_cancel: Option<Latch>,
     response: Obligation<runtime::OneShotSender<Result<(), ReserveError>>>,
@@ -2328,16 +2329,14 @@ impl ScopeRuntime {
     }
 
     fn handle_admission(&mut self, mut request: AdmissionRequest) {
-        let Some(request_control) = request.control.upgrade() else {
+        let Some(control) = request.control.upgrade() else {
             request.complete(Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal)));
             return;
         };
-        let Some(control) = self.dynamic.as_ref().cloned() else {
-            request.complete(Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal)));
-            return;
-        };
-        let current_route: Arc<dyn DynamicRoute> = control.clone();
-        if !Arc::ptr_eq(&current_route, &request_control)
+        if self
+            .dynamic
+            .as_ref()
+            .is_none_or(|current| !Arc::ptr_eq(current, &control))
             || self.lifecycle.is_draining()
             || self.lifecycle.startup_failed()
         {

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -51,7 +51,7 @@ pub type ExitResult = Result<(), ExitError>;
 pub struct ExitError(Arc<ExitErrorInner>);
 
 enum ExitErrorInner {
-    Application(Arc<dyn Error + Send + Sync + 'static>),
+    Application(Box<dyn Error + Send + Sync + 'static>),
     IntensityTrip(StructuredIntensityTrip),
     StartupFailure(StructuredStartupFailure),
 }
@@ -60,7 +60,7 @@ impl ExitError {
     /// Creates an application error from a displayable message.
     #[must_use]
     pub fn message(message: impl Into<String>) -> Self {
-        Self(Arc::new(ExitErrorInner::Application(Arc::new(
+        Self(Arc::new(ExitErrorInner::Application(Box::new(
             MessageError(message.into()),
         ))))
     }
@@ -111,7 +111,7 @@ where
     E: Error + Send + Sync + 'static,
 {
     fn from(value: E) -> Self {
-        Self(Arc::new(ExitErrorInner::Application(Arc::new(value))))
+        Self(Arc::new(ExitErrorInner::Application(Box::new(value))))
     }
 }
 

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1832,6 +1832,10 @@ impl<M: Send + 'static> MailboxReceiver<M> {
         self.mailbox.accepted_sequence()
     }
 
+    pub(crate) fn freeze(&self) {
+        self.mailbox.freeze(self.incarnation);
+    }
+
     pub(crate) async fn changed(&mut self) {
         self.watcher.changed().await;
     }

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -347,25 +347,13 @@ impl<M> EventQueue<M> {
     }
 }
 
-trait ErasedTimerKey: Send {
-    fn as_any(&self) -> &dyn Any;
-}
-
-struct StoredTimerKey<K>(K);
-
-impl<K: Send + 'static> ErasedTimerKey for StoredTimerKey<K> {
-    fn as_any(&self) -> &dyn Any {
-        &self.0
-    }
-}
-
 enum TimerMessage<M> {
     Once(M),
-    Interval(Box<dyn Fn() -> M + Send + 'static>),
+    Interval(M, fn(&M) -> M),
 }
 
 struct TimerEntry<M> {
-    key: Box<dyn ErasedTimerKey>,
+    key: Box<dyn Any + Send>,
     /// `None` when the requested delay overflows the clock: a deadline that
     /// never arrives, mirroring the offload path — never "due now".
     deadline: Option<Instant>,
@@ -430,7 +418,7 @@ impl<M> TimerStore<M> {
         let _ = self.remove(&key);
         let hash = self.hash_key(&key);
         self.keyed.entry(hash).or_default().push(TimerEntry {
-            key: Box::new(StoredTimerKey(key)),
+            key: Box::new(key),
             deadline,
             arming_order,
             message,
@@ -457,7 +445,7 @@ impl<M> TimerStore<M> {
                 {
                     probes += 1;
                 }
-                entry.key.as_any().downcast_ref::<K>() == Some(key)
+                entry.key.downcast_ref::<K>() == Some(key)
             })?;
             #[cfg(test)]
             {
@@ -832,7 +820,6 @@ pub struct RawContext<M> {
     local_stop: Latch,
     readiness: Readiness,
     mailbox_shutdown: MailboxShutdown,
-    mailbox: Arc<MailboxCell<M>>,
     receiver: MailboxReceiver<M>,
     resources: RawResources<M>,
 }
@@ -865,7 +852,6 @@ impl<M: Send + 'static> RawContext<M> {
             local_stop: run.local_stop,
             readiness,
             mailbox_shutdown: run.mailbox_shutdown,
-            mailbox: Arc::clone(&mailbox),
             receiver: MailboxReceiver::new(mailbox, run.incarnation),
             resources: RawResources::default(),
         }
@@ -946,7 +932,7 @@ impl<M: Send + 'static> RawContext<M> {
     /// loop's `Context::stop` is built on (§1 principle 5); the child's
     /// configured §10 ladder bounds the stop.
     pub fn stop(&mut self) {
-        self.mailbox.freeze(self.incarnation);
+        self.receiver.freeze();
         self.freeze_and_report();
         self.local_stop.fire();
     }
@@ -999,10 +985,9 @@ impl<M: Send + 'static> RawContext<M> {
             let _ = self.clear_timer(&key);
             return Ok(());
         }
-        let make_message = Box::new(move || message.clone());
         self.replace_timer(
             key,
-            TimerMessage::Interval(make_message),
+            TimerMessage::Interval(message, Clone::clone),
             period,
             Some(period),
         );
@@ -1381,10 +1366,10 @@ impl<M: Send + 'static> RawContext<M> {
         if let Some(period) = entry.period {
             let deadline = crate::deadline::Deadline::after(runtime::now(), period).instant();
             entry.deadline = deadline;
-            let TimerMessage::Interval(make_message) = &entry.message else {
+            let TimerMessage::Interval(message, clone_message) = &entry.message else {
                 unreachable!("an interval timer must own a message factory")
             };
-            let message = make_message();
+            let message = clone_message(message);
             self.resources.timers.arm_deadline(arming, deadline);
             return Some(message);
         }
@@ -1459,7 +1444,7 @@ impl<M: Send + 'static> RawContext<M> {
 
 /// Restartable raw-actor definition.
 pub struct RawDef<R: RawActor> {
-    factory: Arc<dyn Fn() -> R + Send + Sync + 'static>,
+    factory: Box<dyn Fn() -> R + Send + Sync + 'static>,
     pub(crate) options: CommonOptions,
 }
 
@@ -1476,7 +1461,7 @@ impl<R: RawActor> RawDef<R> {
     /// Creates a restartable definition from a repeatable actor factory.
     pub fn factory(factory: impl Fn() -> R + Send + Sync + 'static) -> Self {
         Self {
-            factory: Arc::new(factory),
+            factory: Box::new(factory),
             options: CommonOptions::default(),
         }
     }

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -131,7 +131,10 @@ impl SlotEndpoint for DynamicSlotEndpoint {
 impl Drop for DynamicSlotEndpoint {
     fn drop(&mut self) {
         if let Some(reservation) = &self.0 {
-            crate::driver::cancel_dynamic_reservation(&reservation.control, &reservation.slot);
+            crate::driver::cancel_dynamic_reservation(
+                reservation.control.as_ref(),
+                &reservation.slot,
+            );
         }
     }
 }
@@ -739,7 +742,7 @@ impl<H> PendingAdmission<H> {
 
     fn cancel_reservation(&self) {
         crate::driver::cancel_dynamic_reservation(
-            &self.reservation.control,
+            self.reservation.control.as_ref(),
             &self.reservation.slot,
         );
     }
@@ -865,7 +868,7 @@ impl<H> Drop for Admission<H> {
                 // the same order the in-flight path uses.
                 if let Some(cancel) = &pending.fused_cancel {
                     crate::driver::signal_fused_cancel(
-                        &pending.reservation.control,
+                        pending.reservation.control.as_ref(),
                         pending.reservation.slot.member.membership(),
                         cancel,
                     );
@@ -875,7 +878,7 @@ impl<H> Drop for Admission<H> {
             AdmissionState::InFlight { pending, .. } => {
                 if let Some(cancel) = &pending.fused_cancel {
                     crate::driver::signal_fused_cancel(
-                        &pending.reservation.control,
+                        pending.reservation.control.as_ref(),
                         pending.reservation.slot.member.membership(),
                         cancel,
                     );
@@ -1023,9 +1026,10 @@ impl Future for Removal {
 
 /// A restartable subtree definition.
 pub struct SubtreeDef<T: Subtree> {
-    factory: Box<dyn Fn() -> T + Send + Sync + 'static>,
+    factory: Arc<dyn Fn() -> BuilderCore + Send + Sync + 'static>,
     options: CommonOptions,
     defaults: DefaultsInheritance,
+    subtree: PhantomData<fn() -> T>,
 }
 
 impl<T: Subtree> fmt::Debug for SubtreeDef<T> {
@@ -1042,9 +1046,10 @@ impl<T: Subtree> SubtreeDef<T> {
     /// Creates a restartable subtree from a repeatable declaration source.
     pub fn factory(factory: impl Fn() -> T + Send + Sync + 'static) -> Self {
         Self {
-            factory: Box::new(factory),
+            factory: Arc::new(move || <T as sealed::Sealed>::into_core(factory())),
             options: CommonOptions::default(),
             defaults: DefaultsInheritance::Inherit,
+            subtree: PhantomData,
         }
     }
 
@@ -1060,9 +1065,7 @@ impl<T: Subtree> SubtreeDef<T> {
     fn erase(self) -> ScopeConstruction {
         let factory = self.factory;
         ScopeConstruction {
-            source: DefinitionSource::Restartable(Arc::new(move || {
-                <T as sealed::Sealed>::into_core(factory())
-            })),
+            source: DefinitionSource::Restartable(factory),
             options: self.options,
             defaults: self.defaults,
         }


### PR DESCRIPTION
Stacked on #96; review only the top commit for this PR.

Part of #91.

## Summary

- replace the `Arc<dyn Any>` dynamic-control escape hatch with a named `DynamicRoute` capability implemented by `DynamicControl`, while preserving stale-route identity rejection
- store subtree factories in their final erased `Arc<dyn Fn() -> BuilderCore>` form instead of adding a second closure/vtable at lowering
- remove the unexercised inner `Arc` from application `ExitError`s
- use `Box<dyn Any + Send>` directly for heterogeneous timer keys
- represent interval cloning as `(M, fn(&M) -> M)` instead of a boxed closure
- use a `Box` for the move-once `RawDef` factory
- freeze through `MailboxReceiver`, removing `RawContext`'s third handle to the same mailbox cell

## Validation

- `./scripts/dev just ci`
- 419/419 nextest cases passed, plus doctests, rustdoc, API reachability, runtime/exit/layering enforcement, packaged-crate verification, and formatting/lint checks
