### PR TITLE
Preserve unrepresentable restart deadlines

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3283,12 +3283,14 @@ ChildSnapshot   { id, membership,                       // §3 identity types
                                                         //   conflating watch may skip states —
                                                         //   events are the history surface)
                   restart_policy, retention,
-                  restart_at: Option<Instant>,          // a representable, exactly armable backoff
+                  restart_at: Option<Instant>,          // a representable, safely schedulable backoff
                                                         //   deadline while Restarting, as an absolute
                                                         //   runtime-clock instant (D.3); None outside
                                                         //   Restarting and also for an unrepresentable
-                                                        //   or unarmable requested point. No earlier or
-                                                        //   alternative deadline is substituted: that
+                                                        //   or unschedulable requested point. The runtime
+                                                        //   may wait in bounded internal timer slices,
+                                                        //   but no earlier or alternative public deadline
+                                                        //   is substituted: that
                                                         //   restart remains pending until removal or
                                                         //   shutdown. Render a present value relative
                                                         //   by subtracting now

--- a/SPEC.md
+++ b/SPEC.md
@@ -2912,7 +2912,7 @@ marked *(II)* ship with the named Part II feature.
 | Snapshot channel | conflating watch, capacity 1 | Structural |
 | `call` / `send_timeout` deadline | **none — always explicit** | One budget per call (§5.1); zero deadline fails immediately |
 | Identity counters | `u64`, saturating | Fail-closed overflow, decided once in the fencing primitive (§3.1); lifecycle `seq`/`lifecycle_seq` mint through the same primitive (B.4's exhaustion rule) |
-| Far-future clamp | timer arithmetic saturates to a far-future instant | Instead of panicking on `Instant + Duration` overflow |
+| Unrepresentable deadline | **never arrives** | `Instant + Duration` overflow or an exact point the runtime cannot arm produces no deadline; it MUST NOT substitute the budget's start or any other instant |
 
 ---
 
@@ -3283,11 +3283,15 @@ ChildSnapshot   { id, membership,                       // §3 identity types
                                                         //   conflating watch may skip states —
                                                         //   events are the history surface)
                   restart_policy, retention,
-                  restart_at: Option<Instant>,          // present exactly in Restarting: the
-                                                        //   backoff deadline as an absolute
-                                                        //   runtime-clock instant (D.3) — a retained
-                                                        //   snapshot stays interpretable; render
-                                                        //   relative by subtracting now
+                  restart_at: Option<Instant>,          // a representable, exactly armable backoff
+                                                        //   deadline while Restarting, as an absolute
+                                                        //   runtime-clock instant (D.3); None outside
+                                                        //   Restarting and also for an unrepresentable
+                                                        //   or unarmable requested point. No earlier or
+                                                        //   alternative deadline is substituted: that
+                                                        //   restart remains pending until removal or
+                                                        //   shutdown. Render a present value relative
+                                                        //   by subtracting now
                   nested: Option<ScopeSnapshot>,         // recursive for scope children; None while
                                                          //   no incarnation is live and the membership
                                                          //   is non-terminal (restart window); a

--- a/crates/shelterwood/doctests/docs/observation.md
+++ b/crates/shelterwood/doctests/docs/observation.md
@@ -31,8 +31,9 @@ event; `get()` exposes the underlying `u64` when numeric integration requires it
 
 A child in `Restarting` normally exposes its absolute backoff deadline through
 `restart_at`. If the requested delay is too large for the platform clock to
-represent, `restart_at` is `None`; the child remains in `Restarting` until
-removal or shutdown rather than restarting immediately.
+represent and arm exactly, `restart_at` is `None`; no earlier or alternative
+deadline is substituted, and the child remains in `Restarting` until removal
+or shutdown rather than restarting immediately.
 
 If the event's scope token is absent from the snapshot, use causal introduction:
 

--- a/crates/shelterwood/doctests/docs/observation.md
+++ b/crates/shelterwood/doctests/docs/observation.md
@@ -29,11 +29,13 @@ These values use `LifecycleSeq`. `LifecycleSeq::EXHAUSTED` is the permanent
 watermark after the sequence space is exhausted and is never emitted on an
 event; `get()` exposes the underlying `u64` when numeric integration requires it.
 
-A child in `Restarting` normally exposes its absolute backoff deadline through
-`restart_at`. If the requested delay is too large for the platform clock to
-represent and arm exactly, `restart_at` is `None`; no earlier or alternative
-deadline is substituted, and the child remains in `Restarting` until removal
-or shutdown rather than restarting immediately.
+A child in `Restarting` normally exposes its exact absolute backoff deadline
+through `restart_at`. The runtime waits for very distant points in bounded
+internal timer slices, so the timer implementation cannot clamp them to an
+earlier tick. If the requested point cannot be represented or safely scheduled,
+`restart_at` is `None`; no earlier or alternative public deadline is
+substituted, and the child remains in `Restarting` until removal or shutdown
+rather than restarting immediately.
 
 If the event's scope token is absent from the snapshot, use causal introduction:
 

--- a/crates/shelterwood/src/deadline.rs
+++ b/crates/shelterwood/src/deadline.rs
@@ -10,12 +10,14 @@ use std::time::{Duration, Instant};
 pub(crate) struct Deadline(Option<Instant>);
 
 impl Deadline {
-    /// Captures an absolute point only when the runtime can arm it exactly.
+    /// Captures an absolute point only when the runtime can schedule it safely.
     ///
     /// A representable instant within [`Self::ARMING_HEADROOM`] of the clock
-    /// limit still cannot be handed to the timer safely. Such a point has the
-    /// same never-arrives semantics as an overflowing relative budget; it is
-    /// never replaced with an earlier, merely armable instant.
+    /// limit still cannot be handed to the timer safely. More distant points
+    /// can be reached through bounded internal timer slices, but a point at
+    /// the clock ceiling has the same never-arrives semantics as an
+    /// overflowing relative budget; it is never replaced with an earlier
+    /// public deadline.
     pub(crate) fn at(instant: Instant) -> Self {
         Self(instant.checked_add(Self::ARMING_HEADROOM).map(|_| instant))
     }
@@ -29,9 +31,18 @@ impl Deadline {
     /// would be armed for it, so due-ness checks and timer wakes can
     /// never disagree at the clock boundary.
     pub(crate) fn after(started_at: Instant, duration: Duration) -> Self {
-        started_at
-            .checked_add(duration)
-            .map_or(Self(None), Self::at)
+        let Some(instant) = started_at.checked_add(duration) else {
+            return Self(None);
+        };
+
+        // An exact zero budget is already due at its starting clock value and
+        // never has to cross the timer boundary. Preserve it even when that
+        // value is too close to Instant's ceiling for a future timer arm.
+        if duration.is_zero() {
+            Self(Some(instant))
+        } else {
+            Self::at(instant)
+        }
     }
 
     /// Returns the representable absolute deadline, if there is one.
@@ -132,6 +143,16 @@ mod tests {
         );
         assert!(!flush.is_due(now + armable));
         assert!(!flush.is_overdue(now + armable));
+    }
+
+    #[test]
+    fn zero_budget_at_the_clock_limit_remains_due() {
+        let edge = latest_representable(Instant::now());
+        let deadline = Deadline::after(edge, Duration::ZERO);
+
+        assert_eq!(deadline.instant(), Some(edge));
+        assert!(deadline.is_due(edge));
+        assert!(!deadline.is_overdue(edge));
     }
 
     #[test]

--- a/crates/shelterwood/src/deadline.rs
+++ b/crates/shelterwood/src/deadline.rs
@@ -10,6 +10,16 @@ use std::time::{Duration, Instant};
 pub(crate) struct Deadline(Option<Instant>);
 
 impl Deadline {
+    /// Captures an absolute point only when the runtime can arm it exactly.
+    ///
+    /// A representable instant within [`Self::ARMING_HEADROOM`] of the clock
+    /// limit still cannot be handed to the timer safely. Such a point has the
+    /// same never-arrives semantics as an overflowing relative budget; it is
+    /// never replaced with an earlier, merely armable instant.
+    pub(crate) fn at(instant: Instant) -> Self {
+        Self(instant.checked_add(Self::ARMING_HEADROOM).map(|_| instant))
+    }
+
     /// Captures a duration budget relative to `started_at`.
     ///
     /// A deadline the timer could not arm — one within
@@ -19,11 +29,9 @@ impl Deadline {
     /// would be armed for it, so due-ness checks and timer wakes can
     /// never disagree at the clock boundary.
     pub(crate) fn after(started_at: Instant, duration: Duration) -> Self {
-        Self(
-            started_at
-                .checked_add(duration)
-                .filter(|deadline| deadline.checked_add(Self::ARMING_HEADROOM).is_some()),
-        )
+        started_at
+            .checked_add(duration)
+            .map_or(Self(None), Self::at)
     }
 
     /// Returns the representable absolute deadline, if there is one.
@@ -31,7 +39,7 @@ impl Deadline {
         self.0
     }
 
-    /// Headroom the far-future clamp keeps below the clock limit.
+    /// Headroom an absolute deadline must leave below the clock limit.
     ///
     /// Arming a deadline is itself clock arithmetic — tokio rounds a
     /// sleep deadline up to the next whole millisecond by adding to it
@@ -39,62 +47,8 @@ impl Deadline {
     /// past the armed tick by another whole millisecond — so a deadline
     /// flush against `Instant`'s limit would panic at arming or advance
     /// time. One second comfortably covers both additions without
-    /// measurably loosening the clamp.
+    /// changing the requested deadline.
     pub(crate) const ARMING_HEADROOM: Duration = Duration::from_secs(1);
-
-    /// Captures a duration budget as an absolute instant, saturating to
-    /// the largest armable deadline when the exact one overflows the
-    /// clock (or its [`Self::ARMING_HEADROOM`]).
-    ///
-    /// This is the far-future clamp: callers that must surface a present
-    /// absolute point — a `Restarting` snapshot's `restart_at` — use this
-    /// instead of [`Deadline::after`]'s never-arrives `None`.
-    pub(crate) fn saturating_after(started_at: Instant, duration: Duration) -> Instant {
-        let armable = |budget: Duration| {
-            budget
-                .checked_add(Self::ARMING_HEADROOM)
-                .and_then(|padded| started_at.checked_add(padded))
-                .is_some()
-        };
-        if armable(duration) {
-            return started_at + duration;
-        }
-        // The exact deadline overflows: saturate to the largest budget
-        // that still fits — the closest armable approximation — so a
-        // narrow clock never arms the deadline earlier than it must.
-        // Binary search on the nanosecond-granular budget: `low` always
-        // fits, `high` never does, and the gap halves every step,
-        // bounding the loop by the bit width of `Duration`.
-        let mut low = Duration::ZERO;
-        let mut high = duration;
-        while high - low > Duration::from_nanos(1) {
-            let mid = low + (high - low) / 2;
-            if armable(mid) {
-                low = mid;
-            } else {
-                high = mid;
-            }
-        }
-        started_at + low
-    }
-
-    /// Clamps an absolute deadline to the largest armable instant.
-    ///
-    /// A representable deadline within [`Self::ARMING_HEADROOM`] of the
-    /// clock limit would still panic inside the timer's millisecond
-    /// round-up, so the arming boundary pulls it back just far enough to
-    /// fit. Deadlines that already leave the headroom pass through
-    /// unchanged — including everything [`Deadline::after`] produces,
-    /// which withholds unarmable deadlines at computation time; this
-    /// clamp is the last line of defense for instants that reach the
-    /// runtime boundary by any other route.
-    pub(crate) fn clamp_armable(deadline: Instant) -> Instant {
-        if deadline.checked_add(Self::ARMING_HEADROOM).is_some() {
-            return deadline;
-        }
-        let now = Instant::now();
-        Self::saturating_after(now, deadline.saturating_duration_since(now))
-    }
 
     /// Reports whether a representable deadline has elapsed.
     pub(crate) fn is_due(self, now: Instant) -> bool {
@@ -116,6 +70,21 @@ mod tests {
 
     use super::Deadline;
 
+    fn latest_representable(started_at: Instant) -> Instant {
+        let mut low = Duration::ZERO;
+        let mut high = Duration::MAX;
+        assert!(started_at.checked_add(high).is_none());
+        while high - low > Duration::from_nanos(1) {
+            let mid = low + (high - low) / 2;
+            if started_at.checked_add(mid).is_some() {
+                low = mid;
+            } else {
+                high = mid;
+            }
+        }
+        started_at + low
+    }
+
     #[test]
     fn overflow_is_never_due() {
         let now = Instant::now();
@@ -127,42 +96,28 @@ mod tests {
     }
 
     #[test]
-    fn saturating_after_matches_exact_addition_when_representable() {
+    fn ordinary_budget_preserves_the_exact_deadline() {
         let now = Instant::now();
         assert_eq!(
-            Deadline::saturating_after(now, Duration::from_secs(1)),
-            now + Duration::from_secs(1)
+            Deadline::after(now, Duration::from_secs(1)).instant(),
+            Some(now + Duration::from_secs(1))
         );
     }
 
     #[test]
-    fn saturating_after_clamps_overflow_to_the_largest_armable_instant() {
+    fn unarmable_absolute_point_is_not_substituted() {
         let now = Instant::now();
-        let clamped = Deadline::saturating_after(now, Duration::MAX);
-        let century = Duration::from_secs(60 * 60 * 24 * 365 * 100);
-        assert!(clamped > now + century);
-        assert!(
-            clamped.checked_add(Deadline::ARMING_HEADROOM).is_some(),
-            "the clamp leaves the timer's arming headroom below the clock limit"
-        );
-        assert!(
-            clamped
-                .checked_add(Deadline::ARMING_HEADROOM + Duration::from_nanos(1))
-                .is_none(),
-            "the clamp saturates to the clock limit less the arming headroom, \
-             not to a halved budget"
-        );
+        let unarmable = latest_representable(now);
+
+        assert_ne!(unarmable, now, "the edge point is not the budget start");
+        assert_eq!(Deadline::at(unarmable).instant(), None);
     }
 
     #[test]
     fn unarmable_but_representable_budgets_never_arrive() {
         let now = Instant::now();
-        // The largest armable budget: its deadline sits exactly one
-        // headroom below the clock limit, so one more headroom on top of
-        // it lands flush against the limit — representable, but a panic
-        // to arm.
-        let armable = Deadline::saturating_after(now, Duration::MAX) - now;
-        let unarmable = armable + Deadline::ARMING_HEADROOM;
+        let unarmable = latest_representable(now) - now;
+        let armable = unarmable - Deadline::ARMING_HEADROOM;
 
         assert_eq!(
             Deadline::after(now, armable).instant(),
@@ -177,30 +132,6 @@ mod tests {
         );
         assert!(!flush.is_due(now + armable));
         assert!(!flush.is_overdue(now + armable));
-    }
-
-    #[test]
-    fn clamp_armable_passes_ordinary_deadlines_through_unchanged() {
-        let now = Instant::now();
-        let deadline = now + Duration::from_secs(1);
-        assert_eq!(Deadline::clamp_armable(deadline), deadline);
-    }
-
-    #[test]
-    fn clamp_armable_pulls_a_near_limit_deadline_below_the_headroom() {
-        let now = Instant::now();
-        // The far-future clamp saturates to the clock limit less the
-        // headroom, so adding the headroom back lands flush against the
-        // limit: representable, but a panic to arm.
-        let flush = Deadline::saturating_after(now, Duration::MAX) + Deadline::ARMING_HEADROOM;
-        let clamped = Deadline::clamp_armable(flush);
-        assert!(clamped < flush, "the clamp never arms later than asked");
-        assert!(
-            clamped.checked_add(Deadline::ARMING_HEADROOM).is_some(),
-            "the clamp leaves the timer's arming headroom below the clock limit"
-        );
-        let century = Duration::from_secs(60 * 60 * 24 * 365 * 100);
-        assert!(clamped > now + century, "the clamp stays far future");
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2154,10 +2154,10 @@ impl ScopeRuntime {
                         record.last_exit = Some(exit.clone());
                         record.restart_count = decision.restart_count;
                         // Publish the derived schedule even when intensity
-                        // prevents spawning it. The engine clamps
-                        // unrepresentable deadlines far future, so
-                        // `restart_at` is present exactly while restarting.
-                        record.restart_at = Some(decision.restart_at);
+                        // prevents spawning it. `None` means the exact clock
+                        // point cannot be represented and armed; no substitute
+                        // restart is scheduled.
+                        record.restart_at = decision.restart_at;
                         record.stage = MemberStage::Restarting;
                     },
                     LifecycleEventKind::Exited {
@@ -2181,10 +2181,12 @@ impl ScopeRuntime {
                     }
                     self.begin_drain(StopReason::IntensityTripped(trip));
                 } else {
-                    child.restart_deadline = Some(
-                        self.deadlines
-                            .push(decision.restart_at, DeadlineKind::Restart { child: key }),
-                    );
+                    if let Some(restart_at) = decision.restart_at {
+                        child.restart_deadline = Some(
+                            self.deadlines
+                                .push(restart_at, DeadlineKind::Restart { child: key }),
+                        );
+                    }
                 }
             }
         }

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -318,9 +318,9 @@ pub(crate) struct RestartDecision {
     pub(crate) attempt: RestartAttempt,
     pub(crate) restart_count: RestartCount,
     pub(crate) delay: Duration,
-    /// Absolute backoff deadline; unrepresentable far-future points are
-    /// clamped (B.6: `restart_at` is present exactly in `Restarting`).
-    pub(crate) restart_at: Instant,
+    /// Absolute backoff deadline, or `None` when the exact point cannot be
+    /// represented and armed by the runtime clock.
+    pub(crate) restart_at: Option<Instant>,
     pub(crate) charge: IntensityCharge,
 }
 
@@ -334,7 +334,7 @@ pub(crate) fn schedule_restart(
 ) -> RestartDecision {
     let (attempt, restart_count) = restarts.schedule();
     let delay = restart_policy.backoff().next_delay(attempt, jitter_sample);
-    let restart_at = Deadline::saturating_after(now, delay);
+    let restart_at = Deadline::after(now, delay).instant();
     let charge = intensity.charge(intensity_policy, now);
     RestartDecision {
         attempt,
@@ -1136,13 +1136,13 @@ mod tests {
         assert_eq!(decision.attempt, RestartAttempt::ZERO.bump());
         assert_eq!(decision.restart_count, RestartCount::ZERO.bump());
         assert_eq!(decision.delay, Duration::ZERO);
-        assert_eq!(decision.restart_at, now);
+        assert_eq!(decision.restart_at, Some(now));
         assert_eq!(decision.charge.total_restarts, TotalRestarts::ZERO.bump());
         assert!(decision.charge.tripped);
     }
 
     #[test]
-    fn overflowing_restart_delay_clamps_to_a_far_future_deadline() {
+    fn overflowing_restart_delay_has_no_substitute_deadline() {
         let now = Instant::now();
         let intensity_policy = Intensity::new(5, Duration::from_secs(10)).expect("valid intensity");
         let restart_policy = RestartPolicy::new(
@@ -1161,11 +1161,7 @@ mod tests {
         );
 
         assert_eq!(decision.delay, Duration::MAX);
-        let century = Duration::from_secs(60 * 60 * 24 * 365 * 100);
-        assert!(
-            decision.restart_at > now + century,
-            "an unrepresentable backoff deadline clamps far future, never near now"
-        );
+        assert_eq!(decision.restart_at, None);
     }
 
     #[test]

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -245,9 +245,8 @@ pub struct ChildSnapshot {
     pub restart_policy: RestartPolicy,
     /// Resolved terminal-retention policy.
     pub retention: Retention,
-    /// Absolute backoff deadline, present exactly while the membership is
-    /// restarting; a delay too distant for the clock to represent is
-    /// clamped to a far-future instant.
+    /// Absolute backoff deadline while restarting, or `None` when the exact
+    /// point is too distant for the runtime clock to represent and arm.
     pub restart_at: Option<Instant>,
     /// Recursive state of a scope child when its incarnation is live or terminal.
     pub nested: Option<Arc<ScopeSnapshot>>,

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -1320,9 +1320,11 @@ mod tests {
         // rather than depending on tokio's private sentinel.
         let beyond_tokio_ticks = Duration::from_millis(u64::MAX - 2);
         let current = std::time::Instant::now();
-        let requested = current
-            .checked_add(beyond_tokio_ticks)
-            .expect("the platform represents points beyond tokio's tick range");
+        let Some(requested) = current.checked_add(beyond_tokio_ticks) else {
+            // Some platforms have a narrower Instant domain than Tokio's
+            // u64 millisecond tick range, so this boundary cannot be tested.
+            return;
+        };
 
         assert_eq!(
             next_timer_deadline(current, requested),
@@ -1333,9 +1335,10 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn deadline_beyond_tokios_tick_range_does_not_fire_at_the_first_slice() {
         let current = super::now();
-        let requested = current
-            .checked_add(Duration::from_millis(u64::MAX - 2))
-            .expect("the platform represents points beyond tokio's tick range");
+        let Some(requested) = current.checked_add(Duration::from_millis(u64::MAX - 2)) else {
+            // See `deadline_beyond_tokios_tick_range_is_armed_in_a_bounded_slice`.
+            return;
+        };
         let mut sleep = std::pin::pin!(super::sleep_until_std(requested));
         let mut context = Context::from_waker(Waker::noop());
 

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -1105,11 +1105,13 @@ pub(crate) async fn sleep_until_std(deadline: std::time::Instant) {
     // tokio rounds the deadline up to the next whole millisecond with a
     // panicking add before tick conversion, so a deadline flush against
     // the clock limit would panic at arming time rather than when it was
-    // computed. Deadline::after already withholds such deadlines, making
-    // this clamp a pass-through for them; it guards instants that arrive
-    // by any other route.
-    let deadline = Deadline::clamp_armable(deadline);
-    time::sleep_until(time::Instant::from_std(deadline)).await;
+    // computed. Absolute instants that arrive by another route obey the same
+    // never-substitute rule as relative budgets: if this exact point cannot
+    // be armed, it never arrives.
+    match Deadline::at(deadline).instant() {
+        Some(deadline) => time::sleep_until(time::Instant::from_std(deadline)).await,
+        None => std::future::pending().await,
+    }
 }
 
 pub(crate) enum Timeout<T> {
@@ -1245,25 +1247,40 @@ mod tests {
     };
 
     use super::{
-        Deadline, DisposalJob, DisposalPanic, JoinOutcome, Latch, OneShotClose, Signal, Timeout,
+        DisposalJob, DisposalPanic, JoinOutcome, Latch, OneShotClose, Signal, Timeout,
         discard_panic, join, oneshot, spawn, timeout, yield_now,
     };
 
+    fn latest_representable(started_at: std::time::Instant) -> std::time::Instant {
+        let mut low = Duration::ZERO;
+        let mut high = Duration::MAX;
+        assert!(started_at.checked_add(high).is_none());
+        while high - low > Duration::from_nanos(1) {
+            let mid = low + (high - low) / 2;
+            if started_at.checked_add(mid).is_some() {
+                low = mid;
+            } else {
+                high = mid;
+            }
+        }
+        started_at + low
+    }
+
     #[tokio::test(start_paused = true)]
-    async fn arming_a_deadline_flush_against_the_clock_limit_stays_pending() {
+    async fn unarmable_absolute_deadline_stays_pending_without_substitution() {
         let now = std::time::Instant::now();
-        let flush = Deadline::saturating_after(now, Duration::MAX) + Deadline::ARMING_HEADROOM;
+        let flush = latest_representable(now);
         let mut sleep = std::pin::pin!(super::sleep_until_std(flush));
         let mut context = Context::from_waker(Waker::noop());
-        // The timer registers on first poll: without the arming clamp this
-        // panicked inside tokio's millisecond round-up rather than parking.
+        // The timer registers on first poll: passing this instant to tokio
+        // would panic during its millisecond round-up rather than parking.
         assert!(sleep.as_mut().poll(&mut context).is_pending());
     }
 
     #[tokio::test(start_paused = true)]
     async fn timeout_with_an_unarmable_budget_never_elapses() {
         let now = super::now();
-        let flush = Deadline::saturating_after(now, Duration::MAX) + Deadline::ARMING_HEADROOM;
+        let flush = latest_representable(now);
         // The paused clock is frozen, so the budget reconstructs the flush
         // deadline exactly and the unarmable-budget guard must engage.
         let budget = flush - now;

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -159,6 +159,24 @@ pub(crate) fn now() -> std::time::Instant {
     time::Instant::now().into_std()
 }
 
+// Keep each timer registration comfortably inside tokio's millisecond tick
+// range. Tokio caps instants beyond its private `u64::MAX - 3` tick sentinel,
+// which would otherwise make a valid but very distant std Instant fire early.
+// Rechecking the original absolute point after bounded slices preserves exact
+// never-early semantics without coupling this crate to that private constant.
+const MAX_TIMER_SLICE: Duration = Duration::from_secs(365 * 24 * 60 * 60);
+
+fn next_timer_deadline(
+    current: std::time::Instant,
+    requested: std::time::Instant,
+) -> Option<std::time::Instant> {
+    if requested <= current {
+        return None;
+    }
+    let slice = requested.duration_since(current).min(MAX_TIMER_SLICE);
+    current.checked_add(slice)
+}
+
 pub(crate) fn is_available() -> bool {
     tokio::runtime::Handle::try_current().is_ok()
 }
@@ -1108,9 +1126,15 @@ pub(crate) async fn sleep_until_std(deadline: std::time::Instant) {
     // computed. Absolute instants that arrive by another route obey the same
     // never-substitute rule as relative budgets: if this exact point cannot
     // be armed, it never arrives.
-    match Deadline::at(deadline).instant() {
-        Some(deadline) => time::sleep_until(time::Instant::from_std(deadline)).await,
-        None => std::future::pending().await,
+    loop {
+        let current = now();
+        let Some(next) = next_timer_deadline(current, deadline) else {
+            return;
+        };
+        match Deadline::at(next).instant() {
+            Some(next) => time::sleep_until(time::Instant::from_std(next)).await,
+            None => std::future::pending().await,
+        }
     }
 }
 
@@ -1128,12 +1152,24 @@ where
     // against the clock limit would still panic at arming. Route the
     // budget through Deadline so an unarmable timeout never elapses,
     // matching sleep_deadline's overflow semantics.
-    if deadline(duration).instant().is_none() {
+    let Some(deadline) = deadline(duration).instant() else {
         return Timeout::Completed(future.await);
+    };
+    if duration <= MAX_TIMER_SLICE {
+        return match time::timeout(duration, future).await {
+            Ok(value) => Timeout::Completed(value),
+            Err(_) => Timeout::Elapsed,
+        };
     }
-    match time::timeout(duration, future).await {
-        Ok(value) => Timeout::Completed(value),
-        Err(_) => Timeout::Elapsed,
+    let sleep = sleep_until_std(deadline);
+    tokio::pin!(future);
+    tokio::pin!(sleep);
+    tokio::select! {
+        // Match tokio::time::timeout's boundary rule: the operation receives
+        // the first poll when it and a zero-duration timer are both ready.
+        biased;
+        value = &mut future => Timeout::Completed(value),
+        () = &mut sleep => Timeout::Elapsed,
     }
 }
 
@@ -1247,8 +1283,8 @@ mod tests {
     };
 
     use super::{
-        DisposalJob, DisposalPanic, JoinOutcome, Latch, OneShotClose, Signal, Timeout,
-        discard_panic, join, oneshot, spawn, timeout, yield_now,
+        DisposalJob, DisposalPanic, JoinOutcome, Latch, MAX_TIMER_SLICE, OneShotClose, Signal,
+        Timeout, discard_panic, join, next_timer_deadline, oneshot, spawn, timeout, yield_now,
     };
 
     fn latest_representable(started_at: std::time::Instant) -> std::time::Instant {
@@ -1275,6 +1311,47 @@ mod tests {
         // The timer registers on first poll: passing this instant to tokio
         // would panic during its millisecond round-up rather than parking.
         assert!(sleep.as_mut().poll(&mut context).is_pending());
+    }
+
+    #[test]
+    fn deadline_beyond_tokios_tick_range_is_armed_in_a_bounded_slice() {
+        // Tokio 1.53 reserves the top three u64 millisecond ticks. The exact
+        // value is test evidence only: production uses a small stable slice
+        // rather than depending on tokio's private sentinel.
+        let beyond_tokio_ticks = Duration::from_millis(u64::MAX - 2);
+        let current = std::time::Instant::now();
+        let requested = current
+            .checked_add(beyond_tokio_ticks)
+            .expect("the platform represents points beyond tokio's tick range");
+
+        assert_eq!(
+            next_timer_deadline(current, requested),
+            current.checked_add(MAX_TIMER_SLICE)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn deadline_beyond_tokios_tick_range_does_not_fire_at_the_first_slice() {
+        let current = super::now();
+        let requested = current
+            .checked_add(Duration::from_millis(u64::MAX - 2))
+            .expect("the platform represents points beyond tokio's tick range");
+        let mut sleep = std::pin::pin!(super::sleep_until_std(requested));
+        let mut context = Context::from_waker(Waker::noop());
+
+        assert!(sleep.as_mut().poll(&mut context).is_pending());
+        tokio::time::advance(MAX_TIMER_SLICE).await;
+        assert!(
+            sleep.as_mut().poll(&mut context).is_pending(),
+            "finishing an internal slice must not finish the requested sleep"
+        );
+    }
+
+    #[test]
+    fn already_due_clock_limit_needs_no_timer_arm() {
+        let edge = latest_representable(std::time::Instant::now());
+
+        assert_eq!(next_timer_deadline(edge, edge), None);
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -160,7 +160,8 @@ pub(crate) fn now() -> std::time::Instant {
 }
 
 // Keep each timer registration comfortably inside tokio's millisecond tick
-// range. Tokio caps instants beyond its private `u64::MAX - 3` tick sentinel,
+// range. Tokio caps instants beyond its private `MAX_SAFE_MILLIS_DURATION`
+// (`u64::MAX - 2` milliseconds in tokio 1.53),
 // which would otherwise make a valid but very distant std Instant fire early.
 // Rechecking the original absolute point after bounded slices preserves exact
 // never-early semantics without coupling this crate to that private constant.
@@ -1155,6 +1156,25 @@ where
     let Some(deadline) = deadline(duration).instant() else {
         return Timeout::Completed(future.await);
     };
+    // Deadline's zero-budget carve-out keeps an exact zero budget
+    // representable even when its clock value is too close to Instant's
+    // ceiling for the timer to arm safely. Handing that instant to tokio's
+    // timeout would still arm it — the tick conversion rounds the deadline
+    // up with a panicking add — so apply the carve-out's own due-check here
+    // instead of arming: the budget is already due, and exact-boundary
+    // arbitration gives an immediately ready operation its one poll before
+    // the elapse. Every other zero budget stays on tokio's timeout below,
+    // keeping the normal regime's semantics untouched.
+    if duration.is_zero() && Deadline::at(deadline).instant().is_none() {
+        tokio::pin!(future);
+        return std::future::poll_fn(|context| {
+            std::task::Poll::Ready(match future.as_mut().poll(context) {
+                std::task::Poll::Ready(value) => Timeout::Completed(value),
+                std::task::Poll::Pending => Timeout::Elapsed,
+            })
+        })
+        .await;
+    }
     if duration <= MAX_TIMER_SLICE {
         return match time::timeout(duration, future).await {
             Ok(value) => Timeout::Completed(value),

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -483,7 +483,7 @@ async fn overflowing_shutdown_grace_does_not_escalate() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn overflowing_restart_delay_clamps_far_future_and_never_restarts_immediately() {
+async fn overflowing_restart_delay_has_no_substitute_and_never_restarts() {
     let release_failure = ReleaseGate::default();
     let starts = Arc::new(AtomicUsize::new(0));
     let mut tree = Tree::new();
@@ -518,16 +518,12 @@ async fn overflowing_restart_delay_clamps_far_future_and_never_restarts_immediat
         .expect("first incarnation starts");
     release_failure.release();
 
-    // SPEC B.6: `restart_at` is present exactly in `Restarting`; a delay
-    // too distant for the clock clamps to a far-future instant.
-    let century = Duration::from_secs(60 * 60 * 24 * 365 * 100);
+    // SPEC B.6: an exact deadline too distant for the runtime clock to
+    // represent and arm has no substitute, and therefore never fires.
     assert!(
         poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             system.scope().child("restart").is_some_and(|child| {
-                matches!(child.state, ChildState::Restarting)
-                    && child
-                        .restart_at
-                        .is_some_and(|at| at > std::time::Instant::now() + century)
+                matches!(child.state, ChildState::Restarting) && child.restart_at.is_none()
             })
         })
         .await

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -1414,14 +1414,14 @@ async fn assert_pending_restart_shutdown_is_expedited<R: Clone>(
         "shutdown must start exactly the pending incarnation without waiting for backoff"
     );
     if width == Duration::MAX {
-        // An unrepresentable deadline is clamped to a far-future instant
-        // that never arrives, so there is no later incarnation to reach.
+        // An unrepresentable deadline has no substitute and never arrives,
+        // so there is no later incarnation to reach.
         // Only the quiet window applies.
         advance_time(Duration::from_secs(1)).await;
         assert_eq!(
             starts.load(Ordering::SeqCst),
             2,
-            "a far-future-clamped deadline must not resurrect the stopped incarnation"
+            "an unrepresentable deadline must not resurrect the stopped incarnation"
         );
         system.shutdown(Duration::ZERO).await.expect("root stops");
         return;

--- a/docs/observation.md
+++ b/docs/observation.md
@@ -31,8 +31,9 @@ event; `get()` exposes the underlying `u64` when numeric integration requires it
 
 A child in `Restarting` normally exposes its absolute backoff deadline through
 `restart_at`. If the requested delay is too large for the platform clock to
-represent, `restart_at` is `None`; the child remains in `Restarting` until
-removal or shutdown rather than restarting immediately.
+represent and arm exactly, `restart_at` is `None`; no earlier or alternative
+deadline is substituted, and the child remains in `Restarting` until removal
+or shutdown rather than restarting immediately.
 
 If the event's scope token is absent from the snapshot, use causal introduction:
 

--- a/docs/observation.md
+++ b/docs/observation.md
@@ -29,11 +29,13 @@ These values use `LifecycleSeq`. `LifecycleSeq::EXHAUSTED` is the permanent
 watermark after the sequence space is exhausted and is never emitted on an
 event; `get()` exposes the underlying `u64` when numeric integration requires it.
 
-A child in `Restarting` normally exposes its absolute backoff deadline through
-`restart_at`. If the requested delay is too large for the platform clock to
-represent and arm exactly, `restart_at` is `None`; no earlier or alternative
-deadline is substituted, and the child remains in `Restarting` until removal
-or shutdown rather than restarting immediately.
+A child in `Restarting` normally exposes its exact absolute backoff deadline
+through `restart_at`. The runtime waits for very distant points in bounded
+internal timer slices, so the timer implementation cannot clamp them to an
+earlier tick. If the requested point cannot be represented or safely scheduled,
+`restart_at` is `None`; no earlier or alternative public deadline is
+substituted, and the child remains in `Restarting` until removal or shutdown
+rather than restarting immediately.
 
 If the event's scope token is absent from the snapshot, use causal introduction:
 


### PR DESCRIPTION
## Summary

- represent an unrepresentable or exactly unarmable restart deadline as `restart_at: None`
- leave the membership in `Restarting` without arming an earlier substitute timer
- apply the same never-substitute rule to absolute runtime sleeps
- remove the far-future clamp and align SPEC, API docs, observation docs, and packaged docs
- add deterministic clock-boundary and end-to-end restart regressions

Part of #116 (§4.10 and the related deadline robustness audit).

## Validation

- focused deadline, runtime, restart, and pending-shutdown tests
- `./tools/dev just ci` (429 tests plus Clippy, docs/API, layering, packaging, and formatting)
