### PR TITLE
Replace supervision mode booleans with domain types

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -80,6 +80,13 @@ pub(crate) enum MemberStage {
     Terminal(Exit),
 }
 
+/// Whether a terminal child incarnation failed during aggregate startup.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum StartupDisposition {
+    NotAborted,
+    Aborted,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct MemberRecord {
     pub(crate) stage: MemberStage,
@@ -219,7 +226,7 @@ impl MemberCell {
             crate::policy::resolve_common(
                 &crate::policy::CommonOptions::default(),
                 &crate::policy::ResolvedDefaults::default(),
-                false,
+                crate::policy::ChildMode::Restartable,
                 Readiness::Immediate,
             )
             .expect("library defaults must be valid")
@@ -758,7 +765,7 @@ impl ScopeCell {
         member: &MemberCell,
         exit: Exit,
         exited_incarnation: Option<Incarnation>,
-        startup_aborted: bool,
+        startup: StartupDisposition,
     ) -> bool {
         self.with_observation_gate(|| {
             let record = member.record();
@@ -781,7 +788,9 @@ impl ScopeCell {
                     .and_then(|resident| resident.projection.scope.as_ref())
                     .cloned()
             });
-            member.update_locked(|record| record.startup_aborted = startup_aborted);
+            member.update_locked(|record| {
+                record.startup_aborted = startup == StartupDisposition::Aborted;
+            });
             member.terminalize(exit.clone());
             if record.last_incarnation.is_none()
                 && let Some(scope) = &nested

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -11,12 +11,15 @@ use crate::{
     ChildId, Exit, ExitKind, Incarnation, IntensityTrip, Membership, Readiness, ReadinessDeadline,
     ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure, StartupFailureCause,
     admission::{NotAdmittingCause, RemoveOutcome, ReserveError},
-    cells::{DynamicRoute, MailboxControl, MemberStage, ResidentProjection, ScopeCell},
+    cells::{
+        DynamicRoute, MailboxControl, MemberStage, ResidentProjection, ScopeCell,
+        StartupDisposition,
+    },
     deadline::Deadline,
     engine::{
-        ArbitrationClass, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch, IntensityState,
-        MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState,
-        ScopeLifecycle, ScopeMode, StopAction, StopLadder, arbitrate, dispatch_exit,
+        ArbitrationClass, ChildCompletionState, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch,
+        IntensityState, MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate,
+        RestartState, ScopeLifecycle, ScopeMode, StopAction, StopLadder, arbitrate, dispatch_exit,
         schedule_restart,
     },
     exit::{
@@ -840,9 +843,12 @@ fn discharge_child_terminality(completion: ChildTerminality) {
     {
         scope.terminalize_never_started();
     }
-    completion
-        .root
-        .terminalize_child(&completion.slot.member, exit, exited_incarnation, false);
+    completion.root.terminalize_child(
+        &completion.slot.member,
+        exit,
+        exited_incarnation,
+        StartupDisposition::NotAborted,
+    );
 }
 
 struct ChildRuntime {
@@ -864,7 +870,7 @@ struct ChildRuntime {
 struct PendingTerminal {
     exit: Exit,
     exited_incarnation: Option<Incarnation>,
-    startup_aborted: bool,
+    startup: StartupDisposition,
 }
 
 impl ChildRuntime {
@@ -923,10 +929,9 @@ impl ChildRuntime {
         root: &ScopeCell,
         exit: Exit,
         exited_incarnation: Option<Incarnation>,
-        startup_aborted: bool,
+        startup: StartupDisposition,
     ) -> bool {
-        let changed =
-            root.terminalize_child(&self.slot.member, exit, exited_incarnation, startup_aborted);
+        let changed = root.terminalize_child(&self.slot.member, exit, exited_incarnation, startup);
         if matches!(self.slot.member.record().stage, MemberStage::Terminal(_)) {
             self.terminality.complete(drop);
         }
@@ -1526,12 +1531,16 @@ impl ScopeRuntime {
                 .record()
                 .last_exit
                 .unwrap_or_else(Exit::never_started);
-            let pre_ready =
-                child.initial && !self.lifecycle.startup_complete() && !child.initial_ready;
+            let startup =
+                if child.initial && !self.lifecycle.startup_complete() && !child.initial_ready {
+                    StartupDisposition::Aborted
+                } else {
+                    StartupDisposition::NotAborted
+                };
             // Exhaustion is a terminal outcome, not an exceptional cleanup
             // path. Join retained-definition disposal before terminality,
             // retention, removal completion, or ordered-scope progression.
-            self.begin_terminal_disposal(key, exit, None, pre_ready);
+            self.begin_terminal_disposal(key, exit, None, startup);
             return;
         };
 
@@ -1801,7 +1810,7 @@ impl ScopeRuntime {
             // A never-ran child and a child stopped between restart
             // incarnations share the same post-disposal terminal route. Hard
             // shutdown still detaches disposal through `hard_forced` below.
-            self.begin_terminal_disposal(key, exit, None, false);
+            self.begin_terminal_disposal(key, exit, None, StartupDisposition::NotAborted);
         }
     }
 
@@ -2069,9 +2078,15 @@ impl ScopeRuntime {
                 // membership failed before its *initial* readiness edge. A
                 // later incarnation stopped pre-ready (e.g. during drain)
                 // does not rewind it.
-                let pre_ready =
-                    child.initial && !self.lifecycle.startup_complete() && !child.initial_ready;
-                self.begin_terminal_disposal(key, exit, Some(incarnation), pre_ready);
+                let startup = if child.initial
+                    && !self.lifecycle.startup_complete()
+                    && !child.initial_ready
+                {
+                    StartupDisposition::Aborted
+                } else {
+                    StartupDisposition::NotAborted
+                };
+                self.begin_terminal_disposal(key, exit, Some(incarnation), startup);
             }
             ExitDispatch::ScheduleRestart => {
                 if !self.lifecycle.startup_complete() {
@@ -2140,7 +2155,7 @@ impl ScopeRuntime {
         key: ChildKey,
         exit: Exit,
         exited_incarnation: Option<Incarnation>,
-        startup_aborted: bool,
+        startup: StartupDisposition,
     ) {
         let construction = {
             let Some(child) = self.children.get_mut(key) else {
@@ -2152,7 +2167,7 @@ impl ScopeRuntime {
             child.pending_terminal = Some(PendingTerminal {
                 exit,
                 exited_incarnation,
-                startup_aborted,
+                startup,
             });
             child.slot.member.set_terminal_disposal_pending(true);
             child.construction.take()
@@ -2212,17 +2227,21 @@ impl ScopeRuntime {
         // when its pre-readiness position still routes the scope's startup
         // failure below. Incarnation exhaustion is the reachable case:
         // it terminalizes an unspawned membership while `pre_ready` holds.
-        let startup_aborted = terminal.exited_incarnation.is_some() && terminal.startup_aborted;
+        let startup = if terminal.exited_incarnation.is_some() {
+            terminal.startup
+        } else {
+            StartupDisposition::NotAborted
+        };
         self.children[key].terminalize(
             &self.root,
             exit.clone(),
             terminal.exited_incarnation,
-            startup_aborted,
+            startup,
         );
         let removing = self.children[key].slot.member.record().removing;
         if removing {
             self.finalize_removal(key);
-        } else if terminal.startup_aborted && !self.lifecycle.is_draining() {
+        } else if terminal.startup == StartupDisposition::Aborted && !self.lifecycle.is_draining() {
             self.fail_startup(key, exit);
             if self.children[key].options.retention == crate::Retention::Remove {
                 self.prune_terminal(key);
@@ -2263,7 +2282,12 @@ impl ScopeRuntime {
                     && !self.children[later].is_disposing()
                     && !self.children[later].is_terminal()
                 {
-                    self.begin_terminal_disposal(later, Exit::never_started(), None, false);
+                    self.begin_terminal_disposal(
+                        later,
+                        Exit::never_started(),
+                        None,
+                        StartupDisposition::NotAborted,
+                    );
                 }
             }
         }
@@ -2324,9 +2348,11 @@ impl ScopeRuntime {
             .values()
             .all(|child| child.is_terminal() && !child.is_disposing());
         self.lifecycle.finish_if_ready(
-            self.root.flavor == ScopeFlavor::Ordered,
-            !self.children.is_empty(),
-            all_terminal,
+            self.root.flavor,
+            ChildCompletionState {
+                has_children: !self.children.is_empty(),
+                all_terminal,
+            },
         )
     }
 
@@ -3039,9 +3065,9 @@ mod tests {
     use super::{
         ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
         GateCapture, MemberCell, MemberStage, Obligation, Pending, RemovalResponses,
-        RuntimeStorage, ScopeCell, ScopeEpochGuard, ScopeFlavor, ScopeRuntime, complete_removals,
-        driver_event_class, mint_child_incarnation, report_channel, resident_projection,
-        restart_shutdown_work, run_nested_tree, run_scope_incarnation,
+        RuntimeStorage, ScopeCell, ScopeEpochGuard, ScopeFlavor, ScopeRuntime, StartupDisposition,
+        complete_removals, driver_event_class, mint_child_incarnation, report_channel,
+        resident_projection, restart_shutdown_work, run_nested_tree, run_scope_incarnation,
     };
 
     /// Bounds every gate-capture probe wait. The probe sender lives inside
@@ -4991,7 +5017,7 @@ mod tests {
             &member,
             Exit::new(ExitKind::Completed, false),
             None,
-            false
+            StartupDisposition::NotAborted,
         ));
         assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Closed));
         snapshots
@@ -5015,7 +5041,12 @@ mod tests {
         parent.set_admitted_children(vec![resident_projection(&slot)]);
         let mut snapshots = parent.subscribe_snapshots();
 
-        assert!(parent.terminalize_child(&nested.member, Exit::never_started(), None, false));
+        assert!(parent.terminalize_child(
+            &nested.member,
+            Exit::never_started(),
+            None,
+            StartupDisposition::NotAborted,
+        ));
         snapshots
             .changed()
             .await

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -7,8 +7,10 @@ use std::{
 };
 
 use crate::{
-    Exit, Intensity, Readiness, RestartPolicy, Shutdown, deadline::Deadline, exit::StopReason,
-    policy::tidy_abort_beat,
+    Exit, Intensity, Readiness, RestartPolicy, Shutdown,
+    deadline::Deadline,
+    exit::StopReason,
+    policy::{ScopeFlavor, tidy_abort_beat},
 };
 
 /// Deterministic priority when one driver wake exposes several events.
@@ -607,6 +609,13 @@ pub(crate) struct DrainEffect {
     pub(crate) startup_pending: bool,
 }
 
+/// The child state relevant to deciding whether a scope can finish.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ChildCompletionState {
+    pub(crate) has_children: bool,
+    pub(crate) all_terminal: bool,
+}
+
 /// Authoritative lifecycle and finish policy for one scope incarnation.
 ///
 /// `ScopeRecord` is only this machine's observation projection; epoch-tagged
@@ -699,14 +708,16 @@ impl ScopeLifecycle {
 
     pub(crate) fn finish_if_ready(
         &self,
-        ordered: bool,
-        has_children: bool,
-        all_terminal: bool,
+        flavor: ScopeFlavor,
+        children: ChildCompletionState,
     ) -> Option<StopReason> {
         if let Some(reason) = self.draining_reason() {
-            return all_terminal.then(|| reason.clone());
+            return children.all_terminal.then(|| reason.clone());
         }
-        (!self.startup_failed() && ordered && has_children && all_terminal)
+        (!self.startup_failed()
+            && flavor == ScopeFlavor::Ordered
+            && children.has_children
+            && children.all_terminal)
             .then_some(StopReason::Finished)
     }
 }
@@ -862,14 +873,15 @@ mod tests {
     };
 
     use crate::{
-        Exit, ExitKind, Intensity, RestartCondition, RestartPolicy, Shutdown, policy::Backoff,
+        Exit, ExitKind, Intensity, RestartCondition, RestartPolicy, Shutdown,
+        policy::{Backoff, ScopeFlavor},
     };
 
     use super::{
-        ArbitrationClass, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch, IntensityState,
-        MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RequestTarget,
-        RestartState, ScopeEpochs, ScopeLifecycle, ScopeMode, StopAction, StopLadder, arbitrate,
-        dispatch_exit, schedule_restart, tidy_abort_beat,
+        ArbitrationClass, ChildCompletionState, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch,
+        IntensityState, MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate,
+        RequestTarget, RestartState, ScopeEpochs, ScopeLifecycle, ScopeMode, StopAction,
+        StopLadder, arbitrate, dispatch_exit, schedule_restart, tidy_abort_beat,
     };
 
     #[test]
@@ -1196,21 +1208,51 @@ mod tests {
             !lifecycle.fail_startup(),
             "simultaneous initial failures publish one transition"
         );
-        assert_eq!(lifecycle.finish_if_ready(true, true, true), None);
+        assert_eq!(
+            lifecycle.finish_if_ready(
+                ScopeFlavor::Ordered,
+                ChildCompletionState {
+                    has_children: true,
+                    all_terminal: true,
+                },
+            ),
+            None
+        );
         let drain = lifecycle
             .begin_drain(crate::exit::StopReason::ShutdownRequested)
             .expect("a failed startup can begin draining");
         assert!(!drain.startup_pending);
         assert_eq!(
-            lifecycle.finish_if_ready(false, true, true),
+            lifecycle.finish_if_ready(
+                ScopeFlavor::Dynamic,
+                ChildCompletionState {
+                    has_children: true,
+                    all_terminal: true,
+                },
+            ),
             Some(crate::exit::StopReason::ShutdownRequested)
         );
 
         let mut running = ScopeLifecycle::starting();
         assert!(running.complete_startup());
-        assert_eq!(running.finish_if_ready(true, false, true), None);
         assert_eq!(
-            running.finish_if_ready(true, true, true),
+            running.finish_if_ready(
+                ScopeFlavor::Ordered,
+                ChildCompletionState {
+                    has_children: false,
+                    all_terminal: true,
+                },
+            ),
+            None
+        );
+        assert_eq!(
+            running.finish_if_ready(
+                ScopeFlavor::Ordered,
+                ChildCompletionState {
+                    has_children: true,
+                    all_terminal: true,
+                },
+            ),
             Some(crate::exit::StopReason::Finished)
         );
 

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -12,8 +12,8 @@ use crate::{
     definition::DefinitionSource,
     identity::{IdError, ScopeIdentity},
     policy::{
-        CommonOptions, InvalidPolicy, PolicyField, ResolvedCommonOptions, ResolvedDefaults,
-        ScopeFlavor, resolve_common,
+        ChildMode, CommonOptions, InvalidPolicy, PolicyField, ResolvedCommonOptions,
+        ResolvedDefaults, ScopeFlavor, resolve_common,
     },
     raw::RawConstruction,
     runtime::{self, Isolated, Latch},
@@ -176,10 +176,10 @@ impl SlotCell {
         definition: &Isolated<ChildConstruction>,
         defaults: &ResolvedDefaults,
     ) -> Result<ResolvedCommonOptions, InvalidPolicy> {
-        let (options, one_shot) = match definition.get() {
-            ChildConstruction::Raw(definition) => (&definition.options, definition.one_shot()),
-            ChildConstruction::Task(definition) => (&definition.options, false),
-            ChildConstruction::TaskOnce(definition) => (&definition.options, true),
+        let (options, mode) = match definition.get() {
+            ChildConstruction::Raw(definition) => (&definition.options, definition.mode()),
+            ChildConstruction::Task(definition) => (&definition.options, ChildMode::Restartable),
+            ChildConstruction::TaskOnce(definition) => (&definition.options, ChildMode::OneShot),
             ChildConstruction::Scope(definition) => {
                 if let DefinitionSource::OneShot(tree) = &definition.source {
                     let inherited = match definition.defaults {
@@ -189,10 +189,10 @@ impl SlotCell {
                     tree.validate_policies(&inherited)
                         .map_err(|invalid| invalid.prepend(self.member.id()))?;
                 }
-                (&definition.options, definition.one_shot())
+                (&definition.options, definition.mode())
             }
         };
-        resolve_common(options, defaults, one_shot, Readiness::Immediate)
+        resolve_common(options, defaults, mode, Readiness::Immediate)
             .map_err(|invalid| invalid.prepend(self.member.id()))
     }
 }
@@ -430,8 +430,12 @@ pub(crate) struct ScopeConstruction {
 pub(crate) type ScopeFactory = Arc<dyn Fn() -> BuilderCore + Send + Sync + 'static>;
 
 impl ScopeConstruction {
-    pub(crate) fn one_shot(&self) -> bool {
-        self.source.is_one_shot()
+    pub(crate) fn mode(&self) -> ChildMode {
+        if self.source.is_one_shot() {
+            ChildMode::OneShot
+        } else {
+            ChildMode::Restartable
+        }
     }
 
     pub(crate) fn restartable(&self) -> Option<&ScopeFactory> {

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -11,6 +11,13 @@ pub(crate) enum ScopeFlavor {
     Dynamic,
 }
 
+/// Whether a child construction can be recreated after its first incarnation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ChildMode {
+    Restartable,
+    OneShot,
+}
+
 /// The default bounded FIFO mailbox capacity.
 pub const DEFAULT_MAILBOX_CAPACITY: usize = 64;
 /// The default child shutdown grace.
@@ -672,7 +679,7 @@ pub(crate) struct ResolvedCommonOptions {
 pub(crate) fn resolve_common(
     options: &CommonOptions,
     defaults: &ResolvedDefaults,
-    one_shot: bool,
+    mode: ChildMode,
     default_readiness: Readiness,
 ) -> Result<ResolvedCommonOptions, InvalidPolicy> {
     defaults.validate()?;
@@ -690,7 +697,7 @@ pub(crate) fn resolve_common(
         value => value,
     };
     let resolved = ResolvedCommonOptions {
-        restart: if one_shot {
+        restart: if mode == ChildMode::OneShot {
             RestartPolicy::new(RestartCondition::Never, Backoff::Immediate)
         } else {
             options.restart.unwrap_or(defaults.child_restart)
@@ -703,7 +710,7 @@ pub(crate) fn resolve_common(
         readiness: options.readiness.unwrap_or(default_readiness),
         readiness_override: options.readiness,
         readiness_deadline,
-        retention: options.retention.unwrap_or(if one_shot {
+        retention: options.retention.unwrap_or(if mode == ChildMode::OneShot {
             Retention::Remove
         } else {
             Retention::Retain

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -19,7 +19,7 @@ use crate::{
     cells::{MailboxControl, MemberCell},
     definition::DefinitionSource,
     mailbox::{MailboxCell, MailboxReceiver},
-    policy::CommonOptions,
+    policy::{ChildMode, CommonOptions},
     runtime::{
         self, ActorWork, Latch, PanicAccumulator, PanicPayload, Signal, SignalWatcher, catch_panic,
         discard_panic, keep_first_panic, resume_preferred_panic,
@@ -1673,6 +1673,14 @@ pub(crate) struct RawConstruction {
 }
 
 impl RawConstruction {
+    pub(crate) fn mode(&self) -> ChildMode {
+        if self.source.is_one_shot() {
+            ChildMode::OneShot
+        } else {
+            ChildMode::Restartable
+        }
+    }
+
     pub(crate) fn one_shot(&self) -> bool {
         self.source.is_one_shot()
     }


### PR DESCRIPTION
Implements the supervision-mode portion of #101.

- replaces `startup_aborted` parameters with `StartupDisposition`
- passes `ScopeFlavor` and a named `ChildCompletionState` into scope finish policy
- passes `ChildMode` into common policy resolution for restartable vs one-shot children
- updates tests to construct each domain explicitly

Validation:
- `./scripts/dev just ci` (426/426 tests, doctests, docs, API/enforcement checks, package verification, and Nix formatting)