### PR TITLE
Extract shared scope handles from tree

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1274,7 +1274,7 @@ fn dispatch_child_construction(
                         id,
                         incarnation,
                         member: Arc::clone(&child.slot.member),
-                        scope: crate::ScopeRef {
+                        scope: crate::scope::ScopeRef {
                             cell: Arc::clone(root),
                         },
                         shutdown: latches.shutdown.clone(),

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -19,6 +19,7 @@ mod plan;
 mod policy;
 mod raw;
 mod runtime;
+mod scope;
 mod task;
 mod tree;
 
@@ -49,11 +50,12 @@ pub use policy::{
 pub use raw::{
     Blocking, DeadlineElapsed, Guard, RawActor, RawContext, RawDef, RawOnceDef, Rejected,
 };
+pub use scope::{DynamicScopeRef, ScopeRef};
 pub use task::{OneShotTaskRef, TaskContext, TaskDef, TaskOnceDef, TaskRef};
 pub use tree::{
-    ActorSlot, Admission, AdmissionReceipt, BuildError, DynamicActorSlot, DynamicScopeRef,
-    DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, Removal, ScopeRef, StartOrShutdownError,
-    Subtree, SubtreeDef, SubtreeOnceDef, SubtreeSlot, System, TaskSlot, Tree,
+    ActorSlot, Admission, AdmissionReceipt, BuildError, DynamicActorSlot, DynamicSubtreeSlot,
+    DynamicTaskSlot, DynamicTree, Removal, StartOrShutdownError, Subtree, SubtreeDef,
+    SubtreeOnceDef, SubtreeSlot, System, TaskSlot, Tree,
 };
 
 // Keep the repository-facing examples in the same rustdoc compilation lane as

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -14,7 +14,7 @@ use std::{
 
 use crate::{
     ActorRef, ChildId, ExitResult, Incarnation, Mailbox, MailboxShutdown, PolicyError, Readiness,
-    ReadinessDeadline, RestartPolicy, Retention, ScopeRef, Shutdown,
+    ReadinessDeadline, RestartPolicy, Retention, Shutdown,
     cancellation::CancellationToken,
     cells::{MailboxControl, MemberCell},
     definition::DefinitionSource,
@@ -25,6 +25,7 @@ use crate::{
         UnwindPanics, catch_panic, discard_panic, keep_first_panic, resume_preferred_panic,
         resume_preferred_panic_outside_unwind,
     },
+    scope::ScopeRef,
 };
 
 type DeferredMessage<M> = Box<dyn FnOnce() -> M + Send + 'static>;

--- a/crates/shelterwood/src/scope.rs
+++ b/crates/shelterwood/src/scope.rs
@@ -1,0 +1,261 @@
+//! Ordered and dynamic scope handles.
+
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    sync::Arc,
+    time::Duration,
+};
+
+use crate::{
+    cells::{MemberStage, ScopeCell},
+    exit::StopReason,
+    identity::{ChildId, Membership},
+    observe::{ChildSnapshot, LifecycleEvents, ScopeSnapshot, SnapshotReceiver, WaitError},
+    policy::ScopeFlavor,
+};
+
+/// A cheap, membership-addressed ordered scope handle.
+#[derive(Clone)]
+pub struct ScopeRef {
+    pub(crate) cell: Arc<ScopeCell>,
+}
+
+impl ScopeRef {
+    /// Returns this scope's child id within its parent.
+    #[must_use]
+    pub fn id(&self) -> &ChildId {
+        self.cell.member.id()
+    }
+
+    /// Returns the scope membership identity.
+    #[must_use]
+    pub fn membership(&self) -> Membership {
+        self.cell.member.membership()
+    }
+
+    /// Computes an authoritative recursive snapshot on demand.
+    #[must_use]
+    pub fn snapshot(&self) -> Arc<ScopeSnapshot> {
+        self.cell.snapshot()
+    }
+
+    /// Subscribes to conflated recursive snapshots.
+    #[must_use]
+    pub fn subscribe_snapshots(&self) -> SnapshotReceiver {
+        self.cell.subscribe_snapshots()
+    }
+
+    /// Subscribes to this scope's lifecycle and all forwarded descendants.
+    #[must_use]
+    pub fn subscribe_lifecycle(&self) -> LifecycleEvents {
+        self.cell.subscribe_lifecycle()
+    }
+
+    /// Looks up a direct child in an authoritative current snapshot.
+    #[must_use]
+    pub fn child(&self, id: impl AsRef<str>) -> Option<ChildSnapshot> {
+        self.snapshot().child(id).cloned()
+    }
+
+    /// Traverses a child-id path in an authoritative current snapshot.
+    #[must_use]
+    pub fn descendant<I, S>(&self, path: I) -> Option<ChildSnapshot>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.snapshot().descendant(path).cloned()
+    }
+
+    /// Waits for a named child snapshot satisfying an at-or-past predicate.
+    ///
+    /// Snapshot watches conflate intermediate states, so `pred` should accept
+    /// every state at or beyond the desired edge and must remain cheap and
+    /// non-blocking.
+    pub async fn wait_for_child<P>(
+        &self,
+        id: impl Into<ChildId>,
+        mut pred: P,
+        timeout: Duration,
+    ) -> Result<ChildSnapshot, WaitError>
+    where
+        P: FnMut(&ChildSnapshot) -> bool + Send,
+    {
+        let id = id.into();
+        let expires = crate::deadline::Deadline::after(crate::runtime::now(), timeout);
+        let mut snapshots = self.subscribe_snapshots();
+
+        loop {
+            let snapshot = snapshots.borrow_latest();
+            if let Some(child) = snapshot.child(id.as_str())
+                && pred(child)
+            {
+                return Ok(child.clone());
+            }
+            // Inspect the current snapshot before rejecting even an already
+            // elapsed (including zero-duration) budget.
+            if expires.is_due(crate::runtime::now()) {
+                return Err(WaitError::TimedOut);
+            }
+            if matches!(self.cell.member.record().stage, MemberStage::Terminal(_)) {
+                return Err(WaitError::ScopeTerminated {
+                    state: snapshot.state.clone(),
+                });
+            }
+            match crate::runtime::select_two(snapshots.changed(), async {
+                match expires.instant() {
+                    Some(expires) => crate::runtime::sleep_until_std(expires).await,
+                    None => std::future::pending().await,
+                }
+            })
+            .await
+            {
+                crate::runtime::Either::Left(Ok(_)) => {}
+                crate::runtime::Either::Left(Err(_)) => {
+                    let snapshot = snapshots.borrow_latest();
+                    if let Some(child) = snapshot.child(id.as_str())
+                        && pred(child)
+                    {
+                        return Ok(child.clone());
+                    }
+                    return Err(WaitError::ScopeTerminated {
+                        state: snapshot.state.clone(),
+                    });
+                }
+                crate::runtime::Either::Right(()) => {
+                    let snapshot = snapshots.borrow_latest();
+                    if let Some(child) = snapshot.child(id.as_str())
+                        && pred(child)
+                    {
+                        return Ok(child.clone());
+                    }
+                    return Err(WaitError::TimedOut);
+                }
+            }
+        }
+    }
+
+    /// Requests shutdown without waiting.
+    pub fn request_shutdown(&self) {
+        let _ = self.cell.request_shutdown();
+    }
+
+    /// Waits for terminal membership state.
+    pub async fn wait_stopped(&self) -> StopReason {
+        self.cell.wait_stopped().await
+    }
+
+    /// Dynamically queries whether this scope has dynamic capabilities.
+    #[must_use]
+    pub fn dynamic(&self) -> Option<DynamicScopeRef> {
+        (self.cell.flavor == ScopeFlavor::Dynamic).then(|| DynamicScopeRef(self.clone()))
+    }
+}
+
+impl fmt::Debug for ScopeRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ScopeRef")
+            .field("membership", &self.membership())
+            .finish()
+    }
+}
+
+// Handle identity is the slot cell, not the membership token: lowering a
+// rebuilt nested declaration rebases the token behind live pre-spawn handles,
+// and a token-value hash would strand entries keyed before the rebase.
+impl PartialEq for ScopeRef {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.cell, &other.cell)
+    }
+}
+
+impl Eq for ScopeRef {}
+
+impl Hash for ScopeRef {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.cell).hash(state);
+    }
+}
+
+/// A cheap scope handle carrying dynamic-membership capability.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct DynamicScopeRef(pub(crate) ScopeRef);
+
+impl DynamicScopeRef {
+    /// Returns the underlying observation/control scope handle.
+    #[must_use]
+    pub fn as_scope(&self) -> &ScopeRef {
+        &self.0
+    }
+
+    /// Returns this scope's child id within its parent.
+    #[must_use]
+    pub fn id(&self) -> &ChildId {
+        self.0.id()
+    }
+
+    /// Returns the scope membership identity.
+    #[must_use]
+    pub fn membership(&self) -> Membership {
+        self.0.membership()
+    }
+
+    /// Computes an authoritative recursive snapshot on demand.
+    #[must_use]
+    pub fn snapshot(&self) -> Arc<ScopeSnapshot> {
+        self.0.snapshot()
+    }
+
+    /// Subscribes to conflated recursive snapshots.
+    #[must_use]
+    pub fn subscribe_snapshots(&self) -> SnapshotReceiver {
+        self.0.subscribe_snapshots()
+    }
+
+    /// Subscribes to this scope's lifecycle and all forwarded descendants.
+    #[must_use]
+    pub fn subscribe_lifecycle(&self) -> LifecycleEvents {
+        self.0.subscribe_lifecycle()
+    }
+
+    /// Looks up a direct child in an authoritative current snapshot.
+    #[must_use]
+    pub fn child(&self, id: impl AsRef<str>) -> Option<ChildSnapshot> {
+        self.0.child(id)
+    }
+
+    /// Traverses a child-id path in an authoritative current snapshot.
+    #[must_use]
+    pub fn descendant<I, S>(&self, path: I) -> Option<ChildSnapshot>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.0.descendant(path)
+    }
+
+    /// Waits for a named child snapshot satisfying an at-or-past predicate.
+    pub async fn wait_for_child<P>(
+        &self,
+        id: impl Into<ChildId>,
+        pred: P,
+        timeout: Duration,
+    ) -> Result<ChildSnapshot, WaitError>
+    where
+        P: FnMut(&ChildSnapshot) -> bool + Send,
+    {
+        self.0.wait_for_child(id, pred, timeout).await
+    }
+
+    /// Requests shutdown without waiting.
+    pub fn request_shutdown(&self) {
+        self.0.request_shutdown();
+    }
+
+    /// Waits for terminal membership state.
+    pub async fn wait_stopped(&self) -> StopReason {
+        self.0.wait_stopped().await
+    }
+}

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -1,9 +1,8 @@
-//! Tree declarations, scope handles, and the owning system façade.
+//! Tree declarations, dynamic construction handles, and the owning system façade.
 
 use std::{
     fmt,
     future::Future,
-    hash::{Hash, Hasher},
     marker::PhantomData,
     pin::Pin,
     sync::Arc,
@@ -12,11 +11,10 @@ use std::{
 };
 
 use crate::{
-    ActorDef, ActorOnceDef, ActorRef, ChildId, DefaultsInheritance, Intensity, LifecycleEvents,
-    Membership, ReadinessDeadline, RestartPolicy, Retention, ScopeDefaults, ScopeSnapshot,
-    Shutdown, ShutdownTimeout, SnapshotReceiver, Strategy, WaitError,
+    ActorDef, ActorOnceDef, ActorRef, ChildId, DefaultsInheritance, Intensity, Membership,
+    ReadinessDeadline, RestartPolicy, Retention, ScopeDefaults, Shutdown, ShutdownTimeout,
+    Strategy,
     admission::{RemoveOutcome, ReserveError},
-    cells::{MemberStage, ScopeCell},
     definition::DefinitionSource,
     driver::DynamicReservation,
     exit::{StartupError, StopReason},
@@ -25,6 +23,7 @@ use crate::{
     policy::{CommonOptions, InvalidPolicy, ResolvedDefaults, ScopeFlavor},
     raw::{RawDef, RawOnceDef},
     runtime::{self, Latch},
+    scope::{DynamicScopeRef, ScopeRef},
     task::{OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
 };
 
@@ -1190,276 +1189,14 @@ impl Subtree for Tree {}
 
 impl Subtree for DynamicTree {}
 
-#[cfg(test)]
-mod tests {
-    use super::{DynamicTree, Tree, sealed::Sealed};
-    use crate::identity::ScopeIdentity;
-
-    #[test]
-    fn subtree_conversion_moves_without_minting_a_phantom_scope() {
-        let tree = Tree::new();
-        let after_tree = ScopeIdentity::current_thread_creations();
-        let core = <Tree as Sealed>::into_core(tree);
-        assert_eq!(ScopeIdentity::current_thread_creations(), after_tree);
-        drop(core);
-
-        let tree = DynamicTree::new();
-        let after_tree = ScopeIdentity::current_thread_creations();
-        let core = <DynamicTree as Sealed>::into_core(tree);
-        assert_eq!(ScopeIdentity::current_thread_creations(), after_tree);
-        drop(core);
-    }
-}
-
-/// A cheap, membership-addressed ordered scope handle.
-#[derive(Clone)]
-pub struct ScopeRef {
-    pub(crate) cell: Arc<ScopeCell>,
-}
-
 impl ScopeRef {
-    /// Returns this scope's child id within its parent.
-    #[must_use]
-    pub fn id(&self) -> &ChildId {
-        self.cell.member.id()
-    }
-
-    /// Returns the scope membership identity.
-    #[must_use]
-    pub fn membership(&self) -> Membership {
-        self.cell.member.membership()
-    }
-
-    /// Computes an authoritative recursive snapshot on demand.
-    #[must_use]
-    pub fn snapshot(&self) -> Arc<ScopeSnapshot> {
-        self.cell.snapshot()
-    }
-
-    /// Subscribes to conflated recursive snapshots.
-    #[must_use]
-    pub fn subscribe_snapshots(&self) -> SnapshotReceiver {
-        self.cell.subscribe_snapshots()
-    }
-
-    /// Subscribes to this scope's lifecycle and all forwarded descendants.
-    #[must_use]
-    pub fn subscribe_lifecycle(&self) -> LifecycleEvents {
-        self.cell.subscribe_lifecycle()
-    }
-
-    /// Looks up a direct child in an authoritative current snapshot.
-    #[must_use]
-    pub fn child(&self, id: impl AsRef<str>) -> Option<crate::ChildSnapshot> {
-        self.snapshot().child(id).cloned()
-    }
-
-    /// Traverses a child-id path in an authoritative current snapshot.
-    #[must_use]
-    pub fn descendant<I, S>(&self, path: I) -> Option<crate::ChildSnapshot>
-    where
-        I: IntoIterator<Item = S>,
-        S: AsRef<str>,
-    {
-        self.snapshot().descendant(path).cloned()
-    }
-
-    /// Waits for a named child snapshot satisfying an at-or-past predicate.
-    ///
-    /// Snapshot watches conflate intermediate states, so `pred` should accept
-    /// every state at or beyond the desired edge and must remain cheap and
-    /// non-blocking.
-    pub async fn wait_for_child<P>(
-        &self,
-        id: impl Into<ChildId>,
-        mut pred: P,
-        timeout: Duration,
-    ) -> Result<crate::ChildSnapshot, WaitError>
-    where
-        P: FnMut(&crate::ChildSnapshot) -> bool + Send,
-    {
-        let id = id.into();
-        let expires = crate::deadline::Deadline::after(crate::runtime::now(), timeout);
-        let mut snapshots = self.subscribe_snapshots();
-
-        loop {
-            let snapshot = snapshots.borrow_latest();
-            if let Some(child) = snapshot.child(id.as_str())
-                && pred(child)
-            {
-                return Ok(child.clone());
-            }
-            // Inspect the current snapshot before rejecting even an already
-            // elapsed (including zero-duration) budget.
-            if expires.is_due(crate::runtime::now()) {
-                return Err(WaitError::TimedOut);
-            }
-            if matches!(self.cell.member.record().stage, MemberStage::Terminal(_)) {
-                return Err(WaitError::ScopeTerminated {
-                    state: snapshot.state.clone(),
-                });
-            }
-            match crate::runtime::select_two(snapshots.changed(), async {
-                match expires.instant() {
-                    Some(expires) => crate::runtime::sleep_until_std(expires).await,
-                    None => std::future::pending().await,
-                }
-            })
-            .await
-            {
-                crate::runtime::Either::Left(Ok(_)) => {}
-                crate::runtime::Either::Left(Err(_)) => {
-                    let snapshot = snapshots.borrow_latest();
-                    if let Some(child) = snapshot.child(id.as_str())
-                        && pred(child)
-                    {
-                        return Ok(child.clone());
-                    }
-                    return Err(WaitError::ScopeTerminated {
-                        state: snapshot.state.clone(),
-                    });
-                }
-                crate::runtime::Either::Right(()) => {
-                    let snapshot = snapshots.borrow_latest();
-                    if let Some(child) = snapshot.child(id.as_str())
-                        && pred(child)
-                    {
-                        return Ok(child.clone());
-                    }
-                    return Err(WaitError::TimedOut);
-                }
-            }
-        }
-    }
-
-    /// Requests shutdown without waiting.
-    pub fn request_shutdown(&self) {
-        let _ = self.cell.request_shutdown();
-    }
-
-    /// Waits for terminal membership state.
-    pub async fn wait_stopped(&self) -> StopReason {
-        self.cell.wait_stopped().await
-    }
-
     /// Requests shutdown and waits for this scope to stop.
     pub async fn shutdown_and_wait(&self, timeout: Duration) -> Result<(), ShutdownTimeout> {
         crate::driver::shutdown_scope(Arc::clone(&self.cell), timeout).await
     }
-
-    /// Dynamically queries whether this scope has dynamic capabilities.
-    #[must_use]
-    pub fn dynamic(&self) -> Option<DynamicScopeRef> {
-        (self.cell.flavor == ScopeFlavor::Dynamic).then(|| DynamicScopeRef(self.clone()))
-    }
 }
-
-impl fmt::Debug for ScopeRef {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("ScopeRef")
-            .field("membership", &self.membership())
-            .finish()
-    }
-}
-
-// Handle identity is the slot cell, not the membership token: lowering a
-// rebuilt nested declaration rebases the token behind live pre-spawn handles,
-// and a token-value hash would strand entries keyed before the rebase.
-impl PartialEq for ScopeRef {
-    fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.cell, &other.cell)
-    }
-}
-
-impl Eq for ScopeRef {}
-
-impl Hash for ScopeRef {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        Arc::as_ptr(&self.cell).hash(state);
-    }
-}
-
-/// A cheap scope handle carrying dynamic-membership capability.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct DynamicScopeRef(ScopeRef);
 
 impl DynamicScopeRef {
-    /// Returns the underlying observation/control scope handle.
-    #[must_use]
-    pub fn as_scope(&self) -> &ScopeRef {
-        &self.0
-    }
-
-    /// Returns this scope's child id within its parent.
-    #[must_use]
-    pub fn id(&self) -> &ChildId {
-        self.0.id()
-    }
-
-    /// Returns the scope membership identity.
-    #[must_use]
-    pub fn membership(&self) -> Membership {
-        self.0.membership()
-    }
-
-    /// Computes an authoritative recursive snapshot on demand.
-    #[must_use]
-    pub fn snapshot(&self) -> Arc<ScopeSnapshot> {
-        self.0.snapshot()
-    }
-
-    /// Subscribes to conflated recursive snapshots.
-    #[must_use]
-    pub fn subscribe_snapshots(&self) -> SnapshotReceiver {
-        self.0.subscribe_snapshots()
-    }
-
-    /// Subscribes to this scope's lifecycle and all forwarded descendants.
-    #[must_use]
-    pub fn subscribe_lifecycle(&self) -> LifecycleEvents {
-        self.0.subscribe_lifecycle()
-    }
-
-    /// Looks up a direct child in an authoritative current snapshot.
-    #[must_use]
-    pub fn child(&self, id: impl AsRef<str>) -> Option<crate::ChildSnapshot> {
-        self.0.child(id)
-    }
-
-    /// Traverses a child-id path in an authoritative current snapshot.
-    #[must_use]
-    pub fn descendant<I, S>(&self, path: I) -> Option<crate::ChildSnapshot>
-    where
-        I: IntoIterator<Item = S>,
-        S: AsRef<str>,
-    {
-        self.0.descendant(path)
-    }
-
-    /// Waits for a named child snapshot satisfying an at-or-past predicate.
-    pub async fn wait_for_child<P>(
-        &self,
-        id: impl Into<ChildId>,
-        pred: P,
-        timeout: Duration,
-    ) -> Result<crate::ChildSnapshot, WaitError>
-    where
-        P: FnMut(&crate::ChildSnapshot) -> bool + Send,
-    {
-        self.0.wait_for_child(id, pred, timeout).await
-    }
-
-    /// Requests shutdown without waiting.
-    pub fn request_shutdown(&self) {
-        self.0.request_shutdown();
-    }
-
-    /// Waits for terminal membership state.
-    pub async fn wait_stopped(&self) -> StopReason {
-        self.0.wait_stopped().await
-    }
-
     /// Requests shutdown and waits for this scope to stop.
     pub async fn shutdown_and_wait(&self, timeout: Duration) -> Result<(), ShutdownTimeout> {
         self.0.shutdown_and_wait(timeout).await
@@ -1718,5 +1455,26 @@ impl<R> Drop for System<R> {
         if self.armed {
             self.run.request_shutdown();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DynamicTree, Tree, sealed::Sealed};
+    use crate::identity::ScopeIdentity;
+
+    #[test]
+    fn subtree_conversion_moves_without_minting_a_phantom_scope() {
+        let tree = Tree::new();
+        let after_tree = ScopeIdentity::current_thread_creations();
+        let core = <Tree as Sealed>::into_core(tree);
+        assert_eq!(ScopeIdentity::current_thread_creations(), after_tree);
+        drop(core);
+
+        let tree = DynamicTree::new();
+        let after_tree = ScopeIdentity::current_thread_creations();
+        let core = <DynamicTree as Sealed>::into_core(tree);
+        assert_eq!(ScopeIdentity::current_thread_creations(), after_tree);
+        drop(core);
     }
 }

--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -83,6 +83,8 @@ expect_case layering-driver-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-cancellation-driver-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
+expect_case layering-scope-driver-below check-layering-paths.sh \
+  "upward driver or tree references found below the driver layer:"
 expect_case layering-tree-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-tree-in-driver check-layering-paths.sh \

--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -85,6 +85,12 @@ expect_case layering-cancellation-driver-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-scope-driver-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
+expect_case layering-scope-tree-alias-below check-layering-paths.sh \
+  "upward driver or tree references found below the driver layer:"
+expect_case layering-scope-tree-grouped-reexport-below check-layering-paths.sh \
+  "upward tree root re-exports found in the scope layer:"
+expect_case layering-scope-tree-root-reexport-below check-layering-paths.sh \
+  "upward tree root re-exports found in the scope layer:"
 expect_case layering-tree-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-tree-in-driver check-layering-paths.sh \

--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -87,6 +87,8 @@ expect_case layering-scope-driver-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-scope-tree-alias-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
+expect_case layering-scope-crate-root-alias-below check-layering-paths.sh \
+  "upward tree root re-exports found in the scope layer:"
 expect_case layering-scope-tree-grouped-reexport-below check-layering-paths.sh \
   "upward tree root re-exports found in the scope layer:"
 expect_case layering-scope-tree-root-reexport-below check-layering-paths.sh \

--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -89,6 +89,8 @@ expect_case layering-scope-tree-alias-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-scope-crate-root-alias-below check-layering-paths.sh \
   "upward tree root re-exports found in the scope layer:"
+expect_case layering-scope-crate-root-glob-below check-layering-paths.sh \
+  "glob imports of the crate root found in the scope layer:"
 expect_case layering-scope-tree-grouped-reexport-below check-layering-paths.sh \
   "upward tree root re-exports found in the scope layer:"
 expect_case layering-scope-tree-root-reexport-below check-layering-paths.sh \

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -25,7 +25,19 @@ readonly below_driver_layers=(
   crates/shelterwood/src/task.rs
 )
 readonly driver_path="crates/shelterwood/src/driver.rs"
+readonly scope_path="crates/shelterwood/src/scope.rs"
 readonly tree_path="crates/shelterwood/src/tree.rs"
+
+# A direct `tree::`/`driver::` reference is the usual spelling, while the
+# longer alternatives cover aliases imported from either the crate root or a
+# grouped root import. `--multiline` below lets the grouped form span the
+# rustfmt-normalized lines of a `use crate::{ ... };` statement.
+readonly upward_module_pattern='\b(driver|tree)::|\b(crate|super)::(driver|tree)\b|\b(crate|super)::\{[^;]*\b(driver|tree)\b[[:space:]]*(,|}|as\b)'
+
+# `lib.rs` re-exports these tree-layer types at the crate root. Naming one via
+# `crate::System`, for example, is still an upward dependency even though the
+# source contains no `tree::` token.
+readonly tree_root_export_pattern='ActorSlot|Admission|AdmissionReceipt|BuildError|DynamicActorSlot|DynamicSubtreeSlot|DynamicTaskSlot|DynamicTree|Removal|StartOrShutdownError|Subtree|SubtreeDef|SubtreeOnceDef|SubtreeSlot|System|TaskSlot|Tree'
 
 check_forbidden() {
   local message="$1"
@@ -35,7 +47,7 @@ check_forbidden() {
   local matches
   local status
   set +e
-  matches="$({ rg --line-number "$forbidden" "$@"; } 2>&1)"
+  matches="$({ rg --multiline --line-number "$forbidden" "$@"; } 2>&1)"
   status=$?
   set -e
 
@@ -55,8 +67,13 @@ check_forbidden() {
 
 check_forbidden \
   "upward driver or tree references found below the driver layer:" \
-  '\b(driver|tree)::' \
+  "$upward_module_pattern" \
   "${below_driver_layers[@]}"
+
+check_forbidden \
+  "upward tree root re-exports found in the scope layer:" \
+  "\\b(crate|super)::($tree_root_export_pattern)\\b|\\buse[[:space:]]+(crate|super)::\\{[^;]*\\b($tree_root_export_pattern)\\b" \
+  "$scope_path"
 
 check_forbidden \
   "upward tree references found in the driver layer:" \

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -65,6 +65,25 @@ check_forbidden() {
   esac
 }
 
+collect_scope_root_aliases() {
+  local pattern="$1"
+  local aliases
+  local status
+  set +e
+  aliases="$({ rg --multiline --no-filename --only-matching --replace '$2' "$pattern" "$scope_path"; } 2>&1)"
+  status=$?
+  set -e
+
+  case "$status" in
+    0) printf '%s\n' "$aliases" ;;
+    1) ;;
+    *)
+      echo "$aliases" >&2
+      exit "$status"
+      ;;
+  esac
+}
+
 check_forbidden \
   "upward driver or tree references found below the driver layer:" \
   "$upward_module_pattern" \
@@ -74,6 +93,21 @@ check_forbidden \
   "upward tree root re-exports found in the scope layer:" \
   "\\b(crate|super)::($tree_root_export_pattern)\\b|\\buse[[:space:]]+(crate|super)::\\{[^;]*\\b($tree_root_export_pattern)\\b" \
   "$scope_path"
+
+# A crate-root alias can hide both direct root exports and the module names
+# checked above. Extract direct and grouped `self` aliases, then scan uses of
+# each exact identifier so unrelated aliases remain permitted.
+scope_root_aliases="$(
+  collect_scope_root_aliases '\buse[[:space:]]+(crate|super)[[:space:]]+as[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*;'
+  collect_scope_root_aliases '\buse[[:space:]]+(crate|super)::\{[^;]*\bself[[:space:]]+as[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*(,|})'
+)"
+while IFS= read -r scope_root_alias; do
+  [[ -z "$scope_root_alias" ]] && continue
+  check_forbidden \
+    "upward tree root re-exports found in the scope layer:" \
+    "\\b${scope_root_alias}::($tree_root_export_pattern|driver|tree)\\b" \
+    "$scope_path"
+done <<< "$scope_root_aliases"
 
 check_forbidden \
   "upward tree references found in the driver layer:" \

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -94,6 +94,15 @@ check_forbidden \
   "\\b(crate|super)::($tree_root_export_pattern)\\b|\\buse[[:space:]]+(crate|super)::\\{[^;]*\\b($tree_root_export_pattern)\\b" \
   "$scope_path"
 
+# A glob import of the crate root pulls in every tree-layer re-export without
+# naming any of them, so neither pattern above can see it. The grouped
+# alternative covers a `*` anywhere inside a `use (crate|super)::{ ... };`
+# tree, which `--multiline` lets span rustfmt-normalized lines.
+check_forbidden \
+  "glob imports of the crate root found in the scope layer:" \
+  '\buse[[:space:]]+(crate|super)::(\*|\{[^;]*\*)' \
+  "$scope_path"
+
 # A crate-root alias can hide both direct root exports and the module names
 # checked above. Extract direct and grouped `self` aliases, then scan uses of
 # each exact identifier so unrelated aliases remain permitted.

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -21,6 +21,7 @@ readonly below_driver_layers=(
   crates/shelterwood/src/policy.rs
   crates/shelterwood/src/raw.rs
   crates/shelterwood/src/runtime.rs
+  crates/shelterwood/src/scope.rs
   crates/shelterwood/src/task.rs
 )
 readonly driver_path="crates/shelterwood/src/driver.rs"

--- a/tools/enforcement-fixtures/overlays/layering-scope-crate-root-alias-below/crates/shelterwood/src/scope.rs
+++ b/tools/enforcement-fixtures/overlays/layering-scope-crate-root-alias-below/crates/shelterwood/src/scope.rs
@@ -1,0 +1,7 @@
+// Known-bad fixture: aliasing the crate root must not hide an upward
+// dependency from the shared scope-handle layer.
+use crate as root;
+
+fn retain_system(system: root::System) {
+    drop(system);
+}

--- a/tools/enforcement-fixtures/overlays/layering-scope-crate-root-glob-below/crates/shelterwood/src/scope.rs
+++ b/tools/enforcement-fixtures/overlays/layering-scope-crate-root-glob-below/crates/shelterwood/src/scope.rs
@@ -1,0 +1,7 @@
+// Known-bad fixture: a glob import of the crate root pulls every tree-layer
+// re-export into the shared scope-handle layer without naming any of them.
+use crate::*;
+
+fn retain_system(system: System) {
+    drop(system);
+}

--- a/tools/enforcement-fixtures/overlays/layering-scope-driver-below/crates/shelterwood/src/scope.rs
+++ b/tools/enforcement-fixtures/overlays/layering-scope-driver-below/crates/shelterwood/src/scope.rs
@@ -1,0 +1,3 @@
+// Known-bad fixture: the shared scope-handle layer must not reference the
+// driver layer.
+use crate::driver::SystemRun;

--- a/tools/enforcement-fixtures/overlays/layering-scope-tree-alias-below/crates/shelterwood/src/scope.rs
+++ b/tools/enforcement-fixtures/overlays/layering-scope-tree-alias-below/crates/shelterwood/src/scope.rs
@@ -1,0 +1,7 @@
+// Known-bad fixture: aliasing the tree module must not hide an upward
+// dependency from the shared scope-handle layer.
+use crate::tree as upper;
+
+fn retain_system(system: upper::System) {
+    drop(system);
+}

--- a/tools/enforcement-fixtures/overlays/layering-scope-tree-grouped-reexport-below/crates/shelterwood/src/scope.rs
+++ b/tools/enforcement-fixtures/overlays/layering-scope-tree-grouped-reexport-below/crates/shelterwood/src/scope.rs
@@ -1,0 +1,7 @@
+// Known-bad fixture: grouped imports through the parent crate cannot hide a
+// tree-layer root re-export from the scope-layer check.
+use super::{System as RootSystem};
+
+fn retain_system(system: RootSystem) {
+    drop(system);
+}

--- a/tools/enforcement-fixtures/overlays/layering-scope-tree-root-reexport-below/crates/shelterwood/src/scope.rs
+++ b/tools/enforcement-fixtures/overlays/layering-scope-tree-root-reexport-below/crates/shelterwood/src/scope.rs
@@ -1,0 +1,3 @@
+// Known-bad fixture: a tree type re-exported at the crate root remains an
+// upward dependency from the shared scope-handle layer.
+use crate::System;

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/scope.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/scope.rs
@@ -1,4 +1,7 @@
 // Known-good fixture for the scope-handle layer: near misses must not match
 // the word-bounded upward-layering pattern.
+use crate::treehouse as lower;
+use crate::{Systematic, Treehouse};
+
 const DRIVERISH: &str = "driver";
 const TREEHOUSE: &str = "tree";

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/scope.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/scope.rs
@@ -1,0 +1,4 @@
+// Known-good fixture for the scope-handle layer: near misses must not match
+// the word-bounded upward-layering pattern.
+const DRIVERISH: &str = "driver";
+const TREEHOUSE: &str = "tree";


### PR DESCRIPTION
Part of #116.\n\nThis cuts the direct raw/tree module cycle by moving ScopeRef, DynamicScopeRef, identity behavior, observation APIs, and lower-layer controls into a focused scope module. Driver-dependent shutdown and dynamic construction/removal extensions remain in tree so the new layer does not point upward. Public root exports and method signatures are unchanged.\n\nLayering enforcement now covers scope.rs and includes a known-bad upward-dependency fixture.\n\nValidation: ./tools/dev just ci (431 tests plus doctests, rustdoc, API reachability, packaging, and enforcement checks).\n\nDraft until fresh adversarial review completes.