### PR TITLE
Name cell state and lifecycle domains

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3076,7 +3076,7 @@ LifecycleEvent { scope_path, scope, seq, kind }
               cell through the same §3.2 machinery; its token and
               sequence behave exactly like a nested scope's — one
               uniform identity for every emitting scope, root included
-  seq:        u64 from the emitting scope's single monotone sequence,
+  seq:        LifecycleSeq from the emitting scope's single monotone sequence,
               owned by the scope's membership cell — continuous across
               subtree restart (a rebuilt incarnation continues it; only
               a replacement membership starts fresh, and `scope`
@@ -3164,7 +3164,8 @@ Ordering and delivery contract:
   it. The same
   protocol is the post-`Lagged` resync. The documentation MUST teach
   it in this form.
-- `seq`/`lifecycle_seq` mint through §3.1's one primitive: `u64`,
+- `LifecycleSeq` exposes `get()` plus the documented `EXHAUSTED` sentinel;
+  `seq`/`lifecycle_seq` mint through §3.1's one primitive: `u64`,
   saturating advance, the saturated value poisoned and never minted.
   Exhaustion — unreachable at `u64` scale, pinned per §3.1's
   decide-once rule — fails closed for observation: the scope mints no
@@ -3276,7 +3277,7 @@ ChildSnapshot   { id, membership,                       // §3 identity types
                                                          //   ScopeSnapshot — Stopped { NeverStarted }
                                                          //   included (§3.2) — so traversal reaches
                                                          //   the terminal scope state
-                  scope_seq: Option<u64> }               // scope children only (None otherwise): the
+                  scope_seq: Option<LifecycleSeq> }      // scope children only (None otherwise): the
                                                          //   nested scope's lifecycle_seq watermark,
                                                          //   sampled at the same publication point —
                                                          //   equal to nested.lifecycle_seq whenever
@@ -3305,7 +3306,7 @@ ScopeSnapshot   { state: Unstarted                              // membership ex
                                                                 //   scope-state twin of §7's exit
                   kind: Ordered | Dynamic, strategy (ordered only), intensity,
                   total_restarts,                        // charges per §9.2 — group respawns count
-                  lifecycle_seq,                         // aligns events with snapshots (§12)
+                  lifecycle_seq: LifecycleSeq,           // aligns events with snapshots (§12)
                   children: Vec<ChildSnapshot> }         // declaration order (ordered scopes);
                                                          //   admission order (dynamic scopes) —
                                                          //   pre-admission reserved cells are

--- a/crates/shelterwood/doctests/docs/observation.md
+++ b/crates/shelterwood/doctests/docs/observation.md
@@ -25,6 +25,10 @@ temporarily absent. For an event emitted by the subscribed scope itself, compare
 `snapshot.watermark(event.scope)` finds the matching watermark. An event is
 already reflected when `event.seq <= watermark`.
 
+These values use `LifecycleSeq`. `LifecycleSeq::EXHAUSTED` is the permanent
+watermark after the sequence space is exhausted and is never emitted on an
+event; `get()` exposes the underlying `u64` when numeric integration requires it.
+
 A child in `Restarting` normally exposes its absolute backoff deadline through
 `restart_at`. If the requested delay is too large for the platform clock to
 represent, `restart_at` is `None`; the child remains in `Restarting` until

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -9,7 +9,7 @@
 use std::{
     fmt,
     sync::{
-        Arc, Mutex, OnceLock, RwLock, Weak,
+        Arc, Mutex, MutexGuard, OnceLock, RwLock, Weak,
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::Instant,
@@ -23,7 +23,8 @@ use crate::{
     identity::ScopeIdentity,
     observe::{
         ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
-        LifecycleHub, MembershipStatus, ScopeKind, ScopeSnapshot, SnapshotHub, SnapshotReceiver,
+        LifecycleHub, LifecycleSeq, MembershipStatus, ScopeKind, ScopeSnapshot, SnapshotHub,
+        SnapshotReceiver,
     },
     plan::SlotCell,
     policy::{ResolvedCommonOptions, ScopeFlavor},
@@ -105,20 +106,33 @@ pub(crate) struct MemberCell {
 }
 
 #[derive(Default)]
-struct MemberMailbox {
-    control: Option<Arc<dyn MailboxControl>>,
-    terminal: Option<Exit>,
-    teardown: Option<Box<dyn MailboxTermination>>,
+enum MemberMailbox {
+    #[default]
+    Unattached,
+    Attached(Arc<dyn MailboxControl>),
+    Terminal {
+        control: Option<Arc<dyn MailboxControl>>,
+        exit: Exit,
+        teardown: Option<Box<dyn MailboxTermination>>,
+    },
 }
 
 impl fmt::Debug for MemberMailbox {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("MemberMailbox")
-            .field("control", &self.control)
-            .field("terminal", &self.terminal)
-            .field("teardown_pending", &self.teardown.is_some())
-            .finish()
+        match self {
+            Self::Unattached => formatter.write_str("Unattached"),
+            Self::Attached(control) => formatter.debug_tuple("Attached").field(control).finish(),
+            Self::Terminal {
+                control,
+                exit,
+                teardown,
+            } => formatter
+                .debug_struct("Terminal")
+                .field("control", control)
+                .field("exit", exit)
+                .field("teardown_pending", &teardown.is_some())
+                .finish(),
+        }
     }
 }
 
@@ -182,8 +196,12 @@ impl MemberCell {
     #[cfg(test)]
     pub(crate) fn stage_terminal_before_mailbox(&self, exit: Exit) {
         let mut mailbox = self.mailbox.lock().expect("member mailbox mutex poisoned");
-        assert!(mailbox.control.is_none());
-        mailbox.terminal = Some(exit);
+        assert!(matches!(*mailbox, MemberMailbox::Unattached));
+        *mailbox = MemberMailbox::Terminal {
+            control: None,
+            exit,
+            teardown: None,
+        };
     }
 
     pub(crate) fn terminal_disposal_pending(&self) -> bool {
@@ -229,14 +247,26 @@ impl MemberCell {
     pub(crate) fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
         let terminal_exit = {
             let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
-            assert!(state.control.is_none(), "a member can own only one mailbox");
-            state.control = Some(Arc::clone(&mailbox));
-            let terminal_exit = state.terminal.clone();
-            if terminal_exit.is_some() {
-                debug_assert!(state.teardown.is_none());
-                state.teardown = mailbox.prepare_termination();
+            match &mut *state {
+                MemberMailbox::Unattached => {
+                    *state = MemberMailbox::Attached(mailbox);
+                    None
+                }
+                MemberMailbox::Attached(_)
+                | MemberMailbox::Terminal {
+                    control: Some(_), ..
+                } => panic!("a member can own only one mailbox"),
+                MemberMailbox::Terminal {
+                    control,
+                    exit,
+                    teardown,
+                } => {
+                    debug_assert!(teardown.is_none());
+                    *teardown = mailbox.prepare_termination();
+                    *control = Some(mailbox);
+                    Some(exit.clone())
+                }
             }
-            terminal_exit
         };
         if let Some(terminal_exit) = terminal_exit {
             self.publish_terminal(terminal_exit);
@@ -244,26 +274,39 @@ impl MemberCell {
     }
 
     pub(crate) fn mailbox(&self) -> Option<Arc<dyn MailboxControl>> {
-        self.mailbox
-            .lock()
-            .expect("member mailbox mutex poisoned")
-            .control
-            .clone()
+        match &*self.mailbox.lock().expect("member mailbox mutex poisoned") {
+            MemberMailbox::Unattached => None,
+            MemberMailbox::Attached(control) => Some(Arc::clone(control)),
+            MemberMailbox::Terminal { control, .. } => control.clone(),
+        }
     }
 
     pub(crate) fn terminalize(&self, exit: Exit) {
         let terminal_exit = {
             let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
-            if let Some(terminal_exit) = &state.terminal {
-                terminal_exit.clone()
-            } else {
-                let teardown = state
-                    .control
-                    .as_ref()
-                    .and_then(|mailbox| mailbox.prepare_termination());
-                state.terminal = Some(exit.clone());
-                state.teardown = teardown;
-                exit
+            match &*state {
+                MemberMailbox::Terminal {
+                    exit: terminal_exit,
+                    ..
+                } => terminal_exit.clone(),
+                MemberMailbox::Unattached => {
+                    *state = MemberMailbox::Terminal {
+                        control: None,
+                        exit: exit.clone(),
+                        teardown: None,
+                    };
+                    exit
+                }
+                MemberMailbox::Attached(control) => {
+                    let control = Arc::clone(control);
+                    let teardown = control.prepare_termination();
+                    *state = MemberMailbox::Terminal {
+                        control: Some(control),
+                        exit: exit.clone(),
+                        teardown,
+                    };
+                    exit
+                }
             }
         };
         self.publish_terminal(terminal_exit);
@@ -284,12 +327,12 @@ impl MemberCell {
         // member terminality. The watch pulse is deliberately delayed until
         // teardown has synchronously finished and unread payload ownership has
         // moved to detached disposal.
-        let teardown = self
-            .mailbox
-            .lock()
-            .expect("member mailbox mutex poisoned")
-            .teardown
-            .take();
+        let teardown = match &mut *self.mailbox.lock().expect("member mailbox mutex poisoned") {
+            MemberMailbox::Terminal { teardown, .. } => teardown.take(),
+            MemberMailbox::Unattached | MemberMailbox::Attached(_) => {
+                unreachable!("terminal publication requires terminal mailbox state")
+            }
+        };
         if let Some(teardown) = teardown
             && let Some(payload) = teardown.finish()
         {
@@ -347,6 +390,30 @@ pub(crate) trait DynamicRoute: Send + Sync {
 
     #[cfg(test)]
     fn request_forwarder_probe(&self) -> (Latch, Latch);
+}
+
+/// Shared critical section for one resident tree's observation projection.
+///
+/// Gate identity, rather than the lock payload, defines tree membership. The
+/// lock deliberately tolerates poisoning: a panic in an observation path must
+/// not permanently wedge later observation or a subtree handoff.
+#[derive(Clone, Debug)]
+pub(crate) struct ObservationGate(Arc<Mutex<()>>);
+
+impl ObservationGate {
+    fn new() -> Self {
+        Self(Arc::new(Mutex::new(())))
+    }
+
+    pub(crate) fn same_gate(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+
+    pub(crate) fn lock(&self) -> MutexGuard<'_, ()> {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
 }
 
 /// Driver-independent view of one declaration slot while its membership is
@@ -447,7 +514,7 @@ pub(crate) struct ScopeCell {
     // inside a mutation callback would self-deadlock; adding one there is safe.
     current_children: runtime::WatchSender<Vec<ResidentChild>>,
     parent: runtime::WatchSender<Option<Weak<ScopeCell>>>,
-    observation_gate: RwLock<Arc<Mutex<()>>>,
+    observation_gate: RwLock<ObservationGate>,
     lifecycle_seq: AtomicU64,
     lifecycle: LifecycleHub,
     snapshots: SnapshotHub,
@@ -507,7 +574,7 @@ impl ScopeCell {
             dynamic_route: Mutex::new(None),
             current_children,
             parent,
-            observation_gate: RwLock::new(Arc::new(Mutex::new(()))),
+            observation_gate: RwLock::new(ObservationGate::new()),
             lifecycle_seq: AtomicU64::new(0),
             lifecycle: LifecycleHub::default(),
             snapshots: SnapshotHub::default(),
@@ -554,7 +621,7 @@ impl ScopeCell {
     }
 
     #[cfg(test)]
-    pub(crate) fn observation_gate(&self) -> Arc<Mutex<()>> {
+    pub(crate) fn observation_gate(&self) -> ObservationGate {
         self.current_observation_gate()
     }
 
@@ -582,16 +649,14 @@ impl ScopeCell {
         }
     }
 
-    fn current_observation_gate(&self) -> Arc<Mutex<()>> {
-        Arc::clone(
-            &self
-                .observation_gate
-                .read()
-                .expect("observation gate handoff mutex poisoned"),
-        )
+    fn current_observation_gate(&self) -> ObservationGate {
+        self.observation_gate
+            .read()
+            .expect("observation gate handoff mutex poisoned")
+            .clone()
     }
 
-    fn adopt_observation_gate(&self, parent: &ScopeCell, gate: &Arc<Mutex<()>>) {
+    fn adopt_observation_gate(&self, parent: &ScopeCell, gate: &ObservationGate) {
         debug_assert!(
             !std::ptr::eq(self, parent),
             "a scope cannot adopt from itself"
@@ -600,12 +665,12 @@ impl ScopeCell {
         // Re-homing the parent would first have to acquire that same gate, so
         // rereading its installed pointer here cannot race a parent handoff.
         debug_assert!(
-            Arc::ptr_eq(gate, &parent.current_observation_gate()),
+            gate.same_gate(&parent.current_observation_gate()),
             "observation gates are adopted only in the parent-to-child direction"
         );
         loop {
             let current = self.current_observation_gate();
-            if Arc::ptr_eq(&current, gate) {
+            if current.same_gate(gate) {
                 return;
             }
 
@@ -616,15 +681,13 @@ impl ScopeCell {
             // check may finish its complete edge before handoff. An operation
             // that merely captured this obsolete gate retries after acquiring
             // it and observing the replacement.
-            let current_guard = current
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let current_guard = current.lock();
             let mut installed = self
                 .observation_gate
                 .write()
                 .expect("observation gate handoff mutex poisoned");
-            if Arc::ptr_eq(&current, &installed) {
-                *installed = Arc::clone(gate);
+            if current.same_gate(&installed) {
+                *installed = gate.clone();
                 drop(installed);
                 self.adopt_descendant_observation_gates_locked(&current, gate);
                 drop(current_guard);
@@ -640,8 +703,8 @@ impl ScopeCell {
     /// while the handoff is installed recursively.
     fn adopt_descendant_observation_gates_locked(
         &self,
-        previous: &Arc<Mutex<()>>,
-        gate: &Arc<Mutex<()>>,
+        previous: &ObservationGate,
+        gate: &ObservationGate,
     ) {
         let descendants = self.current_children.read_with(|children| {
             children
@@ -654,11 +717,11 @@ impl ScopeCell {
                 .observation_gate
                 .write()
                 .expect("observation gate handoff mutex poisoned");
-            if Arc::ptr_eq(&installed, previous) {
-                *installed = Arc::clone(gate);
+            if installed.same_gate(previous) {
+                *installed = gate.clone();
             } else {
                 assert!(
-                    Arc::ptr_eq(&installed, gate),
+                    installed.same_gate(gate),
                     "one resident tree must share one observation gate"
                 );
             }
@@ -676,10 +739,8 @@ impl ScopeCell {
             let gate = self.current_observation_gate();
             #[cfg(test)]
             self.report_gate_capture(GateCapture::Observation);
-            let guard = gate
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if Arc::ptr_eq(&gate, &self.current_observation_gate()) {
+            let guard = gate.lock();
+            if gate.same_gate(&self.current_observation_gate()) {
                 let operation = operation
                     .take()
                     .expect("observation operation runs exactly once");
@@ -881,7 +942,7 @@ impl ScopeCell {
             strategy: (self.flavor == ScopeFlavor::Ordered).then_some(config.strategy),
             intensity: config.intensity,
             total_restarts: record.total_restarts,
-            lifecycle_seq: self.lifecycle_seq.load(Ordering::Acquire),
+            lifecycle_seq: LifecycleSeq::new(self.lifecycle_seq.load(Ordering::Acquire)),
             children: children.into(),
         })
     }
@@ -922,7 +983,7 @@ impl ScopeCell {
             scope_seq: child
                 .scope
                 .as_ref()
-                .map(|scope| scope.lifecycle_seq.load(Ordering::Acquire)),
+                .map(|scope| LifecycleSeq::new(scope.lifecycle_seq.load(Ordering::Acquire))),
         }
     }
 
@@ -956,7 +1017,7 @@ impl ScopeCell {
             })
             .ok()
             .map(|previous| previous.saturating_add(1));
-        let Some(seq) = seq else {
+        let Some(seq) = seq.map(LifecycleSeq::new) else {
             self.lifecycle_seq.store(u64::MAX, Ordering::Release);
             self.publish_snapshot_chain_locked();
             self.lifecycle.publish_lagged(1);
@@ -994,7 +1055,7 @@ impl ScopeCell {
     }
 
     #[cfg(test)]
-    pub(crate) fn replace_observation_gate(&self, gate: Arc<Mutex<()>>) {
+    pub(crate) fn replace_observation_gate(&self, gate: ObservationGate) {
         *self
             .observation_gate
             .write()

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -3080,11 +3080,9 @@ mod tests {
         let second = isolated_scope("second", ScopeFlavor::Ordered);
         let first_gate = first.observation_gate();
         let second_gate = second.observation_gate();
-        assert!(!Arc::ptr_eq(&first_gate, &second_gate));
+        assert!(!first_gate.same_gate(&second_gate));
 
-        let held = first_gate
-            .lock()
-            .expect("first observation gate starts healthy");
+        let held = first_gate.lock();
         let (completed, receiver) = std::sync::mpsc::sync_channel(0);
         let worker = std::thread::spawn(move || {
             second.set_state(ScopeState::Starting);
@@ -3098,6 +3096,22 @@ mod tests {
             Ok(()),
             "holding one system's gate must not stall another system"
         );
+    }
+
+    #[test]
+    fn observation_gate_poison_does_not_wedge_later_observation() {
+        let scope = isolated_scope("scope", ScopeFlavor::Ordered);
+        let gate = scope.observation_gate();
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                let _held = gate.lock();
+                panic!("inject observation failure");
+            }))
+            .is_err()
+        );
+
+        scope.set_state(ScopeState::Starting);
+        assert_eq!(scope.record().state, ScopeState::Starting);
     }
 
     #[test]
@@ -3196,10 +3210,10 @@ mod tests {
 
         root.set_admitted_children(vec![resident_projection(&slot)]);
 
-        assert!(Arc::ptr_eq(
-            &root.observation_gate(),
-            &nested.observation_gate()
-        ));
+        assert!(
+            root.observation_gate()
+                .same_gate(&nested.observation_gate())
+        );
     }
 
     #[test]
@@ -3209,17 +3223,18 @@ mod tests {
         let leaf = isolated_scope("leaf", ScopeFlavor::Ordered);
         let leaf_slot = SlotCell::new(Arc::clone(&leaf.member), Some(Arc::clone(&leaf)));
         nested.set_admitted_children(vec![resident_projection(&leaf_slot)]);
-        assert!(Arc::ptr_eq(
-            &nested.observation_gate(),
-            &leaf.observation_gate()
-        ));
+        assert!(
+            nested
+                .observation_gate()
+                .same_gate(&leaf.observation_gate())
+        );
 
         let nested_slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
         root.set_admitted_children(vec![resident_projection(&nested_slot)]);
 
         let root_gate = root.observation_gate();
-        assert!(Arc::ptr_eq(&root_gate, &nested.observation_gate()));
-        assert!(Arc::ptr_eq(&root_gate, &leaf.observation_gate()));
+        assert!(root_gate.same_gate(&nested.observation_gate()));
+        assert!(root_gate.same_gate(&leaf.observation_gate()));
     }
 
     #[test]
@@ -3228,9 +3243,7 @@ mod tests {
         let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
         let captures = nested.probe_gate_captures();
         let prior_gate = nested.observation_gate();
-        let held = prior_gate
-            .lock()
-            .expect("pre-admission observation gate starts healthy");
+        let held = prior_gate.lock();
         let observer = Arc::clone(&nested);
         let worker = std::thread::spawn(move || observer.set_state(ScopeState::Starting));
 
@@ -3258,10 +3271,10 @@ mod tests {
             "the handoff forces one retry capture on the root gate"
         );
         assert_eq!(nested.record().state, ScopeState::Starting);
-        assert!(Arc::ptr_eq(
-            &root.observation_gate(),
-            &nested.observation_gate()
-        ));
+        assert!(
+            root.observation_gate()
+                .same_gate(&nested.observation_gate())
+        );
     }
 
     #[crate::runtime::test]
@@ -3588,10 +3601,10 @@ mod tests {
             .recv()
             .expect("adoption reports completion after the edge");
         adoption.join().expect("gate handoff completes");
-        assert!(Arc::ptr_eq(
-            &root.observation_gate(),
-            &nested.observation_gate()
-        ));
+        assert!(
+            root.observation_gate()
+                .same_gate(&nested.observation_gate())
+        );
     }
 
     #[test]
@@ -4471,7 +4484,7 @@ mod tests {
 
         let captures = root.probe_gate_captures();
         let gate = root.observation_gate();
-        let held_gate = gate.lock().expect("observation gate starts healthy");
+        let held_gate = gate.lock();
         let removal_root = Arc::clone(&root);
         let removal_id = child_id.clone();
         let worker =
@@ -5062,7 +5075,10 @@ mod tests {
         else {
             panic!("expected the final mintable event");
         };
-        assert_eq!(event.seq, u64::MAX - 1);
-        assert_eq!(scope.snapshot().lifecycle_seq, u64::MAX);
+        assert_eq!(event.seq.get(), u64::MAX - 1);
+        assert_eq!(
+            scope.snapshot().lifecycle_seq,
+            crate::LifecycleSeq::EXHAUSTED
+        );
     }
 }

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -36,8 +36,8 @@ pub use mailbox::{
 };
 pub use observe::{
     ChildSnapshot, ChildState, LIFECYCLE_EVENT_CAPACITY, LifecycleEvent, LifecycleEventKind,
-    LifecycleEvents, LifecycleItem, LifecycleTryRecvError, MembershipStatus, ScopeKind,
-    ScopeSnapshot, ScopeState, SnapshotClosed, SnapshotReceiver, WaitError,
+    LifecycleEvents, LifecycleItem, LifecycleSeq, LifecycleTryRecvError, MembershipStatus,
+    ScopeKind, ScopeSnapshot, ScopeState, SnapshotClosed, SnapshotReceiver, WaitError,
 };
 pub use policy::{
     Backoff, BackoffFactor, DefaultsInheritance, Intensity, InvalidPolicy, Jitter, Mailbox,

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -22,6 +22,30 @@ pub const LIFECYCLE_EVENT_CAPACITY: usize = 128;
 // requested and effective capacities to remain equal.
 const _: () = assert!(LIFECYCLE_EVENT_CAPACITY.is_power_of_two());
 
+/// A sequence in one scope membership's lifecycle event domain.
+///
+/// Values increase monotonically and remain continuous across restarts of the
+/// same membership. A replacement membership starts a distinct sequence
+/// domain, identified by its [`Membership`].
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct LifecycleSeq(u64);
+
+impl LifecycleSeq {
+    /// Permanent watermark used after the lifecycle sequence space is
+    /// exhausted. This value is never assigned to an event.
+    pub const EXHAUSTED: Self = Self(u64::MAX);
+
+    pub(crate) const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the underlying numeric sequence value.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
 /// One item read from a lifecycle subscription.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
@@ -43,7 +67,7 @@ pub struct LifecycleEvent {
     /// Membership identity of the emitting scope.
     pub scope: Membership,
     /// Emitting scope's membership-owned sequence number.
-    pub seq: u64,
+    pub seq: LifecycleSeq,
     /// State transition carried by this event.
     pub kind: LifecycleEventKind,
 }
@@ -228,7 +252,7 @@ pub struct ChildSnapshot {
     /// Recursive state of a scope child when its incarnation is live or terminal.
     pub nested: Option<Arc<ScopeSnapshot>>,
     /// Lifecycle watermark of a scope child, including restart windows.
-    pub scope_seq: Option<u64>,
+    pub scope_seq: Option<LifecycleSeq>,
 }
 
 /// Arc-shareable recursive current-state projection for one scope.
@@ -245,7 +269,7 @@ pub struct ScopeSnapshot {
     /// Cumulative restart charges across children in this incarnation.
     pub total_restarts: u64,
     /// This scope membership's lifecycle watermark.
-    pub lifecycle_seq: u64,
+    pub lifecycle_seq: LifecycleSeq,
     /// Children in declaration or admission order.
     pub children: Arc<[ChildSnapshot]>,
 }
@@ -284,7 +308,7 @@ impl ScopeSnapshot {
     /// For the scope represented by this snapshot itself, compare the event's
     /// membership with the corresponding scope handle and use [`Self::lifecycle_seq`].
     #[must_use]
-    pub fn watermark(&self, membership: Membership) -> Option<u64> {
+    pub fn watermark(&self, membership: Membership) -> Option<LifecycleSeq> {
         self.children.iter().find_map(|child| {
             if child.membership == membership {
                 child.scope_seq
@@ -570,7 +594,7 @@ impl LifecycleHub {
     pub(crate) fn publish(&self, event: LifecycleEvent) {
         tracing::trace!(
             scope = ?event.scope,
-            seq = event.seq,
+            seq = event.seq.get(),
             path = ?event.scope_path,
             kind = ?event.kind,
             "scope lifecycle event"
@@ -663,7 +687,7 @@ mod tests {
         },
     };
 
-    use super::{LIFECYCLE_EVENT_CAPACITY, LifecycleHub, SnapshotHub};
+    use super::{LIFECYCLE_EVENT_CAPACITY, LifecycleHub, LifecycleSeq, SnapshotHub};
 
     fn snapshot(state: ScopeState) -> Arc<ScopeSnapshot> {
         Arc::new(ScopeSnapshot {
@@ -672,7 +696,7 @@ mod tests {
             strategy: None,
             intensity: Intensity::default(),
             total_restarts: 0,
-            lifecycle_seq: 0,
+            lifecycle_seq: LifecycleSeq::new(0),
             children: Arc::from([]),
         })
     }
@@ -764,7 +788,7 @@ mod tests {
         hub.publish_past_fast_path(LifecycleEvent {
             scope_path: Vec::new(),
             scope: membership,
-            seq: 1,
+            seq: LifecycleSeq::new(1),
             kind: LifecycleEventKind::ScopeState {
                 state: ScopeState::Running,
             },
@@ -785,7 +809,7 @@ mod tests {
         let event = |seq| LifecycleEvent {
             scope_path: Vec::new(),
             scope: membership,
-            seq,
+            seq: LifecycleSeq::new(seq),
             kind: LifecycleEventKind::ScopeState {
                 state: ScopeState::Running,
             },
@@ -810,7 +834,7 @@ mod tests {
         else {
             panic!("expected the retained suffix");
         };
-        assert_eq!(first_retained.seq, 3);
+        assert_eq!(first_retained.seq.get(), 3);
     }
 
     #[test]
@@ -822,7 +846,7 @@ mod tests {
         let event = |seq| LifecycleEvent {
             scope_path: Vec::new(),
             scope: membership,
-            seq,
+            seq: LifecycleSeq::new(seq),
             kind: LifecycleEventKind::ScopeState {
                 state: ScopeState::Running,
             },

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -13,10 +13,10 @@ use crate::common::{
 };
 use shelterwood::{
     Backoff, ChildState, DynamicScopeRef, DynamicTree, Intensity, Jitter, LIFECYCLE_EVENT_CAPACITY,
-    LifecycleEvent, LifecycleEventKind, LifecycleEvents, LifecycleItem, LifecycleTryRecvError,
-    MembershipStatus, RemoveOutcome, RestartCondition, RestartPolicy, Retention, ScopeKind,
-    ScopeRef, ScopeState, StopReason, Strategy, SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef,
-    TaskRef, Tree, WaitError,
+    LifecycleEvent, LifecycleEventKind, LifecycleEvents, LifecycleItem, LifecycleSeq,
+    LifecycleTryRecvError, MembershipStatus, RemoveOutcome, RestartCondition, RestartPolicy,
+    Retention, ScopeKind, ScopeRef, ScopeState, StopReason, Strategy, SubtreeDef, SubtreeOnceDef,
+    TaskDef, TaskOnceDef, TaskRef, Tree, WaitError,
 };
 
 async fn next_item(events: &mut LifecycleEvents) -> LifecycleItem {
@@ -34,7 +34,7 @@ async fn next_event(events: &mut LifecycleEvents) -> LifecycleEvent {
     }
 }
 
-fn event_watermark(scope: &ScopeRef, event: &LifecycleEvent) -> Option<u64> {
+fn event_watermark(scope: &ScopeRef, event: &LifecycleEvent) -> Option<LifecycleSeq> {
     let snapshot = scope.snapshot();
     if event.scope == scope.membership() {
         Some(snapshot.lifecycle_seq)
@@ -51,7 +51,7 @@ async fn event_woken_pull_snapshots_are_consistent_at_first_start_and_final_stop
         .expect("valid subtree");
     let initial = nested.snapshot();
     assert_eq!(initial.state, ScopeState::Unstarted);
-    assert_eq!(initial.lifecycle_seq, 0);
+    assert_eq!(initial.lifecycle_seq.get(), 0);
 
     // Deliberately create no snapshot receiver: the pull path must not depend
     // on watch publication having any subscribers.
@@ -468,7 +468,11 @@ async fn descendant_events_forward_with_origin_identity_path_and_causal_order() 
     let mut last_by_origin = HashMap::new();
     for event in &seen {
         if let Some(previous) = last_by_origin.insert(event.scope, event.seq) {
-            assert_eq!(event.seq, previous + 1, "origin sequences stay gap-free");
+            assert_eq!(
+                event.seq.get(),
+                previous.get() + 1,
+                "origin sequences stay gap-free"
+            );
         }
     }
     let snapshot = root.snapshot();
@@ -622,7 +626,7 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
             break event;
         }
     };
-    assert_eq!(starting.seq, stopped_seq + 1);
+    assert_eq!(starting.seq.get(), stopped_seq.get() + 1);
     assert_eq!(starting.scope, scope_membership);
 
     let second_child = loop {

--- a/docs/observation.md
+++ b/docs/observation.md
@@ -25,6 +25,10 @@ temporarily absent. For an event emitted by the subscribed scope itself, compare
 `snapshot.watermark(event.scope)` finds the matching watermark. An event is
 already reflected when `event.seq <= watermark`.
 
+These values use `LifecycleSeq`. `LifecycleSeq::EXHAUSTED` is the permanent
+watermark after the sequence space is exhausted and is never emitted on an
+event; `get()` exposes the underlying `u64` when numeric integration requires it.
+
 A child in `Restarting` normally exposes its absolute backoff deadline through
 `restart_at`. If the requested delay is too large for the platform clock to
 represent, `restart_at` is `None`; the child remains in `Restarting` until


### PR DESCRIPTION
Closes #97.
Part of #101 (section B).

## Scope

This PR implements the three domain carriers deferred by #97:

- replaces the coupled `MemberMailbox` option fields with explicit `Unattached`, `Attached`, and `Terminal` states;
- introduces `ObservationGate` as the single home for resident-tree gate identity and poison-tolerant locking;
- introduces public `LifecycleSeq` across lifecycle events and snapshot watermarks, including `get()` and the never-emitted `EXHAUSTED` sentinel.

It also updates the SPEC appendix and observation documentation for the typed lifecycle sequence surface.

## Behavioral intent

The changes preserve mailbox terminality ordering, subtree gate handoff behavior, lifecycle ordering, and exhaustion semantics while making their invariants explicit in the types.

A regression test deliberately poisons an observation gate and verifies later observation remains live.

## Validation

- `./scripts/dev just ci`
- 427/427 tests passed
- doctests, rustdoc warnings, public API reachability, enforcement checks, packaged-doc sync, and packaged-crate verification passed