### PR TITLE
Fix lib-test build on main after #117/#124 semantic merge

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -3927,6 +3927,10 @@ mod tests {
             ancestor_shutdown_seen: false,
             ancestor_abort_seen: false,
             hard_forced: false,
+            ordered_stop_progressing: false,
+            ordered_stop_cursor: None,
+            ordered_stop_waiting: None,
+            ordered_stop_inspections: 0,
             completion: None,
         };
         plan.armed = false;


### PR DESCRIPTION
PRs #117 and #124 were each CI-green on their own branches, but their combination broke the lib-test build on main: #117's new driver test (same_batch_self_stop_preserves_fired_readiness_for_startup) constructs a ScopeRuntime and #124 added the ordered-stop bookkeeping fields to that struct — the merge-async flow never built the combined tree. This adds the four missing fields to the test initializer, matching the defaults at the other initializer sites. Remaining merges in this round will update each branch against main first so CI runs on the true merged tree.