### PR TITLE
Fix startup readiness races

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1107,9 +1107,14 @@ enum Readiness { Immediate, AfterInit, Manual }   // mode only — the deadline 
   a **nested** scope, the scope rolls itself back and exits as an
   ordinary child failure carrying the structured startup-failure payload
   (§11's nested rule). Readiness reported exactly at the deadline wins
-  over the timeout. Nested scopes report ready recursively once their
-  initial children are up. `spawn()` stays synchronous; `wait_started()`
-  is the readiness barrier.
+  over the timeout. A readiness signal fired before an exit or clean
+  self-stop is observed MUST count for startup accounting even when event
+  arbitration processes the terminal edge first. In particular,
+  ready-then-failed is a post-ready failure: restart policy applies and
+  startup advances exactly as it would if the readiness event had been
+  delivered first. Nested scopes report ready recursively once their initial
+  children are up. `spawn()` stays synchronous; `wait_started()` is the
+  readiness barrier.
 - **Dynamic scopes start their initial members concurrently**, and their
   pre-ready failure rules are the concurrent restatement of the ordered
   ones, not a separate regime. A non-terminal pre-ready exit restarts
@@ -2364,9 +2369,11 @@ integration toolkit for the driver shell and the end-to-end invariants.
    and a shared order log; assert the later sibling never appears until
    release. Deadline expiry under virtual time yields the *typed* readiness
    verdict carrying the deadline. Edge tests: ready-at-deadline beats
-   timeout; shutdown disarms a pending deadline; a *terminal* pre-ready
-   exit aborts startup while an eligible restart re-runs the gate with a
-   fresh per-incarnation deadline (§6) — on abort the never-started
+   timeout; readiness fired before an immediate clean exit, failure, or
+   self-stop counts before that terminal edge; shutdown disarms a pending
+   deadline; a *terminal* pre-ready exit aborts startup while an eligible
+   restart re-runs the gate with a fresh per-incarnation deadline (§6) — on
+   abort the never-started
    siblings terminalize `NeverStarted`; at the root the started prefix
    stays running, while in a nested scope assert the automatic rollback
    and the structured startup-failure exit at the parent (§11).
@@ -2564,7 +2571,10 @@ Both questions are resolved:
    and its intensity charge. A readiness signal precedes its deadline, so
    ready-at-deadline wins. Child exits precede both, making an incarnation
    that has already ended in the same wake an exit rather than a spurious
-   readiness edge. Backoff work follows all newly observed terminal facts,
+   readiness edge. Exit handling nevertheless consults the incarnation's
+   retained readiness latch: a signal causally fired before that exit is
+   accounted before the exit is classified, without reordering the event
+   classes themselves. Backoff work follows all newly observed terminal facts,
    and ladder deadlines follow because the earlier facts can complete or
    disarm them. Queued admissions run after all already-observed terminal and
    temporal facts, so they cannot enter a scope that the same wake has made

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -35,7 +35,7 @@ use crate::{
     },
     policy::{DefaultsInheritance, ResolvedDefaults, ScopeFlavor},
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
-    runtime::{self, Latch},
+    runtime::{self, CompletionGatedLatch, Latch},
     task::{TaskContext, TaskContextLatches, TaskFactory},
 };
 
@@ -96,8 +96,7 @@ struct ReportCompletion {
     sender: mpsc::Sender<RecordedReport>,
     shutdown: Latch,
     local_stop: Option<Latch>,
-    readiness: Latch,
-    completion_boundary: Latch,
+    readiness: CompletionGatedLatch,
 }
 
 pub(crate) struct ReportToken {
@@ -121,8 +120,7 @@ pub(crate) struct ReportReceiver(mpsc::Receiver<RecordedReport>);
 pub(crate) fn report_channel(
     shutdown: Latch,
     local_stop: Option<Latch>,
-    readiness: Latch,
-    completion_boundary: Latch,
+    readiness: CompletionGatedLatch,
 ) -> (ReportToken, ReportReceiver) {
     let (sender, receiver) = mpsc::channel();
     (
@@ -133,7 +131,6 @@ pub(crate) fn report_channel(
                     shutdown,
                     local_stop,
                     readiness,
-                    completion_boundary,
                 },
                 |completion| completion.send(None),
             ),
@@ -150,15 +147,12 @@ impl ReportCompletion {
             } else {
                 Cancellation::NotObserved
             };
+        let readiness_signal_seen = self.readiness.complete();
         let report = RecordedReport {
             outcome,
             cancellation,
-            readiness_signal_seen: self.readiness.is_fired(),
+            readiness_signal_seen,
         };
-        // Close helper observers at the same boundary as the evidence
-        // snapshot. A capability retained outside the supervised future
-        // cannot publish readiness after the future has completed.
-        self.completion_boundary.fire();
         let _ = self.sender.send(report);
     }
 }
@@ -844,7 +838,7 @@ struct ActiveChild {
     hard_abort_phase: Option<GracePhase>,
     readiness: ReadinessGate,
     readiness_deadline: Option<DeadlineHandle>,
-    ready_signal: Latch,
+    ready_signal: CompletionGatedLatch,
     construction_release: Latch,
     framework_abort: Option<Latch>,
     framework_abort_ack: Option<Latch>,
@@ -1078,7 +1072,7 @@ struct AncestorCommandLatches {
 }
 
 struct NestedScopeLatches {
-    parent_ready: Latch,
+    parent_ready: CompletionGatedLatch,
     ancestor: AncestorCommandLatches,
 }
 
@@ -1092,7 +1086,7 @@ impl ScopeRole {
         matches!(self, Self::Root)
     }
 
-    fn parent_ready(&self) -> Option<&Latch> {
+    fn parent_ready(&self) -> Option<&CompletionGatedLatch> {
         match self {
             Self::Root => None,
             Self::Nested(latches) => Some(&latches.parent_ready),
@@ -1223,12 +1217,12 @@ struct SpawnDispatch {
 ///   recursive drain before its task is aborted;
 /// - `construction_release` prevents a raw actor from running before the
 ///   driver has installed the readiness mode reported by construction;
-/// - `ended` makes readiness and self-stop watcher tasks finite.
+/// - `ready` also carries the completion edge that makes readiness and
+///   self-stop watcher tasks finite.
 struct SpawnLatches {
     shutdown: Latch,
     abort: Latch,
-    ready: Latch,
-    ended: Latch,
+    ready: CompletionGatedLatch,
     construction_release: Latch,
     local_stop: Latch,
     framework_abort: Latch,
@@ -1264,8 +1258,7 @@ struct ChildTaskLaunch {
     readiness_override: Option<Readiness>,
     watch_readiness: bool,
     shutdown: Latch,
-    ready: Latch,
-    ended: Latch,
+    ready: CompletionGatedLatch,
     construction_release: Latch,
     local_stop: Latch,
 }
@@ -1377,16 +1370,11 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
         watch_readiness,
         shutdown,
         ready,
-        ended,
         construction_release,
         local_stop,
     } = launch;
-    let (report, report_receiver) = report_channel(
-        shutdown,
-        Some(local_stop.clone()),
-        ready.clone(),
-        ended.clone(),
-    );
+    let (report, report_receiver) =
+        report_channel(shutdown, Some(local_stop.clone()), ready.clone());
     let constructed_sender = events.clone();
     let handle = runtime::spawn(async move {
         let body = async move {
@@ -1458,12 +1446,13 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
         .await;
     });
 
+    let completion = ready.clone();
     if watch_readiness {
         let ready_sender = events.clone();
-        let ready_ended = ended.clone();
+        let ready_completion = ready.clone();
         runtime::spawn(async move {
             if matches!(
-                runtime::select_two(ready.fired(), ready_ended.fired()).await,
+                runtime::select_two(ready.fired(), ready_completion.completed()).await,
                 runtime::Either::Left(())
             ) {
                 let _ = runtime::mpsc_send(
@@ -1480,7 +1469,7 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
 
     runtime::spawn(async move {
         if matches!(
-            runtime::select_two(local_stop.fired(), ended.fired()).await,
+            runtime::select_two(local_stop.fired(), completion.completed()).await,
             runtime::Either::Left(())
         ) {
             let _ = runtime::mpsc_send(
@@ -1609,7 +1598,8 @@ impl ScopeRuntime {
         // Per-incarnation latch topology:
         // - shutdown/abort flow from the ladder into application code;
         // - ready and local_stop flow from application code back to helpers;
-        // - ended terminates those helpers when the child exits first;
+        // - ready's completion edge terminates those helpers when the child
+        //   exits first and orders late retained readiness capabilities;
         // - construction_release keeps a raw actor behind the driver-owned
         //   readiness transition after its construction report is accepted;
         // - framework_abort/ack join nested-scope escalation before exit.
@@ -1617,8 +1607,7 @@ impl ScopeRuntime {
         let latches = SpawnLatches {
             shutdown: Latch::default(),
             abort: Latch::default(),
-            ready: Latch::default(),
-            ended: Latch::default(),
+            ready: CompletionGatedLatch::default(),
             construction_release: Latch::default(),
             local_stop: Latch::default(),
             framework_abort: Latch::default(),
@@ -1685,7 +1674,6 @@ impl ScopeRuntime {
             watch_readiness: gated,
             shutdown: latches.shutdown.clone(),
             ready: latches.ready.clone(),
-            ended: latches.ended.clone(),
             construction_release: latches.construction_release.clone(),
             local_stop: latches.local_stop.clone(),
         });
@@ -3167,7 +3155,7 @@ mod tests {
         identity::{IncarnationCounter, ScopeIdentity},
         mailbox::MailboxCell,
         plan::SlotCell,
-        runtime::Latch,
+        runtime::{CompletionGatedLatch, Latch},
     };
 
     use super::{
@@ -3874,9 +3862,8 @@ mod tests {
     #[test]
     fn owned_report_token_consumes_or_falls_back_once() {
         let shutdown = Latch::default();
-        let readiness = Latch::default();
-        let (token, receiver) =
-            report_channel(shutdown.clone(), None, readiness.clone(), Latch::default());
+        let readiness = CompletionGatedLatch::default();
+        let (token, receiver) = report_channel(shutdown.clone(), None, readiness.clone());
         token.record(RecordedOutcome::Returned(Ok(())));
         shutdown.fire();
         readiness.fire();
@@ -3890,7 +3877,7 @@ mod tests {
 
         let shutdown = Latch::default();
         let (token, receiver) =
-            report_channel(shutdown.clone(), None, Latch::default(), Latch::default());
+            report_channel(shutdown.clone(), None, CompletionGatedLatch::default());
         shutdown.fire();
         drop(token);
         let report = receiver.receive();
@@ -3902,7 +3889,7 @@ mod tests {
     fn owned_report_token_records_prior_cancellation() {
         let shutdown = Latch::default();
         let (token, receiver) =
-            report_channel(shutdown.clone(), None, Latch::default(), Latch::default());
+            report_channel(shutdown.clone(), None, CompletionGatedLatch::default());
         shutdown.fire();
         token.record(RecordedOutcome::Returned(Ok(())));
         let report = receiver.receive();
@@ -3920,8 +3907,7 @@ mod tests {
         let (token, receiver) = report_channel(
             shutdown,
             Some(local_stop.clone()),
-            Latch::default(),
-            Latch::default(),
+            CompletionGatedLatch::default(),
         );
         local_stop.fire();
         token.record(RecordedOutcome::Returned(Ok(())));
@@ -3930,17 +3916,11 @@ mod tests {
 
     #[test]
     fn owned_report_token_records_readiness_at_completion() {
-        let readiness = Latch::default();
-        let completion_boundary = Latch::default();
-        let (token, receiver) = report_channel(
-            Latch::default(),
-            None,
-            readiness.clone(),
-            completion_boundary.clone(),
-        );
+        let readiness = CompletionGatedLatch::default();
+        let (token, receiver) = report_channel(Latch::default(), None, readiness.clone());
         readiness.fire();
         token.record(RecordedOutcome::Returned(Ok(())));
-        assert!(completion_boundary.is_fired());
+        assert!(!readiness.fire(), "completion closes retained capabilities");
         assert!(receiver.receive().readiness_signal_seen);
     }
 
@@ -4024,7 +4004,7 @@ mod tests {
         let driver = crate::runtime::spawn(run_scope_incarnation(
             plan,
             ScopeRole::Nested(NestedScopeLatches {
-                parent_ready: Latch::default(),
+                parent_ready: CompletionGatedLatch::default(),
                 ancestor: AncestorCommandLatches {
                     shutdown: Latch::default(),
                     abort: Latch::default(),
@@ -4158,7 +4138,7 @@ mod tests {
         let mut driver = Box::pin(run_scope_incarnation(
             plan,
             ScopeRole::Nested(NestedScopeLatches {
-                parent_ready: Latch::default(),
+                parent_ready: CompletionGatedLatch::default(),
                 ancestor: AncestorCommandLatches {
                     shutdown: Latch::default(),
                     abort: Latch::default(),
@@ -5095,7 +5075,7 @@ mod tests {
                 TaskDef::new(|_| future::pending::<crate::ExitResult>()),
             )
             .expect("provisional declaration succeeds");
-        let ready = Latch::default();
+        let ready = CompletionGatedLatch::default();
         let error = run_nested_tree(
             tree.into_core_for_test(),
             Arc::clone(&scope),

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -89,12 +89,15 @@ impl<T> Drop for Obligation<T> {
 struct RecordedReport {
     outcome: Option<RecordedOutcome>,
     cancellation: Cancellation,
+    readiness_signal_seen: bool,
 }
 
 struct ReportCompletion {
     sender: mpsc::Sender<RecordedReport>,
     shutdown: Latch,
     local_stop: Option<Latch>,
+    readiness: Latch,
+    completion_boundary: Latch,
 }
 
 pub(crate) struct ReportToken {
@@ -112,11 +115,14 @@ pub(crate) struct ReportReceiver(mpsc::Receiver<RecordedReport>);
 /// language one — any replacement executor behind `runtime` must preserve it),
 /// so the exit joiner may require an immediately available report: one has
 /// already been sent on every return, panic, and cancellation edge. The
-/// shutdown/local-stop latches are sampled by that same send, making the
-/// report and its cancellation evidence one ordered observation.
+/// shutdown/local-stop and readiness latches are sampled by that same send,
+/// making the report and its completion-boundary evidence one ordered
+/// observation.
 pub(crate) fn report_channel(
     shutdown: Latch,
     local_stop: Option<Latch>,
+    readiness: Latch,
+    completion_boundary: Latch,
 ) -> (ReportToken, ReportReceiver) {
     let (sender, receiver) = mpsc::channel();
     (
@@ -126,6 +132,8 @@ pub(crate) fn report_channel(
                     sender,
                     shutdown,
                     local_stop,
+                    readiness,
+                    completion_boundary,
                 },
                 |completion| completion.send(None),
             ),
@@ -142,10 +150,16 @@ impl ReportCompletion {
             } else {
                 Cancellation::NotObserved
             };
-        let _ = self.sender.send(RecordedReport {
+        let report = RecordedReport {
             outcome,
             cancellation,
-        });
+            readiness_signal_seen: self.readiness.is_fired(),
+        };
+        // Close helper observers at the same boundary as the evidence
+        // snapshot. A capability retained outside the supervised future
+        // cannot publish readiness after the future has completed.
+        self.completion_boundary.fire();
+        let _ = self.sender.send(report);
     }
 }
 
@@ -797,6 +811,7 @@ enum ChildEvent {
         recorded: Option<RecordedOutcome>,
         join: JoinVerdict,
         cancellation: Cancellation,
+        readiness_signal_seen: bool,
     },
     ConstructionDisposed {
         child: ChildKey,
@@ -1366,7 +1381,12 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
         construction_release,
         local_stop,
     } = launch;
-    let (report, report_receiver) = report_channel(shutdown, Some(local_stop.clone()));
+    let (report, report_receiver) = report_channel(
+        shutdown,
+        Some(local_stop.clone()),
+        ready.clone(),
+        ended.clone(),
+    );
     let constructed_sender = events.clone();
     let handle = runtime::spawn(async move {
         let body = async move {
@@ -1412,7 +1432,6 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
     let abort_handle = handle.abort_handle();
 
     let exit_sender = events.clone();
-    let exit_ended = ended.clone();
     runtime::spawn(async move {
         let join = match runtime::join(handle).await {
             runtime::JoinOutcome::Ok { .. } => JoinVerdict::Completed,
@@ -1421,7 +1440,6 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
                 phase: GracePhase::WithinGrace,
             },
         };
-        exit_ended.fire();
         // The task owns `report`, whose explicit record or Drop fallback runs
         // before the join completes. `receive` therefore asserts immediate
         // post-join availability without ever blocking this runtime worker.
@@ -1434,6 +1452,7 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
                 recorded: report.outcome,
                 join,
                 cancellation: report.cancellation,
+                readiness_signal_seen: report.readiness_signal_seen,
             }),
         )
         .await;
@@ -2082,6 +2101,7 @@ impl ScopeRuntime {
         recorded: Option<RecordedOutcome>,
         mut join: JoinVerdict,
         cancellation: Cancellation,
+        readiness_signal_seen: bool,
     ) {
         let readiness_effect = self
             .children
@@ -2090,7 +2110,7 @@ impl ScopeRuntime {
             .filter(|active| active.incarnation == incarnation)
             .and_then(|active| {
                 active.readiness.step(ReadinessEvent::Exit {
-                    signal_seen: active.ready_signal.is_fired(),
+                    signal_seen: readiness_signal_seen,
                 })
             });
         let became_ready = readiness_effect
@@ -3027,7 +3047,15 @@ async fn run_scope_incarnation(
                     recorded,
                     join,
                     cancellation,
-                })) => scope.handle_exit(child, incarnation, recorded, join, cancellation),
+                    readiness_signal_seen,
+                })) => scope.handle_exit(
+                    child,
+                    incarnation,
+                    recorded,
+                    join,
+                    cancellation,
+                    readiness_signal_seen,
+                ),
                 Pending::Driver(DriverEvent::Child(ChildEvent::ConstructionDisposed {
                     child,
                     panic,
@@ -3618,6 +3646,7 @@ mod tests {
             )))),
             join: JoinVerdict::Completed,
             cancellation: Cancellation::NotObserved,
+            readiness_signal_seen: false,
         });
         let mut pending = [
             restart_shutdown_work(nested),
@@ -3633,7 +3662,15 @@ mod tests {
                     recorded,
                     join,
                     cancellation,
-                })) => scope.handle_exit(child, incarnation, recorded, join, cancellation),
+                    readiness_signal_seen,
+                })) => scope.handle_exit(
+                    child,
+                    incarnation,
+                    recorded,
+                    join,
+                    cancellation,
+                    readiness_signal_seen,
+                ),
                 _ => unreachable!("the fixture queues only exit and restart work"),
             }
         }
@@ -3837,18 +3874,23 @@ mod tests {
     #[test]
     fn owned_report_token_consumes_or_falls_back_once() {
         let shutdown = Latch::default();
-        let (token, receiver) = report_channel(shutdown.clone(), None);
+        let readiness = Latch::default();
+        let (token, receiver) =
+            report_channel(shutdown.clone(), None, readiness.clone(), Latch::default());
         token.record(RecordedOutcome::Returned(Ok(())));
         shutdown.fire();
+        readiness.fire();
         let report = receiver.receive();
         assert!(matches!(
             report.outcome,
             Some(RecordedOutcome::Returned(Ok(())))
         ));
         assert_eq!(report.cancellation, Cancellation::NotObserved);
+        assert!(!report.readiness_signal_seen);
 
         let shutdown = Latch::default();
-        let (token, receiver) = report_channel(shutdown.clone(), None);
+        let (token, receiver) =
+            report_channel(shutdown.clone(), None, Latch::default(), Latch::default());
         shutdown.fire();
         drop(token);
         let report = receiver.receive();
@@ -3859,7 +3901,8 @@ mod tests {
     #[test]
     fn owned_report_token_records_prior_cancellation() {
         let shutdown = Latch::default();
-        let (token, receiver) = report_channel(shutdown.clone(), None);
+        let (token, receiver) =
+            report_channel(shutdown.clone(), None, Latch::default(), Latch::default());
         shutdown.fire();
         token.record(RecordedOutcome::Returned(Ok(())));
         let report = receiver.receive();
@@ -3874,10 +3917,31 @@ mod tests {
     fn owned_report_token_records_prior_local_stop() {
         let shutdown = Latch::default();
         let local_stop = Latch::default();
-        let (token, receiver) = report_channel(shutdown, Some(local_stop.clone()));
+        let (token, receiver) = report_channel(
+            shutdown,
+            Some(local_stop.clone()),
+            Latch::default(),
+            Latch::default(),
+        );
         local_stop.fire();
         token.record(RecordedOutcome::Returned(Ok(())));
         assert_eq!(receiver.receive().cancellation, Cancellation::Observed);
+    }
+
+    #[test]
+    fn owned_report_token_records_readiness_at_completion() {
+        let readiness = Latch::default();
+        let completion_boundary = Latch::default();
+        let (token, receiver) = report_channel(
+            Latch::default(),
+            None,
+            readiness.clone(),
+            completion_boundary.clone(),
+        );
+        readiness.fire();
+        token.record(RecordedOutcome::Returned(Ok(())));
+        assert!(completion_boundary.is_fired());
+        assert!(receiver.receive().readiness_signal_seen);
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2052,6 +2052,19 @@ impl ScopeRuntime {
     }
 
     fn handle_self_stop(&mut self, key: ChildKey, incarnation: Incarnation) {
+        let ready_before_stop = self
+            .children
+            .get(key)
+            .and_then(|child| child.active.as_ref())
+            .is_some_and(|active| {
+                active.incarnation == incarnation && active.ready_signal.is_fired()
+            });
+        if ready_before_stop {
+            // A local stop is reported on a separate helper task. Preserve
+            // the application task's mark-ready-before-stop order even when
+            // arbitration observes the stop before the readiness event.
+            self.handle_ready(key, incarnation);
+        }
         if self
             .children
             .get(key)
@@ -2070,6 +2083,26 @@ impl ScopeRuntime {
         mut join: JoinVerdict,
         cancellation: Cancellation,
     ) {
+        let readiness_effect = self
+            .children
+            .get_mut(key)
+            .and_then(|child| child.active.as_mut())
+            .filter(|active| active.incarnation == incarnation)
+            .and_then(|active| {
+                active.readiness.step(ReadinessEvent::Exit {
+                    signal_seen: active.ready_signal.is_fired(),
+                })
+            });
+        let became_ready = readiness_effect
+            .map(|effect| self.apply_readiness_effect(key, incarnation, effect))
+            .unwrap_or(false);
+        if became_ready {
+            // Match the natural signal-before-exit order: ordered startup may
+            // advance, and a sole ready child completes aggregate startup
+            // before its post-ready exit is classified.
+            self.progress_startup();
+        }
+
         let Some(child) = self.children.get_mut(key) else {
             return;
         };
@@ -2091,7 +2124,6 @@ impl ScopeRuntime {
         {
             runtime::dispose_detached(teardown);
         }
-        active.readiness.step(ReadinessEvent::Exit);
         if let (JoinVerdict::Cancelled { .. }, Some(phase)) = (&join, active.hard_abort_phase) {
             join = JoinVerdict::Cancelled { phase };
         }
@@ -2372,7 +2404,13 @@ impl ScopeRuntime {
                     self.progress_startup();
                 }
             }
-            DeadlineKind::Restart { child } => self.spawn_child(child),
+            DeadlineKind::Restart { child } => {
+                self.spawn_child(child);
+                // A restart-deadline caller is outside `progress_startup`'s
+                // ordered loop. Revisit the aggregate in case this spawn's
+                // immediate-readiness effect released its last gate.
+                self.progress_startup();
+            }
             DeadlineKind::Stop { child, incarnation } => {
                 if self
                     .children

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2070,6 +2070,10 @@ impl ScopeRuntime {
             // A local stop is reported on a separate helper task. Preserve
             // the application task's mark-ready-before-stop order even when
             // arbitration observes the stop before the readiness event.
+            // An inverted `stop(); mark_ready()` sequence may also count as
+            // ready here when its latch fires before the driver observes the
+            // stop — licensed by the spec's "fired before ... a clean
+            // self-stop is observed" wording (§6).
             self.handle_ready(key, incarnation);
         }
         if self
@@ -3671,6 +3675,155 @@ mod tests {
             factories.load(std::sync::atomic::Ordering::SeqCst),
             0,
             "the production guard must suppress the expedited factory after intensity drain"
+        );
+    }
+
+    /// A `mark_ready(); stop()` child reports its local stop and exit on
+    /// helper tasks, so one driver wake can collect both while the fired
+    /// readiness latch's Ready event is still undrained — and arbitration
+    /// orders the stop ahead of the readiness signal. `handle_self_stop`
+    /// must consult the fired latch before `begin_stop_child`'s Shutdown
+    /// step disarms the gate, or the clean post-ready exit is misread as a
+    /// pre-ready stop and spuriously aborts startup.
+    #[crate::runtime::test]
+    async fn same_batch_self_stop_preserves_fired_readiness_for_startup() {
+        let mut tree = Tree::new();
+        tree.add_task(
+            "ready-then-stop",
+            TaskDef::new(|_| future::pending::<crate::ExitResult>())
+                .readiness(Readiness::Manual)
+                .expect("manual readiness is valid")
+                .readiness_deadline(ReadinessDeadline::Unbounded),
+        )
+        .expect("valid task");
+        let mut plan = tree.lower_for_test();
+        let root = Arc::clone(&plan.root);
+        let epoch = root
+            .begin_incarnation()
+            .expect("test scope epoch is available");
+        root.set_admitted_children(
+            plan.children
+                .iter()
+                .map(|child| resident_projection(&child.slot))
+                .collect(),
+        );
+        let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+        let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+        let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+        let mut children = ChildArena::default();
+        let key = children
+            .insert(child)
+            .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+        let mut scope = ScopeRuntime {
+            root: Arc::clone(&root),
+            defaults: plan.defaults.clone(),
+            intensity_policy: plan.config.intensity,
+            intensity: super::IntensityState::default(),
+            children,
+            events,
+            disposal_events,
+            deadlines: super::DeadlineQueue::default(),
+            jitter: crate::runtime::JitterRng::from_system_entropy(),
+            lifecycle: ScopeLifecycle::starting(),
+            next_ordered_start: Some(key),
+            role: ScopeRole::Root,
+            dynamic: None,
+            epoch,
+            ancestor_shutdown_seen: false,
+            ancestor_abort_seen: false,
+            hard_forced: false,
+            completion: None,
+        };
+        plan.armed = false;
+        drop(plan);
+
+        scope.spawn_child(key);
+        let active = scope.children[key]
+            .active
+            .as_ref()
+            .expect("spawned child is active");
+        let incarnation = active.incarnation;
+        // The application task fired its readiness latch before stopping;
+        // the driver has not yet drained the corresponding Ready event.
+        assert!(active.ready_signal.fire());
+        active.abort_handle.abort();
+
+        let mut pending = [
+            Pending::Driver(DriverEvent::Child(ChildEvent::Exited {
+                child: key,
+                incarnation,
+                recorded: Some(RecordedOutcome::Returned(Ok(()))),
+                join: JoinVerdict::Completed,
+                cancellation: Cancellation::NotObserved,
+                readiness_signal_seen: true,
+            }))
+            .classified(),
+            Pending::Driver(DriverEvent::Child(ChildEvent::SelfStop {
+                child: key,
+                incarnation,
+            }))
+            .classified(),
+        ];
+        arbitrate(&mut pending);
+        assert!(
+            matches!(
+                pending[0].1,
+                Pending::Driver(DriverEvent::Child(ChildEvent::SelfStop { .. }))
+            ),
+            "the regression premise: arbitration orders the stop ahead of the exit"
+        );
+        for (_, event) in pending {
+            match event {
+                Pending::Driver(DriverEvent::Child(ChildEvent::SelfStop {
+                    child,
+                    incarnation,
+                })) => scope.handle_self_stop(child, incarnation),
+                Pending::Driver(DriverEvent::Child(ChildEvent::Exited {
+                    child,
+                    incarnation,
+                    recorded,
+                    join,
+                    cancellation,
+                    readiness_signal_seen,
+                })) => scope.handle_exit(
+                    child,
+                    incarnation,
+                    recorded,
+                    join,
+                    cancellation,
+                    readiness_signal_seen,
+                ),
+                _ => unreachable!("the fixture queues only the stop and the exit"),
+            }
+        }
+
+        let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) =
+            disposal_event_receiver
+                .recv()
+                .await
+                .expect("disposal reports completion")
+        else {
+            panic!("only construction disposal was armed")
+        };
+        scope.handle_construction_disposed(child, panic);
+
+        assert!(
+            scope.lifecycle.startup_complete(),
+            "the ready-before-stop child completes startup"
+        );
+        assert!(
+            matches!(root.record().startup, Some(Ok(()))),
+            "a fired readiness latch must survive a same-batch local stop: {:?}",
+            root.record().startup
+        );
+        assert_eq!(root.record().state, ScopeState::Running);
+        assert!(matches!(
+            scope.children[key].slot.member.record().stage,
+            MemberStage::Terminal(ref exit) if matches!(exit.kind(), ExitKind::Completed)
+        ));
+        assert!(
+            !scope.children[key].slot.member.record().startup_aborted,
+            "a post-ready clean self-stop is not a startup abort"
         );
     }
 

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -375,7 +375,9 @@ pub(crate) enum ReadinessEvent {
         signal_seen: bool,
     },
     Shutdown,
-    Exit,
+    Exit {
+        signal_seen: bool,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -429,7 +431,8 @@ impl ReadinessGate {
                 ReadinessEvent::Deadline {
                     signal_seen: true, ..
                 },
-            ) => {
+            )
+            | (ReadinessState::Waiting { .. }, ReadinessEvent::Exit { signal_seen: true }) => {
                 self.state = ReadinessState::Ready;
                 Some(ReadinessEffect::BecameReady)
             }
@@ -446,8 +449,12 @@ impl ReadinessGate {
                 Some(ReadinessEffect::TimedOut { deadline })
             }
             (
-                ReadinessState::Unconfigured | ReadinessState::Waiting { .. },
-                ReadinessEvent::Shutdown | ReadinessEvent::Exit,
+                ReadinessState::Unconfigured,
+                ReadinessEvent::Shutdown | ReadinessEvent::Exit { .. },
+            )
+            | (
+                ReadinessState::Waiting { .. },
+                ReadinessEvent::Shutdown | ReadinessEvent::Exit { signal_seen: false },
             ) => {
                 self.state = ReadinessState::Disarmed;
                 Some(ReadinessEffect::Disarmed)
@@ -1232,6 +1239,19 @@ mod tests {
                 signal_seen: false,
             }),
             None
+        );
+
+        let mut exited = ReadinessGate::new();
+        assert_eq!(
+            exited.step(ReadinessEvent::Configure {
+                readiness: crate::Readiness::Manual,
+                deadline: None,
+            }),
+            None
+        );
+        assert_eq!(
+            exited.step(ReadinessEvent::Exit { signal_seen: true }),
+            Some(ReadinessEffect::BecameReady)
         );
 
         let mut timed_out = ReadinessGate::new();

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -21,9 +21,9 @@ use crate::{
     mailbox::{AcceptedSequence, MailboxCell, MailboxReceiver},
     policy::{ChildMode, CommonOptions},
     runtime::{
-        self, ActorWork, Latch, PanicAccumulator, PanicPayload, Signal, SignalWatcher,
-        UnwindPanics, catch_panic, discard_panic, keep_first_panic, resume_preferred_panic,
-        resume_preferred_panic_outside_unwind,
+        self, ActorWork, CompletionGatedLatch, Latch, PanicAccumulator, PanicPayload, Signal,
+        SignalWatcher, UnwindPanics, catch_panic, discard_panic, keep_first_panic,
+        resume_preferred_panic, resume_preferred_panic_outside_unwind,
     },
 };
 
@@ -851,7 +851,7 @@ pub struct RawContext<M> {
     scope: ScopeRef,
     shutdown: CancellationToken,
     abort: CancellationToken,
-    ready: Latch,
+    ready: CompletionGatedLatch,
     local_stop: Latch,
     readiness: Readiness,
     mailbox_shutdown: MailboxShutdown,
@@ -1755,7 +1755,7 @@ pub(crate) struct RawRunContext {
     pub(crate) scope: ScopeRef,
     pub(crate) shutdown: Latch,
     pub(crate) abort: Latch,
-    pub(crate) ready: Latch,
+    pub(crate) ready: CompletionGatedLatch,
     pub(crate) local_stop: Latch,
     pub(crate) mailbox_shutdown: MailboxShutdown,
 }

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -603,6 +603,91 @@ impl Latch {
     }
 }
 
+const COMPLETION_GATE_OPEN: u8 = 0;
+const COMPLETION_GATE_FIRED: u8 = 1;
+const COMPLETION_GATE_CLOSED: u8 = 2;
+const COMPLETION_GATE_CLOSED_FIRED: u8 = 3;
+
+/// A one-shot signal whose publication is linearized with a completion edge.
+///
+/// `fire` wins only while the gate is open. `complete` atomically closes the
+/// gate and reports whether the signal won first, so a capability retained by
+/// another task cannot publish after completion or disappear between a sample
+/// and the completion notification.
+#[derive(Clone, Debug)]
+pub(crate) struct CompletionGatedLatch {
+    state: Arc<AtomicU8>,
+    fired: Latch,
+    completed: Latch,
+}
+
+impl Default for CompletionGatedLatch {
+    fn default() -> Self {
+        Self {
+            state: Arc::new(AtomicU8::new(COMPLETION_GATE_OPEN)),
+            fired: Latch::default(),
+            completed: Latch::default(),
+        }
+    }
+}
+
+impl CompletionGatedLatch {
+    pub(crate) fn fire(&self) -> bool {
+        if self
+            .state
+            .compare_exchange(
+                COMPLETION_GATE_OPEN,
+                COMPLETION_GATE_FIRED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return false;
+        }
+        let transitioned = self.fired.fire();
+        debug_assert!(transitioned);
+        true
+    }
+
+    pub(crate) fn is_fired(&self) -> bool {
+        matches!(
+            self.state.load(Ordering::Acquire),
+            COMPLETION_GATE_FIRED | COMPLETION_GATE_CLOSED_FIRED
+        )
+    }
+
+    pub(crate) async fn fired(&self) {
+        self.fired.fired().await;
+    }
+
+    pub(crate) fn complete(&self) -> bool {
+        loop {
+            let current = self.state.load(Ordering::Acquire);
+            let (next, fired) = match current {
+                COMPLETION_GATE_OPEN => (COMPLETION_GATE_CLOSED, false),
+                COMPLETION_GATE_FIRED => (COMPLETION_GATE_CLOSED_FIRED, true),
+                COMPLETION_GATE_CLOSED => return false,
+                COMPLETION_GATE_CLOSED_FIRED => return true,
+                _ => unreachable!("completion-gated latch state is valid"),
+            };
+            if self
+                .state
+                .compare_exchange(current, next, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                let transitioned = self.completed.fire();
+                debug_assert!(transitioned);
+                return fired;
+            }
+        }
+    }
+
+    pub(crate) async fn completed(&self) {
+        self.completed.fired().await;
+    }
+}
+
 const ONESHOT_OPEN: u8 = 0;
 const ONESHOT_SENDING: u8 = 1;
 const ONESHOT_SENT: u8 = 2;
@@ -1245,8 +1330,8 @@ mod tests {
     };
 
     use super::{
-        Deadline, DisposalJob, DisposalPanic, JoinOutcome, Latch, OneShotClose, Signal, Timeout,
-        discard_panic, join, oneshot, spawn, timeout, yield_now,
+        CompletionGatedLatch, Deadline, DisposalJob, DisposalPanic, JoinOutcome, Latch,
+        OneShotClose, Signal, Timeout, discard_panic, join, oneshot, spawn, timeout, yield_now,
     };
 
     #[tokio::test(start_paused = true)]
@@ -1406,6 +1491,49 @@ mod tests {
         assert_eq!(transitions, 1);
         assert!(latch.is_fired());
         assert!(!latch.fire());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn completion_gated_fire_and_completion_choose_one_order() {
+        for _ in 0..256 {
+            let latch = CompletionGatedLatch::default();
+            let started = Arc::new(AtomicUsize::new(0));
+            let fire = spawn({
+                let latch = latch.clone();
+                let started = Arc::clone(&started);
+                async move {
+                    started.fetch_add(1, Ordering::AcqRel);
+                    while started.load(Ordering::Acquire) != 2 {
+                        yield_now().await;
+                    }
+                    latch.fire()
+                }
+            });
+            let complete = spawn({
+                let latch = latch.clone();
+                let started = Arc::clone(&started);
+                async move {
+                    started.fetch_add(1, Ordering::AcqRel);
+                    while started.load(Ordering::Acquire) != 2 {
+                        yield_now().await;
+                    }
+                    latch.complete()
+                }
+            });
+
+            let JoinOutcome::Ok { value: fired } = join(fire).await else {
+                panic!("signal task must complete normally");
+            };
+            let JoinOutcome::Ok {
+                value: completion_saw_fire,
+            } = join(complete).await
+            else {
+                panic!("completion task must complete normally");
+            };
+            assert_eq!(fired, completion_saw_fire);
+            assert_eq!(latch.is_fired(), completion_saw_fire);
+            assert!(!latch.fire(), "completion closes later publication");
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -16,7 +16,7 @@ use crate::{
     cells::MemberCell,
     definition::DefinitionSource,
     policy::CommonOptions,
-    runtime::{self, Latch},
+    runtime::{self, CompletionGatedLatch, Latch},
 };
 
 pub(crate) type TaskFuture = Pin<Box<dyn Future<Output = ExitResult> + Send + 'static>>;
@@ -25,7 +25,7 @@ pub(crate) type TaskFactory = Arc<dyn Fn(TaskContext) -> TaskFuture + Send + Syn
 pub(crate) struct TaskContextLatches {
     pub(crate) shutdown: Latch,
     pub(crate) abort: Latch,
-    pub(crate) ready: Latch,
+    pub(crate) ready: CompletionGatedLatch,
 }
 
 /// Per-incarnation capabilities supplied to a supervised task.
@@ -35,7 +35,7 @@ pub struct TaskContext {
     incarnation: Incarnation,
     shutdown: CancellationToken,
     abort: CancellationToken,
-    ready: Latch,
+    ready: CompletionGatedLatch,
 }
 
 impl TaskContext {
@@ -323,12 +323,12 @@ mod tests {
         Cancellation, ChildId, Exit, ExitKind, GracePhase,
         cells::MemberCell,
         identity::ScopeIdentity,
-        runtime::{self, Latch},
+        runtime::{self, CompletionGatedLatch, Latch},
     };
 
     use super::{OneShotTaskRef, TaskContext, TaskContextLatches, TaskRef};
 
-    fn task_context() -> (TaskContext, Latch, Latch, Latch) {
+    fn task_context() -> (TaskContext, Latch, Latch, CompletionGatedLatch) {
         let id = ChildId::from("task");
         let mut identity = ScopeIdentity::new();
         let membership = identity.mint_membership(&id).expect("membership available");
@@ -336,7 +336,7 @@ mod tests {
         let incarnation = incarnations.mint().expect("incarnation available");
         let shutdown = Latch::default();
         let abort = Latch::default();
-        let ready = Latch::default();
+        let ready = CompletionGatedLatch::default();
         let context = TaskContext::new(
             id,
             incarnation,

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -118,6 +118,43 @@ async fn readiness_fired_before_clean_self_stop_counts_for_startup() {
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
 }
 
+#[tokio::test]
+async fn readiness_fired_after_task_completion_cannot_reclassify_the_exit() {
+    let mut tree = Tree::new();
+    let task = tree
+        .add_task(
+            "late-readiness",
+            TaskDef::new(|context| async move {
+                let late_context = context.clone();
+                tokio::spawn(async move {
+                    late_context.mark_ready();
+                });
+                Ok(())
+            })
+            .restart(never())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness")
+            .readiness_deadline(ReadinessDeadline::Unbounded),
+        )
+        .expect("valid task");
+
+    let system = tree.spawn().expect("runtime is available");
+    let startup = system
+        .wait_started()
+        .await
+        .expect_err("readiness after future completion is stale");
+    assert!(matches!(
+        startup,
+        StartupError::StartupFailed(ref failure)
+            if matches!(failure.cause, StartupFailureCause::Child { ref id, .. } if id.as_str() == "late-readiness")
+    ));
+    assert!(matches!(task.wait().await.kind(), ExitKind::Completed));
+    system
+        .shutdown(Duration::ZERO)
+        .await
+        .expect("the completed child has no straggler");
+}
+
 #[tokio::test(start_paused = true)]
 async fn immediate_restart_deadline_rechecks_aggregate_startup() {
     let backoff = Duration::from_secs(30);

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -10,9 +10,195 @@ use crate::common::{
     POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, policy::never, poll_until,
 };
 use shelterwood::{
-    Cancellation, ChildState, DynamicTree, ExitError, ExitKind, Readiness, ReadinessDeadline,
-    ScopeState, Shutdown, StartupError, StartupFailureCause, SubtreeOnceDef, TaskDef, Tree,
+    Backoff, Cancellation, ChildState, DynamicTree, ExitError, ExitKind, ExitResult, Jitter,
+    RawActor, RawContext, RawOnceDef, Readiness, ReadinessDeadline, RestartCondition,
+    RestartPolicy, ScopeState, Shutdown, StartupError, StartupFailureCause, SubtreeOnceDef,
+    TaskDef, Tree,
 };
+
+struct ReadyThenStop;
+
+impl RawActor for ReadyThenStop {
+    type Msg = ();
+
+    fn readiness(&self) -> Readiness {
+        Readiness::Manual
+    }
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        context.mark_ready();
+        context.stop();
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn readiness_fired_before_clean_exit_counts_for_startup() {
+    let mut tree = Tree::new();
+    let task = tree
+        .add_task(
+            "ready-then-complete",
+            TaskDef::new(|context| async move {
+                context.mark_ready();
+                Ok(())
+            })
+            .restart(never())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness")
+            .readiness_deadline(ReadinessDeadline::Unbounded),
+        )
+        .expect("valid task");
+
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("ready-before-exit completes startup");
+    assert!(matches!(task.wait().await.kind(), ExitKind::Completed));
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+}
+
+#[tokio::test(start_paused = true)]
+async fn readiness_fired_before_failure_makes_the_failure_post_ready() {
+    let backoff = Duration::from_secs(30);
+    let mut tree = Tree::new();
+    tree.add_task(
+        "ready-then-fail",
+        TaskDef::new(|context| async move {
+            context.mark_ready();
+            Err(ExitError::message("post-ready failure"))
+        })
+        .restart(RestartPolicy::new(
+            RestartCondition::OnFailure,
+            Backoff::fixed(backoff, Jitter::None).expect("non-zero backoff"),
+        ))
+        .shutdown(Shutdown::Abort)
+        .readiness(Readiness::Manual)
+        .expect("manual readiness")
+        .readiness_deadline(ReadinessDeadline::Unbounded),
+    )
+    .expect("valid task");
+
+    let system = tree.spawn().expect("runtime is available");
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            system
+                .scope()
+                .child("ready-then-fail")
+                .is_some_and(|child| matches!(child.state, ChildState::Restarting))
+        })
+        .await
+    );
+    assert_eq!(
+        system.scope().snapshot().state,
+        ScopeState::Running,
+        "the ready edge must complete startup before restart backoff"
+    );
+    system
+        .wait_started()
+        .await
+        .expect("post-ready failure does not abort or re-gate startup");
+    system
+        .shutdown(Duration::ZERO)
+        .await
+        .expect("a child in backoff has no straggler");
+}
+
+#[tokio::test]
+async fn readiness_fired_before_clean_self_stop_counts_for_startup() {
+    let mut tree = Tree::new();
+    tree.add_raw_once("ready-then-stop", RawOnceDef::new(ReadyThenStop))
+        .expect("valid raw actor");
+
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("ready-before-stop completes startup");
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+}
+
+#[tokio::test(start_paused = true)]
+async fn immediate_restart_deadline_rechecks_aggregate_startup() {
+    let backoff = Duration::from_secs(30);
+    let incarnations = Arc::new(AtomicUsize::new(0));
+    let release_manual = ReleaseGate::default();
+    let manual_ready = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.add_task(
+        "restarting-immediate",
+        TaskDef::new({
+            let incarnations = Arc::clone(&incarnations);
+            move |context| {
+                let incarnation = incarnations.fetch_add(1, Ordering::SeqCst) + 1;
+                async move {
+                    if incarnation == 1 {
+                        return Err(ExitError::message("restart after sibling starts"));
+                    }
+                    context.shutdown_token().cancelled().await;
+                    Ok(())
+                }
+            }
+        })
+        .restart(RestartPolicy::new(
+            RestartCondition::OnFailure,
+            Backoff::fixed(backoff, Jitter::None).expect("non-zero backoff"),
+        )),
+    )
+    .expect("valid immediate task");
+    tree.add_task(
+        "manual-sibling",
+        TaskDef::new({
+            let release_manual = release_manual.clone();
+            let manual_ready = manual_ready.clone();
+            move |context| {
+                let release_manual = release_manual.clone();
+                let manual_ready = manual_ready.clone();
+                async move {
+                    release_manual.wait().await;
+                    context.mark_ready();
+                    manual_ready.release();
+                    context.shutdown_token().cancelled().await;
+                    Ok(())
+                }
+            }
+        })
+        .readiness(Readiness::Manual)
+        .expect("manual readiness")
+        .readiness_deadline(ReadinessDeadline::Unbounded),
+    )
+    .expect("valid manual sibling");
+
+    let system = tree.spawn().expect("runtime is available");
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            system
+                .scope()
+                .child("restarting-immediate")
+                .is_some_and(|child| matches!(child.state, ChildState::Restarting))
+        })
+        .await
+    );
+    release_manual.release();
+    manual_ready.wait().await;
+    assert_eq!(system.scope().snapshot().state, ScopeState::Starting);
+
+    advance_time(backoff).await;
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            incarnations.load(Ordering::SeqCst) == 2
+        })
+        .await
+    );
+    system
+        .wait_started()
+        .await
+        .expect("immediate restart releases the last aggregate gate");
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("restarted task cooperates");
+}
 
 #[tokio::test]
 async fn ordered_startup_waits_for_manual_readiness() {


### PR DESCRIPTION
Part of #116.

## Summary

- preserve a manual readiness signal that fires before an incarnation's exit is observed, so ready-then-complete and ready-then-fail are classified as post-ready exits
- preserve mark-ready-before-clean-self-stop ordering despite cross-task event arbitration
- revisit aggregate startup after a restart-deadline spawn, allowing an `Immediate` replacement to release the final startup gate
- specify ready-at-exit/self-stop semantics and pin the engine behavior plus end-to-end races

## Why

Child exits and local stops intentionally arbitrate ahead of readiness events. The readiness latch retained the causal fact, but those paths disarmed or removed the incarnation before consulting it. Separately, restart-deadline spawns happened outside the startup progression loop and discarded an `Immediate` readiness effect, which could leave `wait_started()` pending forever.

## Validation

- `./tools/dev cargo test -p shelterwood --test integration readiness::`
- `./tools/dev just ci` (435 tests, doctests, rustdoc/API reachability, runtime/exit/layering enforcement, packaged-crate verification, and nixfmt)
