### PR TITLE
Collapse resolved child readiness state

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -246,7 +246,7 @@ impl MemberCell {
                 &crate::policy::CommonOptions::default(),
                 &crate::policy::ResolvedDefaults::default(),
                 crate::policy::ChildMode::Restartable,
-                Readiness::Immediate,
+                Some(Readiness::Immediate),
             )
             .expect("library defaults must be valid")
         })

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -628,6 +628,8 @@ enum SpawnBody {
     Raw {
         spawn: RawSpawn,
         context: RawRunContext,
+        /// Declared override for the instance-reported readiness mode.
+        readiness: Option<Readiness>,
     },
     TaskRestartable {
         factory: TaskFactory,
@@ -703,7 +705,6 @@ struct ChildTaskLaunch {
     key: ChildKey,
     incarnation: Incarnation,
     body: SpawnBody,
-    readiness: Option<Readiness>,
     watch_readiness: bool,
     shutdown: Latch,
     ready: CompletionGatedLatch,
@@ -739,7 +740,13 @@ fn dispatch_child_construction(
                         local_stop: latches.local_stop.clone(),
                         mailbox_shutdown: child.options.mailbox_shutdown,
                     },
+                    readiness: child.options.readiness,
                 },
+                // `None` means "configure the readiness gate on the
+                // `Constructed` event", not "no readiness": a raw actor's
+                // mode is per-incarnation, so passing `child.options.readiness`
+                // here would arm the readiness deadline at spawn instead of
+                // construction.
                 declared_readiness: None,
                 construction_spent,
                 scope_child: false,
@@ -814,7 +821,6 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
         key,
         incarnation,
         body,
-        readiness,
         watch_readiness,
         shutdown,
         ready,
@@ -826,7 +832,11 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
     let handle = runtime::spawn(async move {
         let body = async move {
             match body {
-                SpawnBody::Raw { spawn, context } => {
+                SpawnBody::Raw {
+                    spawn,
+                    context,
+                    readiness,
+                } => {
                     let instance = spawn.construct();
                     let readiness = readiness.unwrap_or_else(|| instance.readiness());
                     let _ = runtime::mpsc_send(
@@ -1142,7 +1152,6 @@ impl ScopeRuntime {
         });
         let gated = readiness.needs_signal_watch();
 
-        let child_readiness = child.options.readiness;
         if construction_spent {
             // One-shot actor/task/subtree state has moved into `body`; the
             // retained construction is now framework-only spent metadata.
@@ -1155,7 +1164,6 @@ impl ScopeRuntime {
             key,
             incarnation,
             body,
-            readiness: child_readiness,
             watch_readiness: gated,
             shutdown: latches.shutdown.clone(),
             ready: latches.ready.clone(),

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -703,7 +703,7 @@ struct ChildTaskLaunch {
     key: ChildKey,
     incarnation: Incarnation,
     body: SpawnBody,
-    readiness_override: Option<Readiness>,
+    readiness: Option<Readiness>,
     watch_readiness: bool,
     shutdown: Latch,
     ready: CompletionGatedLatch,
@@ -750,7 +750,7 @@ fn dispatch_child_construction(
                 factory: Arc::clone(&definition.factory),
                 context: TaskContext::new(id, incarnation, latches.task_context()),
             },
-            declared_readiness: Some(child.options.readiness),
+            declared_readiness: child.options.readiness,
             construction_spent: false,
             scope_child: false,
         },
@@ -759,7 +759,7 @@ fn dispatch_child_construction(
                 body: definition.take_body(),
                 context: TaskContext::new(id, incarnation, latches.task_context()),
             },
-            declared_readiness: Some(child.options.readiness),
+            declared_readiness: child.options.readiness,
             construction_spent: true,
             scope_child: false,
         },
@@ -800,7 +800,7 @@ fn dispatch_child_construction(
             };
             SpawnDispatch {
                 body,
-                declared_readiness: Some(Readiness::Manual),
+                declared_readiness: child.options.readiness,
                 construction_spent,
                 scope_child: true,
             }
@@ -814,7 +814,7 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
         key,
         incarnation,
         body,
-        readiness_override,
+        readiness,
         watch_readiness,
         shutdown,
         ready,
@@ -828,7 +828,7 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
             match body {
                 SpawnBody::Raw { spawn, context } => {
                     let instance = spawn.construct();
-                    let readiness = readiness_override.unwrap_or_else(|| instance.readiness());
+                    let readiness = readiness.unwrap_or_else(|| instance.readiness());
                     let _ = runtime::mpsc_send(
                         &constructed_sender,
                         DriverEvent::Child(ChildEvent::Constructed {
@@ -1142,7 +1142,7 @@ impl ScopeRuntime {
         });
         let gated = readiness.needs_signal_watch();
 
-        let child_readiness_override = child.options.readiness_override;
+        let child_readiness = child.options.readiness;
         if construction_spent {
             // One-shot actor/task/subtree state has moved into `body`; the
             // retained construction is now framework-only spent metadata.
@@ -1155,7 +1155,7 @@ impl ScopeRuntime {
             key,
             incarnation,
             body,
-            readiness_override: child_readiness_override,
+            readiness: child_readiness,
             watch_readiness: gated,
             shutdown: latches.shutdown.clone(),
             ready: latches.ready.clone(),

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -496,16 +496,18 @@ mod tests {
     };
 
     use crate::{
-        Backoff, ExitError, Readiness, RestartCondition, RestartPolicy, Retention, Shutdown,
-        TaskOnceDef,
-        policy::{ResolvedDefaults, ScopeFlavor},
+        Backoff, DefaultsInheritance, ExitError, Readiness, RestartCondition, RestartPolicy,
+        Retention, Shutdown, TaskOnceDef,
+        definition::DefinitionSource,
+        policy::{CommonOptions, ResolvedDefaults, ScopeFlavor},
+        raw::RawConstruction,
         runtime::{self, Timeout},
         task::TaskDef,
     };
 
     use super::{
-        BuilderCore, ChildConstruction, ChildPlan, SlotCell, concrete_dynamic_slot,
-        concrete_dynamic_slot_ref, erase_dynamic_slot,
+        BuilderCore, ChildConstruction, ChildPlan, ScopeConstruction, SlotCell,
+        concrete_dynamic_slot, concrete_dynamic_slot_ref, erase_dynamic_slot,
     };
 
     fn configured_task() -> TaskDef {
@@ -565,6 +567,96 @@ mod tests {
 
         assert_eq!(static_plan.children[0].options, dynamic_plan.options);
         assert_eq!(dynamic_plan.options.readiness, Some(Readiness::Manual));
+    }
+
+    fn resolved_readiness(construction: ChildConstruction) -> Option<Readiness> {
+        let declaration = BuilderCore::new(ScopeFlavor::Dynamic);
+        let slot = SlotCell::new(Arc::clone(&declaration.root.member), None);
+        slot.define(construction);
+        slot.resolve_policy(&ResolvedDefaults::default())
+            .expect("policy is valid")
+            .expect("slot is defined")
+            .readiness
+    }
+
+    fn raw_construction(options: CommonOptions) -> ChildConstruction {
+        ChildConstruction::Raw(RawConstruction {
+            source: DefinitionSource::Restartable(Arc::new(|| {
+                unreachable!("policy resolution never constructs the actor")
+            })),
+            options,
+        })
+    }
+
+    fn scope_construction(options: CommonOptions) -> ChildConstruction {
+        ChildConstruction::Scope(Box::new(ScopeConstruction {
+            source: DefinitionSource::Restartable(Arc::new(|| {
+                BuilderCore::new(ScopeFlavor::Ordered)
+            })),
+            options,
+            defaults: DefaultsInheritance::Inherit,
+        }))
+    }
+
+    #[test]
+    fn resolution_applies_per_kind_readiness_defaults() {
+        // Undeclared readiness resolves per construction kind: tasks gate
+        // immediately, scopes wait for their startup barrier, and a raw
+        // actor's mode arrives with its construction report, so resolution
+        // declares none.
+        assert_eq!(
+            resolved_readiness(ChildConstruction::Task(TaskDef::new(|_| async { Ok(()) }))),
+            Some(Readiness::Immediate)
+        );
+        let (completion, _claim) = runtime::oneshot();
+        assert_eq!(
+            resolved_readiness(ChildConstruction::TaskOnce(
+                TaskOnceDef::new(|_| async { Ok::<_, ExitError>(()) }).erase(completion)
+            )),
+            Some(Readiness::Immediate)
+        );
+        assert_eq!(
+            resolved_readiness(scope_construction(CommonOptions::default())),
+            Some(Readiness::Manual)
+        );
+        assert_eq!(
+            resolved_readiness(raw_construction(CommonOptions::default())),
+            None
+        );
+
+        // A declared override wins over every per-kind default.
+        assert_eq!(
+            resolved_readiness(ChildConstruction::Task(
+                TaskDef::new(|_| async { Ok(()) })
+                    .readiness(Readiness::Manual)
+                    .expect("manual task readiness is valid")
+            )),
+            Some(Readiness::Manual)
+        );
+        let (completion, _claim) = runtime::oneshot();
+        assert_eq!(
+            resolved_readiness(ChildConstruction::TaskOnce(
+                TaskOnceDef::new(|_| async { Ok::<_, ExitError>(()) })
+                    .readiness(Readiness::Manual)
+                    .expect("manual task readiness is valid")
+                    .erase(completion)
+            )),
+            Some(Readiness::Manual)
+        );
+        assert_eq!(
+            resolved_readiness(scope_construction(CommonOptions {
+                readiness: Some(Readiness::Immediate),
+                ..CommonOptions::default()
+            })),
+            Some(Readiness::Immediate)
+        );
+        assert_eq!(
+            resolved_readiness(raw_construction(CommonOptions {
+                readiness: Some(Readiness::Manual),
+                ..CommonOptions::default()
+            })),
+            Some(Readiness::Manual)
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -195,10 +195,18 @@ impl SlotCell {
         definition: &Isolated<ChildConstruction>,
         defaults: &ResolvedDefaults,
     ) -> Result<ResolvedCommonOptions, InvalidPolicy> {
-        let (options, mode) = match definition.get() {
-            ChildConstruction::Raw(definition) => (&definition.options, definition.mode()),
-            ChildConstruction::Task(definition) => (&definition.options, ChildMode::Restartable),
-            ChildConstruction::TaskOnce(definition) => (&definition.options, ChildMode::OneShot),
+        let (options, mode, default_readiness) = match definition.get() {
+            ChildConstruction::Raw(definition) => (&definition.options, definition.mode(), None),
+            ChildConstruction::Task(definition) => (
+                &definition.options,
+                ChildMode::Restartable,
+                Some(Readiness::Immediate),
+            ),
+            ChildConstruction::TaskOnce(definition) => (
+                &definition.options,
+                ChildMode::OneShot,
+                Some(Readiness::Immediate),
+            ),
             ChildConstruction::Scope(definition) => {
                 if let DefinitionSource::OneShot(tree) = &definition.source {
                     let inherited = match definition.defaults {
@@ -208,10 +216,14 @@ impl SlotCell {
                     tree.validate_policies(&inherited)
                         .map_err(|invalid| invalid.prepend(self.member.id()))?;
                 }
-                (&definition.options, definition.mode())
+                (
+                    &definition.options,
+                    definition.mode(),
+                    Some(Readiness::Manual),
+                )
             }
         };
-        resolve_common(options, defaults, mode, Readiness::Immediate)
+        resolve_common(options, defaults, mode, default_readiness)
             .map_err(|invalid| invalid.prepend(self.member.id()))
     }
 }
@@ -552,6 +564,7 @@ mod tests {
             ChildPlan::with_options(dynamic_slot, dynamic_definition, dynamic_options);
 
         assert_eq!(static_plan.children[0].options, dynamic_plan.options);
+        assert_eq!(dynamic_plan.options.readiness, Some(Readiness::Manual));
     }
 
     #[test]

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -755,8 +755,9 @@ pub(crate) struct ResolvedCommonOptions {
     pub(crate) shutdown: Shutdown,
     pub(crate) mailbox: Mailbox,
     pub(crate) mailbox_shutdown: MailboxShutdown,
-    pub(crate) readiness: Readiness,
-    pub(crate) readiness_override: Option<Readiness>,
+    /// Effective definition readiness, or `None` when a raw actor declares it
+    /// from the constructed incarnation.
+    pub(crate) readiness: Option<Readiness>,
     pub(crate) readiness_deadline: ReadinessDeadline,
     pub(crate) retention: Retention,
 }
@@ -765,7 +766,7 @@ pub(crate) fn resolve_common(
     options: &CommonOptions,
     defaults: &ResolvedDefaults,
     mode: ChildMode,
-    default_readiness: Readiness,
+    default_readiness: Option<Readiness>,
 ) -> Result<ResolvedCommonOptions, InvalidPolicy> {
     defaults.validate()?;
     if let Some(restart) = options.restart {
@@ -786,8 +787,7 @@ pub(crate) fn resolve_common(
         shutdown: resolve(options.shutdown, defaults.child_shutdown),
         mailbox: resolve_mailbox(options.mailbox, defaults.mailbox, defaults.queue_capacity),
         mailbox_shutdown: resolve(options.mailbox_shutdown, defaults.mailbox_shutdown),
-        readiness: resolve(options.readiness, default_readiness),
-        readiness_override: options.readiness,
+        readiness: options.readiness.or(default_readiness),
         readiness_deadline: resolve_readiness_deadline(
             options.readiness_deadline,
             defaults.readiness_deadline,
@@ -1340,15 +1340,14 @@ mod tests {
             &CommonOptions::default(),
             &inherited,
             ChildMode::Restartable,
-            Readiness::Manual,
+            Some(Readiness::Manual),
         )
         .expect("default child options are valid");
         assert_eq!(child.restart, inherited.child_restart);
         assert_eq!(child.shutdown, inherited.child_shutdown);
         assert_eq!(child.mailbox, inherited.mailbox);
         assert_eq!(child.mailbox_shutdown, inherited.mailbox_shutdown);
-        assert_eq!(child.readiness, Readiness::Manual);
-        assert_eq!(child.readiness_override, None);
+        assert_eq!(child.readiness, Some(Readiness::Manual));
         assert_eq!(child.readiness_deadline, inherited.readiness_deadline);
         assert_eq!(child.retention, Retention::Retain);
 
@@ -1364,15 +1363,14 @@ mod tests {
             },
             &inherited,
             ChildMode::Restartable,
-            Readiness::Manual,
+            Some(Readiness::Manual),
         )
         .expect("explicit child options are valid");
         assert_eq!(overridden.restart, RestartPolicy::default());
         assert_eq!(overridden.shutdown, Shutdown::default());
         assert_eq!(overridden.mailbox, inherited.mailbox);
         assert_eq!(overridden.mailbox_shutdown, MailboxShutdown::Drain);
-        assert_eq!(overridden.readiness, Readiness::Immediate);
-        assert_eq!(overridden.readiness_override, Some(Readiness::Immediate));
+        assert_eq!(overridden.readiness, Some(Readiness::Immediate));
         assert_eq!(
             overridden.readiness_deadline,
             ReadinessDeadline::Bounded(Duration::from_nanos(1))
@@ -1400,7 +1398,7 @@ mod tests {
                 },
                 &ResolvedDefaults::default(),
                 ChildMode::OneShot,
-                Readiness::Immediate,
+                Some(Readiness::Immediate),
             ),
             Err(restart_error.clone()),
             "a one-shot child still rejects its ignored restart literal"
@@ -1418,7 +1416,7 @@ mod tests {
                 },
                 &invalid_inherited,
                 ChildMode::Restartable,
-                Readiness::Immediate,
+                Some(Readiness::Immediate),
             ),
             Err(restart_error),
             "an override cannot hide an invalid inherited value"


### PR DESCRIPTION
Part of #151.

## Summary

- replace `ResolvedCommonOptions::{readiness, readiness_override}` with one optional effective readiness field
- resolve task defaults to `Immediate` and subtree defaults to `Manual` while matching the concrete child construction during lowering
- preserve `None` only for raw actors whose constructed incarnation supplies its own declaration
- feed the same field into gate configuration and raw-instance fallback without changing public behavior

## Validation

- `./tools/dev cargo test -p shelterwood policy::tests`
- `./tools/dev cargo test -p shelterwood --test integration raw_readiness_override`
- `./tools/dev cargo test -p shelterwood --test integration readiness::`
- `./tools/dev just ci` (499 tests plus formatting, clippy, docs, API, layering, packaging, and Nix formatting)