### PR TITLE
Name runtime boundary carriers

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3521,7 +3521,7 @@ fn wait_for_child(
     &self,
     id: impl Into<ChildId>,
     pred: impl FnMut(&ChildSnapshot) -> bool + Send,
-    deadline: Duration,                       // trailing, per Appendix B
+    timeout: Duration,                        // trailing, per Appendix B
 ) -> impl Future<Output = Result<ChildSnapshot, WaitError>> + Send;
 // WaitError { TimedOut, ScopeTerminated { state } } — non-exhaustive;
 // ScopeTerminated carries the scope's terminal B.6 state

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2867,8 +2867,10 @@ async fn run_scope_incarnation(
                 let _ = runtime::select_two(shutdown, abort).await;
             };
             match runtime::wait_scope(
-                signal.changed(),
-                ancestor_command,
+                runtime::ScopeWait {
+                    signal: signal.changed(),
+                    parent_shutdown: ancestor_command,
+                },
                 &mut event_receiver,
                 scope.deadlines.next(),
             )

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -21,8 +21,8 @@ use crate::{
     mailbox::{MailboxCell, MailboxReceiver},
     policy::CommonOptions,
     runtime::{
-        self, ActorWork, Latch, PanicAccumulator, PanicPayload, Signal, SignalWatcher, catch_panic,
-        discard_panic, keep_first_panic, resume_preferred_panic,
+        self, ActorWork, Latch, PanicAccumulator, PanicPayload, Signal, SignalWatcher,
+        UnwindPanics, catch_panic, discard_panic, keep_first_panic, resume_preferred_panic,
         resume_preferred_panic_outside_unwind,
     },
 };
@@ -759,7 +759,10 @@ impl<M> RawResources<M> {
         // Reached from the actor's own receive path, never from cleanup. The
         // take is destructive, so containment here would drop the retained
         // offload diagnostic and let the loop keep running.
-        resume_preferred_panic_outside_unwind(self.panic.take(), None);
+        resume_preferred_panic_outside_unwind(UnwindPanics {
+            primary: self.panic.take(),
+            cleanup: None,
+        });
     }
 
     async fn join_offloads(&mut self) {
@@ -1608,7 +1611,10 @@ impl<R: RawActor> Drop for RawIncarnationOwner<R> {
         let mut cleanup = PanicAccumulator::default();
         cleanup.run(|| self.drop_raw());
         cleanup.run(|| self.drop_actor());
-        resume_preferred_panic(primary_panic, cleanup.take());
+        resume_preferred_panic(UnwindPanics {
+            primary: primary_panic,
+            cleanup: cleanup.take(),
+        });
     }
 }
 
@@ -1661,7 +1667,10 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
             // containing the primary payload here would strand `result` at
             // `None` and report the actor's panic as the framework expect
             // below.
-            resume_preferred_panic_outside_unwind(owner.take_primary_panic(), cleanup_panic);
+            resume_preferred_panic_outside_unwind(UnwindPanics {
+                primary: owner.take_primary_panic(),
+                cleanup: cleanup_panic,
+            });
             result.expect("an incarnation without a primary panic returns a result")
         })
     }
@@ -1736,7 +1745,8 @@ mod tests {
         SharedOffloadState,
     };
     use crate::runtime::{
-        Latch, PanicPayload, Signal, resume_preferred_panic, resume_preferred_panic_outside_unwind,
+        Latch, PanicPayload, Signal, UnwindPanics, resume_preferred_panic,
+        resume_preferred_panic_outside_unwind,
     };
 
     fn marker(value: usize) -> QueuedEvent<usize> {
@@ -1760,10 +1770,10 @@ mod tests {
     #[test]
     fn primary_panic_precedence_discards_a_secondary_cleanup_panic() {
         let payload = catch_unwind(AssertUnwindSafe(|| {
-            resume_preferred_panic(
-                Some(Box::new("primary actor panic")),
-                Some(Box::new("secondary cleanup panic")),
-            );
+            resume_preferred_panic(UnwindPanics {
+                primary: Some(Box::new("primary actor panic")),
+                cleanup: Some(Box::new("secondary cleanup panic")),
+            });
         }))
         .expect_err("the primary panic is resumed");
         assert_eq!(panic_message(&payload), Some("primary actor panic"));
@@ -1772,18 +1782,27 @@ mod tests {
     #[test]
     fn the_incarnation_return_path_resumes_a_primary_panic_it_solely_owns() {
         let payload = catch_unwind(AssertUnwindSafe(|| {
-            resume_preferred_panic_outside_unwind(Some(Box::new("primary actor panic")), None);
+            resume_preferred_panic_outside_unwind(UnwindPanics {
+                primary: Some(Box::new("primary actor panic")),
+                cleanup: None,
+            });
         }))
         .expect_err("a sole-owned primary panic is never contained");
         assert_eq!(panic_message(&payload), Some("primary actor panic"));
 
         let payload = catch_unwind(AssertUnwindSafe(|| {
-            resume_preferred_panic_outside_unwind(None, Some(Box::new("cleanup panic")));
+            resume_preferred_panic_outside_unwind(UnwindPanics {
+                primary: None,
+                cleanup: Some(Box::new("cleanup panic")),
+            });
         }))
         .expect_err("cleanup stands in when there is no primary panic");
         assert_eq!(panic_message(&payload), Some("cleanup panic"));
 
-        resume_preferred_panic_outside_unwind(None, None);
+        resume_preferred_panic_outside_unwind(UnwindPanics {
+            primary: None,
+            cleanup: None,
+        });
     }
 
     struct BlockingPollDrop {

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -1264,6 +1264,23 @@ mod tests {
         assert!(timeout.as_mut().poll(&mut context).is_pending());
     }
 
+    #[tokio::test]
+    async fn scope_wait_prefers_signal_when_both_control_futures_are_ready() {
+        let (_sender, mut receiver) = super::bounded_mpsc::<()>(1);
+
+        let wake = super::wait_scope(
+            super::ScopeWait {
+                signal: std::future::ready(()),
+                parent_shutdown: std::future::ready(()),
+            },
+            &mut receiver,
+            None,
+        )
+        .await;
+
+        assert!(matches!(wake, super::ScopeWake::Signal));
+    }
+
     struct RecursivelyPanickingPayload;
 
     impl Drop for RecursivelyPanickingPayload {

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -43,6 +43,12 @@ pub(crate) fn alive_task_count() -> usize {
 /// Runtime-owned spelling for an unwind payload crossing a framework boundary.
 pub(crate) type PanicPayload = Box<dyn Any + Send + 'static>;
 
+/// Panic payloads crossing an unwind boundary, named by precedence.
+pub(crate) struct UnwindPanics {
+    pub(crate) primary: Option<PanicPayload>,
+    pub(crate) cleanup: Option<PanicPayload>,
+}
+
 /// Catches application code without requiring every caller to repeat the
 /// `AssertUnwindSafe` boundary vocabulary.
 pub(crate) fn catch_panic<T>(operation: impl FnOnce() -> T) -> Result<T, PanicPayload> {
@@ -82,7 +88,8 @@ pub(crate) fn keep_first_panic(first: &mut Option<PanicPayload>, candidate: Opti
 /// outcome, which is true in a destructor and false on a normal return path.
 /// Callers that own the sole surviving copy of an authoritative panic must use
 /// [`resume_preferred_panic_outside_unwind`] instead.
-pub(crate) fn resume_preferred_panic(primary: Option<PanicPayload>, cleanup: Option<PanicPayload>) {
+pub(crate) fn resume_preferred_panic(panics: UnwindPanics) {
+    let UnwindPanics { primary, cleanup } = panics;
     if std::thread::panicking() {
         discard_panic(primary);
         discard_panic(cleanup);
@@ -102,10 +109,8 @@ pub(crate) fn resume_preferred_panic(primary: Option<PanicPayload>, cleanup: Opt
 /// erase the authoritative diagnostic and let the caller continue past a
 /// failure it believes it re-raised, so the caller's non-unwinding precondition
 /// is asserted rather than absorbed.
-pub(crate) fn resume_preferred_panic_outside_unwind(
-    primary: Option<PanicPayload>,
-    cleanup: Option<PanicPayload>,
-) {
+pub(crate) fn resume_preferred_panic_outside_unwind(panics: UnwindPanics) {
+    let UnwindPanics { primary, cleanup } = panics;
     debug_assert!(
         !std::thread::panicking(),
         "an unwinding caller must contain its payloads with resume_preferred_panic"
@@ -143,7 +148,10 @@ impl PanicAccumulator {
 
 impl Drop for PanicAccumulator {
     fn drop(&mut self) {
-        resume_preferred_panic(None, self.first.take());
+        resume_preferred_panic(UnwindPanics {
+            primary: None,
+            cleanup: self.first.take(),
+        });
     }
 }
 
@@ -1161,9 +1169,13 @@ pub(crate) enum ScopeWake<T> {
     Deadline,
 }
 
+pub(crate) struct ScopeWait<S, C> {
+    pub(crate) signal: S,
+    pub(crate) parent_shutdown: C,
+}
+
 pub(crate) async fn wait_scope<S, C, T>(
-    signal: S,
-    parent_shutdown: C,
+    wait: ScopeWait<S, C>,
     receiver: &mut MpscReceiver<T>,
     deadline: Option<std::time::Instant>,
 ) -> ScopeWake<T>
@@ -1171,6 +1183,10 @@ where
     S: Future<Output = ()> + Send,
     C: Future<Output = ()> + Send,
 {
+    let ScopeWait {
+        signal,
+        parent_shutdown,
+    } = wait;
     tokio::pin!(signal);
     tokio::pin!(parent_shutdown);
     let deadline = async move {

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -1276,13 +1276,13 @@ impl ScopeRef {
         &self,
         id: impl Into<ChildId>,
         mut pred: P,
-        deadline: Duration,
+        timeout: Duration,
     ) -> Result<crate::ChildSnapshot, WaitError>
     where
         P: FnMut(&crate::ChildSnapshot) -> bool + Send,
     {
         let id = id.into();
-        let expires = crate::deadline::Deadline::after(crate::runtime::now(), deadline);
+        let expires = crate::deadline::Deadline::after(crate::runtime::now(), timeout);
         let mut snapshots = self.subscribe_snapshots();
 
         loop {
@@ -1445,12 +1445,12 @@ impl DynamicScopeRef {
         &self,
         id: impl Into<ChildId>,
         pred: P,
-        deadline: Duration,
+        timeout: Duration,
     ) -> Result<crate::ChildSnapshot, WaitError>
     where
         P: FnMut(&crate::ChildSnapshot) -> bool + Send,
     {
-        self.0.wait_for_child(id, pred, deadline).await
+        self.0.wait_for_child(id, pred, timeout).await
     }
 
     /// Requests shutdown without waiting.


### PR DESCRIPTION
Implements the remaining runtime-boundary items from issue #101.

- carries primary and cleanup unwind payloads in named `UnwindPanics`
- carries same-domain scope wake futures in named `ScopeWait { signal, parent_shutdown }`
- renames both public `wait_for_child` duration parameters from `deadline` to `timeout`
- adds regression coverage for the biased scope-control priority
- updates the normative specification without changing runtime behavior

Validation:
- `./scripts/dev just ci` (427/427 tests, doctests, docs, API/enforcement checks, package verification, and Nix formatting)