### PR TITLE
Align construction spec and harden invariants

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -84,10 +84,13 @@ these, in order.
    escalation, exit classification, child identity: each exists exactly once,
    as a named primitive, and every subsystem consumes that primitive.
    [#361, #363, #364, #370]
-3. **Invariants live in ownership and types, not comments.** A rule that two
-   modules must both remember is a design defect. Exactly-once effects are
-   expressed by consuming owned values (drop = the fallback effect), not by
-   `Mutex<Option<_>>` take-once flags. [#360, #363]
+3. **Construction invariants live in ownership and types, not comments.** A
+   rule that two modules must both remember is a design defect. Exactly-once
+   construction effects are expressed by consuming owned values (drop = the
+   fallback effect), not by `Mutex<Option<_>>` take-once flags. Internal
+   synchronization may still use an optional payload as a non-panicking claim
+   protocol when it does not re-assert a construction capability. [#360,
+   #363]
 4. **Capabilities are never erased and re-asserted.** If the caller proved a
    capability statically (a dynamic scope, a restartable actor), every value
    derived from it carries that proof in its type. Runtime downgrades
@@ -565,8 +568,9 @@ established in the construction-path types, before erasure:
   what they can accept (owned, non-re-mintable args) and return
   (`OneShotTaskRef<T>`), not in how long the child runs.
 - **Restartable** (`add_*`-family): the caller supplies an args *source* —
-  `Args: Clone`, or `Fn() -> Args` re-minted at restart time (so a restart
-  can observe the current world: re-resolve an address, fresh timestamp).
+  `Args: Clone + Sync`, or `Fn() -> Args + Send + Sync` re-minted at restart
+  time (so a restart can observe the current world: re-resolve an address,
+  fresh timestamp).
   This is OTP's `{M, F, A}` translated into ownership: the args value is the
   per-spawn argument, and whether you can clone or re-mint it *is* your
   restart capability. For subtree children the args source *is* the
@@ -576,11 +580,13 @@ established in the construction-path types, before erasure:
 - The erased internal representation of one-shot construction is
   `FnOnce`-shaped all the way down: the closure owns the resource, the
   runner owns the closure, and init-panic / startup-failure /
-  shutdown-before-start all reduce to dropping the owner. `Mutex<Option<_>>`
-  take-once tricks MUST NOT appear, publicly or privately — and the same
-  owned-token shape MUST be reused for the other take-once sites the origin
-  accumulated (cancel guards, readiness signals, exit-report claims): build
-  the consuming primitive once (§1 principle 3, §7).
+  shutdown-before-start all reduce to dropping the owner. Within construction
+  payloads, `Mutex<Option<_>>` take-once tricks MUST NOT appear, publicly or
+  privately — and the same owned-token shape MUST be reused for construction
+  claims throughout the lowering and incarnation path. This prohibition does
+  not cover internal, non-panicking synchronization claims such as disposal
+  completion, where losing the claim race is an ordinary no-op rather than a
+  re-asserted construction capability (§1 principle 3, §7).
 - **Every user-supplied construction source executes inside the single
   incarnation runner** (§7): the restartable forms' `Fn() -> Args` factory
   and `Args::clone`, task body factories, raw-actor factories, and subtree
@@ -1462,21 +1468,21 @@ impl<T: Subtree> SubtreeSlot<T> { fn scope_ref(&self) -> T::Ref; }
 // bound is pinned here, once. Constructors yield default options;
 // options attach via the consuming setters listed in the §8 rule:
 impl<A: Actor> ActorDef<A> {
-    fn cloned(args: A::Args) -> Self where A::Args: Clone;
-    fn factory(f: impl Fn() -> A::Args + Send + 'static) -> Self;
+    fn cloned(args: A::Args) -> Self where A::Args: Clone + Sync;
+    fn factory(f: impl Fn() -> A::Args + Send + Sync + 'static) -> Self;
 }
 impl<A: Actor> ActorOnceDef<A> {
     fn new(args: A::Args) -> Self;               // owned, consumed
 }
 impl<R: RawActor> RawDef<R> {
-    fn factory(f: impl Fn() -> R + Send + 'static) -> Self;
+    fn factory(f: impl Fn() -> R + Send + Sync + 'static) -> Self;
         // the actor value is the per-incarnation input (§4.3)
 }
 impl<R: RawActor> RawOnceDef<R> {
     fn new(actor: R) -> Self;                    // owned `R`, consumed
 }
 impl TaskDef {
-    fn new<F>(factory: impl Fn(TaskContext) -> F + Send + 'static) -> Self
+    fn new<F>(factory: impl Fn(TaskContext) -> F + Send + Sync + 'static) -> Self
         where F: Future<Output = ExitResult> + Send + 'static;
         // §4.1's exact bound — re-invoked with a fresh `TaskContext`
         // (by value, B.2) for each incarnation
@@ -1486,7 +1492,7 @@ impl<T: Send + 'static> TaskOnceDef<T> {
         where F: Future<Output = Result<T, ExitError>> + Send + 'static;
 }
 impl<T: Subtree> SubtreeDef<T> {
-    fn factory(f: impl Fn() -> T + Send + 'static) -> Self;
+    fn factory(f: impl Fn() -> T + Send + Sync + 'static) -> Self;
         // re-lowered per incarnation; a failed lowering is the
         // incarnation's startup failure (§11's lowering rule)
 }
@@ -1649,9 +1655,9 @@ Rules (normative):
 - **Construction-source bounds are pinned in the def constructors
   above** — one
   place, verbatim, per §4.2's capability rule: restartable forms carry a
-  re-mintable source (`Args: Clone` or a `Fn` factory; task bodies a
-  `Fn(TaskContext)` factory; raw actors `Fn() -> R`; subtrees
-  `Fn() -> T`), `_once` forms consume owned values. Cyclic wiring
+  re-mintable shared source (`Args: Clone + Sync` or a `Fn + Send + Sync`
+  factory; task bodies a `Fn(TaskContext)` factory; raw actors `Fn() -> R`;
+  subtrees `Fn() -> T`), `_once` forms consume owned values. Cyclic wiring
   thereby reduces to ordering: every ref a
   factory needs is minted from a sibling slot before any factory is
   written, so factories capture real `ActorRef`s — no `Option<ActorRef>`,
@@ -3567,9 +3573,12 @@ least these. Policy/config data additionally follows §1's plain-data rule
   borrows its handle or owns a clone is implementation latitude; the
   `Send` bound is not.
 - **Closures accepted by the API**: stated at each site (§5.5, §8, §17,
-  B.9) — ingress-path closures that run at concurrent call sites carry
-  `Fn + Send + Sync`; observation predicates and construction sources
-  that run from one place at a time carry `Send` without `Sync`.
+  B.9) — ingress-path closures that run at concurrent call sites and shared
+  restartable construction sources carry `Fn + Send + Sync`. Their invocation
+  still occurs inside one incarnation (§4.2); `Sync` is required because the
+  retained source itself is shared. Equivalently, `ActorDef::cloned` requires
+  `Args: Clone + Sync`. Observation predicates that run from one place at a
+  time carry `FnMut + Send` without `Sync`.
 - **Exactly-once operations are consuming.** Where ownership enforces
   at-most-once (§1 principle 3), the method takes `self`:
   `Guard::cancel`/`detach` (B.7), `Reply::send`, `ReplyReceiver::recv`

--- a/SPEC.md
+++ b/SPEC.md
@@ -84,12 +84,13 @@ these, in order.
    escalation, exit classification, child identity: each exists exactly once,
    as a named primitive, and every subsystem consumes that primitive.
    [#361, #363, #364, #370]
-3. **Construction invariants live in ownership and types, not comments.** A
-   rule that two modules must both remember is a design defect. Exactly-once
-   construction effects are expressed by consuming owned values (drop = the
-   fallback effect), not by `Mutex<Option<_>>` take-once flags. Internal
+3. **Invariants live in ownership and types, not comments.** A rule that two
+   modules must both remember is a design defect. Exactly-once construction
+   effects are expressed by consuming owned values (drop = the fallback
+   effect), not by `Mutex<Option<_>>` take-once flags. Internal
    synchronization may still use an optional payload as a non-panicking claim
-   protocol when it does not re-assert a construction capability. [#360,
+   protocol when it does not re-assert a construction capability or conflict
+   with a more specific ownership requirement elsewhere in this spec. [#360,
    #363]
 4. **Capabilities are never erased and re-asserted.** If the caller proved a
    capability statically (a dynamic scope, a restartable actor), every value
@@ -568,15 +569,16 @@ established in the construction-path types, before erasure:
   what they can accept (owned, non-re-mintable args) and return
   (`OneShotTaskRef<T>`), not in how long the child runs.
 - **Restartable** (`add_*`-family): the caller supplies an args *source* —
-  `Args: Clone + Sync`, or `Fn() -> Args + Send + Sync` re-minted at restart
-  time (so a restart can observe the current world: re-resolve an address,
-  fresh timestamp).
+  `Args: Clone + Sync`, or `Fn() -> Args + Send + Sync + 'static` re-minted at
+  restart time (so a restart can observe the current world: re-resolve an
+  address, fresh timestamp).
   This is OTP's `{M, F, A}` translated into ownership: the args value is the
   per-spawn argument, and whether you can clone or re-mint it *is* your
   restart capability. For subtree children the args source *is* the
-  declaration source: restartable `add_subtree` takes `impl Fn() -> T`
-  (`T: Subtree`, §11), re-invoked at restart so each incarnation lowers a
-  fresh single-use tree; the `_once` twin consumes a tree value outright.
+  declaration source: restartable `add_subtree` takes
+  `impl Fn() -> T + Send + Sync + 'static` (`T: Subtree`, §11), re-invoked at
+  restart so each incarnation lowers a fresh single-use tree; the `_once` twin
+  consumes a tree value outright.
 - The erased internal representation of one-shot construction is
   `FnOnce`-shaped all the way down: the closure owns the resource, the
   runner owns the closure, and init-panic / startup-failure /
@@ -586,12 +588,15 @@ established in the construction-path types, before erasure:
   claims throughout the lowering and incarnation path. This prohibition does
   not cover internal, non-panicking synchronization claims such as disposal
   completion, where losing the claim race is an ordinary no-op rather than a
-  re-asserted construction capability (§1 principle 3, §7).
+  re-asserted construction capability. The independent owned-token and
+  consuming rules for readiness (§6), exit reports (§7), guards (B.7), and
+  public exactly-once operations (B.10) remain mandatory (§1 principle 3).
 - **Every user-supplied construction source executes inside the single
-  incarnation runner** (§7): the restartable forms' `Fn() -> Args` factory
-  and `Args::clone`, task body factories, raw-actor factories, and subtree
-  factories with the lowering they trigger (§11) all run within the
-  incarnation future they are constructing. A panic in any of them is that
+  incarnation runner** (§7): the restartable forms' shared
+  `Fn() -> Args + Send + Sync + 'static` factory and `Args::clone`, task body
+  factories, raw-actor factories, and subtree factories with the lowering
+  they trigger (§11) all run within the incarnation future they are
+  constructing. A panic in any of them is that
   incarnation's own exit, classified `Panicked` by the ordinary path —
   never an engine crash, never a per-source failure model — and §13.5's
   drop guarantees hold unchanged, because the source is owned by the same
@@ -656,7 +661,7 @@ trait RawActor: Send + 'static {
   entry points on both scope flavors. There is no `init`/`Args` phase at
   this layer: the actor value itself is the per-incarnation input, so
   §4.2's args-source rule applies to it directly — the restartable form
-  takes `impl Fn() -> R + Send + 'static`, re-invoked at each restart;
+  takes `impl Fn() -> R + Send + Sync + 'static`, re-invoked at each restart;
   the one-shot form consumes an owned `R`. The value therefore exists
   before `run` is called. The shared options record applies unchanged
   (mailbox settings included — honoring `mailbox_shutdown` is the raw
@@ -1655,9 +1660,12 @@ Rules (normative):
 - **Construction-source bounds are pinned in the def constructors
   above** — one
   place, verbatim, per §4.2's capability rule: restartable forms carry a
-  re-mintable shared source (`Args: Clone + Sync` or a `Fn + Send + Sync`
-  factory; task bodies a `Fn(TaskContext)` factory; raw actors `Fn() -> R`;
-  subtrees `Fn() -> T`), `_once` forms consume owned values. Cyclic wiring
+  re-mintable shared source (`Args: Clone + Sync` or a
+  `Fn() -> Args + Send + Sync + 'static` factory; task bodies a
+  `Fn(TaskContext) -> F + Send + Sync + 'static` factory; raw actors
+  `Fn() -> R + Send + Sync + 'static`; subtrees
+  `Fn() -> T + Send + Sync + 'static`), `_once` forms consume owned values.
+  Cyclic wiring
   thereby reduces to ordering: every ref a
   factory needs is minted from a sibling slot before any factory is
   written, so factories capture real `ActorRef`s — no `Option<ActorRef>`,
@@ -2135,8 +2143,9 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
   spawning a `DynamicTree` yields an owner whose scope handle is a
   `DynamicScopeRef`. The §4.2 mode split applies: `add_subtree_once`
   consumes a single-use tree value (`Never` structural); restartable
-  `add_subtree` takes the declaration *source*, `impl Fn() -> T`
-  (`T: Subtree`), re-invoked at each restart to lower a fresh tree.
+  `add_subtree` takes the declaration *source*,
+  `impl Fn() -> T + Send + Sync + 'static` (`T: Subtree`), re-invoked at each
+  restart to lower a fresh tree.
   `spawn()` consumes a tree value directly — the root has no supervisor
   and no restart, so no source is needed. `dynamic()` survives only as
   the runtime query for name-based traversal [#365].

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -460,6 +460,9 @@ impl<A: Actor> fmt::Debug for ActorDef<A> {
 
 impl<A: Actor> ActorDef<A> {
     /// Creates a restartable definition by cloning args inside each incarnation.
+    ///
+    /// The retained restartable source is shared, so the captured args must be
+    /// [`Sync`] even though each clone is made by one incarnation at a time.
     pub fn cloned(args: A::Args) -> Self
     where
         A::Args: Clone + Sync,

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -440,9 +440,11 @@ pub(crate) struct ScopeCell {
     control: Mutex<ScopeControl>,
     dynamic_route: Mutex<Option<Arc<dyn DynamicRoute>>>,
     // Dropping a resident emits `Removed` and recursively reads this watch.
-    // Mutation callbacks must therefore move removed residents out and drop
-    // them only after the watch guard has been released; dropping one from
-    // inside `send_modify`/`send_if_modified` would self-deadlock.
+    // Every removal path must therefore release the watch guard first:
+    // mutation callbacks move removed residents into outer storage, while a
+    // wholesale clear uses `take`/replacement, whose old collection emerges
+    // only after the channel's internal guard is released. Dropping a resident
+    // inside a mutation callback would self-deadlock; adding one there is safe.
     current_children: runtime::WatchSender<Vec<ResidentChild>>,
     parent: runtime::WatchSender<Option<Weak<ScopeCell>>>,
     observation_gate: RwLock<Arc<Mutex<()>>>,
@@ -594,6 +596,9 @@ impl ScopeCell {
             !std::ptr::eq(self, parent),
             "a scope cannot adopt from itself"
         );
+        // The caller holds `gate` through `parent.with_observation_gate`.
+        // Re-homing the parent would first have to acquire that same gate, so
+        // rereading its installed pointer here cannot race a parent handoff.
         debug_assert!(
             Arc::ptr_eq(gate, &parent.current_observation_gate()),
             "observation gates are adopted only in the parent-to-child direction"

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -439,6 +439,10 @@ pub(crate) struct ScopeCell {
     record: runtime::WatchSender<ScopeRecord>,
     control: Mutex<ScopeControl>,
     dynamic_route: Mutex<Option<Arc<dyn DynamicRoute>>>,
+    // Dropping a resident emits `Removed` and recursively reads this watch.
+    // Mutation callbacks must therefore move removed residents out and drop
+    // them only after the watch guard has been released; dropping one from
+    // inside `send_modify`/`send_if_modified` would self-deadlock.
     current_children: runtime::WatchSender<Vec<ResidentChild>>,
     parent: runtime::WatchSender<Option<Weak<ScopeCell>>>,
     observation_gate: RwLock<Arc<Mutex<()>>>,
@@ -585,7 +589,15 @@ impl ScopeCell {
         )
     }
 
-    fn adopt_observation_gate(&self, gate: &Arc<Mutex<()>>) {
+    fn adopt_observation_gate(&self, parent: &ScopeCell, gate: &Arc<Mutex<()>>) {
+        debug_assert!(
+            !std::ptr::eq(self, parent),
+            "a scope cannot adopt from itself"
+        );
+        debug_assert!(
+            Arc::ptr_eq(gate, &parent.current_observation_gate()),
+            "observation gates are adopted only in the parent-to-child direction"
+        );
         loop {
             let current = self.current_observation_gate();
             if Arc::ptr_eq(&current, gate) {
@@ -1201,7 +1213,7 @@ impl ScopeCell {
             self.clear_residents_locked();
             for child in children {
                 if let Some(scope) = &child.scope {
-                    scope.adopt_observation_gate(&gate);
+                    scope.adopt_observation_gate(self, &gate);
                     scope.parent.replace(Some(Arc::downgrade(self)));
                 }
                 child
@@ -1220,7 +1232,7 @@ impl ScopeCell {
         self.with_observation_gate(|| {
             let gate = self.current_observation_gate();
             if let Some(scope) = &child.scope {
-                scope.adopt_observation_gate(&gate);
+                scope.adopt_observation_gate(self, &gate);
                 scope.parent.replace(Some(Arc::downgrade(self)));
             }
             let id = child.member.id().clone();

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -104,8 +104,8 @@ pub(crate) struct ReportReceiver(mpsc::Receiver<RecordedReport>);
 ///
 /// `ReportToken` is owned by the child task and its fail-closed `Drop` sends a
 /// fallback synchronously. Rust drops those task locals before the join handle
-/// becomes ready, so the exit joiner may safely perform the blocking receive:
-/// a report has already been sent on every return, panic, and cancellation
+/// becomes ready, so the exit joiner may require an immediately available
+/// report: one has already been sent on every return, panic, and cancellation
 /// edge. The shutdown/local-stop latches are sampled by that same send, making
 /// the report and its cancellation evidence one ordered observation.
 pub(crate) fn report_channel(
@@ -148,8 +148,8 @@ impl ReportToken {
 impl ReportReceiver {
     fn receive(self) -> RecordedReport {
         self.0
-            .recv()
-            .expect("owned report token must record or fall back")
+            .try_recv()
+            .expect("owned report token must record or fall back before its task joins")
     }
 }
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -103,11 +103,13 @@ pub(crate) struct ReportReceiver(mpsc::Receiver<RecordedReport>);
 /// asynchronous handoff race.
 ///
 /// `ReportToken` is owned by the child task and its fail-closed `Drop` sends a
-/// fallback synchronously. Rust drops those task locals before the join handle
-/// becomes ready, so the exit joiner may require an immediately available
-/// report: one has already been sent on every return, panic, and cancellation
-/// edge. The shutdown/local-stop latches are sampled by that same send, making
-/// the report and its cancellation evidence one ordered observation.
+/// fallback synchronously. The runtime resolves `runtime::join` only after the
+/// spawned future has been destroyed (a tokio `JoinHandle` guarantee, not a
+/// language one — any replacement executor behind `runtime` must preserve it),
+/// so the exit joiner may require an immediately available report: one has
+/// already been sent on every return, panic, and cancellation edge. The
+/// shutdown/local-stop latches are sampled by that same send, making the
+/// report and its cancellation evidence one ordered observation.
 pub(crate) fn report_channel(
     shutdown: Latch,
     local_stop: Option<Latch>,

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1375,8 +1375,8 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
         };
         exit_ended.fire();
         // The task owns `report`, whose explicit record or Drop fallback runs
-        // before the join completes. Therefore this blocking receive cannot
-        // wait on a producer that is still schedulable on this worker.
+        // before the join completes. `receive` therefore asserts immediate
+        // post-join availability without ever blocking this runtime worker.
         let report = report_receiver.receive();
         let _ = runtime::mpsc_send(
             &exit_sender,

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -673,9 +673,10 @@ impl OffloadResource {
         }
         if let Some(task) = &self.task {
             // These are complementary: `state.cancel()` synchronously
-            // disposes idle work (capturing destructor panic) or marks a
-            // currently polled future, while abort stops the runtime task that
-            // owns that poll. Neither substitutes for the other.
+            // disposes idle work (capturing destructor panic) or marks an
+            // in-progress poll to dispose on return, while abort independently
+            // requests cancellation of the runtime task driving that poll.
+            // Neither substitutes for the other.
             task.abort();
         }
         self.finished.fire();

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -672,6 +672,10 @@ impl OffloadResource {
             state.cancel();
         }
         if let Some(task) = &self.task {
+            // These are complementary: `state.cancel()` synchronously
+            // disposes idle work (capturing destructor panic) or marks a
+            // currently polled future, while abort stops the runtime task that
+            // owns that poll. Neither substitutes for the other.
             task.abort();
         }
         self.finished.fire();


### PR DESCRIPTION
Stacked on #98; review only the top commit for this PR.

Closes #91.

## Summary

- apply #91's latest take-once decision by scoping the `Mutex<Option<_>>` prohibition to construction payloads, keeping `DisposalJob`'s non-panicking claim protocol
- update every normative restartable-constructor signature and B.10 to the post-#37 `Send + Sync` reality, and document why `ActorDef::cloned` requires `Args: Clone + Sync`
- replace `ReportReceiver`'s potentially blocking receive with `try_recv().expect(...)`, encoding the post-join invariant directly
- document the `current_children` residency-drop rule that prevents watch-guard self-deadlock
- assert that observation-gate adoption is parent-to-child and uses the parent's installed gate
- explain why offload cancellation deliberately performs both synchronous state cancellation and runtime-task abort

## Validation

- `./scripts/dev just ci`
- 422/422 nextest cases passed, plus doctests, rustdoc, API reachability, runtime/exit/layering enforcement, packaged-crate verification, and formatting/lint checks
