### PR TITLE
Fix timer-batch offload fairness

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -835,6 +835,11 @@ batch in arming order. Within class 3, ordering between mailbox and
 offload deliveries stays deliberately unspecified (§5.1's ordering
 contract promises per-sender FIFO and nothing more).
 
+For this ordering rule, a timer **fires** when the event loop observes due
+armings and takes their timer batch. "Queued at the fire instant" therefore
+means present at that batch-take linearization point, not merely present when
+the wall clock passed the timer's deadline.
+
 Already-queued messages get one bounded turn to retract an elapsed timer:
 when a timer fires, the messages queued *at that instant* are delivered
 first (they may `clear_timer` the fired key), then the timer message goes

--- a/SPEC.md
+++ b/SPEC.md
@@ -829,30 +829,32 @@ applying between successive continuations. Timers whose deadlines fire
 at the same instant deliver in **arming order** — the order their
 *current* armings were established; re-arming a key (§5.3's
 replacement) takes the new position — and the bounded retraction turn
-below runs once for the whole simultaneous batch: messages queued at
-the fire instant deliver first, then the still-armed members of the
-batch in arming order. Within class 3, ordering between mailbox and
+below runs once for the whole simultaneous batch: work captured in the
+batch's bounded source prefixes delivers first, then the still-armed members
+of the batch in arming order. Within class 3, ordering between mailbox and
 offload deliveries stays deliberately unspecified (§5.1's ordering
 contract promises per-sender FIFO and nothing more).
 
 For this ordering rule, a timer **fires** when the event loop observes due
-armings and takes their timer batch. "Queued at the fire instant" therefore
-means present at that batch-take linearization point, not merely present when
-the wall clock passed the timer's deadline.
+armings and begins taking their timer batch, not merely when the wall clock
+passes the timer's deadline. Batch formation records a bounded prefix of each
+input source — continuations, mailbox acceptances, and offload completions —
+at that source's own cutoff. The sources do not share a global linearization
+point: work arriving concurrently with batch formation may land on either side
+of its source cutoff, and class 3 promises no ordering across sources.
 
 Already-queued messages get one bounded turn to retract an elapsed timer:
-when a timer fires, the messages queued *at that instant* are delivered
-first (they may `clear_timer` the fired key), then the timer message goes
-through if still armed.
+when a timer fires, messages captured by the batch's mailbox prefix are
+delivered first (they may `clear_timer` the fired key), then the timer message
+goes through if still armed.
 
 Timers rank last deliberately; the asymmetry is the rationale. A timer's
-lateness under this order is bounded: once a timer fires, only work already
-queued *at that instant* — queued messages (capped by mailbox capacity),
-offload completions already delivered to the loop (an offload still in
-flight holds nothing back: its completion arrives after the fire instant
-and waits behind the timer), and already-scheduled continuations — runs
-before it; work arriving or scheduled *after* the fire instant,
-continuations included, does not preempt the fired timer. The continuation
+lateness under this order is bounded: once a timer fires, only each source's
+captured prefix — queued messages (capped by mailbox capacity), offload
+completions through the recorded offload watermark, and continuations through
+the recorded queue length — runs before it. An offload still in flight holds
+nothing back; work arriving after its source cutoff, continuations included,
+does not preempt the fired timer. The continuation
 clause is load-bearing — continuations are self-replenishing, so without it
 a continuation chain could starve a fired timer forever despite the
 per-continuation fairness turn above. The reverse order is unbounded: timers are

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -1386,6 +1386,11 @@ impl<M: Send + 'static> RawContext<M> {
         if armings.is_empty() {
             return;
         }
+        // The batch snapshots its own offload prefix. A steady-state credit
+        // captured by an earlier mailbox delivery is superseded here; keeping
+        // it would let completions created during this batch jump mailbox
+        // input accepted after the batch snapshot.
+        self.resources.offloads_lead = 0;
         self.resources.fired_batch = Some(FiredTimerBatch {
             armings,
             continuations_remaining: self.resources.continuations.len(),

--- a/crates/shelterwood/tests/events.rs
+++ b/crates/shelterwood/tests/events.rs
@@ -219,6 +219,110 @@ async fn work_created_during_the_retraction_turn_does_not_preempt_fired_timer() 
 }
 
 #[derive(Clone, Copy, Debug)]
+enum TimerBatchFairnessMessage {
+    Arm,
+    DuringBatch,
+    SeedCompletion,
+    Timer,
+    AfterBatch,
+    DuringBatchCompletion,
+}
+
+struct TimerBatchFairnessActor {
+    log: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl Actor for TimerBatchFairnessActor {
+    type Msg = TimerBatchFairnessMessage;
+    type Args = (ReleaseGate, Arc<Mutex<Vec<&'static str>>>);
+
+    async fn init(args: Self::Args, context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        context
+            .offload(
+                async {},
+                |_| TimerBatchFairnessMessage::SeedCompletion,
+                Duration::ZERO,
+            )
+            .expect("seed completion accepted");
+        args.0.wait().await;
+        Ok(Self { log: args.1 })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        let entry = match message {
+            TimerBatchFairnessMessage::Arm => {
+                context
+                    .set_timeout("timer", TimerBatchFairnessMessage::Timer, Duration::ZERO)
+                    .expect("timer accepted");
+                "arm"
+            }
+            TimerBatchFairnessMessage::DuringBatch => {
+                context
+                    .offload(
+                        async {},
+                        |_| TimerBatchFairnessMessage::DuringBatchCompletion,
+                        Duration::ZERO,
+                    )
+                    .expect("completion accepted during the timer batch");
+                context
+                    .myself()
+                    .try_send(TimerBatchFairnessMessage::AfterBatch)
+                    .expect("post-snapshot mailbox input accepted");
+                "during-batch"
+            }
+            TimerBatchFairnessMessage::SeedCompletion => "seed-completion",
+            TimerBatchFairnessMessage::Timer => "timer",
+            TimerBatchFairnessMessage::AfterBatch => "after-batch",
+            TimerBatchFairnessMessage::DuringBatchCompletion => {
+                context.stop();
+                "during-batch-completion"
+            }
+        };
+        self.log.lock().expect("log mutex poisoned").push(entry);
+        Ok(())
+    }
+}
+
+/// A fired timer batch supersedes the steady-state completion credit captured
+/// by the mailbox delivery that armed it. Completions created during the batch
+/// therefore cannot use that stale credit to jump post-snapshot mailbox input.
+#[tokio::test]
+async fn timer_batch_resets_steady_state_completion_fairness() {
+    let gate = ReleaseGate::default();
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "timer-batch-fairness",
+            ActorOnceDef::<TimerBatchFairnessActor>::new((gate.clone(), Arc::clone(&log))),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    actor
+        .send(TimerBatchFairnessMessage::Arm)
+        .await
+        .expect("arm accepted during init");
+    actor
+        .send(TimerBatchFairnessMessage::DuringBatch)
+        .await
+        .expect("batch work accepted during init");
+    gate.release();
+
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert_eq!(
+        *log.lock().expect("log mutex poisoned"),
+        [
+            "arm",
+            "during-batch",
+            "seed-completion",
+            "timer",
+            "after-batch",
+            "during-batch-completion",
+        ]
+    );
+}
+
+#[derive(Clone, Copy, Debug)]
 enum KeyedMessage {
     Arm,
     FirstType,


### PR DESCRIPTION
Part of #116.

## Summary

- clear stale steady-state offload credit when a fired timer batch takes over scheduling
- pin the ordering so completions created during that batch cannot jump mailbox input accepted after the batch snapshot
- define timer “fire” in the specification as the loop’s batch-take linearization point

## Why

`offloads_lead` captured a completion watermark at a prior mailbox delivery. A later timer batch superseded that snapshot but retained the credit, allowing completions pushed during the batch to run ahead of post-snapshot mailbox input and violate the documented fairness boundary.

## Validation

- deterministic regression that reverses order without the fix
- `./tools/dev just ci` (432 tests, doctests, rustdoc/API reachability, runtime/exit/layering enforcement, packaged-crate verification, and nixfmt)
