### PR TITLE
Type exit cancellation and grace phases

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1229,23 +1229,25 @@ One classification, produced at one point, used by every consumer.
   never input to restart or intensity accounting (both consume
   incarnation exits), and counts as a failure for `is_failure()` —
   awaiting a child that never ran is not success.
-- **`cancelled` is one state-machine fact**, not a narrative judgment:
-  the flag is true iff the incarnation's own shutdown token (B.1/B.2)
-  had fired before its outcome was recorded (the record phase below).
+- **Cancellation observation is one state-machine fact**, not a narrative
+  judgment: the value is `Cancellation::Observed` iff the incarnation's own
+  shutdown token (B.1/B.2) had fired before its outcome was recorded (the
+  record phase below), and `Cancellation::NotObserved` otherwise.
   The token fires for every engine-initiated stop — scope teardown,
   dynamic removal, readiness-timeout teardown, `shutdown(0)`'s immediate
   escalation — and for local `ctx.stop()`, which arms the same ladder
   (§10), so a self-stopped actor's exit reads `Cancellation::Observed`. A stop
   racing natural completion needs no third rule: whichever of token-fire
-  and outcome-record happened first decides the flag. `NeverStarted`
+  and outcome-record happened first decides the value. `NeverStarted`
   sits outside the rule — no incarnation, no token — and carries
   `Cancellation::NotObserved` uniformly, whether the membership ended by
   tree-drop, withdrawal, rejection, or startup abort: the variant itself
   already says nothing ran.
 - **Verdict precedence.** When one incarnation's end admits several
   readings, classification picks the highest of: `Panicked` >
-  `ReadinessTimedOut` > `Failed` > `Aborted` > `Completed`; `cancelled` is
-  orthogonal and never competes. Concretely: a panic is never masked,
+  `ReadinessTimedOut` > `Failed` > `Aborted` > `Completed`; cancellation
+  observation is orthogonal and never competes. Concretely: a panic is
+  never masked,
   wherever it lands (`run`, `on_stop` — superseding the run's outcome,
   §4.1 — or a destructor, via the fallback report token); and a
   readiness-deadline expiry names the *cause* even when the teardown it
@@ -1277,7 +1279,7 @@ One classification, produced at one point, used by every consumer.
 - **Failure classification (feeds §9.2):** an exit is a *failure* iff it is
   not `Completed`. So `Failed`, `Panicked`, `ReadinessTimedOut`, and
   `Aborted` all restart under `OnFailure`; `Always` restarts even clean
-  completions. The `cancelled` flag is **never** consulted by restart
+  completions. The cancellation observation is **never** consulted by restart
   classification — restart suppression comes solely from teardown
   *state*, never from the exit's shape: a draining scope schedules no
   restarts (§10), and a membership whose removal is in progress
@@ -3220,7 +3222,7 @@ convention — so a retained exit stays interpretable; the configured
 *span* is the child's resolved `readiness_deadline` option (§8), not
 this field.
 Helpers:
-`is_failure()` (= not `Completed`), `cancelled()`, accessors per variant,
+`is_failure()` (= not `Completed`), `cancellation()`, accessors per variant,
 and two named cross-variant accessors:
 `intensity_trip() -> Option<&IntensityTrip>` (§9.2's structured trip
 data) and `startup_failure() -> Option<&StartupFailure>` (§11's

--- a/SPEC.md
+++ b/SPEC.md
@@ -1214,12 +1214,13 @@ One classification, produced at one point, used by every consumer.
 - One public exit type covers: `Completed`, `Failed(error)`, `Panicked`
   (carrying the panic message when the payload downcasts to a string — the
   payload itself is never retained, since exits ride `Clone` snapshots and
-  events), `ReadinessTimedOut { deadline }`, `Aborted { after_grace }`,
-  and the membership-level `NeverStarted`, with
+  events), `ReadinessTimedOut { deadline }`, `Aborted { phase:
+  GracePhase }`, and the membership-level `NeverStarted`, with
   cancellation ("supervisor asked it to stop" vs "finished on its own") as
-  an orthogonal, explicit `cancelled: bool` field on every variant.
-  Grace-expiry abort (`after_grace: true`) and scope-level shutdown-timeout
-  are distinguishable. `NeverStarted` is the terminal outcome of a
+  an orthogonal, explicit `Cancellation::{Observed, NotObserved}` value on
+  every exit. `GracePhase::{WithinGrace, AfterGrace}` distinguishes whether
+  cooperative grace expired before an abort; scope-level shutdown-timeout
+  remains a separate verdict. `NeverStarted` is the terminal outcome of a
   membership that ends with no incarnation ever spawned — a declaring
   tree dropped unspawned, a rejected or withdrawn insertion (§3.2, §8),
   removal before first spawn, or a startup abort terminalizing
@@ -1234,11 +1235,11 @@ One classification, produced at one point, used by every consumer.
   The token fires for every engine-initiated stop — scope teardown,
   dynamic removal, readiness-timeout teardown, `shutdown(0)`'s immediate
   escalation — and for local `ctx.stop()`, which arms the same ladder
-  (§10), so a self-stopped actor's exit reads `cancelled: true`. A stop
+  (§10), so a self-stopped actor's exit reads `Cancellation::Observed`. A stop
   racing natural completion needs no third rule: whichever of token-fire
   and outcome-record happened first decides the flag. `NeverStarted`
   sits outside the rule — no incarnation, no token — and carries
-  `cancelled: false` uniformly, whether the membership ended by
+  `Cancellation::NotObserved` uniformly, whether the membership ended by
   tree-drop, withdrawal, rejection, or startup abort: the variant itself
   already says nothing ran.
 - **Verdict precedence.** When one incarnation's end admits several
@@ -1263,8 +1264,8 @@ One classification, produced at one point, used by every consumer.
     structured application error the task already produced, which is the
     only evidence naming *why* the child was failing.
   - A recorded `Completed` does **not** survive: cancellation overrides
-    it and the exit reads `Aborted { after_grace }` with
-    `cancelled: true`. A supervisor that destroyed a child before its
+    it and the exit reads `Aborted { phase }` with
+    `Cancellation::Observed`. A supervisor that destroyed a child before its
     success was observable did not get a successful child. Concretely, a
     one-shot task whose body returned `Ok(value)` inside that window
     exits `Aborted` and `OneShotTaskRef::wait` yields `Err(exit)` — the
@@ -1856,10 +1857,10 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
   before teardown advances, exactly as under grace expiry. The policy does
   not pre-decide the classification: §7's classifier still reads what
   actually happened, so a child that yields an outcome during the beat
-  exits `Completed`/`Failed` (with `cancelled: true`), and
-  `Aborted { after_grace: false }` records only a hard abort actually
+  exits `Completed`/`Failed` (with `Cancellation::Observed`), and
+  `Aborted { phase: GracePhase::WithinGrace }` records only a hard abort actually
   reached — the future destroyed before yielding — distinguishable from
-  grace-expiry abort (`after_grace: true`). The one boundary case, where
+  grace-expiry abort (`phase: GracePhase::AfterGrace`). The one boundary case, where
   the beat expires and the hard abort lands *after* the body recorded its
   outcome but before the join retires, is settled by §7's precedence and
   not here: a recorded `Failed` survives that abort, a recorded
@@ -1869,7 +1870,7 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
   contract. Cancellation-before-escalation ordering is observable to the
   child itself — its `shutdown_token` fires strictly before its
   `abort_token` (B.2), which is what C.2's sidecar reads from the child's
-  own journal — and in the exit's `cancelled`/`after_grace` fields;
+  own journal — and in the exit's `cancellation`/`phase` fields;
   lifecycle events carry **no ladder-transition events** (B.4's inventory
   is deliberately exit-only here), so §13.10's ordering assertions are
   built from child-side observations, not the event stream.
@@ -1881,7 +1882,7 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
 - **Driver death discharges; it never absolves.** A scope driver
   destroyed with obligations outstanding resolves all of them on the way
   down: still-active descendants publish the coarse kill verdict —
-  `Aborted { after_grace: false }` with `cancelled: true` — memberships
+  `Aborted { phase: GracePhase::WithinGrace }` with `Cancellation::Observed` — memberships
   terminalize (sends fail `Terminated`, exit-awaiting surfaces resolve),
   in-flight admissions and removals resolve their enumerated rejections,
   and every `Added` is paired with its `Removed` before the scope's own
@@ -2081,7 +2082,7 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
   `shutdown_and_wait()` on its handle (incarnation-targeted, B.9) —
   tears down through the ordinary
   §10 ladders, publishes `Stopped { reason: ShutdownRequested }` (B.6),
-  and exits at its parent as `Completed` with `cancelled: true` (§7): a
+  and exits at its parent as `Completed` with `Cancellation::Observed` (§7): a
   requested stop is a cooperative completion, not a failure. The
   parent's restart policy then applies as usual — `OnFailure` leaves the
   scope down; `Always` restarts it, and because the shutdown latch is
@@ -2988,7 +2989,7 @@ stop), `abort_token()` (fires at escalation — grace expiry, or
 immediately under `Abort` policy; the tidy-abort beat runs after it
 fires, and §10's classification rule applies: a task that yields an
 outcome during the beat classifies by that outcome, while a future
-destroyed by the ensuing hard abort records `Aborted { after_grace }`),
+destroyed by the ensuing hard abort records `Aborted { phase }`),
 `mark_ready()` (one-shot by construction; no-op only where declared
 readiness makes it meaningless, and that is a documented no-op, not a silent
 state change — the same rule covers a stopping incarnation: once either
@@ -3210,8 +3211,9 @@ One public type (§7): variants `Completed`, `Failed(error)` (the error
 value, not a string), `Panicked { message: Option<String> }` (the panic
 message when the payload downcasts to a string; the payload is never
 retained), `ReadinessTimedOut { deadline }`,
-`Aborted { after_grace }`, `NeverStarted` (membership terminal with no
-incarnation ever spawned, §7); orthogonal `cancelled: bool` on all.
+`Aborted { phase: GracePhase }`, `NeverStarted` (membership terminal with no
+incarnation ever spawned, §7); orthogonal
+`Cancellation::{Observed, NotObserved}` on every exit.
 `ReadinessTimedOut.deadline` is the absolute expiry instant —
 `std::time::Instant` per this appendix's time rule, B.6's `restart_at`
 convention — so a retained exit stays interpretable; the configured
@@ -3630,7 +3632,7 @@ conflation, outlines, metrics) and port in full alongside it.
    startup, per-child `Abort` vs `Graceful`, startup-failure reporting with
    the started prefix left running (then host-driven rollback — the
    motivation for `start_or_shutdown()`), grace-bound enforcement with
-   `after_grace: true` and cancellation-before-escalation ordering read
+   `phase: GracePhase::AfterGrace` and cancellation-before-escalation ordering read
    from the child's own journal, and two full embed/run/stop cycles in one
    process.
 3. **Trading engine — cyclic wiring, pipelining, and a restart breaker.**

--- a/crates/shelterwood/doctests/docs/shutdown-and-resources.md
+++ b/crates/shelterwood/doctests/docs/shutdown-and-resources.md
@@ -8,10 +8,10 @@ cooperative cancellation -> grace expiry -> tidy-abort beat -> hard abort
 
 `Shutdown::Abort` is the zero-grace point on that ladder. The shutdown token
 still fires strictly before the abort token, and the tidy beat still occurs.
-`ExitKind::Aborted { after_grace }` distinguishes hard abort after an expired
-grace (`true`) from the immediate policy (`false`). These token transitions are
-observable inside a child; lifecycle events report the eventual exit, not
-separate ladder steps.
+`ExitKind::Aborted { phase }` distinguishes hard abort after an expired
+grace (`GracePhase::AfterGrace`) from an abort within grace
+(`GracePhase::WithinGrace`). These token transitions are observable inside a
+child; lifecycle events report the eventual exit, not separate ladder steps.
 
 ## Grace is an upper bound
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -85,7 +85,7 @@ impl<T> Drop for Obligation<T> {
 
 struct RecordedReport {
     outcome: Option<RecordedOutcome>,
-    cancelled: bool,
+    cancellation: Cancellation,
 }
 
 struct ReportCompletion {
@@ -133,10 +133,15 @@ pub(crate) fn report_channel(
 
 impl ReportCompletion {
     fn send(self, outcome: Option<RecordedOutcome>) {
+        let cancellation =
+            if self.shutdown.is_fired() || self.local_stop.as_ref().is_some_and(Latch::is_fired) {
+                Cancellation::Observed
+            } else {
+                Cancellation::NotObserved
+            };
         let _ = self.sender.send(RecordedReport {
             outcome,
-            cancelled: self.shutdown.is_fired()
-                || self.local_stop.as_ref().is_some_and(Latch::is_fired),
+            cancellation,
         });
     }
 }
@@ -788,7 +793,7 @@ enum ChildEvent {
         incarnation: Incarnation,
         recorded: Option<RecordedOutcome>,
         join: JoinVerdict,
-        cancelled: bool,
+        cancellation: Cancellation,
     },
     ConstructionDisposed {
         child: ChildKey,
@@ -1405,7 +1410,7 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
                 incarnation,
                 recorded: report.outcome,
                 join,
-                cancelled: report.cancelled,
+                cancellation: report.cancellation,
             }),
         )
         .await;
@@ -2034,7 +2039,7 @@ impl ScopeRuntime {
         incarnation: Incarnation,
         recorded: Option<RecordedOutcome>,
         mut join: JoinVerdict,
-        cancelled: bool,
+        cancellation: Cancellation,
     ) {
         let Some(child) = self.children.get_mut(key) else {
             return;
@@ -2062,11 +2067,6 @@ impl ScopeRuntime {
             join = JoinVerdict::Cancelled { phase };
         }
         let recorded = reconcile_recorded_outcomes(recorded, active.forced_outcome);
-        let cancellation = if cancelled {
-            Cancellation::Observed
-        } else {
-            Cancellation::NotObserved
-        };
         let exit = classify_exit(recorded, join, cancellation);
         child.restarts.settle_if_stable(
             active.started_at,
@@ -2962,8 +2962,8 @@ async fn run_scope_incarnation(
                     incarnation,
                     recorded,
                     join,
-                    cancelled,
-                })) => scope.handle_exit(child, incarnation, recorded, join, cancelled),
+                    cancellation,
+                })) => scope.handle_exit(child, incarnation, recorded, join, cancellation),
                 Pending::Driver(DriverEvent::Child(ChildEvent::ConstructionDisposed {
                     child,
                     panic,
@@ -3531,7 +3531,7 @@ mod tests {
                 "trip intensity",
             )))),
             join: JoinVerdict::Completed,
-            cancelled: false,
+            cancellation: Cancellation::NotObserved,
         });
         let mut pending = [
             restart_shutdown_work(nested),
@@ -3546,8 +3546,8 @@ mod tests {
                     incarnation,
                     recorded,
                     join,
-                    cancelled,
-                })) => scope.handle_exit(child, incarnation, recorded, join, cancelled),
+                    cancellation,
+                })) => scope.handle_exit(child, incarnation, recorded, join, cancellation),
                 _ => unreachable!("the fixture queues only exit and restart work"),
             }
         }
@@ -3759,7 +3759,7 @@ mod tests {
             report.outcome,
             Some(RecordedOutcome::Returned(Ok(())))
         ));
-        assert!(!report.cancelled);
+        assert_eq!(report.cancellation, Cancellation::NotObserved);
 
         let shutdown = Latch::default();
         let (token, receiver) = report_channel(shutdown.clone(), None);
@@ -3767,7 +3767,7 @@ mod tests {
         drop(token);
         let report = receiver.receive();
         assert!(report.outcome.is_none());
-        assert!(report.cancelled);
+        assert_eq!(report.cancellation, Cancellation::Observed);
     }
 
     #[test]
@@ -3781,7 +3781,7 @@ mod tests {
             report.outcome,
             Some(RecordedOutcome::Returned(Ok(())))
         ));
-        assert!(report.cancelled);
+        assert_eq!(report.cancellation, Cancellation::Observed);
     }
 
     #[test]
@@ -3791,7 +3791,7 @@ mod tests {
         let (token, receiver) = report_channel(shutdown, Some(local_stop.clone()));
         local_stop.fire();
         token.record(RecordedOutcome::Returned(Ok(())));
-        assert!(receiver.receive().cancelled);
+        assert_eq!(receiver.receive().cancellation, Cancellation::Observed);
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -8,8 +8,9 @@ use std::{
 };
 
 use crate::{
-    ChildId, Exit, ExitKind, Incarnation, IntensityTrip, Membership, Readiness, ReadinessDeadline,
-    ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure, StartupFailureCause,
+    Cancellation, ChildId, Exit, ExitKind, GracePhase, Incarnation, IntensityTrip, Membership,
+    Readiness, ReadinessDeadline, ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure,
+    StartupFailureCause,
     admission::{NotAdmittingCause, RemoveOutcome, ReserveError},
     cells::{DynamicRoute, MailboxControl, MemberStage, ResidentProjection, ScopeCell},
     deadline::Deadline,
@@ -642,14 +643,19 @@ impl SystemRun {
         match runtime::join(driver).await {
             runtime::JoinOutcome::Ok { .. } => {}
             runtime::JoinOutcome::Panic { message, .. } => {
-                let exit = Exit::new(ExitKind::Panicked { message }, false);
+                let exit = Exit::new(ExitKind::Panicked { message }, Cancellation::NotObserved);
                 self.root
                     .finish_live_root_incarnation(StopReason::ShutdownRequested, exit);
             }
             runtime::JoinOutcome::Cancelled => {
                 self.root.finish_live_root_incarnation(
                     StopReason::ShutdownRequested,
-                    Exit::new(ExitKind::Aborted { after_grace: false }, true),
+                    Exit::new(
+                        ExitKind::Aborted {
+                            phase: GracePhase::WithinGrace,
+                        },
+                        Cancellation::Observed,
+                    ),
                 );
             }
         }
@@ -739,14 +745,19 @@ pub(crate) fn spawn_system(plan: ScopePlan) -> SystemRun {
         match runtime::join(driver).await {
             runtime::JoinOutcome::Ok { value, .. } => value,
             runtime::JoinOutcome::Panic { message, .. } => {
-                let exit = Exit::new(ExitKind::Panicked { message }, false);
+                let exit = Exit::new(ExitKind::Panicked { message }, Cancellation::NotObserved);
                 monitor_root.finish_live_root_incarnation(StopReason::ShutdownRequested, exit);
                 StopReason::ShutdownRequested
             }
             runtime::JoinOutcome::Cancelled => {
                 monitor_root.finish_live_root_incarnation(
                     StopReason::ShutdownRequested,
-                    Exit::new(ExitKind::Aborted { after_grace: false }, true),
+                    Exit::new(
+                        ExitKind::Aborted {
+                            phase: GracePhase::WithinGrace,
+                        },
+                        Cancellation::Observed,
+                    ),
                 );
                 StopReason::ShutdownRequested
             }
@@ -807,7 +818,7 @@ struct ActiveChild {
     abort_handle: runtime::AbortHandle,
     ladder: Option<StopLadder>,
     forced_outcome: Option<RecordedOutcome>,
-    hard_abort_after_grace: Option<bool>,
+    hard_abort_phase: Option<GracePhase>,
     readiness: ReadinessGate,
     readiness_deadline: Option<DeadlineHandle>,
     ready_signal: Latch,
@@ -829,7 +840,12 @@ fn discharge_child_terminality(completion: ChildTerminality) {
     }
     let (exit, exited_incarnation) = if record.last_incarnation.is_some() {
         (
-            Exit::new(ExitKind::Aborted { after_grace: false }, true),
+            Exit::new(
+                ExitKind::Aborted {
+                    phase: GracePhase::WithinGrace,
+                },
+                Cancellation::Observed,
+            ),
             record.incarnation,
         )
     } else {
@@ -1373,7 +1389,9 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
         let join = match runtime::join(handle).await {
             runtime::JoinOutcome::Ok { .. } => JoinVerdict::Completed,
             runtime::JoinOutcome::Panic { message, .. } => JoinVerdict::Panicked { message },
-            runtime::JoinOutcome::Cancelled => JoinVerdict::Cancelled { after_grace: false },
+            runtime::JoinOutcome::Cancelled => JoinVerdict::Cancelled {
+                phase: GracePhase::WithinGrace,
+            },
         };
         exit_ended.fire();
         // The task owns `report`, whose explicit record or Drop fallback runs
@@ -1627,7 +1645,7 @@ impl ScopeRuntime {
             abort_handle,
             ladder: None,
             forced_outcome: None,
-            hard_abort_after_grace: None,
+            hard_abort_phase: None,
             readiness,
             readiness_deadline: None,
             ready_signal: latches.ready,
@@ -1833,10 +1851,10 @@ impl ScopeRuntime {
                 StopAction::Escalate => {
                     active.abort.fire();
                 }
-                StopAction::AbortFramework { after_grace } => {
-                    active.hard_abort_after_grace = Some(after_grace);
+                StopAction::AbortFramework { phase } => {
+                    active.hard_abort_phase = Some(phase);
                     if active.forced_outcome.is_none() {
-                        active.forced_outcome = Some(RecordedOutcome::Aborted { after_grace });
+                        active.forced_outcome = Some(RecordedOutcome::Aborted { phase });
                     }
                     active
                         .framework_abort
@@ -1844,8 +1862,8 @@ impl ScopeRuntime {
                         .expect("framework action belongs only to a framework driver")
                         .fire();
                 }
-                StopAction::HardAbort { after_grace } => {
-                    active.hard_abort_after_grace = Some(after_grace);
+                StopAction::HardAbort { phase } => {
+                    active.hard_abort_phase = Some(phase);
                     active.abort_handle.abort();
                 }
             }
@@ -2040,13 +2058,16 @@ impl ScopeRuntime {
             runtime::dispose_detached(teardown);
         }
         active.readiness.step(ReadinessEvent::Exit);
-        if let (JoinVerdict::Cancelled { .. }, Some(after_grace)) =
-            (&join, active.hard_abort_after_grace)
-        {
-            join = JoinVerdict::Cancelled { after_grace };
+        if let (JoinVerdict::Cancelled { .. }, Some(phase)) = (&join, active.hard_abort_phase) {
+            join = JoinVerdict::Cancelled { phase };
         }
         let recorded = reconcile_recorded_outcomes(recorded, active.forced_outcome);
-        let exit = classify_exit(recorded, join, cancelled);
+        let cancellation = if cancelled {
+            Cancellation::Observed
+        } else {
+            Cancellation::NotObserved
+        };
+        let exit = classify_exit(recorded, join, cancellation);
         child.restarts.settle_if_stable(
             active.started_at,
             runtime::now(),
@@ -2201,7 +2222,7 @@ impl ScopeRuntime {
             // never-started child or a child between restart incarnations
             // keeps its already-authoritative verdict while disposal remains
             // ordered ahead of terminal routing.
-            terminal.exit = Exit::new(ExitKind::Panicked { message }, terminal.exit.cancelled());
+            terminal.exit = Exit::new(ExitKind::Panicked { message }, terminal.exit.cancellation());
         }
 
         let exit = terminal.exit;
@@ -2954,15 +2975,20 @@ async fn run_scope_incarnation(
         if let Some(reason) = scope.finish_if_ready() {
             let root_exit = is_root.then(|| match &reason {
                 StopReason::Finished | StopReason::ShutdownRequested => {
-                    Exit::new(ExitKind::Completed, reason == StopReason::ShutdownRequested)
+                    let cancellation = if reason == StopReason::ShutdownRequested {
+                        Cancellation::Observed
+                    } else {
+                        Cancellation::NotObserved
+                    };
+                    Exit::new(ExitKind::Completed, cancellation)
                 }
                 StopReason::IntensityTripped(trip) => Exit::new(
                     ExitKind::Failed(crate::ExitError::from_intensity_trip(trip.clone())),
-                    false,
+                    Cancellation::NotObserved,
                 ),
                 StopReason::StartupFailed(failure) => Exit::new(
                     ExitKind::Failed(crate::ExitError::from_startup_failure(failure.clone())),
-                    false,
+                    Cancellation::NotObserved,
                 ),
                 StopReason::NeverStarted => Exit::never_started(),
             });
@@ -3024,10 +3050,10 @@ mod tests {
     };
 
     use crate::{
-        ActorRef, ChildId, ChildState, DynamicTree, Exit, ExitError, ExitKind, Intensity,
-        LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Readiness, ReadinessDeadline,
-        RemoveOutcome, Retention, ScopeState, SendErrorKind, StartupError, StartupFailureCause,
-        StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
+        ActorRef, Cancellation, ChildId, ChildState, DynamicTree, Exit, ExitError, ExitKind,
+        GracePhase, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Readiness,
+        ReadinessDeadline, RemoveOutcome, Retention, ScopeState, SendErrorKind, StartupError,
+        StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
         engine::{Epoch, ScopeLifecycle, StopLadder, arbitrate},
         exit::{JoinVerdict, RecordedOutcome},
         identity::{FenceCounter, ScopeIdentity},
@@ -3173,7 +3199,12 @@ mod tests {
         scope.finish_root_incarnation(
             epoch,
             StopReason::ShutdownRequested,
-            Exit::new(ExitKind::Aborted { after_grace: false }, true),
+            Exit::new(
+                ExitKind::Aborted {
+                    phase: GracePhase::WithinGrace,
+                },
+                Cancellation::Observed,
+            ),
         );
         assert!(matches!(
             scope.member.record().stage,
@@ -4135,7 +4166,7 @@ mod tests {
         let first_exit = Exit::never_started();
         let probe = Arc::new(ObserveMemberOnMailboxWake {
             member: Arc::clone(&member),
-            competing_exit: Exit::new(ExitKind::Completed, false),
+            competing_exit: Exit::new(ExitKind::Completed, Cancellation::NotObserved),
             observed: Mutex::new(None),
         });
         let waker = Waker::from(Arc::clone(&probe));
@@ -4176,7 +4207,7 @@ mod tests {
         member.stage_terminal_before_mailbox(first_exit.clone());
         let probe = Arc::new(ObserveMemberOnMailboxWake {
             member: Arc::clone(&member),
-            competing_exit: Exit::new(ExitKind::Completed, false),
+            competing_exit: Exit::new(ExitKind::Completed, Cancellation::NotObserved),
             observed: Mutex::new(None),
         });
         let waker = Waker::from(Arc::clone(&probe));
@@ -4212,18 +4243,21 @@ mod tests {
             identity.mint_membership(&id).expect("membership available"),
         );
         let start = Arc::new(Barrier::new(3));
-        let workers = [Exit::never_started(), Exit::new(ExitKind::Completed, false)]
-            .into_iter()
-            .map(|exit| {
-                let member = Arc::clone(&member);
-                let start = Arc::clone(&start);
-                std::thread::spawn(move || {
-                    start.wait();
-                    member.terminalize(exit);
-                    assert!(matches!(member.record().stage, MemberStage::Terminal(_)));
-                })
+        let workers = [
+            Exit::never_started(),
+            Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+        ]
+        .into_iter()
+        .map(|exit| {
+            let member = Arc::clone(&member);
+            let start = Arc::clone(&start);
+            std::thread::spawn(move || {
+                start.wait();
+                member.terminalize(exit);
+                assert!(matches!(member.record().stage, MemberStage::Terminal(_)));
             })
-            .collect::<Vec<_>>();
+        })
+        .collect::<Vec<_>>();
         start.wait();
         for worker in workers {
             worker.join().expect("terminalizer thread succeeds");
@@ -4638,7 +4672,7 @@ mod tests {
         let member = MemberCell::new(id, membership);
         let previous = Exit::new(
             ExitKind::Failed(ExitError::message("last completed incarnation")),
-            false,
+            Cancellation::NotObserved,
         );
         member.update(|record| {
             record.stage = MemberStage::Restarting;
@@ -4715,7 +4749,7 @@ mod tests {
         };
         let previous = Exit::new(
             ExitKind::Failed(ExitError::message("last completed incarnation")),
-            false,
+            Cancellation::NotObserved,
         );
         root.transition_child(
             &scope.children[key].slot.member,
@@ -4967,7 +5001,7 @@ mod tests {
         member.update(|record| {
             record.stage = MemberStage::Restarting;
             record.last_incarnation = Some(first);
-            record.last_exit = Some(Exit::new(ExitKind::Completed, false));
+            record.last_exit = Some(Exit::new(ExitKind::Completed, Cancellation::NotObserved));
         });
         scope.set_state(ScopeState::Stopped {
             reason: StopReason::Finished,
@@ -4989,7 +5023,7 @@ mod tests {
         assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Empty));
         assert!(parent.terminalize_child(
             &member,
-            Exit::new(ExitKind::Completed, false),
+            Exit::new(ExitKind::Completed, Cancellation::NotObserved),
             None,
             false
         ));

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use crate::{
-    Exit, Intensity, Readiness, RestartPolicy, Shutdown, deadline::Deadline, exit::StopReason,
-    policy::tidy_abort_beat,
+    Exit, GracePhase, Intensity, Readiness, RestartPolicy, Shutdown, deadline::Deadline,
+    exit::StopReason, policy::tidy_abort_beat,
 };
 
 /// Deterministic priority when one driver wake exposes several events.
@@ -32,8 +32,8 @@ pub(crate) fn arbitrate<T>(events: &mut [(ArbitrationClass, T)]) {
 pub(crate) enum StopAction {
     Cancel,
     Escalate,
-    AbortFramework { after_grace: bool },
-    HardAbort { after_grace: bool },
+    AbortFramework { phase: GracePhase },
+    HardAbort { phase: GracePhase },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -51,7 +51,7 @@ pub(crate) struct StopLadder {
     policy: Shutdown,
     phase: StopPhase,
     deadline: Option<Instant>,
-    after_grace: bool,
+    grace_phase: GracePhase,
     force_requested: bool,
     framework_driver: bool,
     framework_abort_acked: bool,
@@ -71,7 +71,7 @@ impl StopLadder {
             policy,
             phase: StopPhase::Idle,
             deadline: None,
-            after_grace: false,
+            grace_phase: GracePhase::WithinGrace,
             force_requested: false,
             framework_driver,
             framework_abort_acked: false,
@@ -92,7 +92,7 @@ impl StopLadder {
                 && matches!(self.policy, Shutdown::Graceful { .. })
                 && self.deadline.is_some_and(|deadline| now >= deadline)
             {
-                self.after_grace = true;
+                self.grace_phase = GracePhase::AfterGrace;
             }
             self.deadline = Some(now);
         }
@@ -127,7 +127,7 @@ impl StopLadder {
                 let grace = match self.policy {
                     Shutdown::Graceful { grace } => {
                         if !self.force_requested {
-                            self.after_grace = true;
+                            self.grace_phase = GracePhase::AfterGrace;
                         }
                         grace
                     }
@@ -137,7 +137,7 @@ impl StopLadder {
                 // A forced ladder is the `Abort` policy's zero-grace point on
                 // this same ladder (§10), so it takes the zero-grace tidy beat
                 // rather than one scaled to the grace force just skipped. The
-                // `after_grace` provenance above is unaffected: whether grace
+                // Grace-phase provenance above is unaffected: whether grace
                 // actually expired is a separate fact from how long the beat
                 // between escalation and hard abort runs.
                 let beat = if self.force_requested {
@@ -153,13 +153,13 @@ impl StopLadder {
                     self.phase = StopPhase::AbortingFramework;
                     self.deadline = Deadline::after(now, tidy_abort_beat(Duration::ZERO)).instant();
                     Some(StopAction::AbortFramework {
-                        after_grace: self.after_grace,
+                        phase: self.grace_phase,
                     })
                 } else {
                     self.phase = StopPhase::Finished;
                     self.deadline = None;
                     Some(StopAction::HardAbort {
-                        after_grace: self.after_grace,
+                        phase: self.grace_phase,
                     })
                 }
             }
@@ -169,7 +169,7 @@ impl StopLadder {
                 self.phase = StopPhase::Finished;
                 self.deadline = None;
                 (!self.framework_abort_acked).then_some(StopAction::HardAbort {
-                    after_grace: self.after_grace,
+                    phase: self.grace_phase,
                 })
             }
             StopPhase::Cooperative
@@ -862,7 +862,8 @@ mod tests {
     };
 
     use crate::{
-        Exit, ExitKind, Intensity, RestartCondition, RestartPolicy, Shutdown, policy::Backoff,
+        Cancellation, Exit, ExitKind, GracePhase, Intensity, RestartCondition, RestartPolicy,
+        Shutdown, policy::Backoff,
     };
 
     use super::{
@@ -902,7 +903,9 @@ mod tests {
         assert_eq!(graceful.advance(start + grace), Some(StopAction::Escalate));
         assert_eq!(
             graceful.advance(graceful.deadline().expect("tidy deadline")),
-            Some(StopAction::HardAbort { after_grace: true })
+            Some(StopAction::HardAbort {
+                phase: GracePhase::AfterGrace
+            })
         );
 
         let mut abort = StopLadder::new(Shutdown::Abort);
@@ -910,7 +913,9 @@ mod tests {
         assert_eq!(abort.advance(start), Some(StopAction::Escalate));
         assert_eq!(
             abort.advance(abort.deadline().expect("tidy deadline")),
-            Some(StopAction::HardAbort { after_grace: false })
+            Some(StopAction::HardAbort {
+                phase: GracePhase::WithinGrace
+            })
         );
     }
 
@@ -952,7 +957,9 @@ mod tests {
         );
         assert_eq!(
             ladder.advance(tidy),
-            Some(StopAction::HardAbort { after_grace: false })
+            Some(StopAction::HardAbort {
+                phase: GracePhase::WithinGrace
+            })
         );
         ladder.force(tidy);
         assert_eq!(
@@ -974,7 +981,9 @@ mod tests {
             .expect("abort policy keeps the first tidy beat");
         assert_eq!(
             ladder.advance(tidy),
-            Some(StopAction::AbortFramework { after_grace: false })
+            Some(StopAction::AbortFramework {
+                phase: GracePhase::WithinGrace
+            })
         );
         ladder.acknowledge_framework_abort();
         let framework_tidy = ladder
@@ -989,12 +998,16 @@ mod tests {
         let tidy = unacked.deadline().expect("abort tidy beat");
         assert_eq!(
             unacked.advance(tidy),
-            Some(StopAction::AbortFramework { after_grace: false })
+            Some(StopAction::AbortFramework {
+                phase: GracePhase::WithinGrace
+            })
         );
         let framework_tidy = unacked.deadline().expect("framework tidy beat");
         assert_eq!(
             unacked.advance(framework_tidy),
-            Some(StopAction::HardAbort { after_grace: false })
+            Some(StopAction::HardAbort {
+                phase: GracePhase::WithinGrace
+            })
         );
     }
 
@@ -1012,7 +1025,10 @@ mod tests {
 
     #[test]
     fn funnel_dispatch_depends_on_mode_and_membership_state() {
-        let failure = Exit::new(ExitKind::Failed(crate::ExitError::message("boom")), false);
+        let failure = Exit::new(
+            ExitKind::Failed(crate::ExitError::message("boom")),
+            Cancellation::NotObserved,
+        );
         let restart = RestartPolicy::new(RestartCondition::OnFailure, Backoff::Immediate);
         assert_eq!(
             dispatch_exit(

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -228,6 +228,24 @@ impl fmt::Display for StructuredStartupFailure {
 
 impl Error for StructuredStartupFailure {}
 
+/// Whether an incarnation observed supervisor cancellation before exiting.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Cancellation {
+    /// The incarnation completed without observing supervisor cancellation.
+    NotObserved,
+    /// The incarnation's shutdown token fired before its outcome was recorded.
+    Observed,
+}
+
+/// Whether a forced abort happened before or after cooperative grace expired.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum GracePhase {
+    /// The future was aborted before the grace deadline expired.
+    WithinGrace,
+    /// The future was aborted after the grace deadline expired.
+    AfterGrace,
+}
+
 /// The structured result of one child incarnation or never-started
 /// membership.
 ///
@@ -243,14 +261,14 @@ impl Error for StructuredStartupFailure {}
 #[derive(Clone, Debug)]
 pub struct Exit {
     kind: ExitKind,
-    cancelled: bool,
+    cancellation: Cancellation,
 }
 
 impl Exit {
     /// Creates an exit from its kind and cancellation observation.
     #[must_use]
-    pub const fn new(kind: ExitKind, cancelled: bool) -> Self {
-        Self { kind, cancelled }
+    pub const fn new(kind: ExitKind, cancellation: Cancellation) -> Self {
+        Self { kind, cancellation }
     }
 
     /// Returns the exit kind.
@@ -259,11 +277,10 @@ impl Exit {
         &self.kind
     }
 
-    /// Reports whether the incarnation's shutdown token fired before its
-    /// outcome was recorded.
+    /// Returns the incarnation's supervisor-cancellation observation.
     #[must_use]
-    pub const fn cancelled(&self) -> bool {
-        self.cancelled
+    pub const fn cancellation(&self) -> Cancellation {
+        self.cancellation
     }
 
     /// Reports whether this exit participates in failure restart policy.
@@ -275,7 +292,7 @@ impl Exit {
     /// Constructs the membership-level never-started exit.
     #[must_use]
     pub const fn never_started() -> Self {
-        Self::new(ExitKind::NeverStarted, false)
+        Self::new(ExitKind::NeverStarted, Cancellation::NotObserved)
     }
 }
 
@@ -285,7 +302,7 @@ impl Exit {
 /// no content equality to consult.
 impl PartialEq for Exit {
     fn eq(&self, other: &Self) -> bool {
-        self.cancelled == other.cancelled && exit_kind_eq(&self.kind, &other.kind)
+        self.cancellation == other.cancellation && exit_kind_eq(&self.kind, &other.kind)
     }
 }
 
@@ -303,9 +320,7 @@ fn exit_kind_eq(left: &ExitKind, right: &ExitKind) -> bool {
             ExitKind::ReadinessTimedOut { deadline: left },
             ExitKind::ReadinessTimedOut { deadline: right },
         ) => left == right,
-        (ExitKind::Aborted { after_grace: left }, ExitKind::Aborted { after_grace: right }) => {
-            left == right
-        }
+        (ExitKind::Aborted { phase: left }, ExitKind::Aborted { phase: right }) => left == right,
         _ => false,
     }
 }
@@ -333,8 +348,8 @@ pub enum ExitKind {
     },
     /// The incarnation future was destroyed before producing an outcome.
     Aborted {
-        /// Whether cooperative grace expired before the abort.
-        after_grace: bool,
+        /// Cooperative-grace phase in which the abort happened.
+        phase: GracePhase,
     },
     /// The membership terminalized without spawning an incarnation.
     NeverStarted,
@@ -346,14 +361,14 @@ pub(crate) enum RecordedOutcome {
     Returned(ExitResult),
     Panicked { message: Option<String> },
     ReadinessTimedOut { deadline: Instant },
-    Aborted { after_grace: bool },
+    Aborted { phase: GracePhase },
 }
 
 #[derive(Clone, Debug)]
 pub(crate) enum JoinVerdict {
     Completed,
     Panicked { message: Option<String> },
-    Cancelled { after_grace: bool },
+    Cancelled { phase: GracePhase },
 }
 
 /// Reconciles task-produced evidence with a later supervisor-forced outcome.
@@ -389,22 +404,24 @@ pub(crate) fn reconcile_recorded_outcomes(
 pub(crate) fn classify_exit(
     recorded: Option<RecordedOutcome>,
     join: JoinVerdict,
-    cancelled: bool,
+    cancellation: Cancellation,
 ) -> Exit {
     let recorded_kind = recorded.map(recorded_kind);
     let join_kind = match join {
         JoinVerdict::Completed => None,
         JoinVerdict::Panicked { message } => Some(ExitKind::Panicked { message }),
-        JoinVerdict::Cancelled { after_grace } => Some(ExitKind::Aborted { after_grace }),
+        JoinVerdict::Cancelled { phase } => Some(ExitKind::Aborted { phase }),
     };
 
     let kind = match (recorded_kind, join_kind) {
         (Some(recorded), Some(join)) if rank(&recorded) >= rank(&join) => recorded,
         (_, Some(join)) => join,
         (Some(recorded), None) => recorded,
-        (None, None) => ExitKind::Aborted { after_grace: false },
+        (None, None) => ExitKind::Aborted {
+            phase: GracePhase::WithinGrace,
+        },
     };
-    Exit::new(kind, cancelled)
+    Exit::new(kind, cancellation)
 }
 
 fn recorded_kind(recorded: RecordedOutcome) -> ExitKind {
@@ -413,7 +430,7 @@ fn recorded_kind(recorded: RecordedOutcome) -> ExitKind {
         RecordedOutcome::Returned(Err(error)) => ExitKind::Failed(error),
         RecordedOutcome::Panicked { message } => ExitKind::Panicked { message },
         RecordedOutcome::ReadinessTimedOut { deadline } => ExitKind::ReadinessTimedOut { deadline },
-        RecordedOutcome::Aborted { after_grace } => ExitKind::Aborted { after_grace },
+        RecordedOutcome::Aborted { phase } => ExitKind::Aborted { phase },
     }
 }
 
@@ -474,8 +491,8 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use super::{
-        ChildId, Exit, ExitError, ExitKind, JoinVerdict, RecordedOutcome, StartupFailure,
-        StartupFailureCause, classify_exit, reconcile_recorded_outcomes,
+        Cancellation, ChildId, Exit, ExitError, ExitKind, GracePhase, JoinVerdict, RecordedOutcome,
+        StartupFailure, StartupFailureCause, classify_exit, reconcile_recorded_outcomes,
     };
 
     #[test]
@@ -487,29 +504,38 @@ mod tests {
                 "recorded completion",
                 Some(RecordedOutcome::Returned(Ok(()))),
                 JoinVerdict::Completed,
-                false,
-                Exit::new(ExitKind::Completed, false),
+                Cancellation::NotObserved,
+                Exit::new(ExitKind::Completed, Cancellation::NotObserved),
             ),
             (
                 "cancellation overrides recorded completion",
                 Some(RecordedOutcome::Returned(Ok(()))),
-                JoinVerdict::Cancelled { after_grace: true },
-                true,
-                Exit::new(ExitKind::Aborted { after_grace: true }, true),
+                JoinVerdict::Cancelled {
+                    phase: GracePhase::AfterGrace,
+                },
+                Cancellation::Observed,
+                Exit::new(
+                    ExitKind::Aborted {
+                        phase: GracePhase::AfterGrace,
+                    },
+                    Cancellation::Observed,
+                ),
             ),
             (
                 "recorded failure",
                 Some(RecordedOutcome::Returned(Err(failure.clone()))),
                 JoinVerdict::Completed,
-                false,
-                Exit::new(ExitKind::Failed(failure.clone()), false),
+                Cancellation::NotObserved,
+                Exit::new(ExitKind::Failed(failure.clone()), Cancellation::NotObserved),
             ),
             (
                 "late cancellation preserves recorded failure",
                 Some(RecordedOutcome::Returned(Err(failure.clone()))),
-                JoinVerdict::Cancelled { after_grace: true },
-                true,
-                Exit::new(ExitKind::Failed(failure.clone()), true),
+                JoinVerdict::Cancelled {
+                    phase: GracePhase::AfterGrace,
+                },
+                Cancellation::Observed,
+                Exit::new(ExitKind::Failed(failure.clone()), Cancellation::Observed),
             ),
             (
                 "join panic overrides recorded failure",
@@ -517,20 +543,25 @@ mod tests {
                 JoinVerdict::Panicked {
                     message: Some("drop panic".to_owned()),
                 },
-                false,
+                Cancellation::NotObserved,
                 Exit::new(
                     ExitKind::Panicked {
                         message: Some("drop panic".to_owned()),
                     },
-                    false,
+                    Cancellation::NotObserved,
                 ),
             ),
             (
                 "readiness timeout overrides cancellation",
                 Some(RecordedOutcome::ReadinessTimedOut { deadline }),
-                JoinVerdict::Cancelled { after_grace: true },
-                true,
-                Exit::new(ExitKind::ReadinessTimedOut { deadline }, true),
+                JoinVerdict::Cancelled {
+                    phase: GracePhase::AfterGrace,
+                },
+                Cancellation::Observed,
+                Exit::new(
+                    ExitKind::ReadinessTimedOut { deadline },
+                    Cancellation::Observed,
+                ),
             ),
             (
                 "join panic overrides recorded completion",
@@ -538,12 +569,12 @@ mod tests {
                 JoinVerdict::Panicked {
                     message: Some("drop panic".to_owned()),
                 },
-                false,
+                Cancellation::NotObserved,
                 Exit::new(
                     ExitKind::Panicked {
                         message: Some("drop panic".to_owned()),
                     },
-                    false,
+                    Cancellation::NotObserved,
                 ),
             ),
             (
@@ -554,60 +585,94 @@ mod tests {
                 JoinVerdict::Panicked {
                     message: Some("drop panic".to_owned()),
                 },
-                true,
+                Cancellation::Observed,
                 Exit::new(
                     ExitKind::Panicked {
                         message: Some("callback panic".to_owned()),
                     },
-                    true,
+                    Cancellation::Observed,
                 ),
             ),
             (
                 "earlier recorded abort wins a tie",
-                Some(RecordedOutcome::Aborted { after_grace: false }),
-                JoinVerdict::Cancelled { after_grace: true },
-                true,
-                Exit::new(ExitKind::Aborted { after_grace: false }, true),
+                Some(RecordedOutcome::Aborted {
+                    phase: GracePhase::WithinGrace,
+                }),
+                JoinVerdict::Cancelled {
+                    phase: GracePhase::AfterGrace,
+                },
+                Cancellation::Observed,
+                Exit::new(
+                    ExitKind::Aborted {
+                        phase: GracePhase::WithinGrace,
+                    },
+                    Cancellation::Observed,
+                ),
             ),
             (
                 "join cancellation supplies a missing outcome",
                 None,
-                JoinVerdict::Cancelled { after_grace: true },
-                true,
-                Exit::new(ExitKind::Aborted { after_grace: true }, true),
+                JoinVerdict::Cancelled {
+                    phase: GracePhase::AfterGrace,
+                },
+                Cancellation::Observed,
+                Exit::new(
+                    ExitKind::Aborted {
+                        phase: GracePhase::AfterGrace,
+                    },
+                    Cancellation::Observed,
+                ),
             ),
             (
                 "missing outcome fails closed",
                 None,
                 JoinVerdict::Completed,
-                false,
-                Exit::new(ExitKind::Aborted { after_grace: false }, false),
+                Cancellation::NotObserved,
+                Exit::new(
+                    ExitKind::Aborted {
+                        phase: GracePhase::WithinGrace,
+                    },
+                    Cancellation::NotObserved,
+                ),
             ),
         ];
 
-        for (case, recorded, join, cancelled, expected) in cases {
-            assert_eq!(classify_exit(recorded, join, cancelled), expected, "{case}");
+        for (case, recorded, join, cancellation, expected) in cases {
+            assert_eq!(
+                classify_exit(recorded, join, cancellation),
+                expected,
+                "{case}"
+            );
         }
     }
 
     #[test]
     fn failed_exit_equality_is_shared_provenance_not_content() {
         let error = ExitError::message("boom");
-        let exit = Exit::new(ExitKind::Failed(error.clone()), false);
+        let exit = Exit::new(ExitKind::Failed(error.clone()), Cancellation::NotObserved);
 
         // Clones of one error — including framework-published copies —
         // compare equal.
         assert_eq!(exit, exit.clone());
-        assert_eq!(exit, Exit::new(ExitKind::Failed(error.clone()), false));
+        assert_eq!(
+            exit,
+            Exit::new(ExitKind::Failed(error.clone()), Cancellation::NotObserved)
+        );
 
         // Independently created errors with identical content do not.
         assert_ne!(
             exit,
-            Exit::new(ExitKind::Failed(ExitError::message("boom")), false)
+            Exit::new(
+                ExitKind::Failed(ExitError::message("boom")),
+                Cancellation::NotObserved
+            )
         );
 
         // Cancellation remains structural even with shared provenance.
-        assert_ne!(exit, Exit::new(ExitKind::Failed(error), true));
+        assert_ne!(
+            exit,
+            Exit::new(ExitKind::Failed(error), Cancellation::Observed)
+        );
     }
 
     #[test]
@@ -622,20 +687,34 @@ mod tests {
             (
                 "application failure survives forced abort",
                 Some(RecordedOutcome::Returned(Err(failure.clone()))),
-                Some(RecordedOutcome::Aborted { after_grace: true }),
-                Exit::new(ExitKind::Failed(failure), true),
+                Some(RecordedOutcome::Aborted {
+                    phase: GracePhase::AfterGrace,
+                }),
+                Exit::new(ExitKind::Failed(failure), Cancellation::Observed),
             ),
             (
                 "forced readiness timeout overrides completion",
                 Some(RecordedOutcome::Returned(Ok(()))),
                 Some(RecordedOutcome::ReadinessTimedOut { deadline }),
-                Exit::new(ExitKind::ReadinessTimedOut { deadline }, true),
+                Exit::new(
+                    ExitKind::ReadinessTimedOut { deadline },
+                    Cancellation::Observed,
+                ),
             ),
             (
                 "earlier abort evidence wins a tie",
-                Some(RecordedOutcome::Aborted { after_grace: false }),
-                Some(RecordedOutcome::Aborted { after_grace: true }),
-                Exit::new(ExitKind::Aborted { after_grace: false }, true),
+                Some(RecordedOutcome::Aborted {
+                    phase: GracePhase::WithinGrace,
+                }),
+                Some(RecordedOutcome::Aborted {
+                    phase: GracePhase::AfterGrace,
+                }),
+                Exit::new(
+                    ExitKind::Aborted {
+                        phase: GracePhase::WithinGrace,
+                    },
+                    Cancellation::Observed,
+                ),
             ),
         ];
 
@@ -644,8 +723,10 @@ mod tests {
             assert_eq!(
                 classify_exit(
                     reconciled,
-                    JoinVerdict::Cancelled { after_grace: true },
-                    true
+                    JoinVerdict::Cancelled {
+                        phase: GracePhase::AfterGrace
+                    },
+                    Cancellation::Observed
                 ),
                 expected,
                 "{case}"

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -26,8 +26,9 @@ pub use actor::{Actor, ActorDef, ActorOnceDef, Context, Handler, StopContext};
 pub use admission::{NotAdmittingCause, RemoveOutcome, ReserveError};
 pub use cancellation::CancellationToken;
 pub use exit::{
-    Exit, ExitError, ExitKind, ExitResult, IntensityTrip, ShutdownStraggler, ShutdownTimeout,
-    StartupError, StartupFailure, StartupFailureCause, StopReason,
+    Cancellation, Exit, ExitError, ExitKind, ExitResult, GracePhase, IntensityTrip,
+    ShutdownStraggler, ShutdownTimeout, StartupError, StartupFailure, StartupFailureCause,
+    StopReason,
 };
 pub use identity::{ChildId, Incarnation, Membership};
 pub use mailbox::{

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -320,7 +320,7 @@ mod tests {
     };
 
     use crate::{
-        ChildId, Exit, ExitKind,
+        Cancellation, ChildId, Exit, ExitKind, GracePhase,
         cells::MemberCell,
         identity::ScopeIdentity,
         runtime::{self, Latch},
@@ -406,7 +406,7 @@ mod tests {
         let mut context = Context::from_waker(Waker::noop());
 
         assert!(matches!(waiting.as_mut().poll(&mut context), Poll::Pending));
-        member.terminalize(Exit::new(ExitKind::Completed, false));
+        member.terminalize(Exit::new(ExitKind::Completed, Cancellation::NotObserved));
         assert_eq!(waiting.await, Ok(42));
     }
 
@@ -416,7 +416,12 @@ mod tests {
         sender.send(42_u8).expect("claim remains open");
         let mut waiting = Box::pin(claim.wait());
         let mut context = Context::from_waker(Waker::noop());
-        let exit = Exit::new(ExitKind::Aborted { after_grace: false }, true);
+        let exit = Exit::new(
+            ExitKind::Aborted {
+                phase: GracePhase::WithinGrace,
+            },
+            Cancellation::Observed,
+        );
 
         assert!(matches!(waiting.as_mut().poll(&mut context), Poll::Pending));
         member.terminalize(exit.clone());
@@ -428,7 +433,7 @@ mod tests {
     async fn completed_terminal_publication_requires_a_typed_value() {
         let (sender, claim, member) = one_shot_claim::<u8>();
         drop(sender);
-        member.terminalize(Exit::new(ExitKind::Completed, false));
+        member.terminalize(Exit::new(ExitKind::Completed, Cancellation::NotObserved));
 
         let _ = claim.wait().await;
     }

--- a/crates/shelterwood/tests/acceptance/sidecar.rs
+++ b/crates/shelterwood/tests/acceptance/sidecar.rs
@@ -2,9 +2,9 @@ use std::{future, time::Duration};
 
 use crate::common::{POLL_TIMEOUT, ReleaseGate, policy::never, poll_until};
 use shelterwood::{
-    Actor, ActorOnceDef, ChildState, Context, ExitError, ExitKind, ExitResult, Readiness,
-    ReadinessDeadline, Shutdown, StartOrShutdownError, StopContext, SubtreeOnceDef, TaskDef,
-    TaskRef, Tree,
+    Actor, ActorOnceDef, ChildState, Context, ExitError, ExitKind, ExitResult, GracePhase,
+    Readiness, ReadinessDeadline, Shutdown, StartOrShutdownError, StopContext, SubtreeOnceDef,
+    TaskDef, TaskRef, Tree,
 };
 
 type JournalEvent = (usize, &'static str, &'static str);
@@ -229,11 +229,15 @@ async fn sidecar_runs_two_host_owned_cycles_with_readiness_and_policy_exact_shut
         let graceful_exit = fixture.graceful_task.wait().await;
         assert!(matches!(
             abort_exit.kind(),
-            ExitKind::Aborted { after_grace: false }
+            ExitKind::Aborted {
+                phase: GracePhase::WithinGrace
+            }
         ));
         assert!(matches!(
             graceful_exit.kind(),
-            ExitKind::Aborted { after_grace: true }
+            ExitKind::Aborted {
+                phase: GracePhase::AfterGrace
+            }
         ));
         assert_eq!(
             log.events(cycle, "abort-worker"),

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -2,14 +2,15 @@ use std::{cell::Cell, error::Error, hash::Hash, time::Duration};
 
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, ActorSlot, Admission, Blocking, BuildError, CallError,
-    CallFuture, CancellationToken, Context, DeadlineElapsed, DefaultsInheritance, DynamicActorSlot,
-    DynamicScopeRef, DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, ExitError, ExitResult,
-    Guard, Handler, Incarnation, Intensity, LifecycleEvents, LifecycleTryRecvError, Mailbox,
-    MailboxShutdown, Membership, OneShotTaskRef, RawActor, RawContext, RawDef, RawOnceDef,
-    Readiness, ReadinessDeadline, Removal, Reply, ReplyReceive, ReplyReceiver, ReserveError,
-    RestartPolicy, Retention, ScopeDefaults, ScopeRef, SendError, SendFuture, SendTimeout,
-    Shutdown, SnapshotClosed, SnapshotReceiver, StopContext, Strategy, SubtreeDef, SubtreeOnceDef,
-    SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, Tree, WaitError,
+    CallFuture, Cancellation, CancellationToken, Context, DeadlineElapsed, DefaultsInheritance,
+    DynamicActorSlot, DynamicScopeRef, DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, ExitError,
+    ExitResult, GracePhase, Guard, Handler, Incarnation, Intensity, LifecycleEvents,
+    LifecycleTryRecvError, Mailbox, MailboxShutdown, Membership, OneShotTaskRef, RawActor,
+    RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline, Removal, Reply, ReplyReceive,
+    ReplyReceiver, ReserveError, RestartPolicy, Retention, ScopeDefaults, ScopeRef, SendError,
+    SendFuture, SendTimeout, Shutdown, SnapshotClosed, SnapshotReceiver, StopContext, Strategy,
+    SubtreeDef, SubtreeOnceDef, SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, Tree,
+    WaitError,
 };
 
 fn assert_error<T: Error>() {}
@@ -24,6 +25,8 @@ fn assert_static<T: 'static>() {}
 fn documented_identity_handle_token_and_owned_value_bounds_compile() {
     assert_copy_eq_hash_send_sync::<Membership>();
     assert_copy_eq_hash_send_sync::<Incarnation>();
+    assert_copy_eq_hash_send_sync::<Cancellation>();
+    assert_copy_eq_hash_send_sync::<GracePhase>();
 
     assert_clone_eq_hash_send_sync::<ActorRef<Cell<()>>>();
     assert_clone_eq_hash_send_sync::<TaskRef>();

--- a/crates/shelterwood/tests/defaults.rs
+++ b/crates/shelterwood/tests/defaults.rs
@@ -12,8 +12,8 @@ use std::{
 
 use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
 use shelterwood::{
-    Actor, ActorDef, Context, ExitError, ExitKind, ExitResult, Readiness, SendErrorKind,
-    StartupError, StopReason, TaskDef, Tree,
+    Actor, ActorDef, Context, ExitError, ExitKind, ExitResult, GracePhase, Readiness,
+    SendErrorKind, StartupError, StopReason, TaskDef, Tree,
 };
 
 enum CapacityMessage {
@@ -120,7 +120,12 @@ async fn default_child_shutdown_grace_is_five_seconds() {
 
     let exit = task.wait().await;
     assert!(
-        matches!(exit.kind(), ExitKind::Aborted { after_grace: true }),
+        matches!(
+            exit.kind(),
+            ExitKind::Aborted {
+                phase: GracePhase::AfterGrace
+            }
+        ),
         "an uncooperative task is aborted after the default grace: {exit:?}"
     );
 }

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -15,8 +15,8 @@ use crate::common::{
     poll_until,
 };
 use shelterwood::{
-    Backoff, CallErrorKind, ChildState, DynamicTree, ExitError, ExitKind, ExitResult, Jitter,
-    LifecycleEventKind, LifecycleItem, Mailbox, RawActor, RawContext, RawDef, RawOnceDef,
+    Backoff, CallErrorKind, Cancellation, ChildState, DynamicTree, ExitError, ExitKind, ExitResult,
+    Jitter, LifecycleEventKind, LifecycleItem, Mailbox, RawActor, RawContext, RawDef, RawOnceDef,
     Readiness, ReadinessDeadline, RemoveOutcome, Reply, ReserveError, RestartCondition,
     RestartPolicy, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
 };
@@ -245,7 +245,7 @@ async fn panicking_unread_messages_are_all_disposed_without_reclassifying_the_ac
         }
     };
     assert!(matches!(exit.kind(), ExitKind::Completed));
-    assert!(exit.cancelled());
+    assert_eq!(exit.cancellation(), Cancellation::Observed);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -819,7 +819,7 @@ async fn hard_shutdown_detaches_a_blocking_factory_disposal() {
     result.expect("post-exit disposal is not an actor straggler");
     let exit = task.wait().await;
     assert!(matches!(exit.kind(), ExitKind::Completed));
-    assert!(exit.cancelled());
+    assert_eq!(exit.cancellation(), Cancellation::Observed);
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -8,9 +8,9 @@ use std::{
 
 use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until};
 use shelterwood::{
-    Actor, ActorOnceDef, Context, Exit, ExitError, ExitKind, ExitResult, LifecycleEventKind,
-    LifecycleEvents, LifecycleItem, Mailbox, MailboxShutdown, SendErrorKind, Shutdown, StopContext,
-    Tree,
+    Actor, ActorOnceDef, Cancellation, Context, Exit, ExitError, ExitKind, ExitResult, GracePhase,
+    LifecycleEventKind, LifecycleEvents, LifecycleItem, Mailbox, MailboxShutdown, SendErrorKind,
+    Shutdown, StopContext, Tree,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -397,7 +397,7 @@ async fn handler_discard_skips_the_prefix_and_still_runs_on_stop() {
     assert_eq!(outcome.drained, 0);
     assert!(outcome.stop_entered);
     assert!(matches!(outcome.exit.kind(), ExitKind::Completed));
-    assert!(outcome.exit.cancelled());
+    assert_eq!(outcome.exit.cancellation(), Cancellation::Observed);
 }
 
 #[tokio::test(start_paused = true)]
@@ -457,7 +457,9 @@ async fn handler_drain_and_on_stop_share_one_grace_budget() {
     assert!(outcome.stop_entered);
     assert!(matches!(
         outcome.exit.kind(),
-        ExitKind::Aborted { after_grace: true }
+        ExitKind::Aborted {
+            phase: GracePhase::AfterGrace
+        }
     ));
     assert!(outcome.elapsed >= Duration::from_secs(10));
     assert!(

--- a/crates/shelterwood/tests/lifecycle.rs
+++ b/crates/shelterwood/tests/lifecycle.rs
@@ -11,9 +11,10 @@ use crate::common::{
     POLL_TIMEOUT, PanicOnDrop, ReleaseGate, assert_quiet, policy::never, poll_until,
 };
 use shelterwood::{
-    Actor, ActorOnceDef, Context, DynamicTree, ExitError, ExitKind, ExitResult, Intensity,
-    LifecycleEventKind, LifecycleItem, Readiness, Retention, ScopeState, Shutdown, StartupError,
-    StartupFailureCause, StopReason, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
+    Actor, ActorOnceDef, Cancellation, Context, DynamicTree, ExitError, ExitKind, ExitResult,
+    GracePhase, Intensity, LifecycleEventKind, LifecycleItem, Readiness, Retention, ScopeState,
+    Shutdown, StartupError, StartupFailureCause, StopReason, SubtreeOnceDef, TaskDef, TaskOnceDef,
+    Tree,
 };
 
 #[tokio::test]
@@ -82,7 +83,7 @@ async fn fire_and_forget_owner_drop_still_tears_down() {
         .await
         .expect("owner drop completes teardown");
     assert!(matches!(exit.kind(), ExitKind::Completed));
-    assert!(exit.cancelled());
+    assert_eq!(exit.cancellation(), Cancellation::Observed);
 }
 
 #[tokio::test]
@@ -130,7 +131,9 @@ async fn framework_task_verdicts_remain_typed() {
         .expect("child grace bounds shutdown");
     assert!(matches!(
         abort_task.wait().await.kind(),
-        ExitKind::Aborted { after_grace: true }
+        ExitKind::Aborted {
+            phase: GracePhase::AfterGrace
+        }
     ));
 }
 
@@ -506,10 +509,15 @@ async fn abort_policy_task_exits_aborted_without_grace() {
         .expect("abort policy bounds teardown");
     let exit = task.wait().await;
     assert!(
-        matches!(exit.kind(), ExitKind::Aborted { after_grace: false }),
+        matches!(
+            exit.kind(),
+            ExitKind::Aborted {
+                phase: GracePhase::WithinGrace
+            }
+        ),
         "no grace ever ran, so the abort is not after-grace: {exit:?}"
     );
-    assert!(exit.cancelled());
+    assert_eq!(exit.cancellation(), Cancellation::Observed);
 }
 
 #[tokio::test]
@@ -536,5 +544,5 @@ async fn completion_during_the_tidy_beat_is_not_reclassified_as_abort() {
         matches!(exit.kind(), ExitKind::Completed),
         "the policy does not pre-decide the classification: {exit:?}"
     );
-    assert!(exit.cancelled());
+    assert_eq!(exit.cancellation(), Cancellation::Observed);
 }

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -10,8 +10,8 @@ use crate::common::{
     POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, policy::never, poll_until,
 };
 use shelterwood::{
-    ChildState, DynamicTree, ExitError, ExitKind, Readiness, ReadinessDeadline, ScopeState,
-    Shutdown, StartupError, StartupFailureCause, SubtreeOnceDef, TaskDef, Tree,
+    Cancellation, ChildState, DynamicTree, ExitError, ExitKind, Readiness, ReadinessDeadline,
+    ScopeState, Shutdown, StartupError, StartupFailureCause, SubtreeOnceDef, TaskDef, Tree,
 };
 
 #[tokio::test]
@@ -241,7 +241,7 @@ async fn ready_at_deadline_wins_and_shutdown_disarms_the_gate() {
     advance_time(width).await;
     let exit = shutdown_task.wait().await;
     assert!(matches!(exit.kind(), ExitKind::Completed));
-    assert!(exit.cancelled());
+    assert_eq!(exit.cancellation(), Cancellation::Observed);
 }
 
 #[tokio::test]
@@ -808,7 +808,7 @@ async fn nested_startup_rollback_includes_runtime_added_members() {
     runtime_cancelled.wait().await;
     let runtime_exit = runtime.wait().await;
     assert!(matches!(runtime_exit.kind(), ExitKind::Completed));
-    assert!(runtime_exit.cancelled());
+    assert_eq!(runtime_exit.cancellation(), Cancellation::Observed);
     assert!(matches!(
         nested.wait_stopped().await,
         shelterwood::StopReason::StartupFailed(_)

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -9,11 +9,12 @@ use std::{
 
 use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
 use shelterwood::{
-    Actor, ActorOnceDef, Backoff, ChildState, Context, DefaultsInheritance, DynamicTree, ExitError,
-    ExitKind, ExitResult, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError,
-    Mailbox, MailboxShutdown, Readiness, ReadinessDeadline, RestartCondition, RestartPolicy,
-    ScopeDefaults, SendErrorKind, Shutdown, StartupError, StartupFailureCause, StopReason,
-    SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef, TaskRef, Tree,
+    Actor, ActorOnceDef, Backoff, Cancellation, ChildState, Context, DefaultsInheritance,
+    DynamicTree, ExitError, ExitKind, ExitResult, GracePhase, Intensity, LifecycleEventKind,
+    LifecycleItem, LifecycleTryRecvError, Mailbox, MailboxShutdown, Readiness, ReadinessDeadline,
+    RestartCondition, RestartPolicy, ScopeDefaults, SendErrorKind, Shutdown, StartupError,
+    StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef, TaskRef,
+    Tree,
 };
 
 #[tokio::test]
@@ -462,7 +463,7 @@ async fn hard_aborted_subtree_descendants_still_publish_exits() {
         .await
         .expect("hard-aborted descendants terminalize");
     assert!(matches!(exit.kind(), ExitKind::Aborted { .. }));
-    assert!(exit.cancelled());
+    assert_eq!(exit.cancellation(), Cancellation::Observed);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -671,8 +672,9 @@ async fn locally_requested_subtree_shutdown_reads_cancelled() {
     };
     assert_eq!(id.as_str(), "nested");
     assert!(matches!(exit.kind(), ExitKind::Completed));
-    assert!(
-        exit.cancelled(),
+    assert_eq!(
+        exit.cancellation(),
+        Cancellation::Observed,
         "a locally requested shutdown is still a stop request: {exit:?}"
     );
 }
@@ -1018,11 +1020,15 @@ async fn subtree_shutdown_defaults_inherit_or_reset_end_to_end() {
         .expect("reset library grace eventually escalates");
     assert!(matches!(
         inherited_task.wait().await.kind(),
-        ExitKind::Aborted { after_grace: false }
+        ExitKind::Aborted {
+            phase: GracePhase::WithinGrace
+        }
     ));
     assert!(matches!(
         reset_task.wait().await.kind(),
-        ExitKind::Aborted { after_grace: true }
+        ExitKind::Aborted {
+            phase: GracePhase::AfterGrace
+        }
     ));
 
     system

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -2,14 +2,15 @@ use std::time::Duration;
 
 use crate::common::LiveFlag;
 use shelterwood::{
-    BuildError, DynamicTree, Exit, ExitError, ExitKind, Readiness, ReadinessDeadline,
-    RemoveOutcome, ReserveError, Shutdown, StopReason, TaskDef, TaskOnceDef, Tree,
+    BuildError, Cancellation, DynamicTree, Exit, ExitError, ExitKind, GracePhase, Readiness,
+    ReadinessDeadline, RemoveOutcome, ReserveError, Shutdown, StopReason, TaskDef, TaskOnceDef,
+    Tree,
 };
 
 #[test]
 fn public_exit_constructor_preserves_evidence_and_classifies_failures() {
-    let completed = Exit::new(ExitKind::Completed, true);
-    assert!(completed.cancelled());
+    let completed = Exit::new(ExitKind::Completed, Cancellation::Observed);
+    assert_eq!(completed.cancellation(), Cancellation::Observed);
     assert!(matches!(completed.kind(), ExitKind::Completed));
     assert!(!completed.is_failure());
 
@@ -21,11 +22,13 @@ fn public_exit_constructor_preserves_evidence_and_classifies_failures() {
         ExitKind::ReadinessTimedOut {
             deadline: std::time::Instant::now(),
         },
-        ExitKind::Aborted { after_grace: true },
+        ExitKind::Aborted {
+            phase: GracePhase::AfterGrace,
+        },
         ExitKind::NeverStarted,
     ] {
-        let exit = Exit::new(kind, false);
-        assert!(!exit.cancelled());
+        let exit = Exit::new(kind, Cancellation::NotObserved);
+        assert_eq!(exit.cancellation(), Cancellation::NotObserved);
         assert!(exit.is_failure(), "non-completed exit: {:?}", exit.kind());
     }
 }
@@ -306,7 +309,7 @@ async fn dropping_the_owner_requests_cooperative_shutdown() {
     system.wait_started().await.expect("tree starts");
     drop(system);
     let exit = task.wait().await;
-    assert!(exit.cancelled());
+    assert_eq!(exit.cancellation(), Cancellation::Observed);
     assert!(matches!(exit.kind(), ExitKind::Completed));
     assert_eq!(completion.wait().await, Ok(()));
     tokio::time::timeout(Duration::from_secs(1), async {
@@ -348,5 +351,5 @@ async fn cancelling_system_wait_keeps_drop_shutdown_armed() {
             .expect("dropping the cancelled wait requests shutdown"),
         StopReason::ShutdownRequested
     );
-    assert!(task.wait().await.cancelled());
+    assert_eq!(task.wait().await.cancellation(), Cancellation::Observed);
 }

--- a/docs/shutdown-and-resources.md
+++ b/docs/shutdown-and-resources.md
@@ -8,10 +8,10 @@ cooperative cancellation -> grace expiry -> tidy-abort beat -> hard abort
 
 `Shutdown::Abort` is the zero-grace point on that ladder. The shutdown token
 still fires strictly before the abort token, and the tidy beat still occurs.
-`ExitKind::Aborted { after_grace }` distinguishes hard abort after an expired
-grace (`true`) from the immediate policy (`false`). These token transitions are
-observable inside a child; lifecycle events report the eventual exit, not
-separate ladder steps.
+`ExitKind::Aborted { phase }` distinguishes hard abort after an expired
+grace (`GracePhase::AfterGrace`) from an abort within grace
+(`GracePhase::WithinGrace`). These token transitions are observable inside a
+child; lifecycle events report the eventual exit, not separate ladder steps.
 
 ## Grace is an upper bound
 


### PR DESCRIPTION
Part of #101 (section C: exit cancellation and grace-phase domains).

## Scope

This PR removes two boolean domains from the exit and stop-ladder pipeline:

- `Exit::new` and the exit classifier now take `Cancellation::{Observed, NotObserved}`;
- the report token, child-exit event, and driver handler carry `Cancellation` from the latch observation through final classification, without a positional-bool conversion boundary;
- `Exit::cancellation()` returns that typed value; the old boolean accessor is removed;
- `ExitKind::Aborted`, recorded/join verdicts, stop actions, and the driver's hard-abort provenance use `GracePhase::{WithinGrace, AfterGrace}`;
- public exports, trait-contract tests, SPEC text, and packaged shutdown documentation are updated.

## Why

Previously, readers had to decode calls such as `Exit::new(ExitKind::Aborted { after_grace: false }, true)`. Both boolean positions were semantically independent and transposable. The new API makes cancellation observation and grace provenance distinct compiler-checked domains throughout the reporting and stop-ladder paths.

## Validation

- `./scripts/dev just ci`
- 426/426 tests passed
- doctests, rustdoc warnings, public API reachability, enforcement checks, packaged-doc sync, and packaged-crate verification passed