### PR TITLE
Break the plan and cell route cycle

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -7,6 +7,7 @@
 //! only as opaque capability payloads; their state remains owned elsewhere.
 
 use std::{
+    any::Any,
     fmt,
     sync::{
         Arc, Mutex, MutexGuard, OnceLock, RwLock, Weak,
@@ -27,7 +28,6 @@ use crate::{
         LifecycleHub, LifecycleSeq, MembershipStatus, ScopeKind, ScopeSnapshot, SnapshotHub,
         SnapshotReceiver,
     },
-    plan::SlotCell,
     policy::{ResolvedCommonOptions, ScopeFlavor},
     runtime::{self, Latch},
 };
@@ -371,21 +371,33 @@ pub(crate) struct ScopeRecord {
     pub(crate) total_restarts: TotalRestarts,
 }
 
+/// Type-erased declaration slot carried by the restart-stable cell layer.
+///
+/// The route implementation chooses the concrete slot allocation. Erasing it
+/// here lets [`ScopeCell`] retain the route without depending on the plan
+/// layer that owns declaration state.
+pub(crate) type ErasedDynamicSlot = dyn Any + Send + Sync;
+
+/// Object-safe dynamic route retained by a restart-stable scope cell.
+pub(crate) type ErasedDynamicRoute = dyn DynamicRoute<Slot = ErasedDynamicSlot>;
+
 pub(crate) trait DynamicRoute: Send + Sync {
+    type Slot: ?Sized + Send + Sync;
+
     fn reserve(
         &self,
         scope: &Arc<ScopeCell>,
         id: ChildId,
         child_scope: Option<ScopeFlavor>,
-    ) -> Result<Arc<SlotCell>, ReserveError>;
+    ) -> Result<Arc<Self::Slot>, ReserveError>;
 
     fn start_admission(
         self: Arc<Self>,
-        slot: Arc<SlotCell>,
+        slot: Arc<Self::Slot>,
         fused_cancel: Option<Latch>,
     ) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError>;
 
-    fn cancel_reservation(&self, slot: &Arc<SlotCell>);
+    fn cancel_reservation(&self, slot: &Self::Slot);
 
     fn signal_fused_cancel(&self, membership: Membership, latch: &Latch);
 
@@ -513,7 +525,7 @@ pub(crate) struct ScopeCell {
     config: runtime::WatchSender<ObservationConfig>,
     record: runtime::WatchSender<ScopeRecord>,
     control: Mutex<ScopeControl>,
-    dynamic_route: Mutex<Option<Arc<dyn DynamicRoute>>>,
+    dynamic_route: Mutex<Option<Arc<ErasedDynamicRoute>>>,
     // Dropping a resident emits `Removed` and recursively reads this watch.
     // Every removal path must therefore release the watch guard first:
     // mutation callbacks move removed residents into outer storage, while a
@@ -1333,7 +1345,7 @@ impl ScopeCell {
         drop(residents);
     }
 
-    pub(crate) fn set_dynamic_route(&self, route: Option<Arc<dyn DynamicRoute>>) {
+    pub(crate) fn set_dynamic_route(&self, route: Option<Arc<ErasedDynamicRoute>>) {
         *self
             .dynamic_route
             .lock()
@@ -1341,7 +1353,7 @@ impl ScopeCell {
         self.member.record.pulse();
     }
 
-    pub(crate) fn dynamic_route(&self) -> Option<Arc<dyn DynamicRoute>> {
+    pub(crate) fn dynamic_route(&self) -> Option<Arc<ErasedDynamicRoute>> {
         self.dynamic_route
             .lock()
             .expect("scope dynamic-route mutex poisoned")

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -13,8 +13,8 @@ use crate::{
     StartupFailure, StartupFailureCause,
     admission::{NotAdmittingCause, RemoveOutcome, ReserveError},
     cells::{
-        DynamicRoute, MailboxControl, MemberStage, ResidentProjection, ScopeCell,
-        StartupDisposition,
+        DynamicRoute, ErasedDynamicRoute, ErasedDynamicSlot, MailboxControl, MemberStage,
+        ResidentProjection, ScopeCell, StartupDisposition,
     },
     deadline::Deadline,
     engine::{
@@ -31,7 +31,8 @@ use crate::{
     observe::LifecycleEventKind,
     plan::{
         BuilderCore, ChildConstruction, ChildPlan, LowerError, ScopeFactory, ScopePlan, SlotCell,
-        checked_id, mint_reserved_slot,
+        checked_id, concrete_dynamic_slot, concrete_dynamic_slot_ref, erase_dynamic_slot,
+        mint_reserved_slot,
     },
     policy::{DefaultsInheritance, ResolvedDefaults, ScopeFlavor},
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
@@ -315,7 +316,7 @@ fn resident_projection(slot: &SlotCell) -> ResidentProjection {
 
 pub(crate) struct DynamicReservation {
     pub(crate) slot: Arc<SlotCell>,
-    pub(crate) control: Arc<dyn DynamicRoute>,
+    pub(crate) control: Arc<ErasedDynamicRoute>,
 }
 
 pub(crate) fn reserve_dynamic(
@@ -347,7 +348,7 @@ pub(crate) fn reserve_dynamic(
             ));
         }
     }
-    let slot = control.reserve(scope, id, child_scope)?;
+    let slot = concrete_dynamic_slot(control.reserve(scope, id, child_scope)?);
     Ok(DynamicReservation { slot, control })
 }
 
@@ -382,11 +383,11 @@ fn reserve_dynamic_slot(
 }
 
 pub(crate) fn start_admission(
-    control: Arc<dyn DynamicRoute>,
+    control: Arc<ErasedDynamicRoute>,
     slot: Arc<SlotCell>,
     fused_cancel: Option<Latch>,
 ) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError> {
-    control.start_admission(slot, fused_cancel)
+    control.start_admission(erase_dynamic_slot(slot), fused_cancel)
 }
 
 fn start_dynamic_admission(
@@ -417,7 +418,7 @@ fn start_dynamic_admission(
 
 fn cancel_dynamic_reservation_parts(
     control: &DynamicControl,
-    slot: &Arc<SlotCell>,
+    slot: &SlotCell,
 ) -> (
     Option<runtime::Isolated<ChildConstruction>>,
     Option<DynamicEntry>,
@@ -437,11 +438,11 @@ fn cancel_dynamic_reservation_parts(
     (definition, removed)
 }
 
-pub(crate) fn cancel_dynamic_reservation(control: &dyn DynamicRoute, slot: &Arc<SlotCell>) {
-    control.cancel_reservation(slot);
+pub(crate) fn cancel_dynamic_reservation(control: &ErasedDynamicRoute, slot: &Arc<SlotCell>) {
+    control.cancel_reservation(slot.as_ref());
 }
 
-fn cancel_dynamic_reservation_impl(control: &DynamicControl, slot: &Arc<SlotCell>) {
+fn cancel_dynamic_reservation_impl(control: &DynamicControl, slot: &SlotCell) {
     let (definition, removed) = cancel_dynamic_reservation_parts(control, slot);
     // The entry's drop completes its removal response; it must follow the
     // member's terminal publication and isolated definition disposal.
@@ -449,7 +450,7 @@ fn cancel_dynamic_reservation_impl(control: &DynamicControl, slot: &Arc<SlotCell
 }
 
 pub(crate) fn signal_fused_cancel(
-    control: &dyn DynamicRoute,
+    control: &ErasedDynamicRoute,
     membership: Membership,
     latch: &Latch,
 ) {
@@ -521,24 +522,27 @@ fn remove_dynamic_impl(
 }
 
 impl DynamicRoute for DynamicControl {
+    type Slot = ErasedDynamicSlot;
+
     fn reserve(
         &self,
         scope: &Arc<ScopeCell>,
         id: ChildId,
         child_scope: Option<ScopeFlavor>,
-    ) -> Result<Arc<SlotCell>, ReserveError> {
-        reserve_dynamic_slot(self, scope, id, child_scope)
+    ) -> Result<Arc<Self::Slot>, ReserveError> {
+        reserve_dynamic_slot(self, scope, id, child_scope).map(erase_dynamic_slot)
     }
 
     fn start_admission(
         self: Arc<Self>,
-        slot: Arc<SlotCell>,
+        slot: Arc<Self::Slot>,
         fused_cancel: Option<Latch>,
     ) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError> {
-        start_dynamic_admission(self, slot, fused_cancel)
+        start_dynamic_admission(self, concrete_dynamic_slot(slot), fused_cancel)
     }
 
-    fn cancel_reservation(&self, slot: &Arc<SlotCell>) {
+    fn cancel_reservation(&self, slot: &Self::Slot) {
+        let slot = concrete_dynamic_slot_ref(slot);
         cancel_dynamic_reservation_impl(self, slot);
     }
 

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::{
     ChildId, DefaultsInheritance, Exit, Intensity, Readiness, ScopeDefaults, Strategy,
     admission::ReserveError,
-    cells::{MemberCell, ScopeCell},
+    cells::{ErasedDynamicSlot, MemberCell, ScopeCell},
     definition::DefinitionSource,
     identity::{IdError, ScopeIdentity},
     policy::{
@@ -67,6 +67,25 @@ pub(crate) struct SlotCell {
     pub(crate) member: Arc<MemberCell>,
     pub(crate) scope: Option<Arc<ScopeCell>>,
     definition: Mutex<DefinitionState>,
+}
+
+/// Erases a plan-owned slot without replacing its canonical `Arc` allocation.
+///
+/// Dynamic-route calls cross the lower cell layer through this representation;
+/// only the paired recovery helpers below consume values from that boundary.
+pub(crate) fn erase_dynamic_slot(slot: Arc<SlotCell>) -> Arc<ErasedDynamicSlot> {
+    slot
+}
+
+/// Recovers the plan-owned slot returned by the crate's dynamic route.
+pub(crate) fn concrete_dynamic_slot(slot: Arc<ErasedDynamicSlot>) -> Arc<SlotCell> {
+    Arc::downcast(slot).expect("the dynamic route must return its plan-owned slot type")
+}
+
+/// Borrows the plan-owned slot passed back to the crate's dynamic route.
+pub(crate) fn concrete_dynamic_slot_ref(slot: &ErasedDynamicSlot) -> &SlotCell {
+    slot.downcast_ref()
+        .expect("the dynamic route must receive its plan-owned slot type")
 }
 
 impl SlotCell {
@@ -472,7 +491,10 @@ mod tests {
         task::TaskDef,
     };
 
-    use super::{BuilderCore, ChildConstruction, ChildPlan};
+    use super::{
+        BuilderCore, ChildConstruction, ChildPlan, SlotCell, concrete_dynamic_slot,
+        concrete_dynamic_slot_ref, erase_dynamic_slot,
+    };
 
     fn configured_task() -> TaskDef {
         TaskDef::new(|_| async { Ok(()) })
@@ -484,6 +506,21 @@ mod tests {
             .readiness(Readiness::Manual)
             .expect("manual task readiness is valid")
             .retention(Retention::Remove)
+    }
+
+    #[test]
+    fn dynamic_slot_erasure_preserves_the_canonical_allocation() {
+        let declaration = BuilderCore::new(ScopeFlavor::Dynamic);
+        let slot = SlotCell::new(Arc::clone(&declaration.root.member), None);
+
+        let erased = erase_dynamic_slot(Arc::clone(&slot));
+        assert!(std::ptr::eq(
+            concrete_dynamic_slot_ref(erased.as_ref()),
+            slot.as_ref(),
+        ));
+
+        let restored = concrete_dynamic_slot(erased);
+        assert!(Arc::ptr_eq(&restored, &slot));
     }
 
     #[test]

--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -91,6 +91,8 @@ expect_case layering-tree-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-tree-in-driver check-layering-paths.sh \
   "upward tree references found in the driver layer:"
+expect_case layering-plan-in-cells check-layering-paths.sh \
+  "plan references found in the restart-stable cell layer:"
 expect_case layering-resolve-common check-layering-paths.sh \
   "child option resolution escaped the shared plan funnel:"
 expect_case layering-checked-id check-layering-paths.sh \

--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -93,6 +93,8 @@ expect_case layering-tree-in-driver check-layering-paths.sh \
   "upward tree references found in the driver layer:"
 expect_case layering-plan-in-cells check-layering-paths.sh \
   "plan references found in the restart-stable cell layer:"
+expect_case layering-directory-module-plan-in-cells check-layering-paths.sh \
+  "plan references found in the restart-stable cell layer:"
 expect_case layering-resolve-common check-layering-paths.sh \
   "child option resolution escaped the shared plan funnel:"
 expect_case layering-checked-id check-layering-paths.sh \

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -8,25 +8,32 @@ cd "${SHELTERWOOD_ENFORCEMENT_ROOT:-.}"
 readonly source_root="crates/shelterwood/src"
 readonly driver_path="$source_root/driver.rs"
 readonly tree_path="$source_root/tree.rs"
+readonly cells_path="$source_root/cells.rs"
 
 # Every Rust source except the two orchestration modules and their submodules
-# belongs below the driver. Derive all three sets recursively so either a flat
+# belongs below the driver. Derive all four sets recursively so either a flat
 # module or the conventional `module/mod.rs` layout cannot silently bypass the
 # check; lib.rs is the crate root and may wire every layer together.
 below_driver_layers=()
 driver_layers=()
 tree_layers=()
+cells_layers=()
 while IFS= read -r -d '' path; do
   case "$path" in
     "$source_root/lib.rs") ;;
     "$driver_path"|"$source_root/driver/"*) driver_layers+=("$path") ;;
     "$tree_path"|"$source_root/tree/"*) tree_layers+=("$path") ;;
+    "$cells_path"|"$source_root/cells/"*)
+      cells_layers+=("$path")
+      below_driver_layers+=("$path")
+      ;;
     *) below_driver_layers+=("$path") ;;
   esac
 done < <(find "$source_root" -type f -name '*.rs' -print0)
 readonly -a below_driver_layers
 readonly -a driver_layers
 readonly -a tree_layers
+readonly -a cells_layers
 
 check_forbidden() {
   local message="$1"
@@ -67,7 +74,7 @@ check_forbidden \
 check_forbidden \
   "plan references found in the restart-stable cell layer:" \
   '\bplan::' \
-  crates/shelterwood/src/cells.rs
+  "${cells_layers[@]}"
 
 check_forbidden \
   "child option resolution escaped the shared plan funnel:" \

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -65,6 +65,11 @@ check_forbidden \
   "${driver_layers[@]}"
 
 check_forbidden \
+  "plan references found in the restart-stable cell layer:" \
+  '\bplan::' \
+  crates/shelterwood/src/cells.rs
+
+check_forbidden \
   "child option resolution escaped the shared plan funnel:" \
   '\bresolve_common\b' \
   "${driver_layers[@]}"

--- a/tools/enforcement-fixtures/overlays/layering-directory-module-plan-in-cells/crates/shelterwood/src/cells/dynamic.rs
+++ b/tools/enforcement-fixtures/overlays/layering-directory-module-plan-in-cells/crates/shelterwood/src/cells/dynamic.rs
@@ -1,0 +1,3 @@
+// Known-bad fixture: cell-layer submodules must not recover a dependency on
+// plan-owned declaration state.
+use crate::plan::SlotCell;

--- a/tools/enforcement-fixtures/overlays/layering-plan-in-cells/crates/shelterwood/src/cells.rs
+++ b/tools/enforcement-fixtures/overlays/layering-plan-in-cells/crates/shelterwood/src/cells.rs
@@ -1,0 +1,3 @@
+// Known-bad fixture: restart-stable cells must not depend on plan-owned
+// declaration state.
+use crate::plan::SlotCell;


### PR DESCRIPTION
Part of #116; stacked on #126 so the new dependency boundary is recursively enforced.\n\nDynamicRoute now has an associated slot type, and the restart-stable cells layer stores an object-safe erased route instead of importing plan::SlotCell. Slot erasure/recovery stays in plan.rs; driver-owned dynamic state remains concrete, preserving canonical Arc identity, definition ownership, and disposal behavior.\n\nA pointer-identity test pins the erased round trip, and layering enforcement forbids plan references in cells with a known-bad fixture. Downcasts remain outside exit paths.\n\nValidation on the stacked branch: ./tools/dev just ci (432 tests plus all docs, API/path/enforcement, packaging, and formatting checks).\n\nDraft until fresh adversarial review completes.