### PR TITLE
Name scope and task latch roles

### DIFF
--- a/crates/shelterwood/src/cancellation.rs
+++ b/crates/shelterwood/src/cancellation.rs
@@ -17,16 +17,12 @@ impl CancellationToken {
         }
     }
 
-    pub(crate) fn from_latches(primary: Latch, secondary: Latch) -> Self {
-        Self {
-            primary,
-            secondary: Some(secondary),
-        }
-    }
-
     pub(crate) fn child(&self, cancellation: Latch) -> Self {
         debug_assert!(self.secondary.is_none());
-        Self::from_latches(self.primary.clone(), cancellation)
+        Self {
+            primary: self.primary.clone(),
+            secondary: Some(cancellation),
+        }
     }
 
     /// Reports whether cancellation has been requested.

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -32,7 +32,7 @@ use crate::{
     policy::{DefaultsInheritance, ResolvedDefaults, ScopeFlavor},
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
     runtime::{self, Latch},
-    task::{TaskContext, TaskFactory},
+    task::{TaskContext, TaskContextLatches, TaskFactory},
 };
 
 #[cfg(test)]
@@ -734,7 +734,7 @@ pub(crate) async fn shutdown_scope(
 pub(crate) fn spawn_system(plan: ScopePlan) -> SystemRun {
     let root = Arc::clone(&plan.root);
     let monitor_root = Arc::clone(&root);
-    let driver = runtime::spawn(async move { run_scope(plan, true, None).await });
+    let driver = runtime::spawn(async move { run_scope(plan, ScopeRole::Root).await });
     let lifecycle = runtime::spawn(async move {
         match runtime::join(driver).await {
             runtime::JoinOutcome::Ok { value, .. } => value,
@@ -1030,6 +1030,42 @@ impl IndexMut<ChildKey> for ChildArena {
     }
 }
 
+struct AncestorCommandLatches {
+    shutdown: Latch,
+    abort: Latch,
+    abort_ack: Latch,
+}
+
+struct NestedScopeLatches {
+    parent_ready: Latch,
+    ancestor: AncestorCommandLatches,
+}
+
+enum ScopeRole {
+    Root,
+    Nested(NestedScopeLatches),
+}
+
+impl ScopeRole {
+    fn is_root(&self) -> bool {
+        matches!(self, Self::Root)
+    }
+
+    fn parent_ready(&self) -> Option<&Latch> {
+        match self {
+            Self::Root => None,
+            Self::Nested(latches) => Some(&latches.parent_ready),
+        }
+    }
+
+    fn ancestor(&self) -> Option<&AncestorCommandLatches> {
+        match self {
+            Self::Root => None,
+            Self::Nested(latches) => Some(&latches.ancestor),
+        }
+    }
+}
+
 struct ScopeRuntime {
     root: Arc<ScopeCell>,
     defaults: ResolvedDefaults,
@@ -1042,14 +1078,10 @@ struct ScopeRuntime {
     jitter: runtime::JitterRng,
     lifecycle: ScopeLifecycle,
     next_ordered_start: Option<ChildKey>,
-    is_root: bool,
-    parent_ready: Option<Latch>,
+    role: ScopeRole,
     dynamic: Option<Arc<DynamicControl>>,
     epoch: Epoch,
-    ancestor_shutdown: Option<Latch>,
     ancestor_shutdown_seen: bool,
-    ancestor_abort: Option<Latch>,
-    ancestor_abort_ack: Option<Latch>,
     ancestor_abort_seen: bool,
     hard_forced: bool,
     completion: Option<ScopeCompletion>,
@@ -1126,19 +1158,13 @@ enum SpawnBody {
         factory: ScopeFactory,
         scope: Arc<ScopeCell>,
         inherited: ResolvedDefaults,
-        ready: Latch,
-        cancel: Latch,
-        abort: Latch,
-        abort_ack: Latch,
+        latches: NestedScopeLatches,
     },
     ScopeOnce {
         tree: Box<BuilderCore>,
         scope: Arc<ScopeCell>,
         inherited: ResolvedDefaults,
-        ready: Latch,
-        cancel: Latch,
-        abort: Latch,
-        abort_ack: Latch,
+        latches: NestedScopeLatches,
     },
 }
 
@@ -1166,6 +1192,27 @@ struct SpawnLatches {
     local_stop: Latch,
     framework_abort: Latch,
     framework_abort_ack: Latch,
+}
+
+impl SpawnLatches {
+    fn task_context(&self) -> TaskContextLatches {
+        TaskContextLatches {
+            shutdown: self.shutdown.clone(),
+            abort: self.abort.clone(),
+            ready: self.ready.clone(),
+        }
+    }
+
+    fn nested_scope(&self) -> NestedScopeLatches {
+        NestedScopeLatches {
+            parent_ready: self.ready.clone(),
+            ancestor: AncestorCommandLatches {
+                shutdown: self.shutdown.clone(),
+                abort: self.framework_abort.clone(),
+                abort_ack: self.framework_abort_ack.clone(),
+            },
+        }
+    }
 }
 
 struct ChildTaskLaunch {
@@ -1219,13 +1266,7 @@ fn dispatch_child_construction(
         ChildConstruction::Task(definition) => SpawnDispatch {
             body: SpawnBody::TaskRestartable {
                 factory: Arc::clone(&definition.factory),
-                context: TaskContext::new(
-                    id,
-                    incarnation,
-                    latches.shutdown.clone(),
-                    latches.abort.clone(),
-                    latches.ready.clone(),
-                ),
+                context: TaskContext::new(id, incarnation, latches.task_context()),
             },
             declared_readiness: Some(child.options.readiness),
             construction_spent: false,
@@ -1234,13 +1275,7 @@ fn dispatch_child_construction(
         ChildConstruction::TaskOnce(definition) => SpawnDispatch {
             body: SpawnBody::TaskOnce {
                 body: definition.take_body(),
-                context: TaskContext::new(
-                    id,
-                    incarnation,
-                    latches.shutdown.clone(),
-                    latches.abort.clone(),
-                    latches.ready.clone(),
-                ),
+                context: TaskContext::new(id, incarnation, latches.task_context()),
             },
             declared_readiness: Some(child.options.readiness),
             construction_spent: true,
@@ -1264,10 +1299,7 @@ fn dispatch_child_construction(
                         factory: Arc::clone(factory),
                         scope,
                         inherited,
-                        ready: latches.ready.clone(),
-                        cancel: latches.shutdown.clone(),
-                        abort: latches.framework_abort.clone(),
-                        abort_ack: latches.framework_abort_ack.clone(),
+                        latches: latches.nested_scope(),
                     },
                     false,
                 )
@@ -1279,10 +1311,7 @@ fn dispatch_child_construction(
                             .expect("one-shot subtree construction invoked more than once"),
                         scope,
                         inherited,
-                        ready: latches.ready.clone(),
-                        cancel: latches.shutdown.clone(),
-                        abort: latches.framework_abort.clone(),
-                        abort_ack: latches.framework_abort_ack.clone(),
+                        latches: latches.nested_scope(),
                     },
                     true,
                 )
@@ -1337,25 +1366,14 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
                     factory,
                     scope,
                     inherited,
-                    ready,
-                    cancel,
-                    abort,
-                    abort_ack,
-                } => {
-                    run_nested_tree(factory(), scope, inherited, ready, cancel, abort, abort_ack)
-                        .await
-                }
+                    latches,
+                } => run_nested_tree(factory(), scope, inherited, latches).await,
                 SpawnBody::ScopeOnce {
                     tree,
                     scope,
                     inherited,
-                    ready,
-                    cancel,
-                    abort,
-                    abort_ack,
-                } => {
-                    run_nested_tree(*tree, scope, inherited, ready, cancel, abort, abort_ack).await
-                }
+                    latches,
+                } => run_nested_tree(*tree, scope, inherited, latches).await,
             }
         };
         let outcome = CatchUnwindFuture::new(body).await;
@@ -1437,8 +1455,10 @@ impl ScopeRuntime {
         if self.lifecycle.is_draining()
             || self.hard_forced
             || self.root.has_stop_request(self.epoch)
-            || self.ancestor_shutdown.as_ref().is_some_and(Latch::is_fired)
-            || self.ancestor_abort.as_ref().is_some_and(Latch::is_fired)
+            || self
+                .role
+                .ancestor()
+                .is_some_and(|latches| latches.shutdown.is_fired() || latches.abort.is_fired())
         {
             return true;
         }
@@ -1752,7 +1772,7 @@ impl ScopeRuntime {
         }
         self.root.set_state(ScopeState::Running);
         self.root.set_startup(Ok(()));
-        if let Some(parent_ready) = &self.parent_ready {
+        if let Some(parent_ready) = self.role.parent_ready() {
             parent_ready.fire();
         }
     }
@@ -2267,7 +2287,7 @@ impl ScopeRuntime {
                 }
             }
         }
-        if self.is_root {
+        if self.role.is_root() {
             self.root.set_state(ScopeState::StartupFailed);
         } else {
             self.begin_drain(StopReason::StartupFailed(failure));
@@ -2615,10 +2635,7 @@ async fn run_nested_tree(
     tree: BuilderCore,
     scope: Arc<ScopeCell>,
     inherited: ResolvedDefaults,
-    ready: Latch,
-    cancel: Latch,
-    abort: Latch,
-    abort_ack: Latch,
+    latches: NestedScopeLatches,
 ) -> crate::ExitResult {
     let Some(epoch) = ScopeEpochGuard::begin(&scope) else {
         let failure = StartupFailure {
@@ -2659,17 +2676,7 @@ async fn run_nested_tree(
             return Err(crate::ExitError::from_startup_failure(failure));
         }
     };
-    match run_scope_incarnation(
-        plan,
-        false,
-        Some(ready),
-        Some(cancel),
-        Some(abort),
-        Some(abort_ack),
-        epoch,
-    )
-    .await
-    {
+    match run_scope_incarnation(plan, ScopeRole::Nested(latches), epoch).await {
         StopReason::Finished | StopReason::ShutdownRequested => Ok(()),
         StopReason::IntensityTripped(trip) => Err(crate::ExitError::from_intensity_trip(trip)),
         StopReason::StartupFailed(failure) => Err(crate::ExitError::from_startup_failure(failure)),
@@ -2677,7 +2684,7 @@ async fn run_nested_tree(
     }
 }
 
-async fn run_scope(plan: ScopePlan, is_root: bool, parent_ready: Option<Latch>) -> StopReason {
+async fn run_scope(plan: ScopePlan, role: ScopeRole) -> StopReason {
     let root = Arc::clone(&plan.root);
     let Some(epoch) = ScopeEpochGuard::begin(&root) else {
         // Dropping the still-armed plan terminalizes every never-started
@@ -2685,20 +2692,16 @@ async fn run_scope(plan: ScopePlan, is_root: bool, parent_ready: Option<Latch>) 
         drop(plan);
         return StopReason::NeverStarted;
     };
-    run_scope_incarnation(plan, is_root, parent_ready, None, None, None, epoch).await
+    run_scope_incarnation(plan, role, epoch).await
 }
 
 async fn run_scope_incarnation(
     mut plan: ScopePlan,
-    is_root: bool,
-    parent_ready: Option<Latch>,
-    incarnation_cancel: Option<Latch>,
-    incarnation_abort: Option<Latch>,
-    incarnation_abort_ack: Option<Latch>,
+    role: ScopeRole,
     epoch: ScopeEpochGuard,
 ) -> StopReason {
     let root = Arc::clone(&plan.root);
-    if is_root {
+    if role.is_root() {
         root.member
             .update(|record| record.stage = MemberStage::Running);
     }
@@ -2755,13 +2758,9 @@ async fn run_scope_incarnation(
         jitter: runtime::JitterRng::from_system_entropy(),
         lifecycle: ScopeLifecycle::starting(),
         next_ordered_start,
-        is_root,
-        parent_ready,
+        role,
         dynamic,
-        ancestor_shutdown: incarnation_cancel,
         ancestor_shutdown_seen: false,
-        ancestor_abort: incarnation_abort,
-        ancestor_abort_ack: incarnation_abort_ack,
         ancestor_abort_seen: false,
         hard_forced: false,
         completion: None,
@@ -2797,14 +2796,18 @@ async fn run_scope_incarnation(
         }
         if !scope.ancestor_shutdown_seen
             && scope
-                .ancestor_shutdown
-                .as_ref()
-                .is_some_and(Latch::is_fired)
+                .role
+                .ancestor()
+                .is_some_and(|latches| latches.shutdown.is_fired())
         {
             scope.ancestor_shutdown_seen = true;
             pending.push((ArbitrationClass::ScopeShutdown, Pending::AncestorShutdown));
         }
-        if !scope.ancestor_abort_seen && scope.ancestor_abort.as_ref().is_some_and(Latch::is_fired)
+        if !scope.ancestor_abort_seen
+            && scope
+                .role
+                .ancestor()
+                .is_some_and(|latches| latches.abort.is_fired())
         {
             scope.ancestor_abort_seen = true;
             pending.push((ArbitrationClass::ScopeShutdown, Pending::AncestorAbort));
@@ -2843,12 +2846,16 @@ async fn run_scope_incarnation(
         }
 
         if pending.is_empty() {
-            let ancestor_shutdown = (!scope.ancestor_shutdown_seen)
-                .then(|| scope.ancestor_shutdown.clone())
-                .flatten();
-            let ancestor_abort = (!scope.ancestor_abort_seen)
-                .then(|| scope.ancestor_abort.clone())
-                .flatten();
+            let ancestor_shutdown = scope
+                .role
+                .ancestor()
+                .filter(|_| !scope.ancestor_shutdown_seen)
+                .map(|latches| latches.shutdown.clone());
+            let ancestor_abort = scope
+                .role
+                .ancestor()
+                .filter(|_| !scope.ancestor_abort_seen)
+                .map(|latches| latches.abort.clone());
             let ancestor_command = async move {
                 let shutdown = async move {
                     if let Some(shutdown) = ancestor_shutdown {
@@ -2895,8 +2902,8 @@ async fn run_scope_incarnation(
         for (_, event) in pending {
             match event {
                 Pending::Shutdown => {
-                    if let Some(cancel) = &scope.ancestor_shutdown {
-                        cancel.fire();
+                    if let Some(latches) = scope.role.ancestor() {
+                        latches.shutdown.fire();
                         scope.ancestor_shutdown_seen = true;
                     }
                     scope.begin_drain(StopReason::ShutdownRequested);
@@ -2906,8 +2913,8 @@ async fn run_scope_incarnation(
                     scope.begin_drain(StopReason::ShutdownRequested);
                 }
                 Pending::AncestorAbort => {
-                    if let Some(ack) = &scope.ancestor_abort_ack {
-                        ack.fire();
+                    if let Some(latches) = scope.role.ancestor() {
+                        latches.abort_ack.fire();
                     }
                     // A scheduled framework driver recursively hard-drains
                     // and joins its children. Its parent only task-aborts it
@@ -2952,7 +2959,7 @@ async fn run_scope_incarnation(
         }
 
         if let Some(reason) = scope.finish_if_ready() {
-            let root_exit = is_root.then(|| match &reason {
+            let root_exit = scope.role.is_root().then(|| match &reason {
                 StopReason::Finished | StopReason::ShutdownRequested => {
                     Exit::new(ExitKind::Completed, reason == StopReason::ShutdownRequested)
                 }
@@ -3037,11 +3044,12 @@ mod tests {
     };
 
     use super::{
-        ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
-        GateCapture, MemberCell, MemberStage, Obligation, Pending, RemovalResponses,
-        RuntimeStorage, ScopeCell, ScopeEpochGuard, ScopeFlavor, ScopeRuntime, complete_removals,
-        driver_event_class, mint_child_incarnation, report_channel, resident_projection,
-        restart_shutdown_work, run_nested_tree, run_scope_incarnation,
+        AncestorCommandLatches, ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent,
+        DynamicControl, DynamicEntry, GateCapture, MemberCell, MemberStage, NestedScopeLatches,
+        Obligation, Pending, RemovalResponses, RuntimeStorage, ScopeCell, ScopeEpochGuard,
+        ScopeFlavor, ScopeRole, ScopeRuntime, complete_removals, driver_event_class,
+        mint_child_incarnation, report_channel, resident_projection, restart_shutdown_work,
+        run_nested_tree, run_scope_incarnation,
     };
 
     /// Bounds every gate-capture probe wait. The probe sender lives inside
@@ -3306,14 +3314,10 @@ mod tests {
             jitter: crate::runtime::JitterRng::from_system_entropy(),
             lifecycle: ScopeLifecycle::running(),
             next_ordered_start: None,
-            is_root: true,
-            parent_ready: None,
+            role: ScopeRole::Root,
             dynamic: None,
             epoch,
-            ancestor_shutdown: None,
             ancestor_shutdown_seen: false,
-            ancestor_abort: None,
-            ancestor_abort_ack: None,
             ancestor_abort_seen: false,
             hard_forced: false,
             completion: None,
@@ -3450,14 +3454,10 @@ mod tests {
             jitter: crate::runtime::JitterRng::from_system_entropy(),
             lifecycle: ScopeLifecycle::running(),
             next_ordered_start,
-            is_root: true,
-            parent_ready: None,
+            role: ScopeRole::Root,
             dynamic: None,
             epoch,
-            ancestor_shutdown: None,
             ancestor_shutdown_seen: false,
-            ancestor_abort: None,
-            ancestor_abort_ack: None,
             ancestor_abort_seen: false,
             hard_forced: false,
             completion: None,
@@ -3842,11 +3842,14 @@ mod tests {
         let epoch = ScopeEpochGuard::begin(&scope).expect("test scope epoch is available");
         let driver = crate::runtime::spawn(run_scope_incarnation(
             plan,
-            false,
-            Some(Latch::default()),
-            None,
-            None,
-            None,
+            ScopeRole::Nested(NestedScopeLatches {
+                parent_ready: Latch::default(),
+                ancestor: AncestorCommandLatches {
+                    shutdown: Latch::default(),
+                    abort: Latch::default(),
+                    abort_ack: Latch::default(),
+                },
+            }),
             epoch,
         ));
         let abort = driver.abort_handle();
@@ -3972,7 +3975,16 @@ mod tests {
         );
 
         let mut driver = Box::pin(run_scope_incarnation(
-            plan, false, None, None, None, None, epoch,
+            plan,
+            ScopeRole::Nested(NestedScopeLatches {
+                parent_ready: Latch::default(),
+                ancestor: AncestorCommandLatches {
+                    shutdown: Latch::default(),
+                    abort: Latch::default(),
+                    abort_ack: Latch::default(),
+                },
+            }),
+            epoch,
         ));
         assert!(
             catch_unwind(AssertUnwindSafe(|| {
@@ -4692,14 +4704,10 @@ mod tests {
             jitter: crate::runtime::JitterRng::from_system_entropy(),
             lifecycle: ScopeLifecycle::running(),
             next_ordered_start: Some(key),
-            is_root: true,
-            parent_ready: None,
+            role: ScopeRole::Root,
             dynamic: None,
             epoch,
-            ancestor_shutdown: None,
             ancestor_shutdown_seen: false,
-            ancestor_abort: None,
-            ancestor_abort_ack: None,
             ancestor_abort_seen: false,
             hard_forced: false,
             completion: None,
@@ -4815,14 +4823,10 @@ mod tests {
             jitter: crate::runtime::JitterRng::from_system_entropy(),
             lifecycle: ScopeLifecycle::starting(),
             next_ordered_start: Some(key),
-            is_root: true,
-            parent_ready: None,
+            role: ScopeRole::Root,
             dynamic: None,
             epoch,
-            ancestor_shutdown: None,
             ancestor_shutdown_seen: false,
-            ancestor_abort: None,
-            ancestor_abort_ack: None,
             ancestor_abort_seen: false,
             hard_forced: false,
             completion: None,
@@ -4916,10 +4920,14 @@ mod tests {
             tree.into_core_for_test(),
             Arc::clone(&scope),
             crate::policy::ResolvedDefaults::default(),
-            ready.clone(),
-            Latch::default(),
-            Latch::default(),
-            Latch::default(),
+            NestedScopeLatches {
+                parent_ready: ready.clone(),
+                ancestor: AncestorCommandLatches {
+                    shutdown: Latch::default(),
+                    abort: Latch::default(),
+                    abort_ack: Latch::default(),
+                },
+            },
         )
         .await
         .expect_err("the stable child-id domain is exhausted");

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -22,6 +22,12 @@ use crate::{
 pub(crate) type TaskFuture = Pin<Box<dyn Future<Output = ExitResult> + Send + 'static>>;
 pub(crate) type TaskFactory = Arc<dyn Fn(TaskContext) -> TaskFuture + Send + Sync + 'static>;
 
+pub(crate) struct TaskContextLatches {
+    pub(crate) shutdown: Latch,
+    pub(crate) abort: Latch,
+    pub(crate) ready: Latch,
+}
+
 /// Per-incarnation capabilities supplied to a supervised task.
 #[derive(Clone, Debug)]
 pub struct TaskContext {
@@ -33,19 +39,13 @@ pub struct TaskContext {
 }
 
 impl TaskContext {
-    pub(crate) fn new(
-        id: ChildId,
-        incarnation: Incarnation,
-        shutdown: Latch,
-        abort: Latch,
-        ready: Latch,
-    ) -> Self {
+    pub(crate) fn new(id: ChildId, incarnation: Incarnation, latches: TaskContextLatches) -> Self {
         Self {
             id,
             incarnation,
-            shutdown: CancellationToken::from_latch(shutdown),
-            abort: CancellationToken::from_latch(abort),
-            ready,
+            shutdown: CancellationToken::from_latch(latches.shutdown),
+            abort: CancellationToken::from_latch(latches.abort),
+            ready: latches.ready,
         }
     }
 
@@ -326,7 +326,7 @@ mod tests {
         runtime::{self, Latch},
     };
 
-    use super::{OneShotTaskRef, TaskContext, TaskRef};
+    use super::{OneShotTaskRef, TaskContext, TaskContextLatches, TaskRef};
 
     fn task_context() -> (TaskContext, Latch, Latch, Latch) {
         let id = ChildId::from("task");
@@ -341,9 +341,11 @@ mod tests {
         let context = TaskContext::new(
             id,
             incarnation,
-            shutdown.clone(),
-            abort.clone(),
-            ready.clone(),
+            TaskContextLatches {
+                shutdown: shutdown.clone(),
+                abort: abort.clone(),
+                ready: ready.clone(),
+            },
         );
         (context, shutdown, abort, ready)
     }


### PR DESCRIPTION
Part of #101 (A1).

## Summary

- replace the positional task shutdown/abort/readiness arguments with `TaskContextLatches`
- build one `NestedScopeLatches` value from `SpawnLatches` and carry its parent-readiness plus ancestor shutdown/abort/ack roles through both restartable and one-shot subtree paths
- replace the independent root flag and optional nested-only latches with `ScopeRole::{Root, Nested}`
- remove `CancellationToken::from_latches(primary, secondary)` and construct derived cancellation sources by named fields

## Why

The old call chains repeatedly lined up interchangeable `Latch` values. Swapping abort with abort acknowledgement compiled but could leave recursive abort unacknowledged until the tidy-beat backstop; swapping task shutdown and abort inverted graceful versus hard-stop behavior. Root/nested state was likewise spread across a bool and four independently optional latches.

The new carriers are constructed once at the ownership boundary and preserve those roles through every downstream hop. `ScopeRole` also makes root-with-parent-latches and nested-with-missing-command-latches unrepresentable.

## Impact

There is no public API or intended runtime behavior change. This is compiler-enforced wiring for task and nested-scope control signals.

## Validation

- `./scripts/dev just ci`
  - Clippy with warnings denied
  - 426/426 tests
  - doctests, rustdoc, API reachability, runtime/exit/layering enforcement
  - packaged-crate verification and Nix formatting
