### PR TITLE
Fix terminal wakeup after mailbox panic

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -385,6 +385,14 @@ Consequences (normative):
   `ScopeState` event (B.6, B.4) — before its streams close, so
   `wait_stopped()` (B.9) and snapshot/lifecycle subscribers resolve
   structurally, never merely by stream closure.
+- Terminal publication has one precise internal order: store the terminal
+  cell record, synchronously discharge parked mailbox operations, then pulse
+  the cell's single change signal. A direct or reentrant borrow MAY therefore
+  observe the terminal record while mailbox discharge is still in progress;
+  the guarantee is **discharge-before-pulse**, not discharge-before-store. A
+  panic collected while waking mailbox operations MUST be resumed only after
+  the cell pulse, so a hostile mailbox waker cannot strand membership-level
+  terminal waiters.
 - Declaration is O(n): no re-projection of the full child list on every
   builder mutation; no shadow runtime object maintained during declaration;
   no global counters joining side tables [#367]. Pre-spawn snapshots, if

--- a/SPEC.md
+++ b/SPEC.md
@@ -385,14 +385,18 @@ Consequences (normative):
   `ScopeState` event (B.6, B.4) — before its streams close, so
   `wait_stopped()` (B.9) and snapshot/lifecycle subscribers resolve
   structurally, never merely by stream closure.
-- Terminal publication has one precise internal order: store the terminal
-  cell record, synchronously discharge parked mailbox operations, then pulse
-  the cell's single change signal. A direct or reentrant borrow MAY therefore
-  observe the terminal record while mailbox discharge is still in progress;
-  the guarantee is **discharge-before-pulse**, not discharge-before-store. A
-  panic collected while waking mailbox operations MUST be resumed only after
-  the cell pulse, so a hostile mailbox waker cannot strand membership-level
-  terminal waiters.
+- When a mailbox is attached at terminal publication, publication has one
+  precise internal order: store the terminal cell record, synchronously
+  discharge parked mailbox operations, then pulse the cell's single change
+  signal. A direct or reentrant borrow MAY therefore observe the terminal
+  record while mailbox discharge is still in progress; the guarantee is
+  **discharge-before-pulse**, not discharge-before-store. If terminality wins
+  before attachment, it stores and pulses first; later attachment immediately
+  closes and discharges the mailbox without a second terminal pulse. A panic
+  collected while waking mailbox operations MUST be resumed only after the
+  complete parent snapshot/lifecycle publication and nested observation-close
+  transaction, so a hostile mailbox waker cannot strand membership waiters or
+  skip the matching terminal observation edges.
 - Declaration is O(n): no re-projection of the full child list on every
   builder mutation; no shadow runtime object maintained during declaration;
   no global counters joining side tables [#367]. Pre-spawn snapshots, if

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -277,7 +277,7 @@ impl MemberCell {
             }
         };
         if let Some(terminal_exit) = terminal_exit {
-            self.publish_terminal(terminal_exit);
+            runtime::resume_preferred_panic(self.publish_terminal(terminal_exit));
         }
     }
 
@@ -290,37 +290,10 @@ impl MemberCell {
     }
 
     pub(crate) fn terminalize(&self, exit: Exit) {
-        let terminal_exit = {
-            let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
-            match &*state {
-                MemberMailbox::Terminal {
-                    exit: terminal_exit,
-                    ..
-                } => terminal_exit.clone(),
-                MemberMailbox::Unattached => {
-                    *state = MemberMailbox::Terminal {
-                        control: None,
-                        exit: exit.clone(),
-                        teardown: None,
-                    };
-                    exit
-                }
-                MemberMailbox::Attached(control) => {
-                    let control = Arc::clone(control);
-                    let teardown = control.prepare_termination();
-                    *state = MemberMailbox::Terminal {
-                        control: Some(control),
-                        exit: exit.clone(),
-                        teardown,
-                    };
-                    exit
-                }
-            }
-        };
-        self.publish_terminal(terminal_exit);
+        runtime::resume_preferred_panic(self.terminalize_for_scope(exit));
     }
 
-    fn publish_terminal(&self, terminal_exit: Exit) {
+    fn publish_terminal(&self, terminal_exit: Exit) -> runtime::UnwindPanics {
         let mut published = false;
         self.record.modify_silently(|record| {
             if !matches!(record.stage, MemberStage::Terminal(_)) {
@@ -355,10 +328,41 @@ impl MemberCell {
         let pulse_panic = published
             .then(|| runtime::catch_panic(|| self.record.pulse()).err())
             .flatten();
-        runtime::resume_preferred_panic(runtime::UnwindPanics {
+        runtime::UnwindPanics {
             primary: teardown_panic,
             cleanup: pulse_panic,
-        });
+        }
+    }
+
+    fn terminalize_for_scope(&self, exit: Exit) -> runtime::UnwindPanics {
+        let terminal_exit = {
+            let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
+            match &*state {
+                MemberMailbox::Terminal {
+                    exit: terminal_exit,
+                    ..
+                } => terminal_exit.clone(),
+                MemberMailbox::Unattached => {
+                    *state = MemberMailbox::Terminal {
+                        control: None,
+                        exit: exit.clone(),
+                        teardown: None,
+                    };
+                    exit
+                }
+                MemberMailbox::Attached(control) => {
+                    let control = Arc::clone(control);
+                    let teardown = control.prepare_termination();
+                    *state = MemberMailbox::Terminal {
+                        control: Some(control),
+                        exit: exit.clone(),
+                        teardown,
+                    };
+                    exit
+                }
+            }
+        };
+        self.publish_terminal(terminal_exit)
     }
 
     pub(crate) async fn wait_terminal(&self) -> Exit {
@@ -863,7 +867,7 @@ impl ScopeCell {
             member.update_locked(|record| {
                 record.startup_aborted = startup == StartupDisposition::Aborted;
             });
-            member.terminalize(exit.clone());
+            let terminal_panics = member.terminalize_for_scope(exit.clone());
             if record.last_incarnation.is_none()
                 && let Some(scope) = &nested
             {
@@ -886,6 +890,11 @@ impl ScopeCell {
             if let Some(scope) = nested {
                 scope.close_observation_locked();
             }
+            // A hostile mailbox waker may panic while discharge makes this
+            // terminal record observable. Keep that panic authoritative, but
+            // defer it until the parent snapshot/lifecycle transaction and
+            // nested observation closure are complete.
+            runtime::resume_preferred_panic(terminal_panics);
             true
         })
     }

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -331,24 +331,34 @@ impl MemberCell {
                 published = true;
             }
         });
-        // Mailbox terminality and waiter completion must become visible before
-        // member terminality. The watch pulse is deliberately delayed until
-        // teardown has synchronously finished and unread payload ownership has
-        // moved to detached disposal.
+        // The terminal record is stored before mailbox discharge so reentrant
+        // mailbox wakers observe the winning exit. The ordering guarantee for
+        // notification-driven readers is discharge-before-pulse, not
+        // discharge-before-store: a direct borrow can see `Terminal` while
+        // teardown is still running. A hostile mailbox waker may panic, but
+        // that panic is resumed only after the pulse so it cannot strand a
+        // waiter parked on membership terminality.
         let teardown = match &mut *self.mailbox.lock().expect("member mailbox mutex poisoned") {
             MemberMailbox::Terminal { teardown, .. } => teardown.take(),
             MemberMailbox::Unattached | MemberMailbox::Attached(_) => {
                 unreachable!("terminal publication requires terminal mailbox state")
             }
         };
-        if let Some(teardown) = teardown
-            && let Some(payload) = teardown.finish()
-        {
-            runtime::dispose_detached(payload);
+        let mut teardown_panic = None;
+        if let Some(teardown) = teardown {
+            match runtime::catch_panic(|| teardown.finish()) {
+                Ok(Some(payload)) => runtime::dispose_detached(payload),
+                Ok(None) => {}
+                Err(payload) => teardown_panic = Some(payload),
+            }
         }
-        if published {
-            self.record.pulse();
-        }
+        let pulse_panic = published
+            .then(|| runtime::catch_panic(|| self.record.pulse()).err())
+            .flatten();
+        runtime::resume_preferred_panic(runtime::UnwindPanics {
+            primary: teardown_panic,
+            cleanup: pulse_panic,
+        });
     }
 
     pub(crate) async fn wait_terminal(&self) -> Exit {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -3086,16 +3086,20 @@ mod tests {
     use std::{
         future::{self, Future},
         panic::{AssertUnwindSafe, catch_unwind},
-        sync::{Arc, Barrier, Mutex},
+        sync::{
+            Arc, Barrier, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
         task::{Context, Poll, Wake, Waker},
         time::Duration,
     };
 
     use crate::{
         ActorRef, Cancellation, ChildId, ChildState, DynamicTree, Exit, ExitError, ExitKind,
-        GracePhase, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Readiness,
-        ReadinessDeadline, RemoveOutcome, Retention, ScopeState, SendErrorKind, StartupError,
-        StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
+        GracePhase, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Mailbox,
+        RawOnceDef, Readiness, ReadinessDeadline, RemoveOutcome, Retention, ScopeState,
+        SendErrorKind, StartupError, StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef,
+        TaskDef, Tree,
         engine::{Epoch, ScopeLifecycle, StopLadder, arbitrate},
         exit::{JoinVerdict, RecordedOutcome},
         identity::{IncarnationCounter, ScopeIdentity},
@@ -3140,6 +3144,43 @@ mod tests {
 
         async fn run(&mut self, _: &mut crate::RawContext<Self::Msg>) -> crate::ExitResult {
             future::pending().await
+        }
+    }
+
+    struct PanicWake;
+
+    impl Wake for PanicWake {
+        fn wake(self: Arc<Self>) {
+            panic!("injected mailbox waker panic");
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            panic!("injected mailbox waker panic");
+        }
+    }
+
+    struct CountWake(Arc<AtomicUsize>);
+
+    impl Wake for CountWake {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct ExitOnSignalRaw {
+        exit: Latch,
+    }
+
+    impl crate::RawActor for ExitOnSignalRaw {
+        type Msg = u8;
+
+        async fn run(&mut self, _: &mut crate::RawContext<Self::Msg>) -> crate::ExitResult {
+            self.exit.fired().await;
+            Ok(())
         }
     }
 
@@ -4179,6 +4220,135 @@ mod tests {
         fn wake_by_ref(self: &Arc<Self>) {
             self.observe();
         }
+    }
+
+    #[test]
+    fn panicking_mailbox_waker_cannot_skip_the_terminal_pulse() {
+        let mut identity = ScopeIdentity::new();
+        let id = ChildId::from("worker");
+        let member = MemberCell::new(
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
+        );
+        let mailbox = MailboxCell::new(member.id().clone());
+        let actor = ActorRef::new(Arc::clone(&member), Arc::clone(&mailbox));
+        member.attach_mailbox(mailbox);
+
+        let mut parked_send = Box::pin(actor.send(1));
+        let panicking_waker = Waker::from(Arc::new(PanicWake));
+        assert!(
+            parked_send
+                .as_mut()
+                .poll(&mut Context::from_waker(&panicking_waker))
+                .is_pending()
+        );
+
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let terminal_waker = Waker::from(Arc::new(CountWake(Arc::clone(&wakes))));
+        let mut terminal = Box::pin(member.wait_terminal());
+        assert!(
+            terminal
+                .as_mut()
+                .poll(&mut Context::from_waker(&terminal_waker))
+                .is_pending()
+        );
+
+        catch_unwind(AssertUnwindSafe(|| {
+            member.terminalize(Exit::never_started());
+        }))
+        .expect_err("the hostile mailbox waker still surfaces its panic");
+        assert_eq!(
+            wakes.load(Ordering::SeqCst),
+            1,
+            "membership terminality is pulsed before the mailbox panic resumes"
+        );
+        assert!(matches!(
+            terminal
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Ready(exit) if matches!(exit.kind(), ExitKind::NeverStarted)
+        ));
+        assert!(matches!(
+            parked_send
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Ready(Err(error)) if error.kind == SendErrorKind::Terminated
+        ));
+    }
+
+    #[crate::runtime::test]
+    async fn mailbox_waker_panic_is_contained_without_wedging_system_completion() {
+        let exit = Latch::default();
+        let mut tree = Tree::new();
+        let actor = tree
+            .add_raw_once(
+                "worker",
+                RawOnceDef::new(ExitOnSignalRaw { exit: exit.clone() })
+                    .mailbox(Mailbox::queue(1).expect("non-zero capacity")),
+            )
+            .expect("valid actor");
+        let plan = tree.lower_for_test();
+        let member = Arc::clone(&plan.children[0].slot.member);
+        let root = Arc::clone(&plan.root);
+        let mut system = super::spawn_system(plan);
+        root.wait_started().await.expect("actor starts");
+        actor
+            .try_send(1)
+            .expect("the first message fills the queue");
+
+        let mut parked_send = Box::pin(actor.send(2));
+        let panicking_waker = Waker::from(Arc::new(PanicWake));
+        assert!(
+            parked_send
+                .as_mut()
+                .poll(&mut Context::from_waker(&panicking_waker))
+                .is_pending()
+        );
+
+        let waiter_started = Latch::default();
+        let terminal_waiter = crate::runtime::spawn({
+            let member = Arc::clone(&member);
+            let waiter_started = waiter_started.clone();
+            async move {
+                waiter_started.fire();
+                member.wait_terminal().await
+            }
+        });
+        waiter_started.fired().await;
+        exit.fire();
+
+        let member_exit = match crate::runtime::timeout(
+            Duration::from_secs(2),
+            crate::runtime::join(terminal_waiter),
+        )
+        .await
+        {
+            crate::runtime::Timeout::Completed(crate::runtime::JoinOutcome::Ok { value }) => value,
+            crate::runtime::Timeout::Completed(crate::runtime::JoinOutcome::Panic { message }) => {
+                panic!("the terminal waiter panicked: {message:?}")
+            }
+            crate::runtime::Timeout::Completed(crate::runtime::JoinOutcome::Cancelled) => {
+                panic!("the terminal waiter was cancelled")
+            }
+            crate::runtime::Timeout::Elapsed => {
+                panic!("the terminal waiter was not pulsed after the mailbox panic")
+            }
+        };
+        assert!(matches!(member_exit.kind(), ExitKind::Completed));
+
+        let reason = match crate::runtime::timeout(Duration::from_secs(2), system.wait()).await {
+            crate::runtime::Timeout::Completed(reason) => reason,
+            crate::runtime::Timeout::Elapsed => {
+                panic!("the system monitor did not contain the driver unwind")
+            }
+        };
+        assert_eq!(reason, StopReason::ShutdownRequested);
+        let root_exit = root.member.wait_terminal().await;
+        assert!(matches!(
+            root_exit.kind(),
+            ExitKind::Panicked { message }
+                if message.as_deref() == Some("injected mailbox waker panic")
+        ));
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -952,11 +952,16 @@ impl ChildRuntime {
         exited_incarnation: Option<Incarnation>,
         startup: StartupDisposition,
     ) -> bool {
-        let changed = root.terminalize_child(&self.slot.member, exit, exited_incarnation, startup);
+        let terminalized = runtime::catch_panic(|| {
+            root.terminalize_child(&self.slot.member, exit, exited_incarnation, startup)
+        });
         if matches!(self.slot.member.record().stage, MemberStage::Terminal(_)) {
             self.terminality.complete(drop);
         }
-        changed
+        match terminalized {
+            Ok(changed) => changed,
+            Err(payload) => runtime::resume_panic(payload),
+        }
     }
 
     fn complete_terminality(&mut self) {
@@ -3147,15 +3152,35 @@ mod tests {
         }
     }
 
-    struct PanicWake;
+    struct PanicWake(&'static str);
 
     impl Wake for PanicWake {
         fn wake(self: Arc<Self>) {
-            panic!("injected mailbox waker panic");
+            std::panic::panic_any(self.0);
         }
 
         fn wake_by_ref(self: &Arc<Self>) {
-            panic!("injected mailbox waker panic");
+            std::panic::panic_any(self.0);
+        }
+    }
+
+    struct PanicDropProbe(Arc<AtomicUsize>);
+
+    impl Drop for PanicDropProbe {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct CountedPanicWake(Arc<AtomicUsize>);
+
+    impl Wake for CountedPanicWake {
+        fn wake(self: Arc<Self>) {
+            std::panic::panic_any(PanicDropProbe(Arc::clone(&self.0)));
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            std::panic::panic_any(PanicDropProbe(Arc::clone(&self.0)));
         }
     }
 
@@ -4235,7 +4260,7 @@ mod tests {
         member.attach_mailbox(mailbox);
 
         let mut parked_send = Box::pin(actor.send(1));
-        let panicking_waker = Waker::from(Arc::new(PanicWake));
+        let panicking_waker = Waker::from(Arc::new(PanicWake("injected mailbox waker panic")));
         assert!(
             parked_send
                 .as_mut()
@@ -4276,6 +4301,72 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn mailbox_teardown_panic_precedes_a_terminal_pulse_panic() {
+        let mut identity = ScopeIdentity::new();
+        let id = ChildId::from("worker");
+        let member = MemberCell::new(
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
+        );
+        let mailbox = MailboxCell::new(member.id().clone());
+        let actor = ActorRef::new(Arc::clone(&member), Arc::clone(&mailbox));
+        member.attach_mailbox(mailbox);
+
+        let mut parked_send = Box::pin(actor.send(1));
+        let mailbox_payload_dropped = Arc::new(AtomicUsize::new(0));
+        let mailbox_waker = Waker::from(Arc::new(CountedPanicWake(Arc::clone(
+            &mailbox_payload_dropped,
+        ))));
+        assert!(
+            parked_send
+                .as_mut()
+                .poll(&mut Context::from_waker(&mailbox_waker))
+                .is_pending()
+        );
+
+        let mut terminal = Box::pin(member.wait_terminal());
+        let pulse_payload_dropped = Arc::new(AtomicUsize::new(0));
+        let terminal_waker = Waker::from(Arc::new(CountedPanicWake(Arc::clone(
+            &pulse_payload_dropped,
+        ))));
+        assert!(
+            terminal
+                .as_mut()
+                .poll(&mut Context::from_waker(&terminal_waker))
+                .is_pending()
+        );
+
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            member.terminalize(Exit::never_started());
+        }))
+        .expect_err("the primary mailbox panic still surfaces");
+        assert_eq!(
+            mailbox_payload_dropped.load(Ordering::SeqCst),
+            0,
+            "the primary mailbox payload is retained for the caller"
+        );
+        assert_eq!(
+            pulse_payload_dropped.load(Ordering::SeqCst),
+            1,
+            "the membership-pulse panic is cleanup and is contained"
+        );
+        drop(payload);
+        assert_eq!(mailbox_payload_dropped.load(Ordering::SeqCst), 1);
+        assert!(matches!(
+            terminal
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Ready(exit) if matches!(exit.kind(), ExitKind::NeverStarted)
+        ));
+        assert!(matches!(
+            parked_send
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Ready(Err(error)) if error.kind == SendErrorKind::Terminated
+        ));
+    }
+
     #[crate::runtime::test]
     async fn mailbox_waker_panic_is_contained_without_wedging_system_completion() {
         let exit = Latch::default();
@@ -4290,6 +4381,7 @@ mod tests {
         let plan = tree.lower_for_test();
         let member = Arc::clone(&plan.children[0].slot.member);
         let root = Arc::clone(&plan.root);
+        let mut events = root.subscribe_lifecycle();
         let mut system = super::spawn_system(plan);
         root.wait_started().await.expect("actor starts");
         actor
@@ -4297,7 +4389,7 @@ mod tests {
             .expect("the first message fills the queue");
 
         let mut parked_send = Box::pin(actor.send(2));
-        let panicking_waker = Waker::from(Arc::new(PanicWake));
+        let panicking_waker = Waker::from(Arc::new(PanicWake("injected mailbox waker panic")));
         assert!(
             parked_send
                 .as_mut()
@@ -4349,6 +4441,22 @@ mod tests {
             ExitKind::Panicked { message }
                 if message.as_deref() == Some("injected mailbox waker panic")
         ));
+        let mut terminal_trace = Vec::new();
+        while let Some(item) = events.recv().await {
+            let LifecycleItem::Event(event) = item else {
+                panic!("the single-child terminal trace cannot lag");
+            };
+            match event.kind {
+                LifecycleEventKind::Exited { .. } => terminal_trace.push("exited"),
+                LifecycleEventKind::Removed { .. } => terminal_trace.push("removed"),
+                _ => {}
+            }
+        }
+        assert_eq!(
+            terminal_trace,
+            ["exited", "removed"],
+            "mailbox panic resumes only after the terminal event, pruning edge, and stream closure"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve the terminal membership wakeup when mailbox teardown invokes a panicking waker
- pulse terminal waiters before resuming the teardown panic while retaining panic precedence
- specify terminal publication as store, mailbox discharge, then pulse
- add focused unit and end-to-end regressions for panic surfacing, waiter wakeup, and driver completion

Part of #116 (items 1.3 and 4.7).

## Validation

- `./tools/dev just ci`
- focused mailbox-waker regressions
- library tests: 153 passed
