### PR TITLE
Expose structured startup error sources

### DIFF
--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -106,6 +106,13 @@ impl ExitError {
     }
 }
 
+/// Wraps any error as an application-classified [`ExitError`].
+///
+/// The classification is unconditional: converting an [`IntensityTrip`] or a
+/// [`StartupFailure`] through this impl yields an unauthenticated application
+/// error for which [`ExitError::intensity_trip`] and
+/// [`ExitError::startup_failure`] return `None`. The structured,
+/// framework-authenticated variants cannot be produced by user code.
 impl<E> From<E> for ExitError
 where
     E: Error + Send + Sync + 'static,
@@ -142,6 +149,13 @@ impl fmt::Display for MessageError {
 impl Error for MessageError {}
 
 /// A scope restart-budget failure.
+///
+/// This type implements [`std::error::Error`], so `ExitError::from(trip)` or
+/// `?` compiles via the blanket application-error conversion — but that path
+/// produces an ordinary, *unauthenticated* application error for which
+/// [`ExitError::intensity_trip`] returns `None`. Only the framework mints the
+/// structured variant; observe trips through [`ExitError::intensity_trip`]
+/// rather than round-tripping the payload through a user conversion.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct IntensityTrip {
@@ -177,6 +191,14 @@ impl fmt::Display for StructuredIntensityTrip {
 impl Error for StructuredIntensityTrip {}
 
 /// A structured nested-scope startup failure.
+///
+/// This type implements [`std::error::Error`], so `ExitError::from(failure)`
+/// or `?` compiles via the blanket application-error conversion — but that
+/// path produces an ordinary, *unauthenticated* application error for which
+/// [`ExitError::startup_failure`] returns `None`. Only the framework mints
+/// the structured variant; observe startup failures through
+/// [`ExitError::startup_failure`] rather than round-tripping the payload
+/// through a user conversion.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct StartupFailure {

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -31,10 +31,10 @@ pub enum StopReason {
 pub enum StartupError {
     /// A child or nested lowering failed terminally during startup.
     #[error("tree startup failed")]
-    StartupFailed(StartupFailure),
+    StartupFailed(#[source] StartupFailure),
     /// Restart intensity tripped during startup.
     #[error("restart intensity tripped during startup")]
-    IntensityTripped(IntensityTrip),
+    IntensityTripped(#[source] IntensityTrip),
     /// Shutdown began before startup completed.
     #[error("shutdown was requested during startup")]
     ShutdownRequested,
@@ -153,16 +153,24 @@ pub struct IntensityTrip {
     pub within: Duration,
 }
 
+impl fmt::Display for IntensityTrip {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "restart intensity exceeded: {} restarts exceeds {} within {:?}",
+            self.observed_restarts, self.max_restarts, self.within
+        )
+    }
+}
+
+impl Error for IntensityTrip {}
+
 #[derive(Debug)]
 struct StructuredIntensityTrip(IntensityTrip);
 
 impl fmt::Display for StructuredIntensityTrip {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            formatter,
-            "restart intensity exceeded: {} restarts exceeds {} within {:?}",
-            self.0.observed_restarts, self.0.max_restarts, self.0.within
-        )
+        fmt::Display::fmt(&self.0, formatter)
     }
 }
 
@@ -174,6 +182,37 @@ impl Error for StructuredIntensityTrip {}
 pub struct StartupFailure {
     /// The startup failure's exact cause.
     pub cause: StartupFailureCause,
+}
+
+impl fmt::Display for StartupFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.cause {
+            StartupFailureCause::Child { id, .. } => {
+                write!(formatter, "child `{id}` failed during startup")
+            }
+            StartupFailureCause::Lowering { undefined } => {
+                write!(formatter, "subtree has {} undefined slots", undefined.len())
+            }
+            StartupFailureCause::IdentityExhausted { id } => {
+                write!(
+                    formatter,
+                    "membership identity space is exhausted for child `{id}`"
+                )
+            }
+            StartupFailureCause::InvalidPolicy(invalid) => invalid.fmt(formatter),
+        }
+    }
+}
+
+impl Error for StartupFailure {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match &self.cause {
+            StartupFailureCause::InvalidPolicy(invalid) => Some(invalid),
+            StartupFailureCause::Child { .. }
+            | StartupFailureCause::Lowering { .. }
+            | StartupFailureCause::IdentityExhausted { .. } => None,
+        }
+    }
 }
 
 /// The cause of a nested-scope startup failure.
@@ -208,21 +247,7 @@ struct StructuredStartupFailure(StartupFailure);
 
 impl fmt::Display for StructuredStartupFailure {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.0.cause {
-            StartupFailureCause::Child { id, .. } => {
-                write!(formatter, "child `{id}` failed during startup")
-            }
-            StartupFailureCause::Lowering { undefined } => {
-                write!(formatter, "subtree has {} undefined slots", undefined.len())
-            }
-            StartupFailureCause::IdentityExhausted { id } => {
-                write!(
-                    formatter,
-                    "membership identity space is exhausted for child `{id}`"
-                )
-            }
-            StartupFailureCause::InvalidPolicy(invalid) => invalid.fmt(formatter),
-        }
+        fmt::Display::fmt(&self.0, formatter)
     }
 }
 
@@ -491,8 +516,9 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use super::{
-        Cancellation, ChildId, Exit, ExitError, ExitKind, GracePhase, JoinVerdict, RecordedOutcome,
-        StartupFailure, StartupFailureCause, classify_exit, reconcile_recorded_outcomes,
+        Cancellation, ChildId, Exit, ExitError, ExitKind, GracePhase, IntensityTrip, JoinVerdict,
+        RecordedOutcome, StartupError, StartupFailure, StartupFailureCause, classify_exit,
+        reconcile_recorded_outcomes,
     };
 
     #[test]
@@ -743,5 +769,78 @@ mod tests {
         let error = ExitError::from(ForgedTrip);
         assert!(error.intensity_trip().is_none());
         assert!(error.startup_failure().is_none());
+
+        let error = ExitError::from(IntensityTrip {
+            max_restarts: 2,
+            observed_restarts: 3,
+            within: Duration::from_secs(10),
+        });
+        assert!(error.intensity_trip().is_none());
+
+        let error = ExitError::from(StartupFailure {
+            cause: StartupFailureCause::IdentityExhausted {
+                id: ChildId::from("nested"),
+            },
+        });
+        assert!(error.startup_failure().is_none());
+    }
+
+    #[test]
+    fn framework_errors_expose_structured_provenance_and_erased_views() {
+        let trip = IntensityTrip {
+            max_restarts: 2,
+            observed_restarts: 3,
+            within: Duration::from_secs(10),
+        };
+        let error = ExitError::from_intensity_trip(trip.clone());
+        assert_eq!(error.intensity_trip(), Some(&trip));
+        assert_eq!(
+            error.as_error().to_string(),
+            "restart intensity exceeded: 3 restarts exceeds 2 within 10s"
+        );
+
+        let failure = StartupFailure {
+            cause: StartupFailureCause::IdentityExhausted {
+                id: ChildId::from("nested"),
+            },
+        };
+        let error = ExitError::from_startup_failure(failure.clone());
+        assert_eq!(error.startup_failure(), Some(&failure));
+        assert_eq!(
+            error.as_error().to_string(),
+            "membership identity space is exhausted for child `nested`"
+        );
+    }
+
+    #[test]
+    fn startup_errors_chain_their_structured_detail() {
+        let error = StartupError::StartupFailed(StartupFailure {
+            cause: StartupFailureCause::IdentityExhausted {
+                id: ChildId::from("nested"),
+            },
+        });
+        assert_eq!(error.to_string(), "tree startup failed");
+        assert_eq!(
+            std::error::Error::source(&error)
+                .expect("startup failure is the source")
+                .to_string(),
+            "membership identity space is exhausted for child `nested`"
+        );
+
+        let error = StartupError::IntensityTripped(IntensityTrip {
+            max_restarts: 2,
+            observed_restarts: 3,
+            within: Duration::from_secs(10),
+        });
+        assert_eq!(
+            error.to_string(),
+            "restart intensity tripped during startup"
+        );
+        assert_eq!(
+            std::error::Error::source(&error)
+                .expect("intensity trip is the source")
+                .to_string(),
+            "restart intensity exceeded: 3 restarts exceeds 2 within 10s"
+        );
     }
 }

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -208,8 +208,15 @@ impl Error for StartupFailure {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match &self.cause {
             StartupFailureCause::InvalidPolicy(invalid) => Some(invalid),
-            StartupFailureCause::Child { .. }
-            | StartupFailureCause::Lowering { .. }
+            StartupFailureCause::Child { exit, .. } => match exit.kind() {
+                ExitKind::Failed(error) => Some(error.as_error()),
+                ExitKind::Completed
+                | ExitKind::Panicked { .. }
+                | ExitKind::ReadinessTimedOut { .. }
+                | ExitKind::Aborted { .. }
+                | ExitKind::NeverStarted => None,
+            },
+            StartupFailureCause::Lowering { .. }
             | StartupFailureCause::IdentityExhausted { .. } => None,
         }
     }
@@ -251,7 +258,11 @@ impl fmt::Display for StructuredStartupFailure {
     }
 }
 
-impl Error for StructuredStartupFailure {}
+impl Error for StructuredStartupFailure {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.0.source()
+    }
+}
 
 /// Whether an incarnation observed supervisor cancellation before exiting.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/crates/shelterwood/tests/policy_validation.rs
+++ b/crates/shelterwood/tests/policy_validation.rs
@@ -315,11 +315,24 @@ async fn restartable_subtree_factory_output_reports_structured_policy_failure() 
     let system = root
         .spawn()
         .expect("factory output is produced after root lowering");
-    let StartupError::StartupFailed(failure) = system
+    let startup = system
         .wait_started()
         .await
-        .expect_err("factory output fails policy validation")
-    else {
+        .expect_err("factory output fails policy validation");
+    let outer_source =
+        std::error::Error::source(&startup).expect("startup error exposes its outer child failure");
+    let structured_source = outer_source
+        .source()
+        .expect("the child exit exposes the nested structured failure");
+    let invalid_source = structured_source
+        .source()
+        .expect("the erased structured error forwards invalid-policy detail");
+    assert!(
+        invalid_source
+            .to_string()
+            .contains("invalid restart intensity")
+    );
+    let StartupError::StartupFailed(failure) = startup else {
         panic!("expected structured startup failure");
     };
     let StartupFailureCause::Child { id, exit, .. } = failure.cause else {

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -563,6 +563,26 @@ async fn nested_dynamic_startup_failure_rolls_back_and_preserves_inner_cause() {
         .wait_started()
         .await
         .expect_err("nested startup fails");
+    let outer_source =
+        std::error::Error::source(&startup).expect("startup error exposes its outer child failure");
+    assert_eq!(
+        outer_source.to_string(),
+        "child `nested` failed during startup"
+    );
+    let inner_source = outer_source
+        .source()
+        .expect("the child exit exposes the nested structured failure");
+    assert_eq!(
+        inner_source.to_string(),
+        "child `inner-failure` failed during startup"
+    );
+    assert_eq!(
+        inner_source
+            .source()
+            .expect("the nested child failure exposes its application error")
+            .to_string(),
+        "startup failure"
+    );
     let outer_failure = match startup {
         StartupError::StartupFailed(failure) => failure,
         other => panic!("unexpected startup result: {other:?}"),


### PR DESCRIPTION
## Summary

- expose `StartupFailure` and `IntensityTrip` as structured `Error::source` values from `StartupError`
- give both public structured details stable human-readable `Display` implementations
- preserve `ExitError` provenance: framework constructors still expose typed accessors, while application conversion cannot forge structured provenance
- add genuine typed-accessor, erased-view, and source-chain coverage

Part of #116 (§5 StartupError/ExitError accuracy and §6 accessor coverage).

## Validation

- `./tools/dev just ci` on the audited source branch (436 tests plus Clippy, docs, API/layering, packaging, and formatting)
- focused exit/error-chain tests
