### PR TITLE
Bind identity counters to their domains

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -23,7 +23,7 @@ use crate::{
         JoinVerdict, RecordedOutcome, StartupError, StopReason, classify_exit,
         reconcile_recorded_outcomes,
     },
-    identity::{FenceCounter, ScopeIdentity},
+    identity::IncarnationCounter,
     observe::LifecycleEventKind,
     plan::{
         BuilderCore, ChildConstruction, ChildPlan, LowerError, ScopeFactory, ScopePlan, SlotCell,
@@ -852,7 +852,7 @@ struct ChildRuntime {
     construction: runtime::Isolated<ChildConstruction>,
     pending_terminal: Option<PendingTerminal>,
     options: crate::policy::ResolvedCommonOptions,
-    incarnations: FenceCounter,
+    incarnations: IncarnationCounter,
     restarts: RestartState,
     restart_deadline: Option<DeadlineHandle>,
     active: Option<ActiveChild>,
@@ -1519,7 +1519,7 @@ impl ScopeRuntime {
         if let Some(deadline) = child.restart_deadline.take() {
             self.deadlines.cancel(deadline);
         }
-        let Some(incarnation) = mint_child_incarnation(&child.slot, &mut child.incarnations) else {
+        let Some(incarnation) = child.incarnations.mint() else {
             let exit = child
                 .slot
                 .member
@@ -2563,10 +2563,6 @@ impl ScopeRuntime {
     }
 }
 
-fn mint_child_incarnation(slot: &Arc<SlotCell>, counter: &mut FenceCounter) -> Option<Incarnation> {
-    ScopeIdentity::mint_incarnation(slot.member.membership(), counter)
-}
-
 /// Owns a scope epoch until a `ScopeRuntime` has taken over its teardown.
 ///
 /// Nested lowering can await isolated disposal before a driver exists. If
@@ -3030,7 +3026,7 @@ mod tests {
         StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
         engine::{Epoch, ScopeLifecycle, StopLadder, arbitrate},
         exit::{JoinVerdict, RecordedOutcome},
-        identity::{FenceCounter, ScopeIdentity},
+        identity::{FenceCounter, IncarnationCounter, ScopeIdentity},
         mailbox::MailboxCell,
         plan::SlotCell,
         runtime::Latch,
@@ -3040,8 +3036,8 @@ mod tests {
         ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
         GateCapture, MemberCell, MemberStage, Obligation, Pending, RemovalResponses,
         RuntimeStorage, ScopeCell, ScopeEpochGuard, ScopeFlavor, ScopeRuntime, complete_removals,
-        driver_event_class, mint_child_incarnation, report_channel, resident_projection,
-        restart_shutdown_work, run_nested_tree, run_scope_incarnation,
+        driver_event_class, report_channel, resident_projection, restart_shutdown_work,
+        run_nested_tree, run_scope_incarnation,
     };
 
     /// Bounds every gate-capture probe wait. The probe sender lives inside
@@ -4644,14 +4640,13 @@ mod tests {
             record.stage = MemberStage::Restarting;
             record.last_exit = Some(previous.clone());
         });
-        let slot = SlotCell::new(Arc::clone(&member), None);
-        let mut counter = FenceCounter::near_exhaustion(71);
+        let mut counter = IncarnationCounter::near_exhaustion(membership);
 
-        assert!(mint_child_incarnation(&slot, &mut counter).is_some());
-        assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+        assert!(counter.mint().is_some());
+        assert!(counter.mint().is_none());
         assert!(matches!(member.record().stage, MemberStage::Restarting));
         assert_eq!(member.record().last_exit, Some(previous));
-        assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+        assert!(counter.mint().is_none());
     }
 
     #[crate::runtime::test]
@@ -4707,12 +4702,12 @@ mod tests {
         plan.armed = false;
         drop(plan);
 
-        scope.children[key].incarnations = FenceCounter::near_exhaustion(71);
-        let first = {
-            let child = &mut scope.children[key];
-            mint_child_incarnation(&child.slot, &mut child.incarnations)
-                .expect("the last usable incarnation mints")
-        };
+        scope.children[key].incarnations =
+            IncarnationCounter::near_exhaustion(scope.children[key].slot.member.membership());
+        let first = scope.children[key]
+            .incarnations
+            .mint()
+            .expect("the last usable incarnation mints");
         let previous = Exit::new(
             ExitKind::Failed(ExitError::message("last completed incarnation")),
             false,
@@ -4833,11 +4828,9 @@ mod tests {
         // Burn the counter's last usable generation without touching the
         // member record: the child is still an unspawned initial member, so
         // its very first `spawn_child` exhausts before any incarnation runs.
-        scope.children[key].incarnations = FenceCounter::near_exhaustion(73);
-        {
-            let child = &mut scope.children[key];
-            assert!(mint_child_incarnation(&child.slot, &mut child.incarnations).is_some());
-        }
+        scope.children[key].incarnations =
+            IncarnationCounter::near_exhaustion(scope.children[key].slot.member.membership());
+        assert!(scope.children[key].incarnations.mint().is_some());
         assert!(scope.children[key].initial);
         assert!(!scope.children[key].initial_ready);
         assert_eq!(
@@ -4962,8 +4955,8 @@ mod tests {
         parent.set_admitted_children(vec![resident_projection(&slot)]);
         let mut snapshots = scope.subscribe_snapshots();
         let mut events = scope.subscribe_lifecycle();
-        let mut counter = FenceCounter::near_exhaustion(83);
-        let first = mint_child_incarnation(&slot, &mut counter).expect("last incarnation mints");
+        let mut counter = IncarnationCounter::near_exhaustion(membership);
+        let first = counter.mint().expect("last incarnation mints");
         member.update(|record| {
             record.stage = MemberStage::Restarting;
             record.last_incarnation = Some(first);
@@ -4973,7 +4966,7 @@ mod tests {
             reason: StopReason::Finished,
         });
 
-        assert!(mint_child_incarnation(&slot, &mut counter).is_none());
+        assert!(counter.mint().is_none());
         assert!(matches!(member.record().stage, MemberStage::Restarting));
         assert!(matches!(
             events.try_recv(),

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -3026,7 +3026,7 @@ mod tests {
         StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
         engine::{Epoch, ScopeLifecycle, StopLadder, arbitrate},
         exit::{JoinVerdict, RecordedOutcome},
-        identity::{FenceCounter, IncarnationCounter, ScopeIdentity},
+        identity::{IncarnationCounter, ScopeIdentity},
         mailbox::MailboxCell,
         plan::SlotCell,
         runtime::Latch,
@@ -4890,8 +4890,7 @@ mod tests {
         let nested_member = MemberCell::new(nested_id, nested_membership);
 
         let worker_id = ChildId::from("worker");
-        let mut child_identity =
-            ScopeIdentity::with_counter(worker_id.clone(), FenceCounter::near_exhaustion(7));
+        let mut child_identity = ScopeIdentity::near_exhaustion(worker_id.clone(), 7);
         child_identity
             .mint_membership(&worker_id)
             .expect("last usable membership is minted before the rebuild");

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -157,7 +157,7 @@ impl Fence {
 /// `u64::MAX` is poison and is never returned. Once the last usable value has
 /// been minted, no successor can be minted.
 #[derive(Debug)]
-pub(crate) struct FenceCounter {
+struct FenceCounter {
     lineage: Lineage,
     current: Generation,
 }
@@ -182,7 +182,7 @@ impl FenceCounter {
     }
 
     #[cfg(test)]
-    pub(crate) fn near_exhaustion(lineage: u64) -> Self {
+    fn near_exhaustion(lineage: u64) -> Self {
         Self {
             lineage: Lineage(lineage),
             current: Generation(u64::MAX - 2),
@@ -207,7 +207,7 @@ impl FenceCounter {
     /// Observation uses the same saturating, poison-never-minted primitive as
     /// membership and incarnation fencing.
     #[cfg(test)]
-    pub(crate) fn mint_sequence(&mut self) -> Option<u64> {
+    fn mint_sequence(&mut self) -> Option<u64> {
         self.mint().map(|fence| fence.generation.get())
     }
 }
@@ -270,9 +270,9 @@ impl ScopeIdentity {
     }
 
     #[cfg(test)]
-    pub(crate) fn with_counter(id: ChildId, memberships: FenceCounter) -> Self {
+    pub(crate) fn near_exhaustion(id: ChildId, lineage: u64) -> Self {
         Self {
-            memberships: HashMap::from([(id, memberships)]),
+            memberships: HashMap::from([(id, FenceCounter::near_exhaustion(lineage))]),
         }
     }
 
@@ -413,8 +413,7 @@ mod tests {
         let id = ChildId::from("worker");
         // A fixture lineage this test does not otherwise allocate, so it
         // cannot collide with an unrelated identity created below.
-        let counter = FenceCounter::near_exhaustion(TEST_LINEAGE);
-        let mut scope = ScopeIdentity::with_counter(id.clone(), counter);
+        let mut scope = ScopeIdentity::near_exhaustion(id.clone(), TEST_LINEAGE);
         let last = scope
             .mint_membership(&id)
             .expect("last usable membership is minted");
@@ -436,7 +435,7 @@ mod tests {
     #[test]
     fn exhausted_stable_domain_rejects_a_rebuilt_declaration() {
         let id = ChildId::from("worker");
-        let mut stable = ScopeIdentity::with_counter(id.clone(), FenceCounter::near_exhaustion(7));
+        let mut stable = ScopeIdentity::near_exhaustion(id.clone(), 7);
         stable
             .mint_membership(&id)
             .expect("last usable stable membership is minted");

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -114,6 +114,7 @@ impl Incarnation {
 struct Generation(u64);
 
 impl Generation {
+    const ZERO: Self = Self(0);
     const POISON: Self = Self(u64::MAX);
 
     fn new(value: u64) -> Option<Self> {
@@ -134,10 +135,14 @@ impl Generation {
     }
 }
 
+/// An unordered identity domain shared by every generation in one fence.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct Lineage(u64);
+
 /// A complete membership fence: its lineage and ordered generation.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct Fence {
-    lineage: u64,
+    lineage: Lineage,
     generation: Generation,
 }
 
@@ -153,33 +158,44 @@ impl Fence {
 /// been minted, no successor can be minted.
 #[derive(Debug)]
 pub(crate) struct FenceCounter {
-    lineage: u64,
-    current: u64,
+    lineage: Lineage,
+    current: Generation,
 }
 
 impl FenceCounter {
-    pub(crate) fn new(lineage: u64) -> Self {
+    fn new(lineage: Lineage) -> Self {
         Self {
             lineage,
-            current: 0,
+            current: Generation::ZERO,
         }
+    }
+
+    fn from_fence(fence: Fence) -> Self {
+        Self {
+            lineage: fence.lineage,
+            current: fence.generation,
+        }
+    }
+
+    fn sequence() -> Self {
+        Self::new(Lineage(0))
     }
 
     #[cfg(test)]
     pub(crate) fn near_exhaustion(lineage: u64) -> Self {
         Self {
-            lineage,
-            current: u64::MAX - 2,
+            lineage: Lineage(lineage),
+            current: Generation(u64::MAX - 2),
         }
     }
 
     fn mint(&mut self) -> Option<Fence> {
-        let next = self.current.checked_add(1)?;
+        let next = self.current.get().checked_add(1)?;
         let Some(generation) = Generation::new(next) else {
-            self.current = u64::MAX;
+            self.current = Generation::POISON;
             return None;
         };
-        self.current = next;
+        self.current = generation;
         Some(Fence {
             lineage: self.lineage,
             generation,
@@ -193,6 +209,30 @@ impl FenceCounter {
     #[cfg(test)]
     pub(crate) fn mint_sequence(&mut self) -> Option<u64> {
         self.mint().map(|fence| fence.generation.get())
+    }
+}
+
+/// A membership and the generation counter that can mint only its incarnations.
+#[derive(Debug)]
+pub(crate) struct IncarnationCounter {
+    membership: Membership,
+    counter: FenceCounter,
+}
+
+impl IncarnationCounter {
+    pub(crate) fn mint(&mut self) -> Option<Incarnation> {
+        self.counter.mint().map(|fence| Incarnation {
+            membership: self.membership,
+            generation: fence.generation,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn near_exhaustion(membership: Membership) -> Self {
+        Self {
+            membership,
+            counter: FenceCounter::near_exhaustion(0),
+        }
     }
 }
 
@@ -221,7 +261,7 @@ impl ScopeIdentity {
             })
             .ok()?
             + 1;
-        Some(FenceCounter::new(lineage))
+        Some(FenceCounter::new(Lineage(lineage)))
     }
 
     #[cfg(test)]
@@ -263,29 +303,19 @@ impl ScopeIdentity {
             Entry::Occupied(mut entry) => entry.get_mut().mint().map(Membership),
             Entry::Vacant(entry) => {
                 debug_assert_ne!(provisional.0.generation, Generation::POISON);
-                entry.insert(FenceCounter {
-                    lineage: provisional.0.lineage,
-                    current: provisional.0.generation.get(),
-                });
+                entry.insert(FenceCounter::from_fence(provisional.0));
                 Some(provisional)
             }
         }
     }
 
-    pub(crate) fn incarnation_counter(&self, _membership: Membership) -> FenceCounter {
+    pub(crate) fn incarnation_counter(&self, membership: Membership) -> IncarnationCounter {
         // Membership already supplies the complete incarnation lineage. The
         // per-membership counter therefore needs only an ordered generation.
-        FenceCounter::new(0)
-    }
-
-    pub(crate) fn mint_incarnation(
-        membership: Membership,
-        counter: &mut FenceCounter,
-    ) -> Option<Incarnation> {
-        counter.mint().map(|fence| Incarnation {
+        IncarnationCounter {
             membership,
-            generation: fence.generation,
-        })
+            counter: FenceCounter::sequence(),
+        }
     }
 }
 
@@ -293,7 +323,7 @@ impl ScopeIdentity {
 mod tests {
     use crate::ChildId;
 
-    use super::{FenceCounter, Generation, ScopeIdentity};
+    use super::{FenceCounter, Generation, IncarnationCounter, ScopeIdentity};
 
     #[test]
     fn cross_scope_tokens_fail_closed() {
@@ -324,15 +354,15 @@ mod tests {
         assert!(!first.supersedes(other));
 
         let mut generations = scope.incarnation_counter(first);
-        let a = ScopeIdentity::mint_incarnation(first, &mut generations)
-            .expect("incarnation available");
-        let b = ScopeIdentity::mint_incarnation(first, &mut generations)
-            .expect("incarnation available");
+        let a = generations.mint().expect("incarnation available");
+        let b = generations.mint().expect("incarnation available");
         assert!(b.supersedes(a));
         assert_eq!(a.membership(), first);
         assert!(
             !b.supersedes(
-                ScopeIdentity::mint_incarnation(second, &mut scope.incarnation_counter(second))
+                scope
+                    .incarnation_counter(second)
+                    .mint()
                     .expect("incarnation available")
             )
         );
@@ -429,11 +459,12 @@ mod tests {
         let membership = scope
             .mint_membership(&ChildId::from("worker"))
             .expect("membership available");
-        let mut incarnations = FenceCounter::near_exhaustion(91);
-        let last = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
+        let mut incarnations = IncarnationCounter::near_exhaustion(membership);
+        let last = incarnations
+            .mint()
             .expect("last usable incarnation is minted");
-        assert!(ScopeIdentity::mint_incarnation(membership, &mut incarnations).is_none());
-        assert!(ScopeIdentity::mint_incarnation(membership, &mut incarnations).is_none());
+        assert!(incarnations.mint().is_none());
+        assert!(incarnations.mint().is_none());
         assert_eq!(last.membership(), membership);
     }
 
@@ -447,7 +478,7 @@ mod tests {
         assert!(!Generation::POISON.supersedes(second));
         assert!(!second.supersedes(Generation::POISON));
 
-        let mut sequence = FenceCounter::new(0);
+        let mut sequence = FenceCounter::sequence();
         assert_eq!(sequence.mint_sequence(), Some(1));
     }
 
@@ -456,7 +487,7 @@ mod tests {
     impl MembershipFixture {
         fn at(lineage: u64, generation: u64) -> super::Membership {
             super::Membership(super::Fence {
-                lineage,
+                lineage: super::Lineage(lineage),
                 generation: super::Generation::fixture(generation),
             })
         }

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1900,8 +1900,7 @@ mod tests {
             .mint_membership(&ChildId::from("actor"))
             .expect("membership available");
         let mut incarnations = identity.incarnation_counter(membership);
-        let incarnation = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
-            .expect("incarnation available");
+        let incarnation = incarnations.mint().expect("incarnation available");
 
         MailboxControl::bind(&*mailbox, incarnation);
     }
@@ -1917,10 +1916,8 @@ mod tests {
             .mint_membership(&ChildId::from("actor"))
             .expect("membership available");
         let mut incarnations = identity.incarnation_counter(membership);
-        let first = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
-            .expect("first incarnation available");
-        let second = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
-            .expect("second incarnation available");
+        let first = incarnations.mint().expect("first incarnation available");
+        let second = incarnations.mint().expect("second incarnation available");
 
         MailboxControl::bind(&*mailbox, first);
         MailboxControl::bind(&*mailbox, second);
@@ -1989,10 +1986,9 @@ mod tests {
             let membership = identity
                 .mint_membership(&ChildId::from("actor"))
                 .expect("membership available");
-            (membership, identity.incarnation_counter(membership))
+            identity.incarnation_counter(membership)
         };
-        let incarnation = ScopeIdentity::mint_incarnation(generations.0, &mut generations.1)
-            .expect("incarnation available");
+        let incarnation = generations.mint().expect("incarnation available");
 
         assert!(
             catch_unwind(AssertUnwindSafe(|| {
@@ -2223,8 +2219,7 @@ mod tests {
             .mint_membership(&ChildId::from("actor"))
             .expect("membership available");
         let mut incarnations = identity.incarnation_counter(membership);
-        let incarnation = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
-            .expect("incarnation available");
+        let incarnation = incarnations.mint().expect("incarnation available");
         MailboxControl::bind(&*mailbox, incarnation);
 
         let mut send = Box::pin(actor.send(1));

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -333,8 +333,7 @@ mod tests {
         let mut identity = ScopeIdentity::new();
         let membership = identity.mint_membership(&id).expect("membership available");
         let mut incarnations = identity.incarnation_counter(membership);
-        let incarnation = ScopeIdentity::mint_incarnation(membership, &mut incarnations)
-            .expect("incarnation available");
+        let incarnation = incarnations.mint().expect("incarnation available");
         let shutdown = Latch::default();
         let abort = Latch::default();
         let ready = Latch::default();

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -655,7 +655,7 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
 }
 
 #[tokio::test]
-async fn rebased_declared_handles_keep_their_map_identity() {
+async fn rebased_declared_handles_and_incarnations_keep_identity() {
     fn hashed(value: &impl std::hash::Hash) -> u64 {
         use std::hash::Hasher;
         let mut hasher = std::hash::DefaultHasher::new();
@@ -702,9 +702,16 @@ async fn rebased_declared_handles_keep_their_map_identity() {
     let system = outer.spawn().expect("runtime is available");
 
     let mut admissions = Vec::new();
-    while admissions.len() < 2 {
-        if let LifecycleEventKind::Added { membership, .. } = next_event(&mut events).await.kind {
-            admissions.push(membership);
+    let mut starts = Vec::new();
+    while admissions.len() < 2 || starts.len() < 2 {
+        match next_event(&mut events).await.kind {
+            LifecycleEventKind::Added { membership, .. } => admissions.push(membership),
+            LifecycleEventKind::Started {
+                membership,
+                incarnation,
+                ..
+            } => starts.push((membership, incarnation)),
+            _ => {}
         }
     }
 
@@ -729,6 +736,8 @@ async fn rebased_declared_handles_keep_their_map_identity() {
         "handle identity survives the rebase that refreshed its membership"
     );
     assert_eq!(second.membership(), admissions[1]);
+    assert_eq!(starts[1].0, second.membership());
+    assert_eq!(starts[1].1.membership(), second.membership());
 
     system
         .shutdown(Duration::from_secs(1))


### PR DESCRIPTION
Part of #101 (A3).

## Summary

- add a private `Lineage` newtype and store `FenceCounter.current` as `Generation`
- reconstruct adopted counters through `FenceCounter::from_fence`, so lineage and current generation are never lined up as raw `u64`s
- give non-identity sequence counters an explicit `FenceCounter::sequence()` constructor
- replace the forgeable `(membership, FenceCounter)` incarnation API with `IncarnationCounter { membership, counter }` and a no-argument `mint()`
- update driver, mailbox, task, and identity tests to carry the bound counter rather than repeatedly supplying a membership

## Why

A lineage and generation were adjacent `u64` fields, including one production construction that unwrapped a `Generation`; swapping them compiled and silently broke fence comparability. Incarnation minting separately accepted any membership/counter pairing, while the driver captured the counter at child setup but re-read the member's potentially rebased membership on every mint.

The new types preserve both pairings at construction time. A counter can mint only the membership it was created for, even if the surrounding member later rebases.

## Impact

There is no public API or intended behavior change. Fence exhaustion, poison handling, and identity ordering are preserved while cross-domain swaps become compile errors.

## Validation

- `./scripts/dev just ci`
  - Clippy with warnings denied
  - 426/426 tests
  - doctests, rustdoc, API reachability, runtime/exit/layering enforcement
  - packaged-crate verification and Nix formatting
