### PR TITLE
Preserve restart-window stop reasons

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -385,7 +385,10 @@ fn discharge_child_terminality(completion: ChildTerminality) {
     if matches!(record.stage, MemberStage::Terminal(_)) {
         return;
     }
-    let (exit, exited_incarnation) = if record.last_incarnation.is_some() {
+    let never_started = record.last_incarnation.is_none();
+    let (exit, exited_incarnation) = if never_started {
+        (Exit::never_started(), None)
+    } else {
         (
             Exit::new(
                 ExitKind::Aborted {
@@ -395,12 +398,13 @@ fn discharge_child_terminality(completion: ChildTerminality) {
             ),
             record.incarnation,
         )
-    } else {
-        (Exit::never_started(), None)
     };
-    if exited_incarnation.is_none()
-        && let Some(scope) = &completion.slot.scope
-    {
+    // `incarnation: None` also describes the gap between two incarnations.
+    // Only a membership that never ran needs a synthesized scope stop; a
+    // restarting scope already published its real reason in its last
+    // incarnation's epilogue, and replacing it here would make `wait_stopped`
+    // incorrectly report `NeverStarted`.
+    if never_started && let Some(scope) = &completion.slot.scope {
         scope.terminalize_never_started();
     }
     completion.root.terminalize_child(

--- a/crates/shelterwood/src/driver/tests.rs
+++ b/crates/shelterwood/src/driver/tests.rs
@@ -25,12 +25,13 @@ use crate::{
 };
 
 use super::{
-    AncestorCommandLatches, ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent,
-    DynamicControl, DynamicEntry, GateCapture, MemberCell, MemberStage, NestedScopeLatches,
-    Pending, RemovalRequest, RemovalResponses, ResidentProjection, RuntimeStorage, ScopeCell,
-    ScopeEpochGuard, ScopeFlavor, ScopeRole, ScopeRuntime, StartupDisposition,
-    cancel_dynamic_reservation, report_slot, reserve_dynamic, resident_projection,
-    restart_shutdown_work, run_nested_factory, run_nested_tree, run_scope_incarnation,
+    AncestorCommandLatches, ChildArena, ChildEvent, ChildKey, ChildRuntime, ChildTerminality,
+    DriverEvent, DynamicControl, DynamicEntry, GateCapture, MemberCell, MemberStage,
+    NestedScopeLatches, Pending, RemovalRequest, RemovalResponses, ResidentProjection,
+    RuntimeStorage, ScopeCell, ScopeEpochGuard, ScopeFlavor, ScopeRole, ScopeRuntime,
+    StartupDisposition, cancel_dynamic_reservation, discharge_child_terminality, report_slot,
+    reserve_dynamic, resident_projection, restart_shutdown_work, run_nested_factory,
+    run_nested_tree, run_scope_incarnation, storage::Obligation,
 };
 
 /// Bounds every gate-capture probe wait. The probe sender lives inside
@@ -414,6 +415,58 @@ async fn terminal_scope_waits_for_its_live_incarnation_to_stop() {
 
     nested.finish_incarnation(epoch, StopReason::ShutdownRequested);
     assert_eq!(waiter.await, StopReason::ShutdownRequested);
+}
+
+#[crate::runtime::test]
+async fn terminality_fallback_preserves_restart_window_scope_reason() {
+    let parent = isolated_scope("parent", ScopeFlavor::Ordered);
+    let nested = isolated_scope("nested", ScopeFlavor::Ordered);
+    let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
+    parent.set_admitted_children(vec![resident_projection(&slot)]);
+
+    let mut incarnations = ScopeIdentity::new().incarnation_counter(nested.member.membership());
+    let last_incarnation = incarnations.mint().expect("child incarnation is available");
+    nested.member.update(|record| {
+        record.stage = MemberStage::Restarting;
+        record.incarnation = None;
+        record.last_incarnation = Some(last_incarnation);
+        record.last_exit = Some(Exit::new(ExitKind::Completed, Cancellation::NotObserved));
+    });
+    nested.set_state(ScopeState::Stopped {
+        reason: StopReason::Finished,
+    });
+    let mut snapshots = nested.subscribe_snapshots();
+
+    let mut terminality = Obligation::new(
+        ChildTerminality {
+            root: Arc::clone(&parent),
+            slot,
+        },
+        discharge_child_terminality,
+    );
+    terminality.discharge();
+
+    assert_eq!(nested.wait_stopped().await, StopReason::Finished);
+    let MemberStage::Terminal(exit) = nested.member.record().stage else {
+        panic!("the fallback must terminalize the nested membership");
+    };
+    assert!(matches!(
+        exit.kind(),
+        ExitKind::Aborted {
+            phase: GracePhase::WithinGrace
+        }
+    ));
+    assert_eq!(exit.cancellation(), Cancellation::Observed);
+    assert_eq!(
+        snapshots.borrow_latest().state,
+        ScopeState::Stopped {
+            reason: StopReason::Finished
+        }
+    );
+    assert!(
+        snapshots.changed().await.is_err(),
+        "the fallback closes observation after retaining the final stopped snapshot"
+    );
 }
 
 #[crate::runtime::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -696,7 +696,7 @@ async fn owning_shutdown_joins_recursively_aborted_scope_drivers() {
 }
 
 #[tokio::test]
-async fn parent_drain_preserves_a_restarting_subtrees_last_stop_reason() {
+async fn shutdown_and_wait_wakes_when_a_parent_drain_terminalizes_a_restarting_subtree() {
     let gate = ReleaseGate::default();
     let inner = Arc::new(Mutex::new(None::<TaskRef>));
     let definition = SubtreeDef::factory({
@@ -767,10 +767,6 @@ async fn parent_drain_preserves_a_restarting_subtrees_last_stop_reason() {
         .await
         .expect("parent drain terminalizes the restarting subtree and wakes waiters")
         .expect("teardown completes in bound");
-    assert!(
-        matches!(sub.wait_stopped().await, StopReason::IntensityTripped(_)),
-        "a scope that ran must retain its last real stop reason"
-    );
 }
 
 /// A subtree that shuts itself down records a cancelled exit: the stop

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -696,7 +696,7 @@ async fn owning_shutdown_joins_recursively_aborted_scope_drivers() {
 }
 
 #[tokio::test]
-async fn shutdown_and_wait_wakes_when_a_parent_drain_terminalizes_a_restarting_subtree() {
+async fn parent_drain_preserves_a_restarting_subtrees_last_stop_reason() {
     let gate = ReleaseGate::default();
     let inner = Arc::new(Mutex::new(None::<TaskRef>));
     let definition = SubtreeDef::factory({
@@ -767,6 +767,10 @@ async fn shutdown_and_wait_wakes_when_a_parent_drain_terminalizes_a_restarting_s
         .await
         .expect("parent drain terminalizes the restarting subtree and wakes waiters")
         .expect("teardown completes in bound");
+    assert!(
+        matches!(sub.wait_stopped().await, StopReason::IntensityTripped(_)),
+        "a scope that ran must retain its last real stop reason"
+    );
 }
 
 /// A subtree that shuts itself down records a cancelled exit: the stop


### PR DESCRIPTION
## Summary

- distinguish a truly never-started nested scope from the no-live-incarnation gap between restarts
- preserve the last real nested-scope stop reason when parent-driver destruction terminalizes the restarting membership
- add a driver-level regression that exercises the armed destruction fallback and verifies stop reason, abort exit, final snapshot, observation closure, and `wait_stopped()` completion

## Root cause

`discharge_child_terminality` used `record.incarnation.is_none()` to decide that a nested scope needed a synthesized `NeverStarted` stop. That condition also holds during restart backoff, after an incarnation has already published a real `Stopped { reason }` state. Parent-driver destruction therefore overwrote the real reason with `NeverStarted`.

The fallback now keys the synthesis on `last_incarnation.is_none()`, which is the actual never-ran predicate. Restart-window terminalization retains the prior scope epilogue while still terminalizing and closing the membership.

The regression directly discharges the same armed `Obligation<ChildTerminality>` used by `ScopeRuntime::drop`. Reverting the predicate to the pre-fix `exited_incarnation.is_none()` makes it fail with `NeverStarted` instead of the prior `Finished` reason.

Part of #151.

## Validation

- `./tools/dev cargo test -p shelterwood terminality_fallback_preserves_restart_window_scope_reason`
- pre-fix predicate mutation: focused test fails with `left: NeverStarted, right: Finished`
- `./tools/dev just ci` (500 nextest tests plus formatting, Clippy, docs, API/layering checks, packaging, and Nix formatting)