### PR TITLE
Replace runtime control booleans with domain enums

### DIFF
--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -143,10 +143,17 @@ macro_rules! actor_context_forwarders {
     };
 }
 
+/// Which mailbox delivery stage owns the current callback.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DeliveryStage {
+    Live,
+    DrainingFrozenPrefix,
+}
+
 /// Callback context used by both live and frozen-prefix handler deliveries.
 pub struct Context<'a, A: Actor> {
     core: ActorContextCore<'a, A::Msg>,
-    draining: bool,
+    stage: DeliveryStage,
     actor: PhantomData<fn() -> A>,
 }
 
@@ -156,16 +163,16 @@ impl<A: Actor> fmt::Debug for Context<'_, A> {
             .debug_struct("Context")
             .field("id", self.core.id())
             .field("incarnation", &self.core.incarnation())
-            .field("draining", &self.draining)
+            .field("stage", &self.stage)
             .finish_non_exhaustive()
     }
 }
 
 impl<'a, A: Actor> Context<'a, A> {
-    fn new(raw: &'a mut RawContext<A::Msg>, draining: bool) -> Self {
+    fn new(raw: &'a mut RawContext<A::Msg>, stage: DeliveryStage) -> Self {
         Self {
             core: ActorContextCore::new(raw),
-            draining,
+            stage,
             actor: PhantomData,
         }
     }
@@ -174,14 +181,14 @@ impl<'a, A: Actor> Context<'a, A> {
 
     /// Releases this incarnation's readiness gate while live.
     pub fn mark_ready(&self) {
-        if !self.draining {
+        if self.stage == DeliveryStage::Live {
             self.core.raw.mark_ready();
         }
     }
 
     /// Requests a clean local stop after the current callback.
     pub fn stop(&mut self) {
-        if !self.draining {
+        if self.stage == DeliveryStage::Live {
             self.core.raw.stop();
         }
     }
@@ -189,12 +196,12 @@ impl<'a, A: Actor> Context<'a, A> {
     /// Reports whether this callback is draining the frozen mailbox prefix.
     #[must_use]
     pub fn is_draining(&self) -> bool {
-        self.draining
+        self.stage == DeliveryStage::DrainingFrozenPrefix
     }
 
     /// Queues an actor-local continuation ahead of external input.
     pub fn continue_with(&mut self, message: A::Msg) -> Result<(), Rejected<A::Msg>> {
-        if self.draining {
+        if self.stage == DeliveryStage::DrainingFrozenPrefix {
             Err(Rejected::new(message))
         } else {
             self.core.raw.continue_with(message)
@@ -211,7 +218,7 @@ impl<'a, A: Actor> Context<'a, A> {
     where
         K: Hash + Eq + Send + 'static,
     {
-        if self.draining {
+        if self.stage == DeliveryStage::DrainingFrozenPrefix {
             Err(Rejected::new((key, message)))
         } else {
             self.core.raw.set_timeout(key, message, after)
@@ -229,7 +236,7 @@ impl<'a, A: Actor> Context<'a, A> {
         K: Hash + Eq + Send + 'static,
         A::Msg: Clone,
     {
-        if self.draining {
+        if self.stage == DeliveryStage::DrainingFrozenPrefix {
             Err(Rejected::new((key, message)))
         } else {
             self.core.raw.set_interval(key, message, period)
@@ -241,7 +248,7 @@ impl<'a, A: Actor> Context<'a, A> {
     where
         K: Hash + Eq + Send + 'static,
     {
-        if self.draining {
+        if self.stage == DeliveryStage::DrainingFrozenPrefix {
             Err(Rejected::new(()))
         } else {
             Ok(self.core.raw.clear_timer(key))
@@ -260,7 +267,7 @@ impl<'a, A: Actor> Context<'a, A> {
         T: Send + 'static,
         C: FnOnce(Result<T, DeadlineElapsed>) -> A::Msg + Send + 'static,
     {
-        if self.draining {
+        if self.stage == DeliveryStage::DrainingFrozenPrefix {
             Err(Rejected::new((work, continuation)))
         } else {
             self.core.raw.offload(work, continuation, deadline)
@@ -279,7 +286,7 @@ impl<'a, A: Actor> Context<'a, A> {
         T: Send + 'static,
         C: FnOnce(Result<T, DeadlineElapsed>) -> A::Msg + Send + 'static,
     {
-        if self.draining {
+        if self.stage == DeliveryStage::DrainingFrozenPrefix {
             Err(Rejected::new((work, continuation)))
         } else {
             self.core.raw.offload_scoped(work, continuation, deadline)
@@ -288,10 +295,10 @@ impl<'a, A: Actor> Context<'a, A> {
 
     /// Re-enters a same-message actor with this exact context and stage.
     pub fn for_actor<B: Actor<Msg = A::Msg>>(&mut self) -> Context<'_, B> {
-        let draining = self.draining;
+        let stage = self.stage;
         Context {
             core: self.core.reborrow(),
-            draining,
+            stage,
             actor: PhantomData,
         }
     }
@@ -382,7 +389,7 @@ impl<A: Actor> RawActor for Handler<A> {
             .take()
             .expect("handler actor initialization invoked more than once");
         let initialized = {
-            let mut context = Context::<A>::new(raw, false);
+            let mut context = Context::<A>::new(raw, DeliveryStage::Live);
             A::init(args, &mut context).await
         };
         let actor = match initialized {
@@ -395,7 +402,7 @@ impl<A: Actor> RawActor for Handler<A> {
 
         while let Some(message) = raw.recv().await {
             let handled = {
-                let mut context = Context::<A>::new(raw, false);
+                let mut context = Context::<A>::new(raw, DeliveryStage::Live);
                 actor.handle(message, &mut context).await
             };
             if let Err(error) = handled {
@@ -407,7 +414,8 @@ impl<A: Actor> RawActor for Handler<A> {
             MailboxShutdown::Drain => {
                 while let Some(message) = raw.try_recv() {
                     let handled = {
-                        let mut context = Context::<A>::new(raw, true);
+                        let mut context =
+                            Context::<A>::new(raw, DeliveryStage::DrainingFrozenPrefix);
                         actor.handle(message, &mut context).await
                     };
                     if let Err(error) = handled {

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -173,6 +173,13 @@ impl fmt::Display for ReplyError {
 
 impl std::error::Error for ReplyError {}
 
+/// Whether an operation is being polled before or after its deadline expires.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DeadlinePhase {
+    BeforeExpiry,
+    Elapsed,
+}
+
 trait DeadlineOperation {
     type Output;
 
@@ -187,7 +194,7 @@ trait DeadlineOperation {
         &mut self,
         context: &mut Context<'_>,
         budget: crate::deadline::Deadline,
-        elapsed: bool,
+        phase: DeadlinePhase,
     ) -> Poll<Self::Output>;
 
     /// Resolves a zero-width budget without ever attempting the operation.
@@ -205,7 +212,7 @@ struct Deadlined<F> {
     budget: Option<crate::deadline::Deadline>,
     timer: Option<crate::runtime::BoxedSleep>,
     started: bool,
-    elapsed: bool,
+    phase: DeadlinePhase,
     done: bool,
 }
 
@@ -217,7 +224,7 @@ impl<F> Deadlined<F> {
             budget: None,
             timer: None,
             started: false,
-            elapsed: false,
+            phase: DeadlinePhase::BeforeExpiry,
             done: false,
         }
     }
@@ -247,11 +254,14 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
         let budget = this
             .budget
             .expect("a started deadline future retains its captured budget");
-        if let Poll::Ready(result) = this.operation.poll_deadlined(context, budget, false) {
+        if let Poll::Ready(result) =
+            this.operation
+                .poll_deadlined(context, budget, DeadlinePhase::BeforeExpiry)
+        {
             this.done = true;
             return Poll::Ready(result);
         }
-        if !this.elapsed {
+        if this.phase == DeadlinePhase::BeforeExpiry {
             if this
                 .timer
                 .as_mut()
@@ -265,10 +275,12 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             // The timer is a one-shot future: polling it again after it
             // resolves panics. Latch the transition and release it, so an
             // elapsed poll that stays pending re-polls only the operation.
-            this.elapsed = true;
+            this.phase = DeadlinePhase::Elapsed;
             this.timer = None;
         }
-        let result = this.operation.poll_deadlined(context, budget, true);
+        let result = this
+            .operation
+            .poll_deadlined(context, budget, DeadlinePhase::Elapsed);
         this.done = result.is_ready();
         result
     }
@@ -364,17 +376,19 @@ impl<T> DeadlineOperation for ReplyOperation<T> {
         &mut self,
         context: &mut Context<'_>,
         _budget: crate::deadline::Deadline,
-        elapsed: bool,
+        phase: DeadlinePhase,
     ) -> Poll<Self::Output> {
         match self.receiver.inner.poll_receive(context) {
             Poll::Ready(Some(value)) => Poll::Ready(Ok(value)),
             Poll::Ready(None) => Poll::Ready(Err(ReplyError::Dropped)),
-            Poll::Pending if elapsed => match self.receiver.inner.close_and_poll_receive(context) {
-                OneShotClose::Value(value) => Poll::Ready(Ok(value)),
-                OneShotClose::SenderClosed => Poll::Ready(Err(ReplyError::Dropped)),
-                OneShotClose::Empty => Poll::Ready(Err(ReplyError::Timeout)),
-                OneShotClose::Pending => Poll::Pending,
-            },
+            Poll::Pending if phase == DeadlinePhase::Elapsed => {
+                match self.receiver.inner.close_and_poll_receive(context) {
+                    OneShotClose::Value(value) => Poll::Ready(Ok(value)),
+                    OneShotClose::SenderClosed => Poll::Ready(Err(ReplyError::Dropped)),
+                    OneShotClose::Empty => Poll::Ready(Err(ReplyError::Timeout)),
+                    OneShotClose::Pending => Poll::Pending,
+                }
+            }
             Poll::Pending => Poll::Pending,
         }
     }
@@ -415,6 +429,13 @@ enum BindingStatus {
     Bound(Incarnation),
     Frozen(Incarnation),
     Terminal(Option<Incarnation>),
+}
+
+/// Which mailbox binding states may yield accepted messages.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReceiveMode {
+    LiveOnly,
+    IncludeFrozen,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -926,13 +947,15 @@ impl<M: Send + 'static> MailboxCell<M> {
     fn receive(
         &self,
         incarnation: Incarnation,
-        allow_frozen: bool,
+        mode: ReceiveMode,
         accepted_through: Option<u64>,
     ) -> Option<M> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         let eligible = match state.status {
             BindingStatus::Bound(current) => current == incarnation,
-            BindingStatus::Frozen(current) => allow_frozen && current == incarnation,
+            BindingStatus::Frozen(current) => {
+                mode == ReceiveMode::IncludeFrozen && current == incarnation
+            }
             BindingStatus::Unbound | BindingStatus::Terminal(_) => false,
         };
         if !eligible {
@@ -1562,12 +1585,12 @@ impl<M: Send + 'static> DeadlineOperation for TimedSend<M> {
         &mut self,
         context: &mut Context<'_>,
         _budget: crate::deadline::Deadline,
-        elapsed: bool,
+        phase: DeadlinePhase,
     ) -> Poll<Self::Output> {
         if let Poll::Ready(result) = Pin::new(&mut self.send).poll(context) {
             return Poll::Ready(result);
         }
-        if !elapsed {
+        if phase == DeadlinePhase::BeforeExpiry {
             Poll::Pending
         } else {
             Poll::Ready(withdraw_send(&mut self.send))
@@ -1638,7 +1661,7 @@ impl<M, T> CallOperation<M, T> {
         &mut self,
         context: &mut Context<'_>,
         incarnation: Incarnation,
-        deadline_elapsed: bool,
+        phase: DeadlinePhase,
     ) -> Poll<Result<Replied<T>, CallError>> {
         let reply = self
             .reply
@@ -1651,7 +1674,7 @@ impl<M, T> CallOperation<M, T> {
                 incarnation_observed: Some(incarnation),
                 kind: CallErrorKind::ReplyDropped,
             })),
-            Poll::Pending if deadline_elapsed => {
+            Poll::Pending if phase == DeadlinePhase::Elapsed => {
                 match reply.inner.close_and_poll_receive(context) {
                     OneShotClose::Value(value) => Poll::Ready(Ok(Replied { value, incarnation })),
                     OneShotClose::SenderClosed => Poll::Ready(Err(CallError {
@@ -1685,10 +1708,10 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
         &mut self,
         context: &mut Context<'_>,
         budget: crate::deadline::Deadline,
-        elapsed: bool,
+        phase: DeadlinePhase,
     ) -> Poll<Self::Output> {
         if self.make_msg.is_some() {
-            if elapsed {
+            if phase == DeadlinePhase::Elapsed {
                 return Poll::Ready(self.short_circuit());
             }
             // Capture the one overall budget before invoking user code. A
@@ -1742,10 +1765,10 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
         // payload yet; that transition wakes the registered waker, so waiting
         // is the answer rather than reaching for a send that no longer exists.
         if let Some(accepted) = self.accepted {
-            return self.poll_reply(context, accepted, elapsed);
+            return self.poll_reply(context, accepted, phase);
         }
 
-        if !elapsed {
+        if phase == DeadlinePhase::BeforeExpiry {
             return Poll::Pending;
         }
 
@@ -1758,7 +1781,7 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
         match result {
             Ok(incarnation) => {
                 self.accepted = Some(incarnation);
-                self.poll_reply(context, incarnation, true)
+                self.poll_reply(context, incarnation, DeadlinePhase::Elapsed)
             }
             Err(error) => {
                 self.close_reply();
@@ -1816,16 +1839,21 @@ impl<M: Send + 'static> MailboxReceiver<M> {
     }
 
     pub(crate) fn try_recv(&self) -> Option<M> {
-        self.mailbox.receive(self.incarnation, true, None)
+        self.mailbox
+            .receive(self.incarnation, ReceiveMode::IncludeFrozen, None)
     }
 
     pub(crate) fn try_recv_live(&self) -> Option<M> {
-        self.mailbox.receive(self.incarnation, false, None)
+        self.mailbox
+            .receive(self.incarnation, ReceiveMode::LiveOnly, None)
     }
 
     pub(crate) fn try_recv_live_through(&self, accepted_sequence: u64) -> Option<M> {
-        self.mailbox
-            .receive(self.incarnation, false, Some(accepted_sequence))
+        self.mailbox.receive(
+            self.incarnation,
+            ReceiveMode::LiveOnly,
+            Some(accepted_sequence),
+        )
     }
 
     pub(crate) fn accepted_sequence(&self) -> u64 {
@@ -2161,9 +2189,9 @@ mod tests {
             &mut self,
             _context: &mut Context<'_>,
             _budget: crate::deadline::Deadline,
-            elapsed: bool,
+            phase: super::DeadlinePhase,
         ) -> Poll<usize> {
-            if !elapsed {
+            if phase == super::DeadlinePhase::BeforeExpiry {
                 return Poll::Pending;
             }
             self.elapsed_polls += 1;

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -537,6 +537,18 @@ struct OffloadFutureState {
     cancelled: bool,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OffloadPoll {
+    Pending,
+    Finished,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OffloadScope {
+    Unscoped,
+    Scoped,
+}
+
 struct SharedOffloadState {
     // Polling takes the future out of this mutex. Cancellation either takes
     // an idle future or marks an in-progress poll so that the poller disposes
@@ -576,10 +588,10 @@ impl SharedOffloadState {
         state.future.take()
     }
 
-    fn finish_poll(&self, future: OffloadFuture, pending: bool) -> Option<OffloadFuture> {
+    fn finish_poll(&self, future: OffloadFuture, outcome: OffloadPoll) -> Option<OffloadFuture> {
         let mut state = self.state.lock().expect("offload future mutex poisoned");
         state.polling = false;
-        if pending && !state.cancelled {
+        if outcome == OffloadPoll::Pending && !state.cancelled {
             debug_assert!(state.future.is_none());
             state.future = Some(future);
             None
@@ -632,7 +644,7 @@ impl Future for SharedOffloadFuture {
         let polled = catch_panic(|| future.as_mut().poll(context));
         match polled {
             Ok(Poll::Pending) => {
-                let dispose = self.0.finish_poll(future, true);
+                let dispose = self.0.finish_poll(future, OffloadPoll::Pending);
                 if dispose.is_some() {
                     self.0.dispose(dispose);
                     self.0.finished.fire();
@@ -642,13 +654,13 @@ impl Future for SharedOffloadFuture {
                 }
             }
             Ok(Poll::Ready(())) => {
-                let dispose = self.0.finish_poll(future, false);
+                let dispose = self.0.finish_poll(future, OffloadPoll::Finished);
                 self.0.dispose(dispose);
                 self.0.finished.fire();
                 Poll::Ready(())
             }
             Err(payload) => {
-                let dispose = self.0.finish_poll(future, false);
+                let dispose = self.0.finish_poll(future, OffloadPoll::Finished);
                 self.0.record(payload);
                 self.0.dispose(dispose);
                 self.0.finished.fire();
@@ -1029,7 +1041,7 @@ impl<M: Send + 'static> RawContext<M> {
         T: Send + 'static,
         C: FnOnce(Result<T, DeadlineElapsed>) -> M + Send + 'static,
     {
-        self.start_offload(work, continuation, deadline, false)
+        self.start_offload(work, continuation, deadline, OffloadScope::Unscoped)
             .map(|_| ())
     }
 
@@ -1049,7 +1061,7 @@ impl<M: Send + 'static> RawContext<M> {
         T: Send + 'static,
         C: FnOnce(Result<T, DeadlineElapsed>) -> M + Send + 'static,
     {
-        self.start_offload(work, continuation, deadline, true)
+        self.start_offload(work, continuation, deadline, OffloadScope::Scoped)
             .map(|guard| guard.expect("scoped offload must produce a guard"))
     }
 
@@ -1127,7 +1139,7 @@ impl<M: Send + 'static> RawContext<M> {
         work: F,
         continuation: C,
         deadline: Duration,
-        scoped: bool,
+        scope: OffloadScope,
     ) -> Result<Option<Guard>, Rejected<(F, C)>>
     where
         F: Future<Output = T> + Send + 'static,
@@ -1142,7 +1154,7 @@ impl<M: Send + 'static> RawContext<M> {
 
         let cancellation = Latch::default();
         let finished = Latch::default();
-        let guard = scoped.then(|| Guard {
+        let guard = (scope == OffloadScope::Scoped).then(|| Guard {
             cancellation: cancellation.clone(),
             finished: finished.clone(),
             armed: true,


### PR DESCRIPTION
Implements the remaining private positional-bool cluster from #101.

- names live-only versus frozen-prefix mailbox receives with `ReceiveMode`
- carries `DeadlinePhase` through the shared mailbox deadline scaffold and its operations
- distinguishes scoped and unscoped offloads with `OffloadScope`
- distinguishes pending and finished offload polls with `OffloadPoll`
- replaces handler-context `draining` construction booleans with `DeliveryStage`

Validation:
- `./scripts/dev just ci` (426/426 tests, doctests, docs, API/enforcement checks, package verification, and Nix formatting)