### PR TITLE
Fix framework message disposal venues

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -800,10 +800,13 @@ the survivor is the newest accepted value.
 payload inline on the displacing task, after acceptance of its replacement
 is visible. This is the deliberate hot-path exception: a panicking foreign
 payload destructor surfaces on that task even though the replacement remains
-accepted. Every framework-initiated discard — including teardown,
-timeout/withdrawal cleanup, and batch disposal — runs detached from the
-initiating task with per-element panic containment. No single disposal-thread
-identity is promised.
+accepted. Framework-initiated disposal of externally submitted mailbox or
+reply-bearing payloads — including mailbox teardown, timeout/withdrawal
+cleanup, and accepted-prefix batch disposal — runs detached from the
+initiating task with per-element panic containment. Incarnation-owned
+continuations, timer messages, and offload state instead follow §5.5 and §7's
+incarnation teardown and verdict rules. No single disposal-thread identity is
+promised.
 
 Request/reply on a conflating mailbox is a correctness trap (a barrier can
 be conflated away). A static fence is not possible — mailbox kind is
@@ -873,13 +876,14 @@ skip-missed-ticks posture already accepts bounded lateness as the timer
 contract.
 
 On stop (supervisor shutdown, removal, readiness-timeout teardown, or
-local `ctx.stop()`): close
-external intake to freeze the accepted prefix; drain or drop that prefix
-per the mailbox shutdown policy (`Drain` delivers it, `Discard` drops
-it — §10; handlers observe draining state); then `on_stop`.
-For `Discard`, the actor loop returns without draining and the framework
-disposes the frozen prefix under §5.1's detached, per-element containment
-rule. A payload-destructor panic there is a disposal fault: it MUST NOT
+local `ctx.stop()`), close external intake to freeze the accepted prefix; then
+follow the mailbox shutdown policy (§10; handlers observe draining state).
+For `Drain`, the actor loop delivers the frozen prefix before `on_stop`. For
+`Discard`, freezing makes the prefix permanently undeliverable and the actor
+loop returns without draining, then runs `on_stop`; the framework extracts and
+schedules the prefix for §5.1's detached, per-element disposal after the actor
+run returns. Physical destruction is not ordered before `on_stop` or exit
+publication. A payload-destructor panic there is a disposal fault: it MUST NOT
 reclassify the actor's exit or skip `on_stop`.
 The stop boundary is exact about what drains: **only the frozen accepted
 mailbox prefix** — under `queue`, every accepted-but-undelivered message

--- a/SPEC.md
+++ b/SPEC.md
@@ -1945,7 +1945,9 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
   freeze itself is unconditional and engine-enforced — new sends are
   rejected under either policy — so there is no separate "reject-new"
   variant. `Drain` delivers the frozen prefix before `on_stop`;
-  `Discard` drops it. The blanket handler loop honors the policy itself;
+  `Discard` drops it — where and on what task per §5.1's destruction-venue
+  clause, with disposal faults outside the exit verdict (§7). The blanket
+  handler loop honors the policy itself;
   for a raw actor the framework enforces only the freeze — the loop owns
   delivery, so honoring the policy is the raw loop's documented
   obligation, using `RawContext`'s resolved-policy accessor and the
@@ -2916,7 +2918,7 @@ marked *(II)* ship with the named Part II feature.
 | Bounded mailbox capacity | **64** messages | Scope-overridable; per-child overridable; zero rejected at construction |
 | `latest()` slot | **1** | Structural, not configurable |
 | `latest_by_key` capacity *(II §16)* | defers to scope/library mailbox default | Full key set evicts oldest key |
-| Mailbox shutdown policy | **Drain** | Two variants: `Drain` delivers the frozen prefix, `Discard` drops it; the intake freeze is unconditional either way (§5.2, §10) |
+| Mailbox shutdown policy | **Drain** | Two variants: `Drain` delivers the frozen prefix, `Discard` drops it (destruction venue per §5.1; disposal faults per §7); the intake freeze is unconditional either way (§5.2, §10) |
 | Child shutdown policy | **`Graceful { grace: 5 s }`** | `Abort` opt-in |
 | Tidy-abort beat | **`grace / 10`, clamped to [1 ms, 10 ms]** | §10 |
 | Restart condition | **`OnFailure`** | Failure = any non-`Completed` exit (§7) |

--- a/SPEC.md
+++ b/SPEC.md
@@ -796,6 +796,15 @@ it), and none between mailbox messages and timer or offload deliveries
 beyond §5.2's loop priority. Conflating mailboxes order by replacement:
 the survivor is the newest accepted value.
 
+**Destruction venue.** Live `latest()` displacement drops the displaced
+payload inline on the displacing task, after acceptance of its replacement
+is visible. This is the deliberate hot-path exception: a panicking foreign
+payload destructor surfaces on that task even though the replacement remains
+accepted. Every framework-initiated discard — including teardown,
+timeout/withdrawal cleanup, and batch disposal — runs detached from the
+initiating task with per-element panic containment. No single disposal-thread
+identity is promised.
+
 Request/reply on a conflating mailbox is a correctness trap (a barrier can
 be conflated away). A static fence is not possible — mailbox kind is
 per-declaration configuration, invisible in `ActorRef<M>`'s type — so the
@@ -868,6 +877,10 @@ local `ctx.stop()`): close
 external intake to freeze the accepted prefix; drain or drop that prefix
 per the mailbox shutdown policy (`Drain` delivers it, `Discard` drops
 it — §10; handlers observe draining state); then `on_stop`.
+For `Discard`, the actor loop returns without draining and the framework
+disposes the frozen prefix under §5.1's detached, per-element containment
+rule. A payload-destructor panic there is a disposal fault: it MUST NOT
+reclassify the actor's exit or skip `on_stop`.
 The stop boundary is exact about what drains: **only the frozen accepted
 mailbox prefix** — under `queue`, every accepted-but-undelivered message
 at the freeze, in acceptance order; under `latest()`, the surviving slot
@@ -1249,7 +1262,9 @@ One classification, produced at one point, used by every consumer.
   observation is orthogonal and never competes. Concretely: a panic is
   never masked,
   wherever it lands (`run`, `on_stop` — superseding the run's outcome,
-  §4.1 — or a destructor, via the fallback report token); and a
+  §4.1 — or an incarnation-owned destructor, via the fallback report token;
+  §5.1's detached message-disposal faults are outside the incarnation
+  verdict); and a
   readiness-deadline expiry names the *cause* even when the teardown it
   triggers ends in a grace-expiry abort (the mechanism).
 - **`Aborted` genuinely competes with a recorded outcome, and the rule is

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -423,11 +423,10 @@ impl<A: Actor> RawActor for Handler<A> {
                     }
                 }
             }
-            MailboxShutdown::Discard => {
-                while let Some(message) = raw.try_recv() {
-                    drop(message);
-                }
-            }
+            // The raw-loop contract assigns disposal of the frozen prefix to
+            // the framework. Returning without draining keeps hostile message
+            // destructors off the actor task and out of its exit verdict.
+            MailboxShutdown::Discard => {}
         }
 
         let mut context = StopContext::<A>::new(raw);

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1833,8 +1833,9 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
     }
 
     fn short_circuit(&mut self) -> Self::Output {
-        // No message was ever constructed, so there is nothing to withdraw
-        // and no accepting incarnation to report.
+        // No message was submitted to the mailbox (any constructed message
+        // was already routed to isolated disposal), so there is nothing to
+        // withdraw and no accepting incarnation to report.
         Err(CallError {
             actor_id: self.actor.id().clone(),
             incarnation_observed: self.actor.mailbox.current_observation(),

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1297,16 +1297,30 @@ impl<M> ActorRef<M> {
 
 impl<M: Send + 'static> ActorRef<M> {
     /// Sends with backpressure and transparently waits through rebind windows.
+    ///
+    /// On a live latest-value mailbox, acceptance can replace the previous
+    /// message. The displaced message is dropped inline on the task polling
+    /// this send, after the new message's acceptance is visible; a panicking
+    /// displaced-message destructor therefore resumes on that task.
     pub fn send(&self, message: M) -> SendFuture<M> {
         SendFuture::new(Arc::clone(&self.mailbox), message)
     }
 
     /// Attempts immediate acceptance without parking.
+    ///
+    /// On a live latest-value mailbox, acceptance can replace the previous
+    /// message. The displaced message is dropped inline on the calling task,
+    /// after the new message's acceptance is visible; a panicking
+    /// displaced-message destructor therefore resumes on that task.
     pub fn try_send(&self, message: M) -> Result<Incarnation, SendError<M>> {
         self.mailbox.try_send(message)
     }
 
     /// Sends within one acceptance budget, recovering an unaccepted message.
+    ///
+    /// Live latest-value displacement follows [`send`](Self::send): the
+    /// displaced message is dropped inline on the task polling this send,
+    /// after acceptance of the replacement is visible.
     pub fn send_timeout(&self, message: M, deadline: Duration) -> SendTimeout<M> {
         SendTimeout {
             deadlined: Deadlined::new(
@@ -1738,6 +1752,10 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
             // existed before it completed, so do not start one after the
             // captured budget is strictly in the past.
             if budget.is_overdue(crate::runtime::now()) {
+                // Construction completed, but timeout cleanup owns the
+                // unsubmitted message. Keep its potentially blocking or
+                // panicking destructor off the caller task.
+                dispose_detached(message);
                 return Poll::Ready(self.short_circuit());
             }
             self.reply = receiver.receiver.take();

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -1478,6 +1478,52 @@ async fn acceptance_timed_out_call_disposes_recovered_message_off_the_caller() {
 }
 
 #[tokio::test]
+async fn overdue_call_construction_disposes_message_off_constructor_task_and_contains_panic() {
+    let (constructed, mut construction_threads) = tokio::sync::mpsc::unbounded_channel();
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "unread",
+            RawOnceDef::new(Unread::<ProbedCall<DropProbe>>::default()),
+        )
+        .expect("valid actor");
+
+    let probe = DropProbe::panicking(dropped, "overdue call message destructor");
+    let error = actor
+        .call(
+            move |reply| {
+                constructed
+                    .send(thread::current().id())
+                    .expect("construction thread is observed");
+                // The deadline is captured immediately before invoking this
+                // synchronous constructor, so sleeping here deterministically
+                // finishes construction outside the call's total budget.
+                thread::sleep(Duration::from_millis(25));
+                ProbedCall {
+                    _reply: reply,
+                    _probe: probe,
+                }
+            },
+            Duration::from_millis(1),
+        )
+        .await
+        .expect_err("overdue construction times out before mailbox submission");
+    assert!(matches!(error.kind, CallErrorKind::AcceptanceTimedOut));
+
+    let construction_thread = construction_threads
+        .recv()
+        .await
+        .expect("constructor reports its thread");
+    let disposal_thread = drops
+        .recv()
+        .await
+        .expect("overdue message destructor runs despite its contained panic");
+    assert_ne!(disposal_thread, construction_thread);
+    drop(tree);
+}
+
+#[tokio::test]
 async fn dropped_unstarted_call_disposes_constructor_off_the_caller() {
     let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
     let mut tree = Tree::new();

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -516,10 +516,9 @@ impl Drop for HostileFallbackCapture {
 }
 
 #[tokio::test]
-async fn non_runtime_disposals_share_one_thread_and_contain_panics() {
+async fn non_runtime_disposals_run_off_callers_and_contain_panics() {
     const VALUES: usize = 8;
 
-    let test_thread = thread::current().id();
     let tree = DynamicTree::new();
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("dynamic root starts");
@@ -537,8 +536,8 @@ async fn non_runtime_disposals_share_one_thread_and_contain_panics() {
         admissions.push(slot.define(TaskDef::new({
             let capture = HostileFallbackCapture {
                 dropped: dropped.clone(),
-                // The first destructor blocks so every later job queues
-                // behind it on the shared fallback disposal thread.
+                // Include a blocking destructor to exercise isolation without
+                // requiring any particular disposal-worker topology.
                 blocker: (index == 0).then(|| gate.blocker()),
                 panic: (index == VALUES - 1).then_some("hostile fallback destructor"),
             };
@@ -567,15 +566,12 @@ async fn non_runtime_disposals_share_one_thread_and_contain_panics() {
         disposal_threads.push(drops.recv().await.expect("every capture is disposed"));
     }
     assert!(drops.recv().await.is_none());
-    let disposal_thread = disposal_threads[0];
     assert!(
         disposal_threads
             .iter()
-            .all(|thread| *thread == disposal_thread),
-        "queued fallback disposals share one disposal thread instead of one thread per value"
+            .all(|thread| *thread != dropper_thread),
+        "every disposal runs off the thread that submitted it"
     );
-    assert_ne!(disposal_thread, dropper_thread);
-    assert_ne!(disposal_thread, test_thread);
     for task in tasks {
         assert!(matches!(task.wait().await.kind(), ExitKind::NeverStarted));
     }

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -213,10 +213,21 @@ enum FaultMode {
     StopBlocking,
 }
 
-#[derive(Clone, Copy)]
 enum FaultMessage {
     Hold,
     Fault,
+    DiscardPanicking(DiscardPanicking),
+}
+
+struct DiscardPanicking {
+    dropped: tokio::sync::mpsc::UnboundedSender<()>,
+}
+
+impl Drop for DiscardPanicking {
+    fn drop(&mut self) {
+        let _ = self.dropped.send(());
+        panic!("discarded message destructor panic");
+    }
 }
 
 struct FaultArgs {
@@ -268,6 +279,13 @@ impl Actor for FaultActor {
                     FaultMode::Discard | FaultMode::StopPanic | FaultMode::StopBlocking => Ok(()),
                 }
             }
+            FaultMessage::DiscardPanicking(probe) => {
+                // This message is queued only behind `Hold`; reaching this
+                // arm means the frozen Discard prefix was incorrectly
+                // delivered instead of transferred to framework disposal.
+                drop(probe);
+                Ok(())
+            }
         }
     }
 
@@ -314,7 +332,7 @@ async fn run_fault_fixture(
     mode: FaultMode,
     mailbox_shutdown: MailboxShutdown,
     grace: Duration,
-    queue_fault: bool,
+    queued: Option<FaultMessage>,
 ) -> FaultOutcome {
     let hold_entered = ReleaseGate::default();
     let hold_release = ReleaseGate::default();
@@ -349,11 +367,11 @@ async fn run_fault_fixture(
         .await
         .expect("hold message is accepted");
     hold_entered.wait().await;
-    if queue_fault {
+    if let Some(message) = queued {
         actor
-            .send(FaultMessage::Fault)
+            .send(message)
             .await
-            .expect("fault message joins the accepted prefix");
+            .expect("message joins the accepted prefix");
     }
 
     let started_at = tokio::time::Instant::now();
@@ -391,11 +409,31 @@ async fn handler_discard_skips_the_prefix_and_still_runs_on_stop() {
         FaultMode::Discard,
         MailboxShutdown::Discard,
         Duration::from_secs(10),
-        true,
+        Some(FaultMessage::Fault),
     )
     .await;
     assert_eq!(outcome.drained, 0);
     assert!(outcome.stop_entered);
+    assert!(matches!(outcome.exit.kind(), ExitKind::Completed));
+    assert_eq!(outcome.exit.cancellation(), Cancellation::Observed);
+}
+
+#[tokio::test(start_paused = true)]
+async fn handler_discard_contains_payload_panic_without_reclassifying_or_skipping_on_stop() {
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let outcome = run_fault_fixture(
+        FaultMode::Discard,
+        MailboxShutdown::Discard,
+        Duration::from_secs(10),
+        Some(FaultMessage::DiscardPanicking(DiscardPanicking { dropped })),
+    )
+    .await;
+
+    drops
+        .recv()
+        .await
+        .expect("the discarded payload destructor runs");
+    assert!(outcome.stop_entered, "discard must still reach on_stop");
     assert!(matches!(outcome.exit.kind(), ExitKind::Completed));
     assert_eq!(outcome.exit.cancellation(), Cancellation::Observed);
 }
@@ -406,7 +444,7 @@ async fn handler_drain_errors_and_panics_keep_their_authoritative_exit() {
         FaultMode::DrainError,
         MailboxShutdown::Drain,
         Duration::from_secs(10),
-        true,
+        Some(FaultMessage::Fault),
     )
     .await;
     assert!(matches!(
@@ -419,7 +457,7 @@ async fn handler_drain_errors_and_panics_keep_their_authoritative_exit() {
         FaultMode::DrainPanic,
         MailboxShutdown::Drain,
         Duration::from_secs(10),
-        true,
+        Some(FaultMessage::Fault),
     )
     .await;
     assert!(matches!(
@@ -435,7 +473,7 @@ async fn handler_on_stop_panic_is_contained_and_classified() {
         FaultMode::StopPanic,
         MailboxShutdown::Drain,
         Duration::from_secs(10),
-        false,
+        None,
     )
     .await;
     assert!(matches!(
@@ -450,7 +488,7 @@ async fn handler_drain_and_on_stop_share_one_grace_budget() {
         FaultMode::SharedGrace,
         MailboxShutdown::Drain,
         Duration::from_secs(10),
-        true,
+        Some(FaultMessage::Fault),
     )
     .await;
     assert_eq!(outcome.drained, 1);
@@ -474,7 +512,7 @@ async fn stop_context_run_blocking_returns_inside_cooperative_grace() {
         FaultMode::StopBlocking,
         MailboxShutdown::Drain,
         Duration::from_secs(1),
-        false,
+        None,
     )
     .await;
     assert_eq!(outcome.blocking_result, 73);


### PR DESCRIPTION
Part of #116.

## Summary

- let handler `MailboxShutdown::Discard` return without draining so the framework disposes the frozen prefix detached and panic-contained
- route messages produced after a call-constructor budget expires through detached disposal
- document the deliberate live-`latest()` exception: displaced payloads drop inline on the displacing task after replacement acceptance is visible
- specify disposal venues and pin hostile-destructor regressions

## Why

Dropping a discarded message inline on the actor task allowed a hostile payload destructor to reclassify an otherwise clean stop and skip `on_stop`. The overdue call-constructor path similarly dropped user payloads on the caller task even though it is framework timeout cleanup.

## Validation

- focused drain and disposal test suites
- `./tools/dev just ci` (433 tests, doctests, rustdoc/API reachability, runtime/exit/layering enforcement, packaged-crate verification, and nixfmt)
