### PR TITLE
Remove dead internal bookkeeping

### DIFF
--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -201,15 +201,6 @@ impl FenceCounter {
             generation,
         })
     }
-
-    /// Mints a generation for a non-identity monotone sequence.
-    ///
-    /// Observation uses the same saturating, poison-never-minted primitive as
-    /// membership and incarnation fencing.
-    #[cfg(test)]
-    fn mint_sequence(&mut self) -> Option<u64> {
-        self.mint().map(|fence| fence.generation.get())
-    }
 }
 
 /// A membership and the generation counter that can mint only its incarnations.
@@ -478,7 +469,7 @@ mod tests {
         assert!(!second.supersedes(Generation::POISON));
 
         let mut sequence = FenceCounter::sequence();
-        assert_eq!(sequence.mint_sequence(), Some(1));
+        assert_eq!(sequence.mint().map(|fence| fence.generation.get()), Some(1));
     }
 
     struct MembershipFixture;

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -213,7 +213,6 @@ struct Deadlined<F> {
     timer: Option<crate::runtime::BoxedSleep>,
     started: bool,
     phase: DeadlinePhase,
-    done: bool,
 }
 
 impl<F> Deadlined<F> {
@@ -225,7 +224,6 @@ impl<F> Deadlined<F> {
             timer: None,
             started: false,
             phase: DeadlinePhase::BeforeExpiry,
-            done: false,
         }
     }
 }
@@ -248,7 +246,6 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
         // boundary below governs only non-zero budgets, and the two rules
         // therefore never compete.
         if this.duration.is_zero() {
-            this.done = true;
             return Poll::Ready(this.operation.short_circuit());
         }
         let budget = this
@@ -258,7 +255,6 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             this.operation
                 .poll_deadlined(context, budget, DeadlinePhase::BeforeExpiry)
         {
-            this.done = true;
             return Poll::Ready(result);
         }
         if this.phase == DeadlinePhase::BeforeExpiry {
@@ -278,11 +274,8 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             this.phase = DeadlinePhase::Elapsed;
             this.timer = None;
         }
-        let result = this
-            .operation
-            .poll_deadlined(context, budget, DeadlinePhase::Elapsed);
-        this.done = result.is_ready();
-        result
+        this.operation
+            .poll_deadlined(context, budget, DeadlinePhase::Elapsed)
     }
 }
 
@@ -410,7 +403,6 @@ impl<T> fmt::Debug for ReplyReceive<T> {
         formatter
             .debug_struct("ReplyReceive")
             .field("started", &self.deadlined.started)
-            .field("done", &self.deadlined.done)
             .finish_non_exhaustive()
     }
 }
@@ -1565,7 +1557,6 @@ impl<M> fmt::Debug for SendTimeout<M> {
         formatter
             .debug_struct("SendTimeout")
             .field("started", &self.deadlined.started)
-            .field("done", &self.deadlined.done)
             .finish_non_exhaustive()
     }
 }
@@ -1662,7 +1653,6 @@ impl<M, T> fmt::Debug for CallFuture<M, T> {
             .debug_struct("CallFuture")
             .field("started", &self.deadlined.started)
             .field("accepted", &self.deadlined.operation.accepted)
-            .field("done", &self.deadlined.done)
             .finish_non_exhaustive()
     }
 }

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -216,16 +216,12 @@ pub(crate) fn spawn_actor_work(future: impl Future<Output = ()> + Send + 'static
 }
 
 pub(crate) struct BlockingWork<T> {
-    handle: Option<JoinHandle<T>>,
+    handle: JoinHandle<T>,
 }
 
 impl<T: Send + 'static> BlockingWork<T> {
-    pub(crate) async fn join(mut self) -> T {
-        let handle = self
-            .handle
-            .take()
-            .expect("blocking operation was joined more than once");
-        join_resuming(handle).await
+    pub(crate) async fn join(self) -> T {
+        join_resuming(self.handle).await
     }
 }
 
@@ -233,7 +229,7 @@ pub(crate) fn spawn_blocking_work<T: Send + 'static>(
     operation: impl FnOnce() -> T + Send + 'static,
 ) -> BlockingWork<T> {
     BlockingWork {
-        handle: Some(spawn_blocking(operation)),
+        handle: spawn_blocking(operation),
     }
 }
 


### PR DESCRIPTION
Part of #116.\n\nThis removes three behavior-neutral internal leftovers: Deadlined's write-only done bit, BlockingWork's redundant Option around an owned JoinHandle, and the test-only FenceCounter mint_sequence wrapper with its inaccurate observation claim. Broader lookalikes that still encode distinct lifecycle boundaries or test observability were left intact.\n\nValidation: focused identity coverage and full ./tools/dev just ci (431 tests plus all lint, docs, API/layering, packaging, and Nix checks).\n\nDraft until fresh adversarial review completes.