### PR TITLE
Make forced ordered drain iterative

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1110,6 +1110,7 @@ struct ScopeRuntime {
     ancestor_shutdown_seen: bool,
     ancestor_abort_seen: bool,
     hard_forced: bool,
+    ordered_stop_progressing: bool,
     completion: Option<ScopeCompletion>,
 }
 
@@ -1934,20 +1935,25 @@ impl ScopeRuntime {
     }
 
     fn stop_next_ordered(&mut self) {
-        if self.root.flavor != ScopeFlavor::Ordered || !self.lifecycle.is_draining() {
+        if self.root.flavor != ScopeFlavor::Ordered
+            || !self.lifecycle.is_draining()
+            || self.ordered_stop_progressing
+        {
             return;
         }
+        self.ordered_stop_progressing = true;
         loop {
             let Some(key) = self.children.keys().rev().find(|key| {
                 !self.children[*key].is_terminal() || self.children[*key].is_disposing()
             }) else {
-                return;
+                break;
             };
             self.begin_stop_child(key, None);
             if self.children[key].active.is_some() || self.children[key].is_disposing() {
-                return;
+                break;
             }
         }
+        self.ordered_stop_progressing = false;
     }
 
     fn force_all(&mut self) {
@@ -2809,6 +2815,7 @@ async fn run_scope_incarnation(
         ancestor_shutdown_seen: false,
         ancestor_abort_seen: false,
         hard_forced: false,
+        ordered_stop_progressing: false,
         completion: None,
         // Transfer last: every fallible setup expression above remains
         // covered by the pre-driver guard, and completed construction moves
@@ -3399,6 +3406,7 @@ mod tests {
             ancestor_shutdown_seen: false,
             ancestor_abort_seen: false,
             hard_forced: false,
+            ordered_stop_progressing: false,
             completion: None,
         };
         plan.armed = false;
@@ -3473,6 +3481,74 @@ mod tests {
         }
     }
 
+    #[test]
+    fn forced_ordered_drain_advances_an_inactive_suffix_iteratively() {
+        const CHILDREN: usize = 1_024;
+
+        let mut tree = Tree::new();
+        for index in 0..CHILDREN {
+            tree.add_task(
+                format!("inactive-{index}"),
+                TaskDef::new(|_| future::pending()),
+            )
+            .expect("unique child declaration");
+        }
+        let mut plan = tree.lower_for_test();
+        let root = Arc::clone(&plan.root);
+        let epoch = root
+            .begin_incarnation()
+            .expect("test scope epoch is available");
+        root.set_admitted_children(
+            plan.children
+                .iter()
+                .map(|child| resident_projection(&child.slot))
+                .collect(),
+        );
+        let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+        let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+        let mut children = ChildArena::default();
+        plan.children.reverse();
+        while let Some(child) = plan.children.pop() {
+            children
+                .insert(ChildRuntime::from_plan(child, &root))
+                .unwrap_or_else(|_| panic!("the fixture fits in the child-key domain"));
+        }
+        // Model restart-window children: no incarnation and no retained
+        // construction remains, so forced terminalization completes inline.
+        // This used to re-enter `stop_next_ordered` once per child.
+        for child in children.values_mut() {
+            drop(child.construction.take());
+        }
+        let mut scope = ScopeRuntime {
+            root,
+            defaults: plan.defaults.clone(),
+            intensity_policy: plan.config.intensity,
+            intensity: super::IntensityState::default(),
+            children,
+            events,
+            disposal_events,
+            deadlines: super::DeadlineQueue::default(),
+            jitter: crate::runtime::JitterRng::from_system_entropy(),
+            lifecycle: ScopeLifecycle::running(),
+            next_ordered_start: None,
+            role: ScopeRole::Root,
+            dynamic: None,
+            epoch,
+            ancestor_shutdown_seen: false,
+            ancestor_abort_seen: false,
+            hard_forced: true,
+            ordered_stop_progressing: false,
+            completion: None,
+        };
+        plan.armed = false;
+        drop(plan);
+
+        scope.begin_drain(StopReason::ShutdownRequested);
+
+        assert!(scope.children.values().all(ChildRuntime::is_terminal));
+        assert!(!scope.ordered_stop_progressing);
+    }
+
     #[crate::runtime::test]
     async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
         let factories = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -3539,6 +3615,7 @@ mod tests {
             ancestor_shutdown_seen: false,
             ancestor_abort_seen: false,
             hard_forced: false,
+            ordered_stop_progressing: false,
             completion: None,
         };
         plan.armed = false;
@@ -4791,6 +4868,7 @@ mod tests {
             ancestor_shutdown_seen: false,
             ancestor_abort_seen: false,
             hard_forced: false,
+            ordered_stop_progressing: false,
             completion: None,
         };
         plan.armed = false;
@@ -4910,6 +4988,7 @@ mod tests {
             ancestor_shutdown_seen: false,
             ancestor_abort_seen: false,
             hard_forced: false,
+            ordered_stop_progressing: false,
             completion: None,
         };
         plan.armed = false;

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1015,6 +1015,10 @@ impl ChildArena {
             .map(|(key, _)| *key)
     }
 
+    fn previous_key(&self, key: ChildKey) -> Option<ChildKey> {
+        self.children.range(..key).next_back().map(|(key, _)| *key)
+    }
+
     fn values(&self) -> impl Iterator<Item = &ChildRuntime> {
         self.children.values()
     }
@@ -1111,6 +1115,9 @@ struct ScopeRuntime {
     ancestor_abort_seen: bool,
     hard_forced: bool,
     ordered_stop_progressing: bool,
+    ordered_stop_cursor: Option<ChildKey>,
+    #[cfg(test)]
+    ordered_stop_inspections: usize,
     completion: Option<ScopeCompletion>,
 }
 
@@ -1924,7 +1931,10 @@ impl ScopeRuntime {
         }
         self.root.set_state(ScopeState::Draining);
         match self.root.flavor {
-            ScopeFlavor::Ordered => self.stop_next_ordered(),
+            ScopeFlavor::Ordered => {
+                self.ordered_stop_cursor = self.children.keys().next_back();
+                self.stop_next_ordered();
+            }
             ScopeFlavor::Dynamic => {
                 let children: Vec<_> = self.children.keys().collect();
                 for child in children {
@@ -1942,12 +1952,15 @@ impl ScopeRuntime {
             return;
         }
         self.ordered_stop_progressing = true;
-        loop {
-            let Some(key) = self.children.keys().rev().find(|key| {
-                !self.children[*key].is_terminal() || self.children[*key].is_disposing()
-            }) else {
-                break;
-            };
+        while let Some(key) = self.ordered_stop_cursor {
+            self.ordered_stop_cursor = self.children.previous_key(key);
+            #[cfg(test)]
+            {
+                self.ordered_stop_inspections += 1;
+            }
+            if self.children[key].is_terminal() && !self.children[key].is_disposing() {
+                continue;
+            }
             self.begin_stop_child(key, None);
             if self.children[key].active.is_some() || self.children[key].is_disposing() {
                 break;
@@ -2816,6 +2829,9 @@ async fn run_scope_incarnation(
         ancestor_abort_seen: false,
         hard_forced: false,
         ordered_stop_progressing: false,
+        ordered_stop_cursor: None,
+        #[cfg(test)]
+        ordered_stop_inspections: 0,
         completion: None,
         // Transfer last: every fallible setup expression above remains
         // covered by the pre-driver guard, and completed construction moves
@@ -3407,6 +3423,8 @@ mod tests {
             ancestor_abort_seen: false,
             hard_forced: false,
             ordered_stop_progressing: false,
+            ordered_stop_cursor: None,
+            ordered_stop_inspections: 0,
             completion: None,
         };
         plan.armed = false;
@@ -3538,6 +3556,8 @@ mod tests {
             ancestor_abort_seen: false,
             hard_forced: true,
             ordered_stop_progressing: false,
+            ordered_stop_cursor: None,
+            ordered_stop_inspections: 0,
             completion: None,
         };
         plan.armed = false;
@@ -3547,6 +3567,10 @@ mod tests {
 
         assert!(scope.children.values().all(ChildRuntime::is_terminal));
         assert!(!scope.ordered_stop_progressing);
+        assert_eq!(
+            scope.ordered_stop_inspections, CHILDREN,
+            "the reverse cursor inspects each ordered child exactly once"
+        );
     }
 
     #[crate::runtime::test]
@@ -3616,6 +3640,8 @@ mod tests {
             ancestor_abort_seen: false,
             hard_forced: false,
             ordered_stop_progressing: false,
+            ordered_stop_cursor: None,
+            ordered_stop_inspections: 0,
             completion: None,
         };
         plan.armed = false;
@@ -4869,6 +4895,8 @@ mod tests {
             ancestor_abort_seen: false,
             hard_forced: false,
             ordered_stop_progressing: false,
+            ordered_stop_cursor: None,
+            ordered_stop_inspections: 0,
             completion: None,
         };
         plan.armed = false;
@@ -4989,6 +5017,8 @@ mod tests {
             ancestor_abort_seen: false,
             hard_forced: false,
             ordered_stop_progressing: false,
+            ordered_stop_cursor: None,
+            ordered_stop_inspections: 0,
             completion: None,
         };
         plan.armed = false;

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1970,11 +1970,19 @@ impl ScopeRuntime {
             {
                 self.ordered_stop_inspections += 1;
             }
-            if self.children[key].is_terminal() && !self.children[key].is_disposing() {
+            // The cursor key is held across await boundaries, so never index
+            // the arena with it: a reclaimed slot is treated as already gone.
+            let Some(child) = self.children.get(key) else {
+                continue;
+            };
+            if child.is_terminal() && !child.is_disposing() {
                 continue;
             }
             self.begin_stop_child(key, None);
-            if self.children[key].active.is_some() || self.children[key].is_disposing() {
+            let Some(child) = self.children.get(key) else {
+                continue;
+            };
+            if child.active.is_some() || child.is_disposing() {
                 self.ordered_stop_waiting = Some(key);
                 break;
             }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1116,6 +1116,7 @@ struct ScopeRuntime {
     hard_forced: bool,
     ordered_stop_progressing: bool,
     ordered_stop_cursor: Option<ChildKey>,
+    ordered_stop_waiting: Option<ChildKey>,
     #[cfg(test)]
     ordered_stop_inspections: usize,
     completion: Option<ScopeCompletion>,
@@ -1952,6 +1953,17 @@ impl ScopeRuntime {
             return;
         }
         self.ordered_stop_progressing = true;
+        if let Some(key) = self.ordered_stop_waiting {
+            let waiting = self
+                .children
+                .get(key)
+                .is_some_and(|child| !child.is_terminal() || child.is_disposing());
+            if waiting {
+                self.ordered_stop_progressing = false;
+                return;
+            }
+            self.ordered_stop_waiting = None;
+        }
         while let Some(key) = self.ordered_stop_cursor {
             self.ordered_stop_cursor = self.children.previous_key(key);
             #[cfg(test)]
@@ -1963,6 +1975,7 @@ impl ScopeRuntime {
             }
             self.begin_stop_child(key, None);
             if self.children[key].active.is_some() || self.children[key].is_disposing() {
+                self.ordered_stop_waiting = Some(key);
                 break;
             }
         }
@@ -2830,6 +2843,7 @@ async fn run_scope_incarnation(
         hard_forced: false,
         ordered_stop_progressing: false,
         ordered_stop_cursor: None,
+        ordered_stop_waiting: None,
         #[cfg(test)]
         ordered_stop_inspections: 0,
         completion: None,
@@ -3424,6 +3438,7 @@ mod tests {
             hard_forced: false,
             ordered_stop_progressing: false,
             ordered_stop_cursor: None,
+            ordered_stop_waiting: None,
             ordered_stop_inspections: 0,
             completion: None,
         };
@@ -3557,6 +3572,7 @@ mod tests {
             hard_forced: true,
             ordered_stop_progressing: false,
             ordered_stop_cursor: None,
+            ordered_stop_waiting: None,
             ordered_stop_inspections: 0,
             completion: None,
         };
@@ -3567,6 +3583,7 @@ mod tests {
 
         assert!(scope.children.values().all(ChildRuntime::is_terminal));
         assert!(!scope.ordered_stop_progressing);
+        assert_eq!(scope.ordered_stop_waiting, None);
         assert_eq!(
             scope.ordered_stop_inspections, CHILDREN,
             "the reverse cursor inspects each ordered child exactly once"
@@ -3641,6 +3658,7 @@ mod tests {
             hard_forced: false,
             ordered_stop_progressing: false,
             ordered_stop_cursor: None,
+            ordered_stop_waiting: None,
             ordered_stop_inspections: 0,
             completion: None,
         };
@@ -4896,6 +4914,7 @@ mod tests {
             hard_forced: false,
             ordered_stop_progressing: false,
             ordered_stop_cursor: None,
+            ordered_stop_waiting: None,
             ordered_stop_inspections: 0,
             completion: None,
         };
@@ -5018,6 +5037,7 @@ mod tests {
             hard_forced: false,
             ordered_stop_progressing: false,
             ordered_stop_cursor: None,
+            ordered_stop_waiting: None,
             ordered_stop_inspections: 0,
             completion: None,
         };

--- a/crates/shelterwood/tests/lifecycle.rs
+++ b/crates/shelterwood/tests/lifecycle.rs
@@ -340,6 +340,86 @@ async fn ordered_teardown_is_reverse_and_joins_before_advancing() {
 }
 
 #[tokio::test]
+async fn ordered_teardown_keeps_its_frontier_when_an_earlier_child_exits() {
+    let first_stopping = Arc::new(AtomicBool::new(false));
+    let middle_exit = ReleaseGate::default();
+    let last_stopping = ReleaseGate::default();
+    let last_exit = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.add_task(
+        "first",
+        TaskDef::new({
+            let first_stopping = Arc::clone(&first_stopping);
+            move |context| {
+                let first_stopping = Arc::clone(&first_stopping);
+                async move {
+                    context.shutdown_token().cancelled().await;
+                    first_stopping.store(true, Ordering::SeqCst);
+                    Ok(())
+                }
+            }
+        }),
+    )
+    .expect("valid first task");
+    let middle = tree
+        .add_task(
+            "middle",
+            TaskDef::new({
+                let middle_exit = middle_exit.clone();
+                move |_| {
+                    let middle_exit = middle_exit.clone();
+                    async move {
+                        middle_exit.wait().await;
+                        Ok(())
+                    }
+                }
+            }),
+        )
+        .expect("valid middle task");
+    tree.add_task(
+        "last",
+        TaskDef::new({
+            let last_stopping = last_stopping.clone();
+            let last_exit = last_exit.clone();
+            move |context| {
+                let last_stopping = last_stopping.clone();
+                let last_exit = last_exit.clone();
+                async move {
+                    context.shutdown_token().cancelled().await;
+                    last_stopping.release();
+                    last_exit.wait().await;
+                    Ok(())
+                }
+            }
+        }),
+    )
+    .expect("valid last task");
+
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("tree starts");
+    let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(2)));
+    tokio::time::timeout(POLL_TIMEOUT, last_stopping.wait())
+        .await
+        .expect("the reverse-order frontier starts stopping");
+
+    middle_exit.release();
+    tokio::time::timeout(POLL_TIMEOUT, middle.wait())
+        .await
+        .expect("the earlier child exits independently");
+    assert_quiet(Duration::from_millis(15), || {
+        first_stopping.load(Ordering::SeqCst)
+    })
+    .await;
+
+    last_exit.release();
+    shutdown
+        .await
+        .expect("shutdown task joins")
+        .expect("clean shutdown");
+    assert!(first_stopping.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
 async fn dynamic_teardown_cancels_children_concurrently() {
     let cancelled = Arc::new([AtomicBool::new(false), AtomicBool::new(false)]);
     let gate = ReleaseGate::default();


### PR DESCRIPTION
## Summary

- guard ordered stop progression against synchronous re-entry from inline construction disposal
- let the outer stop loop advance consecutive inactive/restart-window children iteratively
- add a 1,024-child forced-drain regression that previously accumulated one stack frame per child

Part of #116 (§2 forced ordered-drain recursion robustness).

## Validation

- `./tools/dev just ci` on the audited source branch (436 tests plus Clippy, docs, API/layering, packaging, and formatting)
- focused 1,024-child iterative-drain regression
