### PR TITLE
Harden restart derivation inputs

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -142,7 +142,7 @@ any single design rule:
   invariant makes bit-equality correct: §9.2's backoff factor),
   serializable where Part II §21 needs it, and carrying **no
   behavior** beyond small pure derivation functions of the
-  `should_restart(is_failure)` / `next_delay(attempt, jitter_sample)` /
+  `should_restart(exit)` / `next_delay(attempt, JitterSample)` /
   `validate()` shape. Runtime behavior is *derived from* the data by local
   functions; it is never encoded as trait objects, callbacks, or builder
   side effects.
@@ -1702,8 +1702,11 @@ Two separated concerns:
   or exponential: `base × factor^(n−1)` clamped to `max`, with optional
   equal-jitter drawing uniformly from `[d/2, d]`; all durations validated
   non-zero at construction). Delay computation is a pure function of
-  (attempt, policy, jitter sample) — the sample is an input, not drawn
-  inside (§1 implementation shape; D.3 names the source). Pinned
+  (attempt, policy, `JitterSample`) — the sample is an input, not drawn
+  inside (§1 implementation shape; D.3 names the source). `JitterSample`
+  owns the `[0, 1)` invariant: its constructor clamps finite inputs and maps
+  non-finite inputs to zero, while `from_u64_ratio` owns the driver's integer
+  random-source normalization. Pinned
   arithmetic: `factor` is a validated newtype over `f64` — finite and
   `≥ 1.0`, checked at construction — implementing `Eq`/`Hash` as
   bit-equality of the underlying bits, sound because the invariant
@@ -1714,8 +1717,8 @@ Two separated concerns:
   count is used exactly, with no float round-trip; otherwise the base
   delay's whole-nanosecond count is multiplied as `f64`, rounded to the
   nearest nanosecond, and a product at or above `max` saturates to the
-  exact configured `max` (never an overflow panic); jitter maps a
-  pre-drawn `f64` sample in `[0, 1)` as `delay = d/2 + sample × d/2`,
+  exact configured `max` (never an overflow panic); jitter maps the
+  pre-drawn `JitterSample` as `delay = d/2 + sample × d/2`,
   rounded the same way — a zero sample yields the exact half,
   half-nanosecond remainders rounding up with no float round-trip. The
   attempt counter is per
@@ -1725,6 +1728,8 @@ Two separated concerns:
   an incarnation that exits after running at least the scope's intensity
   window `within` (one clock answers "has it settled"); the snapshot's
   `restart_count` (B.6) is its non-resetting cumulative twin. Running time is
+  passed to the settling decision as one named `IncarnationRun {
+  started_at, stopped_at }`, so its endpoints cannot be transposed, and is
   measured between two engine-stamped instants: the incarnation's **start
   instant**, stamped once when the engine schedules the spawn (the
   `Started` event's instant — the same stamp anchors §6's readiness
@@ -2555,8 +2560,10 @@ Both questions are resolved:
    disarm them. Queued admissions run after all already-observed terminal and
    temporal facts, so they cannot enter a scope that the same wake has made
    non-admitting. The decision layer represents this as an ordered class and
-   pins the complete table without runtime selection; the driver drains all
-   currently eligible inputs into that table before applying effects.
+   pins the complete table without runtime selection; each pending item
+   derives its class through `Pending::class()` rather than accepting a class
+   beside it at collection sites, and the driver drains all currently eligible
+   inputs into that table before applying effects.
 
 (Resolved elsewhere: stage-generic `handle` is rejected — drain-stage
 rejection stays value-level, §5.4; the conflating-mailbox control lane is

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -8,15 +8,16 @@ use std::{
 };
 
 use crate::{
-    ChildId, Exit, ExitKind, Incarnation, IntensityTrip, Membership, Readiness, ReadinessDeadline,
-    ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure, StartupFailureCause,
+    ChildId, Exit, ExitKind, Incarnation, IntensityTrip, JitterSample, Membership, Readiness,
+    ReadinessDeadline, ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure,
+    StartupFailureCause,
     admission::{NotAdmittingCause, RemoveOutcome, ReserveError},
     cells::{DynamicRoute, MailboxControl, MemberStage, ResidentProjection, ScopeCell},
     deadline::Deadline,
     engine::{
-        ArbitrationClass, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch, IntensityState,
-        MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState,
-        ScopeLifecycle, ScopeMode, StopAction, StopLadder, arbitrate, dispatch_exit,
+        ArbitrationClass, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch, IncarnationRun,
+        IntensityState, MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate,
+        RestartState, ScopeLifecycle, ScopeMode, StopAction, StopLadder, arbitrate, dispatch_exit,
         schedule_restart,
     },
     exit::{
@@ -2048,8 +2049,10 @@ impl ScopeRuntime {
         let recorded = reconcile_recorded_outcomes(recorded, active.forced_outcome);
         let exit = classify_exit(recorded, join, cancelled);
         child.restarts.settle_if_stable(
-            active.started_at,
-            runtime::now(),
+            IncarnationRun {
+                started_at: active.started_at,
+                stopped_at: runtime::now(),
+            },
             self.intensity_policy.within,
         );
 
@@ -2077,7 +2080,8 @@ impl ScopeRuntime {
                 if !self.lifecycle.startup_complete() {
                     child.initial_ready = false;
                 }
-                let sample = self.jitter.sample(0..u64::MAX) as f64 / u64::MAX as f64;
+                let sample =
+                    JitterSample::from_u64_ratio(self.jitter.sample(0..u64::MAX), u64::MAX);
                 let now = runtime::now();
                 let decision = schedule_restart(
                     &mut child.restarts,
@@ -2790,7 +2794,7 @@ async fn run_scope_incarnation(
     loop {
         let mut pending = Vec::new();
         if root.take_shutdown_request(scope.epoch) {
-            pending.push((ArbitrationClass::ScopeShutdown, Pending::Shutdown));
+            pending.push(Pending::Shutdown.classified());
         }
         for child in scope.pending_restart_shutdowns() {
             pending.push(restart_shutdown_work(child));
@@ -2802,21 +2806,20 @@ async fn run_scope_incarnation(
                 .is_some_and(Latch::is_fired)
         {
             scope.ancestor_shutdown_seen = true;
-            pending.push((ArbitrationClass::ScopeShutdown, Pending::AncestorShutdown));
+            pending.push(Pending::AncestorShutdown.classified());
         }
         if !scope.ancestor_abort_seen && scope.ancestor_abort.as_ref().is_some_and(Latch::is_fired)
         {
             scope.ancestor_abort_seen = true;
-            pending.push((ArbitrationClass::ScopeShutdown, Pending::AncestorAbort));
+            pending.push(Pending::AncestorAbort.classified());
         }
         if root.take_force_request(scope.epoch) {
             // Force owns shutdown arbitration: readiness from the same wake
             // cannot publish Running after the stop boundary.
-            pending.push((ArbitrationClass::ScopeShutdown, Pending::Force));
+            pending.push(Pending::Force.classified());
         }
         while let Some(event) = runtime::mpsc_try_recv(&mut event_receiver) {
-            let class = driver_event_class(&event);
-            pending.push((class, Pending::Driver(event)));
+            pending.push(Pending::Driver(event).classified());
         }
         // Disposal completions drain after the bounded lane, and `arbitrate`
         // sorts stably, so a `ConstructionDisposed` always trails every
@@ -2829,17 +2832,11 @@ async fn run_scope_incarnation(
         // one: disposal runs on the blocking pool, so its completion never had
         // a fixed position relative to concurrent exits.
         while let Some(event) = runtime::unbounded_mpsc_try_recv(&mut disposal_event_receiver) {
-            let class = driver_event_class(&event);
-            pending.push((class, Pending::Driver(event)));
+            pending.push(Pending::Driver(event).classified());
         }
         let now = runtime::now();
         while let Some(deadline) = scope.deadlines.pop_due(now) {
-            let class = match deadline {
-                DeadlineKind::Readiness { .. } => ArbitrationClass::ReadinessDeadline,
-                DeadlineKind::Restart { .. } => ArbitrationClass::BackoffDue,
-                DeadlineKind::Stop { .. } => ArbitrationClass::StopDeadline,
-            };
-            pending.push((class, Pending::Deadline(deadline)));
+            pending.push(Pending::Deadline(deadline).classified());
         }
 
         if pending.is_empty() {
@@ -2884,8 +2881,7 @@ async fn run_scope_incarnation(
                     continue;
                 }
                 runtime::ScopeWake::Message(Some(event)) => {
-                    let class = driver_event_class(&event);
-                    pending.push((class, Pending::Driver(event)));
+                    pending.push(Pending::Driver(event).classified());
                 }
                 runtime::ScopeWake::Message(None) => continue,
             }
@@ -2988,15 +2984,31 @@ enum Pending {
     Deadline(DeadlineKind),
 }
 
+impl Pending {
+    fn class(&self) -> ArbitrationClass {
+        match self {
+            Self::Shutdown | Self::AncestorShutdown | Self::AncestorAbort | Self::Force => {
+                ArbitrationClass::ScopeShutdown
+            }
+            Self::RestartShutdown(_) => ArbitrationClass::BackoffDue,
+            Self::Driver(event) => driver_event_class(event),
+            Self::Deadline(DeadlineKind::Readiness { .. }) => ArbitrationClass::ReadinessDeadline,
+            Self::Deadline(DeadlineKind::Restart { .. }) => ArbitrationClass::BackoffDue,
+            Self::Deadline(DeadlineKind::Stop { .. }) => ArbitrationClass::StopDeadline,
+        }
+    }
+
+    fn classified(self) -> (ArbitrationClass, Self) {
+        (self.class(), self)
+    }
+}
+
 fn restart_shutdown_work(child: ChildKey) -> (ArbitrationClass, Pending) {
     // This starts a pending incarnation, so it is restart work, not a
     // scope-shutdown transition. A child exit collected in the same wake must
     // first get the chance to trip intensity or fail startup; the
     // execution-time suppression check then observes that drain.
-    (
-        ArbitrationClass::BackoffDue,
-        Pending::RestartShutdown(child),
-    )
+    Pending::RestartShutdown(child).classified()
 }
 
 fn driver_event_class(event: &DriverEvent) -> ArbitrationClass {
@@ -3040,8 +3052,8 @@ mod tests {
         ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent, DynamicControl, DynamicEntry,
         GateCapture, MemberCell, MemberStage, Obligation, Pending, RemovalResponses,
         RuntimeStorage, ScopeCell, ScopeEpochGuard, ScopeFlavor, ScopeRuntime, complete_removals,
-        driver_event_class, mint_child_incarnation, report_channel, resident_projection,
-        restart_shutdown_work, run_nested_tree, run_scope_incarnation,
+        mint_child_incarnation, report_channel, resident_projection, restart_shutdown_work,
+        run_nested_tree, run_scope_incarnation,
     };
 
     /// Bounds every gate-capture probe wait. The probe sender lives inside
@@ -3504,7 +3516,7 @@ mod tests {
         });
         let mut pending = [
             restart_shutdown_work(nested),
-            (driver_event_class(&exit), Pending::Driver(exit)),
+            Pending::Driver(exit).classified(),
         ];
         arbitrate(&mut pending);
         for (_, event) in pending {

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use crate::{
-    Exit, Intensity, Readiness, RestartPolicy, Shutdown, deadline::Deadline, exit::StopReason,
-    policy::tidy_abort_beat,
+    Exit, Intensity, JitterSample, Readiness, RestartPolicy, Shutdown, deadline::Deadline,
+    exit::StopReason, policy::tidy_abort_beat,
 };
 
 /// Deterministic priority when one driver wake exposes several events.
@@ -207,7 +207,7 @@ pub(crate) fn dispatch_exit(
     if scope == ScopeMode::Draining || membership == MembershipMode::Removing {
         return ExitDispatch::Terminal;
     }
-    if restart.should_restart(exit.is_failure()) {
+    if restart.should_restart(exit) {
         ExitDispatch::ScheduleRestart
     } else {
         ExitDispatch::Terminal
@@ -252,6 +252,12 @@ pub(crate) struct RestartState {
     cumulative: u64,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct IncarnationRun {
+    pub(crate) started_at: Instant,
+    pub(crate) stopped_at: Instant,
+}
+
 impl RestartState {
     pub(crate) fn new() -> Self {
         Self {
@@ -274,13 +280,8 @@ impl RestartState {
     ///
     /// Saturating elapsed time deliberately treats a clock regression as a
     /// zero-length run, so it cannot accidentally forgive restart pressure.
-    pub(crate) fn settle_if_stable(
-        &mut self,
-        started_at: Instant,
-        stopped_at: Instant,
-        stable_for: Duration,
-    ) -> bool {
-        if stopped_at.saturating_duration_since(started_at) < stable_for {
+    pub(crate) fn settle_if_stable(&mut self, run: IncarnationRun, stable_for: Duration) -> bool {
+        if run.stopped_at.saturating_duration_since(run.started_at) < stable_for {
             return false;
         }
         self.settled();
@@ -306,7 +307,7 @@ pub(crate) fn schedule_restart(
     intensity_policy: Intensity,
     restart_policy: RestartPolicy,
     now: Instant,
-    jitter_sample: f64,
+    jitter_sample: JitterSample,
 ) -> RestartDecision {
     let (attempt, restart_count) = restarts.schedule();
     let delay = restart_policy.backoff().next_delay(attempt, jitter_sample);
@@ -862,14 +863,15 @@ mod tests {
     };
 
     use crate::{
-        Exit, ExitKind, Intensity, RestartCondition, RestartPolicy, Shutdown, policy::Backoff,
+        Exit, ExitKind, Intensity, JitterSample, RestartCondition, RestartPolicy, Shutdown,
+        policy::Backoff,
     };
 
     use super::{
-        ArbitrationClass, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch, IntensityState,
-        MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate, RequestTarget,
-        RestartState, ScopeEpochs, ScopeLifecycle, ScopeMode, StopAction, StopLadder, arbitrate,
-        dispatch_exit, schedule_restart, tidy_abort_beat,
+        ArbitrationClass, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch, IncarnationRun,
+        IntensityState, MembershipMode, ReadinessEffect, ReadinessEvent, ReadinessGate,
+        RequestTarget, RestartState, ScopeEpochs, ScopeLifecycle, ScopeMode, StopAction,
+        StopLadder, arbitrate, dispatch_exit, schedule_restart, tidy_abort_beat,
     };
 
     #[test]
@@ -1073,7 +1075,7 @@ mod tests {
             intensity_policy,
             restart_policy,
             now,
-            0.5,
+            JitterSample::new(0.5),
         );
 
         assert_eq!(decision.attempt, 1);
@@ -1100,7 +1102,7 @@ mod tests {
             intensity_policy,
             restart_policy,
             now,
-            0.5,
+            JitterSample::new(0.5),
         );
 
         assert_eq!(decision.delay, Duration::MAX);
@@ -1118,16 +1120,30 @@ mod tests {
         let mut restarts = RestartState::new();
         assert_eq!(restarts.schedule(), (1, 1));
         assert!(!restarts.settle_if_stable(
-            start,
-            start + stable_for - Duration::from_nanos(1),
+            IncarnationRun {
+                started_at: start,
+                stopped_at: start + stable_for - Duration::from_nanos(1),
+            },
             stable_for,
         ));
         assert_eq!(restarts.schedule(), (2, 2));
-        assert!(restarts.settle_if_stable(start, start + stable_for, stable_for));
+        assert!(restarts.settle_if_stable(
+            IncarnationRun {
+                started_at: start,
+                stopped_at: start + stable_for,
+            },
+            stable_for,
+        ));
         assert_eq!(restarts.schedule(), (1, 3));
 
         assert!(
-            !restarts.settle_if_stable(start, start - Duration::from_nanos(1), stable_for),
+            !restarts.settle_if_stable(
+                IncarnationRun {
+                    started_at: start,
+                    stopped_at: start - Duration::from_nanos(1),
+                },
+                stable_for,
+            ),
             "a regressed clock cannot forgive restart pressure"
         );
     }

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -40,9 +40,9 @@ pub use observe::{
     ScopeSnapshot, ScopeState, SnapshotClosed, SnapshotReceiver, WaitError,
 };
 pub use policy::{
-    Backoff, BackoffFactor, DefaultsInheritance, Intensity, InvalidPolicy, Jitter, Mailbox,
-    MailboxShutdown, PolicyError, PolicyField, Readiness, ReadinessDeadline, RestartCondition,
-    RestartPolicy, Retention, ScopeDefaults, Shutdown, Strategy,
+    Backoff, BackoffFactor, DefaultsInheritance, Intensity, InvalidPolicy, Jitter, JitterSample,
+    Mailbox, MailboxShutdown, PolicyError, PolicyField, Readiness, ReadinessDeadline,
+    RestartCondition, RestartPolicy, Retention, ScopeDefaults, Shutdown, Strategy,
 };
 pub use raw::{
     Blocking, DeadlineElapsed, Guard, RawActor, RawContext, RawDef, RawOnceDef, Rejected,

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt, num::NonZeroUsize, time::Duration};
 
-use crate::identity::ChildId;
+use crate::{Exit, identity::ChildId};
 
 /// Whether a scope has fixed ordered membership or runtime-dynamic membership.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -36,6 +36,29 @@ pub enum Jitter {
     None,
     /// Select uniformly from the upper half of the derived delay.
     Equal,
+}
+
+/// A jitter sample clamped to the half-open interval `[0, 1)`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct JitterSample(f64);
+
+impl JitterSample {
+    /// Clamps a sample into `[0, 1)`; non-finite values become zero.
+    #[must_use]
+    pub fn new(value: f64) -> Self {
+        let value = if value.is_finite() {
+            value.clamp(0.0, 1.0 - f64::EPSILON)
+        } else {
+            0.0
+        };
+        Self(value)
+    }
+
+    /// Normalizes an integer ratio and clamps it into `[0, 1)`.
+    #[must_use]
+    pub fn from_u64_ratio(numerator: u64, denominator: u64) -> Self {
+        Self::new(numerator as f64 / denominator as f64)
+    }
 }
 
 /// A validated exponential-backoff multiplier.
@@ -143,10 +166,9 @@ impl Backoff {
 
     /// Derives the delay for a one-origin restart attempt.
     ///
-    /// `jitter_sample` is clamped into `[0, 1)` so callers cannot violate
-    /// the equal-jitter range. Randomness is deliberately external data.
+    /// Randomness is deliberately supplied as external, range-checked data.
     #[must_use]
-    pub fn next_delay(self, attempt: u64, jitter_sample: f64) -> Duration {
+    pub fn next_delay(self, attempt: u64, jitter_sample: JitterSample) -> Duration {
         let attempt = attempt.max(1);
         let (delay, jitter, maximum) = match self {
             Self::Immediate => return Duration::ZERO,
@@ -180,11 +202,7 @@ impl Backoff {
         let delay = match jitter {
             Jitter::None => delay,
             Jitter::Equal => {
-                let sample = if jitter_sample.is_finite() {
-                    jitter_sample.clamp(0.0, 1.0 - f64::EPSILON)
-                } else {
-                    0.0
-                };
+                let sample = jitter_sample.0;
                 if sample == 0.0 {
                     // The lower jitter edge is exactly half the delay,
                     // rounded to the nearest nanosecond without a float
@@ -286,10 +304,10 @@ impl RestartPolicy {
         self.backoff.validate()
     }
 
-    pub(crate) fn should_restart(self, failure: bool) -> bool {
+    pub(crate) fn should_restart(self, exit: &Exit) -> bool {
         match self.condition {
             RestartCondition::Always => true,
-            RestartCondition::OnFailure => failure,
+            RestartCondition::OnFailure => exit.is_failure(),
             RestartCondition::Never => false,
         }
     }
@@ -725,9 +743,9 @@ mod tests {
     use std::{num::NonZeroUsize, time::Duration};
 
     use super::{
-        Backoff, BackoffFactor, Intensity, InvalidPolicy, Jitter, Mailbox, PolicyError,
-        PolicyField, ReadinessDeadline, ResolvedDefaults, RestartCondition, RestartPolicy,
-        ScopeDefaults, Shutdown, tidy_abort_beat,
+        Backoff, BackoffFactor, Intensity, InvalidPolicy, Jitter, JitterSample, Mailbox,
+        PolicyError, PolicyField, ReadinessDeadline, ResolvedDefaults, RestartCondition,
+        RestartPolicy, ScopeDefaults, Shutdown, tidy_abort_beat,
     };
 
     #[test]
@@ -775,15 +793,46 @@ mod tests {
             Jitter::None,
         )
         .expect("valid backoff");
-        assert_eq!(backoff.next_delay(1, 0.9), Duration::from_millis(10));
-        assert_eq!(backoff.next_delay(2, 0.1), Duration::from_millis(20));
-        assert_eq!(backoff.next_delay(3, 0.5), Duration::from_millis(35));
-        assert_eq!(backoff.next_delay(99, 0.5), Duration::from_millis(35));
+        assert_eq!(
+            backoff.next_delay(1, JitterSample::new(0.9)),
+            Duration::from_millis(10)
+        );
+        assert_eq!(
+            backoff.next_delay(2, JitterSample::new(0.1)),
+            Duration::from_millis(20)
+        );
+        assert_eq!(
+            backoff.next_delay(3, JitterSample::new(0.5)),
+            Duration::from_millis(35)
+        );
+        assert_eq!(
+            backoff.next_delay(99, JitterSample::new(0.5)),
+            Duration::from_millis(35)
+        );
 
         let jittered =
             Backoff::fixed(Duration::from_millis(10), Jitter::Equal).expect("valid backoff");
-        assert_eq!(jittered.next_delay(1, 0.0), Duration::from_millis(5));
-        assert_eq!(jittered.next_delay(1, 0.5), Duration::from_micros(7_500));
+        assert_eq!(
+            jittered.next_delay(1, JitterSample::new(0.0)),
+            Duration::from_millis(5)
+        );
+        assert_eq!(
+            jittered.next_delay(1, JitterSample::new(0.5)),
+            Duration::from_micros(7_500)
+        );
+    }
+
+    #[test]
+    fn jitter_samples_own_the_half_open_unit_interval() {
+        assert_eq!(JitterSample::new(-1.0).0, 0.0);
+        assert_eq!(JitterSample::new(f64::NAN).0, 0.0);
+        assert_eq!(JitterSample::new(f64::INFINITY).0, 0.0);
+        assert_eq!(JitterSample::new(1.0).0, 1.0 - f64::EPSILON);
+        assert_eq!(JitterSample::from_u64_ratio(0, u64::MAX).0, 0.0);
+        assert_eq!(
+            JitterSample::from_u64_ratio(u64::MAX, u64::MAX).0,
+            1.0 - f64::EPSILON
+        );
     }
 
     #[test]
@@ -806,12 +855,12 @@ mod tests {
                 f64::INFINITY,
                 f64::NAN,
             ] {
-                assert!(backoff.next_delay(u64::MAX, sample) <= maximum);
+                assert!(backoff.next_delay(u64::MAX, JitterSample::new(sample)) <= maximum);
             }
         }
 
         let fixed = Backoff::fixed(maximum, Jitter::Equal).expect("valid fixed backoff");
-        assert!(fixed.next_delay(u64::MAX, 1.0) <= maximum);
+        assert!(fixed.next_delay(u64::MAX, JitterSample::new(1.0)) <= maximum);
     }
 
     #[test]
@@ -892,7 +941,7 @@ mod tests {
             Jitter::None,
         )
         .expect("valid backoff");
-        assert_eq!(doubling.next_delay(1, 0.9), base);
+        assert_eq!(doubling.next_delay(1, JitterSample::new(0.9)), base);
 
         let flat = Backoff::exponential(
             base,
@@ -901,14 +950,17 @@ mod tests {
             Jitter::None,
         )
         .expect("valid backoff");
-        assert_eq!(flat.next_delay(1, 0.0), base);
-        assert_eq!(flat.next_delay(u64::MAX, 0.0), base);
+        assert_eq!(flat.next_delay(1, JitterSample::new(0.0)), base);
+        assert_eq!(flat.next_delay(u64::MAX, JitterSample::new(0.0)), base);
 
         let fixed = Backoff::fixed(base, Jitter::None).expect("valid backoff");
-        assert_eq!(fixed.next_delay(u64::MAX, 0.99), base);
+        assert_eq!(fixed.next_delay(u64::MAX, JitterSample::new(0.99)), base);
 
         let huge_fixed = Backoff::fixed(Duration::MAX, Jitter::None).expect("valid backoff");
-        assert_eq!(huge_fixed.next_delay(u64::MAX, 0.5), Duration::MAX);
+        assert_eq!(
+            huge_fixed.next_delay(u64::MAX, JitterSample::new(0.5)),
+            Duration::MAX
+        );
     }
 
     #[test]
@@ -923,8 +975,8 @@ mod tests {
             Jitter::None,
         )
         .expect("valid backoff");
-        assert_eq!(explosive.next_delay(2, 0.0), max);
-        assert_eq!(explosive.next_delay(u64::MAX, 0.0), max);
+        assert_eq!(explosive.next_delay(2, JitterSample::new(0.0)), max);
+        assert_eq!(explosive.next_delay(u64::MAX, JitterSample::new(0.0)), max);
 
         let doubling = Backoff::exponential(
             Duration::from_secs(1),
@@ -933,7 +985,7 @@ mod tests {
             Jitter::None,
         )
         .expect("valid backoff");
-        assert_eq!(doubling.next_delay(200, 0.0), max);
+        assert_eq!(doubling.next_delay(200, JitterSample::new(0.0)), max);
     }
 
     #[test]
@@ -943,15 +995,18 @@ mod tests {
         let odd = Duration::from_nanos((1 << 60) + 1);
         let fixed = Backoff::fixed(odd, Jitter::Equal).expect("valid backoff");
         let exact_half = Duration::from_nanos((1 << 59) + 1);
-        assert_eq!(fixed.next_delay(1, 0.0), exact_half);
+        assert_eq!(fixed.next_delay(1, JitterSample::new(0.0)), exact_half);
         // Non-finite and negative samples clamp to the same exact edge.
         for sample in [f64::NAN, f64::NEG_INFINITY, -3.0] {
-            assert_eq!(fixed.next_delay(1, sample), exact_half);
+            assert_eq!(fixed.next_delay(1, JitterSample::new(sample)), exact_half);
         }
 
         let even =
             Backoff::fixed(Duration::from_nanos(1 << 60), Jitter::Equal).expect("valid backoff");
-        assert_eq!(even.next_delay(1, 0.0), Duration::from_nanos(1 << 59));
+        assert_eq!(
+            even.next_delay(1, JitterSample::new(0.0)),
+            Duration::from_nanos(1 << 59)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Implements the restart-related items from issue #101 section E.

- carries stable-run endpoints in named `IncarnationRun { started_at, stopped_at }`
- adds public `JitterSample`, whose constructors own the `[0, 1)` clamp and integer-ratio normalization
- makes `RestartPolicy` evaluate `&Exit` directly instead of accepting a failure boolean
- derives every collected driver's arbitration class from `Pending::class()`
- updates invariant tests and the normative specification

Validation:
- `./scripts/dev just ci` (427/427 tests, doctests, docs, API/enforcement checks, package verification, and Nix formatting)