### PR TITLE
Unify raw event arbitration batches

### DIFF
--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -1854,11 +1854,6 @@ impl<M: Send + 'static> MailboxReceiver<M> {
             .receive(self.incarnation, ReceiveMode::IncludeFrozen, None)
     }
 
-    pub(crate) fn try_recv_live(&self) -> Option<M> {
-        self.mailbox
-            .receive(self.incarnation, ReceiveMode::LiveOnly, None)
-    }
-
     pub(crate) fn try_recv_live_through(&self, accepted_sequence: AcceptedSequence) -> Option<M> {
         self.mailbox.receive(
             self.incarnation,

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -251,8 +251,8 @@ impl PanicSlot {
 /// The queue is deliberately unbounded, but sustained traffic cannot grow it
 /// without bound. Every entry is produced by work this incarnation itself
 /// started — exactly one completion per offload, no external sender can
-/// reach it — and `next_ready` snapshots the queued completions at each
-/// mailbox delivery (timer batches snapshot likewise) and drains that prefix
+/// reach it — and `next_ready` snapshots the queued completions into each
+/// arbitration batch and drains that prefix
 /// ahead of later mailbox input, so the population stays bounded by the
 /// actor's own in-flight offload count plus the completions arriving within
 /// one such window. Bounded-mailbox policy governs external input only (SPEC §5.5:
@@ -261,9 +261,10 @@ impl PanicSlot {
 /// total-continuation contract promises to deliver. Freezing at stop clears
 /// the queue, and dropped `RawResources` clear it on every exit path.
 struct EventQueue<M> {
-    // Timer batches snapshot the number of currently queued events. Insertion
-    // and the snapshot share this lock, so FIFO order itself is the sequence
-    // and there is no integer counter whose saturation could blur a boundary.
+    // Arbitration batches snapshot the number of currently queued events.
+    // Insertion and the snapshot share this lock, so FIFO order itself is the
+    // sequence and there is no integer counter whose saturation could blur a
+    // boundary.
     queue: Mutex<VecDeque<QueuedEvent<M>>>,
     signal: Signal,
 }
@@ -312,6 +313,7 @@ impl<M> EventQueue<M> {
             .len()
     }
 
+    #[cfg(test)]
     fn pop(&self) -> Option<QueuedEvent<M>> {
         self.queue
             .lock()
@@ -537,13 +539,71 @@ impl<M> TimerStore<M> {
     }
 }
 
-struct FiredTimerBatch {
+struct ReadyBatch {
     armings: VecDeque<ArmingOrder>,
     continuations_remaining: usize,
     mailbox_through: AcceptedSequence,
+    // Steady state takes one mailbox delivery before its captured offload
+    // prefix. A timer promotion removes that budget and drains the entire
+    // pre-fire mailbox prefix before delivering the timer armings.
+    mailbox_remaining: Option<usize>,
     mailbox_complete: bool,
     offloads_remaining: usize,
     offloads_complete: bool,
+}
+
+impl ReadyBatch {
+    fn steady(
+        continuations_remaining: usize,
+        mailbox_through: AcceptedSequence,
+        offloads_remaining: usize,
+    ) -> Self {
+        Self {
+            armings: VecDeque::new(),
+            continuations_remaining,
+            mailbox_through,
+            mailbox_remaining: Some(1),
+            mailbox_complete: false,
+            offloads_remaining,
+            offloads_complete: false,
+        }
+    }
+
+    fn promote_to_fired(
+        &mut self,
+        armings: VecDeque<ArmingOrder>,
+        continuations_remaining: usize,
+        mailbox_through: AcceptedSequence,
+        offloads_remaining: usize,
+    ) {
+        debug_assert!(!armings.is_empty());
+        debug_assert!(self.mailbox_remaining.is_some());
+        self.armings = armings;
+        self.continuations_remaining = continuations_remaining;
+        self.mailbox_through = mailbox_through;
+        self.mailbox_remaining = None;
+        self.mailbox_complete = false;
+        self.offloads_remaining = offloads_remaining;
+        self.offloads_complete = false;
+    }
+
+    fn mailbox_budget_exhausted(&self) -> bool {
+        self.mailbox_remaining == Some(0)
+    }
+
+    fn is_fired(&self) -> bool {
+        self.mailbox_remaining.is_none()
+    }
+
+    fn record_mailbox_delivery(&mut self) {
+        if let Some(remaining) = &mut self.mailbox_remaining {
+            debug_assert!(*remaining > 0);
+            *remaining -= 1;
+            if *remaining == 0 {
+                self.mailbox_complete = true;
+            }
+        }
+    }
 }
 
 struct OffloadFutureState {
@@ -717,16 +777,9 @@ struct RawResources<M> {
     // mailbox/offload/timer item. `next_ready` uses it to prohibit two local
     // continuations from leading while an external source remains eligible.
     continuation_needs_external: bool,
-    // Queued offload completions granted the lead over the mailbox, captured
-    // as the event-queue watermark at the previous steady-state mailbox
-    // delivery. `next_ready` drains this many completion entries before
-    // consulting the mailbox again, so an always-readable mailbox cannot
-    // starve the completion queue, while completions pushed after the
-    // capture wait behind the next mailbox message and cannot starve it.
-    offloads_lead: usize,
     timers: TimerStore<M>,
     next_timer_order: ArmingOrder,
-    fired_batch: Option<FiredTimerBatch>,
+    ready_batch: Option<ReadyBatch>,
     events: Arc<EventQueue<M>>,
     panic: Arc<PanicSlot>,
     event_watcher: SignalWatcher,
@@ -741,10 +794,9 @@ impl<M> Default for RawResources<M> {
             accepting: true,
             continuations: VecDeque::new(),
             continuation_needs_external: false,
-            offloads_lead: 0,
             timers: TimerStore::default(),
             next_timer_order: ArmingOrder::ZERO,
-            fired_batch: None,
+            ready_batch: None,
             events,
             panic: Arc::new(PanicSlot::default()),
             event_watcher,
@@ -767,8 +819,7 @@ impl<M> RawResources<M> {
         }
         self.continuations.clear();
         self.timers.clear();
-        self.fired_batch = None;
-        self.offloads_lead = 0;
+        self.ready_batch = None;
         self.events.clear();
         dropped_continuations
     }
@@ -1243,25 +1294,22 @@ impl<M: Send + 'static> RawContext<M> {
 
     /// Selects one live-incarnation input without awaiting.
     ///
-    /// A due timer snapshots continuations, accepted live-mailbox messages,
-    /// queued offload completions, and timer armings before any timer message
-    /// is emitted. Stage priority is: at most one fairness continuation,
-    /// mailbox prefix, offload prefix, remaining snapshotted continuations,
-    /// then timer armings. Each external delivery permits one continuation to
-    /// lead the next call, so continuations can interleave with the mailbox and
-    /// offload stages without repeatedly cutting ahead of them. Once those
-    /// external prefixes are exhausted, the captured continuation remainder
-    /// drains before timers; arrivals after any watermark cannot jump the due
-    /// timers. This prevents both an always-readable mailbox and a self-feeding
-    /// continuation queue from starving the other.
+    /// Every selection runs through one bounded arbitration batch. Steady
+    /// state captures at most one mailbox delivery together with the queued
+    /// offload and continuation prefixes. If a timer is due, that same batch
+    /// is promoted by widening the mailbox cutoff to everything accepted at
+    /// the fire observation and refreshing the other source cutoffs.
     ///
-    /// Outside a timer batch, each mailbox delivery snapshots the queued
-    /// offload completions, and that prefix leads the mailbox on later
-    /// calls. An always-readable mailbox therefore cannot starve the
-    /// completion queue — the backlog never grows across mailbox deliveries
-    /// — while completions pushed after the snapshot wait behind the next
-    /// mailbox message, so a self-feeding offload chain cannot starve
-    /// external input either.
+    /// Stage priority is: at most one fairness continuation, mailbox prefix,
+    /// offload prefix, remaining snapshotted continuations, then timer
+    /// armings. Each external delivery permits one continuation to lead the
+    /// next call, so continuations can interleave with the mailbox and offload
+    /// stages without repeatedly cutting ahead of them. Once those external
+    /// prefixes are exhausted, the captured continuation remainder drains
+    /// before timers; arrivals after a fired batch's cutoffs cannot jump its
+    /// timers. The one-mailbox steady-state bound prevents an always-readable
+    /// mailbox from starving completions, while the completion cutoff prevents
+    /// a self-feeding offload chain from starving the mailbox.
     ///
     /// Frozen mailbox input is deliberately absent. Once stopping begins,
     /// [`try_recv`](Self::try_recv) bypasses this selector and drains the
@@ -1269,105 +1317,79 @@ impl<M: Send + 'static> RawContext<M> {
     fn next_ready(&mut self) -> Option<M> {
         loop {
             self.resources.resume_pending_panic();
-            self.begin_fired_batch();
-            if let Some(mut batch) = self.resources.fired_batch.take() {
-                if !self.resources.continuation_needs_external
-                    && batch.continuations_remaining > 0
-                    && let Some(message) = self.resources.continuations.pop_front()
-                {
-                    batch.continuations_remaining -= 1;
-                    self.resources.continuation_needs_external = true;
-                    self.resources.fired_batch = Some(batch);
-                    return Some(message);
-                }
-
-                if !batch.mailbox_complete {
-                    let message = self.receiver.try_recv_live_through(batch.mailbox_through);
-                    if let Some(message) = message {
-                        self.resources.continuation_needs_external = false;
-                        self.resources.fired_batch = Some(batch);
-                        return Some(message);
-                    }
-                    batch.mailbox_complete = true;
-                }
-
-                if !batch.offloads_complete {
-                    while let Some(event) = self
-                        .resources
-                        .events
-                        .pop_through(&mut batch.offloads_remaining)
-                    {
-                        if let Some(message) = Self::materialize_event(event) {
-                            self.resources.continuation_needs_external = false;
-                            self.resources.fired_batch = Some(batch);
-                            return Some(message);
-                        }
-                    }
-                    batch.offloads_complete = true;
-                }
-
-                if batch.continuations_remaining > 0
-                    && let Some(message) = self.resources.continuations.pop_front()
-                {
-                    batch.continuations_remaining -= 1;
-                    self.resources.continuation_needs_external = true;
-                    self.resources.fired_batch = Some(batch);
-                    return Some(message);
-                }
-                batch.continuations_remaining = 0;
-
-                while let Some(arming) = batch.armings.pop_front() {
-                    if let Some(message) = self.deliver_timer(arming) {
-                        self.resources.continuation_needs_external = false;
-                        self.resources.fired_batch = Some(batch);
-                        return Some(message);
-                    }
-                }
-                self.resources.fired_batch = None;
-                continue;
-            }
-
+            self.begin_ready_batch();
+            let mut batch = self
+                .resources
+                .ready_batch
+                .take()
+                .expect("ready selection always owns an arbitration batch");
             if !self.resources.continuation_needs_external
+                && batch.continuations_remaining > 0
                 && let Some(message) = self.resources.continuations.pop_front()
             {
+                batch.continuations_remaining -= 1;
                 self.resources.continuation_needs_external = true;
+                self.resources.ready_batch = Some(batch);
                 return Some(message);
             }
 
-            while self.resources.offloads_lead > 0 {
-                let Some(event) = self.resources.events.pop() else {
-                    self.resources.offloads_lead = 0;
-                    break;
-                };
-                self.resources.offloads_lead -= 1;
-                if let Some(message) = Self::materialize_event(event) {
+            if !batch.mailbox_complete {
+                let message = self.receiver.try_recv_live_through(batch.mailbox_through);
+                if let Some(message) = message {
+                    batch.record_mailbox_delivery();
                     self.resources.continuation_needs_external = false;
+                    self.resources.ready_batch = Some(batch);
+                    return Some(message);
+                }
+                batch.mailbox_complete = true;
+            }
+
+            if !batch.offloads_complete {
+                while let Some(event) = self
+                    .resources
+                    .events
+                    .pop_through(&mut batch.offloads_remaining)
+                {
+                    if let Some(message) = Self::materialize_event(event) {
+                        self.resources.continuation_needs_external = false;
+                        self.resources.ready_batch = Some(batch);
+                        return Some(message);
+                    }
+                }
+                batch.offloads_complete = true;
+            }
+
+            if batch.continuations_remaining > 0
+                && let Some(message) = self.resources.continuations.pop_front()
+            {
+                batch.continuations_remaining -= 1;
+                self.resources.continuation_needs_external = true;
+                self.resources.ready_batch = Some(batch);
+                return Some(message);
+            }
+            batch.continuations_remaining = 0;
+
+            while let Some(arming) = batch.armings.pop_front() {
+                if let Some(message) = self.deliver_timer(arming) {
+                    self.resources.continuation_needs_external = false;
+                    self.resources.ready_batch = Some(batch);
                     return Some(message);
                 }
             }
 
-            let mailbox = self.receiver.try_recv_live();
-            if let Some(message) = mailbox {
-                // Completions already queued at this delivery lead the
-                // mailbox on later calls, so the completion backlog cannot
-                // grow across mailbox deliveries, while completions pushed
-                // after this snapshot wait their turn and cannot starve the
-                // mailbox.
-                self.resources.offloads_lead = self.resources.events.watermark();
-                self.resources.continuation_needs_external = false;
-                return Some(message);
-            }
-
-            while let Some(event) = self.resources.events.pop() {
-                if let Some(message) = Self::materialize_event(event) {
-                    self.resources.continuation_needs_external = false;
-                    return Some(message);
-                }
-            }
-
-            if let Some(message) = self.resources.continuations.pop_front() {
-                self.resources.continuation_needs_external = true;
-                return Some(message);
+            let mailbox_may_remain = batch.mailbox_budget_exhausted();
+            let mailbox_cutoff = batch.mailbox_through;
+            self.resources.ready_batch = None;
+            let timer_is_due = self
+                .next_timer_deadline()
+                .is_some_and(|deadline| deadline <= runtime::now());
+            if mailbox_may_remain
+                || self.receiver.accepted_sequence() > mailbox_cutoff
+                || self.resources.events.watermark() > 0
+                || !self.resources.continuations.is_empty()
+                || timer_is_due
+            {
+                continue;
             }
             return None;
         }
@@ -1377,28 +1399,39 @@ impl<M: Send + 'static> RawContext<M> {
         (!event.cancellation.is_fired()).then(event.make_message)
     }
 
-    fn begin_fired_batch(&mut self) {
-        if self.resources.fired_batch.is_some() || self.resources.timers.is_empty() {
+    fn begin_ready_batch(&mut self) {
+        if self.resources.ready_batch.is_none() {
+            self.resources.ready_batch = Some(ReadyBatch::steady(
+                self.resources.continuations.len(),
+                self.receiver.accepted_sequence(),
+                self.resources.events.watermark(),
+            ));
+        }
+        if self
+            .resources
+            .ready_batch
+            .as_ref()
+            .is_some_and(ReadyBatch::is_fired)
+            || self.resources.timers.is_empty()
+        {
             return;
         }
+
         let now = runtime::now();
         let armings = self.resources.timers.take_due(now);
         if armings.is_empty() {
             return;
         }
-        // The batch snapshots its own offload prefix. A steady-state credit
-        // captured by an earlier mailbox delivery is superseded here; keeping
-        // it would let completions created during this batch jump mailbox
-        // input accepted after the batch snapshot.
-        self.resources.offloads_lead = 0;
-        self.resources.fired_batch = Some(FiredTimerBatch {
-            armings,
-            continuations_remaining: self.resources.continuations.len(),
-            mailbox_through: self.receiver.accepted_sequence(),
-            mailbox_complete: false,
-            offloads_remaining: self.resources.events.watermark(),
-            offloads_complete: false,
-        });
+        self.resources
+            .ready_batch
+            .as_mut()
+            .expect("steady batch was initialized")
+            .promote_to_fired(
+                armings,
+                self.resources.continuations.len(),
+                self.receiver.accepted_sequence(),
+                self.resources.events.watermark(),
+            );
     }
 
     fn deliver_timer(&mut self, arming: ArmingOrder) -> Option<M> {

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -251,15 +251,16 @@ impl PanicSlot {
 /// The queue is deliberately unbounded, but sustained traffic cannot grow it
 /// without bound. Every entry is produced by work this incarnation itself
 /// started — exactly one completion per offload, no external sender can
-/// reach it — and `next_ready` snapshots the queued completions into each
-/// arbitration batch and drains that prefix
-/// ahead of later mailbox input, so the population stays bounded by the
-/// actor's own in-flight offload count plus the completions arriving within
-/// one such window. Bounded-mailbox policy governs external input only (SPEC §5.5:
-/// offload completions do not consume mailbox capacity), and imposing a
-/// bound here would either block the offload task or drop a completion the
-/// total-continuation contract promises to deliver. Freezing at stop clears
-/// the queue, and dropped `RawResources` clear it on every exit path.
+/// reach it — and `next_ready` snapshots queued completions into bounded
+/// arbitration turns. A turn admits at most one mailbox delivery before its
+/// captured completion prefix, with continuation fairness interleaved, so the
+/// population stays bounded by the actor's own in-flight offload count plus
+/// the completions arriving within one such window. Bounded-mailbox policy
+/// governs external input only (SPEC §5.5: offload completions do not consume
+/// mailbox capacity), and imposing a bound here would either block the offload
+/// task or drop a completion the total-continuation contract promises to
+/// deliver. Freezing at stop clears the queue, and dropped `RawResources`
+/// clear it on every exit path.
 struct EventQueue<M> {
     // Arbitration batches snapshot the number of currently queued events.
     // Insertion and the snapshot share this lock, so FIFO order itself is the
@@ -541,6 +542,9 @@ impl<M> TimerStore<M> {
 
 struct ReadyBatch {
     armings: VecDeque<ArmingOrder>,
+    // Only fired batches constrain continuations to a captured prefix.
+    // Steady-state continuations stay live so one queued by an external
+    // handler retains `continue_with`'s next-message priority.
     continuations_remaining: usize,
     mailbox_through: AcceptedSequence,
     // Steady state takes one mailbox delivery before its captured offload
@@ -553,14 +557,10 @@ struct ReadyBatch {
 }
 
 impl ReadyBatch {
-    fn steady(
-        continuations_remaining: usize,
-        mailbox_through: AcceptedSequence,
-        offloads_remaining: usize,
-    ) -> Self {
+    fn steady(mailbox_through: AcceptedSequence, offloads_remaining: usize) -> Self {
         Self {
             armings: VecDeque::new(),
-            continuations_remaining,
+            continuations_remaining: 0,
             mailbox_through,
             mailbox_remaining: Some(1),
             mailbox_complete: false,
@@ -593,6 +593,17 @@ impl ReadyBatch {
 
     fn is_fired(&self) -> bool {
         self.mailbox_remaining.is_none()
+    }
+
+    fn continuation_is_eligible(&self) -> bool {
+        !self.is_fired() || self.continuations_remaining > 0
+    }
+
+    fn record_continuation_delivery(&mut self) {
+        if self.is_fired() {
+            debug_assert!(self.continuations_remaining > 0);
+            self.continuations_remaining -= 1;
+        }
     }
 
     fn record_mailbox_delivery(&mut self) {
@@ -1093,9 +1104,9 @@ impl<M: Send + 'static> RawContext<M> {
     /// Completions re-enter the loop through incarnation-internal storage
     /// that does not consume mailbox capacity (SPEC §5.5). That storage is
     /// unbounded but cannot accumulate a backlog: it holds at most one entry
-    /// per offload the actor itself started, and completions already queued
-    /// when a mailbox message is delivered are consumed ahead of later
-    /// mailbox input, so its population stays proportional to the caller's
+    /// per offload the actor itself started, and each bounded arbitration turn
+    /// admits at most one mailbox delivery before its captured completion
+    /// prefix. Its population therefore stays proportional to the caller's
     /// in-flight count even under sustained mailbox traffic. Bookkeeping for
     /// finished offloads is reclaimed when a new offload starts and when the
     /// loop goes idle.
@@ -1117,8 +1128,8 @@ impl<M: Send + 'static> RawContext<M> {
     /// Starts guarded incarnation-owned async work with one deadline budget.
     ///
     /// Completion storage follows [`offload`](Self::offload): unbounded, but
-    /// one entry per offload the actor itself started, drained ahead of
-    /// later mailbox input so no backlog accumulates.
+    /// one entry per offload the actor itself started and drained in bounded
+    /// arbitration turns alongside mailbox input so no backlog accumulates.
     pub fn offload_scoped<F, T, C>(
         &mut self,
         work: F,
@@ -1296,9 +1307,10 @@ impl<M: Send + 'static> RawContext<M> {
     ///
     /// Every selection runs through one bounded arbitration batch. Steady
     /// state captures at most one mailbox delivery together with the queued
-    /// offload and continuation prefixes. If a timer is due, that same batch
-    /// is promoted by widening the mailbox cutoff to everything accepted at
-    /// the fire observation and refreshing the other source cutoffs.
+    /// offload prefix, while continuations remain live across handler calls.
+    /// If a timer is due, that same batch is promoted by widening the mailbox
+    /// cutoff to everything accepted at the fire observation and capturing
+    /// the continuation and offload prefixes at that point.
     ///
     /// Stage priority is: at most one fairness continuation, mailbox prefix,
     /// offload prefix, remaining snapshotted continuations, then timer
@@ -1324,10 +1336,10 @@ impl<M: Send + 'static> RawContext<M> {
                 .take()
                 .expect("ready selection always owns an arbitration batch");
             if !self.resources.continuation_needs_external
-                && batch.continuations_remaining > 0
+                && batch.continuation_is_eligible()
                 && let Some(message) = self.resources.continuations.pop_front()
             {
-                batch.continuations_remaining -= 1;
+                batch.record_continuation_delivery();
                 self.resources.continuation_needs_external = true;
                 self.resources.ready_batch = Some(batch);
                 return Some(message);
@@ -1359,10 +1371,26 @@ impl<M: Send + 'static> RawContext<M> {
                 batch.offloads_complete = true;
             }
 
-            if batch.continuations_remaining > 0
+            // A steady batch may have exhausted its captured external turn
+            // while a continuation handler made later external work ready.
+            // Start a fresh bounded turn before allowing another continuation
+            // so that work receives §5.2's mandatory fairness opportunity.
+            // Fired batches deliberately retain their immutable cutoffs:
+            // post-fire arrivals must not jump the already-fired timers.
+            if !batch.is_fired()
+                && self.resources.continuation_needs_external
+                && (batch.mailbox_budget_exhausted()
+                    || self.receiver.accepted_sequence() > batch.mailbox_through
+                    || self.resources.events.watermark() > 0)
+            {
+                self.resources.ready_batch = None;
+                continue;
+            }
+
+            if batch.continuation_is_eligible()
                 && let Some(message) = self.resources.continuations.pop_front()
             {
-                batch.continuations_remaining -= 1;
+                batch.record_continuation_delivery();
                 self.resources.continuation_needs_external = true;
                 self.resources.ready_batch = Some(batch);
                 return Some(message);
@@ -1402,7 +1430,6 @@ impl<M: Send + 'static> RawContext<M> {
     fn begin_ready_batch(&mut self) {
         if self.resources.ready_batch.is_none() {
             self.resources.ready_batch = Some(ReadyBatch::steady(
-                self.resources.continuations.len(),
                 self.receiver.accepted_sequence(),
                 self.resources.events.watermark(),
             ));

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -1321,7 +1321,12 @@ impl<M: Send + 'static> RawContext<M> {
     /// before timers; arrivals after a fired batch's cutoffs cannot jump its
     /// timers. The one-mailbox steady-state bound prevents an always-readable
     /// mailbox from starving completions, while the completion cutoff prevents
-    /// a self-feeding offload chain from starving the mailbox.
+    /// a self-feeding offload chain from starving the mailbox. One steady-batch
+    /// consequence: a mailbox message arriving mid-drain waits behind the
+    /// batch's captured completion prefix (bounded by the in-flight offload
+    /// count) — a cross-source ordering the spec leaves unspecified (SPEC §5.2:
+    /// no global linearization point across source cutoffs), so tests must not
+    /// pin any particular interleaving.
     ///
     /// Frozen mailbox input is deliberately absent. Once stopping begins,
     /// [`try_recv`](Self::try_recv) bypasses this selector and drains the

--- a/crates/shelterwood/tests/events.rs
+++ b/crates/shelterwood/tests/events.rs
@@ -212,6 +212,169 @@ async fn due_timer_promotes_the_steady_batch_without_changing_source_priority() 
 }
 
 #[derive(Clone, Copy, Debug)]
+enum LiveContinuationMessage {
+    Start,
+    FirstOffload,
+    SecondOffload,
+    Continuation,
+}
+
+struct LiveContinuationActor {
+    handled: usize,
+    log: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl Actor for LiveContinuationActor {
+    type Msg = LiveContinuationMessage;
+    type Args = Arc<Mutex<Vec<&'static str>>>;
+
+    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self {
+            handled: 0,
+            log: args,
+        })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        let entry = match message {
+            LiveContinuationMessage::Start => {
+                context
+                    .offload(
+                        async {},
+                        |_| LiveContinuationMessage::FirstOffload,
+                        Duration::ZERO,
+                    )
+                    .expect("first completion accepted");
+                context
+                    .offload(
+                        async {},
+                        |_| LiveContinuationMessage::SecondOffload,
+                        Duration::ZERO,
+                    )
+                    .expect("second completion accepted");
+                "start"
+            }
+            LiveContinuationMessage::FirstOffload => {
+                context
+                    .continue_with(LiveContinuationMessage::Continuation)
+                    .expect("continuation accepted");
+                "offload-1"
+            }
+            LiveContinuationMessage::SecondOffload => "offload-2",
+            LiveContinuationMessage::Continuation => "continuation",
+        };
+        self.handled += 1;
+        if self.handled == 4 {
+            context.stop();
+        }
+        self.log.lock().expect("log mutex poisoned").push(entry);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn continuation_queued_by_external_handler_leads_remaining_steady_batch_work() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "live-continuation",
+            ActorOnceDef::<LiveContinuationActor>::new(Arc::clone(&log)),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    actor
+        .send(LiveContinuationMessage::Start)
+        .await
+        .expect("actor accepts start");
+
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert_eq!(
+        *log.lock().expect("log mutex poisoned"),
+        ["start", "offload-1", "continuation", "offload-2"]
+    );
+}
+
+#[derive(Clone, Copy, Debug)]
+enum MidContinuationExternalMessage {
+    Start,
+    FirstContinuation,
+    SecondContinuation,
+    External,
+}
+
+struct MidContinuationExternalActor {
+    handled: usize,
+    log: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl Actor for MidContinuationExternalActor {
+    type Msg = MidContinuationExternalMessage;
+    type Args = Arc<Mutex<Vec<&'static str>>>;
+
+    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self {
+            handled: 0,
+            log: args,
+        })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        let entry = match message {
+            MidContinuationExternalMessage::Start => {
+                context
+                    .continue_with(MidContinuationExternalMessage::FirstContinuation)
+                    .expect("first continuation accepted");
+                context
+                    .continue_with(MidContinuationExternalMessage::SecondContinuation)
+                    .expect("second continuation accepted");
+                "start"
+            }
+            MidContinuationExternalMessage::FirstContinuation => {
+                context
+                    .myself()
+                    .try_send(MidContinuationExternalMessage::External)
+                    .expect("external message accepted during continuation");
+                "continuation-1"
+            }
+            MidContinuationExternalMessage::SecondContinuation => "continuation-2",
+            MidContinuationExternalMessage::External => "external",
+        };
+        self.handled += 1;
+        if self.handled == 4 {
+            context.stop();
+        }
+        self.log.lock().expect("log mutex poisoned").push(entry);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn external_work_added_during_a_continuation_gets_the_fairness_turn() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "mid-continuation-external",
+            ActorOnceDef::<MidContinuationExternalActor>::new(Arc::clone(&log)),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    actor
+        .send(MidContinuationExternalMessage::Start)
+        .await
+        .expect("actor accepts start");
+
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert_eq!(
+        *log.lock().expect("log mutex poisoned"),
+        ["start", "continuation-1", "external", "continuation-2"]
+    );
+}
+
+#[derive(Clone, Copy, Debug)]
 enum NestedTimerMessage {
     Start,
     First,

--- a/crates/shelterwood/tests/events.rs
+++ b/crates/shelterwood/tests/events.rs
@@ -84,6 +84,210 @@ async fn continuations_are_fifo_and_yield_one_turn_to_ready_external_input() {
 }
 
 #[derive(Clone, Copy, Debug)]
+enum BatchMessage {
+    Start,
+    FirstContinuation,
+    SecondContinuation,
+    Mailbox,
+    Offload,
+    Timer,
+}
+
+struct BatchTraceActor {
+    fire_timer: bool,
+    log: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl Actor for BatchTraceActor {
+    type Msg = BatchMessage;
+    type Args = (ReleaseGate, bool, Arc<Mutex<Vec<&'static str>>>);
+
+    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        args.0.wait().await;
+        Ok(Self {
+            fire_timer: args.1,
+            log: args.2,
+        })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        let entry = match message {
+            BatchMessage::Start => {
+                context
+                    .continue_with(BatchMessage::FirstContinuation)
+                    .expect("first continuation accepted");
+                context
+                    .continue_with(BatchMessage::SecondContinuation)
+                    .expect("second continuation accepted");
+                context
+                    .offload(
+                        async {},
+                        |result| {
+                            assert!(result.is_err(), "zero-budget work reports its deadline");
+                            BatchMessage::Offload
+                        },
+                        Duration::ZERO,
+                    )
+                    .expect("offload accepted");
+                if self.fire_timer {
+                    context
+                        .set_timeout("batch", BatchMessage::Timer, Duration::ZERO)
+                        .expect("timer accepted");
+                }
+                "start"
+            }
+            BatchMessage::FirstContinuation => "continuation-1",
+            BatchMessage::SecondContinuation => "continuation-2",
+            BatchMessage::Mailbox => "mailbox",
+            BatchMessage::Offload => {
+                if !self.fire_timer {
+                    context.stop();
+                }
+                "offload"
+            }
+            BatchMessage::Timer => {
+                context.stop();
+                "timer"
+            }
+        };
+        self.log.lock().expect("log mutex poisoned").push(entry);
+        Ok(())
+    }
+}
+
+async fn assert_batch_trace(fire_timer: bool, expected: &[&str]) {
+    let gate = ReleaseGate::default();
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "batch-trace",
+            ActorOnceDef::<BatchTraceActor>::new((gate.clone(), fire_timer, Arc::clone(&log))),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    actor
+        .send(BatchMessage::Start)
+        .await
+        .expect("start accepted during init");
+    actor
+        .send(BatchMessage::Mailbox)
+        .await
+        .expect("mailbox message accepted during init");
+    gate.release();
+
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert_eq!(log.lock().expect("log mutex poisoned").as_slice(), expected);
+}
+
+#[tokio::test]
+async fn steady_state_uses_the_shared_bounded_batch_trace() {
+    assert_batch_trace(
+        false,
+        &[
+            "start",
+            "continuation-1",
+            "mailbox",
+            "continuation-2",
+            "offload",
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn due_timer_promotes_the_steady_batch_without_changing_source_priority() {
+    assert_batch_trace(
+        true,
+        &[
+            "start",
+            "continuation-1",
+            "mailbox",
+            "continuation-2",
+            "offload",
+            "timer",
+        ],
+    )
+    .await;
+}
+
+#[derive(Clone, Copy, Debug)]
+enum NestedTimerMessage {
+    Start,
+    First,
+    Second,
+    AddedDuringBatch,
+}
+
+struct NestedTimerActor {
+    log: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl Actor for NestedTimerActor {
+    type Msg = NestedTimerMessage;
+    type Args = Arc<Mutex<Vec<&'static str>>>;
+
+    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self { log: args })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        let entry = match message {
+            NestedTimerMessage::Start => {
+                context
+                    .set_timeout("first", NestedTimerMessage::First, Duration::ZERO)
+                    .expect("first timer accepted");
+                context
+                    .set_timeout("second", NestedTimerMessage::Second, Duration::ZERO)
+                    .expect("second timer accepted");
+                "start"
+            }
+            NestedTimerMessage::First => {
+                context
+                    .set_timeout(
+                        "added",
+                        NestedTimerMessage::AddedDuringBatch,
+                        Duration::ZERO,
+                    )
+                    .expect("later timer accepted");
+                "first"
+            }
+            NestedTimerMessage::Second => "second",
+            NestedTimerMessage::AddedDuringBatch => {
+                context.stop();
+                "added"
+            }
+        };
+        self.log.lock().expect("log mutex poisoned").push(entry);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn a_newly_due_timer_cannot_replace_remaining_fired_batch_armings() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "nested-timer",
+            ActorOnceDef::<NestedTimerActor>::new(Arc::clone(&log)),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    actor
+        .send(NestedTimerMessage::Start)
+        .await
+        .expect("actor accepts start");
+
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert_eq!(
+        *log.lock().expect("log mutex poisoned"),
+        ["start", "first", "second", "added"]
+    );
+}
+
+#[derive(Clone, Copy, Debug)]
 enum RetractionMessage {
     Arm,
     Cancel,

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -1483,9 +1483,10 @@ impl Actor for SaturatedActor {
 }
 
 /// A continuously nonempty mailbox cannot starve queued offload completions:
-/// the completions queued at each mailbox delivery are consumed ahead of
-/// later mailbox input, so the completion backlog stays proportional to the
-/// actor's own in-flight issuance instead of growing with mailbox history.
+/// every bounded arbitration turn admits at most one mailbox delivery before
+/// its captured completion prefix, so the completion backlog stays
+/// proportional to the actor's own in-flight issuance instead of growing with
+/// mailbox history.
 #[tokio::test]
 async fn saturated_mailbox_does_not_grow_the_completion_backlog() {
     let gate = ReleaseGate::default();
@@ -1510,8 +1511,8 @@ async fn saturated_mailbox_does_not_grow_the_completion_backlog() {
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert!(
         peak_backlog.load(Ordering::SeqCst) <= 2,
-        "queued completions drain ahead of later mailbox input instead of \
-         accumulating while the mailbox stays nonempty"
+        "bounded arbitration turns drain completions instead of accumulating \
+         them while the mailbox stays nonempty"
     );
 }
 


### PR DESCRIPTION
Part of #116; stacked on #119 because it replaces the fairness state touched by that fix.\n\nThis removes the parallel steady-state and fired-timer selectors. One ReadyBatch now owns both: steady state has a one-mailbox budget, a due timer promotes and refreshes the same batch cutoffs, and later due timers cannot overwrite already-fired armings. The duplicate offloads_lead state and try_recv_live path disappear.\n\nDeterministic traces cover steady priority, fired promotion, mid-batch timer arming, and #119's stale-credit regression on the combined branch.\n\nValidation: ./tools/dev just ci (435 tests plus all lint, docs, API/layering, packaging, and Nix checks).\n\nDraft until fresh adversarial review completes.