### PR TITLE
Type mailbox and timer sequence domains

### DIFF
--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -425,8 +425,11 @@ enum MailboxKind {
 
 struct Envelope<M> {
     message: M,
-    accepted_sequence: u64,
+    accepted_sequence: AcceptedSequence,
 }
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct AcceptedSequence(u64);
 
 enum OperationOutcome<M> {
     Waiting {
@@ -552,6 +555,16 @@ enum Submission<M> {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct WaiterId(u64);
 
+impl WaiterId {
+    const ZERO: Self = Self(0);
+    const POISON: Self = Self(u64::MAX);
+
+    fn checked_next(self) -> Option<Self> {
+        let next = self.0.checked_add(1)?;
+        (next != Self::POISON.0).then_some(Self(next))
+    }
+}
+
 /// FIFO registrations with direct removal by a send operation.
 ///
 /// Monotonic keys are insertion order, so the first map entry is the oldest
@@ -560,7 +573,7 @@ struct WaiterId(u64);
 /// instead of wrapping back into the live id domain.
 struct WaiterQueue<M> {
     entries: BTreeMap<WaiterId, Arc<SendOperation<M>>>,
-    next_id: u64,
+    next_id: WaiterId,
     #[cfg(test)]
     direct_removals: usize,
 }
@@ -569,7 +582,7 @@ impl<M> Default for WaiterQueue<M> {
     fn default() -> Self {
         Self {
             entries: BTreeMap::new(),
-            next_id: 0,
+            next_id: WaiterId::ZERO,
             #[cfg(test)]
             direct_removals: 0,
         }
@@ -587,18 +600,14 @@ impl<M> WaiterQueue<M> {
     }
 
     fn push_back(&mut self, operation: Arc<SendOperation<M>>) -> WaiterId {
-        let Some(next) = self.next_id.checked_add(1) else {
+        let Some(next) = self.next_id.checked_next() else {
+            self.next_id = WaiterId::POISON;
             panic!("mailbox waiter identity space exhausted");
         };
-        if next == u64::MAX {
-            self.next_id = u64::MAX;
-            panic!("mailbox waiter identity space exhausted");
-        }
         self.next_id = next;
-        let id = WaiterId(next);
-        let replaced = self.entries.insert(id, operation);
+        let replaced = self.entries.insert(next, operation);
         debug_assert!(replaced.is_none());
-        id
+        next
     }
 
     fn park(&mut self, operation: &Arc<SendOperation<M>>) {
@@ -856,7 +865,7 @@ impl<M: Send + 'static> MailboxCell<M> {
         }
     }
 
-    fn mint_accepted_sequence(&self) -> u64 {
+    fn mint_accepted_sequence(&self) -> AcceptedSequence {
         mint_accepted_sequence(&self.accepted)
     }
 
@@ -927,7 +936,7 @@ impl<M: Send + 'static> MailboxCell<M> {
         &self,
         incarnation: Incarnation,
         allow_frozen: bool,
-        accepted_through: Option<u64>,
+        accepted_through: Option<AcceptedSequence>,
     ) -> Option<M> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         let eligible = match state.status {
@@ -985,8 +994,8 @@ impl<M: Send + 'static> MailboxCell<M> {
         self.changed.watcher()
     }
 
-    fn accepted_sequence(&self) -> u64 {
-        self.accepted.load(Ordering::Acquire)
+    fn accepted_sequence(&self) -> AcceptedSequence {
+        AcceptedSequence(self.accepted.load(Ordering::Acquire))
     }
 }
 
@@ -1168,13 +1177,15 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
     }
 }
 
-fn mint_accepted_sequence(accepted: &AtomicU64) -> u64 {
-    accepted
-        .try_update(Ordering::Release, Ordering::Relaxed, |accepted| {
-            Some(accepted.saturating_add(1))
-        })
-        .expect("accepted sequence updates never reject")
-        .saturating_add(1)
+fn mint_accepted_sequence(accepted: &AtomicU64) -> AcceptedSequence {
+    AcceptedSequence(
+        accepted
+            .try_update(Ordering::Release, Ordering::Relaxed, |accepted| {
+                Some(accepted.saturating_add(1))
+            })
+            .expect("accepted sequence updates never reject")
+            .saturating_add(1),
+    )
 }
 
 fn promote_waiters<M: Send + 'static>(
@@ -1823,12 +1834,12 @@ impl<M: Send + 'static> MailboxReceiver<M> {
         self.mailbox.receive(self.incarnation, false, None)
     }
 
-    pub(crate) fn try_recv_live_through(&self, accepted_sequence: u64) -> Option<M> {
+    pub(crate) fn try_recv_live_through(&self, accepted_sequence: AcceptedSequence) -> Option<M> {
         self.mailbox
             .receive(self.incarnation, false, Some(accepted_sequence))
     }
 
-    pub(crate) fn accepted_sequence(&self) -> u64 {
+    pub(crate) fn accepted_sequence(&self) -> AcceptedSequence {
         self.mailbox.accepted_sequence()
     }
 
@@ -2123,7 +2134,7 @@ mod tests {
     #[test]
     fn waiter_identity_exhaustion_poison_is_never_minted() {
         let mut waiters = super::WaiterQueue {
-            next_id: u64::MAX - 2,
+            next_id: super::WaiterId(u64::MAX - 2),
             ..super::WaiterQueue::default()
         };
         let last = waiters.push_back(super::SendOperation::new(1_u8));
@@ -2136,8 +2147,8 @@ mod tests {
             .is_err(),
             "the poison key is never minted"
         );
-        assert_eq!(waiters.next_id, u64::MAX);
-        assert!(!waiters.entries.contains_key(&super::WaiterId(u64::MAX)));
+        assert_eq!(waiters.next_id, super::WaiterId::POISON);
+        assert!(!waiters.entries.contains_key(&super::WaiterId::POISON));
         assert!(
             catch_unwind(AssertUnwindSafe(|| {
                 waiters.push_back(super::SendOperation::new(3_u8));

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -18,7 +18,7 @@ use crate::{
     cancellation::CancellationToken,
     cells::{MailboxControl, MemberCell},
     definition::DefinitionSource,
-    mailbox::{MailboxCell, MailboxReceiver},
+    mailbox::{AcceptedSequence, MailboxCell, MailboxReceiver},
     policy::CommonOptions,
     runtime::{
         self, ActorWork, Latch, PanicAccumulator, PanicPayload, Signal, SignalWatcher, catch_panic,
@@ -352,12 +352,27 @@ enum TimerMessage<M> {
     Interval(M, fn(&M) -> M),
 }
 
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct ArmingOrder(u64);
+
+impl ArmingOrder {
+    const ZERO: Self = Self(0);
+    const MAX: Self = Self(u64::MAX);
+
+    fn saturating_next(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct KeyHash(u64);
+
 struct TimerEntry<M> {
     key: Box<dyn Any + Send>,
     /// `None` when the requested delay overflows the clock: a deadline that
     /// never arrives, mirroring the offload path — never "due now".
     deadline: Option<Instant>,
-    arming_order: u64,
+    arming_order: ArmingOrder,
     message: TimerMessage<M>,
     period: Option<Duration>,
 }
@@ -370,9 +385,9 @@ struct TimerEntry<M> {
 /// preserve `Eq` semantics in the unlikely event of a collision.
 struct TimerStore<M> {
     key_hasher: RandomState,
-    keyed: HashMap<u64, Vec<TimerEntry<M>>>,
-    armings: HashMap<u64, u64>,
-    deadlines: BTreeSet<(Instant, u64)>,
+    keyed: HashMap<KeyHash, Vec<TimerEntry<M>>>,
+    armings: HashMap<ArmingOrder, KeyHash>,
+    deadlines: BTreeSet<(Instant, ArmingOrder)>,
     #[cfg(test)]
     lookup_probes: usize,
 }
@@ -391,8 +406,8 @@ impl<M> Default for TimerStore<M> {
 }
 
 impl<M> TimerStore<M> {
-    fn hash_key<K: Hash + 'static>(&self, key: &K) -> u64 {
-        self.key_hasher.hash_one((TypeId::of::<K>(), key))
+    fn hash_key<K: Hash + 'static>(&self, key: &K) -> KeyHash {
+        KeyHash(self.key_hasher.hash_one((TypeId::of::<K>(), key)))
     }
 
     fn is_empty(&self) -> bool {
@@ -409,7 +424,7 @@ impl<M> TimerStore<M> {
         &mut self,
         key: K,
         deadline: Option<Instant>,
-        arming_order: u64,
+        arming_order: ArmingOrder,
         message: TimerMessage<M>,
         period: Option<Duration>,
     ) where
@@ -464,7 +479,7 @@ impl<M> TimerStore<M> {
         Some(entry)
     }
 
-    fn remove_arming(&mut self, arming_order: u64) -> Option<TimerEntry<M>> {
+    fn remove_arming(&mut self, arming_order: ArmingOrder) -> Option<TimerEntry<M>> {
         let hash = self.armings.remove(&arming_order)?;
         let (entry, empty) = {
             let bucket = self
@@ -487,7 +502,7 @@ impl<M> TimerStore<M> {
         Some(entry)
     }
 
-    fn entry_mut(&mut self, arming_order: u64) -> Option<&mut TimerEntry<M>> {
+    fn entry_mut(&mut self, arming_order: ArmingOrder) -> Option<&mut TimerEntry<M>> {
         let hash = *self.armings.get(&arming_order)?;
         let entry = self
             .keyed
@@ -499,10 +514,10 @@ impl<M> TimerStore<M> {
         Some(entry)
     }
 
-    fn take_due(&mut self, now: Instant) -> VecDeque<u64> {
+    fn take_due(&mut self, now: Instant) -> VecDeque<ArmingOrder> {
         let due = self
             .deadlines
-            .range(..=(now, u64::MAX))
+            .range(..=(now, ArmingOrder::MAX))
             .copied()
             .collect::<Vec<_>>();
         for deadline in &due {
@@ -511,7 +526,7 @@ impl<M> TimerStore<M> {
         due.into_iter().map(|(_, arming)| arming).collect()
     }
 
-    fn arm_deadline(&mut self, arming_order: u64, deadline: Option<Instant>) {
+    fn arm_deadline(&mut self, arming_order: ArmingOrder, deadline: Option<Instant>) {
         if let Some(deadline) = deadline {
             self.deadlines.insert((deadline, arming_order));
         }
@@ -523,9 +538,9 @@ impl<M> TimerStore<M> {
 }
 
 struct FiredTimerBatch {
-    armings: VecDeque<u64>,
+    armings: VecDeque<ArmingOrder>,
     continuations_remaining: usize,
-    mailbox_through: u64,
+    mailbox_through: AcceptedSequence,
     mailbox_complete: bool,
     offloads_remaining: usize,
     offloads_complete: bool,
@@ -698,7 +713,7 @@ struct RawResources<M> {
     // capture wait behind the next mailbox message and cannot starve it.
     offloads_lead: usize,
     timers: TimerStore<M>,
-    next_timer_order: u64,
+    next_timer_order: ArmingOrder,
     fired_batch: Option<FiredTimerBatch>,
     events: Arc<EventQueue<M>>,
     panic: Arc<PanicSlot>,
@@ -716,7 +731,7 @@ impl<M> Default for RawResources<M> {
             continuation_needs_external: false,
             offloads_lead: 0,
             timers: TimerStore::default(),
-            next_timer_order: 0,
+            next_timer_order: ArmingOrder::ZERO,
             fired_batch: None,
             events,
             panic: Arc::new(PanicSlot::default()),
@@ -1110,7 +1125,7 @@ impl<M: Send + 'static> RawContext<M> {
     ) where
         K: Hash + Eq + Send + 'static,
     {
-        self.resources.next_timer_order = self.resources.next_timer_order.saturating_add(1);
+        self.resources.next_timer_order = self.resources.next_timer_order.saturating_next();
         let now = runtime::now();
         let deadline = crate::deadline::Deadline::after(now, after).instant();
         self.resources.timers.replace(
@@ -1366,7 +1381,7 @@ impl<M: Send + 'static> RawContext<M> {
         });
     }
 
-    fn deliver_timer(&mut self, arming: u64) -> Option<M> {
+    fn deliver_timer(&mut self, arming: ArmingOrder) -> Option<M> {
         let entry = self.resources.timers.entry_mut(arming)?;
         if let Some(period) = entry.period {
             let deadline = crate::deadline::Deadline::after(runtime::now(), period).instant();
@@ -2076,7 +2091,11 @@ mod timer_store_tests {
         time::{Duration, Instant},
     };
 
-    use super::{TimerMessage, TimerStore};
+    use super::{ArmingOrder, TimerMessage, TimerStore};
+
+    fn order(value: u64) -> ArmingOrder {
+        ArmingOrder(value)
+    }
 
     #[derive(Eq, PartialEq)]
     struct CollidingKey(u8);
@@ -2101,21 +2120,21 @@ mod timer_store_tests {
         timers.replace(
             7_u8,
             Some(start + Duration::from_secs(3)),
-            1,
+            order(1),
             TimerMessage::Once("old-u8"),
             None,
         );
         timers.replace(
             7_u16,
             Some(start + Duration::from_secs(1)),
-            2,
+            order(2),
             TimerMessage::Once("u16"),
             None,
         );
         timers.replace(
             7_u8,
             Some(start + Duration::from_secs(2)),
-            3,
+            order(3),
             TimerMessage::Once("new-u8"),
             None,
         );
@@ -2123,15 +2142,15 @@ mod timer_store_tests {
         assert_eq!(timers.next_deadline(), Some(start + Duration::from_secs(1)));
         assert_eq!(
             timers.take_due(start + Duration::from_secs(3)),
-            [2, 3],
+            [order(2), order(3)],
             "different key types coexist and replacement takes a fresh order"
         );
         assert_eq!(
-            once(timers.remove_arming(2).expect("u16 timer remains")),
+            once(timers.remove_arming(order(2)).expect("u16 timer remains")),
             "u16"
         );
         assert_eq!(
-            once(timers.remove_arming(3).expect("replacement remains")),
+            once(timers.remove_arming(order(3)).expect("replacement remains")),
             "new-u8"
         );
         assert!(timers.is_empty());
@@ -2140,12 +2159,24 @@ mod timer_store_tests {
     #[test]
     fn hash_collision_uses_exact_erased_key_equality() {
         let mut timers = TimerStore::default();
-        timers.replace(CollidingKey(1), None, 1, TimerMessage::Once("first"), None);
-        timers.replace(CollidingKey(2), None, 2, TimerMessage::Once("second"), None);
         timers.replace(
             CollidingKey(1),
             None,
-            3,
+            order(1),
+            TimerMessage::Once("first"),
+            None,
+        );
+        timers.replace(
+            CollidingKey(2),
+            None,
+            order(2),
+            TimerMessage::Once("second"),
+            None,
+        );
+        timers.replace(
+            CollidingKey(1),
+            None,
+            order(3),
             TimerMessage::Once("replacement"),
             None,
         );
@@ -2190,7 +2221,7 @@ mod timer_store_tests {
             timers.replace(
                 key,
                 Some(start + Duration::from_secs((TIMERS - index) as u64)),
-                index as u64,
+                order(index as u64),
                 TimerMessage::Once(()),
                 None,
             );


### PR DESCRIPTION
Part of #101 (A4).

## Summary

- add private `ArmingOrder` and `KeyHash` newtypes throughout `TimerStore`, its deadline index, and fired-timer batches
- add a crate-private ordered `AcceptedSequence` type at the mailbox boundary and carry it through accepted envelopes, receive watermarks, and raw-actor timer fairness snapshots
- store `RawResources.next_timer_order` as `ArmingOrder`
- store `WaiterQueue.next_id` as the existing `WaiterId`, including its zero/poison values and successor logic

## Why

Timer armings, erased key hashes, and mailbox accepted-sequence watermarks were all raw `u64`s in adjacent storage and control flow. In particular, the arming index was `HashMap<u64, u64>` and removal held both values in one scope, so reversing key and value compiled. The waiter queue similarly left its counter in the raw domain even though its map key already had a dedicated type.

The newtypes preserve each sequence domain end to end. Only the atomic accepted counter remains raw at the atomic boundary; its values are wrapped immediately when minted or loaded.

## Impact

There is no public API or intended behavior change. Timer ordering, hash collision handling, mailbox fairness watermarks, saturation, and waiter poison semantics are preserved.

## Validation

- `./scripts/dev just ci`
  - Clippy with warnings denied
  - 426/426 tests
  - doctests, rustdoc, API reachability, runtime/exit/layering enforcement
  - packaged-crate verification and Nix formatting
