### PR TITLE
Prefer message passing over shared mutexes in acceptance tests

### DIFF
--- a/crates/shelterwood/tests/acceptance/assistant.rs
+++ b/crates/shelterwood/tests/acceptance/assistant.rs
@@ -29,6 +29,9 @@ async fn next_event(events: &mut LifecycleEvents) -> LifecycleEvent {
 
 #[derive(Clone, Default)]
 struct TransportState {
+    /// The journal's durable ledger. It must survive the injected crash of
+    /// `JournalActor` (a restart re-inits from cloned `Args`), so it models
+    /// the disk underneath the actor rather than actor-owned state.
     delivered: Arc<Mutex<HashSet<u64>>>,
     processed: Arc<AtomicUsize>,
     duplicate_notices: Arc<AtomicUsize>,
@@ -254,12 +257,12 @@ impl Actor for SessionControlActor {
 }
 
 struct StreamActor {
-    values: Arc<Mutex<Vec<u64>>>,
+    values: tokio::sync::mpsc::UnboundedSender<u64>,
 }
 
 impl Actor for StreamActor {
     type Msg = u64;
-    type Args = (ReleaseGate, Arc<Mutex<Vec<u64>>>);
+    type Args = (ReleaseGate, tokio::sync::mpsc::UnboundedSender<u64>);
 
     async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
         args.0.wait().await;
@@ -267,10 +270,8 @@ impl Actor for StreamActor {
     }
 
     async fn handle(&mut self, value: u64, _: &mut Context<'_, Self>) -> ExitResult {
-        self.values
-            .lock()
-            .expect("stream values mutex poisoned")
-            .push(value);
+        // A fixture whose log is never read has dropped the receiver.
+        let _ = self.values.send(value);
         Ok(())
     }
 }
@@ -335,7 +336,7 @@ struct SessionFixture {
     control: ActorRef<SessionControlMessage>,
     stream: ActorRef<u64>,
     stream_gate: ReleaseGate,
-    stream_values: Arc<Mutex<Vec<u64>>>,
+    stream_log: tokio::sync::mpsc::UnboundedReceiver<u64>,
     rehydrated: Arc<AtomicUsize>,
     stop_entered: Arc<AtomicBool>,
     stop_gate: ReleaseGate,
@@ -348,11 +349,11 @@ fn session_fixture() -> SessionFixture {
         .add_subtree_once("tools", SubtreeOnceDef::new(tools_tree))
         .expect("nested tool scope declared");
     let stream_gate = ReleaseGate::default();
-    let stream_values = Arc::new(Mutex::new(Vec::new()));
+    let (stream_values, stream_log) = tokio::sync::mpsc::unbounded_channel();
     let stream = tree
         .add_actor_once(
             "stream",
-            ActorOnceDef::<StreamActor>::new((stream_gate.clone(), Arc::clone(&stream_values)))
+            ActorOnceDef::<StreamActor>::new((stream_gate.clone(), stream_values))
                 .mailbox(Mailbox::latest()),
         )
         .expect("stream actor declared");
@@ -377,7 +378,7 @@ fn session_fixture() -> SessionFixture {
         control,
         stream,
         stream_gate,
-        stream_values,
+        stream_log,
         rehydrated,
         stop_entered,
         stop_gate,
@@ -441,7 +442,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
 
     let session_data = session_fixture();
     let stream_gate = session_data.stream_gate.clone();
-    let stream_values = Arc::clone(&session_data.stream_values);
+    let mut stream_log = session_data.stream_log;
     let rehydrated = Arc::clone(&session_data.rehydrated);
     let stop_entered = Arc::clone(&session_data.stop_entered);
     let stop_gate = session_data.stop_gate.clone();
@@ -476,11 +477,12 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         )
         .await
         .expect("session aggregate readiness completes");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
-            *stream_values.lock().expect("stream values mutex poisoned") == [3]
-        })
-        .await,
+    let newest = tokio::time::timeout(POLL_TIMEOUT, stream_log.recv())
+        .await
+        .expect("released stream handles its retained update")
+        .expect("stream actor is alive");
+    assert_eq!(
+        newest, 3,
         "latest mailbox keeps the newest accepted streaming update"
     );
     assert!(
@@ -744,7 +746,7 @@ impl Actor for IdleSessionActor {
 async fn assistant_sessions_idle_evict_on_timers_and_streams_cancel_mid_flight() {
     let (evictions, mut evicted) = tokio::sync::mpsc::unbounded_channel();
     let activities = Arc::new(AtomicUsize::new(0));
-    let stream_values = Arc::new(Mutex::new(Vec::new()));
+    let (stream_values, mut stream_log) = tokio::sync::mpsc::unbounded_channel();
     let mut session = Tree::new();
     let idle = session
         .add_actor(
@@ -756,7 +758,7 @@ async fn assistant_sessions_idle_evict_on_timers_and_streams_cancel_mid_flight()
     let stream = session
         .add_actor_once(
             "stream",
-            ActorOnceDef::<StreamActor>::new((stream_gate.clone(), Arc::clone(&stream_values)))
+            ActorOnceDef::<StreamActor>::new((stream_gate.clone(), stream_values))
                 .mailbox(Mailbox::latest()),
         )
         .expect("stream actor declared");
@@ -777,16 +779,11 @@ async fn assistant_sessions_idle_evict_on_timers_and_streams_cancel_mid_flight()
 
     // Mid-life streaming works and the idle timer is armed from init.
     stream.send(5).await.expect("stream accepts mid-life value");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
-            stream_values
-                .lock()
-                .expect("stream values mutex poisoned")
-                .as_slice()
-                == [5]
-        })
+    let mid_life = tokio::time::timeout(POLL_TIMEOUT, stream_log.recv())
         .await
-    );
+        .expect("live stream handles the mid-life value")
+        .expect("stream actor is alive");
+    assert_eq!(mid_life, 5);
 
     // Activity half-way through the idle window replaces the deadline …
     tokio::time::advance(Duration::from_secs(30)).await;
@@ -823,12 +820,8 @@ async fn assistant_sessions_idle_evict_on_timers_and_streams_cancel_mid_flight()
         .try_send(9)
         .expect_err("a cancelled stream rejects new values");
     assert_eq!(error.kind, shelterwood::SendErrorKind::Terminated);
-    assert_eq!(
-        stream_values
-            .lock()
-            .expect("stream values mutex poisoned")
-            .as_slice(),
-        [5],
+    assert!(
+        stream_log.try_recv().is_err(),
         "no value leaks past cancellation"
     );
     system

--- a/crates/shelterwood/tests/acceptance/assistant.rs
+++ b/crates/shelterwood/tests/acceptance/assistant.rs
@@ -35,10 +35,6 @@ struct TransportState {
     /// the disk underneath the actor rather than actor-owned state.
     delivered: Arc<Mutex<HashSet<u64>>>,
     processed: UnboundedSender<u64>,
-    /// Crash injection, not observation: the flag must survive the restart it
-    /// causes and is read-and-cleared by the actor itself, which a channel
-    /// cannot express — so it stays an atomic.
-    fail_once: Arc<AtomicBool>,
 }
 
 enum IngressMessage {
@@ -119,15 +115,15 @@ impl Actor for JournalActor {
             .insert(id);
         if inserted {
             let _ = self.0.state.processed.send(id);
-        }
-        if inserted && self.0.state.fail_once.swap(false, Ordering::SeqCst) {
+            // The crash window under test, derived from the durable ledger
+            // instead of an injection flag: every fresh durable write crashes
+            // before acknowledgement, so an ack can only come from a
+            // redelivery finding its id already journaled.
             return Err(ExitError::message(
                 "injected crash after durable write before acknowledgement",
             ));
         }
-        if !inserted {
-            let _ = self.0.ingress.try_send(IngressMessage::DuplicateObserved);
-        }
+        let _ = self.0.ingress.try_send(IngressMessage::DuplicateObserved);
         reply.send(());
         Ok(())
     }
@@ -203,7 +199,6 @@ fn gateway() -> GatewayFixture {
         state: TransportState {
             delivered: Arc::default(),
             processed,
-            fail_once: Arc::new(AtomicBool::new(true)),
         },
     }));
     let bridge_gate = ReleaseGate::default();

--- a/crates/shelterwood/tests/acceptance/assistant.rs
+++ b/crates/shelterwood/tests/acceptance/assistant.rs
@@ -179,7 +179,7 @@ struct GatewayFixture {
     duplicate_notices: UnboundedReceiver<()>,
 }
 
-fn gateway(fail_once: bool) -> GatewayFixture {
+fn gateway() -> GatewayFixture {
     let (processed, processed_log) = unbounded_channel();
     let (duplicate_notices, duplicates_log) = unbounded_channel();
     let mut tree = Tree::new();
@@ -203,7 +203,7 @@ fn gateway(fail_once: bool) -> GatewayFixture {
         state: TransportState {
             delivered: Arc::default(),
             processed,
-            fail_once: Arc::new(AtomicBool::new(fail_once)),
+            fail_once: Arc::new(AtomicBool::new(true)),
         },
     }));
     let bridge_gate = ReleaseGate::default();
@@ -421,7 +421,7 @@ fn event_is_restart_for(event: &LifecycleEvent, membership: Membership) -> bool 
 
 #[tokio::test]
 async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_and_remount() {
-    let mut gateway = gateway(true);
+    let mut gateway = gateway();
     let mut root_tree = Tree::new();
     let sessions = root_tree
         .add_subtree_once("sessions", SubtreeOnceDef::new(DynamicTree::new()))

--- a/crates/shelterwood/tests/acceptance/assistant.rs
+++ b/crates/shelterwood/tests/acceptance/assistant.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashSet,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, Ordering},
     },
     time::Duration,
 };
@@ -14,6 +14,7 @@ use shelterwood::{
     LifecycleItem, Mailbox, Membership, RemoveOutcome, Reply, ReserveError, RestartPolicy,
     ScopeState, StopContext, SubtreeOnceDef, Tree,
 };
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 async fn next_event(events: &mut LifecycleEvents) -> LifecycleEvent {
     loop {
@@ -27,14 +28,16 @@ async fn next_event(events: &mut LifecycleEvents) -> LifecycleEvent {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 struct TransportState {
     /// The journal's durable ledger. It must survive the injected crash of
     /// `JournalActor` (a restart re-inits from cloned `Args`), so it models
     /// the disk underneath the actor rather than actor-owned state.
     delivered: Arc<Mutex<HashSet<u64>>>,
-    processed: Arc<AtomicUsize>,
-    duplicate_notices: Arc<AtomicUsize>,
+    processed: UnboundedSender<u64>,
+    /// Crash injection, not observation: the flag must survive the restart it
+    /// causes and is read-and-cleared by the actor itself, which a channel
+    /// cannot express — so it stays an atomic.
     fail_once: Arc<AtomicBool>,
 }
 
@@ -50,7 +53,7 @@ enum JournalMessage {
 #[derive(Clone)]
 struct IngressArgs {
     journal: ActorRef<JournalMessage>,
-    duplicate_notices: Arc<AtomicUsize>,
+    duplicate_notices: UnboundedSender<()>,
 }
 
 struct IngressActor(IngressArgs);
@@ -82,7 +85,7 @@ impl Actor for IngressActor {
                 reply.send(());
             }
             IngressMessage::DuplicateObserved => {
-                self.0.duplicate_notices.fetch_add(1, Ordering::SeqCst);
+                let _ = self.0.duplicate_notices.send(());
             }
         }
         Ok(())
@@ -115,7 +118,7 @@ impl Actor for JournalActor {
             .expect("transport journal mutex poisoned")
             .insert(id);
         if inserted {
-            self.0.state.processed.fetch_add(1, Ordering::SeqCst);
+            let _ = self.0.state.processed.send(id);
         }
         if inserted && self.0.state.fail_once.swap(false, Ordering::SeqCst) {
             return Err(ExitError::message(
@@ -172,9 +175,13 @@ struct GatewayFixture {
     ingress: ActorRef<IngressMessage>,
     bridge: ActorRef<BridgeMessage>,
     bridge_gate: ReleaseGate,
+    processed: UnboundedReceiver<u64>,
+    duplicate_notices: UnboundedReceiver<()>,
 }
 
-fn gateway(state: TransportState) -> GatewayFixture {
+fn gateway(fail_once: bool) -> GatewayFixture {
+    let (processed, processed_log) = unbounded_channel();
+    let (duplicate_notices, duplicates_log) = unbounded_channel();
     let mut tree = Tree::new();
     let ingress_slot = tree
         .reserve_actor::<IngressMessage>("ingress")
@@ -189,11 +196,15 @@ fn gateway(state: TransportState) -> GatewayFixture {
     // no registry and no Option<ActorRef> initialization phase.
     let _defined_ingress = ingress_slot.define(ActorDef::<IngressActor>::cloned(IngressArgs {
         journal: journal.clone(),
-        duplicate_notices: Arc::clone(&state.duplicate_notices),
+        duplicate_notices,
     }));
     let _defined_journal = journal_slot.define(ActorDef::<JournalActor>::cloned(JournalArgs {
         ingress: ingress.clone(),
-        state,
+        state: TransportState {
+            delivered: Arc::default(),
+            processed,
+            fail_once: Arc::new(AtomicBool::new(fail_once)),
+        },
     }));
     let bridge_gate = ReleaseGate::default();
     let bridge = tree
@@ -207,14 +218,18 @@ fn gateway(state: TransportState) -> GatewayFixture {
         ingress,
         bridge,
         bridge_gate,
+        processed: processed_log,
+        duplicate_notices: duplicates_log,
     }
 }
 
 #[derive(Clone)]
 struct SessionControlArgs {
+    /// Crash injection, kept as an atomic: it must survive the restart it
+    /// causes and the actor read-and-clears it itself.
     crash_once: Arc<AtomicBool>,
-    rehydrated: Arc<AtomicUsize>,
-    stop_entered: Arc<AtomicBool>,
+    rehydrated: UnboundedSender<()>,
+    stop_entered: UnboundedSender<()>,
     stop_gate: ReleaseGate,
 }
 
@@ -239,7 +254,7 @@ impl Actor for SessionControlActor {
     async fn handle(&mut self, message: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
         match message {
             SessionControlMessage::Rehydrate => {
-                self.0.rehydrated.fetch_add(1, Ordering::SeqCst);
+                let _ = self.0.rehydrated.send(());
             }
             SessionControlMessage::Crash => {
                 if self.0.crash_once.swap(false, Ordering::SeqCst) {
@@ -251,18 +266,18 @@ impl Actor for SessionControlActor {
     }
 
     async fn on_stop(&mut self, _: &mut StopContext<'_, Self>) {
-        self.0.stop_entered.store(true, Ordering::SeqCst);
+        let _ = self.0.stop_entered.send(());
         self.0.stop_gate.wait().await;
     }
 }
 
 struct StreamActor {
-    values: tokio::sync::mpsc::UnboundedSender<u64>,
+    values: UnboundedSender<u64>,
 }
 
 impl Actor for StreamActor {
     type Msg = u64;
-    type Args = (ReleaseGate, tokio::sync::mpsc::UnboundedSender<u64>);
+    type Args = (ReleaseGate, UnboundedSender<u64>);
 
     async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
         args.0.wait().await;
@@ -278,8 +293,10 @@ impl Actor for StreamActor {
 
 #[derive(Clone)]
 struct ToolArgs {
+    /// Crash injection, kept as an atomic: it must survive the restart it
+    /// causes and the actor read-and-clears it itself.
     crash_once: Arc<AtomicBool>,
-    completions: Arc<AtomicUsize>,
+    completions: UnboundedSender<()>,
 }
 
 enum ToolMessage {
@@ -315,7 +332,7 @@ impl Actor for ToolActor {
                     .expect("live tool accepts incarnation-owned offload");
             }
             ToolMessage::Completed(Ok(7)) => {
-                self.0.completions.fetch_add(1, Ordering::SeqCst);
+                let _ = self.0.completions.send(());
             }
             ToolMessage::Completed(Ok(value)) => {
                 return Err(ExitError::message(format!(
@@ -336,9 +353,9 @@ struct SessionFixture {
     control: ActorRef<SessionControlMessage>,
     stream: ActorRef<u64>,
     stream_gate: ReleaseGate,
-    stream_log: tokio::sync::mpsc::UnboundedReceiver<u64>,
-    rehydrated: Arc<AtomicUsize>,
-    stop_entered: Arc<AtomicBool>,
+    stream_log: UnboundedReceiver<u64>,
+    rehydrated: UnboundedReceiver<()>,
+    stop_entered: UnboundedReceiver<()>,
     stop_gate: ReleaseGate,
 }
 
@@ -349,7 +366,7 @@ fn session_fixture() -> SessionFixture {
         .add_subtree_once("tools", SubtreeOnceDef::new(tools_tree))
         .expect("nested tool scope declared");
     let stream_gate = ReleaseGate::default();
-    let (stream_values, stream_log) = tokio::sync::mpsc::unbounded_channel();
+    let (stream_values, stream_log) = unbounded_channel();
     let stream = tree
         .add_actor_once(
             "stream",
@@ -357,16 +374,16 @@ fn session_fixture() -> SessionFixture {
                 .mailbox(Mailbox::latest()),
         )
         .expect("stream actor declared");
-    let rehydrated = Arc::new(AtomicUsize::new(0));
-    let stop_entered = Arc::new(AtomicBool::new(false));
+    let (rehydrated, rehydration_log) = unbounded_channel();
+    let (stop_entered, stop_log) = unbounded_channel();
     let stop_gate = ReleaseGate::default();
     let control = tree
         .add_actor(
             "control",
             ActorDef::<SessionControlActor>::cloned(SessionControlArgs {
                 crash_once: Arc::new(AtomicBool::new(true)),
-                rehydrated: Arc::clone(&rehydrated),
-                stop_entered: Arc::clone(&stop_entered),
+                rehydrated,
+                stop_entered,
                 stop_gate: stop_gate.clone(),
             })
             .restart(RestartPolicy::default()),
@@ -379,8 +396,8 @@ fn session_fixture() -> SessionFixture {
         stream,
         stream_gate,
         stream_log,
-        rehydrated,
-        stop_entered,
+        rehydrated: rehydration_log,
+        stop_entered: stop_log,
         stop_gate,
     }
 }
@@ -404,11 +421,7 @@ fn event_is_restart_for(event: &LifecycleEvent, membership: Membership) -> bool 
 
 #[tokio::test]
 async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_and_remount() {
-    let transport = TransportState {
-        fail_once: Arc::new(AtomicBool::new(true)),
-        ..TransportState::default()
-    };
-    let gateway = gateway(transport.clone());
+    let mut gateway = gateway(true);
     let mut root_tree = Tree::new();
     let sessions = root_tree
         .add_subtree_once("sessions", SubtreeOnceDef::new(DynamicTree::new()))
@@ -443,8 +456,8 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
     let session_data = session_fixture();
     let stream_gate = session_data.stream_gate.clone();
     let mut stream_log = session_data.stream_log;
-    let rehydrated = Arc::clone(&session_data.rehydrated);
-    let stop_entered = Arc::clone(&session_data.stop_entered);
+    let mut rehydrated = session_data.rehydrated;
+    let mut stop_entered = session_data.stop_entered;
     let stop_gate = session_data.stop_gate.clone();
     let tools = session_data.tools.clone();
     let control = session_data.control.clone();
@@ -485,12 +498,10 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         newest, 3,
         "latest mailbox keeps the newest accepted streaming update"
     );
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
-            rehydrated.load(Ordering::SeqCst) >= 1
-        })
+    tokio::time::timeout(POLL_TIMEOUT, rehydrated.recv())
         .await
-    );
+        .expect("session control rehydrates from its init continuation")
+        .expect("control actor is alive");
 
     let forwarded = loop {
         let event = next_event(&mut lifecycle).await;
@@ -536,9 +547,10 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         "session actor panic is isolated and restarted"
     );
 
+    let (completions, mut completed) = unbounded_channel();
     let tool_args = ToolArgs {
         crash_once: Arc::new(AtomicBool::new(true)),
-        completions: Arc::new(AtomicUsize::new(0)),
+        completions,
     };
     let tool = tools
         .add_actor(
@@ -579,13 +591,10 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
     tool.send(ToolMessage::Work)
         .await
         .expect("offload request accepted");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
-            tool_args.completions.load(Ordering::SeqCst) == 1
-        })
-        .await,
-        "incarnation-owned offload completes through the actor loop"
-    );
+    tokio::time::timeout(POLL_TIMEOUT, completed.recv())
+        .await
+        .expect("incarnation-owned offload completes through the actor loop")
+        .expect("tool actor is alive");
     assert_eq!(
         tools.remove_actor(&tool).await,
         RemoveOutcome::Removed,
@@ -612,13 +621,16 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         )
         .await
         .expect("redelivery of the same journal id is acknowledged");
-    assert_eq!(transport.processed.load(Ordering::SeqCst), 1);
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
-            transport.duplicate_notices.load(Ordering::SeqCst) == 1
-        })
-        .await
+    assert_eq!(
+        gateway.processed.try_recv().ok(),
+        Some(7),
+        "the durable write happened exactly once"
     );
+    assert!(gateway.processed.try_recv().is_err());
+    tokio::time::timeout(POLL_TIMEOUT, gateway.duplicate_notices.recv())
+        .await
+        .expect("the redelivered id surfaces as a duplicate notice")
+        .expect("ingress actor is alive");
 
     let mut saw_control_restart = false;
     let mut saw_tool_restart = false;
@@ -634,12 +646,10 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
     assert!(saw_control_restart && saw_tool_restart && saw_gateway_restart);
 
     let removal = sessions.remove_scope(&session);
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
-            stop_entered.load(Ordering::SeqCst)
-        })
+    tokio::time::timeout(POLL_TIMEOUT, stop_entered.recv())
         .await
-    );
+        .expect("removal drives the control actor into on_stop")
+        .expect("control actor reports entering on_stop");
     let racing = session_fixture();
     racing.stream_gate.release();
     racing.stop_gate.release();
@@ -699,15 +709,15 @@ enum IdleMessage {
 }
 
 struct IdleSessionActor {
-    evictions: tokio::sync::mpsc::UnboundedSender<()>,
-    activities: Arc<AtomicUsize>,
+    evictions: UnboundedSender<()>,
+    activities: UnboundedSender<()>,
 }
 
 const IDLE_AFTER: Duration = Duration::from_secs(60);
 
 impl Actor for IdleSessionActor {
     type Msg = IdleMessage;
-    type Args = (tokio::sync::mpsc::UnboundedSender<()>, Arc<AtomicUsize>);
+    type Args = (UnboundedSender<()>, UnboundedSender<()>);
 
     async fn init(args: Self::Args, context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
         context
@@ -728,7 +738,7 @@ impl Actor for IdleSessionActor {
                 context
                     .set_timeout("idle", IdleMessage::IdleExpired, IDLE_AFTER)
                     .expect("live session re-arms its idle timer");
-                self.activities.fetch_add(1, Ordering::SeqCst);
+                let _ = self.activities.send(());
             }
             IdleMessage::IdleExpired => {
                 let _ = self.evictions.send(());
@@ -744,14 +754,14 @@ impl Actor for IdleSessionActor {
 /// `Terminated` while never leaking another value.
 #[tokio::test(start_paused = true)]
 async fn assistant_sessions_idle_evict_on_timers_and_streams_cancel_mid_flight() {
-    let (evictions, mut evicted) = tokio::sync::mpsc::unbounded_channel();
-    let activities = Arc::new(AtomicUsize::new(0));
-    let (stream_values, mut stream_log) = tokio::sync::mpsc::unbounded_channel();
+    let (evictions, mut evicted) = unbounded_channel();
+    let (activities, mut activity_log) = unbounded_channel();
+    let (stream_values, mut stream_log) = unbounded_channel();
     let mut session = Tree::new();
     let idle = session
         .add_actor(
             "idle",
-            ActorDef::<IdleSessionActor>::cloned((evictions, Arc::clone(&activities))),
+            ActorDef::<IdleSessionActor>::cloned((evictions, activities)),
         )
         .expect("idle actor declared");
     let stream_gate = ReleaseGate::default();
@@ -790,13 +800,10 @@ async fn assistant_sessions_idle_evict_on_timers_and_streams_cancel_mid_flight()
     idle.send(IdleMessage::Activity)
         .await
         .expect("live session accepts activity");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
-            activities.load(Ordering::SeqCst) == 1
-        })
-        .await,
-        "the activity is handled (and the timer re-armed) before time moves"
-    );
+    tokio::time::timeout(POLL_TIMEOUT, activity_log.recv())
+        .await
+        .expect("the activity is handled (and the timer re-armed) before time moves")
+        .expect("idle actor is alive");
     // … so the original deadline passing evicts nothing …
     tokio::time::advance(Duration::from_secs(40)).await;
     assert!(

--- a/crates/shelterwood/tests/acceptance/assistant.rs
+++ b/crates/shelterwood/tests/acceptance/assistant.rs
@@ -1,9 +1,6 @@
 use std::{
     collections::HashSet,
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -220,9 +217,6 @@ fn gateway() -> GatewayFixture {
 
 #[derive(Clone)]
 struct SessionControlArgs {
-    /// Crash injection, kept as an atomic: it must survive the restart it
-    /// causes and the actor read-and-clears it itself.
-    crash_once: Arc<AtomicBool>,
     rehydrated: UnboundedSender<()>,
     stop_entered: UnboundedSender<()>,
     stop_gate: ReleaseGate,
@@ -252,9 +246,10 @@ impl Actor for SessionControlActor {
                 let _ = self.0.rehydrated.send(());
             }
             SessionControlMessage::Crash => {
-                if self.0.crash_once.swap(false, Ordering::SeqCst) {
-                    panic!("injected session-control panic");
-                }
+                // The crashing incarnation consumes this message and a
+                // restart cannot replay it, so the injection needs no
+                // once-flag.
+                panic!("injected session-control panic");
             }
         }
         Ok(())
@@ -286,36 +281,28 @@ impl Actor for StreamActor {
     }
 }
 
-#[derive(Clone)]
-struct ToolArgs {
-    /// Crash injection, kept as an atomic: it must survive the restart it
-    /// causes and the actor read-and-clears it itself.
-    crash_once: Arc<AtomicBool>,
-    completions: UnboundedSender<()>,
-}
-
 enum ToolMessage {
     Crash,
     Work,
     Completed(Result<u64, DeadlineElapsed>),
 }
 
-struct ToolActor(ToolArgs);
+struct ToolActor(UnboundedSender<()>);
 
 impl Actor for ToolActor {
     type Msg = ToolMessage;
-    type Args = ToolArgs;
+    type Args = UnboundedSender<()>;
 
-    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
-        Ok(Self(args))
+    async fn init(completions: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self(completions))
     }
 
     async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
         match message {
             ToolMessage::Crash => {
-                if self.0.crash_once.swap(false, Ordering::SeqCst) {
-                    panic!("injected tool panic");
-                }
+                // As with the session control actor: the message is consumed
+                // by the incarnation it crashes.
+                panic!("injected tool panic");
             }
             ToolMessage::Work => {
                 context
@@ -327,7 +314,7 @@ impl Actor for ToolActor {
                     .expect("live tool accepts incarnation-owned offload");
             }
             ToolMessage::Completed(Ok(7)) => {
-                let _ = self.0.completions.send(());
+                let _ = self.0.send(());
             }
             ToolMessage::Completed(Ok(value)) => {
                 return Err(ExitError::message(format!(
@@ -376,7 +363,6 @@ fn session_fixture() -> SessionFixture {
         .add_actor(
             "control",
             ActorDef::<SessionControlActor>::cloned(SessionControlArgs {
-                crash_once: Arc::new(AtomicBool::new(true)),
                 rehydrated,
                 stop_entered,
                 stop_gate: stop_gate.clone(),
@@ -543,14 +529,10 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
     );
 
     let (completions, mut completed) = unbounded_channel();
-    let tool_args = ToolArgs {
-        crash_once: Arc::new(AtomicBool::new(true)),
-        completions,
-    };
     let tool = tools
         .add_actor(
             "temporary-tool",
-            ActorDef::<ToolActor>::cloned(tool_args.clone()).restart(RestartPolicy::default()),
+            ActorDef::<ToolActor>::cloned(completions).restart(RestartPolicy::default()),
         )
         .await
         .expect("temporary tool admitted")

--- a/crates/shelterwood/tests/acceptance/shard_store.rs
+++ b/crates/shelterwood/tests/acceptance/shard_store.rs
@@ -4,6 +4,7 @@ use std::{
     time::Duration,
 };
 
+use crate::common::ReleaseGate;
 use shelterwood::{
     Actor, ActorDef, ActorRef, CallErrorKind, Context, DynamicScopeRef, DynamicTree, ExitError,
     ExitResult, Membership, RemoveOutcome, Reply, ScopeRef, SubtreeOnceDef, Tree,
@@ -560,7 +561,7 @@ async fn shard_store_reconciles_both_crash_windows_with_exact_idempotent_retries
 struct GatedShardActor {
     durable: DurableShard,
     entered: tokio::sync::mpsc::UnboundedSender<()>,
-    gate: Arc<tokio::sync::Notify>,
+    gate: ReleaseGate,
 }
 
 impl Actor for GatedShardActor {
@@ -568,7 +569,7 @@ impl Actor for GatedShardActor {
     type Args = (
         DurableShard,
         tokio::sync::mpsc::UnboundedSender<()>,
-        Arc<tokio::sync::Notify>,
+        ReleaseGate,
     );
 
     async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
@@ -583,7 +584,7 @@ impl Actor for GatedShardActor {
     async fn handle(&mut self, message: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
         let ShardMessage::Put { key, value, reply } = message;
         let _ = self.entered.send(());
-        self.gate.notified().await;
+        self.gate.wait().await;
         self.durable
             .0
             .lock()
@@ -601,7 +602,7 @@ impl Actor for GatedShardActor {
 async fn shard_store_retire_waits_for_accepted_requests() {
     let durable = DurableShard::default();
     let (entered, mut entered_log) = tokio::sync::mpsc::unbounded_channel();
-    let gate = Arc::new(tokio::sync::Notify::new());
+    let gate = ReleaseGate::default();
     let mut root = Tree::new();
     let ranges = root
         .add_subtree_once("ranges", SubtreeOnceDef::new(DynamicTree::new()))
@@ -613,7 +614,7 @@ async fn shard_store_retire_waits_for_accepted_requests() {
     let actor = mount
         .add_actor(
             "shard",
-            ActorDef::<GatedShardActor>::cloned((durable.clone(), entered, Arc::clone(&gate))),
+            ActorDef::<GatedShardActor>::cloned((durable.clone(), entered, gate.clone())),
         )
         .expect("valid shard");
     let scope = ranges
@@ -663,7 +664,7 @@ async fn shard_store_retire_waits_for_accepted_requests() {
         .await
         .expect("removal is underway");
 
-    gate.notify_one();
+    gate.release();
     write
         .await
         .expect("write task joins")

--- a/crates/shelterwood/tests/acceptance/shard_store.rs
+++ b/crates/shelterwood/tests/acceptance/shard_store.rs
@@ -560,7 +560,7 @@ async fn shard_store_reconciles_both_crash_windows_with_exact_idempotent_retries
 
 struct GatedShardActor {
     durable: DurableShard,
-    entered: Arc<std::sync::atomic::AtomicBool>,
+    entered: tokio::sync::mpsc::UnboundedSender<()>,
     gate: Arc<tokio::sync::Notify>,
 }
 
@@ -568,7 +568,7 @@ impl Actor for GatedShardActor {
     type Msg = ShardMessage;
     type Args = (
         DurableShard,
-        Arc<std::sync::atomic::AtomicBool>,
+        tokio::sync::mpsc::UnboundedSender<()>,
         Arc<tokio::sync::Notify>,
     );
 
@@ -583,8 +583,7 @@ impl Actor for GatedShardActor {
 
     async fn handle(&mut self, message: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
         let ShardMessage::Put { key, value, reply } = message;
-        self.entered
-            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let _ = self.entered.send(());
         self.gate.notified().await;
         self.durable
             .0
@@ -602,7 +601,7 @@ impl Actor for GatedShardActor {
 #[tokio::test]
 async fn shard_store_retire_waits_for_accepted_requests() {
     let durable = DurableShard::default();
-    let entered = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (entered, mut entered_log) = tokio::sync::mpsc::unbounded_channel();
     let gate = Arc::new(tokio::sync::Notify::new());
     let mut root = Tree::new();
     let ranges = root
@@ -615,11 +614,7 @@ async fn shard_store_retire_waits_for_accepted_requests() {
     let actor = mount
         .add_actor(
             "shard",
-            ActorDef::<GatedShardActor>::cloned((
-                durable.clone(),
-                Arc::clone(&entered),
-                Arc::clone(&gate),
-            )),
+            ActorDef::<GatedShardActor>::cloned((durable.clone(), entered, Arc::clone(&gate))),
         )
         .expect("valid shard");
     let scope = ranges
@@ -643,13 +638,10 @@ async fn shard_store_retire_waits_for_accepted_requests() {
                 .await
         }
     });
-    tokio::time::timeout(Duration::from_secs(1), async {
-        while !entered.load(std::sync::atomic::Ordering::SeqCst) {
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("the accepted write reaches the handler");
+    tokio::time::timeout(Duration::from_secs(1), entered_log.recv())
+        .await
+        .expect("the accepted write reaches the handler")
+        .expect("shard actor is alive");
 
     // Retirement starts while the accepted write is mid-handling;
     // `membership_status` flips synchronously at the call (§13.12).

--- a/crates/shelterwood/tests/acceptance/shard_store.rs
+++ b/crates/shelterwood/tests/acceptance/shard_store.rs
@@ -9,6 +9,9 @@ use shelterwood::{
     ExitResult, Membership, RemoveOutcome, Reply, ScopeRef, SubtreeOnceDef, Tree,
 };
 
+/// A shard's durable contents. Deliberately not actor-owned state: the test
+/// reads a retired mount's data after its serving actor is gone, so this
+/// models the disk underneath the actor.
 #[derive(Clone, Debug, Default)]
 struct DurableShard(Arc<Mutex<HashMap<String, u64>>>);
 
@@ -119,6 +122,10 @@ enum Fault {
     AfterCommitBeforeReply,
 }
 
+/// The router's durable operation journal. Router incarnations are replaced
+/// across the injected crashes and each re-init starts from cloned `Args`, so
+/// this is the durable store the §3.3 retry discipline reconciles against —
+/// state that must outlive any incarnation, not shared actor state.
 #[derive(Clone, Default)]
 struct DurableTopology {
     operations: Arc<Mutex<HashMap<u64, OperationRecord>>>,

--- a/crates/shelterwood/tests/acceptance/shard_store.rs
+++ b/crates/shelterwood/tests/acceptance/shard_store.rs
@@ -130,24 +130,9 @@ enum Fault {
 struct DurableTopology {
     operations: Arc<Mutex<HashMap<u64, OperationRecord>>>,
     current: Arc<Mutex<Option<Mount>>>,
-    faults: Arc<Mutex<HashMap<u64, Fault>>>,
 }
 
 impl DurableTopology {
-    fn inject(&self, operation: u64, fault: Fault) {
-        self.faults
-            .lock()
-            .expect("fault map mutex poisoned")
-            .insert(operation, fault);
-    }
-
-    fn take_fault(&self, operation: u64) -> Option<Fault> {
-        self.faults
-            .lock()
-            .expect("fault map mutex poisoned")
-            .remove(&operation)
-    }
-
     fn operation(&self, operation: u64) -> Option<OperationRecord> {
         self.operations
             .lock()
@@ -166,6 +151,10 @@ struct RouterArgs {
     ranges: DynamicScopeRef,
     directory: ActorRef<DirectoryMessage>,
     durable: DurableTopology,
+    /// Fault injection as plain per-incarnation config: once-semantics come
+    /// from the durable journal (a retry finds the record its first attempt
+    /// wrote before crashing), not from mutating shared state.
+    faults: HashMap<u64, Fault>,
 }
 
 struct RouterActor(RouterArgs);
@@ -265,7 +254,16 @@ impl RouterActor {
     }
 
     async fn replace(&self, operation: u64) -> Result<Route, ExitError> {
-        if let Some(record) = self.0.durable.operation(operation) {
+        let record = self.0.durable.operation(operation);
+        // A configured fault fires only on the operation's first attempt,
+        // recognized by the absence of a durable record: every crash window
+        // under test opens after the attempt journaled itself, so a retry
+        // can never re-arm the fault.
+        let fault = record
+            .is_none()
+            .then(|| self.0.faults.get(&operation).copied())
+            .flatten();
+        if let Some(record) = record {
             match record {
                 OperationRecord::Committed {
                     candidate,
@@ -318,7 +316,6 @@ impl RouterActor {
                 },
             );
 
-        let fault = self.0.durable.take_fault(operation);
         if matches!(fault, Some(Fault::BeforeCommit)) {
             return Err(ExitError::message("injected pre-commit router crash"));
         }
@@ -462,6 +459,10 @@ async fn shard_store_reconciles_both_crash_windows_with_exact_idempotent_retries
                 ranges: ranges.clone(),
                 directory: directory.clone(),
                 durable: durable.clone(),
+                faults: HashMap::from([
+                    (1, Fault::BeforeCommit),
+                    (2, Fault::AfterCommitBeforeReply),
+                ]),
             }),
         )
         .expect("valid topology writer");
@@ -469,7 +470,6 @@ async fn shard_store_reconciles_both_crash_windows_with_exact_idempotent_retries
     system.wait_started().await.expect("store starts");
     let root_scope = system.scope();
 
-    durable.inject(1, Fault::BeforeCommit);
     let first_error = router
         .call(
             |reply| RouterMessage::Replace {
@@ -505,7 +505,6 @@ async fn shard_store_reconciles_both_crash_windows_with_exact_idempotent_retries
         shelterwood::StopReason::ShutdownRequested
     );
 
-    durable.inject(2, Fault::AfterCommitBeforeReply);
     let second_error = router
         .call(
             |reply| RouterMessage::Replace {

--- a/crates/shelterwood/tests/acceptance/sidecar.rs
+++ b/crates/shelterwood/tests/acceptance/sidecar.rs
@@ -1,7 +1,7 @@
 use std::{
     future,
     sync::{
-        Arc, Mutex,
+        Arc,
         atomic::{AtomicBool, Ordering},
     },
     time::Duration,
@@ -15,23 +15,42 @@ use shelterwood::{
 };
 
 type JournalEvent = (usize, &'static str, &'static str);
-type JournalEntries = Arc<Mutex<Vec<JournalEvent>>>;
 
-#[derive(Clone, Debug, Default)]
-struct HostJournal(JournalEntries);
+/// The sender half handed to children: events reach the host by message
+/// passing, so no child ever shares mutable journal state with the test.
+#[derive(Clone, Debug)]
+struct HostJournal(tokio::sync::mpsc::UnboundedSender<JournalEvent>);
 
 impl HostJournal {
-    fn push(&self, cycle: usize, child: &'static str, event: &'static str) {
-        self.0
-            .lock()
-            .expect("host journal mutex poisoned")
-            .push((cycle, child, event));
+    fn new() -> (Self, JournalLog) {
+        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+        (
+            Self(sender),
+            JournalLog {
+                receiver,
+                entries: Vec::new(),
+            },
+        )
     }
 
-    fn events(&self, cycle: usize, child: &'static str) -> Vec<&'static str> {
-        self.0
-            .lock()
-            .expect("host journal mutex poisoned")
+    fn push(&self, cycle: usize, child: &'static str, event: &'static str) {
+        // A host that never reads its log has dropped the receiver.
+        let _ = self.0.send((cycle, child, event));
+    }
+}
+
+/// The host's receiving half of the journal.
+struct JournalLog {
+    receiver: tokio::sync::mpsc::UnboundedReceiver<JournalEvent>,
+    entries: Vec<JournalEvent>,
+}
+
+impl JournalLog {
+    fn events(&mut self, cycle: usize, child: &'static str) -> Vec<&'static str> {
+        while let Ok(event) = self.receiver.try_recv() {
+            self.entries.push(event);
+        }
+        self.entries
             .iter()
             .filter_map(|(entry_cycle, entry_child, event)| {
                 (*entry_cycle == cycle && *entry_child == child).then_some(*event)
@@ -202,7 +221,7 @@ fn sidecar(cycle: usize, journal: HostJournal) -> SidecarFixture {
 
 #[tokio::test]
 async fn sidecar_runs_two_host_owned_cycles_with_readiness_and_policy_exact_shutdown() {
-    let journal = HostJournal::default();
+    let (journal, mut log) = HostJournal::new();
 
     for cycle in 0..2 {
         let fixture = sidecar(cycle, journal.clone());
@@ -252,14 +271,14 @@ async fn sidecar_runs_two_host_owned_cycles_with_readiness_and_policy_exact_shut
             ExitKind::Aborted { after_grace: true }
         ));
         assert_eq!(
-            journal.events(cycle, "abort-worker"),
+            log.events(cycle, "abort-worker"),
             ["started", "cancelled", "aborted"]
         );
         assert_eq!(
-            journal.events(cycle, "graceful-worker"),
+            log.events(cycle, "graceful-worker"),
             ["started", "cancelled", "aborted"]
         );
-        assert_eq!(journal.events(cycle, "actor"), ["started", "stopped"]);
+        assert_eq!(log.events(cycle, "actor"), ["started", "stopped"]);
     }
 }
 
@@ -271,7 +290,10 @@ struct FailedStartupFixture {
     suffix_started: Arc<AtomicBool>,
 }
 
-fn failing_sidecar(journal: HostJournal) -> FailedStartupFixture {
+fn failing_sidecar() -> FailedStartupFixture {
+    // This scenario asserts child states, not journal events, so the log is
+    // dropped and every push is a no-op.
+    let (journal, _) = HostJournal::new();
     let gate = ReleaseGate::default();
     let prefix_one = Arc::new(AtomicBool::new(false));
     let prefix_two = Arc::new(AtomicBool::new(false));
@@ -284,7 +306,7 @@ fn failing_sidecar(journal: HostJournal) -> FailedStartupFixture {
     .expect("valid config task");
     tree.add_task(
         "telemetry",
-        cooperative_task(99, "telemetry", journal, Arc::clone(&prefix_two)),
+        cooperative_task(99, "telemetry", journal.clone(), Arc::clone(&prefix_two)),
     )
     .expect("valid telemetry task");
     tree.add_task(
@@ -314,10 +336,7 @@ fn failing_sidecar(journal: HostJournal) -> FailedStartupFixture {
     .expect("valid suffix task");
     let mut actors = Tree::new();
     actors
-        .add_actor_once(
-            "probe",
-            ActorOnceDef::<ProbeActor>::new((99, HostJournal::default())),
-        )
+        .add_actor_once("probe", ActorOnceDef::<ProbeActor>::new((99, journal)))
         .expect("valid actor subtree");
     tree.add_subtree_once("actors", SubtreeOnceDef::new(actors))
         .expect("valid actor subtree");
@@ -332,7 +351,7 @@ fn failing_sidecar(journal: HostJournal) -> FailedStartupFixture {
 
 #[tokio::test]
 async fn sidecar_startup_failure_leaves_prefix_supervised_until_host_rolls_it_back() {
-    let fixture = failing_sidecar(HostJournal::default());
+    let fixture = failing_sidecar();
     let system = fixture.tree.spawn().expect("runtime is available");
     let scope = system.scope();
     assert!(

--- a/crates/shelterwood/tests/acceptance/sidecar.rs
+++ b/crates/shelterwood/tests/acceptance/sidecar.rs
@@ -1,11 +1,4 @@
-use std::{
-    future,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-    time::Duration,
-};
+use std::{future, time::Duration};
 
 use crate::common::{POLL_TIMEOUT, ReleaseGate, policy::never, poll_until};
 use shelterwood::{
@@ -59,17 +52,10 @@ impl JournalLog {
     }
 }
 
-fn cooperative_task(
-    cycle: usize,
-    child: &'static str,
-    journal: HostJournal,
-    started: Arc<AtomicBool>,
-) -> TaskDef {
+fn cooperative_task(cycle: usize, child: &'static str, journal: HostJournal) -> TaskDef {
     TaskDef::new(move |context| {
         let journal = journal.clone();
-        let started = Arc::clone(&started);
         async move {
-            started.store(true, Ordering::SeqCst);
             journal.push(cycle, child, "started");
             context.shutdown_token().cancelled().await;
             journal.push(cycle, child, "cancelled");
@@ -79,18 +65,11 @@ fn cooperative_task(
     .restart(never())
 }
 
-fn gated_task(
-    cycle: usize,
-    gate: ReleaseGate,
-    journal: HostJournal,
-    started: Arc<AtomicBool>,
-) -> TaskDef {
+fn gated_task(cycle: usize, gate: ReleaseGate, journal: HostJournal) -> TaskDef {
     TaskDef::new(move |context| {
         let gate = gate.clone();
         let journal = journal.clone();
-        let started = Arc::clone(&started);
         async move {
-            started.store(true, Ordering::SeqCst);
             journal.push(cycle, "config", "started");
             gate.wait().await;
             context.mark_ready();
@@ -155,34 +134,21 @@ impl Actor for ProbeActor {
 struct SidecarFixture {
     tree: Tree,
     readiness: ReleaseGate,
-    config_started: Arc<AtomicBool>,
     abort_task: TaskRef,
     graceful_task: TaskRef,
 }
 
 fn sidecar(cycle: usize, journal: HostJournal) -> SidecarFixture {
     let readiness = ReleaseGate::default();
-    let config_started = Arc::new(AtomicBool::new(false));
-    let telemetry_started = Arc::new(AtomicBool::new(false));
     let mut tree = Tree::new();
     tree.add_task(
         "config",
-        gated_task(
-            cycle,
-            readiness.clone(),
-            journal.clone(),
-            Arc::clone(&config_started),
-        ),
+        gated_task(cycle, readiness.clone(), journal.clone()),
     )
     .expect("valid config task");
     tree.add_task(
         "telemetry",
-        cooperative_task(
-            cycle,
-            "telemetry",
-            journal.clone(),
-            Arc::clone(&telemetry_started),
-        ),
+        cooperative_task(cycle, "telemetry", journal.clone()),
     )
     .expect("valid telemetry task");
     let abort_task = tree
@@ -213,7 +179,6 @@ fn sidecar(cycle: usize, journal: HostJournal) -> SidecarFixture {
     SidecarFixture {
         tree,
         readiness,
-        config_started,
         abort_task,
         graceful_task,
     }
@@ -229,7 +194,7 @@ async fn sidecar_runs_two_host_owned_cycles_with_readiness_and_policy_exact_shut
         let scope = system.scope();
         assert!(
             poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
-                fixture.config_started.load(Ordering::SeqCst)
+                log.events(cycle, "config") == ["started"]
             })
             .await
         );
@@ -285,28 +250,18 @@ async fn sidecar_runs_two_host_owned_cycles_with_readiness_and_policy_exact_shut
 struct FailedStartupFixture {
     tree: Tree,
     gate: ReleaseGate,
-    prefix_one: Arc<AtomicBool>,
-    prefix_two: Arc<AtomicBool>,
-    suffix_started: Arc<AtomicBool>,
+    log: JournalLog,
 }
 
 fn failing_sidecar() -> FailedStartupFixture {
-    // This scenario asserts child states, not journal events, so the log is
-    // dropped and every push is a no-op.
-    let (journal, _) = HostJournal::new();
+    let (journal, log) = HostJournal::new();
     let gate = ReleaseGate::default();
-    let prefix_one = Arc::new(AtomicBool::new(false));
-    let prefix_two = Arc::new(AtomicBool::new(false));
-    let suffix_started = Arc::new(AtomicBool::new(false));
     let mut tree = Tree::new();
-    tree.add_task(
-        "config",
-        gated_task(99, gate.clone(), journal.clone(), Arc::clone(&prefix_one)),
-    )
-    .expect("valid config task");
+    tree.add_task("config", gated_task(99, gate.clone(), journal.clone()))
+        .expect("valid config task");
     tree.add_task(
         "telemetry",
-        cooperative_task(99, "telemetry", journal.clone(), Arc::clone(&prefix_two)),
+        cooperative_task(99, "telemetry", journal.clone()),
     )
     .expect("valid telemetry task");
     tree.add_task(
@@ -325,9 +280,9 @@ fn failing_sidecar() -> FailedStartupFixture {
     tree.add_task(
         "suffix",
         TaskDef::new({
-            let suffix_started = Arc::clone(&suffix_started);
+            let journal = journal.clone();
             move |_| {
-                suffix_started.store(true, Ordering::SeqCst);
+                journal.push(99, "suffix", "started");
                 future::pending()
             }
         })
@@ -340,23 +295,17 @@ fn failing_sidecar() -> FailedStartupFixture {
         .expect("valid actor subtree");
     tree.add_subtree_once("actors", SubtreeOnceDef::new(actors))
         .expect("valid actor subtree");
-    FailedStartupFixture {
-        tree,
-        gate,
-        prefix_one,
-        prefix_two,
-        suffix_started,
-    }
+    FailedStartupFixture { tree, gate, log }
 }
 
 #[tokio::test]
 async fn sidecar_startup_failure_leaves_prefix_supervised_until_host_rolls_it_back() {
-    let fixture = failing_sidecar();
+    let mut fixture = failing_sidecar();
     let system = fixture.tree.spawn().expect("runtime is available");
     let scope = system.scope();
     assert!(
         poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
-            fixture.prefix_one.load(Ordering::SeqCst)
+            fixture.log.events(99, "config") == ["started"]
         })
         .await
     );
@@ -365,9 +314,12 @@ async fn sidecar_startup_failure_leaves_prefix_supervised_until_host_rolls_it_ba
         .wait_started()
         .await
         .expect_err("manual readiness times out");
-    assert!(fixture.prefix_one.load(Ordering::SeqCst));
-    assert!(fixture.prefix_two.load(Ordering::SeqCst));
-    assert!(!fixture.suffix_started.load(Ordering::SeqCst));
+    assert_eq!(fixture.log.events(99, "config"), ["started", "ready"]);
+    assert_eq!(fixture.log.events(99, "telemetry"), ["started"]);
+    assert!(
+        fixture.log.events(99, "suffix").is_empty(),
+        "ordered startup never reaches the suffix"
+    );
     let snapshot = scope.snapshot();
     assert_eq!(snapshot.state, shelterwood::ScopeState::StartupFailed);
     assert!(matches!(


### PR DESCRIPTION
## Summary

The acceptance tests leaned on shared mutable state (`Arc<Mutex<..>>`, `Arc<Atomic*>` probes) for things actors should own or report themselves. This series converts every test *observation* to message passing and documents the shared state that remains on purpose.

**Commit 1 — mutexes to channels**
- `StreamActor` owns an `UnboundedSender<u64>`; tests observe by receiving. The latest-mailbox assertion becomes "first value received is 3" (equivalent strength) and the no-leak assertion becomes `try_recv().is_err()`, which still catches buffered leaks after the sender drops.
- `HostJournal` becomes the sender half of an mpsc channel; a test-side `JournalLog` drains and filters events.

**Commit 2 — remaining observation probes to channels**
- Transport processed-writes (now carrying the journal id) and duplicate notices, session rehydration, `on_stop` entry, tool offload completions, idle-session activity, and the gated shard's `entered` signal all report over mpsc senders, replacing `Arc<AtomicUsize/AtomicBool>` probes and one `yield_now` busy-wait.
- The sidecar started-flags fold into the existing `HostJournal` channel; the failed-startup scenario now asserts exact per-child event sequences (`config == ["started", "ready"]`, suffix never started) instead of boolean flags.

**Commits 3–5 — derive the injections instead of sharing them**
- `gateway()` loses its boolean parameter (its only caller armed the crash).
- `fail_once` is gone: the journal crashes on every fresh insert, since the test's only ack path is a redelivery finding its id already in the durable ledger.
- Both `crash_once` flags are gone: the crashing incarnation consumes its `Crash` message and a restart cannot replay it, so an unconditional panic is indistinguishable.
- The shard-store fault map (`Arc<Mutex<HashMap<u64, Fault>>>`) becomes plain per-incarnation config in `RouterArgs`; once-semantics derive from the durable journal, because every crash window opens after the attempt journaled itself.

**What stays shared, with comments at the definition:**
- Durable-storage models only (`TransportState.delivered`, `DurableShard`, `DurableTopology`): restarts re-init from cloned `Args`, and the tests read a retired mount's data and reconcile against the operation journal across injected crashes. They are the disk under the actor, not shared actor state.

## Testing

- `./scripts/dev just ci` green: fmt, clippy `-D warnings`, all 418 tests, doctests, nixfmt.
- Acceptance tests stressed 15 consecutive runs with no flakes (the sidecar assertions got stricter).

