### PR TITLE
Use the rust-env check context for API enforcement

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,17 +5,17 @@
       "Bash(git checkout *)",
       "Bash(git commit *)",
       "Bash(git push *)",
-      "Bash(./scripts/dev just *)",
-      "Bash(./scripts/dev cargo check *)",
-      "Bash(./scripts/dev cargo build *)",
-      "Bash(./scripts/dev cargo test *)",
-      "Bash(./scripts/dev cargo nextest *)",
-      "Bash(./scripts/dev cargo run *)",
-      "Bash(./scripts/dev cargo +nightly clippy *)",
-      "Bash(./scripts/dev cargo +nightly fmt *)",
-      "Bash(./scripts/dev env TRYBUILD=overwrite cargo test *)",
-      "Bash(./scripts/dev mdbook *)",
-      "Bash(./scripts/dev nixfmt *)"
+      "Bash(./tools/dev just *)",
+      "Bash(./tools/dev cargo check *)",
+      "Bash(./tools/dev cargo build *)",
+      "Bash(./tools/dev cargo test *)",
+      "Bash(./tools/dev cargo nextest *)",
+      "Bash(./tools/dev cargo run *)",
+      "Bash(./tools/dev cargo +nightly clippy *)",
+      "Bash(./tools/dev cargo +nightly fmt *)",
+      "Bash(./tools/dev env TRYBUILD=overwrite cargo test *)",
+      "Bash(./tools/dev mdbook *)",
+      "Bash(./tools/dev nixfmt *)"
     ]
   },
   "hooks": {

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -2,79 +2,79 @@
 # the tracked task runner and the recurring, bounded tool families to leave the
 # sandbox without an approval round trip.
 prefix_rule(
-    pattern = ["./scripts/dev", "just"],
+    pattern = ["./tools/dev", "just"],
     decision = "allow",
     justification = "Run Kokage's tracked just recipes through its pinned Nix devshell.",
     match = [
-        "./scripts/dev just ci",
-        "./scripts/dev just ci-nix",
-        "./scripts/dev just test-docs",
+        "./tools/dev just ci",
+        "./tools/dev just ci-nix",
+        "./tools/dev just test-docs",
     ],
     not_match = [
-        "./scripts/dev",
-        "./scripts/dev cargo check --workspace",
+        "./tools/dev",
+        "./tools/dev cargo check --workspace",
     ],
 )
 
 prefix_rule(
-    pattern = ["./scripts/dev", "cargo", ["check", "build", "test", "nextest", "run"]],
+    pattern = ["./tools/dev", "cargo", ["check", "build", "test", "nextest", "run"]],
     decision = "allow",
     justification = "Run Kokage's routine Cargo verification commands through its pinned Nix devshell.",
     match = [
-        "./scripts/dev cargo check --workspace --all-targets --all-features",
-        "./scripts/dev cargo build --workspace",
-        "./scripts/dev cargo test --workspace",
-        "./scripts/dev cargo nextest run --workspace",
-        "./scripts/dev cargo run --example agent_control",
+        "./tools/dev cargo check --workspace --all-targets --all-features",
+        "./tools/dev cargo build --workspace",
+        "./tools/dev cargo test --workspace",
+        "./tools/dev cargo nextest run --workspace",
+        "./tools/dev cargo run --example agent_control",
     ],
     not_match = [
-        "./scripts/dev cargo clean",
-        "./scripts/dev cargo install cargo-edit",
-        "./scripts/dev cargo package -p kokage --allow-dirty",
-        "./scripts/dev cargo publish",
+        "./tools/dev cargo clean",
+        "./tools/dev cargo install cargo-edit",
+        "./tools/dev cargo package -p kokage --allow-dirty",
+        "./tools/dev cargo publish",
     ],
 )
 
 prefix_rule(
-    pattern = ["./scripts/dev", "cargo", "+nightly", ["clippy", "fmt"]],
+    pattern = ["./tools/dev", "cargo", "+nightly", ["clippy", "fmt"]],
     decision = "allow",
     justification = "Run Kokage's pinned nightly lint and formatting commands through its Nix devshell.",
     match = [
-        "./scripts/dev cargo +nightly clippy --workspace --all-targets --all-features",
-        "./scripts/dev cargo +nightly fmt --all -- --check",
+        "./tools/dev cargo +nightly clippy --workspace --all-targets --all-features",
+        "./tools/dev cargo +nightly fmt --all -- --check",
     ],
     not_match = [
-        "./scripts/dev cargo +nightly miri test",
-        "./scripts/dev cargo clippy --workspace",
+        "./tools/dev cargo +nightly miri test",
+        "./tools/dev cargo clippy --workspace",
     ],
 )
 
 # Updating trybuild snapshots is the one recurring Cargo form with a leading
 # environment assignment. Keep both the assignment and Cargo subcommand exact.
 prefix_rule(
-    pattern = ["./scripts/dev", "env", "TRYBUILD=overwrite", "cargo", "test"],
+    pattern = ["./tools/dev", "env", "TRYBUILD=overwrite", "cargo", "test"],
     decision = "allow",
     justification = "Run Kokage's trybuild snapshot tests through its pinned Nix devshell.",
     match = [
-        "./scripts/dev env TRYBUILD=overwrite cargo test -p kokage --test derive_ui",
+        "./tools/dev env TRYBUILD=overwrite cargo test -p kokage --test derive_ui",
     ],
     not_match = [
-        "./scripts/dev env RUSTFLAGS=-Dwarnings cargo test",
-        "./scripts/dev env TRYBUILD=overwrite cargo publish",
-        "./scripts/dev env TRYBUILD=overwrite bash scripts/test-docs.sh",
+        "./tools/dev env RUSTFLAGS=-Dwarnings cargo test",
+        "./tools/dev env TRYBUILD=overwrite cargo publish",
+        "./tools/dev env TRYBUILD=overwrite bash scripts/test-docs.sh",
     ],
 )
 
 prefix_rule(
-    pattern = ["./scripts/dev", ["mdbook", "nixfmt"]],
+    pattern = ["./tools/dev", ["mdbook", "nixfmt"]],
     decision = "allow",
     justification = "Run Kokage's documentation and Nix formatters through its pinned Nix devshell.",
     match = [
-        "./scripts/dev mdbook build docs",
-        "./scripts/dev nixfmt --check flake.nix nix/crane-checks.nix",
+        "./tools/dev mdbook build docs",
+        "./tools/dev nixfmt --check flake.nix nix/crane-checks.nix",
     ],
     not_match = [
-        "./scripts/dev bash scripts/test-docs.sh",
-        "./scripts/dev rustfmt src/lib.rs",
+        "./tools/dev bash scripts/test-docs.sh",
+        "./tools/dev rustfmt src/lib.rs",
     ],
 )

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -1,10 +1,10 @@
-# Kokage's tracked devshell wrapper is required for every project tool. Allow
+# Shelterwood's tracked devshell wrapper is required for every project tool. Allow
 # the tracked task runner and the recurring, bounded tool families to leave the
 # sandbox without an approval round trip.
 prefix_rule(
     pattern = ["./tools/dev", "just"],
     decision = "allow",
-    justification = "Run Kokage's tracked just recipes through its pinned Nix devshell.",
+    justification = "Run Shelterwood's tracked just recipes through its pinned Nix devshell.",
     match = [
         "./tools/dev just ci",
         "./tools/dev just ci-nix",
@@ -19,7 +19,7 @@ prefix_rule(
 prefix_rule(
     pattern = ["./tools/dev", "cargo", ["check", "build", "test", "nextest", "run"]],
     decision = "allow",
-    justification = "Run Kokage's routine Cargo verification commands through its pinned Nix devshell.",
+    justification = "Run Shelterwood's routine Cargo verification commands through its pinned Nix devshell.",
     match = [
         "./tools/dev cargo check --workspace --all-targets --all-features",
         "./tools/dev cargo build --workspace",
@@ -30,7 +30,7 @@ prefix_rule(
     not_match = [
         "./tools/dev cargo clean",
         "./tools/dev cargo install cargo-edit",
-        "./tools/dev cargo package -p kokage --allow-dirty",
+        "./tools/dev cargo package -p shelterwood --allow-dirty",
         "./tools/dev cargo publish",
     ],
 )
@@ -38,7 +38,7 @@ prefix_rule(
 prefix_rule(
     pattern = ["./tools/dev", "cargo", "+nightly", ["clippy", "fmt"]],
     decision = "allow",
-    justification = "Run Kokage's pinned nightly lint and formatting commands through its Nix devshell.",
+    justification = "Run Shelterwood's pinned nightly lint and formatting commands through its Nix devshell.",
     match = [
         "./tools/dev cargo +nightly clippy --workspace --all-targets --all-features",
         "./tools/dev cargo +nightly fmt --all -- --check",
@@ -54,9 +54,9 @@ prefix_rule(
 prefix_rule(
     pattern = ["./tools/dev", "env", "TRYBUILD=overwrite", "cargo", "test"],
     decision = "allow",
-    justification = "Run Kokage's trybuild snapshot tests through its pinned Nix devshell.",
+    justification = "Run Shelterwood's trybuild snapshot tests through its pinned Nix devshell.",
     match = [
-        "./tools/dev env TRYBUILD=overwrite cargo test -p kokage --test derive_ui",
+        "./tools/dev env TRYBUILD=overwrite cargo test -p shelterwood --test derive_ui",
     ],
     not_match = [
         "./tools/dev env RUSTFLAGS=-Dwarnings cargo test",
@@ -68,7 +68,7 @@ prefix_rule(
 prefix_rule(
     pattern = ["./tools/dev", ["mdbook", "nixfmt"]],
     decision = "allow",
-    justification = "Run Kokage's documentation and Nix formatters through its pinned Nix devshell.",
+    justification = "Run Shelterwood's documentation and Nix formatters through its pinned Nix devshell.",
     match = [
         "./tools/dev mdbook build docs",
         "./tools/dev nixfmt --check flake.nix nix/crane-checks.nix",

--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,6 @@
 use flake
 
-# Marker consumed by ./scripts/dev: the physical path of this checkout plus a
+# Marker consumed by ./tools/dev: the physical path of this checkout plus a
 # fingerprint of the flake inputs the devshell was built from. Lets the wrapper
 # tell a correctly loaded devshell apart from one inherited from a sibling
 # worktree — or from this same checkout before a branch switch changed the flake.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,15 +3,15 @@
 ## Running anything
 
 All tooling (`cargo`, `just`, `nextest`, `nixfmt`) comes from the Nix
-devshell. It is **not** on the base PATH. Prefix commands with `./scripts/dev`:
+devshell. It is **not** on the base PATH. Prefix commands with `./tools/dev`:
 
 ```sh
-./scripts/dev just ci          # the full local CI mirror
-./scripts/dev just test
-./scripts/dev cargo nextest run --workspace
+./tools/dev just ci          # the full local CI mirror
+./tools/dev just test
+./tools/dev cargo nextest run --workspace
 ```
 
-`./scripts/dev` exec's straight through when the devshell for *this* checkout is already
+`./tools/dev` exec's straight through when the devshell for *this* checkout is already
 active, so it is free in an interactive shell and correct everywhere else. Use
 it rather than assuming direnv has loaded — see below for why.
 
@@ -24,11 +24,11 @@ recipes mirror those checks — keep the two in sync when changing either.
 
 Create them under `.worktrees`.
 
-`./scripts/dev` gives any worktree the correct toolchain no matter how it was created:
+`./tools/dev` gives any worktree the correct toolchain no matter how it was created:
 
 - direnv never loads in non-interactive (agent) shells, and `direnv allow` is
   keyed on the absolute `.envrc` path, so a fresh worktree has no toolchain on
   the base PATH at all.
 - A shell spawned from another checkout inherits *that* checkout's devshell, so
   a worktree can appear to work while silently using the wrong toolchain.
-  `./scripts/dev` detects this via `REPO_DEVSHELL` and re-enters the right one.
+  `./tools/dev` detects this via `REPO_DEVSHELL` and re-enters the right one.

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ the core API yet.
 
 ## Getting started
 
-The repository toolchain comes from Nix. `scripts/dev` enters the dev shell for
+The repository toolchain comes from Nix. `tools/dev` enters the dev shell for
 the current checkout, including when invoked from a worktree:
 
 ```sh
-./scripts/dev just test
-./scripts/dev just ci
-./scripts/dev just ci-nix
+./tools/dev just test
+./tools/dev just ci
+./tools/dev just ci-nix
 ```
 
 A task-first application needs no actor merely to obtain supervision:

--- a/crates/shelterwood/doctests/README.md
+++ b/crates/shelterwood/doctests/README.md
@@ -14,13 +14,13 @@ the core API yet.
 
 ## Getting started
 
-The repository toolchain comes from Nix. `scripts/dev` enters the dev shell for
+The repository toolchain comes from Nix. `tools/dev` enters the dev shell for
 the current checkout, including when invoked from a worktree:
 
 ```sh
-./scripts/dev just test
-./scripts/dev just ci
-./scripts/dev just ci-nix
+./tools/dev just test
+./tools/dev just ci
+./tools/dev just ci-nix
 ```
 
 A task-first application needs no actor merely to obtain supervision:

--- a/flake.lock
+++ b/flake.lock
@@ -51,10 +51,6 @@
     },
     "root": {
       "inputs": {
-        "crane": [
-          "rust-env",
-          "crane"
-        ],
         "nixpkgs": [
           "rust-env",
           "nixpkgs"
@@ -74,11 +70,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1785964588,
-        "narHash": "sha256-v27dWKuf7CnDoh835ui8pQywmr3XTxfK+ei8WQRgWsQ=",
+        "lastModified": 1786309496,
+        "narHash": "sha256-8qy0c/s32KzlNoV4xTe1lBGmth+vZGMkefegjh2NI5k=",
         "owner": "ralexstokes",
         "repo": "rust-nix-template",
-        "rev": "36517aa923b8d8760bd6afcd05ef37826e445a72",
+        "rev": "844a6ee6506bd04d59224f2e23f804273dc8744f",
         "type": "github"
       },
       "original": {
@@ -95,11 +91,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785993740,
-        "narHash": "sha256-naSJ+p7zkIT2hHNSJkhxiPZlmVRgE3UdODinMM7rpD8=",
+        "lastModified": 1785907205,
+        "narHash": "sha256-Ds1vTi53af4wDMAveSR/K0JnywDslLwmgwhVIiwnNmY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3d1b34a12a26be073f7ae67165a6b61229ca6025",
+        "rev": "c5cb13481d718fac906aa9cfd85f9b60e1a546cb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
           ...
         }:
         {
-          part0-enforcement = craneLibNightly.mkCargoDerivation (
+          api-enforcement = craneLibNightly.mkCargoDerivation (
             commonArgs
             // {
               cargoArtifacts = cargoArtifactsNightly;

--- a/flake.nix
+++ b/flake.nix
@@ -3,62 +3,39 @@
 
   inputs = {
     rust-env.url = "github:ralexstokes/rust-nix-template";
-    crane.follows = "rust-env/crane";
     nixpkgs.follows = "rust-env/nixpkgs";
     rust-overlay.follows = "rust-env/rust-overlay";
   };
 
   outputs =
-    {
-      crane,
-      rust-env,
-      ...
-    }:
+    { rust-env, ... }:
     rust-env.lib.mkRustProject {
       src = ./.;
       # Repository docs and their packaged doctest copies are compared in the
-      # clean build sandbox, so keep Markdown alongside Cargo sources.
+      # clean build sandbox, so keep Markdown alongside Cargo sources; the
+      # enforcement scripts under tools/ run there too (.sh), and nextest
+      # reads its timeout config.
       extraSourceFilter =
         path: type:
         type == "regular"
         && (
           builtins.match ".*\\.md" (toString path) != null
+          || builtins.match ".*\\.sh" (toString path) != null
           || builtins.match ".*/\\.config/nextest\\.toml" (toString path) != null
         );
       extraChecks =
-        pkgs:
-        let
-          nightlyToolchain = pkgs.rust-bin.selectLatestNightlyWith (
-            toolchain:
-            toolchain.default.override {
-              extensions = [ "rustfmt" ];
-            }
-          );
-          craneLib = crane.mkLib pkgs;
-          craneLibNightly = craneLib.overrideToolchain nightlyToolchain;
-          source = pkgs.lib.cleanSourceWith {
-            src = pkgs.lib.cleanSource ./.;
-            filter =
-              path: type:
-              type == "directory"
-              || craneLib.filterCargoSources path type
-              || pkgs.lib.hasSuffix ".sh" (toString path)
-              || pkgs.lib.hasSuffix ".md" (toString path);
-          };
-          commonArgs = {
-            pname = "shelterwood-part0-enforcement";
-            version = "0.1.0";
-            src = source;
-            strictDeps = true;
-            cargoExtraArgs = "--locked --workspace --all-features";
-          };
-          cargoArtifacts = craneLibNightly.buildDepsOnly commonArgs;
-        in
+        {
+          pkgs,
+          craneLibNightly,
+          commonArgs,
+          cargoArtifactsNightly,
+          ...
+        }:
         {
           part0-enforcement = craneLibNightly.mkCargoDerivation (
             commonArgs
             // {
-              inherit cargoArtifacts;
+              cargoArtifacts = cargoArtifactsNightly;
               nativeBuildInputs = [ pkgs.ripgrep ];
               buildPhaseCargoCommand = ''
                 RUSTDOCFLAGS="-Z unstable-options --output-format json" \

--- a/tools/dev
+++ b/tools/dev
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
 # Run a command inside this checkout's Nix devshell.
 #
-#     ./scripts/dev just ci
-#     ./scripts/dev cargo nextest run --workspace
+#     ./tools/dev just ci
+#     ./tools/dev cargo nextest run --workspace
 #
 # .envrc loads the devshell through direnv, but `direnv allow` is keyed on the
 # absolute path of .envrc, so every new git worktree starts blocked — and the
@@ -17,7 +17,7 @@
 set -eu
 
 if [ "$#" -eq 0 ]; then
-    echo "usage: ./scripts/dev <command> [args...]" >&2
+    echo "usage: ./tools/dev <command> [args...]" >&2
     exit 2
 fi
 


### PR DESCRIPTION
Follow-up to [rust-nix-template#1](https://github.com/ralexstokes/rust-nix-template/pull/1): `extraChecks` can now take a set pattern whose named attributes are supplied from the template's check context.

`api-enforcement` consumes the shared `craneLibNightly`, `commonArgs`, and prebuilt `cargoArtifactsNightly` instead of reconstructing the nightly toolchain, re-filtering the source, and running its own `buildDepsOnly` — which was a second full dependency compile per CI run. Net −30 lines in `flake.nix`.

Two behavioral notes:

- The check now builds from the shared cargo source, so the `.sh` enforcement scripts moved from the check's private filter into the top-level `extraSourceFilter` (a strict superset of the old private filter's contents).
- The shared dependency artifacts are built with the template's `--all-targets` / dev-profile arguments, so the enforcement check reuses the same artifact set as `cargo-ci`/`cargo-clippy` rather than maintaining a third one.

The `crane` input is removed with its last use; `rust-env` is relocked to the merged template main (`844a6ee`).

Also renames `scripts/dev` to `tools/dev`, matching the template's rename — the wrapper joins the enforcement scripts already under `tools/`. All references updated (AGENTS.md/CLAUDE.md, READMEs including the packaged doctest copy via `sync-packaged-docs.sh --write`, `.claude/settings.json` permission allowlists, `.codex/rules`, `.envrc` comment).

## Testing

- `./tools/dev nix flake check --no-update-lock-file` — green after each commit (all checks including `api-enforcement` and the packaged-docs sync check)
