### PR TITLE
Make disposal and admission outcomes explicit

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -781,7 +781,7 @@ enum ChildEvent {
     },
     ConstructionDisposed {
         child: ChildKey,
-        outcome: runtime::DisposalOutcome,
+        panic: Option<runtime::DisposalPanic>,
     },
 }
 
@@ -1929,7 +1929,7 @@ impl ScopeRuntime {
             // The incarnation has already exited; only its retained factory
             // remains. Hard escalation detaches that cleanup, but must not
             // rewrite the actor's recorded verdict.
-            self.handle_construction_disposed(key, runtime::DisposalOutcome::Clean);
+            self.handle_construction_disposed(key, None);
         }
     }
 
@@ -2158,13 +2158,13 @@ impl ScopeRuntime {
             child.construction.take()
         };
         let Some(construction) = construction else {
-            self.handle_construction_disposed(key, runtime::DisposalOutcome::Clean);
+            self.handle_construction_disposed(key, None);
             return;
         };
 
         if self.hard_forced {
             runtime::dispose_detached(construction);
-            self.handle_construction_disposed(key, runtime::DisposalOutcome::Clean);
+            self.handle_construction_disposed(key, None);
             return;
         }
 
@@ -2173,13 +2173,10 @@ impl ScopeRuntime {
         // failure to spawn an auxiliary async joiner cannot strand the child.
         let sender = self.disposal_events.clone();
         let signal = self.root.signal().clone();
-        runtime::dispose_then(construction, move |outcome| {
+        runtime::dispose_then(construction, move |panic| {
             if runtime::unbounded_mpsc_send(
                 &sender,
-                DriverEvent::Child(ChildEvent::ConstructionDisposed {
-                    child: key,
-                    outcome,
-                }),
+                DriverEvent::Child(ChildEvent::ConstructionDisposed { child: key, panic }),
             )
             .is_ok()
             {
@@ -2188,7 +2185,11 @@ impl ScopeRuntime {
         });
     }
 
-    fn handle_construction_disposed(&mut self, key: ChildKey, outcome: runtime::DisposalOutcome) {
+    fn handle_construction_disposed(
+        &mut self,
+        key: ChildKey,
+        panic: Option<runtime::DisposalPanic>,
+    ) {
         let Some(child) = self.children.get_mut(key) else {
             return;
         };
@@ -2197,7 +2198,7 @@ impl ScopeRuntime {
         };
         child.slot.member.set_terminal_disposal_pending(false);
         if terminal.exited_incarnation.is_some()
-            && let runtime::DisposalOutcome::Panicked { message } = outcome
+            && let Some(runtime::DisposalPanic { message }) = panic
             && !matches!(terminal.exit.kind(), ExitKind::Panicked { .. })
         {
             // Only an exited incarnation can own a destructor failure. A
@@ -2948,8 +2949,8 @@ async fn run_scope_incarnation(
                 })) => scope.handle_exit(child, incarnation, recorded, join, cancelled),
                 Pending::Driver(DriverEvent::Child(ChildEvent::ConstructionDisposed {
                     child,
-                    outcome,
-                })) => scope.handle_construction_disposed(child, outcome),
+                    panic,
+                })) => scope.handle_construction_disposed(child, panic),
                 Pending::Deadline(deadline) => scope.handle_deadline(deadline),
             }
         }
@@ -4750,7 +4751,7 @@ mod tests {
         ));
         assert_eq!(root.snapshot().children.len(), 1);
 
-        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, outcome }) =
+        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) =
             disposal_event_receiver
                 .recv()
                 .await
@@ -4762,7 +4763,7 @@ mod tests {
             event_receiver.try_recv(),
             Ok(DriverEvent::Child(ChildEvent::Ready { .. }))
         ));
-        scope.handle_construction_disposed(child, outcome);
+        scope.handle_construction_disposed(child, panic);
 
         assert!(!scope.children[key].is_disposing());
         assert!(matches!(
@@ -4851,7 +4852,7 @@ mod tests {
         scope.spawn_child(key);
         assert!(scope.children[key].is_disposing());
 
-        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, outcome }) =
+        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) =
             disposal_event_receiver
                 .recv()
                 .await
@@ -4859,7 +4860,7 @@ mod tests {
         else {
             panic!("only construction disposal was armed")
         };
-        scope.handle_construction_disposed(child, outcome);
+        scope.handle_construction_disposed(child, panic);
 
         assert!(matches!(
             scope.children[key].slot.member.record().stage,

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -781,7 +781,7 @@ enum ChildEvent {
     },
     ConstructionDisposed {
         child: ChildKey,
-        panic: Option<Option<String>>,
+        outcome: runtime::DisposalOutcome,
     },
 }
 
@@ -1929,7 +1929,7 @@ impl ScopeRuntime {
             // The incarnation has already exited; only its retained factory
             // remains. Hard escalation detaches that cleanup, but must not
             // rewrite the actor's recorded verdict.
-            self.handle_construction_disposed(key, None);
+            self.handle_construction_disposed(key, runtime::DisposalOutcome::Clean);
         }
     }
 
@@ -2158,13 +2158,13 @@ impl ScopeRuntime {
             child.construction.take()
         };
         let Some(construction) = construction else {
-            self.handle_construction_disposed(key, None);
+            self.handle_construction_disposed(key, runtime::DisposalOutcome::Clean);
             return;
         };
 
         if self.hard_forced {
             runtime::dispose_detached(construction);
-            self.handle_construction_disposed(key, None);
+            self.handle_construction_disposed(key, runtime::DisposalOutcome::Clean);
             return;
         }
 
@@ -2173,10 +2173,13 @@ impl ScopeRuntime {
         // failure to spawn an auxiliary async joiner cannot strand the child.
         let sender = self.disposal_events.clone();
         let signal = self.root.signal().clone();
-        runtime::dispose_then(construction, move |panic| {
+        runtime::dispose_then(construction, move |outcome| {
             if runtime::unbounded_mpsc_send(
                 &sender,
-                DriverEvent::Child(ChildEvent::ConstructionDisposed { child: key, panic }),
+                DriverEvent::Child(ChildEvent::ConstructionDisposed {
+                    child: key,
+                    outcome,
+                }),
             )
             .is_ok()
             {
@@ -2185,7 +2188,7 @@ impl ScopeRuntime {
         });
     }
 
-    fn handle_construction_disposed(&mut self, key: ChildKey, panic: Option<Option<String>>) {
+    fn handle_construction_disposed(&mut self, key: ChildKey, outcome: runtime::DisposalOutcome) {
         let Some(child) = self.children.get_mut(key) else {
             return;
         };
@@ -2194,7 +2197,7 @@ impl ScopeRuntime {
         };
         child.slot.member.set_terminal_disposal_pending(false);
         if terminal.exited_incarnation.is_some()
-            && let Some(message) = panic
+            && let runtime::DisposalOutcome::Panicked { message } = outcome
             && !matches!(terminal.exit.kind(), ExitKind::Panicked { .. })
         {
             // Only an exited incarnation can own a destructor failure. A
@@ -2945,8 +2948,8 @@ async fn run_scope_incarnation(
                 })) => scope.handle_exit(child, incarnation, recorded, join, cancelled),
                 Pending::Driver(DriverEvent::Child(ChildEvent::ConstructionDisposed {
                     child,
-                    panic,
-                })) => scope.handle_construction_disposed(child, panic),
+                    outcome,
+                })) => scope.handle_construction_disposed(child, outcome),
                 Pending::Deadline(deadline) => scope.handle_deadline(deadline),
             }
         }
@@ -4747,7 +4750,7 @@ mod tests {
         ));
         assert_eq!(root.snapshot().children.len(), 1);
 
-        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) =
+        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, outcome }) =
             disposal_event_receiver
                 .recv()
                 .await
@@ -4759,7 +4762,7 @@ mod tests {
             event_receiver.try_recv(),
             Ok(DriverEvent::Child(ChildEvent::Ready { .. }))
         ));
-        scope.handle_construction_disposed(child, panic);
+        scope.handle_construction_disposed(child, outcome);
 
         assert!(!scope.children[key].is_disposing());
         assert!(matches!(
@@ -4848,7 +4851,7 @@ mod tests {
         scope.spawn_child(key);
         assert!(scope.children[key].is_disposing());
 
-        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) =
+        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, outcome }) =
             disposal_event_receiver
                 .recv()
                 .await
@@ -4856,7 +4859,7 @@ mod tests {
         else {
             panic!("only construction disposal was armed")
         };
-        scope.handle_construction_disposed(child, panic);
+        scope.handle_construction_disposed(child, outcome);
 
         assert!(matches!(
             scope.children[key].slot.member.record().stage,

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -319,10 +319,16 @@ impl<T: Send + 'static> Drop for Isolated<T> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DisposalOutcome {
+    Clean,
+    Panicked { message: Option<String> },
+}
+
 struct DisposalJob<T, C>
 where
     T: Send + 'static,
-    C: FnOnce(Option<Option<String>>) + Send + 'static,
+    C: FnOnce(DisposalOutcome) + Send + 'static,
 {
     state: Mutex<Option<(T, C)>>,
 }
@@ -330,7 +336,7 @@ where
 impl<T, C> DisposalJob<T, C>
 where
     T: Send + 'static,
-    C: FnOnce(Option<Option<String>>) + Send + 'static,
+    C: FnOnce(DisposalOutcome) + Send + 'static,
 {
     fn new(value: T, completion: C) -> Arc<Self> {
         Arc::new(Self {
@@ -347,18 +353,23 @@ where
         else {
             return;
         };
-        let panic = catch_panic(|| drop(value)).err().map(contain_panic_payload);
+        let outcome = match catch_panic(|| drop(value)) {
+            Ok(()) => DisposalOutcome::Clean,
+            Err(payload) => DisposalOutcome::Panicked {
+                message: contain_panic_payload(payload),
+            },
+        };
         // Completion is framework bookkeeping. Contain it as well so a
         // hostile waker or a runtime teardown race cannot unwind a blocking
         // worker or double-panic while the job is being dropped.
-        discard_panic(catch_panic(|| completion(panic)).err());
+        discard_panic(catch_panic(|| completion(outcome)).err());
     }
 }
 
 impl<T, C> Drop for DisposalJob<T, C>
 where
     T: Send + 'static,
-    C: FnOnce(Option<Option<String>>) + Send + 'static,
+    C: FnOnce(DisposalOutcome) + Send + 'static,
 {
     fn drop(&mut self) {
         self.finish();
@@ -373,7 +384,7 @@ trait QueuedDisposal: Send + Sync {
 impl<T, C> QueuedDisposal for DisposalJob<T, C>
 where
     T: Send + 'static,
-    C: FnOnce(Option<Option<String>>) + Send + 'static,
+    C: FnOnce(DisposalOutcome) + Send + 'static,
 {
     fn run(&self) {
         self.finish();
@@ -449,7 +460,7 @@ fn run_fallback_disposals() {
 fn dispatch_disposal<T, C>(job: Arc<DisposalJob<T, C>>)
 where
     T: Send + 'static,
-    C: FnOnce(Option<Option<String>>) + Send + 'static,
+    C: FnOnce(DisposalOutcome) + Send + 'static,
 {
     if is_available() {
         let worker = Arc::clone(&job);
@@ -489,7 +500,7 @@ where
 pub(crate) fn dispose_then<T, C>(value: T, completion: C)
 where
     T: Send + 'static,
-    C: FnOnce(Option<Option<String>>) + Send + 'static,
+    C: FnOnce(DisposalOutcome) + Send + 'static,
 {
     dispatch_disposal(DisposalJob::new(value, completion));
 }
@@ -1219,8 +1230,8 @@ mod tests {
     };
 
     use super::{
-        Deadline, DisposalJob, JoinOutcome, Latch, OneShotClose, Signal, Timeout, discard_panic,
-        join, oneshot, spawn, timeout, yield_now,
+        Deadline, DisposalJob, DisposalOutcome, JoinOutcome, Latch, OneShotClose, Signal, Timeout,
+        discard_panic, join, oneshot, spawn, timeout, yield_now,
     };
 
     #[tokio::test(start_paused = true)]
@@ -1287,7 +1298,9 @@ mod tests {
         let diagnostic = diagnostic.lock().expect("diagnostic mutex poisoned");
         assert!(matches!(
             diagnostic.as_ref(),
-            Some(Some(Some(message))) if message == "cancelled disposal job payload"
+            Some(DisposalOutcome::Panicked {
+                message: Some(message)
+            }) if message == "cancelled disposal job payload"
         ));
     }
 

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -320,15 +320,14 @@ impl<T: Send + 'static> Drop for Isolated<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum DisposalOutcome {
-    Clean,
-    Panicked { message: Option<String> },
+pub(crate) struct DisposalPanic {
+    pub(crate) message: Option<String>,
 }
 
 struct DisposalJob<T, C>
 where
     T: Send + 'static,
-    C: FnOnce(DisposalOutcome) + Send + 'static,
+    C: FnOnce(Option<DisposalPanic>) + Send + 'static,
 {
     state: Mutex<Option<(T, C)>>,
 }
@@ -336,7 +335,7 @@ where
 impl<T, C> DisposalJob<T, C>
 where
     T: Send + 'static,
-    C: FnOnce(DisposalOutcome) + Send + 'static,
+    C: FnOnce(Option<DisposalPanic>) + Send + 'static,
 {
     fn new(value: T, completion: C) -> Arc<Self> {
         Arc::new(Self {
@@ -353,23 +352,23 @@ where
         else {
             return;
         };
-        let outcome = match catch_panic(|| drop(value)) {
-            Ok(()) => DisposalOutcome::Clean,
-            Err(payload) => DisposalOutcome::Panicked {
+        let panic = match catch_panic(|| drop(value)) {
+            Ok(()) => None,
+            Err(payload) => Some(DisposalPanic {
                 message: contain_panic_payload(payload),
-            },
+            }),
         };
         // Completion is framework bookkeeping. Contain it as well so a
         // hostile waker or a runtime teardown race cannot unwind a blocking
         // worker or double-panic while the job is being dropped.
-        discard_panic(catch_panic(|| completion(outcome)).err());
+        discard_panic(catch_panic(|| completion(panic)).err());
     }
 }
 
 impl<T, C> Drop for DisposalJob<T, C>
 where
     T: Send + 'static,
-    C: FnOnce(DisposalOutcome) + Send + 'static,
+    C: FnOnce(Option<DisposalPanic>) + Send + 'static,
 {
     fn drop(&mut self) {
         self.finish();
@@ -384,7 +383,7 @@ trait QueuedDisposal: Send + Sync {
 impl<T, C> QueuedDisposal for DisposalJob<T, C>
 where
     T: Send + 'static,
-    C: FnOnce(DisposalOutcome) + Send + 'static,
+    C: FnOnce(Option<DisposalPanic>) + Send + 'static,
 {
     fn run(&self) {
         self.finish();
@@ -460,7 +459,7 @@ fn run_fallback_disposals() {
 fn dispatch_disposal<T, C>(job: Arc<DisposalJob<T, C>>)
 where
     T: Send + 'static,
-    C: FnOnce(DisposalOutcome) + Send + 'static,
+    C: FnOnce(Option<DisposalPanic>) + Send + 'static,
 {
     if is_available() {
         let worker = Arc::clone(&job);
@@ -500,7 +499,7 @@ where
 pub(crate) fn dispose_then<T, C>(value: T, completion: C)
 where
     T: Send + 'static,
-    C: FnOnce(DisposalOutcome) + Send + 'static,
+    C: FnOnce(Option<DisposalPanic>) + Send + 'static,
 {
     dispatch_disposal(DisposalJob::new(value, completion));
 }
@@ -1230,7 +1229,7 @@ mod tests {
     };
 
     use super::{
-        Deadline, DisposalJob, DisposalOutcome, JoinOutcome, Latch, OneShotClose, Signal, Timeout,
+        Deadline, DisposalJob, DisposalPanic, JoinOutcome, Latch, OneShotClose, Signal, Timeout,
         discard_panic, join, oneshot, spawn, timeout, yield_now,
     };
 
@@ -1298,9 +1297,9 @@ mod tests {
         let diagnostic = diagnostic.lock().expect("diagnostic mutex poisoned");
         assert!(matches!(
             diagnostic.as_ref(),
-            Some(DisposalOutcome::Panicked {
+            Some(Some(DisposalPanic {
                 message: Some(message)
-            }) if message == "cancelled disposal job payload"
+            })) if message == "cancelled disposal job payload"
         ));
     }
 

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -62,12 +62,6 @@ enum AdmissionOwnership {
     Fused,
 }
 
-impl AdmissionOwnership {
-    fn is_fused(self) -> bool {
-        matches!(self, Self::Fused)
-    }
-}
-
 trait SlotEndpoint: Sized {
     type Output<H>;
 
@@ -124,7 +118,7 @@ impl SlotEndpoint for DynamicSlotEndpoint {
             .take()
             .expect("dynamic slot reservation was already consumed");
         reservation.slot.define(construction);
-        Admission::new(reservation, handles, ownership.is_fused())
+        Admission::new(reservation, handles, ownership)
     }
 }
 
@@ -802,7 +796,7 @@ impl<H> Admission<H> {
         }
     }
 
-    fn new(reservation: DynamicReservation, handles: H, fused: bool) -> Self {
+    fn new(reservation: DynamicReservation, handles: H, ownership: AdmissionOwnership) -> Self {
         let membership = reservation.slot.member.membership();
         Self {
             state: AdmissionState::Unpolled(PendingAdmission {
@@ -811,7 +805,10 @@ impl<H> Admission<H> {
                     membership,
                     handles,
                 },
-                fused_cancel: fused.then(Latch::default),
+                fused_cancel: match ownership {
+                    AdmissionOwnership::Split => None,
+                    AdmissionOwnership::Fused => Some(Latch::default()),
+                },
             }),
         }
     }

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -118,6 +118,14 @@ impl Drop for PanicAnyOnDrop {
     }
 }
 
+struct NonStringPanicOnDrop;
+
+impl Drop for NonStringPanicOnDrop {
+    fn drop(&mut self) {
+        std::panic::panic_any(17_u8);
+    }
+}
+
 struct Unread<M>(PhantomData<M>);
 
 impl<M> Default for Unread<M> {
@@ -293,6 +301,32 @@ async fn factory_capture_destructor_panics_are_isolated_classified_and_independe
     assert!(matches!(
         second_exit.kind(),
         ExitKind::Panicked { message } if message.as_deref() == Some("second factory destructor")
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn non_string_factory_destructor_panic_remains_a_panic_exit() {
+    let mut tree = Tree::new();
+    let task = tree
+        .add_task(
+            "non-string",
+            TaskDef::new({
+                let capture = NonStringPanicOnDrop;
+                move |_| {
+                    let _ = &capture;
+                    async { Ok(()) }
+                }
+            })
+            .restart(never()),
+        )
+        .expect("valid task");
+
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("task starts");
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert!(matches!(
+        task.wait().await.kind(),
+        ExitKind::Panicked { message: None }
     ));
 }
 


### PR DESCRIPTION
Part of #101 (A2 and A5).

## Summary

- replace disposal completion's ambiguous `Option<Option<String>>` with `Option<DisposalPanic>`, whose `message: Option<String>` field cannot be flattened into a clean result
- thread the typed panic through the driver event and terminal-verdict override path while accurately representing no construction or an intentionally unobserved detached disposal as no recorded panic
- pass `AdmissionOwnership` directly into `Admission::new` and derive fused cancellation state there instead of erasing the enum to a positional bool
- cover a non-string factory-destructor panic after a real incarnation exit, proving it remains a panic verdict with no message

## Why

The nested option encoded two independent facts—whether destruction panicked and whether its payload was a string—without naming either state. A routine `flatten` or wrapping mistake could silently turn a destructor panic into clean disposal. `Option<DisposalPanic>` preserves the same semantics without nesting and remains truthful on hard-force paths where destruction is detached and its result is intentionally not observed.

The admission path similarly discarded an existing enum into a bool that controlled drop semantics, then reconstructed the distinction later.

## Impact

There is no public API or intended behavior change. Destructor-panic verdict precedence and fused-versus-split admission ownership are preserved while invalid state mix-ups become compile errors.

## Validation

- `./scripts/dev just ci`
  - Clippy with warnings denied
  - 427/427 tests
  - doctests, rustdoc, API reachability, runtime/exit/layering enforcement
  - packaged-crate verification and Nix formatting
