### PR TITLE
Consolidate stopped scope publication

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -996,7 +996,7 @@ impl ScopeCell {
             if record.last_incarnation.is_none()
                 && let Some(scope) = &nested
             {
-                scope.publish_never_started_locked(wakes);
+                scope.publish_stopped_locked(wakes, StopReason::NeverStarted, None, None);
             }
             if let Some(incarnation) = exited_incarnation {
                 self.emit_locked(
@@ -1298,27 +1298,8 @@ impl ScopeCell {
             if control.force.is_some_and(|request| request.epoch <= epoch) {
                 control.force = None;
             }
-            let state = ScopeState::Stopped {
-                reason: reason.clone(),
-            };
-            self.record.modify_silently(|record| {
-                if record.startup.is_none() {
-                    record.startup = Some(Err(StartupError::ShutdownRequested));
-                }
-                record.state = state.clone();
-            });
             let terminal = terminal_exit.is_some();
-            if let Some(exit) = terminal_exit {
-                self.member.terminalize_locked(exit, wakes);
-            }
-            // Keep epoch ownership through the final record mutation so a
-            // newer begin cannot race an old driver into publishing Stopped.
-            drop(control);
-            wakes.pulse(&self.member.record);
-            // `wait_started` must not observe terminal startup until the member
-            // and incarnation-control planes are mutually consistent.
-            wakes.pulse(&self.record);
-            self.emit_locked(wakes, LifecycleEventKind::ScopeState { state });
+            self.publish_stopped_locked(wakes, reason, terminal_exit, Some(control));
             if terminal {
                 self.close_observation_locked(wakes);
             }
@@ -1334,17 +1315,7 @@ impl ScopeCell {
             self.finish_root_incarnation(epoch, reason, exit);
         } else {
             self.with_observation_gate(|wakes| {
-                let state = ScopeState::Stopped { reason };
-                self.record.modify_silently(|record| {
-                    if record.startup.is_none() {
-                        record.startup = Some(Err(StartupError::ShutdownRequested));
-                    }
-                    record.state = state.clone();
-                });
-                self.member.terminalize_locked(exit, wakes);
-                wakes.pulse(&self.member.record);
-                wakes.pulse(&self.record);
-                self.emit_locked(wakes, LifecycleEventKind::ScopeState { state });
+                self.publish_stopped_locked(wakes, reason, Some(exit), None);
                 self.close_observation_locked(wakes);
             });
         }
@@ -1522,25 +1493,40 @@ impl ScopeCell {
         }
     }
 
-    fn publish_never_started_locked(&self, wakes: &mut ObservationWakes) {
+    /// Commits one stopped-scope projection and its optional member terminal
+    /// edge under the resident-tree observation gate.
+    ///
+    /// Member terminalization prepares mailbox teardown first; its deferred
+    /// discharge is therefore queued before either member or scope pulses.
+    /// `epoch_owner` carries a live incarnation's control ownership through
+    /// both retained record mutations and is released before snapshot and
+    /// lifecycle publication, preserving the stop transition's ownership
+    /// boundary. Observation closure remains a caller decision because a
+    /// nested scope's final event must precede its parent's terminal event and
+    /// only then close the nested streams.
+    fn publish_stopped_locked(
+        &self,
+        wakes: &mut ObservationWakes,
+        reason: StopReason,
+        terminal_exit: Option<Exit>,
+        epoch_owner: Option<MutexGuard<'_, ScopeControl>>,
+    ) {
+        let state = ScopeState::Stopped { reason };
         self.record.modify_silently(|record| {
             if record.startup.is_none() {
                 record.startup = Some(Err(StartupError::ShutdownRequested));
             }
-            record.state = ScopeState::Stopped {
-                reason: StopReason::NeverStarted,
-            };
+            record.state = state.clone();
         });
+        if let Some(exit) = terminal_exit {
+            self.member.terminalize_locked(exit, wakes);
+        }
+        drop(epoch_owner);
         wakes.pulse(&self.member.record);
+        // `wait_started` must not observe terminal startup until the member
+        // and incarnation-control planes are mutually consistent.
         wakes.pulse(&self.record);
-        self.emit_locked(
-            wakes,
-            LifecycleEventKind::ScopeState {
-                state: ScopeState::Stopped {
-                    reason: StopReason::NeverStarted,
-                },
-            },
-        );
+        self.emit_locked(wakes, LifecycleEventKind::ScopeState { state });
     }
 
     pub(crate) fn terminalize_never_started(&self) {
@@ -1549,7 +1535,7 @@ impl ScopeCell {
                 return;
             }
             self.member.terminalize_locked(Exit::never_started(), wakes);
-            self.publish_never_started_locked(wakes);
+            self.publish_stopped_locked(wakes, StopReason::NeverStarted, None, None);
             self.close_observation_locked(wakes);
         });
     }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -4368,6 +4368,74 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Copy, Debug)]
+    enum TerminalStopPath {
+        LiveEpoch,
+        NoLiveEpoch,
+        NeverStarted,
+    }
+
+    #[crate::runtime::test]
+    async fn terminal_stop_paths_share_one_complete_observation_transition() {
+        for (path, reason) in [
+            (TerminalStopPath::LiveEpoch, StopReason::ShutdownRequested),
+            (TerminalStopPath::NoLiveEpoch, StopReason::ShutdownRequested),
+            (TerminalStopPath::NeverStarted, StopReason::NeverStarted),
+        ] {
+            let scope = isolated_scope("root", ScopeFlavor::Ordered);
+            let epoch = matches!(path, TerminalStopPath::LiveEpoch).then(|| {
+                scope
+                    .begin_incarnation()
+                    .expect("test scope epoch is available")
+            });
+            let handle = ScopeRef {
+                cell: Arc::clone(&scope),
+            };
+            let mut snapshots = handle.subscribe_snapshots();
+            let mut events = handle.subscribe_lifecycle();
+
+            match path {
+                TerminalStopPath::LiveEpoch => scope.finish_root_incarnation(
+                    epoch.expect("live path owns an epoch"),
+                    reason.clone(),
+                    Exit::never_started(),
+                ),
+                TerminalStopPath::NoLiveEpoch => {
+                    scope.finish_live_root_incarnation(reason.clone(), Exit::never_started())
+                }
+                TerminalStopPath::NeverStarted => scope.terminalize_never_started(),
+            }
+
+            let expected_state = ScopeState::Stopped {
+                reason: reason.clone(),
+            };
+            assert!(matches!(
+                scope.member.record().stage,
+                MemberStage::Terminal(_)
+            ));
+            assert_eq!(scope.record().state, expected_state);
+            assert_eq!(
+                epoch.map(|epoch| scope.incarnation_finished(epoch)),
+                epoch.map(|_| true)
+            );
+            assert_eq!(snapshots.borrow_latest().state, expected_state);
+            assert!(matches!(
+                events.try_recv(),
+                Ok(LifecycleItem::Event(crate::LifecycleEvent {
+                    kind: LifecycleEventKind::ScopeState { state },
+                    ..
+                })) if state == expected_state
+            ));
+            assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Closed));
+
+            snapshots
+                .changed()
+                .await
+                .expect("the final snapshot precedes observation closure");
+            assert!(snapshots.changed().await.is_err());
+        }
+    }
+
     impl Wake for ObserveScopeOnStartupWake {
         fn wake(self: Arc<Self>) {
             self.observe();
@@ -4376,6 +4444,88 @@ mod tests {
         fn wake_by_ref(self: &Arc<Self>) {
             self.observe();
         }
+    }
+
+    #[test]
+    fn stopped_publication_keeps_mailbox_panic_primary_and_finishes_observation() {
+        let scope = isolated_scope("root", ScopeFlavor::Ordered);
+        let epoch = scope
+            .begin_incarnation()
+            .expect("test scope epoch is available");
+        let handle = ScopeRef {
+            cell: Arc::clone(&scope),
+        };
+        let mut events = handle.subscribe_lifecycle();
+        let mailbox = MailboxCell::new(scope.member.id().clone());
+        let actor: ActorRef<u8> = ActorRef::new(Arc::clone(&scope.member), Arc::clone(&mailbox));
+        scope.member.attach_mailbox(mailbox);
+
+        let mailbox_payload_dropped = Arc::new(AtomicUsize::new(0));
+        let mailbox_waker = Waker::from(Arc::new(CountedPanicWake(Arc::clone(
+            &mailbox_payload_dropped,
+        ))));
+        let mut parked_send = Box::pin(actor.send(1));
+        assert!(
+            parked_send
+                .as_mut()
+                .poll(&mut Context::from_waker(&mailbox_waker))
+                .is_pending()
+        );
+
+        let terminal_payload_dropped = Arc::new(AtomicUsize::new(0));
+        let terminal_waker = Waker::from(Arc::new(CountedPanicWake(Arc::clone(
+            &terminal_payload_dropped,
+        ))));
+        let mut terminal = Box::pin(scope.member.wait_terminal());
+        assert!(
+            terminal
+                .as_mut()
+                .poll(&mut Context::from_waker(&terminal_waker))
+                .is_pending()
+        );
+
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            scope.finish_root_incarnation(
+                epoch,
+                StopReason::ShutdownRequested,
+                Exit::never_started(),
+            );
+        }))
+        .expect_err("the primary mailbox panic still surfaces");
+        assert_eq!(
+            mailbox_payload_dropped.load(Ordering::SeqCst),
+            0,
+            "the mailbox panic payload remains owned by the caller"
+        );
+        assert!(
+            terminal_payload_dropped.load(Ordering::SeqCst) > 0,
+            "later member-pulse panics are contained as cleanup"
+        );
+        assert!(matches!(
+            scope.record().state,
+            ScopeState::Stopped {
+                reason: StopReason::ShutdownRequested
+            }
+        ));
+        assert!(scope.incarnation_finished(epoch));
+        assert!(matches!(
+            events.try_recv(),
+            Ok(LifecycleItem::Event(crate::LifecycleEvent {
+                kind: LifecycleEventKind::ScopeState {
+                    state: ScopeState::Stopped {
+                        reason: StopReason::ShutdownRequested
+                    }
+                },
+                ..
+            }))
+        ));
+        assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Closed));
+        assert!(matches!(
+            scope.member.record().stage,
+            MemberStage::Terminal(ref exit) if matches!(exit.kind(), ExitKind::NeverStarted)
+        ));
+        drop(payload);
+        assert_eq!(mailbox_payload_dropped.load(Ordering::SeqCst), 1);
     }
 
     #[test]


### PR DESCRIPTION
Part of #116; stacked on #129 so the helper preserves its reviewed no-wake-under-gate and #121 terminal ordering guarantees.\n\nThis introduces one ScopeCell::publish_stopped_locked transition for live-epoch stops, no-live root terminal stops, and never-started nested/root publication. It carries epoch ownership through retained mutations, queues mailbox teardown before terminal pulses, releases control before snapshot/lifecycle emission, and leaves observation closure at callers where parent/nested ordering differs.\n\nupdate_locked remains because its deferred-pulse semantics are not equivalent to immediate update. Tests cover all three paths plus hostile mailbox/member waker precedence.\n\nValidation: ./tools/dev just ci (441 tests plus all other lanes).\n\nDraft until fresh adversarial review completes.