### PR TITLE
Preserve mailbox capacity across kind defaults

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1831,7 +1831,13 @@ Resolution and mechanics:
   a child declaring `queue` with deferred capacity under a scope
   default of `latest()` gets `queue` at the library default capacity —
   the scope default neither converts the declared kind nor supplies a
-  capacity across kinds.
+  capacity across kinds. For the full outward walk, suppose the root
+  defaults to `queue(10)`, an inheriting child scope defaults to
+  `latest()`, and an inheriting grandchild scope contains an actor declared
+  with `queue_inherit()`: that actor resolves to `queue(10)`, because the
+  intervening `latest()` is passed over when resolving queue capacity. If
+  the grandchild edge is `Reset` instead, the same declaration resolves to
+  the library `queue(64)`; the reset severs the root's contribution.
 - Validation is eager: any configuration that would fail spawn fails at the
   point of declaration where it is decidable — duplicate/empty ids at add
   time, zero capacities at construction, zero backoff durations at

--- a/SPEC.md
+++ b/SPEC.md
@@ -1829,9 +1829,11 @@ Resolution and mechanics:
   declaration named no kind); kind-matched deferral governs a
   *declaration's* unfinished capacity. The exact policy case, decided:
   a child declaring `queue` with deferred capacity under a scope
-  default of `latest()` gets `queue` at the library default capacity —
-  the scope default neither converts the declared kind nor supplies a
-  capacity across kinds. For the full outward walk, suppose the root
+  default of `latest()`, with no enclosing `queue` default beyond it,
+  gets `queue` at the library default capacity — the scope default
+  neither converts the declared kind nor supplies a capacity across
+  kinds, and with no outer `queue` default the outward walk ends at
+  the library default. For the full outward walk, suppose the root
   defaults to `queue(10)`, an inheriting child scope defaults to
   `latest()`, and an inheriting grandchild scope contains an actor declared
   with `queue_inherit()`: that actor resolves to `queue(10)`, because the

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -681,16 +681,21 @@ pub(crate) struct ResolvedDefaults {
     pub(crate) child_restart: RestartPolicy,
     pub(crate) child_shutdown: Shutdown,
     pub(crate) mailbox: Mailbox,
+    /// Nearest resolved queue capacity, retained across defaults of other kinds.
+    pub(crate) queue_capacity: NonZeroUsize,
     pub(crate) mailbox_shutdown: MailboxShutdown,
     pub(crate) readiness_deadline: ReadinessDeadline,
 }
 
 impl Default for ResolvedDefaults {
     fn default() -> Self {
+        let queue_capacity = NonZeroUsize::new(DEFAULT_MAILBOX_CAPACITY)
+            .expect("the library mailbox capacity is non-zero");
         Self {
             child_restart: RestartPolicy::default(),
             child_shutdown: Shutdown::default(),
-            mailbox: Mailbox::default(),
+            mailbox: Mailbox::Queue(Some(queue_capacity)),
+            queue_capacity,
             mailbox_shutdown: MailboxShutdown::default(),
             readiness_deadline: ReadinessDeadline::Bounded(DEFAULT_READINESS_DEADLINE),
         }
@@ -713,7 +718,11 @@ impl ResolvedDefaults {
         let resolved = Self {
             child_restart: values.child_restart.unwrap_or(self.child_restart),
             child_shutdown: values.child_shutdown.unwrap_or(self.child_shutdown),
-            mailbox: resolve_default_mailbox(values.mailbox, self.mailbox),
+            mailbox: resolve_mailbox(values.mailbox, self.mailbox, self.queue_capacity),
+            queue_capacity: match values.mailbox {
+                Some(Mailbox::Queue(Some(capacity))) => capacity,
+                None | Some(Mailbox::Queue(None) | Mailbox::Latest) => self.queue_capacity,
+            },
             mailbox_shutdown: values.mailbox_shutdown.unwrap_or(self.mailbox_shutdown),
             readiness_deadline: match values.readiness_deadline.unwrap_or(self.readiness_deadline) {
                 ReadinessDeadline::Inherit => self.readiness_deadline,
@@ -734,13 +743,14 @@ impl ResolvedDefaults {
     }
 }
 
-fn resolve_default_mailbox(value: Option<Mailbox>, inherited: Mailbox) -> Mailbox {
+fn resolve_mailbox(
+    value: Option<Mailbox>,
+    inherited: Mailbox,
+    inherited_queue_capacity: NonZeroUsize,
+) -> Mailbox {
     match value {
         None => inherited,
-        Some(Mailbox::Queue(None)) => match inherited {
-            Mailbox::Queue(Some(capacity)) => Mailbox::Queue(Some(capacity)),
-            Mailbox::Queue(None) | Mailbox::Latest => Mailbox::default(),
-        },
+        Some(Mailbox::Queue(None)) => Mailbox::Queue(Some(inherited_queue_capacity)),
         Some(value) => value,
     }
 }
@@ -784,7 +794,7 @@ pub(crate) fn resolve_common(
             options.restart.unwrap_or(defaults.child_restart)
         },
         shutdown: options.shutdown.unwrap_or(defaults.child_shutdown),
-        mailbox: resolve_default_mailbox(options.mailbox, defaults.mailbox),
+        mailbox: resolve_mailbox(options.mailbox, defaults.mailbox, defaults.queue_capacity),
         mailbox_shutdown: options
             .mailbox_shutdown
             .unwrap_or(defaults.mailbox_shutdown),
@@ -1129,9 +1139,29 @@ mod tests {
     }
 
     #[test]
-    fn defaults_overlay_as_one_value_and_mailbox_capacity_resolves_by_kind() {
+    fn mailbox_capacity_walks_outward_by_kind_across_defaults_overlays() {
         let library = ResolvedDefaults::default();
-        let latest = library
+        let library_latest = library
+            .overlay(&ScopeDefaults {
+                mailbox: Some(Mailbox::latest()),
+                ..ScopeDefaults::default()
+            })
+            .expect("valid defaults");
+        let library_queue = library_latest
+            .overlay(&ScopeDefaults {
+                mailbox: Some(Mailbox::queue_inherit()),
+                ..ScopeDefaults::default()
+            })
+            .expect("valid defaults");
+        assert_eq!(library_queue.mailbox, Mailbox::default());
+
+        let outer_queue = library
+            .overlay(&ScopeDefaults {
+                mailbox: Some(Mailbox::queue(10).expect("non-zero capacity")),
+                ..ScopeDefaults::default()
+            })
+            .expect("valid defaults");
+        let latest = outer_queue
             .overlay(&ScopeDefaults {
                 mailbox: Some(Mailbox::latest()),
                 ..ScopeDefaults::default()
@@ -1145,9 +1175,20 @@ mod tests {
                 ..ScopeDefaults::default()
             })
             .expect("valid defaults");
-        assert_eq!(deferred_queue.mailbox, Mailbox::default());
+        assert_eq!(
+            deferred_queue.mailbox,
+            Mailbox::queue(10).expect("non-zero capacity")
+        );
         assert_eq!(deferred_queue.child_restart, latest.child_restart);
         assert_eq!(deferred_queue.child_shutdown, latest.child_shutdown);
+
+        let reset_queue = ResolvedDefaults::default()
+            .overlay(&ScopeDefaults {
+                mailbox: Some(Mailbox::queue_inherit()),
+                ..ScopeDefaults::default()
+            })
+            .expect("valid reset defaults");
+        assert_eq!(reset_queue.mailbox, Mailbox::default());
     }
 
     #[test]

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -863,6 +863,99 @@ async fn subtree_defaults_inherit_or_reset_end_to_end() {
 }
 
 #[tokio::test]
+async fn three_level_mailbox_capacity_walk_honors_inherit_and_reset() {
+    let inherited_entered = ReleaseGate::default();
+    let inherited_release = ReleaseGate::default();
+    let reset_entered = ReleaseGate::default();
+    let reset_release = ReleaseGate::default();
+
+    let mut inherited_leaf = Tree::new();
+    let inherited_actor = inherited_leaf
+        .add_actor_once(
+            "actor",
+            ActorOnceDef::<CapacityActor>::new((
+                inherited_entered.clone(),
+                inherited_release.clone(),
+            ))
+            .mailbox(Mailbox::queue_inherit()),
+        )
+        .expect("valid inherited actor");
+    let mut reset_leaf = Tree::new();
+    let reset_actor = reset_leaf
+        .add_actor_once(
+            "actor",
+            ActorOnceDef::<CapacityActor>::new((reset_entered.clone(), reset_release.clone()))
+                .mailbox(Mailbox::queue_inherit()),
+        )
+        .expect("valid reset actor");
+
+    let mut middle = Tree::new();
+    middle.defaults(ScopeDefaults {
+        mailbox: Some(Mailbox::latest()),
+        ..ScopeDefaults::default()
+    });
+    middle
+        .add_subtree_once(
+            "inherited",
+            SubtreeOnceDef::new(inherited_leaf).defaults(DefaultsInheritance::Inherit),
+        )
+        .expect("valid inherited leaf");
+    middle
+        .add_subtree_once(
+            "reset",
+            SubtreeOnceDef::new(reset_leaf).defaults(DefaultsInheritance::Reset),
+        )
+        .expect("valid reset leaf");
+
+    let mut root = Tree::new();
+    root.defaults(ScopeDefaults {
+        mailbox: Some(Mailbox::queue(1).expect("valid outer capacity")),
+        ..ScopeDefaults::default()
+    });
+    root.add_subtree_once(
+        "middle",
+        SubtreeOnceDef::new(middle).defaults(DefaultsInheritance::Inherit),
+    )
+    .expect("valid middle subtree");
+
+    let system = root.spawn().expect("runtime is available");
+    system.wait_started().await.expect("all scopes start");
+
+    inherited_actor
+        .send(CapacityMessage::Hold)
+        .await
+        .expect("inherited actor accepts hold");
+    reset_actor
+        .send(CapacityMessage::Hold)
+        .await
+        .expect("reset actor accepts hold");
+    inherited_entered.wait().await;
+    reset_entered.wait().await;
+
+    inherited_actor
+        .try_send(CapacityMessage::Queued)
+        .expect("the inherited outer capacity accepts one pending message");
+    let inherited_full = inherited_actor
+        .try_send(CapacityMessage::Queued)
+        .expect_err("latest is passed over and the outer one-slot queue is full");
+    assert_eq!(inherited_full.kind, SendErrorKind::Full);
+
+    reset_actor
+        .try_send(CapacityMessage::Queued)
+        .expect("reset uses the library queue capacity");
+    reset_actor
+        .try_send(CapacityMessage::Queued)
+        .expect("reset severs the outer one-slot queue capacity");
+
+    inherited_release.release();
+    reset_release.release();
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[tokio::test]
 async fn subtree_restart_defaults_inherit_or_reset_end_to_end() {
     let inherited_starts = Arc::new(AtomicUsize::new(0));
     let inherited_fail = ReleaseGate::default();


### PR DESCRIPTION
Part of #116.

## Summary

- retain the nearest queue capacity while scope defaults switch through other mailbox kinds
- resolve `queue_inherit()` through an intervening `latest()` to the outer queue capacity
- preserve `DefaultsInheritance::Reset` as a hard boundary back to the library queue capacity
- add unit and three-level end-to-end coverage plus the normative §9.3 worked example

## Why

`ResolvedDefaults` previously retained only the currently selected mailbox value. Choosing `latest()` therefore erased an outer queue capacity even though the specification requires kind-mismatched defaults to be passed over during the outward capacity walk.

## Validation

- focused policy, defaults, and subtree test suites
- `./tools/dev just ci` (432 tests, doctests, rustdoc/API reachability, runtime/exit/layering enforcement, packaged-crate verification, and nixfmt)
