### PR TITLE
Type the three restart counter domains

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -142,7 +142,7 @@ any single design rule:
   invariant makes bit-equality correct: §9.2's backoff factor),
   serializable where Part II §21 needs it, and carrying **no
   behavior** beyond small pure derivation functions of the
-  `should_restart(is_failure)` / `next_delay(attempt, jitter_sample)` /
+  `should_restart(is_failure)` / `next_delay(restart_attempt, jitter_sample)` /
   `validate()` shape. Runtime behavior is *derived from* the data by local
   functions; it is never encoded as trait objects, callbacks, or builder
   side effects.
@@ -1724,7 +1724,13 @@ Two separated concerns:
   still advanced it, mirroring the intensity charge below — and reset by
   an incarnation that exits after running at least the scope's intensity
   window `within` (one clock answers "has it settled"); the snapshot's
-  `restart_count` (B.6) is its non-resetting cumulative twin. Running time is
+  `restart_count` (B.6) is its non-resetting cumulative twin. These three
+  reset-distinct domains are public opaque values: `RestartAttempt` for the
+  resettable backoff position, `RestartCount` for one membership's cumulative
+  charges, and `TotalRestarts` for one scope incarnation's cumulative charges.
+  Each exposes only `ZERO`, a saturating `bump()`, and `get()`; none implements
+  arithmetic traits, so the domains cannot be added, substituted, or compared
+  across one another accidentally. Running time is
   measured between two engine-stamped instants: the incarnation's **start
   instant**, stamped once when the engine schedules the spawn (the
   `Started` event's instant — the same stamp anchors §6's readiness
@@ -3088,7 +3094,8 @@ LifecycleEvent { scope_path, scope, seq, kind }
         Started          { id, membership, incarnation }  // incarnation spawned
         Ready            { id, membership, incarnation }  // readiness gate released (§6)
         Exited           { id, membership, incarnation, exit }   // the §7 exit type
-        RestartScheduled { id, membership, attempt, delay }      // charged per §9.2
+        RestartScheduled { id, membership,
+                           attempt: RestartAttempt, delay }       // charged per §9.2
         Removed          { id, membership,
                            last_incarnation: Option<Incarnation> }  // terminal; None = never started
         ScopeState       { state }                        // the emitting scope's own B.6 state transitions
@@ -3251,7 +3258,7 @@ ChildSnapshot   { id, membership,                       // §3 identity types
                          | StartupAborted { exit },     // terminal pre-ready failure (§6)
                   last_exit: Option<Exit>,              // newest prior exit, if any incarnation has exited
                   membership_status: Active | Removing,
-                  restart_count,                        // cumulative scheduled-restart charges for
+                  restart_count: RestartCount,          // cumulative scheduled-restart charges for
                                                         //   this membership (§9.2): incremented at
                                                         //   scheduling, never reset, the over-budget
                                                         //   scheduled-but-never-spawned charge
@@ -3304,7 +3311,7 @@ ScopeSnapshot   { state: Unstarted                              // membership ex
                                                                 //   aborted ordered sibling (§6) — the
                                                                 //   scope-state twin of §7's exit
                   kind: Ordered | Dynamic, strategy (ordered only), intensity,
-                  total_restarts,                        // charges per §9.2 — group respawns count
+                  total_restarts: TotalRestarts,         // charges per §9.2 — group respawns count
                   lifecycle_seq,                         // aligns events with snapshots (§12)
                   children: Vec<ChildSnapshot> }         // declaration order (ordered scopes);
                                                          //   admission order (dynamic scopes) —

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -16,7 +16,8 @@ use std::{
 };
 
 use crate::{
-    ChildId, Exit, Incarnation, Intensity, Mailbox, Membership, Readiness, ScopeState, Strategy,
+    ChildId, Exit, Incarnation, Intensity, Mailbox, Membership, Readiness, RestartCount,
+    ScopeState, Strategy, TotalRestarts,
     admission::{RemoveOutcome, ReserveError},
     engine::{Epoch, RequestTarget, ScopeEpochs},
     exit::{StartupError, StopReason},
@@ -86,7 +87,7 @@ pub(crate) struct MemberRecord {
     pub(crate) incarnation: Option<Incarnation>,
     pub(crate) last_incarnation: Option<Incarnation>,
     pub(crate) last_exit: Option<Exit>,
-    pub(crate) restart_count: u64,
+    pub(crate) restart_count: RestartCount,
     pub(crate) restart_at: Option<Instant>,
     pub(crate) removing: bool,
     pub(crate) startup_aborted: bool,
@@ -129,7 +130,7 @@ impl MemberCell {
             incarnation: None,
             last_incarnation: None,
             last_exit: None,
-            restart_count: 0,
+            restart_count: RestartCount::ZERO,
             restart_at: None,
             removing: false,
             startup_aborted: false,
@@ -317,7 +318,7 @@ impl MemberCell {
 pub(crate) struct ScopeRecord {
     pub(crate) state: ScopeState,
     pub(crate) startup: Option<Result<(), StartupError>>,
-    pub(crate) total_restarts: u64,
+    pub(crate) total_restarts: TotalRestarts,
 }
 
 pub(crate) trait DynamicRoute: Send + Sync {
@@ -493,7 +494,7 @@ impl ScopeCell {
         let (record, _) = runtime::watch(ScopeRecord {
             state: ScopeState::Unstarted,
             startup: None,
-            total_restarts: 0,
+            total_restarts: TotalRestarts::ZERO,
         });
         let (current_children, _) = runtime::watch(Vec::new());
         let (parent, _) = runtime::watch(None);
@@ -695,7 +696,7 @@ impl ScopeCell {
         self.with_observation_gate(|| {
             self.record.send_modify(|record| {
                 if state == ScopeState::Starting {
-                    record.total_restarts = 0;
+                    record.total_restarts = TotalRestarts::ZERO;
                 }
                 record.state = state.clone();
             });
@@ -738,7 +739,7 @@ impl ScopeCell {
     pub(crate) fn publish_child_restart(
         &self,
         member: &MemberCell,
-        total_restarts: u64,
+        total_restarts: TotalRestarts,
         update: impl FnOnce(&mut MemberRecord),
         exited: LifecycleEventKind,
         scheduled: LifecycleEventKind,
@@ -1028,7 +1029,7 @@ impl ScopeCell {
             let epoch = control.epochs.begin()?;
             let state = ScopeState::Starting;
             self.record.send_modify(|record| {
-                record.total_restarts = 0;
+                record.total_restarts = TotalRestarts::ZERO;
                 record.state = state.clone();
             });
             // Hold epoch ownership through its observation projection. A

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2115,11 +2115,7 @@ impl ScopeRuntime {
                     },
                 );
                 if decision.charge.tripped {
-                    let trip = IntensityTrip {
-                        max_restarts: self.intensity_policy.max_restarts,
-                        observed_restarts: decision.charge.in_window,
-                        within: self.intensity_policy.within,
-                    };
+                    let trip = IntensityTrip::new(self.intensity_policy, decision.charge);
                     if self.lifecycle.is_starting() {
                         self.root
                             .set_startup(Err(StartupError::IntensityTripped(trip.clone())));

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use crate::{
-    Exit, Intensity, Readiness, RestartPolicy, Shutdown, deadline::Deadline, exit::StopReason,
-    policy::tidy_abort_beat,
+    Exit, Intensity, IntensityTrip, Readiness, RestartAttempt, RestartCount, RestartPolicy,
+    Shutdown, TotalRestarts, deadline::Deadline, exit::StopReason, policy::tidy_abort_beat,
 };
 
 /// Deterministic priority when one driver wake exposes several events.
@@ -214,17 +214,37 @@ pub(crate) fn dispatch_exit(
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct IntensityState {
     charges: VecDeque<Instant>,
-    total_restarts: u64,
+    total_restarts: TotalRestarts,
+}
+
+impl Default for IntensityState {
+    fn default() -> Self {
+        Self {
+            charges: VecDeque::new(),
+            total_restarts: TotalRestarts::ZERO,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct IntensityCharge {
     pub(crate) in_window: u64,
-    pub(crate) total_restarts: u64,
+    pub(crate) total_restarts: TotalRestarts,
     pub(crate) tripped: bool,
+}
+
+impl IntensityTrip {
+    pub(crate) fn new(policy: Intensity, charge: IntensityCharge) -> Self {
+        debug_assert_eq!(charge.tripped, charge.in_window > policy.max_restarts);
+        Self {
+            max_restarts: policy.max_restarts,
+            observed_restarts: charge.in_window,
+            within: policy.within,
+        }
+    }
 }
 
 impl IntensityState {
@@ -236,7 +256,7 @@ impl IntensityState {
             self.charges.pop_front();
         }
         self.charges.push_back(now);
-        self.total_restarts = self.total_restarts.saturating_add(1);
+        self.total_restarts = self.total_restarts.bump();
         let in_window = u64::try_from(self.charges.len()).unwrap_or(u64::MAX);
         IntensityCharge {
             in_window,
@@ -248,26 +268,26 @@ impl IntensityState {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct RestartState {
-    attempt: u64,
-    cumulative: u64,
+    attempt: RestartAttempt,
+    cumulative: RestartCount,
 }
 
 impl RestartState {
     pub(crate) fn new() -> Self {
         Self {
-            attempt: 0,
-            cumulative: 0,
+            attempt: RestartAttempt::ZERO,
+            cumulative: RestartCount::ZERO,
         }
     }
 
-    pub(crate) fn schedule(&mut self) -> (u64, u64) {
-        self.attempt = self.attempt.saturating_add(1);
-        self.cumulative = self.cumulative.saturating_add(1);
+    pub(crate) fn schedule(&mut self) -> (RestartAttempt, RestartCount) {
+        self.attempt = self.attempt.bump();
+        self.cumulative = self.cumulative.bump();
         (self.attempt, self.cumulative)
     }
 
     pub(crate) fn settled(&mut self) {
-        self.attempt = 0;
+        self.attempt = RestartAttempt::ZERO;
     }
 
     /// Resets the consecutive-attempt counter after one stable incarnation.
@@ -291,8 +311,8 @@ impl RestartState {
 /// Complete restart verdict consumed verbatim by the scope driver.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct RestartDecision {
-    pub(crate) attempt: u64,
-    pub(crate) restart_count: u64,
+    pub(crate) attempt: RestartAttempt,
+    pub(crate) restart_count: RestartCount,
     pub(crate) delay: Duration,
     /// Absolute backoff deadline; unrepresentable far-future points are
     /// clamped (B.6: `restart_at` is present exactly in `Restarting`).
@@ -862,7 +882,8 @@ mod tests {
     };
 
     use crate::{
-        Exit, ExitKind, Intensity, RestartCondition, RestartPolicy, Shutdown, policy::Backoff,
+        Exit, ExitKind, Intensity, RestartAttempt, RestartCondition, RestartCount, RestartPolicy,
+        Shutdown, TotalRestarts, policy::Backoff,
     };
 
     use super::{
@@ -1052,12 +1073,19 @@ mod tests {
         let trip = state.charge(policy, start + Duration::from_secs(10));
         assert!(trip.tripped);
         assert_eq!(trip.in_window, 2);
-        assert_eq!(trip.total_restarts, 2);
+        assert_eq!(trip.total_restarts, TotalRestarts::ZERO.bump().bump());
+        let trip_payload = crate::IntensityTrip::new(policy, trip);
+        assert_eq!(trip_payload.max_restarts, policy.max_restarts);
+        assert_eq!(trip_payload.observed_restarts, trip.in_window);
+        assert_eq!(trip_payload.within, policy.within);
 
         let aged = state.charge(policy, start + Duration::from_secs(21));
         assert!(!aged.tripped);
         assert_eq!(aged.in_window, 1);
-        assert_eq!(aged.total_restarts, 3);
+        assert_eq!(
+            aged.total_restarts,
+            TotalRestarts::ZERO.bump().bump().bump()
+        );
     }
 
     #[test]
@@ -1076,11 +1104,11 @@ mod tests {
             0.5,
         );
 
-        assert_eq!(decision.attempt, 1);
-        assert_eq!(decision.restart_count, 1);
+        assert_eq!(decision.attempt, RestartAttempt::ZERO.bump());
+        assert_eq!(decision.restart_count, RestartCount::ZERO.bump());
         assert_eq!(decision.delay, Duration::ZERO);
         assert_eq!(decision.restart_at, now);
-        assert_eq!(decision.charge.total_restarts, 1);
+        assert_eq!(decision.charge.total_restarts, TotalRestarts::ZERO.bump());
         assert!(decision.charge.tripped);
     }
 
@@ -1116,15 +1144,20 @@ mod tests {
         let start = Instant::now();
         let stable_for = Duration::from_secs(10);
         let mut restarts = RestartState::new();
-        assert_eq!(restarts.schedule(), (1, 1));
+        let attempt_one = RestartAttempt::ZERO.bump();
+        let attempt_two = attempt_one.bump();
+        let count_one = RestartCount::ZERO.bump();
+        let count_two = count_one.bump();
+        let count_three = count_two.bump();
+        assert_eq!(restarts.schedule(), (attempt_one, count_one));
         assert!(!restarts.settle_if_stable(
             start,
             start + stable_for - Duration::from_nanos(1),
             stable_for,
         ));
-        assert_eq!(restarts.schedule(), (2, 2));
+        assert_eq!(restarts.schedule(), (attempt_two, count_two));
         assert!(restarts.settle_if_stable(start, start + stable_for, stable_for));
-        assert_eq!(restarts.schedule(), (1, 3));
+        assert_eq!(restarts.schedule(), (attempt_one, count_three));
 
         assert!(
             !restarts.settle_if_stable(start, start - Duration::from_nanos(1), stable_for),

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -41,8 +41,9 @@ pub use observe::{
 };
 pub use policy::{
     Backoff, BackoffFactor, DefaultsInheritance, Intensity, InvalidPolicy, Jitter, Mailbox,
-    MailboxShutdown, PolicyError, PolicyField, Readiness, ReadinessDeadline, RestartCondition,
-    RestartPolicy, Retention, ScopeDefaults, Shutdown, Strategy,
+    MailboxShutdown, PolicyError, PolicyField, Readiness, ReadinessDeadline, RestartAttempt,
+    RestartCondition, RestartCount, RestartPolicy, Retention, ScopeDefaults, Shutdown, Strategy,
+    TotalRestarts,
 };
 pub use raw::{
     Blocking, DeadlineElapsed, Guard, RawActor, RawContext, RawDef, RawOnceDef, Rejected,

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -10,8 +10,8 @@ use std::{
 };
 
 use crate::{
-    ChildId, Exit, Incarnation, Intensity, Membership, RestartPolicy, Retention, Strategy,
-    exit::StopReason, runtime,
+    ChildId, Exit, Incarnation, Intensity, Membership, RestartAttempt, RestartCount, RestartPolicy,
+    Retention, Strategy, TotalRestarts, exit::StopReason, runtime,
 };
 
 /// Number of lifecycle events retained independently for each subscriber.
@@ -95,7 +95,7 @@ pub enum LifecycleEventKind {
         /// Child membership identity.
         membership: Membership,
         /// Resettable backoff attempt number.
-        attempt: u64,
+        attempt: RestartAttempt,
         /// Sampled restart delay.
         delay: Duration,
     },
@@ -216,7 +216,7 @@ pub struct ChildSnapshot {
     /// Planned-removal status.
     pub membership_status: MembershipStatus,
     /// Cumulative scheduled-restart charges for this membership.
-    pub restart_count: u64,
+    pub restart_count: RestartCount,
     /// Resolved restart policy.
     pub restart_policy: RestartPolicy,
     /// Resolved terminal-retention policy.
@@ -243,7 +243,7 @@ pub struct ScopeSnapshot {
     /// Scope-wide restart budget.
     pub intensity: Intensity,
     /// Cumulative restart charges across children in this incarnation.
-    pub total_restarts: u64,
+    pub total_restarts: TotalRestarts,
     /// This scope membership's lifecycle watermark.
     pub lifecycle_seq: u64,
     /// Children in declaration or admission order.
@@ -671,7 +671,7 @@ mod tests {
             kind: ScopeKind::Dynamic,
             strategy: None,
             intensity: Intensity::default(),
-            total_restarts: 0,
+            total_restarts: crate::TotalRestarts::ZERO,
             lifecycle_seq: 0,
             children: Arc::from([]),
         })

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -11,6 +11,69 @@ pub(crate) enum ScopeFlavor {
     Dynamic,
 }
 
+/// A one-origin backoff attempt that resets after a stable incarnation.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct RestartAttempt(u64);
+
+impl RestartAttempt {
+    /// The state before a restart has been scheduled.
+    pub const ZERO: Self = Self(0);
+
+    /// Returns the next attempt, saturating at the numeric limit.
+    #[must_use]
+    pub const fn bump(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+
+    /// Returns the numeric attempt value.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Cumulative scheduled-restart charges for one child membership.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct RestartCount(u64);
+
+impl RestartCount {
+    /// A membership with no scheduled restarts.
+    pub const ZERO: Self = Self(0);
+
+    /// Returns the next count, saturating at the numeric limit.
+    #[must_use]
+    pub const fn bump(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+
+    /// Returns the numeric restart count.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Cumulative restart charges across one scope incarnation.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TotalRestarts(u64);
+
+impl TotalRestarts {
+    /// A scope incarnation with no restart charges.
+    pub const ZERO: Self = Self(0);
+
+    /// Returns the next total, saturating at the numeric limit.
+    #[must_use]
+    pub const fn bump(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+
+    /// Returns the numeric restart total.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
 /// The default bounded FIFO mailbox capacity.
 pub const DEFAULT_MAILBOX_CAPACITY: usize = 64;
 /// The default child shutdown grace.
@@ -146,8 +209,8 @@ impl Backoff {
     /// `jitter_sample` is clamped into `[0, 1)` so callers cannot violate
     /// the equal-jitter range. Randomness is deliberately external data.
     #[must_use]
-    pub fn next_delay(self, attempt: u64, jitter_sample: f64) -> Duration {
-        let attempt = attempt.max(1);
+    pub fn next_delay(self, attempt: RestartAttempt, jitter_sample: f64) -> Duration {
+        let attempt = attempt.get().max(1);
         let (delay, jitter, maximum) = match self {
             Self::Immediate => return Duration::ZERO,
             Self::Fixed { delay, jitter } => (delay, jitter, delay),
@@ -726,8 +789,8 @@ mod tests {
 
     use super::{
         Backoff, BackoffFactor, Intensity, InvalidPolicy, Jitter, Mailbox, PolicyError,
-        PolicyField, ReadinessDeadline, ResolvedDefaults, RestartCondition, RestartPolicy,
-        ScopeDefaults, Shutdown, tidy_abort_beat,
+        PolicyField, ReadinessDeadline, ResolvedDefaults, RestartAttempt, RestartCondition,
+        RestartPolicy, ScopeDefaults, Shutdown, tidy_abort_beat,
     };
 
     #[test]
@@ -775,15 +838,33 @@ mod tests {
             Jitter::None,
         )
         .expect("valid backoff");
-        assert_eq!(backoff.next_delay(1, 0.9), Duration::from_millis(10));
-        assert_eq!(backoff.next_delay(2, 0.1), Duration::from_millis(20));
-        assert_eq!(backoff.next_delay(3, 0.5), Duration::from_millis(35));
-        assert_eq!(backoff.next_delay(99, 0.5), Duration::from_millis(35));
+        assert_eq!(
+            backoff.next_delay(RestartAttempt(1), 0.9),
+            Duration::from_millis(10)
+        );
+        assert_eq!(
+            backoff.next_delay(RestartAttempt(2), 0.1),
+            Duration::from_millis(20)
+        );
+        assert_eq!(
+            backoff.next_delay(RestartAttempt(3), 0.5),
+            Duration::from_millis(35)
+        );
+        assert_eq!(
+            backoff.next_delay(RestartAttempt(99), 0.5),
+            Duration::from_millis(35)
+        );
 
         let jittered =
             Backoff::fixed(Duration::from_millis(10), Jitter::Equal).expect("valid backoff");
-        assert_eq!(jittered.next_delay(1, 0.0), Duration::from_millis(5));
-        assert_eq!(jittered.next_delay(1, 0.5), Duration::from_micros(7_500));
+        assert_eq!(
+            jittered.next_delay(RestartAttempt(1), 0.0),
+            Duration::from_millis(5)
+        );
+        assert_eq!(
+            jittered.next_delay(RestartAttempt(1), 0.5),
+            Duration::from_micros(7_500)
+        );
     }
 
     #[test]
@@ -806,12 +887,12 @@ mod tests {
                 f64::INFINITY,
                 f64::NAN,
             ] {
-                assert!(backoff.next_delay(u64::MAX, sample) <= maximum);
+                assert!(backoff.next_delay(RestartAttempt(u64::MAX), sample) <= maximum);
             }
         }
 
         let fixed = Backoff::fixed(maximum, Jitter::Equal).expect("valid fixed backoff");
-        assert!(fixed.next_delay(u64::MAX, 1.0) <= maximum);
+        assert!(fixed.next_delay(RestartAttempt(u64::MAX), 1.0) <= maximum);
     }
 
     #[test]
@@ -892,7 +973,7 @@ mod tests {
             Jitter::None,
         )
         .expect("valid backoff");
-        assert_eq!(doubling.next_delay(1, 0.9), base);
+        assert_eq!(doubling.next_delay(RestartAttempt(1), 0.9), base);
 
         let flat = Backoff::exponential(
             base,
@@ -901,14 +982,17 @@ mod tests {
             Jitter::None,
         )
         .expect("valid backoff");
-        assert_eq!(flat.next_delay(1, 0.0), base);
-        assert_eq!(flat.next_delay(u64::MAX, 0.0), base);
+        assert_eq!(flat.next_delay(RestartAttempt(1), 0.0), base);
+        assert_eq!(flat.next_delay(RestartAttempt(u64::MAX), 0.0), base);
 
         let fixed = Backoff::fixed(base, Jitter::None).expect("valid backoff");
-        assert_eq!(fixed.next_delay(u64::MAX, 0.99), base);
+        assert_eq!(fixed.next_delay(RestartAttempt(u64::MAX), 0.99), base);
 
         let huge_fixed = Backoff::fixed(Duration::MAX, Jitter::None).expect("valid backoff");
-        assert_eq!(huge_fixed.next_delay(u64::MAX, 0.5), Duration::MAX);
+        assert_eq!(
+            huge_fixed.next_delay(RestartAttempt(u64::MAX), 0.5),
+            Duration::MAX
+        );
     }
 
     #[test]
@@ -923,8 +1007,8 @@ mod tests {
             Jitter::None,
         )
         .expect("valid backoff");
-        assert_eq!(explosive.next_delay(2, 0.0), max);
-        assert_eq!(explosive.next_delay(u64::MAX, 0.0), max);
+        assert_eq!(explosive.next_delay(RestartAttempt(2), 0.0), max);
+        assert_eq!(explosive.next_delay(RestartAttempt(u64::MAX), 0.0), max);
 
         let doubling = Backoff::exponential(
             Duration::from_secs(1),
@@ -933,7 +1017,7 @@ mod tests {
             Jitter::None,
         )
         .expect("valid backoff");
-        assert_eq!(doubling.next_delay(200, 0.0), max);
+        assert_eq!(doubling.next_delay(RestartAttempt(200), 0.0), max);
     }
 
     #[test]
@@ -943,15 +1027,18 @@ mod tests {
         let odd = Duration::from_nanos((1 << 60) + 1);
         let fixed = Backoff::fixed(odd, Jitter::Equal).expect("valid backoff");
         let exact_half = Duration::from_nanos((1 << 59) + 1);
-        assert_eq!(fixed.next_delay(1, 0.0), exact_half);
+        assert_eq!(fixed.next_delay(RestartAttempt(1), 0.0), exact_half);
         // Non-finite and negative samples clamp to the same exact edge.
         for sample in [f64::NAN, f64::NEG_INFINITY, -3.0] {
-            assert_eq!(fixed.next_delay(1, sample), exact_half);
+            assert_eq!(fixed.next_delay(RestartAttempt(1), sample), exact_half);
         }
 
         let even =
             Backoff::fixed(Duration::from_nanos(1 << 60), Jitter::Equal).expect("valid backoff");
-        assert_eq!(even.next_delay(1, 0.0), Duration::from_nanos(1 << 59));
+        assert_eq!(
+            even.next_delay(RestartAttempt(1), 0.0),
+            Duration::from_nanos(1 << 59)
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -790,8 +790,19 @@ mod tests {
     use super::{
         Backoff, BackoffFactor, Intensity, InvalidPolicy, Jitter, Mailbox, PolicyError,
         PolicyField, ReadinessDeadline, ResolvedDefaults, RestartAttempt, RestartCondition,
-        RestartPolicy, ScopeDefaults, Shutdown, tidy_abort_beat,
+        RestartCount, RestartPolicy, ScopeDefaults, Shutdown, TotalRestarts, tidy_abort_beat,
     };
+
+    #[test]
+    fn restart_counters_saturate_at_the_numeric_limit() {
+        let attempt = RestartAttempt(u64::MAX);
+        let count = RestartCount(u64::MAX);
+        let total = TotalRestarts(u64::MAX);
+
+        assert_eq!(attempt.bump(), attempt);
+        assert_eq!(count.bump(), count);
+        assert_eq!(total.bump(), total);
+    }
 
     #[test]
     fn shipped_defaults_match_the_normative_policy() {

--- a/crates/shelterwood/tests/acceptance/assistant.rs
+++ b/crates/shelterwood/tests/acceptance/assistant.rs
@@ -8,8 +8,8 @@ use crate::common::{POLL_TIMEOUT, ReleaseGate, poll_until};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, ChildState, Context, DeadlineElapsed, DynamicScopeRef,
     DynamicTree, ExitError, ExitResult, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
-    LifecycleItem, Mailbox, Membership, RemoveOutcome, Reply, ReserveError, RestartPolicy,
-    ScopeState, StopContext, SubtreeOnceDef, Tree,
+    LifecycleItem, Mailbox, Membership, RemoveOutcome, Reply, ReserveError, RestartCount,
+    RestartPolicy, ScopeState, StopContext, SubtreeOnceDef, Tree,
 };
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
@@ -518,7 +518,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             session.snapshot().child("control").is_some_and(|child| {
                 matches!(child.state, ChildState::Running)
-                    && child.restart_count == 1
+                    && child.restart_count == RestartCount::ZERO.bump()
                     && child.incarnation.is_some_and(|incarnation| {
                         incarnation.supersedes(first_control_incarnation)
                     })
@@ -556,7 +556,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
                 .child("temporary-tool")
                 .is_some_and(|child| {
                     matches!(child.state, ChildState::Running)
-                        && child.restart_count == 1
+                        && child.restart_count == RestartCount::ZERO.bump()
                         && child.incarnation.is_some_and(|incarnation| {
                             incarnation.supersedes(first_tool_incarnation)
                         })
@@ -664,7 +664,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .expect("replacement is resident")
         .clone();
     assert_eq!(replacement_snapshot.membership, replacement.membership());
-    assert_eq!(replacement_snapshot.restart_count, 0);
+    assert_eq!(replacement_snapshot.restart_count, RestartCount::ZERO);
     replacement_stop.release();
 
     assert_eq!(

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -7,9 +7,10 @@ use shelterwood::{
     Guard, Handler, Incarnation, Intensity, LifecycleEvents, LifecycleTryRecvError, Mailbox,
     MailboxShutdown, Membership, OneShotTaskRef, RawActor, RawContext, RawDef, RawOnceDef,
     Readiness, ReadinessDeadline, Removal, Reply, ReplyReceive, ReplyReceiver, ReserveError,
-    RestartPolicy, Retention, ScopeDefaults, ScopeRef, SendError, SendFuture, SendTimeout,
-    Shutdown, SnapshotClosed, SnapshotReceiver, StopContext, Strategy, SubtreeDef, SubtreeOnceDef,
-    SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, Tree, WaitError,
+    RestartAttempt, RestartCount, RestartPolicy, Retention, ScopeDefaults, ScopeRef, SendError,
+    SendFuture, SendTimeout, Shutdown, SnapshotClosed, SnapshotReceiver, StopContext, Strategy,
+    SubtreeDef, SubtreeOnceDef, SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot,
+    TotalRestarts, Tree, WaitError,
 };
 
 fn assert_error<T: Error>() {}
@@ -24,6 +25,12 @@ fn assert_static<T: 'static>() {}
 fn documented_identity_handle_token_and_owned_value_bounds_compile() {
     assert_copy_eq_hash_send_sync::<Membership>();
     assert_copy_eq_hash_send_sync::<Incarnation>();
+    assert_copy_eq_hash_send_sync::<RestartAttempt>();
+    assert_copy_eq_hash_send_sync::<RestartCount>();
+    assert_copy_eq_hash_send_sync::<TotalRestarts>();
+    assert_eq!(RestartAttempt::ZERO.bump().get(), 1);
+    assert_eq!(RestartCount::ZERO.bump().get(), 1);
+    assert_eq!(TotalRestarts::ZERO.bump().get(), 1);
 
     assert_clone_eq_hash_send_sync::<ActorRef<Cell<()>>>();
     assert_clone_eq_hash_send_sync::<TaskRef>();

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -14,9 +14,9 @@ use crate::common::{
 use shelterwood::{
     Backoff, ChildState, DynamicScopeRef, DynamicTree, Intensity, Jitter, LIFECYCLE_EVENT_CAPACITY,
     LifecycleEvent, LifecycleEventKind, LifecycleEvents, LifecycleItem, LifecycleTryRecvError,
-    MembershipStatus, RemoveOutcome, RestartCondition, RestartPolicy, Retention, ScopeKind,
-    ScopeRef, ScopeState, StopReason, Strategy, SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef,
-    TaskRef, Tree, WaitError,
+    MembershipStatus, RemoveOutcome, RestartCondition, RestartCount, RestartPolicy, Retention,
+    ScopeKind, ScopeRef, ScopeState, StopReason, Strategy, SubtreeDef, SubtreeOnceDef, TaskDef,
+    TaskOnceDef, TaskRef, TotalRestarts, Tree, WaitError,
 };
 
 async fn next_item(events: &mut LifecycleEvents) -> LifecycleItem {
@@ -594,10 +594,10 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
     assert!(child.incarnation.is_none());
     assert!(child.nested.is_none());
     assert!(child.restart_at.is_some());
-    assert_eq!(child.restart_count, 1);
-    assert_eq!(restart_window.total_restarts, 1);
+    assert_eq!(child.restart_count, RestartCount::ZERO.bump());
+    assert_eq!(restart_window.total_restarts, TotalRestarts::ZERO.bump());
     assert_eq!(child.scope_seq, Some(stopped_seq));
-    assert_eq!(nested.snapshot().total_restarts, 1);
+    assert_eq!(nested.snapshot().total_restarts, TotalRestarts::ZERO.bump());
     assert_eq!(
         restart_window
             .descendant(["nested"])
@@ -637,7 +637,7 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
         "corresponding descendants retain ordering across a scope restart"
     );
     assert_eq!(nested.membership(), scope_membership);
-    assert_eq!(nested.snapshot().total_restarts, 0);
+    assert_eq!(nested.snapshot().total_restarts, TotalRestarts::ZERO);
     assert!(nested.snapshot().lifecycle_seq >= starting.seq);
     assert!(
         poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
@@ -1297,7 +1297,7 @@ async fn end_to_end_snapshot_projects_kinds_policies_membership_status_and_stopp
         running.intensity,
         Intensity::new(7, Duration::from_secs(90)).expect("valid intensity")
     );
-    assert_eq!(running.total_restarts, 0);
+    assert_eq!(running.total_restarts, TotalRestarts::ZERO);
     assert_eq!(
         running
             .children
@@ -1314,7 +1314,7 @@ async fn end_to_end_snapshot_projects_kinds_policies_membership_status_and_stopp
     assert!(matches!(nested_row.state, ChildState::Running));
     assert_eq!(nested_row.last_exit, None);
     assert_eq!(nested_row.membership_status, MembershipStatus::Active);
-    assert_eq!(nested_row.restart_count, 0);
+    assert_eq!(nested_row.restart_count, RestartCount::ZERO);
     assert!(
         nested_row.restart_policy.is_never(),
         "a one-shot subtree cannot restart"

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -11,9 +11,9 @@ use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_
 use shelterwood::{
     Actor, ActorOnceDef, Backoff, ChildState, Context, DefaultsInheritance, DynamicTree, ExitError,
     ExitKind, ExitResult, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError,
-    Mailbox, MailboxShutdown, Readiness, ReadinessDeadline, RestartCondition, RestartPolicy,
-    ScopeDefaults, SendErrorKind, Shutdown, StartupError, StartupFailureCause, StopReason,
-    SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef, TaskRef, Tree,
+    Mailbox, MailboxShutdown, Readiness, ReadinessDeadline, RestartAttempt, RestartCondition,
+    RestartPolicy, ScopeDefaults, SendErrorKind, Shutdown, StartupError, StartupFailureCause,
+    StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef, TaskRef, Tree,
 };
 
 #[tokio::test]
@@ -741,7 +741,10 @@ async fn restart_attempt_resets_after_a_ready_incarnation_settles() {
             Ok(_) | Err(_) => panic!("unexpected future lifecycle variant"),
         }
     }
-    assert_eq!(attempts, [1, 1]);
+    assert_eq!(
+        attempts,
+        [RestartAttempt::ZERO.bump(), RestartAttempt::ZERO.bump()]
+    );
 
     system
         .shutdown(Duration::from_secs(1))

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -13,8 +13,8 @@ use shelterwood::{
     DynamicTree, ExitError, ExitKind, ExitResult, GracePhase, Intensity, LifecycleEventKind,
     LifecycleItem, LifecycleTryRecvError, Mailbox, MailboxShutdown, Readiness, ReadinessDeadline,
     RestartAttempt, RestartCondition, RestartPolicy, ScopeDefaults, SendErrorKind, Shutdown,
-    StartupError, StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, TaskOnceDef,
-    TaskRef, Tree,
+    StartupError, StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef,
+    TaskOnceDef, TaskRef, Tree,
 };
 
 #[tokio::test]


### PR DESCRIPTION
Implements issue #101 section D.

- adds public opaque `RestartAttempt`, `RestartCount`, and `TotalRestarts` domains
- limits each counter to `ZERO`, saturating `bump()`, and `get()` with no arithmetic traits
- carries the domains through backoff derivation, restart state/decisions, intensity charges, observation records, lifecycle events, and public snapshots
- replaces raw `IntensityTrip` field construction in the driver with one derived constructor from the intensity policy and authoritative charge
- updates API/integration tests and the normative specification

Validation:
- `./scripts/dev just ci` (427/427 tests, doctests, docs, API/enforcement checks, package verification, and Nix formatting)