### PR TITLE
Pin issue 116 robustness edge cases

### DIFF
--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -1,6 +1,6 @@
 use std::{
     sync::{
-        Arc, Mutex,
+        Arc, Barrier, Condvar, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
@@ -147,6 +147,151 @@ async fn timers_and_offload_completions_never_cross_an_incarnation_boundary() {
         .send(RestartMessage::Fresh)
         .await
         .expect("replacement live");
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert!(!stale_seen.load(Ordering::SeqCst));
+}
+
+enum DetachedBlockingMessage {
+    Poison,
+    Fresh,
+    StaleCompletion,
+}
+
+struct DetachedBlockingActor {
+    generation: usize,
+    thread_started: Arc<Barrier>,
+    thread_release: Arc<(Mutex<bool>, Condvar)>,
+    thread_done: Arc<AtomicBool>,
+    stale_seen: Arc<AtomicBool>,
+}
+
+impl Actor for DetachedBlockingActor {
+    type Msg = DetachedBlockingMessage;
+    type Args = (
+        usize,
+        Arc<Barrier>,
+        Arc<(Mutex<bool>, Condvar)>,
+        Arc<AtomicBool>,
+        Arc<AtomicBool>,
+    );
+
+    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self {
+            generation: args.0,
+            thread_started: args.1,
+            thread_release: args.2,
+            thread_done: args.3,
+            stale_seen: args.4,
+        })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            DetachedBlockingMessage::Poison => {
+                assert_eq!(self.generation, 1);
+                let thread_started = Arc::clone(&self.thread_started);
+                let thread_release = Arc::clone(&self.thread_release);
+                let thread_done = Arc::clone(&self.thread_done);
+                let work = context.run_blocking(move |cancellation| {
+                    thread_started.wait();
+                    let (released, changed) = &*thread_release;
+                    let mut released = released.lock().expect("release mutex poisoned");
+                    while !*released {
+                        released = changed
+                            .wait(released)
+                            .expect("release mutex poisoned while waiting");
+                    }
+                    assert!(
+                        cancellation.is_cancelled(),
+                        "the old incarnation cancels detached blocking work"
+                    );
+                    thread_done.store(true, Ordering::SeqCst);
+                });
+                self.thread_started.wait();
+                context
+                    .offload(
+                        work,
+                        |_| DetachedBlockingMessage::StaleCompletion,
+                        Duration::MAX,
+                    )
+                    .expect("blocking future is accepted before failure");
+                Err(ExitError::message("poisoned incarnation"))
+            }
+            DetachedBlockingMessage::Fresh => {
+                assert_eq!(self.generation, 2);
+                context.stop();
+                Ok(())
+            }
+            DetachedBlockingMessage::StaleCompletion => {
+                self.stale_seen.store(true, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn detached_run_blocking_completion_stays_with_its_old_incarnation() {
+    let generations = Arc::new(AtomicUsize::new(0));
+    let thread_started = Arc::new(Barrier::new(2));
+    let thread_release = Arc::new((Mutex::new(false), Condvar::new()));
+    let thread_done = Arc::new(AtomicBool::new(false));
+    let stale_seen = Arc::new(AtomicBool::new(false));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor(
+            "actor",
+            ActorDef::<DetachedBlockingActor>::factory({
+                let generations = Arc::clone(&generations);
+                let thread_started = Arc::clone(&thread_started);
+                let thread_release = Arc::clone(&thread_release);
+                let thread_done = Arc::clone(&thread_done);
+                let stale_seen = Arc::clone(&stale_seen);
+                move || {
+                    (
+                        generations.fetch_add(1, Ordering::SeqCst) + 1,
+                        Arc::clone(&thread_started),
+                        Arc::clone(&thread_release),
+                        Arc::clone(&thread_done),
+                        Arc::clone(&stale_seen),
+                    )
+                }
+            }),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("first actor starts");
+    actor
+        .send(DetachedBlockingMessage::Poison)
+        .await
+        .expect("actor accepts poison");
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            generations.load(Ordering::SeqCst) >= 2
+        })
+        .await,
+        "replacement starts while the old blocking thread remains detached"
+    );
+
+    let (released, changed) = &*thread_release;
+    *released.lock().expect("release mutex poisoned") = true;
+    changed.notify_one();
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            thread_done.load(Ordering::SeqCst)
+        })
+        .await,
+        "detached old-incarnation thread completes"
+    );
+    assert_quiet(Duration::from_millis(20), || {
+        stale_seen.load(Ordering::SeqCst)
+    })
+    .await;
+
+    actor
+        .send(DetachedBlockingMessage::Fresh)
+        .await
+        .expect("replacement remains live");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert!(!stale_seen.load(Ordering::SeqCst));
 }

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -196,6 +196,7 @@ struct DetachedBlockingActor {
     result_disposed: ReleaseGate,
     fresh_seen: ReleaseGate,
     stale_seen: Arc<AtomicBool>,
+    map_ran: Arc<AtomicBool>,
 }
 
 impl Actor for DetachedBlockingActor {
@@ -207,6 +208,7 @@ impl Actor for DetachedBlockingActor {
         ReleaseGate,
         ReleaseGate,
         Arc<AtomicBool>,
+        Arc<AtomicBool>,
     );
 
     async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
@@ -217,6 +219,7 @@ impl Actor for DetachedBlockingActor {
             result_disposed: args.3,
             fresh_seen: args.4,
             stale_seen: args.5,
+            map_ran: args.6,
         })
     }
 
@@ -246,7 +249,13 @@ impl Actor for DetachedBlockingActor {
                 context
                     .offload(
                         work,
-                        |_| DetachedBlockingMessage::StaleCompletion,
+                        {
+                            let map_ran = Arc::clone(&self.map_ran);
+                            move |_| {
+                                map_ran.store(true, Ordering::SeqCst);
+                                DetachedBlockingMessage::StaleCompletion
+                            }
+                        },
                         Duration::MAX,
                     )
                     .expect("blocking future is accepted before failure");
@@ -280,6 +289,7 @@ async fn detached_run_blocking_completion_stays_with_its_old_incarnation() {
     let result_disposed = ReleaseGate::default();
     let fresh_seen = ReleaseGate::default();
     let stale_seen = Arc::new(AtomicBool::new(false));
+    let map_ran = Arc::new(AtomicBool::new(false));
     let mut tree = Tree::new();
     let actor = tree
         .add_actor(
@@ -291,6 +301,7 @@ async fn detached_run_blocking_completion_stays_with_its_old_incarnation() {
                 let result_disposed = result_disposed.clone();
                 let fresh_seen = fresh_seen.clone();
                 let stale_seen = Arc::clone(&stale_seen);
+                let map_ran = Arc::clone(&map_ran);
                 move || {
                     (
                         generations.fetch_add(1, Ordering::SeqCst) + 1,
@@ -299,6 +310,7 @@ async fn detached_run_blocking_completion_stays_with_its_old_incarnation() {
                         result_disposed.clone(),
                         fresh_seen.clone(),
                         Arc::clone(&stale_seen),
+                        Arc::clone(&map_ran),
                     )
                 }
             }),
@@ -319,9 +331,16 @@ async fn detached_run_blocking_completion_stays_with_its_old_incarnation() {
     );
 
     thread_release.release();
+    // The gate only witnesses that the result's destructor ran somewhere; the
+    // `map_ran` assertions below pin down that disposal, not the map closure,
+    // consumed it.
     tokio::time::timeout(POLL_TIMEOUT, result_disposed.wait())
         .await
-        .expect("the detached blocking result is disposed");
+        .expect("the detached blocking result's destructor runs");
+    assert!(
+        !map_ran.load(Ordering::SeqCst),
+        "the detached completion is disposed without running the map closure"
+    );
 
     actor
         .send(DetachedBlockingMessage::Fresh)
@@ -340,6 +359,10 @@ async fn detached_run_blocking_completion_stays_with_its_old_incarnation() {
         .expect("replacement accepts the final stop");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert!(!stale_seen.load(Ordering::SeqCst));
+    assert!(
+        !map_ran.load(Ordering::SeqCst),
+        "the stale completion was never mapped"
+    );
 }
 
 enum DeadlineMessage {

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -1,6 +1,6 @@
 use std::{
     sync::{
-        Arc, Barrier, Condvar, Mutex,
+        Arc, Condvar, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
@@ -154,14 +154,24 @@ async fn timers_and_offload_completions_never_cross_an_incarnation_boundary() {
 enum DetachedBlockingMessage {
     Poison,
     Fresh,
+    Stop,
     StaleCompletion,
+}
+
+struct DetachedBlockingResult(ReleaseGate);
+
+impl Drop for DetachedBlockingResult {
+    fn drop(&mut self) {
+        self.0.release();
+    }
 }
 
 struct DetachedBlockingActor {
     generation: usize,
-    thread_started: Arc<Barrier>,
+    thread_started: ReleaseGate,
     thread_release: Arc<(Mutex<bool>, Condvar)>,
-    thread_done: Arc<AtomicBool>,
+    result_disposed: ReleaseGate,
+    fresh_seen: ReleaseGate,
     stale_seen: Arc<AtomicBool>,
 }
 
@@ -169,9 +179,10 @@ impl Actor for DetachedBlockingActor {
     type Msg = DetachedBlockingMessage;
     type Args = (
         usize,
-        Arc<Barrier>,
+        ReleaseGate,
         Arc<(Mutex<bool>, Condvar)>,
-        Arc<AtomicBool>,
+        ReleaseGate,
+        ReleaseGate,
         Arc<AtomicBool>,
     );
 
@@ -180,8 +191,9 @@ impl Actor for DetachedBlockingActor {
             generation: args.0,
             thread_started: args.1,
             thread_release: args.2,
-            thread_done: args.3,
-            stale_seen: args.4,
+            result_disposed: args.3,
+            fresh_seen: args.4,
+            stale_seen: args.5,
         })
     }
 
@@ -189,11 +201,11 @@ impl Actor for DetachedBlockingActor {
         match message {
             DetachedBlockingMessage::Poison => {
                 assert_eq!(self.generation, 1);
-                let thread_started = Arc::clone(&self.thread_started);
+                let thread_started = self.thread_started.clone();
                 let thread_release = Arc::clone(&self.thread_release);
-                let thread_done = Arc::clone(&self.thread_done);
+                let result_disposed = self.result_disposed.clone();
                 let work = context.run_blocking(move |cancellation| {
-                    thread_started.wait();
+                    thread_started.release();
                     let (released, changed) = &*thread_release;
                     let mut released = released.lock().expect("release mutex poisoned");
                     while !*released {
@@ -205,9 +217,9 @@ impl Actor for DetachedBlockingActor {
                         cancellation.is_cancelled(),
                         "the old incarnation cancels detached blocking work"
                     );
-                    thread_done.store(true, Ordering::SeqCst);
+                    DetachedBlockingResult(result_disposed)
                 });
-                self.thread_started.wait();
+                self.thread_started.wait().await;
                 context
                     .offload(
                         work,
@@ -218,6 +230,11 @@ impl Actor for DetachedBlockingActor {
                 Err(ExitError::message("poisoned incarnation"))
             }
             DetachedBlockingMessage::Fresh => {
+                assert_eq!(self.generation, 2);
+                self.fresh_seen.release();
+                Ok(())
+            }
+            DetachedBlockingMessage::Stop => {
                 assert_eq!(self.generation, 2);
                 context.stop();
                 Ok(())
@@ -233,9 +250,10 @@ impl Actor for DetachedBlockingActor {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn detached_run_blocking_completion_stays_with_its_old_incarnation() {
     let generations = Arc::new(AtomicUsize::new(0));
-    let thread_started = Arc::new(Barrier::new(2));
+    let thread_started = ReleaseGate::default();
     let thread_release = Arc::new((Mutex::new(false), Condvar::new()));
-    let thread_done = Arc::new(AtomicBool::new(false));
+    let result_disposed = ReleaseGate::default();
+    let fresh_seen = ReleaseGate::default();
     let stale_seen = Arc::new(AtomicBool::new(false));
     let mut tree = Tree::new();
     let actor = tree
@@ -243,16 +261,18 @@ async fn detached_run_blocking_completion_stays_with_its_old_incarnation() {
             "actor",
             ActorDef::<DetachedBlockingActor>::factory({
                 let generations = Arc::clone(&generations);
-                let thread_started = Arc::clone(&thread_started);
+                let thread_started = thread_started.clone();
                 let thread_release = Arc::clone(&thread_release);
-                let thread_done = Arc::clone(&thread_done);
+                let result_disposed = result_disposed.clone();
+                let fresh_seen = fresh_seen.clone();
                 let stale_seen = Arc::clone(&stale_seen);
                 move || {
                     (
                         generations.fetch_add(1, Ordering::SeqCst) + 1,
-                        Arc::clone(&thread_started),
+                        thread_started.clone(),
                         Arc::clone(&thread_release),
-                        Arc::clone(&thread_done),
+                        result_disposed.clone(),
+                        fresh_seen.clone(),
                         Arc::clone(&stale_seen),
                     )
                 }
@@ -276,22 +296,25 @@ async fn detached_run_blocking_completion_stays_with_its_old_incarnation() {
     let (released, changed) = &*thread_release;
     *released.lock().expect("release mutex poisoned") = true;
     changed.notify_one();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
-            thread_done.load(Ordering::SeqCst)
-        })
-        .await,
-        "detached old-incarnation thread completes"
-    );
-    assert_quiet(Duration::from_millis(20), || {
-        stale_seen.load(Ordering::SeqCst)
-    })
-    .await;
+    tokio::time::timeout(POLL_TIMEOUT, result_disposed.wait())
+        .await
+        .expect("the detached blocking result is disposed");
 
     actor
         .send(DetachedBlockingMessage::Fresh)
         .await
         .expect("replacement remains live");
+    tokio::time::timeout(POLL_TIMEOUT, fresh_seen.wait())
+        .await
+        .expect("replacement processes the synchronization message");
+    assert_quiet(Duration::from_millis(20), || {
+        stale_seen.load(Ordering::SeqCst)
+    })
+    .await;
+    actor
+        .send(DetachedBlockingMessage::Stop)
+        .await
+        .expect("replacement accepts the final stop");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert!(!stale_seen.load(Ordering::SeqCst));
 }

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -166,6 +166,29 @@ impl Drop for DetachedBlockingResult {
     }
 }
 
+#[derive(Default)]
+struct BlockingThreadRelease {
+    gate: Arc<(Mutex<bool>, Condvar)>,
+}
+
+impl BlockingThreadRelease {
+    fn gate(&self) -> Arc<(Mutex<bool>, Condvar)> {
+        Arc::clone(&self.gate)
+    }
+
+    fn release(&self) {
+        let (released, changed) = &*self.gate;
+        *released.lock().expect("release mutex poisoned") = true;
+        changed.notify_all();
+    }
+}
+
+impl Drop for BlockingThreadRelease {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
 struct DetachedBlockingActor {
     generation: usize,
     thread_started: ReleaseGate,
@@ -251,7 +274,9 @@ impl Actor for DetachedBlockingActor {
 async fn detached_run_blocking_completion_stays_with_its_old_incarnation() {
     let generations = Arc::new(AtomicUsize::new(0));
     let thread_started = ReleaseGate::default();
-    let thread_release = Arc::new((Mutex::new(false), Condvar::new()));
+    // A failed assertion must not leave Tokio's blocking pool stuck waiting
+    // while the test runtime tries to shut down.
+    let thread_release = BlockingThreadRelease::default();
     let result_disposed = ReleaseGate::default();
     let fresh_seen = ReleaseGate::default();
     let stale_seen = Arc::new(AtomicBool::new(false));
@@ -262,7 +287,7 @@ async fn detached_run_blocking_completion_stays_with_its_old_incarnation() {
             ActorDef::<DetachedBlockingActor>::factory({
                 let generations = Arc::clone(&generations);
                 let thread_started = thread_started.clone();
-                let thread_release = Arc::clone(&thread_release);
+                let thread_release = thread_release.gate();
                 let result_disposed = result_disposed.clone();
                 let fresh_seen = fresh_seen.clone();
                 let stale_seen = Arc::clone(&stale_seen);
@@ -293,9 +318,7 @@ async fn detached_run_blocking_completion_stays_with_its_old_incarnation() {
         "replacement starts while the old blocking thread remains detached"
     );
 
-    let (released, changed) = &*thread_release;
-    *released.lock().expect("release mutex poisoned") = true;
-    changed.notify_one();
+    thread_release.release();
     tokio::time::timeout(POLL_TIMEOUT, result_disposed.wait())
         .await
         .expect("the detached blocking result is disposed");

--- a/crates/shelterwood/tests/one_shot_resource_ownership.rs
+++ b/crates/shelterwood/tests/one_shot_resource_ownership.rs
@@ -1,4 +1,10 @@
-use std::time::Duration;
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use crate::common::{
     ConsumeCount, ConsumeGuard, POLL_TIMEOUT, ReleaseGate, policy::never, poll_once, poll_until,
@@ -383,6 +389,57 @@ fn one_shot_subtree_with_guard(count: &ConsumeCount, mode: &'static str) -> Tree
     tree
 }
 
+struct CancelledResourceActor {
+    _guard: ConsumeGuard,
+}
+
+impl Actor for CancelledResourceActor {
+    type Msg = ();
+    type Args = (ConsumeGuard, Arc<AtomicBool>);
+
+    async fn init(
+        (guard, started): Self::Args,
+        _: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        started.store(true, Ordering::SeqCst);
+        Ok(Self { _guard: guard })
+    }
+
+    async fn handle(&mut self, _: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+        std::future::pending().await
+    }
+}
+
+struct CancelledResourceRawActor {
+    _guard: ConsumeGuard,
+    started: Arc<AtomicBool>,
+}
+
+impl RawActor for CancelledResourceRawActor {
+    type Msg = ();
+
+    async fn run(&mut self, _: &mut RawContext<Self::Msg>) -> ExitResult {
+        self.started.store(true, Ordering::SeqCst);
+        std::future::pending().await
+    }
+}
+
+fn cancelled_one_shot_subtree(count: &ConsumeCount, started: Arc<AtomicBool>) -> Tree {
+    let guard = count.guard();
+    let mut tree = Tree::new();
+    let (_task, _completion) = tree
+        .add_task_once(
+            "resource",
+            TaskOnceDef::new(move |_| async move {
+                let _guard = guard;
+                started.store(true, Ordering::SeqCst);
+                std::future::pending::<Result<(), ExitError>>().await
+            }),
+        )
+        .expect("valid task");
+    tree
+}
+
 #[tokio::test]
 async fn cancelling_inflight_one_shot_adds_drops_every_kind_resource_once() {
     let system = DynamicTree::new().spawn().expect("runtime is available");
@@ -390,55 +447,73 @@ async fn cancelling_inflight_one_shot_adds_drops_every_kind_resource_once() {
     let scope = system.scope();
 
     let task_count = ConsumeCount::default();
+    let task_started = Arc::new(AtomicBool::new(false));
     let task_guard = task_count.guard();
     let mut task = Box::pin(scope.add_task_once(
         "task",
-        TaskOnceDef::new(move |_| async move {
-            let _guard = task_guard;
-            std::future::pending::<Result<(), ExitError>>().await
+        TaskOnceDef::new({
+            let task_started = Arc::clone(&task_started);
+            move |_| async move {
+                let _guard = task_guard;
+                task_started.store(true, Ordering::SeqCst);
+                std::future::pending::<Result<(), ExitError>>().await
+            }
         }),
     ));
     assert!(poll_once(task.as_mut()).is_pending());
     drop(task);
 
     let actor_count = ConsumeCount::default();
+    let actor_started = Arc::new(AtomicBool::new(false));
     let mut actor = Box::pin(scope.add_actor_once(
         "actor",
-        ActorOnceDef::<ResourceActor>::new(ResourceArgs {
-            guard: actor_count.guard(),
-            mode: ActorResourceMode::Normal,
-        }),
+        ActorOnceDef::<CancelledResourceActor>::new((
+            actor_count.guard(),
+            Arc::clone(&actor_started),
+        )),
     ));
     assert!(poll_once(actor.as_mut()).is_pending());
     drop(actor);
 
     let raw_count = ConsumeCount::default();
+    let raw_started = Arc::new(AtomicBool::new(false));
     let mut raw = Box::pin(scope.add_raw_once(
         "raw",
-        RawOnceDef::new(resource_raw_actor(&raw_count, RawResourceMode::Normal)),
+        RawOnceDef::new(CancelledResourceRawActor {
+            _guard: raw_count.guard(),
+            started: Arc::clone(&raw_started),
+        }),
     ));
     assert!(poll_once(raw.as_mut()).is_pending());
     drop(raw);
 
     let subtree_count = ConsumeCount::default();
+    let subtree_started = Arc::new(AtomicBool::new(false));
     let mut subtree = Box::pin(scope.add_subtree_once(
         "subtree",
-        SubtreeOnceDef::new(one_shot_subtree_with_guard(&subtree_count, "normal")),
+        SubtreeOnceDef::new(cancelled_one_shot_subtree(
+            &subtree_count,
+            Arc::clone(&subtree_started),
+        )),
     ));
     assert!(poll_once(subtree.as_mut()).is_pending());
     drop(subtree);
 
-    for (kind, count) in [
-        ("task", &task_count),
-        ("actor", &actor_count),
-        ("raw actor", &raw_count),
-        ("subtree", &subtree_count),
+    for (kind, count, started) in [
+        ("task", &task_count, &task_started),
+        ("actor", &actor_count, &actor_started),
+        ("raw actor", &raw_count, &raw_started),
+        ("subtree", &subtree_count, &subtree_started),
     ] {
         assert!(
             poll_until(POLL_TIMEOUT, Duration::from_millis(1), || count.get() == 1).await,
             "cancelled {kind} admission disposes its resource"
         );
         count.assert_once();
+        assert!(
+            !started.load(Ordering::SeqCst),
+            "cancelled {kind} admission never starts construction"
+        );
     }
 
     system
@@ -449,6 +524,10 @@ async fn cancelling_inflight_one_shot_adds_drops_every_kind_resource_once() {
     actor_count.assert_once();
     raw_count.assert_once();
     subtree_count.assert_once();
+    assert!(!task_started.load(Ordering::SeqCst));
+    assert!(!actor_started.load(Ordering::SeqCst));
+    assert!(!raw_started.load(Ordering::SeqCst));
+    assert!(!subtree_started.load(Ordering::SeqCst));
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/one_shot_resource_ownership.rs
+++ b/crates/shelterwood/tests/one_shot_resource_ownership.rs
@@ -1,9 +1,11 @@
 use std::time::Duration;
 
-use crate::common::{ConsumeCount, ConsumeGuard, ReleaseGate, policy::never};
+use crate::common::{
+    ConsumeCount, ConsumeGuard, POLL_TIMEOUT, ReleaseGate, policy::never, poll_once, poll_until,
+};
 use shelterwood::{
-    Actor, ActorOnceDef, Context, ExitError, ExitResult, RawActor, RawContext, RawOnceDef,
-    Readiness, ReadinessDeadline, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
+    Actor, ActorOnceDef, Context, DynamicTree, ExitError, ExitResult, RawActor, RawContext,
+    RawOnceDef, Readiness, ReadinessDeadline, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
 };
 
 #[derive(Clone, Copy)]
@@ -379,6 +381,74 @@ fn one_shot_subtree_with_guard(count: &ConsumeCount, mode: &'static str) -> Tree
         .add_task_once("resource", definition)
         .expect("valid task");
     tree
+}
+
+#[tokio::test]
+async fn cancelling_inflight_one_shot_adds_drops_every_kind_resource_once() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+
+    let task_count = ConsumeCount::default();
+    let task_guard = task_count.guard();
+    let mut task = Box::pin(scope.add_task_once(
+        "task",
+        TaskOnceDef::new(move |_| async move {
+            let _guard = task_guard;
+            std::future::pending::<Result<(), ExitError>>().await
+        }),
+    ));
+    assert!(poll_once(task.as_mut()).is_pending());
+    drop(task);
+
+    let actor_count = ConsumeCount::default();
+    let mut actor = Box::pin(scope.add_actor_once(
+        "actor",
+        ActorOnceDef::<ResourceActor>::new(ResourceArgs {
+            guard: actor_count.guard(),
+            mode: ActorResourceMode::Normal,
+        }),
+    ));
+    assert!(poll_once(actor.as_mut()).is_pending());
+    drop(actor);
+
+    let raw_count = ConsumeCount::default();
+    let mut raw = Box::pin(scope.add_raw_once(
+        "raw",
+        RawOnceDef::new(resource_raw_actor(&raw_count, RawResourceMode::Normal)),
+    ));
+    assert!(poll_once(raw.as_mut()).is_pending());
+    drop(raw);
+
+    let subtree_count = ConsumeCount::default();
+    let mut subtree = Box::pin(scope.add_subtree_once(
+        "subtree",
+        SubtreeOnceDef::new(one_shot_subtree_with_guard(&subtree_count, "normal")),
+    ));
+    assert!(poll_once(subtree.as_mut()).is_pending());
+    drop(subtree);
+
+    for (kind, count) in [
+        ("task", &task_count),
+        ("actor", &actor_count),
+        ("raw actor", &raw_count),
+        ("subtree", &subtree_count),
+    ] {
+        assert!(
+            poll_until(POLL_TIMEOUT, Duration::from_millis(1), || count.get() == 1).await,
+            "cancelled {kind} admission disposes its resource"
+        );
+        count.assert_once();
+    }
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("cancelled admissions leave no stragglers");
+    task_count.assert_once();
+    actor_count.assert_once();
+    raw_count.assert_once();
+    subtree_count.assert_once();
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/one_shot_resource_ownership.rs
+++ b/crates/shelterwood/tests/one_shot_resource_ownership.rs
@@ -449,6 +449,10 @@ async fn cancelling_inflight_one_shot_adds_drops_every_kind_resource_once() {
     let task_count = ConsumeCount::default();
     let task_started = Arc::new(AtomicBool::new(false));
     let task_guard = task_count.guard();
+    // The `!started` assertions below are deterministic only on the
+    // current_thread runtime: no await separates each enqueueing poll from its
+    // fused drop, so the driver cannot process the admission first (under
+    // multi_thread this would race).
     let mut task = Box::pin(scope.add_task_once(
         "task",
         TaskOnceDef::new({

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -256,16 +256,28 @@ async fn over_budget_restart_is_charged_but_never_spawned() {
                     snapshot.total_restarts, expected_total,
                     "the public scope counter advances with each scheduling event"
                 );
-                assert_eq!(
-                    snapshot
-                        .child("failing")
-                        .expect("the restartable child is retained")
-                        .restart_count,
-                    expected_count,
-                    "the membership counter includes the scheduling charge"
-                );
                 if scheduled < releases.len() {
+                    // The next incarnation is still gated, so the member is
+                    // guaranteed to remain resident while we inspect it.
+                    assert_eq!(
+                        snapshot
+                            .child("failing")
+                            .expect("the restartable child is retained")
+                            .restart_count,
+                        expected_count,
+                        "the membership counter includes the scheduling charge"
+                    );
                     releases[scheduled].release();
+                } else if let Some(child) = snapshot.child("failing") {
+                    // No gate holds the tripping charge: the driver drains and
+                    // tears the scope down without waiting for this subscriber,
+                    // so the member may already be pruned by the time event #3
+                    // is processed. Only pin its counter while it is resident;
+                    // `total_restarts` above stays authoritative either way.
+                    assert_eq!(
+                        child.restart_count, expected_count,
+                        "the membership counter includes the tripping charge"
+                    );
                 }
             }
             LifecycleEventKind::ScopeState {

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -141,24 +141,35 @@ async fn one_shot_subtree_lowering_failure_retains_structured_provenance() {
 #[tokio::test]
 async fn over_budget_restart_is_charged_but_never_spawned() {
     let starts = Arc::new(AtomicUsize::new(0));
+    let release_first = ReleaseGate::default();
     let mut root = Tree::new();
     root.intensity(Intensity::new(2, Duration::from_secs(10)).expect("valid intensity"));
     root.add_task(
         "failing",
         TaskDef::new({
             let starts = Arc::clone(&starts);
+            let release_first = release_first.clone();
             move |_| {
-                starts.fetch_add(1, Ordering::SeqCst);
-                async { Err(ExitError::message("retry")) }
+                let incarnation = starts.fetch_add(1, Ordering::SeqCst);
+                let release_first = release_first.clone();
+                async move {
+                    if incarnation == 0 {
+                        release_first.wait().await;
+                    }
+                    Err(ExitError::message("retry"))
+                }
             }
         }),
     )
     .expect("valid task");
     let system = root.spawn().expect("runtime is available");
+    let scope = system.scope();
+    let mut events = scope.subscribe_lifecycle();
     system
         .wait_started()
         .await
         .expect("immediate readiness starts root");
+    release_first.release();
     let reason = system.wait().await;
     let StopReason::IntensityTripped(trip) = reason else {
         panic!("expected intensity trip");
@@ -168,6 +179,39 @@ async fn over_budget_restart_is_charged_but_never_spawned() {
         starts.load(Ordering::SeqCst),
         3,
         "fourth spawn is suppressed"
+    );
+
+    assert_eq!(
+        scope.snapshot().total_restarts,
+        shelterwood::TotalRestarts::ZERO.bump().bump().bump(),
+        "the tripping scheduling charge advances the public scope counter"
+    );
+    let mut trace = Vec::new();
+    while let Some(item) = events.recv().await {
+        let LifecycleItem::Event(event) = item else {
+            panic!("the short restart trace cannot lag");
+        };
+        match event.kind {
+            LifecycleEventKind::Exited { .. } => trace.push("exited"),
+            LifecycleEventKind::RestartScheduled { .. } => trace.push("scheduled"),
+            LifecycleEventKind::ScopeState {
+                state: shelterwood::ScopeState::Draining,
+            } => trace.push("draining"),
+            _ => {}
+        }
+    }
+    assert_eq!(
+        trace,
+        [
+            "exited",
+            "scheduled",
+            "exited",
+            "scheduled",
+            "exited",
+            "scheduled",
+            "draining"
+        ],
+        "the tripping charge is emitted before the scope failure"
     );
 }
 

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -141,21 +141,26 @@ async fn one_shot_subtree_lowering_failure_retains_structured_provenance() {
 #[tokio::test]
 async fn over_budget_restart_is_charged_but_never_spawned() {
     let starts = Arc::new(AtomicUsize::new(0));
-    let release_first = ReleaseGate::default();
+    let releases = Arc::new([
+        ReleaseGate::default(),
+        ReleaseGate::default(),
+        ReleaseGate::default(),
+    ]);
     let mut root = Tree::new();
     root.intensity(Intensity::new(2, Duration::from_secs(10)).expect("valid intensity"));
     root.add_task(
         "failing",
         TaskDef::new({
             let starts = Arc::clone(&starts);
-            let release_first = release_first.clone();
+            let releases = Arc::clone(&releases);
             move |_| {
                 let incarnation = starts.fetch_add(1, Ordering::SeqCst);
-                let release_first = release_first.clone();
+                let release = releases
+                    .get(incarnation)
+                    .cloned()
+                    .expect("the over-budget restart is never spawned");
                 async move {
-                    if incarnation == 0 {
-                        release_first.wait().await;
-                    }
+                    release.wait().await;
                     Err(ExitError::message("retry"))
                 }
             }
@@ -169,7 +174,55 @@ async fn over_budget_restart_is_charged_but_never_spawned() {
         .wait_started()
         .await
         .expect("immediate readiness starts root");
-    release_first.release();
+    releases[0].release();
+    let mut trace = Vec::new();
+    let mut scheduled = 0usize;
+    loop {
+        let item = events
+            .recv()
+            .await
+            .expect("the lifecycle stream remains open through scope failure");
+        let LifecycleItem::Event(event) = item else {
+            panic!("the short restart trace cannot lag");
+        };
+        match event.kind {
+            LifecycleEventKind::Exited { .. } => trace.push("exited"),
+            LifecycleEventKind::RestartScheduled { attempt, .. } => {
+                scheduled += 1;
+                trace.push("scheduled");
+                let expected_attempt =
+                    (0..scheduled).fold(RestartAttempt::ZERO, |attempt, _| attempt.bump());
+                let expected_total =
+                    (0..scheduled).fold(shelterwood::TotalRestarts::ZERO, |total, _| total.bump());
+                let expected_count =
+                    (0..scheduled).fold(shelterwood::RestartCount::ZERO, |count, _| count.bump());
+                assert_eq!(attempt, expected_attempt);
+                let snapshot = scope.snapshot();
+                assert_eq!(
+                    snapshot.total_restarts, expected_total,
+                    "the public scope counter advances with each scheduling event"
+                );
+                assert_eq!(
+                    snapshot
+                        .child("failing")
+                        .expect("the restartable child is retained")
+                        .restart_count,
+                    expected_count,
+                    "the membership counter includes the scheduling charge"
+                );
+                if scheduled < releases.len() {
+                    releases[scheduled].release();
+                }
+            }
+            LifecycleEventKind::ScopeState {
+                state: shelterwood::ScopeState::Draining,
+            } => {
+                trace.push("draining");
+                break;
+            }
+            _ => {}
+        }
+    }
     let reason = system.wait().await;
     let StopReason::IntensityTripped(trip) = reason else {
         panic!("expected intensity trip");
@@ -180,26 +233,12 @@ async fn over_budget_restart_is_charged_but_never_spawned() {
         3,
         "fourth spawn is suppressed"
     );
-
+    assert_eq!(scheduled, 3);
     assert_eq!(
         scope.snapshot().total_restarts,
         shelterwood::TotalRestarts::ZERO.bump().bump().bump(),
-        "the tripping scheduling charge advances the public scope counter"
+        "the tripping scheduling charge remains visible after failure"
     );
-    let mut trace = Vec::new();
-    while let Some(item) = events.recv().await {
-        let LifecycleItem::Event(event) = item else {
-            panic!("the short restart trace cannot lag");
-        };
-        match event.kind {
-            LifecycleEventKind::Exited { .. } => trace.push("exited"),
-            LifecycleEventKind::RestartScheduled { .. } => trace.push("scheduled"),
-            LifecycleEventKind::ScopeState {
-                state: shelterwood::ScopeState::Draining,
-            } => trace.push("draining"),
-            _ => {}
-        }
-    }
     assert_eq!(
         trace,
         [

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -178,9 +178,9 @@ async fn over_budget_restart_is_charged_but_never_spawned() {
     let mut trace = Vec::new();
     let mut scheduled = 0usize;
     loop {
-        let item = events
-            .recv()
+        let item = tokio::time::timeout(POLL_TIMEOUT, events.recv())
             .await
+            .expect("the next lifecycle event arrives promptly")
             .expect("the lifecycle stream remains open through scope failure");
         let LifecycleItem::Event(event) = item else {
             panic!("the short restart trace cannot lag");

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -139,6 +139,60 @@ async fn one_shot_subtree_lowering_failure_retains_structured_provenance() {
 }
 
 #[tokio::test]
+async fn subtree_intensity_trip_retains_structured_provenance() {
+    // The nested scope's zero budget trips on the first failure, before its
+    // manually gated task ever becomes ready, so the parent deterministically
+    // observes the subtree child terminalize during startup.
+    let mut nested = Tree::new();
+    nested.intensity(Intensity::new(0, Duration::from_secs(10)).expect("valid intensity"));
+    nested
+        .add_task(
+            "failing",
+            TaskDef::new(|_| async { Err(ExitError::message("retry")) })
+                .readiness(Readiness::Manual)
+                .expect("manual readiness"),
+        )
+        .expect("valid task");
+    let mut root = Tree::new();
+    root.add_subtree_once("nested", SubtreeOnceDef::new(nested))
+        .expect("valid subtree edge");
+    let system = root.spawn().expect("runtime is available");
+    let StartupError::StartupFailed(failure) = system
+        .wait_started()
+        .await
+        .expect_err("nested budget trips during startup")
+    else {
+        panic!("expected structured startup failure");
+    };
+    let StartupFailureCause::Child { id, exit, .. } = failure.cause else {
+        panic!("root failure must name its nested child");
+    };
+    assert_eq!(id.as_str(), "nested");
+    let ExitKind::Failed(error) = exit.kind() else {
+        panic!("a tripped subtree is a child failure");
+    };
+    let trip = error
+        .intensity_trip()
+        .expect("framework provenance is retained");
+    assert_eq!(trip.max_restarts, 0);
+    assert_eq!(trip.observed_restarts, 1);
+    assert_eq!(trip.within, Duration::from_secs(10));
+    assert!(
+        error.startup_failure().is_none(),
+        "an intensity trip is not a startup failure"
+    );
+    assert_eq!(
+        error.as_error().to_string(),
+        error.to_string(),
+        "as_error exposes the same erased failure that Display renders"
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed root rolls back");
+}
+
+#[tokio::test]
 async fn over_budget_restart_is_charged_but_never_spawned() {
     let starts = Arc::new(AtomicUsize::new(0));
     let releases = Arc::new([


### PR DESCRIPTION
## Summary

- assert the intensity-tripping `RestartScheduled` edge precedes scope drain and advances `total_restarts`
- fence a detached `run_blocking` completion to its old incarnation across restart
- cancel in-flight one-shot admissions for task, actor, raw actor, and subtree forms and prove each resource is disposed exactly once

This closes the concrete §6 coverage gaps from #116 without changing production behavior.

## Validation

- `./tools/dev just ci` on the audited source branch (436 tests plus Clippy, docs, API/layering, packaging, and formatting)
- focused lifecycle, offload, and one-shot ownership regressions
