### PR TITLE
Derive tree export layering rules

### DIFF
--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -94,13 +94,19 @@ expect_case layering-scope-driver-below check-layering-paths.sh \
 expect_case layering-scope-tree-alias-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-scope-crate-root-alias-below check-layering-paths.sh \
-  "upward tree root re-exports found in the scope layer:"
+  "upward tree root re-exports found below the driver layer:"
 expect_case layering-scope-crate-root-glob-below check-layering-paths.sh \
-  "glob imports of the crate root found in the scope layer:"
+  "glob imports of the crate root found below the driver layer:"
 expect_case layering-scope-tree-grouped-reexport-below check-layering-paths.sh \
-  "upward tree root re-exports found in the scope layer:"
+  "upward tree root re-exports found below the driver layer:"
 expect_case layering-scope-tree-root-reexport-below check-layering-paths.sh \
-  "upward tree root re-exports found in the scope layer:"
+  "upward tree root re-exports found below the driver layer:"
+expect_case layering-policy-tree-root-reexport-below check-layering-paths.sh \
+  "upward tree root re-exports found below the driver layer:"
+expect_case layering-observe-crate-root-alias-below check-layering-paths.sh \
+  "upward tree root re-exports found below the driver layer:"
+expect_case layering-mailbox-crate-root-glob-below check-layering-paths.sh \
+  "glob imports of the crate root found below the driver layer:"
 expect_case layering-tree-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-tree-in-driver check-layering-paths.sh \

--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -117,6 +117,12 @@ expect_case layering-crate-root-grouped-alias-below check-layering-paths.sh \
   "crate-root aliases found below the driver layer:"
 expect_case layering-crate-root-glob-alias-below check-layering-paths.sh \
   "crate-root aliases found below the driver layer:"
+expect_case layering-extern-crate-self-alias-below check-layering-paths.sh \
+  "crate-root aliases found below the driver layer:"
+expect_case layering-raw-tree-root-reexport-below check-layering-paths.sh \
+  "upward tree root re-exports found below the driver layer:"
+expect_case layering-raw-inline-module-tree-root-reexport-below check-layering-paths.sh \
+  "upward tree root re-exports found below the driver layer:"
 expect_case layering-lib-alternate-tree-group-reexport-below check-layering-paths.sh \
   "upward tree root re-exports found below the driver layer:"
 expect_case layering-lib-restricted-tree-reexport-below check-layering-paths.sh \

--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -113,6 +113,16 @@ expect_case layering-nested-crate-root-glob-below check-layering-paths.sh \
   "glob imports of the crate root found below the driver layer:"
 expect_case layering-nested-crate-root-alias-below check-layering-paths.sh \
   "crate-root aliases found below the driver layer:"
+expect_case layering-nested-group-tree-root-reexport-below check-layering-paths.sh \
+  "upward tree root re-exports found below the driver layer:"
+expect_case layering-nested-group-crate-root-glob-below check-layering-paths.sh \
+  "glob imports of the crate root found below the driver layer:"
+expect_case layering-nested-group-crate-root-alias-below check-layering-paths.sh \
+  "crate-root aliases found below the driver layer:"
+expect_case layering-grouped-super-tree-root-reexport-below check-layering-paths.sh \
+  "upward tree root re-exports found below the driver layer:"
+expect_case layering-grouped-super-crate-root-glob-below check-layering-paths.sh \
+  "glob imports of the crate root found below the driver layer:"
 expect_case layering-crate-root-grouped-alias-below check-layering-paths.sh \
   "crate-root aliases found below the driver layer:"
 expect_case layering-crate-root-glob-alias-below check-layering-paths.sh \
@@ -131,6 +141,14 @@ expect_case layering-lib-commented-tree-group-reexport-below check-layering-path
   "upward tree root re-exports found below the driver layer:"
 expect_case layering-lib-chained-tree-reexport-below check-layering-paths.sh \
   "upward tree root re-exports found below the driver layer:"
+expect_case layering-lib-crate-root-alias-reexport-below check-layering-paths.sh \
+  "upward tree root re-exports found below the driver layer:"
+expect_case layering-lib-crate-root-glob-fails-closed check-layering-paths.sh \
+  "crate-root glob imports cannot be derived safely"
+expect_case layering-lib-nested-reexport-fails-closed check-layering-paths.sh \
+  "nested use items cannot participate in the crate-root derivation"
+expect_case layering-lib-tree-type-alias-fails-closed check-layering-paths.sh \
+  "crate-root type aliases over tree exports cannot be derived"
 expect_case layering-lib-tree-glob-fails-closed check-layering-paths.sh \
   "tree glob imports cannot be derived safely"
 expect_case layering-lib-tree-alias-glob-fails-closed check-layering-paths.sh \

--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -94,7 +94,7 @@ expect_case layering-scope-driver-below check-layering-paths.sh \
 expect_case layering-scope-tree-alias-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-scope-crate-root-alias-below check-layering-paths.sh \
-  "upward tree root re-exports found below the driver layer:"
+  "crate-root aliases found below the driver layer:"
 expect_case layering-scope-crate-root-glob-below check-layering-paths.sh \
   "glob imports of the crate root found below the driver layer:"
 expect_case layering-scope-tree-grouped-reexport-below check-layering-paths.sh \
@@ -104,9 +104,27 @@ expect_case layering-scope-tree-root-reexport-below check-layering-paths.sh \
 expect_case layering-policy-tree-root-reexport-below check-layering-paths.sh \
   "upward tree root re-exports found below the driver layer:"
 expect_case layering-observe-crate-root-alias-below check-layering-paths.sh \
-  "upward tree root re-exports found below the driver layer:"
+  "crate-root aliases found below the driver layer:"
 expect_case layering-mailbox-crate-root-glob-below check-layering-paths.sh \
   "glob imports of the crate root found below the driver layer:"
+expect_case layering-nested-tree-root-reexport-below check-layering-paths.sh \
+  "upward tree root re-exports found below the driver layer:"
+expect_case layering-nested-crate-root-glob-below check-layering-paths.sh \
+  "glob imports of the crate root found below the driver layer:"
+expect_case layering-nested-crate-root-alias-below check-layering-paths.sh \
+  "crate-root aliases found below the driver layer:"
+expect_case layering-crate-root-grouped-alias-below check-layering-paths.sh \
+  "crate-root aliases found below the driver layer:"
+expect_case layering-crate-root-glob-alias-below check-layering-paths.sh \
+  "crate-root aliases found below the driver layer:"
+expect_case layering-lib-alternate-tree-group-reexport-below check-layering-paths.sh \
+  "upward tree root re-exports found below the driver layer:"
+expect_case layering-lib-restricted-tree-reexport-below check-layering-paths.sh \
+  "upward tree root re-exports found below the driver layer:"
+expect_case layering-lib-commented-tree-group-reexport-below check-layering-paths.sh \
+  "upward tree root re-exports found below the driver layer:"
+expect_case layering-lib-tree-glob-fails-closed check-layering-paths.sh \
+  "tree glob imports cannot be derived safely"
 expect_case layering-tree-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"
 expect_case layering-tree-in-driver check-layering-paths.sh \

--- a/tools/check-enforcement-fixtures.sh
+++ b/tools/check-enforcement-fixtures.sh
@@ -129,7 +129,11 @@ expect_case layering-lib-restricted-tree-reexport-below check-layering-paths.sh 
   "upward tree root re-exports found below the driver layer:"
 expect_case layering-lib-commented-tree-group-reexport-below check-layering-paths.sh \
   "upward tree root re-exports found below the driver layer:"
+expect_case layering-lib-chained-tree-reexport-below check-layering-paths.sh \
+  "upward tree root re-exports found below the driver layer:"
 expect_case layering-lib-tree-glob-fails-closed check-layering-paths.sh \
+  "tree glob imports cannot be derived safely"
+expect_case layering-lib-tree-alias-glob-fails-closed check-layering-paths.sh \
   "tree glob imports cannot be derived safely"
 expect_case layering-tree-below check-layering-paths.sh \
   "upward driver or tree references found below the driver layer:"

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -6,10 +6,10 @@ set -euo pipefail
 cd "${SHELTERWOOD_ENFORCEMENT_ROOT:-.}"
 
 readonly source_root="crates/shelterwood/src"
+readonly lib_path="$source_root/lib.rs"
 readonly driver_path="$source_root/driver.rs"
 readonly tree_path="$source_root/tree.rs"
 readonly cells_path="$source_root/cells.rs"
-readonly scope_path="$source_root/scope.rs"
 
 # Every Rust source except the two orchestration modules and their submodules
 # belongs below the driver. Derive all four sets recursively so either a flat
@@ -42,10 +42,93 @@ readonly -a cells_layers
 # rustfmt-normalized lines of a `use crate::{ ... };` statement.
 readonly upward_module_pattern='\b(driver|tree)::|\b(crate|super)::(driver|tree)\b|\b(crate|super)::\{[^;]*\b(driver|tree)\b[[:space:]]*(,|}|as\b)'
 
-# `lib.rs` re-exports these tree-layer types at the crate root. Naming one via
-# `crate::System`, for example, is still an upward dependency even though the
-# source contains no `tree::` token.
-readonly tree_root_export_pattern='ActorSlot|Admission|AdmissionReceipt|BuildError|DynamicActorSlot|DynamicSubtreeSlot|DynamicTaskSlot|DynamicTree|Removal|StartOrShutdownError|Subtree|SubtreeDef|SubtreeOnceDef|SubtreeSlot|System|TaskSlot|Tree'
+# Derive the tree-layer names visible at the crate root from the source of
+# truth. The parser accepts rustfmt's grouped form plus a single-item re-export
+# and honors `as` aliases, which are the identifiers lower layers can name.
+set +e
+tree_root_exports="$(
+  awk '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+
+    function emit(item, parts, count) {
+      sub(/\/\/.*/, "", item)
+      item = trim(item)
+      if (item == "") {
+        return
+      }
+      count = split(item, parts, /[[:space:]]+as[[:space:]]+/)
+      item = trim(parts[count])
+      if (item !~ /^[A-Za-z_][A-Za-z0-9_]*$/) {
+        print "unsupported tree re-export item in lib.rs: " item > "/dev/stderr"
+        invalid = 1
+        return
+      }
+      print item
+    }
+
+    BEGIN {
+      prefix = "^[[:space:]]*pub[[:space:]]+use[[:space:]]+((crate|self)::)?tree::"
+      group_prefix = prefix "[{]"
+    }
+
+    {
+      line = $0
+      if (!in_group) {
+        if (line ~ group_prefix) {
+          sub(group_prefix, "", line)
+          in_group = 1
+        } else if (line ~ prefix) {
+          sub(prefix, "", line)
+          sub(/[[:space:]]*;.*/, "", line)
+          emit(line)
+          next
+        } else {
+          next
+        }
+      }
+
+      if (line ~ /[}][[:space:]]*;/) {
+        sub(/[}][[:space:]]*;.*/, "", line)
+        in_group = 0
+      }
+      item_count = split(line, items, ",")
+      for (item_index = 1; item_index <= item_count; item_index++) {
+        emit(items[item_index])
+      }
+    }
+
+    END {
+      if (in_group) {
+        print "unterminated pub use tree group in lib.rs" > "/dev/stderr"
+        invalid = 1
+      }
+      if (invalid) {
+        exit 2
+      }
+    }
+  ' "$lib_path"
+)"
+tree_root_export_status=$?
+set -e
+if [[ "$tree_root_export_status" -ne 0 ]]; then
+  exit "$tree_root_export_status"
+fi
+readonly tree_root_exports
+
+tree_root_export_pattern=""
+while IFS= read -r tree_root_export; do
+  [[ -z "$tree_root_export" ]] && continue
+  tree_root_export_pattern+="${tree_root_export_pattern:+|}${tree_root_export}"
+done <<< "$tree_root_exports"
+if [[ -z "$tree_root_export_pattern" ]]; then
+  echo "no pub use tree re-exports derived from $lib_path" >&2
+  exit 1
+fi
+readonly tree_root_export_pattern
 
 check_forbidden() {
   local message="$1"
@@ -81,12 +164,13 @@ check_forbidden() {
   esac
 }
 
-collect_scope_root_aliases() {
+collect_root_aliases() {
   local pattern="$1"
+  local layer_file="$2"
   local aliases
   local status
   set +e
-  aliases="$({ rg --multiline --no-filename --only-matching --replace '$2' "$pattern" "$scope_path"; } 2>&1)"
+  aliases="$({ rg --multiline --no-filename --only-matching --replace '$2' "$pattern" "$layer_file"; } 2>&1)"
   status=$?
   set -e
 
@@ -106,33 +190,36 @@ check_forbidden \
   "${below_driver_layers[@]}"
 
 check_forbidden \
-  "upward tree root re-exports found in the scope layer:" \
+  "upward tree root re-exports found below the driver layer:" \
   "\\b(crate|super)::($tree_root_export_pattern)\\b|\\buse[[:space:]]+(crate|super)::\\{[^;]*\\b($tree_root_export_pattern)\\b" \
-  "$scope_path"
+  "${below_driver_layers[@]}"
 
 # A glob import of the crate root pulls in every tree-layer re-export without
 # naming any of them, so neither pattern above can see it. The grouped
 # alternative covers a `*` anywhere inside a `use (crate|super)::{ ... };`
 # tree, which `--multiline` lets span rustfmt-normalized lines.
 check_forbidden \
-  "glob imports of the crate root found in the scope layer:" \
+  "glob imports of the crate root found below the driver layer:" \
   '\buse[[:space:]]+(crate|super)::(\*|\{[^;]*\*)' \
-  "$scope_path"
+  "${below_driver_layers[@]}"
 
 # A crate-root alias can hide both direct root exports and the module names
 # checked above. Extract direct and grouped `self` aliases, then scan uses of
-# each exact identifier so unrelated aliases remain permitted.
-scope_root_aliases="$(
-  collect_scope_root_aliases '\buse[[:space:]]+(crate|super)[[:space:]]+as[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*;'
-  collect_scope_root_aliases '\buse[[:space:]]+(crate|super)::\{[^;]*\bself[[:space:]]+as[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*(,|})'
-)"
-while IFS= read -r scope_root_alias; do
-  [[ -z "$scope_root_alias" ]] && continue
-  check_forbidden \
-    "upward tree root re-exports found in the scope layer:" \
-    "\\b${scope_root_alias}::($tree_root_export_pattern|driver|tree)\\b" \
-    "$scope_path"
-done <<< "$scope_root_aliases"
+# each exact identifier in the file that declared it so unrelated aliases in
+# another module remain permitted.
+for layer_file in "${below_driver_layers[@]}"; do
+  root_aliases="$(
+    collect_root_aliases '\buse[[:space:]]+(crate|super)[[:space:]]+as[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*;' "$layer_file"
+    collect_root_aliases '\buse[[:space:]]+(crate|super)::\{[^;]*\bself[[:space:]]+as[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*(,|})' "$layer_file"
+  )"
+  while IFS= read -r root_alias; do
+    [[ -z "$root_alias" ]] && continue
+    check_forbidden \
+      "upward tree root re-exports found below the driver layer:" \
+      "\\b${root_alias}::($tree_root_export_pattern|driver|tree)\\b" \
+      "$layer_file"
+  done <<< "$root_aliases"
+done
 
 check_forbidden \
   "upward tree references found in the driver layer:" \

--- a/tools/check-layering-paths.sh
+++ b/tools/check-layering-paths.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly script_dir
+
 # The fixture harness re-points this scan at a mirrored source tree; the
 # default scans the repository from the invoking directory as before.
 cd "${SHELTERWOOD_ENFORCEMENT_ROOT:-.}"
@@ -10,6 +13,7 @@ readonly lib_path="$source_root/lib.rs"
 readonly driver_path="$source_root/driver.rs"
 readonly tree_path="$source_root/tree.rs"
 readonly cells_path="$source_root/cells.rs"
+readonly use_parser_path="$script_dir/check-layering-uses.awk"
 
 # Every Rust source except the two orchestration modules and their submodules
 # belongs below the driver. Derive all four sets recursively so either a flat
@@ -36,82 +40,17 @@ readonly -a driver_layers
 readonly -a tree_layers
 readonly -a cells_layers
 
-# A direct `tree::`/`driver::` reference is the usual spelling, while the
-# longer alternatives cover aliases imported from either the crate root or a
-# grouped root import. `--multiline` below lets the grouped form span the
-# rustfmt-normalized lines of a `use crate::{ ... };` statement.
-readonly upward_module_pattern='\b(driver|tree)::|\b(crate|super)::(driver|tree)\b|\b(crate|super)::\{[^;]*\b(driver|tree)\b[[:space:]]*(,|}|as\b)'
+# Direct `tree::`/`driver::` references are independent of how a source file is
+# nested. Crate-root paths and use trees need module-depth-aware parsing and
+# are checked below by `check-layering-uses.awk`.
+readonly upward_module_pattern='\b(driver|tree)::'
 
 # Derive the tree-layer names visible at the crate root from the source of
-# truth. The parser accepts rustfmt's grouped form plus a single-item re-export
-# and honors `as` aliases, which are the identifiers lower layers can name.
+# truth. The token parser handles visibility modifiers, alternate/nested use
+# trees, aliases, and comments. It fails closed on tree globs or unsupported
+# syntax instead of silently returning an incomplete pattern.
 set +e
-tree_root_exports="$(
-  awk '
-    function trim(value) {
-      sub(/^[[:space:]]+/, "", value)
-      sub(/[[:space:]]+$/, "", value)
-      return value
-    }
-
-    function emit(item, parts, count) {
-      sub(/\/\/.*/, "", item)
-      item = trim(item)
-      if (item == "") {
-        return
-      }
-      count = split(item, parts, /[[:space:]]+as[[:space:]]+/)
-      item = trim(parts[count])
-      if (item !~ /^[A-Za-z_][A-Za-z0-9_]*$/) {
-        print "unsupported tree re-export item in lib.rs: " item > "/dev/stderr"
-        invalid = 1
-        return
-      }
-      print item
-    }
-
-    BEGIN {
-      prefix = "^[[:space:]]*pub[[:space:]]+use[[:space:]]+((crate|self)::)?tree::"
-      group_prefix = prefix "[{]"
-    }
-
-    {
-      line = $0
-      if (!in_group) {
-        if (line ~ group_prefix) {
-          sub(group_prefix, "", line)
-          in_group = 1
-        } else if (line ~ prefix) {
-          sub(prefix, "", line)
-          sub(/[[:space:]]*;.*/, "", line)
-          emit(line)
-          next
-        } else {
-          next
-        }
-      }
-
-      if (line ~ /[}][[:space:]]*;/) {
-        sub(/[}][[:space:]]*;.*/, "", line)
-        in_group = 0
-      }
-      item_count = split(line, items, ",")
-      for (item_index = 1; item_index <= item_count; item_index++) {
-        emit(items[item_index])
-      }
-    }
-
-    END {
-      if (in_group) {
-        print "unterminated pub use tree group in lib.rs" > "/dev/stderr"
-        invalid = 1
-      }
-      if (invalid) {
-        exit 2
-      }
-    }
-  ' "$lib_path"
-)"
+tree_root_exports="$(awk -v mode=lib -v base_module_depth=0 -f "$use_parser_path" "$lib_path")"
 tree_root_export_status=$?
 set -e
 if [[ "$tree_root_export_status" -ne 0 ]]; then
@@ -164,24 +103,73 @@ check_forbidden() {
   esac
 }
 
-collect_root_aliases() {
-  local pattern="$1"
-  local layer_file="$2"
-  local aliases
-  local status
-  set +e
-  aliases="$({ rg --multiline --no-filename --only-matching --replace '$2' "$pattern" "$layer_file"; } 2>&1)"
-  status=$?
-  set -e
+module_depth_for_file() {
+  local layer_file="$1"
+  local relative="${layer_file#"$source_root/"}"
+  local -a components
+  IFS=/ read -r -a components <<< "$relative"
 
-  case "$status" in
-    0) printf '%s\n' "$aliases" ;;
-    1) ;;
-    *)
-      echo "$aliases" >&2
-      exit "$status"
-      ;;
-  esac
+  local depth="${#components[@]}"
+  if [[ "${components[-1]}" == "mod.rs" ]]; then
+    ((depth--))
+  fi
+  printf '%s\n' "$depth"
+}
+
+collect_layer_findings() {
+  local layer_file
+  for layer_file in "${below_driver_layers[@]}"; do
+    local module_depth
+    module_depth="$(module_depth_for_file "$layer_file")"
+
+    local analysis
+    local status
+    set +e
+    analysis="$(
+      awk \
+        -v mode=lower \
+        -v base_module_depth="$module_depth" \
+        -v forbidden_exports="$tree_root_export_pattern" \
+        -f "$use_parser_path" \
+        "$layer_file" 2>&1
+    )"
+    status=$?
+    set -e
+    if [[ "$status" -ne 0 ]]; then
+      printf '%s\n' "$analysis"
+      return "$status"
+    fi
+
+    local kind
+    local line
+    local detail
+    while IFS=$'\t' read -r kind line detail; do
+      [[ -z "$kind" ]] && continue
+      printf '%s\t%s:%s\t%s\n' "$kind" "$layer_file" "$line" "$detail"
+    done <<< "$analysis"
+  done
+}
+
+check_layer_findings() {
+  local message="$1"
+  local expected_kind="$2"
+  local findings="$3"
+  local matches=""
+
+  local kind
+  local location
+  local detail
+  while IFS=$'\t' read -r kind location detail; do
+    if [[ "$kind" == "$expected_kind" ]]; then
+      matches+="${matches:+$'\n'}$location: $detail"
+    fi
+  done <<< "$findings"
+
+  if [[ -n "$matches" ]]; then
+    echo "$message" >&2
+    echo "$matches" >&2
+    exit 1
+  fi
 }
 
 check_forbidden \
@@ -189,37 +177,36 @@ check_forbidden \
   "$upward_module_pattern" \
   "${below_driver_layers[@]}"
 
-check_forbidden \
+set +e
+layer_findings="$(collect_layer_findings)"
+layer_findings_status=$?
+set -e
+if [[ "$layer_findings_status" -ne 0 ]]; then
+  echo "$layer_findings" >&2
+  exit "$layer_findings_status"
+fi
+readonly layer_findings
+
+check_layer_findings \
+  "upward driver or tree references found below the driver layer:" \
+  module \
+  "$layer_findings"
+check_layer_findings \
   "upward tree root re-exports found below the driver layer:" \
-  "\\b(crate|super)::($tree_root_export_pattern)\\b|\\buse[[:space:]]+(crate|super)::\\{[^;]*\\b($tree_root_export_pattern)\\b" \
-  "${below_driver_layers[@]}"
-
-# A glob import of the crate root pulls in every tree-layer re-export without
-# naming any of them, so neither pattern above can see it. The grouped
-# alternative covers a `*` anywhere inside a `use (crate|super)::{ ... };`
-# tree, which `--multiline` lets span rustfmt-normalized lines.
-check_forbidden \
+  export \
+  "$layer_findings"
+check_layer_findings \
   "glob imports of the crate root found below the driver layer:" \
-  '\buse[[:space:]]+(crate|super)::(\*|\{[^;]*\*)' \
-  "${below_driver_layers[@]}"
+  glob \
+  "$layer_findings"
 
-# A crate-root alias can hide both direct root exports and the module names
-# checked above. Extract direct and grouped `self` aliases, then scan uses of
-# each exact identifier in the file that declared it so unrelated aliases in
-# another module remain permitted.
-for layer_file in "${below_driver_layers[@]}"; do
-  root_aliases="$(
-    collect_root_aliases '\buse[[:space:]]+(crate|super)[[:space:]]+as[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*;' "$layer_file"
-    collect_root_aliases '\buse[[:space:]]+(crate|super)::\{[^;]*\bself[[:space:]]+as[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*(,|})' "$layer_file"
-  )"
-  while IFS= read -r root_alias; do
-    [[ -z "$root_alias" ]] && continue
-    check_forbidden \
-      "upward tree root re-exports found below the driver layer:" \
-      "\\b${root_alias}::($tree_root_export_pattern|driver|tree)\\b" \
-      "$layer_file"
-  done <<< "$root_aliases"
-done
+# A crate-root alias can hide a forbidden name across files and nested modules.
+# There is no useful lower-layer spelling that requires one, so reject the
+# alias at its declaration instead of trying to reconstruct Rust name lookup.
+check_layer_findings \
+  "crate-root aliases found below the driver layer:" \
+  alias \
+  "$layer_findings"
 
 check_forbidden \
   "upward tree references found in the driver layer:" \

--- a/tools/check-layering-uses.awk
+++ b/tools/check-layering-uses.awk
@@ -106,6 +106,15 @@ function tokenize(source, number, offset, length_, character, pair, rest, found,
       continue
     }
 
+    # Raw identifiers have the same semantic name as the identifier after
+    # `r#`. Normalize them to one token so paths and `mod` declarations cannot
+    # bypass name or depth checks.
+    if (match(rest, /^r#[A-Za-z_][A-Za-z0-9_]*/)) {
+      add_token(substr(rest, 3, RLENGTH - 2), number)
+      offset += RLENGTH
+      continue
+    }
+
     character = substr(source, offset, 1)
     if (character == "\"") {
       in_string = 1
@@ -417,6 +426,11 @@ function find_lower_violations(index_, names_count, names) {
   }
 
   for (index_ = 1; index_ <= token_count; index_++) {
+    if (tokens[index_] == "extern" && tokens[index_ + 1] == "crate" \
+        && tokens[index_ + 2] == "self" && tokens[index_ + 3] == "as" \
+        && is_identifier(tokens[index_ + 4])) {
+      emit_finding("alias", index_, "extern crate self alias")
+    }
     if (root_path_at(index_, module_depth_at[index_])) {
       inspect_root_path(index_)
     }

--- a/tools/check-layering-uses.awk
+++ b/tools/check-layering-uses.awk
@@ -212,12 +212,8 @@ function last_path_segment(path, count, parts) {
   return parts[count]
 }
 
-function record_tree_binding(path, alias, index_, normalized, binding, parent) {
+function record_import_binding(path, alias, index_, normalized, binding, parent, key) {
   normalized = normalized_path(path)
-  if (normalized != "tree" && normalized !~ /^tree\//) {
-    return
-  }
-
   if (alias == "_") {
     return
   }
@@ -232,10 +228,60 @@ function record_tree_binding(path, alias, index_, normalized, binding, parent) {
   }
 
   if (!is_identifier(binding)) {
-    parse_error("unsupported tree import binding: " binding, index_)
+    parse_error("unsupported import binding: " binding, index_)
     return
   }
-  tree_bindings[binding] = 1
+
+  key = binding SUBSEP normalized
+  if (!import_bindings_seen[key]) {
+    import_bindings_seen[key] = 1
+    import_binding_count++
+    import_bindings[import_binding_count] = binding
+    import_paths[import_binding_count] = normalized
+  }
+}
+
+function record_import_glob(path, index_, normalized, key) {
+  normalized = normalized_path(path)
+  key = normalized SUBSEP index_
+  if (!import_globs_seen[key]) {
+    import_globs_seen[key] = 1
+    import_glob_count++
+    import_glob_paths[import_glob_count] = normalized
+    import_glob_indices[import_glob_count] = index_
+  }
+}
+
+function path_is_tree_derived(path, count, parts) {
+  count = split(path, parts, "/")
+  return parts[1] == "tree" || (parts[1] in tree_bindings)
+}
+
+function resolve_tree_bindings(index_, changed, binding) {
+  # Rust item order is irrelevant, so resolve aliases to a fixed point rather
+  # than depending on the order of the crate-root use statements. This covers
+  # chains such as `tree::System as First` followed by `First as Second`.
+  do {
+    changed = 0
+    for (index_ = 1; index_ <= import_binding_count; index_++) {
+      binding = import_bindings[index_]
+      if (!(binding in tree_bindings) \
+          && path_is_tree_derived(import_paths[index_])) {
+        tree_bindings[binding] = 1
+        changed = 1
+      }
+    }
+  } while (changed)
+
+  # A glob through a derived alias is just as opaque as `use tree::*`; fail
+  # closed once alias resolution has identified its tree-layer source.
+  for (index_ = 1; index_ <= import_glob_count; index_++) {
+    if (path_is_tree_derived(import_glob_paths[index_])) {
+      parse_error("tree glob imports cannot be derived safely", \
+        import_glob_indices[index_])
+      return
+    }
+  }
 }
 
 function parse_use_group(position, prefix) {
@@ -267,10 +313,7 @@ function parse_use_tree(position, prefix, segment, path, alias) {
     return parse_use_group(position, prefix)
   }
   if (tokens[position] == "*") {
-    if (normalized_path(prefix) == "tree" \
-        || normalized_path(prefix) ~ /^tree\//) {
-      parse_error("tree glob imports cannot be derived safely", position)
-    }
+    record_import_glob(prefix, position)
     return position + 1
   }
   if (!is_identifier(tokens[position])) {
@@ -288,14 +331,14 @@ function parse_use_tree(position, prefix, segment, path, alias) {
       parse_error("unsupported use-tree alias", position)
       return position + 1
     }
-    record_tree_binding(path, alias, position + 1)
+    record_import_binding(path, alias, position + 1)
     return position + 2
   }
   if (tokens[position] == "::") {
     return parse_use_tree(position + 1, path)
   }
 
-  record_tree_binding(path, "", position - 1)
+  record_import_binding(path, "", position - 1)
   return position
 }
 
@@ -313,6 +356,11 @@ function derive_lib_bindings(index_, position, count, names, name) {
       return
     }
     index_ = position
+  }
+
+  resolve_tree_bindings()
+  if (failed) {
+    return
   }
 
   count = asorti(tree_bindings, names)

--- a/tools/check-layering-uses.awk
+++ b/tools/check-layering-uses.awk
@@ -1,0 +1,452 @@
+# Tokenize the Rust source just deeply enough to reason about `use` trees and
+# crate-root paths. Comments and literals are discarded so examples and doc
+# text cannot trip the enforcement check.
+
+function add_token(value, number) {
+  token_count++
+  tokens[token_count] = value
+  token_lines[token_count] = number
+}
+
+function is_identifier(value) {
+  return value ~ /^[A-Za-z_][A-Za-z0-9_]*$/
+}
+
+function repeat(value, count, result) {
+  result = ""
+  while (count > 0) {
+    result = result value
+    count--
+  }
+  return result
+}
+
+function begin_raw_string(source, offset, cursor, hashes, character) {
+  cursor = offset
+  if (substr(source, cursor, 2) == "br") {
+    cursor += 2
+  } else if (substr(source, cursor, 1) == "r") {
+    cursor++
+  } else {
+    return 0
+  }
+
+  hashes = 0
+  while (substr(source, cursor, 1) == "#") {
+    hashes++
+    cursor++
+  }
+  character = substr(source, cursor, 1)
+  if (character != "\"") {
+    return 0
+  }
+
+  raw_string_end = "\"" repeat("#", hashes)
+  return cursor - offset + 1
+}
+
+function tokenize(source, number, offset, length_, character, pair, rest, found, raw_length) {
+  source = source "\n"
+  length_ = length(source)
+  offset = 1
+
+  while (offset <= length_) {
+    rest = substr(source, offset)
+
+    if (raw_string_end != "") {
+      found = index(rest, raw_string_end)
+      if (found == 0) {
+        return
+      }
+      offset += found - 1 + length(raw_string_end)
+      raw_string_end = ""
+      continue
+    }
+
+    if (in_string) {
+      character = substr(source, offset, 1)
+      if (string_escape) {
+        string_escape = 0
+      } else if (character == "\\") {
+        string_escape = 1
+      } else if (character == "\"") {
+        in_string = 0
+      }
+      offset++
+      continue
+    }
+
+    if (block_comment_depth > 0) {
+      pair = substr(source, offset, 2)
+      if (pair == "/*") {
+        block_comment_depth++
+        offset += 2
+      } else if (pair == "*/") {
+        block_comment_depth--
+        offset += 2
+      } else {
+        offset++
+      }
+      continue
+    }
+
+    pair = substr(source, offset, 2)
+    if (pair == "//") {
+      return
+    }
+    if (pair == "/*") {
+      block_comment_depth = 1
+      offset += 2
+      continue
+    }
+
+    raw_length = begin_raw_string(source, offset)
+    if (raw_length > 0) {
+      offset += raw_length
+      continue
+    }
+
+    character = substr(source, offset, 1)
+    if (character == "\"") {
+      in_string = 1
+      string_escape = 0
+      offset++
+      continue
+    }
+
+    # Skip a character literal, but leave lifetimes such as `'a` tokenizable.
+    if (character == "'") {
+      if (match(rest, /^'([^'\\]|\\.)'/)) {
+        offset += RLENGTH
+        continue
+      }
+      offset++
+      continue
+    }
+
+    if (character ~ /[A-Za-z_]/) {
+      match(rest, /^[A-Za-z_][A-Za-z0-9_]*/)
+      add_token(substr(rest, 1, RLENGTH), number)
+      offset += RLENGTH
+      continue
+    }
+
+    if (pair == "::") {
+      add_token("::", number)
+      offset += 2
+      continue
+    }
+
+    if (character ~ /[{}(),;*\[\]]/) {
+      add_token(character, number)
+    }
+    offset++
+  }
+}
+
+function build_depths(index_, module_depth, stack_depth, opens_module) {
+  module_depth = base_module_depth + 0
+  stack_depth = 0
+
+  for (index_ = 1; index_ <= token_count; index_++) {
+    module_depth_at[index_] = module_depth
+    brace_depth_at[index_] = stack_depth
+
+    if (tokens[index_] == "{") {
+      opens_module = index_ >= 3 && tokens[index_ - 2] == "mod" \
+        && is_identifier(tokens[index_ - 1])
+      stack_depth++
+      module_braces[stack_depth] = opens_module
+      if (opens_module) {
+        module_depth++
+      }
+    } else if (tokens[index_] == "}") {
+      if (stack_depth <= 0) {
+        parse_error("unmatched closing brace", index_)
+        continue
+      }
+      if (module_braces[stack_depth]) {
+        module_depth--
+      }
+      delete module_braces[stack_depth]
+      stack_depth--
+    }
+  }
+
+  if (stack_depth != 0) {
+    parse_error("unterminated brace-delimited source", token_count)
+  }
+}
+
+function parse_error(message, index_) {
+  if (!failed) {
+    if (index_ > 0) {
+      print FILENAME ":" token_lines[index_] ": " message > "/dev/stderr"
+    } else {
+      print FILENAME ": " message > "/dev/stderr"
+    }
+  }
+  failed = 1
+}
+
+function append_path(prefix, segment) {
+  return prefix == "" ? segment : prefix "/" segment
+}
+
+function normalized_path(path) {
+  sub(/^(crate|self)\//, "", path)
+  return path
+}
+
+function last_path_segment(path, count, parts) {
+  count = split(path, parts, "/")
+  return parts[count]
+}
+
+function record_tree_binding(path, alias, index_, normalized, binding, parent) {
+  normalized = normalized_path(path)
+  if (normalized != "tree" && normalized !~ /^tree\//) {
+    return
+  }
+
+  if (alias == "_") {
+    return
+  }
+  if (alias != "") {
+    binding = alias
+  } else if (last_path_segment(normalized) == "self") {
+    parent = normalized
+    sub(/\/self$/, "", parent)
+    binding = last_path_segment(parent)
+  } else {
+    binding = last_path_segment(normalized)
+  }
+
+  if (!is_identifier(binding)) {
+    parse_error("unsupported tree import binding: " binding, index_)
+    return
+  }
+  tree_bindings[binding] = 1
+}
+
+function parse_use_group(position, prefix) {
+  position++
+  while (position <= token_count && tokens[position] != "}") {
+    position = parse_use_tree(position, prefix)
+    if (failed) {
+      return position
+    }
+    if (tokens[position] == ",") {
+      position++
+    } else if (tokens[position] != "}") {
+      parse_error("unsupported use-tree group", position)
+      return position
+    }
+  }
+  if (tokens[position] != "}") {
+    parse_error("unterminated use-tree group", position - 1)
+    return position
+  }
+  return position + 1
+}
+
+function parse_use_tree(position, prefix, segment, path, alias) {
+  if (tokens[position] == "::") {
+    position++
+  }
+  if (tokens[position] == "{") {
+    return parse_use_group(position, prefix)
+  }
+  if (tokens[position] == "*") {
+    if (normalized_path(prefix) == "tree" \
+        || normalized_path(prefix) ~ /^tree\//) {
+      parse_error("tree glob imports cannot be derived safely", position)
+    }
+    return position + 1
+  }
+  if (!is_identifier(tokens[position])) {
+    parse_error("unsupported use-tree token: " tokens[position], position)
+    return position + 1
+  }
+
+  segment = tokens[position]
+  path = append_path(prefix, segment)
+  position++
+
+  if (tokens[position] == "as") {
+    alias = tokens[position + 1]
+    if (!is_identifier(alias)) {
+      parse_error("unsupported use-tree alias", position)
+      return position + 1
+    }
+    record_tree_binding(path, alias, position + 1)
+    return position + 2
+  }
+  if (tokens[position] == "::") {
+    return parse_use_tree(position + 1, path)
+  }
+
+  record_tree_binding(path, "", position - 1)
+  return position
+}
+
+function derive_lib_bindings(index_, position, count, names, name) {
+  for (index_ = 1; index_ <= token_count; index_++) {
+    if (tokens[index_] != "use" || brace_depth_at[index_] != 0) {
+      continue
+    }
+    position = parse_use_tree(index_ + 1, "")
+    if (failed) {
+      return
+    }
+    if (tokens[position] != ";") {
+      parse_error("unsupported crate-root use statement", position)
+      return
+    }
+    index_ = position
+  }
+
+  count = asorti(tree_bindings, names)
+  for (index_ = 1; index_ <= count; index_++) {
+    name = names[index_]
+    print name
+  }
+}
+
+function root_path_at(index_, required_depth, position, supers) {
+  if (tokens[index_] == "crate") {
+    root_after = index_ + 1
+    return 1
+  }
+  if (tokens[index_] != "super") {
+    return 0
+  }
+
+  position = index_
+  supers = 1
+  while (tokens[position + 1] == "::" && tokens[position + 2] == "super") {
+    supers++
+    position += 2
+  }
+  if (supers != required_depth) {
+    return 0
+  }
+  root_after = position + 1
+  return 1
+}
+
+function emit_finding(kind, index_, detail, key) {
+  key = kind SUBSEP token_lines[index_] SUBSEP detail
+  if (findings_seen[key]) {
+    return
+  }
+  findings_seen[key] = 1
+  print kind "\t" token_lines[index_] "\t" detail
+}
+
+function inspect_root_group(position, origin, depth, item_start, token_) {
+  depth = 1
+  item_start = 1
+  for (position = position + 1; position <= token_count; position++) {
+    token_ = tokens[position]
+    if (token_ == "{") {
+      depth++
+      continue
+    }
+    if (token_ == "}") {
+      depth--
+      if (depth == 0) {
+        return
+      }
+      continue
+    }
+    if (depth != 1) {
+      continue
+    }
+    if (token_ == ",") {
+      item_start = 1
+      continue
+    }
+    if (!item_start) {
+      continue
+    }
+
+    item_start = 0
+    if (token_ == "*") {
+      emit_finding("glob", origin, "crate-root glob import")
+    } else if (token_ == "self") {
+      emit_finding("alias", origin, "crate-root self import or alias")
+    } else if (token_ == "driver" || token_ == "tree") {
+      emit_finding("module", origin, "crate-root " token_ " import")
+    } else if (forbidden_names[token_]) {
+      emit_finding("export", origin, "crate-root tree export " token_)
+    }
+  }
+  parse_error("unterminated crate-root use group", origin)
+}
+
+function inspect_root_path(index_, position, token_) {
+  position = root_after
+  if (tokens[position] == "as") {
+    emit_finding("alias", index_, "crate-root alias")
+    return
+  }
+  if (tokens[position] != "::") {
+    return
+  }
+
+  position++
+  token_ = tokens[position]
+  if (token_ == "{") {
+    inspect_root_group(position, index_)
+  } else if (token_ == "*") {
+    emit_finding("glob", index_, "crate-root glob import")
+  } else if (token_ == "driver" || token_ == "tree") {
+    emit_finding("module", index_, "crate-root " token_ " reference")
+  } else if (forbidden_names[token_]) {
+    emit_finding("export", index_, "crate-root tree export " token_)
+  }
+}
+
+function find_lower_violations(index_, names_count, names) {
+  names_count = split(forbidden_exports, names, /\|/)
+  for (index_ = 1; index_ <= names_count; index_++) {
+    if (names[index_] != "") {
+      forbidden_names[names[index_]] = 1
+    }
+  }
+
+  for (index_ = 1; index_ <= token_count; index_++) {
+    if (root_path_at(index_, module_depth_at[index_])) {
+      inspect_root_path(index_)
+    }
+  }
+}
+
+{
+  tokenize($0, FNR)
+}
+
+END {
+  if (block_comment_depth > 0) {
+    parse_error("unterminated block comment", 0)
+  }
+  if (raw_string_end != "" || in_string) {
+    parse_error("unterminated string literal", 0)
+  }
+
+  build_depths()
+  if (!failed) {
+    if (mode == "lib") {
+      derive_lib_bindings()
+    } else if (mode == "lower") {
+      find_lower_violations()
+    } else {
+      parse_error("unknown checker mode: " mode, 0)
+    }
+  }
+
+  if (failed) {
+    exit 2
+  }
+}

--- a/tools/check-layering-uses.awk
+++ b/tools/check-layering-uses.awk
@@ -213,6 +213,13 @@ function last_path_segment(path, count, parts) {
 }
 
 function record_import_binding(path, alias, index_, normalized, binding, parent, key) {
+  # In lower mode the parsed use-tree items are inspected for crate-root
+  # violations instead of contributing to the lib.rs export derivation.
+  if (mode == "lower") {
+    inspect_lower_use_item(path, 0, index_)
+    return
+  }
+
   normalized = normalized_path(path)
   if (alias == "_") {
     return
@@ -242,6 +249,11 @@ function record_import_binding(path, alias, index_, normalized, binding, parent,
 }
 
 function record_import_glob(path, index_, normalized, key) {
+  if (mode == "lower") {
+    inspect_lower_use_item(path, 1, index_)
+    return
+  }
+
   normalized = normalized_path(path)
   key = normalized SUBSEP index_
   if (!import_globs_seen[key]) {
@@ -252,19 +264,38 @@ function record_import_glob(path, index_, normalized, key) {
   }
 }
 
-function path_is_tree_derived(path, count, parts) {
+function path_is_crate_root(path, count, parts) {
   count = split(path, parts, "/")
-  return parts[1] == "tree" || (parts[1] in tree_bindings)
+  return count == 1 \
+    && (parts[1] == "crate" || parts[1] == "self" || (parts[1] in root_bindings))
+}
+
+function path_is_tree_derived(path, count, parts, first) {
+  count = split(path, parts, "/")
+  first = parts[1]
+  # A crate-root alias re-roots the path one segment later: after
+  # `use crate as root`, the path `root::tree::X` means `crate::tree::X`.
+  if (first in root_bindings) {
+    first = parts[2]
+  }
+  return first == "tree" || (first in tree_bindings)
 }
 
 function resolve_tree_bindings(index_, changed, binding) {
   # Rust item order is irrelevant, so resolve aliases to a fixed point rather
   # than depending on the order of the crate-root use statements. This covers
-  # chains such as `tree::System as First` followed by `First as Second`.
+  # chains such as `tree::System as First` followed by `First as Second`, and
+  # crate-root aliases such as `use crate as root` followed by
+  # `root::tree::System as Third`.
   do {
     changed = 0
     for (index_ = 1; index_ <= import_binding_count; index_++) {
       binding = import_bindings[index_]
+      if (!(binding in root_bindings) \
+          && path_is_crate_root(import_paths[index_])) {
+        root_bindings[binding] = 1
+        changed = 1
+      }
       if (!(binding in tree_bindings) \
           && path_is_tree_derived(import_paths[index_])) {
         tree_bindings[binding] = 1
@@ -273,9 +304,16 @@ function resolve_tree_bindings(index_, changed, binding) {
     }
   } while (changed)
 
-  # A glob through a derived alias is just as opaque as `use tree::*`; fail
-  # closed once alias resolution has identified its tree-layer source.
   for (index_ = 1; index_ <= import_glob_count; index_++) {
+    # A glob of the crate root re-imports every root name, tree exports
+    # included, so the derivation cannot stay complete; fail closed.
+    if (path_is_crate_root(import_glob_paths[index_])) {
+      parse_error("crate-root glob imports cannot be derived safely", \
+        import_glob_indices[index_])
+      return
+    }
+    # A glob through a derived alias is just as opaque as `use tree::*`; fail
+    # closed once alias resolution has identified its tree-layer source.
     if (path_is_tree_derived(import_glob_paths[index_])) {
       parse_error("tree glob imports cannot be derived safely", \
         import_glob_indices[index_])
@@ -344,21 +382,56 @@ function parse_use_tree(position, prefix, segment, path, alias) {
 
 function derive_lib_bindings(index_, position, count, names, name) {
   for (index_ = 1; index_ <= token_count; index_++) {
-    if (tokens[index_] != "use" || brace_depth_at[index_] != 0) {
+    if (tokens[index_] == "use") {
+      # A use item inside a nested module (for example a future
+      # `pub mod prelude { pub use crate::tree::System; }`) can re-export a
+      # tree name the crate-root derivation would never see; fail closed.
+      if (brace_depth_at[index_] != 0) {
+        parse_error("nested use items cannot participate in the crate-root " \
+          "derivation", index_)
+        return
+      }
+      position = parse_use_tree(index_ + 1, "")
+      if (failed) {
+        return
+      }
+      if (tokens[position] != ";") {
+        parse_error("unsupported crate-root use statement", position)
+        return
+      }
+      index_ = position
       continue
     }
-    position = parse_use_tree(index_ + 1, "")
-    if (failed) {
-      return
+    # `extern crate self as name` is one more crate-root alias spelling; feed
+    # it into the fixed-point resolution like `use crate as name`.
+    if (tokens[index_] == "extern" && tokens[index_ + 1] == "crate" \
+        && tokens[index_ + 2] == "self" && tokens[index_ + 3] == "as" \
+        && is_identifier(tokens[index_ + 4])) {
+      record_import_binding("crate", tokens[index_ + 4], index_ + 4)
+      index_ += 4
+      continue
     }
-    if (tokens[position] != ";") {
-      parse_error("unsupported crate-root use statement", position)
-      return
+    # A crate-root type alias such as `pub type Renamed = tree::System;` is a
+    # re-export the use-tree derivation cannot see; record it for the
+    # post-resolution rejection below.
+    if (tokens[index_] == "type" && brace_depth_at[index_] == 0) {
+      type_alias_count++
+      type_alias_starts[type_alias_count] = index_
+      position = index_ + 1
+      while (position <= token_count && tokens[position] != ";") {
+        position++
+      }
+      type_alias_ends[type_alias_count] = position
+      index_ = position
     }
-    index_ = position
   }
 
   resolve_tree_bindings()
+  if (failed) {
+    return
+  }
+
+  reject_tree_type_aliases()
   if (failed) {
     return
   }
@@ -367,6 +440,20 @@ function derive_lib_bindings(index_, position, count, names, name) {
   for (index_ = 1; index_ <= count; index_++) {
     name = names[index_]
     print name
+  }
+}
+
+function reject_tree_type_aliases(index_, position, token_) {
+  for (index_ = 1; index_ <= type_alias_count; index_++) {
+    for (position = type_alias_starts[index_]; \
+         position <= type_alias_ends[index_]; position++) {
+      token_ = tokens[position]
+      if (token_ == "tree" || (token_ in tree_bindings)) {
+        parse_error("crate-root type aliases over tree exports cannot be " \
+          "derived", position)
+        return
+      }
+    }
   }
 }
 
@@ -401,48 +488,87 @@ function emit_finding(kind, index_, detail, key) {
   print kind "\t" token_lines[index_] "\t" detail
 }
 
-function inspect_root_group(position, origin, depth, item_start, token_) {
-  depth = 1
-  item_start = 1
-  for (position = position + 1; position <= token_count; position++) {
-    token_ = tokens[position]
-    if (token_ == "{") {
-      depth++
-      continue
+# Resolve one parsed use-tree path against the module depth of its use
+# statement. Returns 1 when the path reaches the crate root, leaving any
+# remaining segments in lower_root_rest. Parsing resolves each group item to
+# a full path first, so a `super` chain continued inside a nested group
+# (`use super::{super::System}`) counts like the flat spelling.
+function lower_path_reaches_root(path, count, parts, supers, cursor) {
+  count = split(path, parts, "/")
+  cursor = 1
+  if (parts[1] == "crate") {
+    cursor = 2
+  } else {
+    supers = 0
+    while (cursor <= count && parts[cursor] == "super") {
+      supers++
+      cursor++
     }
-    if (token_ == "}") {
-      depth--
-      if (depth == 0) {
-        return
-      }
-      continue
-    }
-    if (depth != 1) {
-      continue
-    }
-    if (token_ == ",") {
-      item_start = 1
-      continue
-    }
-    if (!item_start) {
-      continue
-    }
-
-    item_start = 0
-    if (token_ == "*") {
-      emit_finding("glob", origin, "crate-root glob import")
-    } else if (token_ == "self") {
-      emit_finding("alias", origin, "crate-root self import or alias")
-    } else if (token_ == "driver" || token_ == "tree") {
-      emit_finding("module", origin, "crate-root " token_ " import")
-    } else if (forbidden_names[token_]) {
-      emit_finding("export", origin, "crate-root tree export " token_)
+    # Fewer `super` segments than the module depth stays below the crate
+    # root. More than the depth cannot compile, so treat it as reaching the
+    # root and let the segment inspection fail closed.
+    if (supers == 0 || supers < lower_use_depth) {
+      return 0
     }
   }
-  parse_error("unterminated crate-root use group", origin)
+
+  lower_root_rest = ""
+  while (cursor <= count) {
+    lower_root_rest = append_path(lower_root_rest, parts[cursor])
+    cursor++
+  }
+  return 1
 }
 
-function inspect_root_path(index_, position, token_) {
+function inspect_lower_use_item(path, is_glob, index_, parts) {
+  if (!lower_path_reaches_root(path)) {
+    return
+  }
+  if (lower_root_rest == "") {
+    if (is_glob) {
+      emit_finding("glob", index_, "crate-root glob import")
+    } else {
+      emit_finding("alias", index_, "crate-root alias")
+    }
+    return
+  }
+
+  split(lower_root_rest, parts, "/")
+  if (parts[1] == "self") {
+    emit_finding("alias", index_, "crate-root self import or alias")
+  } else if (parts[1] == "driver" || parts[1] == "tree") {
+    emit_finding("module", index_, "crate-root " parts[1] " import")
+  } else if (forbidden_names[parts[1]]) {
+    emit_finding("export", index_, "crate-root tree export " parts[1])
+  }
+}
+
+function scan_lower_uses(index_, position, cursor) {
+  for (index_ = 1; index_ <= token_count; index_++) {
+    if (tokens[index_] != "use") {
+      continue
+    }
+    # A use statement cannot contain a module declaration, so its module
+    # depth is uniform; capture it for the per-item path resolution.
+    lower_use_depth = module_depth_at[index_]
+    position = parse_use_tree(index_ + 1, "")
+    if (failed) {
+      return
+    }
+    if (tokens[position] != ";") {
+      parse_error("unsupported use statement", position)
+      return
+    }
+    for (cursor = index_; cursor <= position; cursor++) {
+      in_use_statement[cursor] = 1
+    }
+    index_ = position
+  }
+}
+
+# Inspect a crate-root path outside a use statement: an expression, type
+# position, or cast such as `crate::System::new()`.
+function inspect_root_reference(index_, position, token_) {
   position = root_after
   if (tokens[position] == "as") {
     emit_finding("alias", index_, "crate-root alias")
@@ -455,7 +581,7 @@ function inspect_root_path(index_, position, token_) {
   position++
   token_ = tokens[position]
   if (token_ == "{") {
-    inspect_root_group(position, index_)
+    parse_error("crate-root use group outside a use statement", index_)
   } else if (token_ == "*") {
     emit_finding("glob", index_, "crate-root glob import")
   } else if (token_ == "driver" || token_ == "tree") {
@@ -473,14 +599,25 @@ function find_lower_violations(index_, names_count, names) {
     }
   }
 
+  # Use statements get the full recursive use-tree parse so nested groups
+  # and grouped `super` continuations resolve to complete per-item paths.
+  scan_lower_uses()
+  if (failed) {
+    return
+  }
+
+  # Everything else is scanned token-by-token for crate-root paths.
   for (index_ = 1; index_ <= token_count; index_++) {
+    if (in_use_statement[index_]) {
+      continue
+    }
     if (tokens[index_] == "extern" && tokens[index_ + 1] == "crate" \
         && tokens[index_ + 2] == "self" && tokens[index_ + 3] == "as" \
         && is_identifier(tokens[index_ + 4])) {
       emit_finding("alias", index_, "extern crate self alias")
     }
     if (root_path_at(index_, module_depth_at[index_])) {
-      inspect_root_path(index_)
+      inspect_root_reference(index_)
     }
   }
 }

--- a/tools/enforcement-fixtures/overlays/layering-crate-root-glob-alias-below/crates/shelterwood/src/observe.rs
+++ b/tools/enforcement-fixtures/overlays/layering-crate-root-glob-alias-below/crates/shelterwood/src/observe.rs
@@ -1,0 +1,4 @@
+// Known-bad fixture: glob access through a crate alias must not bypass the
+// tree-root export restriction.
+use crate as root;
+use root::*;

--- a/tools/enforcement-fixtures/overlays/layering-crate-root-grouped-alias-below/crates/shelterwood/src/observe.rs
+++ b/tools/enforcement-fixtures/overlays/layering-crate-root-grouped-alias-below/crates/shelterwood/src/observe.rs
@@ -1,0 +1,4 @@
+// Known-bad fixture: grouped access through a crate alias must not bypass the
+// tree-root export restriction.
+use crate as root;
+use root::{DerivedTreeExport, System};

--- a/tools/enforcement-fixtures/overlays/layering-extern-crate-self-alias-below/crates/shelterwood/src/observe.rs
+++ b/tools/enforcement-fixtures/overlays/layering-extern-crate-self-alias-below/crates/shelterwood/src/observe.rs
@@ -1,0 +1,4 @@
+// Known-bad fixture: `extern crate self` is another crate-root alias spelling
+// and must be rejected where the alias is declared.
+extern crate self as root;
+use root::DerivedTreeExport;

--- a/tools/enforcement-fixtures/overlays/layering-grouped-super-crate-root-glob-below/crates/shelterwood/src/policy/child.rs
+++ b/tools/enforcement-fixtures/overlays/layering-grouped-super-crate-root-glob-below/crates/shelterwood/src/policy/child.rs
@@ -1,0 +1,3 @@
+// Known-bad fixture: a `super` chain continued inside a use group can also
+// end in a glob of the crate root.
+use super::{super::*};

--- a/tools/enforcement-fixtures/overlays/layering-grouped-super-tree-root-reexport-below/crates/shelterwood/src/policy/child.rs
+++ b/tools/enforcement-fixtures/overlays/layering-grouped-super-tree-root-reexport-below/crates/shelterwood/src/policy/child.rs
@@ -1,0 +1,3 @@
+// Known-bad fixture: a `super` chain continued inside a use group reaches the
+// crate root exactly like the flat `super::super` spelling.
+use super::{super::DerivedTreeExport};

--- a/tools/enforcement-fixtures/overlays/layering-lib-alternate-tree-group-reexport-below/crates/shelterwood/src/lib.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-alternate-tree-group-reexport-below/crates/shelterwood/src/lib.rs
@@ -1,0 +1,4 @@
+mod tree;
+
+pub use tree::System;
+pub use {tree::AlternateTreeExport};

--- a/tools/enforcement-fixtures/overlays/layering-lib-alternate-tree-group-reexport-below/crates/shelterwood/src/policy.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-alternate-tree-group-reexport-below/crates/shelterwood/src/policy.rs
@@ -1,0 +1,3 @@
+// Known-bad fixture: an alternate root group in lib.rs still contributes a
+// tree-layer name to the derived pattern.
+use crate::AlternateTreeExport;

--- a/tools/enforcement-fixtures/overlays/layering-lib-chained-tree-reexport-below/crates/shelterwood/src/lib.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-chained-tree-reexport-below/crates/shelterwood/src/lib.rs
@@ -1,0 +1,4 @@
+mod tree;
+
+pub use tree::System as FirstTreeExport;
+pub use FirstTreeExport as ChainedTreeExport;

--- a/tools/enforcement-fixtures/overlays/layering-lib-chained-tree-reexport-below/crates/shelterwood/src/policy.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-chained-tree-reexport-below/crates/shelterwood/src/policy.rs
@@ -1,0 +1,3 @@
+// Known-bad fixture: a renamed tree export remains tree-derived when another
+// crate-root use statement gives it a second name.
+use crate::ChainedTreeExport;

--- a/tools/enforcement-fixtures/overlays/layering-lib-commented-tree-group-reexport-below/crates/shelterwood/src/lib.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-commented-tree-group-reexport-below/crates/shelterwood/src/lib.rs
@@ -1,0 +1,7 @@
+mod tree;
+
+pub use tree::{
+    System,
+    // This delimiter-like comment must not terminate the use tree: };
+    CommentSafeTreeExport,
+};

--- a/tools/enforcement-fixtures/overlays/layering-lib-commented-tree-group-reexport-below/crates/shelterwood/src/policy.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-commented-tree-group-reexport-below/crates/shelterwood/src/policy.rs
@@ -1,0 +1,2 @@
+// Known-bad fixture: comment stripping cannot hide later tree exports.
+use crate::CommentSafeTreeExport;

--- a/tools/enforcement-fixtures/overlays/layering-lib-crate-root-alias-reexport-below/crates/shelterwood/src/lib.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-crate-root-alias-reexport-below/crates/shelterwood/src/lib.rs
@@ -1,0 +1,8 @@
+mod actor;
+mod tree;
+
+pub use actor::Actor;
+pub use tree::{OriginalTreeExport as DerivedTreeExport, System};
+
+use crate as root;
+pub use root::tree::AliasedTreeExport as LaunderedTreeExport;

--- a/tools/enforcement-fixtures/overlays/layering-lib-crate-root-alias-reexport-below/crates/shelterwood/src/observe.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-crate-root-alias-reexport-below/crates/shelterwood/src/observe.rs
@@ -1,0 +1,3 @@
+// Known-bad fixture: a crate-root alias in lib.rs must not hide the tree
+// exports it re-exports from the derived pattern.
+use crate::LaunderedTreeExport;

--- a/tools/enforcement-fixtures/overlays/layering-lib-crate-root-glob-fails-closed/crates/shelterwood/src/lib.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-crate-root-glob-fails-closed/crates/shelterwood/src/lib.rs
@@ -1,0 +1,11 @@
+// Known-bad fixture: a glob of the crate root would re-import every tree
+// export without naming it, so the derivation fails closed. rustc rejects
+// this spelling too (E0432); the fixture pins the checker's own diagnostic.
+mod actor;
+mod tree;
+
+pub use actor::Actor;
+pub use tree::{OriginalTreeExport as DerivedTreeExport, System};
+
+use crate as root;
+pub use root::*;

--- a/tools/enforcement-fixtures/overlays/layering-lib-nested-reexport-fails-closed/crates/shelterwood/src/lib.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-nested-reexport-fails-closed/crates/shelterwood/src/lib.rs
@@ -1,0 +1,9 @@
+mod actor;
+mod tree;
+
+pub use actor::Actor;
+pub use tree::{OriginalTreeExport as DerivedTreeExport, System};
+
+pub mod prelude {
+    pub use crate::tree::System;
+}

--- a/tools/enforcement-fixtures/overlays/layering-lib-restricted-tree-reexport-below/crates/shelterwood/src/lib.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-restricted-tree-reexport-below/crates/shelterwood/src/lib.rs
@@ -1,0 +1,4 @@
+mod tree;
+
+pub use tree::System;
+pub(crate) use tree::InternalTreeExport;

--- a/tools/enforcement-fixtures/overlays/layering-lib-restricted-tree-reexport-below/crates/shelterwood/src/policy.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-restricted-tree-reexport-below/crates/shelterwood/src/policy.rs
@@ -1,0 +1,3 @@
+// Known-bad fixture: crate-visible imports in lib.rs remain visible to lower
+// modules and therefore belong in the derived tree-root pattern.
+use crate::InternalTreeExport;

--- a/tools/enforcement-fixtures/overlays/layering-lib-tree-alias-glob-fails-closed/crates/shelterwood/src/lib.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-tree-alias-glob-fails-closed/crates/shelterwood/src/lib.rs
@@ -1,0 +1,4 @@
+mod tree;
+
+use tree as tree_alias;
+use tree_alias::*;

--- a/tools/enforcement-fixtures/overlays/layering-lib-tree-glob-fails-closed/crates/shelterwood/src/lib.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-tree-glob-fails-closed/crates/shelterwood/src/lib.rs
@@ -1,0 +1,3 @@
+mod tree;
+
+pub use tree::*;

--- a/tools/enforcement-fixtures/overlays/layering-lib-tree-type-alias-fails-closed/crates/shelterwood/src/lib.rs
+++ b/tools/enforcement-fixtures/overlays/layering-lib-tree-type-alias-fails-closed/crates/shelterwood/src/lib.rs
@@ -1,0 +1,7 @@
+mod actor;
+mod tree;
+
+pub use actor::Actor;
+pub use tree::{OriginalTreeExport as DerivedTreeExport, System};
+
+pub type LaunderedTree = tree::OriginalTreeExport;

--- a/tools/enforcement-fixtures/overlays/layering-mailbox-crate-root-glob-below/crates/shelterwood/src/mailbox.rs
+++ b/tools/enforcement-fixtures/overlays/layering-mailbox-crate-root-glob-below/crates/shelterwood/src/mailbox.rs
@@ -1,0 +1,7 @@
+// Known-bad fixture: a crate-root glob exposes tree-layer exports in every
+// below-driver module without naming them at the import.
+use crate::*;
+
+fn retain_export(value: DerivedTreeExport) {
+    drop(value);
+}

--- a/tools/enforcement-fixtures/overlays/layering-nested-crate-root-alias-below/crates/shelterwood/src/policy/child.rs
+++ b/tools/enforcement-fixtures/overlays/layering-nested-crate-root-alias-below/crates/shelterwood/src/policy/child.rs
@@ -1,0 +1,2 @@
+// Known-bad fixture: a nested crate-root alias uses the complete `super` chain.
+use super::super as root;

--- a/tools/enforcement-fixtures/overlays/layering-nested-crate-root-glob-below/crates/shelterwood/src/policy/child.rs
+++ b/tools/enforcement-fixtures/overlays/layering-nested-crate-root-glob-below/crates/shelterwood/src/policy/child.rs
@@ -1,0 +1,2 @@
+// Known-bad fixture: a nested crate-root glob uses the complete `super` chain.
+use super::super::*;

--- a/tools/enforcement-fixtures/overlays/layering-nested-group-crate-root-alias-below/crates/shelterwood/src/engine.rs
+++ b/tools/enforcement-fixtures/overlays/layering-nested-group-crate-root-alias-below/crates/shelterwood/src/engine.rs
@@ -1,0 +1,3 @@
+// Known-bad fixture: a `self` alias nested inside another use group is still
+// an alias of the crate root.
+use crate::{{self as root}};

--- a/tools/enforcement-fixtures/overlays/layering-nested-group-crate-root-glob-below/crates/shelterwood/src/engine.rs
+++ b/tools/enforcement-fixtures/overlays/layering-nested-group-crate-root-glob-below/crates/shelterwood/src/engine.rs
@@ -1,0 +1,3 @@
+// Known-bad fixture: a glob nested inside another use group is still a glob
+// import of the crate root.
+use crate::{{*}};

--- a/tools/enforcement-fixtures/overlays/layering-nested-group-tree-root-reexport-below/crates/shelterwood/src/engine.rs
+++ b/tools/enforcement-fixtures/overlays/layering-nested-group-tree-root-reexport-below/crates/shelterwood/src/engine.rs
@@ -1,0 +1,3 @@
+// Known-bad fixture: a use group nested inside another group must not hide a
+// crate-root tree export from the layering check.
+use crate::{{System}};

--- a/tools/enforcement-fixtures/overlays/layering-nested-tree-root-reexport-below/crates/shelterwood/src/policy/child.rs
+++ b/tools/enforcement-fixtures/overlays/layering-nested-tree-root-reexport-below/crates/shelterwood/src/policy/child.rs
@@ -1,0 +1,3 @@
+// Known-bad fixture: a nested file needs two `super` segments to reach the
+// crate root, and that spelling must not bypass a derived tree export.
+use super::super::DerivedTreeExport;

--- a/tools/enforcement-fixtures/overlays/layering-observe-crate-root-alias-below/crates/shelterwood/src/observe.rs
+++ b/tools/enforcement-fixtures/overlays/layering-observe-crate-root-alias-below/crates/shelterwood/src/observe.rs
@@ -1,0 +1,7 @@
+// Known-bad fixture: aliasing the crate root must not hide a tree-layer export
+// outside the scope module.
+use crate as root;
+
+fn retain_export(value: root::DerivedTreeExport) {
+    drop(value);
+}

--- a/tools/enforcement-fixtures/overlays/layering-policy-tree-root-reexport-below/crates/shelterwood/src/policy.rs
+++ b/tools/enforcement-fixtures/overlays/layering-policy-tree-root-reexport-below/crates/shelterwood/src/policy.rs
@@ -1,0 +1,7 @@
+// Known-bad fixture: a tree-layer export discovered only from lib.rs remains
+// an upward dependency from every below-driver layer.
+use crate::DerivedTreeExport;
+
+fn retain_export(value: DerivedTreeExport) {
+    drop(value);
+}

--- a/tools/enforcement-fixtures/overlays/layering-raw-inline-module-tree-root-reexport-below/crates/shelterwood/src/policy.rs
+++ b/tools/enforcement-fixtures/overlays/layering-raw-inline-module-tree-root-reexport-below/crates/shelterwood/src/policy.rs
@@ -1,0 +1,4 @@
+// Known-bad fixture: raw inline-module names still add one module level.
+mod r#nested {
+    use super::super::DerivedTreeExport;
+}

--- a/tools/enforcement-fixtures/overlays/layering-raw-tree-root-reexport-below/crates/shelterwood/src/policy.rs
+++ b/tools/enforcement-fixtures/overlays/layering-raw-tree-root-reexport-below/crates/shelterwood/src/policy.rs
@@ -1,0 +1,2 @@
+// Known-bad fixture: raw identifiers normalize to their underlying name.
+use crate::r#DerivedTreeExport;

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/actor.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/actor.rs
@@ -1,2 +1,3 @@
-// Placeholder mirroring crates/shelterwood/src/actor.rs so every path the
-// enforcement scripts scan exists in the fixture tree.
+// A non-tree root export keeps the derived pattern from widening to every
+// crate-root import while it follows aliases.
+pub struct Actor;

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/lib.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/lib.rs
@@ -1,3 +1,5 @@
+mod actor;
 mod tree;
 
+pub use actor::Actor;
 pub use tree::{OriginalTreeExport as DerivedTreeExport, System};

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/lib.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/lib.rs
@@ -1,0 +1,3 @@
+mod tree;
+
+pub use tree::{OriginalTreeExport as DerivedTreeExport, System};

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/policy.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/policy.rs
@@ -1,6 +1,7 @@
 // Known-good fixture: an identifier that merely ends in a forbidden crate
 // name must not match the word-bounded runtime-path pattern.
 use crate::{policy::System, policy::*};
+use crate::Actor as RootActorNearMiss;
 
 pub fn sample() {
     not_fastrand::seed();

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/policy.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/policy.rs
@@ -6,7 +6,7 @@ pub fn sample() {
     not_fastrand::seed();
 }
 
-mod nested {
+mod r#nested {
     // One `super` reaches only the containing policy module here, not the
     // crate root, even though the imported name shadows a tree export.
     use super::{System, *};

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/policy.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/policy.rs
@@ -1,5 +1,13 @@
 // Known-good fixture: an identifier that merely ends in a forbidden crate
 // name must not match the word-bounded runtime-path pattern.
+use crate::{policy::System, policy::*};
+
 pub fn sample() {
     not_fastrand::seed();
+}
+
+mod nested {
+    // One `super` reaches only the containing policy module here, not the
+    // crate root, even though the imported name shadows a tree export.
+    use super::{System, *};
 }

--- a/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/policy/child.rs
+++ b/tools/enforcement-fixtures/skeleton/crates/shelterwood/src/policy/child.rs
@@ -1,0 +1,3 @@
+// Known-good nested-file fixture: one `super` reaches the parent policy
+// module, not the crate root.
+use super::{System, *};


### PR DESCRIPTION
Part of #151.

## Summary
- derive the crate-root tree export pattern directly from `lib.rs`, including renamed re-exports, re-exports spelled through crate-root aliases (`use crate as root; pub use root::tree::...`), and `extern crate self` aliases
- apply direct re-export, crate-root alias, and crate-root glob restrictions to every layer below the driver
- parse lower-layer `use` statements with the same recursive use-tree parser as the `lib.rs` derivation, so nested groups (`use crate::{{System}}`) and `super` chains continued inside groups (`use super::{super::System}`) resolve to complete per-item paths instead of evading the depth-1 token walk; crate-root paths outside `use` statements keep the token scan
- fail closed on shapes the derivation cannot represent: crate-root globs in `lib.rs`, `use` items nested inside `lib.rs` modules (a future `pub mod prelude`), and crate-root type aliases over tree exports
- add enforcement fixtures outside `scope.rs` so policy, observe, and mailbox regressions are pinned, plus fixtures for every parser hole closed above (nested groups, grouped `super` continuations, crate-root alias laundering, and each `lib.rs` fail-closed diagnostic); each known-bad shape was verified against rustc before being encoded

## Why
The layering check kept a hand-maintained copy of tree exports and enforced several escape-hatch rules only in the scope layer. That allowed the checker to drift from `lib.rs` and left equivalent upward dependencies available from other below-driver modules. Review then showed the first derivation used a shallow group scanner that nested use trees could evade, so the checker now shares one recursive parser between both modes and rejects anything it cannot resolve.

## Validation
- `./tools/dev just layering-path-check enforcement-fixture-check`
- `./tools/dev just ci` (499 tests plus docs, API/layering enforcement, package verification, and Nix formatting)
