### PR TITLE
Consolidate dynamic membership lifecycle

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -387,7 +387,7 @@ pub(crate) trait DynamicRoute: Send + Sync {
 
     fn cancel_reservation(&self, slot: &Arc<SlotCell>);
 
-    fn signal_fused_cancel(&self, membership: Membership, latch: &Latch);
+    fn signal_fused_cancel(&self, slot: &Arc<SlotCell>, latch: &Latch);
 
     fn remove(
         &self,

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2079,6 +2079,11 @@ impl ScopeRuntime {
             }
         };
         let plan = ChildPlan::with_options(Arc::clone(&request.slot), definition, resolved);
+        // Conversion can unwind while acquiring child identity or configuring
+        // the mailbox. Keep that fallible work outside the control-plane lock
+        // so driver teardown can still close reservations and removals.
+        let mut child = ChildRuntime::from_plan(plan, &self.root);
+        child.initial = false;
         let key = {
             let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
             let id = request.slot.member.id();
@@ -2096,7 +2101,8 @@ impl ScopeRuntime {
                 // the same terminality-before-completion ordering as every
                 // other reservation-cancellation path. Definition disposal
                 // is also complete before either waiter regains ownership.
-                let ChildPlan { construction, .. } = plan;
+                child.complete_terminality();
+                let ChildRuntime { construction, .. } = child;
                 reject_admission_after_disposal(
                     request,
                     Some(construction),
@@ -2109,8 +2115,6 @@ impl ScopeRuntime {
             // state transition: an exact remover sees either the reservation
             // or a resident carrying its live arena key, never an unindexed
             // admitted intermediate.
-            let mut child = ChildRuntime::from_plan(plan, &self.root);
-            child.initial = false;
             let key = match self.children.insert(child) {
                 Ok(key) => key,
                 Err(child) => {
@@ -4339,6 +4343,97 @@ mod tests {
         };
         assert_eq!(observed_second.membership, second);
         assert_eq!(observed_second.key, second_key);
+    }
+
+    #[crate::runtime::test]
+    async fn admission_conversion_panic_does_not_poison_dynamic_cleanup() {
+        let root = isolated_scope("root", ScopeFlavor::Dynamic);
+        let epoch = root
+            .begin_incarnation()
+            .expect("test scope epoch is available");
+        root.member
+            .update(|record| record.stage = MemberStage::Running);
+        root.set_state(ScopeState::Running);
+        root.set_startup(Ok(()));
+
+        let (events, mut event_receiver) = crate::runtime::bounded_mpsc(1);
+        let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+        let control = DynamicControl::new(events.clone());
+        root.set_dynamic_route(Some(control.clone()));
+        root.set_admitted_children(Vec::new());
+        let mut scope = ScopeRuntime {
+            root: Arc::clone(&root),
+            defaults: ResolvedDefaults::default(),
+            intensity_policy: Intensity::default(),
+            intensity: super::IntensityState::default(),
+            children: ChildArena::default(),
+            events,
+            disposal_events,
+            deadlines: super::DeadlineQueue::default(),
+            jitter: crate::runtime::JitterRng::from_system_entropy(),
+            lifecycle: ScopeLifecycle::running(),
+            next_ordered_start: None,
+            role: ScopeRole::Root,
+            dynamic: Some(control.clone()),
+            epoch,
+            ancestor_shutdown_seen: false,
+            ancestor_abort_seen: false,
+            hard_forced: false,
+            completion: None,
+        };
+
+        let reservation = super::reserve_dynamic(&root, ChildId::from("worker"), None)
+            .expect("running dynamic scope reserves the child");
+        let member = Arc::clone(&reservation.slot.member);
+        reservation
+            .slot
+            .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
+        let response = super::start_admission(
+            Arc::clone(&reservation.control),
+            Arc::clone(&reservation.slot),
+            None,
+        )
+        .expect("admission starts inside the runtime");
+        let Some(DriverEvent::Admission(request)) = event_receiver.recv().await else {
+            panic!("the admission forwarder submits the request")
+        };
+
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                let _identity = root
+                    .child_identity
+                    .lock()
+                    .expect("scope identity mutex starts healthy");
+                panic!("inject admission conversion failure");
+            }))
+            .is_err()
+        );
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| scope.handle_admission(request))).is_err(),
+            "the poisoned child identity injects the conversion panic"
+        );
+        assert!(matches!(
+            response.receive().await,
+            Some(Err(ReserveError::NotAdmitting(
+                crate::NotAdmittingCause::Terminal
+            )))
+        ));
+        assert!(matches!(member.record().stage, MemberStage::Terminal(_)));
+
+        let cleanup = catch_unwind(AssertUnwindSafe(|| drop(scope)));
+        assert!(
+            cleanup.is_ok(),
+            "conversion failure must not poison dynamic cleanup"
+        );
+        assert!(
+            control
+                .state
+                .lock()
+                .expect("dynamic-state mutex remains healthy")
+                .entries
+                .is_empty(),
+            "cleanup discharges the stranded reservation"
+        );
     }
 
     pub(crate) async fn exercise_saturated_fused_drop_before_exit<A>(

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2364,12 +2364,6 @@ async fn run_scope_incarnation(
     let (disposal_events, mut disposal_event_receiver) = runtime::unbounded_mpsc();
     let dynamic =
         (plan.root.flavor == ScopeFlavor::Dynamic).then(|| DynamicControl::new(events.clone()));
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
     // Transfer children one at a time. The not-yet-converted suffix remains
     // owned by ScopePlan, while ChildRuntime::from_plan arms the current
     // child's obligation before fallible setup. Thus a panic at any point has
@@ -2389,7 +2383,6 @@ async fn run_scope_incarnation(
                 .iter()
                 .map(|(key, child)| (&child.slot, *key)),
         );
-        root.set_dynamic_route(Some(control.clone()));
     }
     let next_ordered_start = children.keys().next();
     let mut scope = ScopeRuntime {
@@ -2415,10 +2408,26 @@ async fn run_scope_incarnation(
         // the raw epoch directly into ScopeRuntime's synchronous epilogue.
         epoch: epoch.transfer(),
     };
-    #[cfg(test)]
-    scope.record_storage();
     plan.armed = false;
     drop(plan);
+
+    // ScopeRuntime owns teardown before the route becomes public. If either
+    // route notification or initial-child publication unwinds, its epilogue
+    // closes dynamic state, terminalizes every child, and clears any resident
+    // prefix. Install the fully keyed route before publishing Added so a
+    // synchronous observer never sees membership without its control plane.
+    if let Some(control) = &scope.dynamic {
+        scope.root.set_dynamic_route(Some(control.clone()));
+    }
+    scope.root.set_admitted_children(
+        scope
+            .children
+            .values()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    #[cfg(test)]
+    scope.record_storage();
 
     match scope.root.flavor {
         ScopeFlavor::Ordered => scope.progress_startup(),
@@ -2698,8 +2707,8 @@ mod tests {
     use crate::{
         ActorRef, Cancellation, ChildId, ChildState, DynamicTree, Exit, ExitError, ExitKind,
         GracePhase, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Readiness,
-        ReadinessDeadline, RemoveOutcome, Retention, ScopeState, SendErrorKind, StartupError,
-        StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
+        ReadinessDeadline, RemoveOutcome, ReserveError, Retention, ScopeState, SendErrorKind,
+        StartupError, StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
         engine::{Epoch, ScopeLifecycle, StopLadder, arbitrate},
         exit::{JoinVerdict, RecordedOutcome},
         identity::{IncarnationCounter, ScopeIdentity},
@@ -2713,8 +2722,9 @@ mod tests {
         AncestorCommandLatches, ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent,
         DynamicControl, DynamicEntry, GateCapture, MemberCell, MemberStage, NestedScopeLatches,
         Pending, RemovalRequest, RemovalResponses, RuntimeStorage, ScopeCell, ScopeEpochGuard,
-        ScopeFlavor, ScopeRole, ScopeRuntime, StartupDisposition, report_channel,
-        resident_projection, restart_shutdown_work, run_nested_tree, run_scope_incarnation,
+        ScopeFlavor, ScopeRole, ScopeRuntime, StartupDisposition, cancel_dynamic_reservation,
+        report_channel, reserve_dynamic, resident_projection, restart_shutdown_work,
+        run_nested_tree, run_scope_incarnation,
     };
 
     /// Bounds every gate-capture probe wait. The probe sender lives inside
@@ -3705,7 +3715,92 @@ mod tests {
                 removed += 1;
             }
         }
-        assert_eq!(removed, 2, "every Added edge needs a matching Removed edge");
+        assert_eq!(
+            removed, 0,
+            "conversion must finish before publication begins"
+        );
+    }
+
+    struct ReserveOnLifecycleWake {
+        scope: Arc<ScopeCell>,
+        result: Mutex<Option<Result<(), ReserveError>>>,
+        observed: Latch,
+    }
+
+    impl ReserveOnLifecycleWake {
+        fn observe(&self) {
+            let mut result = self.result.lock().expect("observation mutex poisoned");
+            if result.is_none() {
+                *result = Some(
+                    reserve_dynamic(&self.scope, ChildId::from("reentrant"), None).map(
+                        |reservation| {
+                            cancel_dynamic_reservation(
+                                reservation.control.as_ref(),
+                                &reservation.slot,
+                            );
+                        },
+                    ),
+                );
+                self.observed.fire();
+            }
+        }
+    }
+
+    impl Wake for ReserveOnLifecycleWake {
+        fn wake(self: Arc<Self>) {
+            self.observe();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.observe();
+        }
+    }
+
+    #[crate::runtime::test]
+    async fn initial_added_wake_observes_the_keyed_dynamic_route() {
+        let mut tree = DynamicTree::new();
+        tree.add_task("initial", TaskDef::new(|_| future::pending()))
+            .expect("valid task");
+        let plan = tree.lower_for_test();
+        let root = Arc::clone(&plan.root);
+        let mut events = root.subscribe_lifecycle();
+        let epoch = ScopeEpochGuard::begin(&root).expect("test scope epoch is available");
+        assert!(events.recv().await.is_some(), "Starting is observed first");
+
+        let probe = Arc::new(ReserveOnLifecycleWake {
+            scope: Arc::clone(&root),
+            result: Mutex::new(None),
+            observed: Latch::default(),
+        });
+        let waker = Waker::from(Arc::clone(&probe));
+        let mut added = Box::pin(events.recv());
+        assert!(
+            added
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending()
+        );
+
+        let driver = crate::runtime::spawn(run_scope_incarnation(plan, ScopeRole::Root, epoch));
+        let abort = driver.abort_handle();
+        assert!(matches!(
+            crate::runtime::timeout(Duration::from_secs(1), probe.observed.fired()).await,
+            crate::runtime::Timeout::Completed(())
+        ));
+        drop(added);
+        assert!(matches!(
+            probe
+                .result
+                .lock()
+                .expect("observation mutex poisoned")
+                .as_ref(),
+            Some(Ok(()))
+        ));
+        abort.abort();
+        assert!(matches!(
+            crate::runtime::join(driver).await,
+            crate::runtime::JoinOutcome::Cancelled
+        ));
     }
 
     struct TrySendOnWake {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -38,7 +38,7 @@ use crate::{
 };
 
 use admission_control::{
-    AdmissionRequest, DynamicControl, cancel_dynamic_reservation_parts,
+    AdmissionRequest, DynamicControl, DynamicEntry, cancel_dynamic_reservation_parts,
     reject_admission_after_disposal,
 };
 pub(crate) use admission_control::{
@@ -49,7 +49,7 @@ pub(crate) use admission_control::{
 #[cfg(test)]
 use crate::cells::{GateCapture, MemberCell, RuntimeStorage};
 #[cfg(test)]
-use admission_control::{DynamicEntry, RemovalResponses, complete_removals};
+use admission_control::RemovalResponses;
 
 /// An exactly-once synchronous completion.
 ///
@@ -185,7 +185,13 @@ fn resident_projection(slot: &SlotCell) -> ResidentProjection {
 enum DriverEvent {
     Child(ChildEvent),
     Admission(AdmissionRequest),
-    Removal(Membership),
+    Removal(RemovalRequest),
+}
+
+#[derive(Clone, Copy)]
+struct RemovalRequest {
+    membership: Membership,
+    key: ChildKey,
 }
 
 impl SystemRun {
@@ -1040,6 +1046,36 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
 }
 
 impl ScopeRuntime {
+    fn dynamic_membership_is_removing(&self, key: ChildKey) -> bool {
+        let Some(child) = self.children.get(key) else {
+            return false;
+        };
+        self.dynamic.as_ref().is_some_and(|control| {
+            control
+                .state
+                .lock()
+                .expect("dynamic-state mutex poisoned")
+                .entries
+                .get(child.slot.member.id())
+                .filter(|entry| entry.slot.member.membership() == child.slot.member.membership())
+                .is_some_and(|entry| entry.is_removing() && entry.matches_key(key))
+        })
+    }
+
+    fn publish_dynamic_removal(&self, key: ChildKey) {
+        let Some(member) = self
+            .children
+            .get(key)
+            .map(|child| Arc::clone(&child.slot.member))
+        else {
+            return;
+        };
+        if !member.record().removing {
+            self.root
+                .transition_child(&member, |record| record.removing = true, None);
+        }
+    }
+
     fn restart_is_suppressed(&self, key: ChildKey) -> bool {
         if self.lifecycle.is_draining()
             || self.hard_forced
@@ -1054,10 +1090,6 @@ impl ScopeRuntime {
         let Some(child) = self.children.get(key) else {
             return true;
         };
-        let record = child.slot.member.record();
-        if record.removing || child.slot.member.removal.is_fired() {
-            return true;
-        }
         self.dynamic.as_ref().is_some_and(|control| {
             control
                 .state
@@ -1066,10 +1098,7 @@ impl ScopeRuntime {
                 .entries
                 .get(child.slot.member.id())
                 .filter(|entry| entry.slot.member.membership() == child.slot.member.membership())
-                .is_some_and(|entry| {
-                    entry.removal_started
-                        || entry.fused_cancel.as_ref().is_some_and(Latch::is_fired)
-                })
+                .is_some_and(|entry| entry.restart_is_suppressed(key))
         })
     }
 
@@ -1852,8 +1881,12 @@ impl ScopeRuntime {
             terminal.exited_incarnation,
             startup,
         );
-        let removing = self.children[key].slot.member.record().removing;
-        if removing {
+        if self.dynamic_membership_is_removing(key) {
+            // A foreign remover may have committed the control-plane state
+            // and be waiting for this thread's observation gate. Publish the
+            // Removing projection before pruning so the public lifecycle
+            // cannot skip directly from resident to Removed.
+            self.publish_dynamic_removal(key);
             self.finalize_removal(key);
         } else if terminal.startup == StartupDisposition::Aborted && !self.lifecycle.is_draining() {
             self.fail_startup(key, exit);
@@ -2046,12 +2079,12 @@ impl ScopeRuntime {
             }
         };
         let plan = ChildPlan::with_options(Arc::clone(&request.slot), definition, resolved);
-        {
+        let key = {
             let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
             let id = request.slot.member.id();
             let matches_reservation = state.entries.get(id).is_some_and(|entry| {
                 entry.slot.member.membership() == request.slot.member.membership()
-                    && !entry.admitted
+                    && entry.is_reserved()
             });
             if !matches_reservation || request.fused_cancel.as_ref().is_some_and(Latch::is_fired) {
                 let removed = matches_reservation
@@ -2072,41 +2105,36 @@ impl ScopeRuntime {
                 );
                 return;
             }
+            // The control-plane lock makes arena insertion and promotion one
+            // state transition: an exact remover sees either the reservation
+            // or a resident carrying its live arena key, never an unindexed
+            // admitted intermediate.
+            let mut child = ChildRuntime::from_plan(plan, &self.root);
+            child.initial = false;
+            let key = match self.children.insert(child) {
+                Ok(key) => key,
+                Err(child) => {
+                    let removed = state.entries.remove(id);
+                    drop(state);
+                    let mut child = *child;
+                    request.slot.terminalize_never_started();
+                    child.complete_terminality();
+                    let ChildRuntime { construction, .. } = child;
+                    reject_admission_after_disposal(
+                        request,
+                        Some(construction),
+                        removed,
+                        ReserveError::IdentityExhausted,
+                    );
+                    return;
+                }
+            };
             let entry = state
                 .entries
                 .get_mut(id)
                 .expect("the matching reservation was just resolved");
-            entry.admitted = true;
-            entry.fused_cancel = request.fused_cancel.take();
-        }
-        let mut child = ChildRuntime::from_plan(plan, &self.root);
-        child.initial = false;
-        let key = match self.children.insert(child) {
-            Ok(key) => key,
-            Err(child) => {
-                let mut child = *child;
-                let removed = {
-                    let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-                    let id = request.slot.member.id();
-                    let matches_admission = state.entries.get(id).is_some_and(|entry| {
-                        entry.slot.member.membership() == request.slot.member.membership()
-                            && entry.admitted
-                    });
-                    matches_admission
-                        .then(|| state.entries.remove(id))
-                        .flatten()
-                };
-                request.slot.terminalize_never_started();
-                child.complete_terminality();
-                let ChildRuntime { construction, .. } = child;
-                reject_admission_after_disposal(
-                    request,
-                    Some(construction),
-                    removed,
-                    ReserveError::IdentityExhausted,
-                );
-                return;
-            }
+            entry.promote(key, request.fused_cancel.take());
+            key
         };
         self.root.admit_child(resident_projection(&request.slot));
         #[cfg(test)]
@@ -2115,32 +2143,32 @@ impl ScopeRuntime {
         self.spawn_child(key);
     }
 
-    fn handle_removal(&mut self, membership: Membership) {
-        if let Some(control) = &self.dynamic {
-            let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-            if let Some(entry) = state
-                .entries
-                .values_mut()
-                .find(|entry| entry.slot.member.membership() == membership)
-            {
-                if entry.removal_started {
-                    return;
-                }
-                entry.removal_started = true;
-            }
-        }
-        let Some(key) = self
+    fn handle_removal(&mut self, removal: RemovalRequest) {
+        let RemovalRequest { membership, key } = removal;
+        let Some(member) = self
             .children
-            .keys()
-            .find(|key| self.children[*key].slot.member.membership() == membership)
+            .get(key)
+            .map(|child| Arc::clone(&child.slot.member))
+            .filter(|member| member.membership() == membership)
         else {
             return;
         };
-        self.root.transition_child(
-            &self.children[key].slot.member,
-            |record| record.removing = true,
-            None,
-        );
+        let Some(control) = &self.dynamic else {
+            return;
+        };
+        let tracked = {
+            let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
+            state
+                .entries
+                .get_mut(member.id())
+                .filter(|entry| entry.slot.member.membership() == membership)
+                .and_then(DynamicEntry::mark_removing)
+                .is_some_and(|tracked| tracked == key)
+        };
+        if !tracked {
+            return;
+        }
+        self.publish_dynamic_removal(key);
         if self.children[key].is_terminal() {
             self.finalize_removal(key);
         } else {
@@ -2158,11 +2186,11 @@ impl ScopeRuntime {
         let member = Arc::clone(&self.children[key].slot.member);
         let id = member.id().clone();
         let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-        if state
-            .entries
-            .get(&id)
-            .is_some_and(|entry| entry.slot.member.membership() == member.membership())
-        {
+        if state.entries.get(&id).is_some_and(|entry| {
+            entry.slot.member.membership() == member.membership()
+                && entry.matches_key(key)
+                && entry.is_removing()
+        }) {
             let entry = state.entries.remove(&id).expect("entry was just resolved");
             drop(state);
             self.root.prune_child(&member);
@@ -2177,11 +2205,9 @@ impl ScopeRuntime {
         if let Some(control) = &self.dynamic {
             let id = member.id().clone();
             let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-            if state
-                .entries
-                .get(&id)
-                .is_some_and(|entry| entry.slot.member.membership() == member.membership())
-            {
+            if state.entries.get(&id).is_some_and(|entry| {
+                entry.slot.member.membership() == member.membership() && entry.matches_key(key)
+            }) {
                 removed = state.entries.remove(&id);
             }
         }
@@ -2338,10 +2364,6 @@ async fn run_scope_incarnation(
     let (disposal_events, mut disposal_event_receiver) = runtime::unbounded_mpsc();
     let dynamic =
         (plan.root.flavor == ScopeFlavor::Dynamic).then(|| DynamicControl::new(events.clone()));
-    if let Some(control) = &dynamic {
-        control.register_initial(plan.children.iter().map(|child| &child.slot));
-        root.set_dynamic_route(Some(control.clone()));
-    }
     root.set_admitted_children(
         plan.children
             .iter()
@@ -2359,6 +2381,15 @@ async fn run_scope_incarnation(
         if children.insert(child).is_err() {
             unreachable!("a fresh child-key domain accommodates an in-memory child collection");
         }
+    }
+    if let Some(control) = &dynamic {
+        control.register_initial(
+            children
+                .children
+                .iter()
+                .map(|(key, child)| (&child.slot, *key)),
+        );
+        root.set_dynamic_route(Some(control.clone()));
     }
     let next_ordered_start = children.keys().next();
     let mut scope = ScopeRuntime {
@@ -2534,9 +2565,7 @@ async fn run_scope_incarnation(
                 Pending::Force => {
                     scope.force_all();
                 }
-                Pending::Driver(DriverEvent::Removal(membership)) => {
-                    scope.handle_removal(membership)
-                }
+                Pending::Driver(DriverEvent::Removal(removal)) => scope.handle_removal(removal),
                 Pending::Driver(DriverEvent::Admission(request)) => {
                     scope.handle_admission(request);
                 }
@@ -2683,10 +2712,9 @@ mod tests {
     use super::{
         AncestorCommandLatches, ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent,
         DynamicControl, DynamicEntry, GateCapture, MemberCell, MemberStage, NestedScopeLatches,
-        Obligation, Pending, RemovalResponses, RuntimeStorage, ScopeCell, ScopeEpochGuard,
-        ScopeFlavor, ScopeRole, ScopeRuntime, StartupDisposition, complete_removals,
-        report_channel, resident_projection, restart_shutdown_work, run_nested_tree,
-        run_scope_incarnation,
+        Pending, RemovalRequest, RemovalResponses, RuntimeStorage, ScopeCell, ScopeEpochGuard,
+        ScopeFlavor, ScopeRole, ScopeRuntime, StartupDisposition, report_channel,
+        resident_projection, restart_shutdown_work, run_nested_tree, run_scope_incarnation,
     };
 
     /// Bounds every gate-capture probe wait. The probe sender lives inside
@@ -4027,13 +4055,7 @@ mod tests {
             .entries
             .insert(
                 ChildId::from("worker"),
-                DynamicEntry {
-                    slot,
-                    admitted: true,
-                    fused_cancel: None,
-                    removal: Obligation::new(responses, complete_removals),
-                    removal_started: true,
-                },
+                DynamicEntry::removing(slot, ChildKey(1), responses),
             );
 
         let entries = control.close();
@@ -4106,21 +4128,13 @@ mod tests {
         root.set_admitted_children(vec![resident_projection(&slot)]);
         let (events, _receiver) = crate::runtime::bounded_mpsc(1);
         let control = DynamicControl::new(events);
+        let key = ChildKey(1);
         control
             .state
             .lock()
             .expect("dynamic-state mutex poisoned")
             .entries
-            .insert(
-                child_id.clone(),
-                DynamicEntry {
-                    slot,
-                    admitted: true,
-                    fused_cancel: None,
-                    removal: Obligation::new(RemovalResponses::default(), complete_removals),
-                    removal_started: false,
-                },
-            );
+            .insert(child_id.clone(), DynamicEntry::resident(slot, key, None));
         root.set_dynamic_route(Some(control.clone()));
 
         let captures = root.probe_gate_captures();
@@ -4141,12 +4155,25 @@ mod tests {
                 .expect("removal reports its gate capture within the bound"),
             GateCapture::Observation
         );
-        drop(
-            control
-                .state
-                .try_lock()
-                .expect("a removal waiting on observation must release dynamic state"),
-        );
+        let state = control
+            .state
+            .try_lock()
+            .expect("a removal waiting on observation must release dynamic state");
+        let entry = state
+            .entries
+            .get(&child_id)
+            .expect("the removal keeps its resident registration");
+        assert!(entry.is_removing());
+        assert!(entry.matches_key(key));
+        drop(state);
+
+        let route = root
+            .dynamic_route()
+            .expect("the fixture exposes its dynamic route");
+        assert!(matches!(
+            route.reserve(&root, child_id.clone(), None),
+            Err(crate::ReserveError::RemovalInProgress(id)) if id == child_id
+        ));
 
         drop(held_gate);
         let response = worker.join().expect("removal transition completes");
@@ -4164,19 +4191,37 @@ mod tests {
         let second = identity
             .mint_membership(&second_id)
             .expect("second membership available");
+        let member = MemberCell::new(second_id.clone(), second);
+        let slot = SlotCell::new(Arc::clone(&member), None);
+        let second_key = ChildKey(2);
         let (events, mut event_receiver) = crate::runtime::bounded_mpsc(1);
         assert!(
-            events.try_send(DriverEvent::Removal(first)).is_ok(),
+            events
+                .try_send(DriverEvent::Removal(RemovalRequest {
+                    membership: first,
+                    key: ChildKey(1),
+                }))
+                .is_ok(),
             "the fixture saturates the bounded driver lane"
         );
         let control = DynamicControl::new(events);
+        control
+            .state
+            .lock()
+            .expect("dynamic-state mutex poisoned")
+            .entries
+            .insert(
+                second_id,
+                DynamicEntry::resident(Arc::clone(&slot), second_key, Some(Latch::default())),
+            );
         let foreign_control = Arc::clone(&control);
+        let foreign_slot = Arc::clone(&slot);
         std::thread::spawn(move || {
             assert!(
                 !crate::runtime::is_available(),
                 "Tokio context is not inherited by a foreign thread"
             );
-            super::signal_fused_cancel(foreign_control.as_ref(), second, &Latch::default());
+            super::signal_fused_cancel(foreign_control.as_ref(), &foreign_slot, &Latch::default());
         })
         .join()
         .expect("foreign-thread removal signaling succeeds");
@@ -4184,7 +4229,7 @@ mod tests {
         let Some(DriverEvent::Removal(observed_first)) = event_receiver.recv().await else {
             panic!("the saturated event remains first");
         };
-        assert_eq!(observed_first, first);
+        assert_eq!(observed_first.membership, first);
         let second_event =
             match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
                 crate::runtime::Timeout::Completed(event) => {
@@ -4197,7 +4242,8 @@ mod tests {
         let DriverEvent::Removal(observed_second) = second_event else {
             panic!("the forwarded event is the requested removal");
         };
-        assert_eq!(observed_second, second);
+        assert_eq!(observed_second.membership, second);
+        assert_eq!(observed_second.key, second_key);
     }
 
     pub(crate) async fn exercise_saturated_fused_drop_before_exit<A>(
@@ -4303,7 +4349,10 @@ mod tests {
         assert!(
             scope
                 .events
-                .try_send(DriverEvent::Removal(root.member.membership()))
+                .try_send(DriverEvent::Removal(RemovalRequest {
+                    membership: root.member.membership(),
+                    key: ChildKey(u64::MAX - 1),
+                }))
                 .is_ok(),
             "the fixture saturates the bounded driver lane"
         );
@@ -4315,9 +4364,8 @@ mod tests {
                 .expect("dynamic-state mutex poisoned")
                 .entries
                 .get(member.id())
-                .and_then(|entry| entry.fused_cancel.as_ref())
-                .is_some_and(Latch::is_fired),
-            "fused drop latches cancellation before its queued edge can advance"
+                .is_some_and(|entry| entry.is_removing() && entry.matches_key(key)),
+            "fused drop marks the indexed membership removing before its queued edge advances"
         );
 
         scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4);
@@ -4338,7 +4386,8 @@ mod tests {
 
         assert!(matches!(
             event_receiver.recv().await,
-            Some(DriverEvent::Removal(queued)) if queued == root.member.membership()
+            Some(DriverEvent::Removal(queued))
+                if queued.membership == root.member.membership()
         ));
         let forwarded =
             match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
@@ -4346,8 +4395,12 @@ mod tests {
                 crate::runtime::Timeout::Completed(None) => panic!("the driver lane remains open"),
                 crate::runtime::Timeout::Elapsed => panic!("the fused removal edge is forwarded"),
             };
-        assert!(matches!(forwarded, DriverEvent::Removal(removed) if removed == membership));
-        scope.handle_removal(membership);
+        let DriverEvent::Removal(removal) = forwarded else {
+            panic!("the forwarded event is the fused removal")
+        };
+        assert_eq!(removal.membership, membership);
+        assert_eq!(removal.key, key);
+        scope.handle_removal(removal);
         let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
             crate::runtime::unbounded_mpsc_recv(&mut disposal_event_receiver).await
         else {

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -14,7 +14,7 @@ use crate::{
     runtime::{self, Latch},
 };
 
-use super::{DriverEvent, Obligation};
+use super::{ChildKey, DriverEvent, Obligation, RemovalRequest};
 
 pub(crate) type RemovalResponse = runtime::OneShotReceiver<RemoveOutcome>;
 
@@ -53,27 +53,104 @@ fn completed_removal(outcome: RemoveOutcome) -> RemovalResponse {
 
 pub(super) struct DynamicEntry {
     pub(super) slot: Arc<SlotCell>,
-    pub(super) admitted: bool,
-    pub(super) fused_cancel: Option<Latch>,
+    state: DynamicMembershipState,
     pub(super) removal: Obligation<RemovalResponses>,
-    pub(super) removal_started: bool,
+}
+
+// The authoritative dynamic control-plane phase. `MemberRecord::removing`
+// is only its public observation projection; driver decisions use this enum.
+// A resident owns its arena key, so removal and restart paths never have to
+// rediscover the corresponding `ChildRuntime` with a linear scan.
+enum DynamicMembershipState {
+    Reserved,
+    Resident {
+        key: ChildKey,
+        fused_cancel: Option<Latch>,
+    },
+    Removing {
+        key: ChildKey,
+    },
 }
 
 impl DynamicEntry {
-    fn reserved(slot: Arc<SlotCell>) -> Self {
+    pub(super) fn reserved(slot: Arc<SlotCell>) -> Self {
         Self {
             slot,
-            admitted: false,
-            fused_cancel: None,
+            state: DynamicMembershipState::Reserved,
             removal: Obligation::new(RemovalResponses::default(), complete_removals),
-            removal_started: false,
         }
     }
 
-    fn admitted(slot: Arc<SlotCell>) -> Self {
+    pub(super) fn resident(
+        slot: Arc<SlotCell>,
+        key: ChildKey,
+        fused_cancel: Option<Latch>,
+    ) -> Self {
         Self {
-            admitted: true,
-            ..Self::reserved(slot)
+            slot,
+            state: DynamicMembershipState::Resident { key, fused_cancel },
+            removal: Obligation::new(RemovalResponses::default(), complete_removals),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn removing(slot: Arc<SlotCell>, key: ChildKey, removal: RemovalResponses) -> Self {
+        Self {
+            slot,
+            state: DynamicMembershipState::Removing { key },
+            removal: Obligation::new(removal, complete_removals),
+        }
+    }
+
+    pub(super) fn is_reserved(&self) -> bool {
+        matches!(self.state, DynamicMembershipState::Reserved)
+    }
+
+    pub(super) fn is_removing(&self) -> bool {
+        matches!(self.state, DynamicMembershipState::Removing { .. })
+    }
+
+    fn removal_requested(&self) -> bool {
+        match &self.state {
+            DynamicMembershipState::Resident { fused_cancel, .. } => {
+                fused_cancel.as_ref().is_some_and(Latch::is_fired)
+            }
+            DynamicMembershipState::Removing { .. } => true,
+            DynamicMembershipState::Reserved => false,
+        }
+    }
+
+    pub(super) fn key(&self) -> Option<ChildKey> {
+        match self.state {
+            DynamicMembershipState::Reserved => None,
+            DynamicMembershipState::Resident { key, .. }
+            | DynamicMembershipState::Removing { key } => Some(key),
+        }
+    }
+
+    pub(super) fn matches_key(&self, key: ChildKey) -> bool {
+        self.key() == Some(key)
+    }
+
+    pub(super) fn promote(&mut self, key: ChildKey, fused_cancel: Option<Latch>) {
+        debug_assert!(self.is_reserved(), "only a reservation can become resident");
+        self.state = DynamicMembershipState::Resident { key, fused_cancel };
+    }
+
+    pub(super) fn mark_removing(&mut self) -> Option<ChildKey> {
+        let key = self.key()?;
+        self.state = DynamicMembershipState::Removing { key };
+        Some(key)
+    }
+
+    pub(super) fn restart_is_suppressed(&self, key: ChildKey) -> bool {
+        match &self.state {
+            DynamicMembershipState::Reserved => false,
+            DynamicMembershipState::Resident {
+                key: resident,
+                fused_cancel,
+            } => *resident == key && fused_cancel.as_ref().is_some_and(Latch::is_fired),
+            DynamicMembershipState::Removing { key: removing } => *removing == key,
         }
     }
 }
@@ -150,12 +227,15 @@ impl DynamicControl {
         control
     }
 
-    pub(super) fn register_initial<'a>(&self, slots: impl IntoIterator<Item = &'a Arc<SlotCell>>) {
+    pub(super) fn register_initial<'a>(
+        &self,
+        slots: impl IntoIterator<Item = (&'a Arc<SlotCell>, ChildKey)>,
+    ) {
         let mut state = self.state.lock().expect("dynamic-state mutex poisoned");
-        for slot in slots {
+        for (slot, key) in slots {
             state.entries.insert(
                 slot.member.id().clone(),
-                DynamicEntry::admitted(Arc::clone(slot)),
+                DynamicEntry::resident(Arc::clone(slot), key, None),
             );
         }
     }
@@ -171,7 +251,7 @@ impl DynamicControl {
         self.request_forwarder_close.fire();
         let mut retained = HashMap::new();
         for (id, entry) in entries {
-            if !entry.admitted {
+            if entry.is_reserved() {
                 let definition = entry.slot.take_never_started();
                 dispose_definition_then(definition, move || drop(entry));
             } else {
@@ -234,7 +314,7 @@ fn reserve_dynamic_slot(
         return Err(ReserveError::NotAdmitting(NotAdmittingCause::Draining));
     }
     if let Some(existing) = state.entries.get(&id) {
-        if existing.slot.member.record().removing {
+        if existing.removal_requested() {
             return Err(ReserveError::RemovalInProgress(id));
         }
         return Err(ReserveError::DuplicateId(id));
@@ -290,7 +370,7 @@ pub(super) fn cancel_dynamic_reservation_parts(
     let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
     let id = slot.member.id().clone();
     let cancelled = state.entries.get(&id).is_some_and(|entry| {
-        entry.slot.member.membership() == slot.member.membership() && !entry.admitted
+        entry.slot.member.membership() == slot.member.membership() && entry.is_reserved()
     });
     let removed = cancelled.then(|| state.entries.remove(&id)).flatten();
     drop(state);
@@ -313,17 +393,28 @@ fn cancel_dynamic_reservation_impl(control: &DynamicControl, slot: &Arc<SlotCell
     dispose_definition_then(definition, move || drop(removed));
 }
 
-pub(crate) fn signal_fused_cancel(
-    control: &dyn DynamicRoute,
-    membership: Membership,
-    latch: &Latch,
-) {
-    control.signal_fused_cancel(membership, latch);
+pub(crate) fn signal_fused_cancel(control: &dyn DynamicRoute, slot: &Arc<SlotCell>, latch: &Latch) {
+    control.signal_fused_cancel(slot, latch);
 }
 
-fn signal_fused_cancel_impl(control: &DynamicControl, membership: Membership, latch: &Latch) {
-    if latch.fire() {
-        queue_driver_event(control, DriverEvent::Removal(membership));
+fn signal_fused_cancel_impl(control: &DynamicControl, slot: &Arc<SlotCell>, latch: &Latch) {
+    if !latch.fire() {
+        return;
+    }
+    let removal = {
+        let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
+        state
+            .entries
+            .get_mut(slot.member.id())
+            .filter(|entry| entry.slot.member.membership() == slot.member.membership())
+            .and_then(DynamicEntry::mark_removing)
+            .map(|key| RemovalRequest {
+                membership: slot.member.membership(),
+                key,
+            })
+    };
+    if let Some(removal) = removal {
+        queue_driver_event(control, DriverEvent::Removal(removal));
     }
 }
 
@@ -358,7 +449,7 @@ fn remove_dynamic_impl(
         return completed_removal(RemoveOutcome::AlreadyAbsent);
     }
     let response = entry.removal.payload_mut().subscribe();
-    if !entry.admitted {
+    if entry.is_reserved() {
         let entry = state.entries.remove(id).expect("entry was just resolved");
         drop(state);
         let definition = entry.slot.take_never_started();
@@ -370,6 +461,9 @@ fn remove_dynamic_impl(
     // registration is reclaimed before the removal response completes.
     let member = Arc::clone(&entry.slot.member);
     let membership = member.membership();
+    let key = entry
+        .mark_removing()
+        .expect("a non-reservation has a resident child key");
     // Dynamic-state protects admission/removal bookkeeping; the observation
     // gate protects the public projection. Release the former before entering
     // the latter. No path takes the two in the opposite order, so this is not
@@ -378,9 +472,14 @@ fn remove_dynamic_impl(
     // observation work, and blocking there while holding dynamic state would
     // stall every concurrent reservation, removal, and driver admission.
     drop(state);
-    scope.transition_child(&member, |record| record.removing = true, None);
+    if !member.record().removing {
+        scope.transition_child(&member, |record| record.removing = true, None);
+    }
     if member.removal.fire() {
-        queue_driver_event(control, DriverEvent::Removal(membership));
+        queue_driver_event(
+            control,
+            DriverEvent::Removal(RemovalRequest { membership, key }),
+        );
     }
     response
 }
@@ -407,8 +506,8 @@ impl DynamicRoute for DynamicControl {
         cancel_dynamic_reservation_impl(self, slot);
     }
 
-    fn signal_fused_cancel(&self, membership: Membership, latch: &Latch) {
-        signal_fused_cancel_impl(self, membership, latch);
+    fn signal_fused_cancel(&self, slot: &Arc<SlotCell>, latch: &Latch) {
+        signal_fused_cancel_impl(self, slot, latch);
     }
 
     fn remove(

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -867,7 +867,7 @@ impl<H> Drop for Admission<H> {
                     crate::runtime::catch_panic(|| {
                         crate::driver::signal_fused_cancel(
                             pending.reservation.control.as_ref(),
-                            pending.reservation.slot.member.membership(),
+                            &pending.reservation.slot,
                             cancel,
                         );
                     })
@@ -885,7 +885,7 @@ impl<H> Drop for Admission<H> {
                     let signal_panic = crate::runtime::catch_panic(|| {
                         crate::driver::signal_fused_cancel(
                             pending.reservation.control.as_ref(),
-                            pending.reservation.slot.member.membership(),
+                            &pending.reservation.slot,
                             cancel,
                         );
                     })

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -584,6 +584,15 @@ impl Tree {
     }
 }
 
+#[cfg(test)]
+impl DynamicTree {
+    pub(crate) fn lower_for_test(self) -> crate::plan::ScopePlan {
+        self.core
+            .lower(ResolvedDefaults::default(), None)
+            .expect("test tree must be fully defined")
+    }
+}
+
 /// An owned pre-spawn actor slot with a stable mailbox binding.
 pub struct ActorSlot<M> {
     core: ActorSlotCore<StaticSlotEndpoint, M>,


### PR DESCRIPTION
Part of #116. Stacked on #139.

Replaces overlapping dynamic-entry booleans and free-standing fuse combinations with one authoritative internal lifecycle: `Reserved | Resident { key, fused_cancel } | Removing { key }`. Promotion installs the arena key atomically; explicit and fused removal linearize the state transition before public observation or queue backpressure; keyed removal events eliminate the child-arena scan. The public member `removing` bit remains a projection for observation compatibility.

Focused reservation/removal gate, fused-cancel/restart, and saturated off-runtime forwarding regressions pass. Full `./tools/dev just ci` passes locally (433 tests plus docs, layering, packaging, clippy, and formatting checks).

Review verified a bonus fix riding along with the state consolidation: arena insertion now happens inside the control lock during admission promotion. On main, a removal request landing in the window between admit-unlock and the arena insert found no registered child to route through the stop path, stranding the removal response until scope teardown — a pre-existing lost-removal window. Holding the lock across promotion makes the entry's `Resident { key }` state and the arena registration visible atomically, so a concurrent removal either sees the reservation (and cancels it) or sees the resident (and routes it), never neither.
