### PR TITLE
Fail closed on lost removal responses

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3376,7 +3376,7 @@ path. If that invariant regresses, release builds nevertheless fail
 closed: admission observes `NotAdmitting(Terminal)` and a latched removal
 observes `Removed`, since its route becoming terminal satisfies the
 removal goal. Debug builds MAY instead assert and panic at that boundary
-to expose the internal regression before returning an outcome. The public
+to expose the internal regression instead of returning an outcome. The public
 `ReserveError` enum is non-exhaustive and includes `NoRuntime`: it names
 the absent ambient runtime at dynamic reservation or first poll, with
 the cleanup and precedence pinned in §8. Dynamic `add_*`

--- a/SPEC.md
+++ b/SPEC.md
@@ -3372,11 +3372,11 @@ futures are observation only: removal latches synchronously at the
 call (§11's remove rule), so dropping the future — polled or not —
 detaches, and a latched removal still completes. The owned-completion
 invariant makes an internal response loss unreachable on a conforming
-path. If that invariant regresses, the public operation nevertheless
-fails closed: admission observes `NotAdmitting(Terminal)` and a latched
-removal observes `Removed`, since its route becoming terminal satisfies
-the removal goal. Debug builds MAY additionally assert at that boundary
-to expose the internal regression. The public
+path. If that invariant regresses, release builds nevertheless fail
+closed: admission observes `NotAdmitting(Terminal)` and a latched removal
+observes `Removed`, since its route becoming terminal satisfies the
+removal goal. Debug builds MAY instead assert and panic at that boundary
+to expose the internal regression before returning an outcome. The public
 `ReserveError` enum is non-exhaustive and includes `NoRuntime`: it names
 the absent ambient runtime at dynamic reservation or first poll, with
 the cleanup and precedence pinned in §8. Dynamic `add_*`

--- a/SPEC.md
+++ b/SPEC.md
@@ -3370,7 +3370,13 @@ it fires no `Removed` event and leaves no tombstone, §3.2's
 minting/admission split) — §11's idempotency, made concrete. `remove`
 futures are observation only: removal latches synchronously at the
 call (§11's remove rule), so dropping the future — polled or not —
-detaches, and a latched removal still completes. The public
+detaches, and a latched removal still completes. The owned-completion
+invariant makes an internal response loss unreachable on a conforming
+path. If that invariant regresses, the public operation nevertheless
+fails closed: admission observes `NotAdmitting(Terminal)` and a latched
+removal observes `Removed`, since its route becoming terminal satisfies
+the removal goal. Debug builds MAY additionally assert at that boundary
+to expose the internal regression. The public
 `ReserveError` enum is non-exhaustive and includes `NoRuntime`: it names
 the absent ambient runtime at dynamic reservation or first poll, with
 the cleanup and precedence pinned in §8. Dynamic `add_*`

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -1007,6 +1007,10 @@ impl fmt::Debug for Removal {
     }
 }
 
+fn lost_removal_response_outcome() -> RemoveOutcome {
+    RemoveOutcome::Removed
+}
+
 impl Removal {
     fn new(response: crate::driver::RemovalResponse) -> Self {
         Self {
@@ -1018,7 +1022,7 @@ impl Removal {
                     // preserve the removal goal, but flag the invariant break
                     // in debug builds just as admission does above.
                     debug_assert!(false, "removal response obligation must complete");
-                    RemoveOutcome::Removed
+                    lost_removal_response_outcome()
                 })
             }),
         }
@@ -1227,6 +1231,14 @@ mod tests {
         let core = <DynamicTree as Sealed>::into_core(tree);
         assert_eq!(ScopeIdentity::current_thread_creations(), after_tree);
         drop(core);
+    }
+
+    #[test]
+    fn lost_removal_response_policy_fails_closed() {
+        assert_eq!(
+            super::lost_removal_response_outcome(),
+            crate::RemoveOutcome::Removed
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -697,8 +697,11 @@ impl<H> AdmissionReceipt<H> {
 /// Fused additions abort on drop; split definitions detach after their first
 /// poll starts admission. Reservation and that first poll require an ambient
 /// Tokio runtime. A first poll outside one returns [`ReserveError::NoRuntime`]
-/// and releases the reservation. Like a fused future, it remains pending if
-/// polled again after completion.
+/// and releases the reservation. If the driver's internal completion route is
+/// lost, release builds fail closed with [`ReserveError::NotAdmitting`] and a
+/// [`crate::NotAdmittingCause::Terminal`] cause. Debug builds additionally
+/// assert that the completion obligation regressed.
+/// Like a fused future, it remains pending if polled again after completion.
 #[must_use]
 pub struct Admission<H> {
     state: AdmissionState<H>,
@@ -989,6 +992,10 @@ impl<T: Subtree> DynamicSubtreeSlot<T> {
 }
 
 /// Observation future for a synchronously latched dynamic removal.
+///
+/// If the driver's internal completion route is lost after the request is
+/// latched, release builds fail closed with [`RemoveOutcome::Removed`]; debug
+/// builds additionally assert that the completion obligation regressed.
 #[must_use]
 pub struct Removal {
     inner: Pin<Box<dyn Future<Output = RemoveOutcome> + Send + 'static>>,
@@ -1004,10 +1011,15 @@ impl Removal {
     fn new(response: crate::driver::RemovalResponse) -> Self {
         Self {
             inner: Box::pin(async move {
-                response
-                    .receive()
-                    .await
-                    .expect("removal response obligation must complete")
+                response.receive().await.unwrap_or_else(|| {
+                    // The driver's removal `Obligation` publishes `Removed`
+                    // on every destruction path. A missing response therefore
+                    // means the terminal route vanished after removal latched:
+                    // preserve the removal goal, but flag the invariant break
+                    // in debug builds just as admission does above.
+                    debug_assert!(false, "removal response obligation must complete");
+                    RemoveOutcome::Removed
+                })
             }),
         }
     }
@@ -1192,7 +1204,14 @@ impl Subtree for DynamicTree {}
 
 #[cfg(test)]
 mod tests {
-    use super::{DynamicTree, Tree, sealed::Sealed};
+    use std::{
+        future::Future,
+        panic::{AssertUnwindSafe, catch_unwind},
+        pin::Pin,
+        task::{Context, Waker},
+    };
+
+    use super::{DynamicTree, Removal, Tree, sealed::Sealed};
     use crate::identity::ScopeIdentity;
 
     #[test]
@@ -1208,6 +1227,28 @@ mod tests {
         let core = <DynamicTree as Sealed>::into_core(tree);
         assert_eq!(ScopeIdentity::current_thread_creations(), after_tree);
         drop(core);
+    }
+
+    #[test]
+    fn closed_removal_response_fails_closed_after_debug_diagnostic() {
+        let (sender, response) = crate::runtime::oneshot();
+        drop(sender);
+        let mut removal = Removal::new(response);
+        let mut context = Context::from_waker(Waker::noop());
+        let observed = catch_unwind(AssertUnwindSafe(|| {
+            Pin::new(&mut removal).poll(&mut context)
+        }));
+
+        #[cfg(debug_assertions)]
+        assert!(
+            observed.is_err(),
+            "debug builds expose the broken removal response obligation"
+        );
+        #[cfg(not(debug_assertions))]
+        assert_eq!(
+            observed.expect("release fallback does not panic"),
+            std::task::Poll::Ready(crate::RemoveOutcome::Removed)
+        );
     }
 }
 


### PR DESCRIPTION
Part of #116.\n\nThis aligns Removal with Admission when an internal owned-completion invariant regresses. A closed removal response still trips a debug assertion, but release builds fail closed as RemoveOutcome::Removed because the already-latched removal route becoming terminal satisfies the removal goal.\n\nPublic rustdocs and the normative spec now state the policy. A deterministic closed-response regression covers both build modes.\n\nValidation: ./tools/dev just ci (432 tests plus all lint, docs, API/layering, packaging, and Nix checks).\n\nDraft until fresh adversarial review completes.