### PR TITLE
Fix fused admission restart cancellation race

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1601,7 +1601,13 @@ Rules (normative):
   **level-triggered cancellation latch** owned by the fused future and
   registered on the cell: dropping the future flips the latch
   synchronously (a token edge that always succeeds, like §10's shutdown
-  latch), and the driver converts the edge into an engine event that
+  latch). For an admitted cell that same synchronous edge publishes its
+  membership as `Removing` before attempting the bounded command channel;
+  both exit-time restart scheduling and execution of an already-due restart
+  deadline MUST recheck that level-triggered suppression. Queue saturation
+  therefore cannot run user construction for a cancelled membership while
+  its removal event waits for forwarding. The driver converts the edge into
+  an engine event that
   resolves the race by stage — a not-yet-admitted operation, whether
   its command is unsent, still queued, or dequeued-but-unprocessed, is
   annulled at the admission check (reservation released, cell

--- a/SPEC.md
+++ b/SPEC.md
@@ -1601,13 +1601,13 @@ Rules (normative):
   **level-triggered cancellation latch** owned by the fused future and
   registered on the cell: dropping the future flips the latch
   synchronously (a token edge that always succeeds, like §10's shutdown
-  latch). For an admitted cell that same synchronous edge publishes its
-  membership as `Removing` before attempting the bounded command channel;
-  both exit-time restart scheduling and execution of an already-due restart
-  deadline MUST recheck that level-triggered suppression. Queue saturation
-  therefore cannot run user construction for a cancelled membership while
-  its removal event waits for forwarding. The driver converts the edge into
-  an engine event that
+  latch). Both exit-time restart scheduling and execution of an already-due
+  restart deadline MUST consult that level-triggered source directly before
+  charging or running a restart; the public `Removing` projection follows the
+  forwarded removal event and is not the synchronization primitive. Queue
+  saturation therefore cannot charge restart intensity or run user
+  construction for a cancelled membership while its removal event waits for
+  forwarding. The driver converts the edge into an engine event that
   resolves the race by stage — a not-yet-admitted operation, whether
   its command is unsent, still queued, or dequeued-but-unprocessed, is
   annulled at the admission check (reservation released, cell

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1479,17 +1479,14 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
 }
 
 impl ScopeRuntime {
-    fn restart_is_suppressed(&self, key: ChildKey) -> bool {
-        if self.lifecycle.is_draining()
-            || self.hard_forced
-            || self.root.has_stop_request(self.epoch)
-            || self
-                .role
-                .ancestor()
-                .is_some_and(|latches| latches.shutdown.is_fired() || latches.abort.is_fired())
-        {
-            return true;
-        }
+    /// Reports whether a *removal* source has latched for this membership:
+    /// the public `removing` projection, the forwarded removal latch, or the
+    /// dynamic entry's `removal_started`/fused-cancel state. Scope-level stop
+    /// sources (drain, force, latched shutdown requests, ancestor latches)
+    /// are deliberately excluded: each of those has a guaranteed follow-up
+    /// event that owns the scope verdict, so exit dispatch must not
+    /// reclassify the membership as `Removing` on their behalf.
+    fn membership_is_removing(&self, key: ChildKey) -> bool {
         let Some(child) = self.children.get(key) else {
             return true;
         };
@@ -1510,6 +1507,24 @@ impl ScopeRuntime {
                         || entry.fused_cancel.as_ref().is_some_and(Latch::is_fired)
                 })
         })
+    }
+
+    /// Reports whether any level-triggered stop source forbids constructing
+    /// a new incarnation: a removal source for the membership itself, or a
+    /// scope-level stop (drain, force, a latched shutdown request, or an
+    /// ancestor latch). Every scope-level source has a guaranteed follow-up
+    /// event, so this broad consult belongs only at sites that would
+    /// otherwise invoke user construction — not at exit dispatch, where it
+    /// would misclassify the membership and reroute the scope verdict.
+    fn restart_is_suppressed(&self, key: ChildKey) -> bool {
+        self.lifecycle.is_draining()
+            || self.hard_forced
+            || self.root.has_stop_request(self.epoch)
+            || self
+                .role
+                .ancestor()
+                .is_some_and(|latches| latches.shutdown.is_fired() || latches.abort.is_fired())
+            || self.membership_is_removing(key)
     }
 
     fn pending_restart_shutdowns(&self) -> Vec<ChildKey> {
@@ -2107,8 +2122,15 @@ impl ScopeRuntime {
         // Fused cancellation is a level-triggered source. It can linearize
         // before the forwarded Removal event or its public `removing`
         // projection reaches this driver, so exit dispatch must consult the
-        // source directly before charging or publishing a restart.
-        let restart_suppressed = self.restart_is_suppressed(key);
+        // removal sources directly before charging or publishing a restart.
+        // Only removal sources classify the membership here: a latched but
+        // unprocessed scope stop (shutdown request or ancestor latch) must
+        // not turn this exit Terminal, or a restartable initial child
+        // failing pre-ready would publish `StartupFailed` where the stop's
+        // own follow-up event owns the verdict. The broader
+        // `restart_is_suppressed` still gates the restart deadline arm,
+        // where every suppression source has a guaranteed follow-up event.
+        let membership_removing = self.membership_is_removing(key);
         let child = self
             .children
             .get_mut(key)
@@ -2119,7 +2141,7 @@ impl ScopeRuntime {
         } else {
             ScopeMode::Running
         };
-        let member_mode = if restart_suppressed {
+        let member_mode = if membership_removing {
             MembershipMode::Removing
         } else {
             MembershipMode::Active
@@ -4828,6 +4850,152 @@ mod tests {
         control.request_forwarder_ended.fired().await;
     }
 
+    /// Exercises the `DeadlineKind::Restart` suppression gate on its own:
+    /// the restart deadline is scheduled first (no stop source latched at
+    /// exit time), then the fused cancellation lands before the deadline's
+    /// batch runs. The gate must clear the stale backoff edge without
+    /// invoking user construction.
+    #[crate::runtime::test]
+    async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_scheduling() {
+        let root = isolated_scope("root", ScopeFlavor::Dynamic);
+        let epoch = root
+            .begin_incarnation()
+            .expect("test scope epoch is available");
+        root.member
+            .update(|record| record.stage = MemberStage::Running);
+        root.set_state(ScopeState::Running);
+        root.set_startup(Ok(()));
+
+        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(64);
+        let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+        let control = DynamicControl::new(events.clone());
+        root.set_dynamic_route(Some(control.clone()));
+        root.set_admitted_children(Vec::new());
+        let mut scope = ScopeRuntime {
+            root: Arc::clone(&root),
+            defaults: ResolvedDefaults::default(),
+            intensity_policy: Intensity::default(),
+            intensity: super::IntensityState::default(),
+            children: ChildArena::default(),
+            events,
+            disposal_events,
+            deadlines: super::DeadlineQueue::default(),
+            jitter: crate::runtime::JitterRng::from_system_entropy(),
+            lifecycle: ScopeLifecycle::running(),
+            next_ordered_start: None,
+            role: ScopeRole::Root,
+            dynamic: Some(control.clone()),
+            epoch,
+            ancestor_shutdown_seen: false,
+            ancestor_abort_seen: false,
+            hard_forced: false,
+            completion: None,
+        };
+
+        let starts = Arc::new(AtomicUsize::new(0));
+        let reservation = super::reserve_dynamic(&root, ChildId::from("worker"), None)
+            .expect("running dynamic scope reserves the child");
+        let member = Arc::clone(&reservation.slot.member);
+        reservation
+            .slot
+            .define(ChildConstruction::Task(TaskDef::new({
+                let starts = Arc::clone(&starts);
+                move |_| {
+                    let invocation = starts.fetch_add(1, Ordering::SeqCst) + 1;
+                    async move {
+                        if invocation == 1 {
+                            Err(ExitError::message("first incarnation failed"))
+                        } else {
+                            future::pending().await
+                        }
+                    }
+                }
+            })));
+        let membership = member.membership();
+        let fused_cancel = Latch::default();
+        let mut response = super::start_admission(
+            Arc::clone(&reservation.control),
+            Arc::clone(&reservation.slot),
+            Some(fused_cancel.clone()),
+        )
+        .expect("the running scope accepts the admission");
+        let Some(DriverEvent::Admission(request)) = event_receiver.recv().await else {
+            panic!("the admission forwarder submits the request")
+        };
+        scope.handle_admission(request);
+        assert!(matches!(response.try_receive(), Some(Ok(()))));
+
+        let exit = match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv())
+            .await
+        {
+            crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {
+                child,
+                incarnation,
+                recorded,
+                join,
+                cancellation,
+            }))) => (child, incarnation, recorded, join, cancellation),
+            crate::runtime::Timeout::Completed(_) => panic!("the first incarnation reports exit"),
+            crate::runtime::Timeout::Elapsed => panic!("the first incarnation exit must arrive"),
+        };
+        let key = exit.0;
+        scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4);
+        assert!(
+            scope.children[key].restart_deadline.is_some(),
+            "a live fused admission does not suppress the restart at exit dispatch"
+        );
+        assert!(matches!(
+            scope.children[key].slot.member.record().stage,
+            MemberStage::Restarting
+        ));
+
+        // The fused admission handle drops only now: the cancellation latch
+        // fires after the backoff was scheduled, and its Removal edge queues
+        // behind the already-due restart deadline.
+        super::signal_fused_cancel(control.as_ref(), membership, &fused_cancel);
+        assert!(fused_cancel.is_fired());
+
+        let deadline = scope
+            .deadlines
+            .pop_due(crate::runtime::now() + Duration::from_secs(60 * 60))
+            .expect("the immediate-backoff restart deadline is registered");
+        assert!(matches!(deadline, super::DeadlineKind::Restart { .. }));
+        scope.handle_deadline(deadline);
+
+        assert!(
+            scope.children[key].restart_deadline.is_none(),
+            "the gate clears the stale backoff edge"
+        );
+        assert!(scope.children[key].active.is_none());
+        for _ in 0..16 {
+            crate::runtime::yield_now().await;
+        }
+        assert_eq!(
+            starts.load(Ordering::SeqCst),
+            1,
+            "the restart deadline arm rechecks level-triggered stop sources"
+        );
+
+        let forwarded =
+            match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
+                crate::runtime::Timeout::Completed(Some(event)) => event,
+                crate::runtime::Timeout::Completed(None) => panic!("the driver lane remains open"),
+                crate::runtime::Timeout::Elapsed => panic!("the fused removal edge is forwarded"),
+            };
+        assert!(matches!(forwarded, DriverEvent::Removal(removed) if removed == membership));
+        scope.handle_removal(membership);
+        let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
+            crate::runtime::unbounded_mpsc_recv(&mut disposal_event_receiver).await
+        else {
+            panic!("removal joins retained construction disposal")
+        };
+        scope.handle_construction_disposed(child, panic);
+        assert!(scope.children.get(key).is_none());
+
+        control.request_forwarder_close.fire();
+        control.request_forwarder_ended.fired().await;
+    }
+
     #[crate::runtime::test]
     async fn saturated_admissions_share_one_forwarder_task_and_all_resolve() {
         const ADMISSIONS: usize = 64;
@@ -5156,6 +5324,136 @@ mod tests {
             ),
             "the pre-readiness position still routes the scope's startup failure"
         );
+    }
+
+    /// Pins main's linearization for a scope stop latched cross-batch: a
+    /// restartable initial child failing pre-ready still dispatches
+    /// `ScheduleRestart`, and the latched stop's own follow-up event owns
+    /// the startup verdict (`ShutdownRequested`). Exit dispatch must not
+    /// consult latched-but-unprocessed scope-stop sources for its membership
+    /// classification, or the failure would be rerouted into
+    /// `StartupFailed` while restart suppression claims the stop was first.
+    #[crate::runtime::test]
+    async fn latched_shutdown_keeps_the_startup_verdict_for_its_follow_up_event() {
+        let mut tree = Tree::new();
+        tree.add_task(
+            "worker",
+            TaskDef::new(|_| async { Err(ExitError::message("failed before readiness")) })
+                .readiness(Readiness::Manual)
+                .expect("manual readiness is valid"),
+        )
+        .expect("valid task");
+        let mut plan = tree.lower_for_test();
+        let root = Arc::clone(&plan.root);
+        let epoch = root
+            .begin_incarnation()
+            .expect("test scope epoch is available");
+        root.set_admitted_children(
+            plan.children
+                .iter()
+                .map(|child| resident_projection(&child.slot))
+                .collect(),
+        );
+        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(64);
+        let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+        let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+        let mut children = ChildArena::default();
+        let key = children
+            .insert(child)
+            .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+        let mut scope = ScopeRuntime {
+            root: Arc::clone(&root),
+            defaults: plan.defaults.clone(),
+            intensity_policy: plan.config.intensity,
+            intensity: super::IntensityState::default(),
+            children,
+            events,
+            disposal_events,
+            deadlines: super::DeadlineQueue::default(),
+            jitter: crate::runtime::JitterRng::from_system_entropy(),
+            lifecycle: ScopeLifecycle::starting(),
+            next_ordered_start: Some(key),
+            role: ScopeRole::Root,
+            dynamic: None,
+            epoch,
+            ancestor_shutdown_seen: false,
+            ancestor_abort_seen: false,
+            hard_forced: false,
+            completion: None,
+        };
+        plan.armed = false;
+        drop(plan);
+
+        assert!(scope.children[key].initial);
+        scope.spawn_child(key);
+        assert!(!scope.children[key].initial_ready);
+        let exit = match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv())
+            .await
+        {
+            crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {
+                child,
+                incarnation,
+                recorded,
+                join,
+                cancellation,
+            }))) => (child, incarnation, recorded, join, cancellation),
+            crate::runtime::Timeout::Completed(_) => panic!("the pre-ready failure reports exit"),
+            crate::runtime::Timeout::Elapsed => panic!("the pre-ready failure exit must arrive"),
+        };
+
+        // The stop request latches after this batch was collected: it is
+        // visible to `has_stop_request`, but its `Pending::Shutdown` follow-up
+        // event belongs to the next batch.
+        assert!(root.request_shutdown().is_some());
+        assert!(root.has_stop_request(scope.epoch));
+
+        scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4);
+        assert!(
+            scope.children[key].restart_deadline.is_some(),
+            "a latched scope stop does not reclassify exit dispatch"
+        );
+        assert!(matches!(
+            scope.children[key].slot.member.record().stage,
+            MemberStage::Restarting
+        ));
+        assert!(
+            root.record().startup.is_none(),
+            "the pre-ready failure must not claim the startup verdict: {:?}",
+            root.record().startup
+        );
+
+        // The latched stop's guaranteed follow-up event runs in the next
+        // batch and owns the verdict, exactly as an unlatched scope would.
+        assert!(root.take_shutdown_request(scope.epoch));
+        scope.begin_drain(StopReason::ShutdownRequested);
+        assert!(
+            matches!(
+                root.record().startup,
+                Some(Err(StartupError::ShutdownRequested))
+            ),
+            "the latched stop owns the startup verdict: {:?}",
+            root.record().startup
+        );
+        assert!(scope.children[key].restart_deadline.is_none());
+
+        let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
+            crate::runtime::unbounded_mpsc_recv(&mut disposal_event_receiver).await
+        else {
+            panic!("only construction disposal was armed")
+        };
+        scope.handle_construction_disposed(child, panic);
+        assert!(matches!(
+            scope.children[key].slot.member.record().stage,
+            MemberStage::Terminal(_)
+        ));
+        assert!(
+            !scope.children[key].slot.member.record().startup_aborted,
+            "shutdown-first linearization publishes no startup abort"
+        );
+        assert!(matches!(
+            root.record().startup,
+            Some(Err(StartupError::ShutdownRequested))
+        ));
     }
 
     #[crate::runtime::test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -218,6 +218,7 @@ struct DynamicState {
 }
 
 pub(crate) struct DynamicControl {
+    root: Weak<ScopeCell>,
     events: runtime::MpscSender<DriverEvent>,
     state: Mutex<DynamicState>,
     requests: runtime::UnboundedMpscSender<DriverEvent>,
@@ -227,7 +228,7 @@ pub(crate) struct DynamicControl {
 }
 
 impl DynamicControl {
-    fn new(events: runtime::MpscSender<DriverEvent>) -> Arc<Self> {
+    fn new(root: &Arc<ScopeCell>, events: runtime::MpscSender<DriverEvent>) -> Arc<Self> {
         let (requests, mut request_receiver) = runtime::unbounded_mpsc();
         let forward_events = events.clone();
         let request_forwarder_close = Latch::default();
@@ -237,6 +238,7 @@ impl DynamicControl {
         #[cfg(test)]
         let forwarder_ended = request_forwarder_ended.clone();
         let control = Arc::new(Self {
+            root: Arc::downgrade(root),
             events,
             state: Mutex::new(DynamicState {
                 accepting: true,
@@ -458,6 +460,28 @@ pub(crate) fn signal_fused_cancel(
 
 fn signal_fused_cancel_impl(control: &DynamicControl, membership: Membership, latch: &Latch) {
     if latch.fire() {
+        let member = control
+            .state
+            .lock()
+            .expect("dynamic-state mutex poisoned")
+            .entries
+            .values()
+            .find(|entry| entry.slot.member.membership() == membership)
+            .map(|entry| Arc::clone(&entry.slot.member));
+        if let Some(member) = member {
+            // Cancellation is level-triggered state, not merely a queued
+            // command. Publish it before attempting the bounded driver lane
+            // so an exit or already-due backoff cannot start another
+            // incarnation while the removal event waits in the forwarder.
+            if let Some(root) = control.root.upgrade() {
+                root.transition_child(&member, |record| record.removing = true, None);
+            } else {
+                // Teardown can outlive the root's dynamic-route ownership.
+                // Keep the member-local suppression state monotonic even
+                // though no containing snapshot remains to publish.
+                member.update(|record| record.removing = true);
+            }
+        }
         queue_driver_event(control, DriverEvent::Removal(membership));
     }
 }
@@ -2372,7 +2396,19 @@ impl ScopeRuntime {
                     self.progress_startup();
                 }
             }
-            DeadlineKind::Restart { child } => self.spawn_child(child),
+            DeadlineKind::Restart { child } => {
+                // A removal or scope stop can latch after the exit scheduled
+                // this deadline but before the deadline's batch runs. Recheck
+                // the level-triggered sources at execution time so a stale
+                // backoff edge never invokes user construction.
+                if self.restart_is_suppressed(child) {
+                    if let Some(child) = self.children.get_mut(child) {
+                        child.restart_deadline.take();
+                    }
+                } else {
+                    self.spawn_child(child);
+                }
+            }
             DeadlineKind::Stop { child, incarnation } => {
                 if self
                     .children
@@ -2754,8 +2790,8 @@ async fn run_scope_incarnation(
     let capacity = plan.children.len().saturating_mul(3).max(64);
     let (events, mut event_receiver) = runtime::bounded_mpsc(capacity);
     let (disposal_events, mut disposal_event_receiver) = runtime::unbounded_mpsc();
-    let dynamic =
-        (plan.root.flavor == ScopeFlavor::Dynamic).then(|| DynamicControl::new(events.clone()));
+    let dynamic = (plan.root.flavor == ScopeFlavor::Dynamic)
+        .then(|| DynamicControl::new(&root, events.clone()));
     if let Some(control) = &dynamic {
         let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
         for child in &plan.children {
@@ -3082,11 +3118,17 @@ fn driver_event_class(event: &DriverEvent) -> ArbitrationClass {
 }
 
 #[cfg(test)]
+pub(crate) use tests::exercise_saturated_fused_drop_racing_due_restart;
+
+#[cfg(test)]
 mod tests {
     use std::{
         future::{self, Future},
         panic::{AssertUnwindSafe, catch_unwind},
-        sync::{Arc, Barrier, Mutex},
+        sync::{
+            Arc, Barrier, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
         task::{Context, Poll, Wake, Waker},
         time::Duration,
     };
@@ -3100,7 +3142,8 @@ mod tests {
         exit::{JoinVerdict, RecordedOutcome},
         identity::{IncarnationCounter, ScopeIdentity},
         mailbox::MailboxCell,
-        plan::SlotCell,
+        plan::{ChildConstruction, SlotCell},
+        policy::ResolvedDefaults,
         runtime::Latch,
     };
 
@@ -4456,7 +4499,7 @@ mod tests {
         let slot = SlotCell::new(Arc::clone(&member), None);
         root.set_admitted_children(vec![resident_projection(&slot)]);
         let (events, _receiver) = crate::runtime::bounded_mpsc(1);
-        let control = DynamicControl::new(events);
+        let control = DynamicControl::new(&root, events);
         let (sender, mut response) = crate::runtime::oneshot();
         let mut responses = RemovalResponses::default();
         responses.0.push(sender);
@@ -4545,7 +4588,7 @@ mod tests {
         let slot = SlotCell::new(Arc::clone(&member), None);
         root.set_admitted_children(vec![resident_projection(&slot)]);
         let (events, _receiver) = crate::runtime::bounded_mpsc(1);
-        let control = DynamicControl::new(events);
+        let control = DynamicControl::new(&root, events);
         control
             .state
             .lock()
@@ -4595,6 +4638,7 @@ mod tests {
 
     #[crate::runtime::test]
     async fn saturated_removal_from_a_foreign_thread_reaches_the_driver() {
+        let root = isolated_scope("root", ScopeFlavor::Dynamic);
         let mut identity = ScopeIdentity::new();
         let first_id = ChildId::from("first");
         let second_id = ChildId::from("second");
@@ -4609,7 +4653,7 @@ mod tests {
             events.try_send(DriverEvent::Removal(first)).is_ok(),
             "the fixture saturates the bounded driver lane"
         );
-        let control = DynamicControl::new(events);
+        let control = DynamicControl::new(&root, events);
         let foreign_control = Arc::clone(&control);
         std::thread::spawn(move || {
             assert!(
@@ -4640,13 +4684,172 @@ mod tests {
         assert_eq!(observed_second, second);
     }
 
+    pub(crate) async fn exercise_saturated_fused_drop_racing_due_restart<A>(
+        make_admission: impl FnOnce(super::DynamicReservation) -> A,
+    ) where
+        A: Future,
+    {
+        let root = isolated_scope("root", ScopeFlavor::Dynamic);
+        let epoch = root
+            .begin_incarnation()
+            .expect("test scope epoch is available");
+        root.member
+            .update(|record| record.stage = MemberStage::Running);
+        root.set_state(ScopeState::Running);
+        root.set_startup(Ok(()));
+
+        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(1);
+        let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+        let control = DynamicControl::new(&root, events.clone());
+        root.set_dynamic_route(Some(control.clone()));
+        root.set_admitted_children(Vec::new());
+        let mut scope = ScopeRuntime {
+            root: Arc::clone(&root),
+            defaults: ResolvedDefaults::default(),
+            intensity_policy: Intensity::default(),
+            intensity: super::IntensityState::default(),
+            children: ChildArena::default(),
+            events,
+            disposal_events,
+            deadlines: super::DeadlineQueue::default(),
+            jitter: crate::runtime::JitterRng::from_system_entropy(),
+            lifecycle: ScopeLifecycle::running(),
+            next_ordered_start: None,
+            role: ScopeRole::Root,
+            dynamic: Some(control.clone()),
+            epoch,
+            ancestor_shutdown_seen: false,
+            ancestor_abort_seen: false,
+            hard_forced: false,
+            completion: None,
+        };
+
+        let release_failure = Latch::default();
+        let starts = Arc::new(AtomicUsize::new(0));
+        let reservation = super::reserve_dynamic(&root, ChildId::from("worker"), None)
+            .expect("running dynamic scope reserves the child");
+        let member = Arc::clone(&reservation.slot.member);
+        reservation
+            .slot
+            .define(ChildConstruction::Task(TaskDef::new({
+                let release_failure = release_failure.clone();
+                let starts = Arc::clone(&starts);
+                move |_| {
+                    let release_failure = release_failure.clone();
+                    let invocation = starts.fetch_add(1, Ordering::SeqCst) + 1;
+                    async move {
+                        if invocation == 1 {
+                            release_failure.fired().await;
+                            Err(ExitError::message("first incarnation failed"))
+                        } else {
+                            future::pending().await
+                        }
+                    }
+                }
+            })));
+        let membership = member.membership();
+        let mut admission = Box::pin(make_admission(reservation));
+        assert!(
+            admission
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending(),
+            "first poll submits the fused admission"
+        );
+        let Some(DriverEvent::Admission(request)) = event_receiver.recv().await else {
+            panic!("the admission forwarder submits the request")
+        };
+        scope.handle_admission(request);
+
+        for _ in 0..64 {
+            if starts.load(Ordering::SeqCst) == 1 {
+                break;
+            }
+            crate::runtime::yield_now().await;
+        }
+        assert_eq!(starts.load(Ordering::SeqCst), 1);
+
+        release_failure.fire();
+        let exit = match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv())
+            .await
+        {
+            crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {
+                child,
+                incarnation,
+                recorded,
+                join,
+                cancellation,
+            }))) => (child, incarnation, recorded, join, cancellation),
+            crate::runtime::Timeout::Completed(_) => panic!("the first incarnation reports exit"),
+            crate::runtime::Timeout::Elapsed => panic!("the first incarnation exit must arrive"),
+        };
+        let key = exit.0;
+        scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4);
+        assert!(
+            scope.children[key].restart_deadline.is_some(),
+            "the immediate restart is scheduled before cancellation"
+        );
+
+        assert!(
+            scope
+                .events
+                .try_send(DriverEvent::Removal(root.member.membership()))
+                .is_ok(),
+            "the fixture saturates the bounded driver lane"
+        );
+        drop(admission);
+        assert!(
+            member.record().removing,
+            "fused drop publishes removal state before its queued edge can advance"
+        );
+
+        let restart = scope
+            .deadlines
+            .pop_due(crate::runtime::now())
+            .expect("immediate backoff is already due");
+        assert!(matches!(restart, super::DeadlineKind::Restart { child } if child == key));
+        scope.handle_deadline(restart);
+        assert!(scope.children[key].restart_deadline.is_none());
+        for _ in 0..16 {
+            crate::runtime::yield_now().await;
+        }
+        assert_eq!(
+            starts.load(Ordering::SeqCst),
+            1,
+            "a due restart rechecks the fused cancellation before construction"
+        );
+
+        assert!(matches!(
+            event_receiver.recv().await,
+            Some(DriverEvent::Removal(queued)) if queued == root.member.membership()
+        ));
+        let forwarded =
+            match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
+                crate::runtime::Timeout::Completed(Some(event)) => event,
+                crate::runtime::Timeout::Completed(None) => panic!("the driver lane remains open"),
+                crate::runtime::Timeout::Elapsed => panic!("the fused removal edge is forwarded"),
+            };
+        assert!(matches!(forwarded, DriverEvent::Removal(removed) if removed == membership));
+        scope.handle_removal(membership);
+        let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
+            crate::runtime::unbounded_mpsc_recv(&mut disposal_event_receiver).await
+        else {
+            panic!("removal joins retained construction disposal")
+        };
+        scope.handle_construction_disposed(child, panic);
+        assert!(scope.children.get(key).is_none());
+
+        control.request_forwarder_close.fire();
+        control.request_forwarder_ended.fired().await;
+    }
+
     #[crate::runtime::test]
     async fn saturated_admissions_share_one_forwarder_task_and_all_resolve() {
         const ADMISSIONS: usize = 64;
 
         let root = isolated_scope("root", ScopeFlavor::Dynamic);
         let (events, event_receiver) = crate::runtime::bounded_mpsc(1);
-        let control = DynamicControl::new(events);
+        let control = DynamicControl::new(&root, events);
         let child_id = ChildId::from("worker");
         let member = MemberCell::new(
             child_id.clone(),

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -218,7 +218,6 @@ struct DynamicState {
 }
 
 pub(crate) struct DynamicControl {
-    root: Weak<ScopeCell>,
     events: runtime::MpscSender<DriverEvent>,
     state: Mutex<DynamicState>,
     requests: runtime::UnboundedMpscSender<DriverEvent>,
@@ -228,7 +227,7 @@ pub(crate) struct DynamicControl {
 }
 
 impl DynamicControl {
-    fn new(root: &Arc<ScopeCell>, events: runtime::MpscSender<DriverEvent>) -> Arc<Self> {
+    fn new(events: runtime::MpscSender<DriverEvent>) -> Arc<Self> {
         let (requests, mut request_receiver) = runtime::unbounded_mpsc();
         let forward_events = events.clone();
         let request_forwarder_close = Latch::default();
@@ -238,7 +237,6 @@ impl DynamicControl {
         #[cfg(test)]
         let forwarder_ended = request_forwarder_ended.clone();
         let control = Arc::new(Self {
-            root: Arc::downgrade(root),
             events,
             state: Mutex::new(DynamicState {
                 accepting: true,
@@ -460,28 +458,6 @@ pub(crate) fn signal_fused_cancel(
 
 fn signal_fused_cancel_impl(control: &DynamicControl, membership: Membership, latch: &Latch) {
     if latch.fire() {
-        let member = control
-            .state
-            .lock()
-            .expect("dynamic-state mutex poisoned")
-            .entries
-            .values()
-            .find(|entry| entry.slot.member.membership() == membership)
-            .map(|entry| Arc::clone(&entry.slot.member));
-        if let Some(member) = member {
-            // Cancellation is level-triggered state, not merely a queued
-            // command. Publish it before attempting the bounded driver lane
-            // so an exit or already-due backoff cannot start another
-            // incarnation while the removal event waits in the forwarder.
-            if let Some(root) = control.root.upgrade() {
-                root.transition_child(&member, |record| record.removing = true, None);
-            } else {
-                // Teardown can outlive the root's dynamic-route ownership.
-                // Keep the member-local suppression state monotonic even
-                // though no containing snapshot remains to publish.
-                member.update(|record| record.removing = true);
-            }
-        }
         queue_driver_event(control, DriverEvent::Removal(membership));
     }
 }
@@ -1527,8 +1503,8 @@ impl ScopeRuntime {
                 .lock()
                 .expect("dynamic-state mutex poisoned")
                 .entries
-                .values()
-                .find(|entry| entry.slot.member.membership() == child.slot.member.membership())
+                .get(child.slot.member.id())
+                .filter(|entry| entry.slot.member.membership() == child.slot.member.membership())
                 .is_some_and(|entry| {
                     entry.removal_started
                         || entry.fused_cancel.as_ref().is_some_and(Latch::is_fired)
@@ -1543,8 +1519,7 @@ impl ScopeRuntime {
                 let child = &self.children[*key];
                 // Only a nested scope can hold a pending-incarnation stop, and
                 // only its own control plane can answer whether one exists.
-                // Both are cheap, so they gate the suppression sweep, which
-                // takes the dynamic-state lock and scans every entry.
+                // Both are cheap, so they gate the dynamic-state lookup.
                 child.active.is_none()
                     && matches!(child.slot.member.record().stage, MemberStage::Restarting)
                     && child
@@ -2129,12 +2104,22 @@ impl ScopeRuntime {
             self.intensity_policy.within,
         );
 
+        // Fused cancellation is a level-triggered source. It can linearize
+        // before the forwarded Removal event or its public `removing`
+        // projection reaches this driver, so exit dispatch must consult the
+        // source directly before charging or publishing a restart.
+        let restart_suppressed = self.restart_is_suppressed(key);
+        let child = self
+            .children
+            .get_mut(key)
+            .expect("the exiting child remains registered");
+
         let mode = if self.lifecycle.is_draining() {
             ScopeMode::Draining
         } else {
             ScopeMode::Running
         };
-        let member_mode = if child.slot.member.record().removing {
+        let member_mode = if restart_suppressed {
             MembershipMode::Removing
         } else {
             MembershipMode::Active
@@ -2790,8 +2775,8 @@ async fn run_scope_incarnation(
     let capacity = plan.children.len().saturating_mul(3).max(64);
     let (events, mut event_receiver) = runtime::bounded_mpsc(capacity);
     let (disposal_events, mut disposal_event_receiver) = runtime::unbounded_mpsc();
-    let dynamic = (plan.root.flavor == ScopeFlavor::Dynamic)
-        .then(|| DynamicControl::new(&root, events.clone()));
+    let dynamic =
+        (plan.root.flavor == ScopeFlavor::Dynamic).then(|| DynamicControl::new(events.clone()));
     if let Some(control) = &dynamic {
         let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
         for child in &plan.children {
@@ -3118,7 +3103,7 @@ fn driver_event_class(event: &DriverEvent) -> ArbitrationClass {
 }
 
 #[cfg(test)]
-pub(crate) use tests::exercise_saturated_fused_drop_racing_due_restart;
+pub(crate) use tests::exercise_saturated_fused_drop_before_exit;
 
 #[cfg(test)]
 mod tests {
@@ -4499,7 +4484,7 @@ mod tests {
         let slot = SlotCell::new(Arc::clone(&member), None);
         root.set_admitted_children(vec![resident_projection(&slot)]);
         let (events, _receiver) = crate::runtime::bounded_mpsc(1);
-        let control = DynamicControl::new(&root, events);
+        let control = DynamicControl::new(events);
         let (sender, mut response) = crate::runtime::oneshot();
         let mut responses = RemovalResponses::default();
         responses.0.push(sender);
@@ -4588,7 +4573,7 @@ mod tests {
         let slot = SlotCell::new(Arc::clone(&member), None);
         root.set_admitted_children(vec![resident_projection(&slot)]);
         let (events, _receiver) = crate::runtime::bounded_mpsc(1);
-        let control = DynamicControl::new(&root, events);
+        let control = DynamicControl::new(events);
         control
             .state
             .lock()
@@ -4638,7 +4623,6 @@ mod tests {
 
     #[crate::runtime::test]
     async fn saturated_removal_from_a_foreign_thread_reaches_the_driver() {
-        let root = isolated_scope("root", ScopeFlavor::Dynamic);
         let mut identity = ScopeIdentity::new();
         let first_id = ChildId::from("first");
         let second_id = ChildId::from("second");
@@ -4653,7 +4637,7 @@ mod tests {
             events.try_send(DriverEvent::Removal(first)).is_ok(),
             "the fixture saturates the bounded driver lane"
         );
-        let control = DynamicControl::new(&root, events);
+        let control = DynamicControl::new(events);
         let foreign_control = Arc::clone(&control);
         std::thread::spawn(move || {
             assert!(
@@ -4684,7 +4668,7 @@ mod tests {
         assert_eq!(observed_second, second);
     }
 
-    pub(crate) async fn exercise_saturated_fused_drop_racing_due_restart<A>(
+    pub(crate) async fn exercise_saturated_fused_drop_before_exit<A>(
         make_admission: impl FnOnce(super::DynamicReservation) -> A,
     ) where
         A: Future,
@@ -4700,7 +4684,7 @@ mod tests {
 
         let (events, mut event_receiver) = crate::runtime::bounded_mpsc(1);
         let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
-        let control = DynamicControl::new(&root, events.clone());
+        let control = DynamicControl::new(events.clone());
         root.set_dynamic_route(Some(control.clone()));
         root.set_admitted_children(Vec::new());
         let mut scope = ScopeRuntime {
@@ -4784,12 +4768,6 @@ mod tests {
             crate::runtime::Timeout::Elapsed => panic!("the first incarnation exit must arrive"),
         };
         let key = exit.0;
-        scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4);
-        assert!(
-            scope.children[key].restart_deadline.is_some(),
-            "the immediate restart is scheduled before cancellation"
-        );
-
         assert!(
             scope
                 .events
@@ -4799,24 +4777,31 @@ mod tests {
         );
         drop(admission);
         assert!(
-            member.record().removing,
-            "fused drop publishes removal state before its queued edge can advance"
+            control
+                .state
+                .lock()
+                .expect("dynamic-state mutex poisoned")
+                .entries
+                .get(member.id())
+                .and_then(|entry| entry.fused_cancel.as_ref())
+                .is_some_and(Latch::is_fired),
+            "fused drop latches cancellation before its queued edge can advance"
         );
 
-        let restart = scope
-            .deadlines
-            .pop_due(crate::runtime::now())
-            .expect("immediate backoff is already due");
-        assert!(matches!(restart, super::DeadlineKind::Restart { child } if child == key));
-        scope.handle_deadline(restart);
+        scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4);
         assert!(scope.children[key].restart_deadline.is_none());
+        assert_eq!(
+            root.snapshot().total_restarts,
+            crate::TotalRestarts::ZERO,
+            "cancellation that linearized before exit incurs no restart charge"
+        );
         for _ in 0..16 {
             crate::runtime::yield_now().await;
         }
         assert_eq!(
             starts.load(Ordering::SeqCst),
             1,
-            "a due restart rechecks the fused cancellation before construction"
+            "exit dispatch consults fused cancellation before restart construction"
         );
 
         assert!(matches!(
@@ -4849,7 +4834,7 @@ mod tests {
 
         let root = isolated_scope("root", ScopeFlavor::Dynamic);
         let (events, event_receiver) = crate::runtime::bounded_mpsc(1);
-        let control = DynamicControl::new(&root, events);
+        let control = DynamicControl::new(events);
         let child_id = ChildId::from("worker");
         let member = MemberCell::new(
             child_id.clone(),

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -1192,7 +1192,7 @@ impl Subtree for DynamicTree {}
 
 #[cfg(test)]
 mod tests {
-    use super::{DynamicTree, Tree, sealed::Sealed};
+    use super::{Admission, AdmissionOwnership, DynamicTree, Tree, sealed::Sealed};
     use crate::identity::ScopeIdentity;
 
     #[test]
@@ -1208,6 +1208,14 @@ mod tests {
         let core = <DynamicTree as Sealed>::into_core(tree);
         assert_eq!(ScopeIdentity::current_thread_creations(), after_tree);
         drop(core);
+    }
+
+    #[crate::runtime::test]
+    async fn saturated_fused_drop_suppresses_an_already_due_restart() {
+        crate::driver::exercise_saturated_fused_drop_racing_due_restart(|reservation| {
+            Admission::new(reservation, (), AdmissionOwnership::Fused)
+        })
+        .await;
     }
 }
 

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -863,23 +863,39 @@ impl<H> Drop for Admission<H> {
                 // polled or not. Firing the latch before cancelling keeps the
                 // scope's control-plane wake and the cancellation evidence in
                 // the same order the in-flight path uses.
-                if let Some(cancel) = &pending.fused_cancel {
-                    crate::driver::signal_fused_cancel(
-                        pending.reservation.control.as_ref(),
-                        pending.reservation.slot.member.membership(),
-                        cancel,
-                    );
-                }
-                pending.cancel_reservation();
+                let signal_panic = pending.fused_cancel.as_ref().and_then(|cancel| {
+                    crate::runtime::catch_panic(|| {
+                        crate::driver::signal_fused_cancel(
+                            pending.reservation.control.as_ref(),
+                            pending.reservation.slot.member.membership(),
+                            cancel,
+                        );
+                    })
+                    .err()
+                });
+                let cleanup_panic =
+                    crate::runtime::catch_panic(|| pending.cancel_reservation()).err();
+                crate::runtime::resume_preferred_panic(crate::runtime::UnwindPanics {
+                    primary: signal_panic,
+                    cleanup: cleanup_panic,
+                });
             }
             AdmissionState::InFlight { pending, .. } => {
                 if let Some(cancel) = &pending.fused_cancel {
-                    crate::driver::signal_fused_cancel(
-                        pending.reservation.control.as_ref(),
-                        pending.reservation.slot.member.membership(),
-                        cancel,
-                    );
-                    pending.cancel_reservation();
+                    let signal_panic = crate::runtime::catch_panic(|| {
+                        crate::driver::signal_fused_cancel(
+                            pending.reservation.control.as_ref(),
+                            pending.reservation.slot.member.membership(),
+                            cancel,
+                        );
+                    })
+                    .err();
+                    let cleanup_panic =
+                        crate::runtime::catch_panic(|| pending.cancel_reservation()).err();
+                    crate::runtime::resume_preferred_panic(crate::runtime::UnwindPanics {
+                        primary: signal_panic,
+                        cleanup: cleanup_panic,
+                    });
                 }
             }
             AdmissionState::Immediate(_) | AdmissionState::Done => {}
@@ -1192,8 +1208,42 @@ impl Subtree for DynamicTree {}
 
 #[cfg(test)]
 mod tests {
-    use super::{Admission, AdmissionOwnership, DynamicTree, Tree, sealed::Sealed};
-    use crate::identity::ScopeIdentity;
+    use std::{
+        future::Future,
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::{Arc, Mutex},
+        task::{Context, Poll, Wake, Waker},
+        time::Duration,
+    };
+
+    use super::{Admission, AdmissionOwnership, DynamicTree, TaskRef, Tree, sealed::Sealed};
+    use crate::{ExitKind, TaskDef, identity::ScopeIdentity};
+
+    struct DropAdmissionAndPanic {
+        admission: Mutex<Option<Admission<TaskRef>>>,
+    }
+
+    impl Wake for DropAdmissionAndPanic {
+        fn wake(self: Arc<Self>) {
+            drop(
+                self.admission
+                    .lock()
+                    .expect("admission mutex poisoned")
+                    .take(),
+            );
+            panic!("hostile observation waker");
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            drop(
+                self.admission
+                    .lock()
+                    .expect("admission mutex poisoned")
+                    .take(),
+            );
+            panic!("hostile observation waker");
+        }
+    }
 
     #[test]
     fn subtree_conversion_moves_without_minting_a_phantom_scope() {
@@ -1211,11 +1261,61 @@ mod tests {
     }
 
     #[crate::runtime::test]
-    async fn saturated_fused_drop_suppresses_an_already_due_restart() {
-        crate::driver::exercise_saturated_fused_drop_racing_due_restart(|reservation| {
+    async fn saturated_fused_drop_before_exit_suppresses_restart_accounting() {
+        crate::driver::exercise_saturated_fused_drop_before_exit(|reservation| {
             Admission::new(reservation, (), AdmissionOwnership::Fused)
         })
         .await;
+    }
+
+    #[crate::runtime::test]
+    async fn unpolled_fused_drop_releases_reservations_despite_a_reentrant_panicking_waker() {
+        let system = DynamicTree::new().spawn().expect("runtime is available");
+        system.wait_started().await.expect("dynamic root starts");
+        let scope = system.scope();
+
+        let first_slot = scope.reserve_task("first").expect("first id is free");
+        let first = first_slot.task_ref();
+        let first_admission = first_slot.define(TaskDef::new(|_| std::future::pending()));
+        let second_slot = scope.reserve_task("second").expect("second id is free");
+        let second = second_slot.task_ref();
+        let second_admission = second_slot.define(TaskDef::new(|_| std::future::pending()));
+
+        let mut first_wait = Box::pin(first.wait());
+        let waker = Waker::from(Arc::new(DropAdmissionAndPanic {
+            admission: Mutex::new(Some(second_admission)),
+        }));
+        assert!(
+            first_wait
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending()
+        );
+
+        catch_unwind(AssertUnwindSafe(|| drop(first_admission)))
+            .expect_err("the hostile membership waker still surfaces");
+        assert!(matches!(
+            first_wait
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Ready(exit) if matches!(exit.kind(), ExitKind::NeverStarted)
+        ));
+        assert!(matches!(second.wait().await.kind(), ExitKind::NeverStarted));
+
+        drop(
+            scope
+                .reserve_task("first")
+                .expect("first reservation was released"),
+        );
+        drop(
+            scope
+                .reserve_task("second")
+                .expect("reentrant second reservation was released"),
+        );
+        system
+            .shutdown(Duration::from_secs(1))
+            .await
+            .expect("cancelled reservations leave no stragglers");
     }
 }
 


### PR DESCRIPTION
## Summary

- synchronously publish fused-admission cancellation as membership removal state before bounded driver forwarding
- recheck level-triggered restart suppression when an already-due restart deadline executes
- retain a weak owning-scope link for coherent snapshot publication, with a teardown-safe member fallback
- add a deterministic saturated-driver-lane regression using a real fused `Admission` drop

Part of #116 (item 1.5).

## Validation

- `./tools/dev just ci`
- deterministic saturated-lane fused-cancellation regression
