### PR TITLE
Discover layering-check modules automatically

### DIFF
--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -81,6 +81,8 @@ expect_case exit-downcast-mut check-exit-paths.sh \
   "runtime type recovery found on the exit path:"
 expect_case layering-driver-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
+expect_case layering-new-module-driver-below check-layering-paths.sh \
+  "upward driver or tree references found below the driver layer:"
 expect_case layering-cancellation-driver-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-tree-below check-layering-paths.sh \

--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -83,6 +83,8 @@ expect_case layering-driver-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-new-module-driver-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
+expect_case layering-directory-module-driver-below check-layering-paths.sh \
+  "upward driver or tree references found below the driver layer:"
 expect_case layering-cancellation-driver-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-tree-below check-layering-paths.sh \

--- a/tools/check-exit-paths.sh
+++ b/tools/check-exit-paths.sh
@@ -6,14 +6,19 @@ set -euo pipefail
 cd "${SHELTERWOOD_ENFORCEMENT_ROOT:-.}"
 
 readonly forbidden='[.]downcast(_ref|_mut)?([[:space:]]*)?(::)?[<(]'
-readonly exit_path=(
-  crates/shelterwood/src/driver.rs
+readonly driver_path="crates/shelterwood/src/driver.rs"
+readonly driver_module_root="crates/shelterwood/src/driver"
+
+shopt -s globstar nullglob
+readonly exit_paths=(
+  "$driver_path"
+  "$driver_module_root"/**/*.rs
   crates/shelterwood/src/engine.rs
   crates/shelterwood/src/exit.rs
 )
 
 set +e
-matches="$({ rg --line-number "$forbidden" "${exit_path[@]}"; } 2>&1)"
+matches="$({ rg --line-number "$forbidden" "${exit_paths[@]}"; } 2>&1)"
 status=$?
 set -e
 

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -5,20 +5,28 @@ set -euo pipefail
 # default scans the repository from the invoking directory as before.
 cd "${SHELTERWOOD_ENFORCEMENT_ROOT:-.}"
 
-readonly driver_path="crates/shelterwood/src/driver.rs"
-readonly tree_path="crates/shelterwood/src/tree.rs"
+readonly source_root="crates/shelterwood/src"
+readonly driver_path="$source_root/driver.rs"
+readonly tree_path="$source_root/tree.rs"
 
-# Every top-level Rust module except the two orchestration layers belongs below
-# the driver. Derive the set so adding a module cannot silently bypass this
-# check; lib.rs is the crate root and is allowed to wire every layer together.
+# Every Rust source except the two orchestration modules and their submodules
+# belongs below the driver. Derive all three sets recursively so either a flat
+# module or the conventional `module/mod.rs` layout cannot silently bypass the
+# check; lib.rs is the crate root and may wire every layer together.
 below_driver_layers=()
-for path in crates/shelterwood/src/*.rs; do
+driver_layers=()
+tree_layers=()
+while IFS= read -r -d '' path; do
   case "$path" in
-    "$driver_path"|"$tree_path"|crates/shelterwood/src/lib.rs) ;;
+    "$source_root/lib.rs") ;;
+    "$driver_path"|"$source_root/driver/"*) driver_layers+=("$path") ;;
+    "$tree_path"|"$source_root/tree/"*) tree_layers+=("$path") ;;
     *) below_driver_layers+=("$path") ;;
   esac
-done
+done < <(find "$source_root" -type f -name '*.rs' -print0)
 readonly -a below_driver_layers
+readonly -a driver_layers
+readonly -a tree_layers
 
 check_forbidden() {
   local message="$1"
@@ -54,16 +62,16 @@ check_forbidden \
 check_forbidden \
   "upward tree references found in the driver layer:" \
   '\btree::' \
-  "$driver_path"
+  "${driver_layers[@]}"
 
 check_forbidden \
   "child option resolution escaped the shared plan funnel:" \
   '\bresolve_common\b' \
-  "$driver_path"
+  "${driver_layers[@]}"
 
 check_forbidden \
   "dynamic child-id validation escaped the reservation boundary:" \
   '\bchecked_id\b' \
-  "$tree_path"
+  "${tree_layers[@]}"
 
 echo "supervision layering restrictions: clean"

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -5,26 +5,20 @@ set -euo pipefail
 # default scans the repository from the invoking directory as before.
 cd "${SHELTERWOOD_ENFORCEMENT_ROOT:-.}"
 
-readonly below_driver_layers=(
-  crates/shelterwood/src/admission.rs
-  crates/shelterwood/src/actor.rs
-  crates/shelterwood/src/cancellation.rs
-  crates/shelterwood/src/cells.rs
-  crates/shelterwood/src/deadline.rs
-  crates/shelterwood/src/definition.rs
-  crates/shelterwood/src/engine.rs
-  crates/shelterwood/src/exit.rs
-  crates/shelterwood/src/identity.rs
-  crates/shelterwood/src/mailbox.rs
-  crates/shelterwood/src/observe.rs
-  crates/shelterwood/src/plan.rs
-  crates/shelterwood/src/policy.rs
-  crates/shelterwood/src/raw.rs
-  crates/shelterwood/src/runtime.rs
-  crates/shelterwood/src/task.rs
-)
 readonly driver_path="crates/shelterwood/src/driver.rs"
 readonly tree_path="crates/shelterwood/src/tree.rs"
+
+# Every top-level Rust module except the two orchestration layers belongs below
+# the driver. Derive the set so adding a module cannot silently bypass this
+# check; lib.rs is the crate root and is allowed to wire every layer together.
+below_driver_layers=()
+for path in crates/shelterwood/src/*.rs; do
+  case "$path" in
+    "$driver_path"|"$tree_path"|crates/shelterwood/src/lib.rs) ;;
+    *) below_driver_layers+=("$path") ;;
+  esac
+done
+readonly -a below_driver_layers
 
 check_forbidden() {
   local message="$1"

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -33,6 +33,14 @@ check_forbidden() {
   local forbidden="$2"
   shift 2
 
+  # With no paths `rg` falls back to scanning the working directory
+  # recursively, so an empty derived set would silently widen the check
+  # instead of failing it.
+  if (($# == 0)); then
+    echo "no files derived for check: $message" >&2
+    exit 1
+  fi
+
   local matches
   local status
   set +e

--- a/tools/enforcement-fixtures/overlays/layering-directory-module-driver-below/crates/shelterwood/src/new_module/mod.rs
+++ b/tools/enforcement-fixtures/overlays/layering-directory-module-driver-below/crates/shelterwood/src/new_module/mod.rs
@@ -1,0 +1,1 @@
+use crate::driver::Driver;

--- a/tools/enforcement-fixtures/overlays/layering-new-module-driver-below/crates/shelterwood/src/new_module.rs
+++ b/tools/enforcement-fixtures/overlays/layering-new-module-driver-below/crates/shelterwood/src/new_module.rs
@@ -1,0 +1,1 @@
+use crate::driver::Driver;


### PR DESCRIPTION
## Summary

- derive the below-driver module set from every top-level Rust source file instead of a hand-maintained list
- explicitly exempt only the driver, tree, and crate-root orchestration layers
- add an enforcement fixture proving a newly introduced module cannot silently reference upward

Part of #116 (§5 layering-check accuracy).

## Validation

- `./tools/dev just ci` on the audited source branch (436 tests plus Clippy, docs, API/layering, packaging, and formatting)
- enforcement fixture suite, including the new-module counterexample
