### PR TITLE
Centralize exit classification

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -186,25 +186,23 @@ impl SystemRun {
         let Some(driver) = self.driver.take() else {
             return;
         };
-        match runtime::join(driver).await {
-            runtime::JoinOutcome::Ok { .. } => {}
-            runtime::JoinOutcome::Panic { message, .. } => {
-                let exit = Exit::new(ExitKind::Panicked { message }, Cancellation::NotObserved);
-                self.root
-                    .finish_live_root_incarnation(StopReason::ShutdownRequested, exit);
-            }
+        // Only a crashed or cancelled driver leaves a live root incarnation to
+        // classify; cancellation of the driver itself is the one join verdict
+        // that proves the root observed cancellation.
+        let (join, cancellation) = match runtime::join(driver).await {
+            runtime::JoinOutcome::Ok { .. } => return,
+            runtime::JoinOutcome::Panic { message } => (
+                runtime::JoinOutcome::Panic { message },
+                Cancellation::NotObserved,
+            ),
             runtime::JoinOutcome::Cancelled => {
-                self.root.finish_live_root_incarnation(
-                    StopReason::ShutdownRequested,
-                    Exit::new(
-                        ExitKind::Aborted {
-                            phase: GracePhase::WithinGrace,
-                        },
-                        Cancellation::Observed,
-                    ),
-                );
+                (runtime::JoinOutcome::Cancelled, Cancellation::Observed)
             }
-        }
+        };
+        self.root.finish_live_root_incarnation(
+            StopReason::ShutdownRequested,
+            classify_exit(None, join, None, cancellation),
+        );
     }
 }
 
@@ -288,26 +286,21 @@ pub(crate) fn spawn_system(plan: ScopePlan) -> SystemRun {
     let monitor_root = Arc::clone(&root);
     let driver = runtime::spawn(async move { run_scope(plan, ScopeRole::Root).await });
     let lifecycle = runtime::spawn(async move {
-        match runtime::join(driver).await {
-            runtime::JoinOutcome::Ok { value, .. } => value,
-            runtime::JoinOutcome::Panic { message, .. } => {
-                let exit = Exit::new(ExitKind::Panicked { message }, Cancellation::NotObserved);
-                monitor_root.finish_live_root_incarnation(StopReason::ShutdownRequested, exit);
-                StopReason::ShutdownRequested
-            }
+        let (join, cancellation) = match runtime::join(driver).await {
+            runtime::JoinOutcome::Ok { value } => return value,
+            runtime::JoinOutcome::Panic { message } => (
+                runtime::JoinOutcome::Panic { message },
+                Cancellation::NotObserved,
+            ),
             runtime::JoinOutcome::Cancelled => {
-                monitor_root.finish_live_root_incarnation(
-                    StopReason::ShutdownRequested,
-                    Exit::new(
-                        ExitKind::Aborted {
-                            phase: GracePhase::WithinGrace,
-                        },
-                        Cancellation::Observed,
-                    ),
-                );
-                StopReason::ShutdownRequested
+                (runtime::JoinOutcome::Cancelled, Cancellation::Observed)
             }
-        }
+        };
+        monitor_root.finish_live_root_incarnation(
+            StopReason::ShutdownRequested,
+            classify_exit(None, join, None, cancellation),
+        );
+        StopReason::ShutdownRequested
     });
     SystemRun {
         root,

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -25,7 +25,7 @@ use crate::{
         dispatch_exit, schedule_restart,
     },
     exit::{
-        JoinVerdict, RecordedOutcome, StartupError, StopReason, classify_exit,
+        RecordedOutcome, StartupError, StopReason, classify_disposal_panic, classify_exit,
         reconcile_recorded_outcomes,
     },
     identity::IncarnationCounter,
@@ -333,7 +333,7 @@ enum ChildEvent {
         child: ChildKey,
         incarnation: Incarnation,
         recorded: Option<RecordedOutcome>,
-        join: JoinVerdict,
+        join: runtime::JoinOutcome<()>,
         cancellation: Cancellation,
         readiness_signal_seen: bool,
     },
@@ -868,13 +868,7 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
 
     let exit_sender = events.clone();
     runtime::spawn(async move {
-        let join = match runtime::join(handle).await {
-            runtime::JoinOutcome::Ok { .. } => JoinVerdict::Completed,
-            runtime::JoinOutcome::Panic { message, .. } => JoinVerdict::Panicked { message },
-            runtime::JoinOutcome::Cancelled => JoinVerdict::Cancelled {
-                phase: GracePhase::WithinGrace,
-            },
-        };
+        let join = runtime::join(handle).await;
         // The task owns `report`, whose explicit record or Drop fallback runs
         // before the join completes. `receive` therefore asserts sole
         // ownership and immediate post-join availability without ever
@@ -1607,7 +1601,7 @@ impl ScopeRuntime {
         key: ChildKey,
         incarnation: Incarnation,
         recorded: Option<RecordedOutcome>,
-        mut join: JoinVerdict,
+        join: runtime::JoinOutcome<()>,
         cancellation: Cancellation,
         readiness_signal_seen: bool,
     ) {
@@ -1652,11 +1646,8 @@ impl ScopeRuntime {
         {
             runtime::dispose_detached(teardown);
         }
-        if let (JoinVerdict::Cancelled { .. }, Some(phase)) = (&join, active.hard_abort_phase) {
-            join = JoinVerdict::Cancelled { phase };
-        }
         let recorded = reconcile_recorded_outcomes(recorded, active.forced_outcome);
-        let exit = classify_exit(recorded, join, cancellation);
+        let exit = classify_exit(recorded, join, active.hard_abort_phase, cancellation);
         child.restarts.settle_if_stable(
             IncarnationRun {
                 started_at: active.started_at,
@@ -1833,13 +1824,12 @@ impl ScopeRuntime {
         child.slot.member.set_terminal_disposal_pending(false);
         if terminal.exited_incarnation.is_some()
             && let Some(runtime::DisposalPanic { message }) = panic
-            && !matches!(terminal.exit.kind(), ExitKind::Panicked { .. })
         {
             // Only an exited incarnation can own a destructor failure. A
             // never-started child or a child between restart incarnations
             // keeps its already-authoritative verdict while disposal remains
             // ordered ahead of terminal routing.
-            terminal.exit = Exit::new(ExitKind::Panicked { message }, terminal.exit.cancellation());
+            terminal.exit = classify_disposal_panic(terminal.exit, message);
         }
 
         let exit = terminal.exit;
@@ -2354,12 +2344,9 @@ async fn run_nested_tree_with_epoch(
             return Err(crate::ExitError::from_startup_failure(failure));
         }
     };
-    match run_scope_incarnation(plan, ScopeRole::Nested(latches), epoch).await {
-        StopReason::Finished | StopReason::ShutdownRequested => Ok(()),
-        StopReason::IntensityTripped(trip) => Err(crate::ExitError::from_intensity_trip(trip)),
-        StopReason::StartupFailed(failure) => Err(crate::ExitError::from_startup_failure(failure)),
-        StopReason::NeverStarted => Err(crate::ExitError::message("nested scope never started")),
-    }
+    run_scope_incarnation(plan, ScopeRole::Nested(latches), epoch)
+        .await
+        .into_nested_result()
 }
 
 async fn run_scope(plan: ScopePlan, role: ScopeRole) -> StopReason {
@@ -2638,25 +2625,7 @@ async fn run_scope_incarnation(
         }
 
         if let Some(reason) = scope.finish_if_ready() {
-            let root_exit = scope.role.is_root().then(|| match &reason {
-                StopReason::Finished | StopReason::ShutdownRequested => {
-                    let cancellation = if reason == StopReason::ShutdownRequested {
-                        Cancellation::Observed
-                    } else {
-                        Cancellation::NotObserved
-                    };
-                    Exit::new(ExitKind::Completed, cancellation)
-                }
-                StopReason::IntensityTripped(trip) => Exit::new(
-                    ExitKind::Failed(crate::ExitError::from_intensity_trip(trip.clone())),
-                    Cancellation::NotObserved,
-                ),
-                StopReason::StartupFailed(failure) => Exit::new(
-                    ExitKind::Failed(crate::ExitError::from_startup_failure(failure.clone())),
-                    Cancellation::NotObserved,
-                ),
-                StopReason::NeverStarted => Exit::never_started(),
-            });
+            let root_exit = scope.role.is_root().then(|| reason.root_exit());
             // ScopeRuntime's synchronous epilogue clears dynamic state,
             // discharges child obligations and residency, and only then
             // publishes the scope's terminal state.

--- a/crates/shelterwood/src/driver/tests.rs
+++ b/crates/shelterwood/src/driver/tests.rs
@@ -16,7 +16,7 @@ use crate::{
     RestartPolicy, Retention, ScopeRef, ScopeState, SendErrorKind, StartupError,
     StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
     engine::{Epoch, ScopeLifecycle, StopLadder, arbitrate},
-    exit::{JoinVerdict, RecordedOutcome},
+    exit::RecordedOutcome,
     identity::{IncarnationCounter, ScopeIdentity},
     mailbox::MailboxCell,
     plan::{ChildConstruction, SlotCell},
@@ -1109,7 +1109,7 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
         recorded: Some(RecordedOutcome::returned(Err(ExitError::message(
             "trip intensity",
         )))),
-        join: JoinVerdict::Completed,
+        join: crate::runtime::JoinOutcome::Ok { value: () },
         cancellation: Cancellation::NotObserved,
         readiness_signal_seen: false,
     });
@@ -1230,7 +1230,7 @@ async fn same_batch_self_stop_preserves_fired_readiness_for_startup() {
             child: key,
             incarnation,
             recorded: Some(RecordedOutcome::returned(Ok(()))),
-            join: JoinVerdict::Completed,
+            join: crate::runtime::JoinOutcome::Ok { value: () },
             cancellation: Cancellation::NotObserved,
             readiness_signal_seen: true,
         }))

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -7,7 +7,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::identity::{ChildId, Membership};
+use crate::{
+    identity::{ChildId, Membership},
+    runtime,
+};
 
 /// The terminal reason for a scope incarnation or root system.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -23,6 +26,33 @@ pub enum StopReason {
     StartupFailed(StartupFailure),
     /// The membership terminalized without an incarnation.
     NeverStarted,
+}
+
+impl StopReason {
+    pub(crate) fn into_nested_result(self) -> ExitResult {
+        match self {
+            Self::Finished | Self::ShutdownRequested => Ok(()),
+            Self::IntensityTripped(trip) => Err(ExitError::from_intensity_trip(trip)),
+            Self::StartupFailed(failure) => Err(ExitError::from_startup_failure(failure)),
+            Self::NeverStarted => Err(ExitError::message("nested scope never started")),
+        }
+    }
+
+    pub(crate) fn root_exit(&self) -> Exit {
+        match self {
+            Self::Finished => Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+            Self::ShutdownRequested => Exit::new(ExitKind::Completed, Cancellation::Observed),
+            Self::IntensityTripped(trip) => Exit::new(
+                ExitKind::Failed(ExitError::from_intensity_trip(trip.clone())),
+                Cancellation::NotObserved,
+            ),
+            Self::StartupFailed(failure) => Exit::new(
+                ExitKind::Failed(ExitError::from_startup_failure(failure.clone())),
+                Cancellation::NotObserved,
+            ),
+            Self::NeverStarted => Exit::never_started(),
+        }
+    }
 }
 
 /// Failure of the root startup barrier.
@@ -446,13 +476,6 @@ impl RecordedOutcome {
     }
 }
 
-#[derive(Clone, Debug)]
-pub(crate) enum JoinVerdict {
-    Completed,
-    Panicked { message: Option<String> },
-    Cancelled { phase: GracePhase },
-}
-
 /// Reconciles task-produced evidence with a later supervisor-forced outcome.
 ///
 /// The same diagnostic precedence used for the final join applies here, and
@@ -484,17 +507,22 @@ pub(crate) fn reconcile_recorded_outcomes(
 /// cancellation reported while joining only proves that destruction ended the
 /// task; it must not erase an application error recorded before destruction.
 /// Equal-ranked outcomes keep the earlier recorded evidence, including its
-/// panic payload or abort provenance.
+/// panic payload or abort provenance. A cancelled join uses the supervisor's
+/// hard-abort phase when one was recorded and otherwise fails closed to
+/// [`GracePhase::WithinGrace`].
 pub(crate) fn classify_exit(
     recorded: Option<RecordedOutcome>,
-    join: JoinVerdict,
+    join: runtime::JoinOutcome<()>,
+    hard_abort_phase: Option<GracePhase>,
     cancellation: Cancellation,
 ) -> Exit {
     let recorded_kind = recorded.map(RecordedOutcome::into_kind);
     let join_kind = match join {
-        JoinVerdict::Completed => None,
-        JoinVerdict::Panicked { message } => Some(ExitKind::Panicked { message }),
-        JoinVerdict::Cancelled { phase } => Some(ExitKind::Aborted { phase }),
+        runtime::JoinOutcome::Ok { .. } => None,
+        runtime::JoinOutcome::Panic { message } => Some(ExitKind::Panicked { message }),
+        runtime::JoinOutcome::Cancelled => Some(ExitKind::Aborted {
+            phase: hard_abort_phase.unwrap_or(GracePhase::WithinGrace),
+        }),
     };
 
     let kind = match (recorded_kind, join_kind) {
@@ -505,6 +533,14 @@ pub(crate) fn classify_exit(
             phase: GracePhase::WithinGrace,
         },
     };
+    Exit::new(kind, cancellation)
+}
+
+/// Adds a destructor panic to an already-classified exit without erasing an
+/// earlier panic, which has equal diagnostic precedence and happened first.
+pub(crate) fn classify_disposal_panic(exit: Exit, message: Option<String>) -> Exit {
+    let Exit { kind, cancellation } = exit;
+    let kind = prefer_earlier(kind, ExitKind::Panicked { message });
     Exit::new(kind, cancellation)
 }
 
@@ -563,10 +599,12 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use super::{
-        Cancellation, ChildId, Exit, ExitError, ExitKind, GracePhase, IntensityTrip, JoinVerdict,
-        RecordedOutcome, StartupError, StartupFailure, StartupFailureCause, classify_exit,
-        exit_kind_eq, prefer_earlier, reconcile_recorded_outcomes,
+        Cancellation, ChildId, Exit, ExitError, ExitKind, GracePhase, IntensityTrip,
+        RecordedOutcome, StartupError, StartupFailure, StartupFailureCause, StopReason,
+        classify_disposal_panic, classify_exit, exit_kind_eq, prefer_earlier,
+        reconcile_recorded_outcomes,
     };
+    use crate::runtime::JoinOutcome;
 
     #[test]
     fn recorded_outcomes_are_canonical_exit_kinds() {
@@ -667,16 +705,16 @@ mod tests {
             (
                 "recorded completion",
                 Some(RecordedOutcome::returned(Ok(()))),
-                JoinVerdict::Completed,
+                JoinOutcome::Ok { value: () },
+                None,
                 Cancellation::NotObserved,
                 Exit::new(ExitKind::Completed, Cancellation::NotObserved),
             ),
             (
                 "cancellation overrides recorded completion",
                 Some(RecordedOutcome::returned(Ok(()))),
-                JoinVerdict::Cancelled {
-                    phase: GracePhase::AfterGrace,
-                },
+                JoinOutcome::Cancelled,
+                Some(GracePhase::AfterGrace),
                 Cancellation::Observed,
                 Exit::new(
                     ExitKind::Aborted {
@@ -688,25 +726,26 @@ mod tests {
             (
                 "recorded failure",
                 Some(RecordedOutcome::returned(Err(failure.clone()))),
-                JoinVerdict::Completed,
+                JoinOutcome::Ok { value: () },
+                None,
                 Cancellation::NotObserved,
                 Exit::new(ExitKind::Failed(failure.clone()), Cancellation::NotObserved),
             ),
             (
                 "late cancellation preserves recorded failure",
                 Some(RecordedOutcome::returned(Err(failure.clone()))),
-                JoinVerdict::Cancelled {
-                    phase: GracePhase::AfterGrace,
-                },
+                JoinOutcome::Cancelled,
+                Some(GracePhase::AfterGrace),
                 Cancellation::Observed,
                 Exit::new(ExitKind::Failed(failure.clone()), Cancellation::Observed),
             ),
             (
                 "join panic overrides recorded failure",
                 Some(RecordedOutcome::returned(Err(failure.clone()))),
-                JoinVerdict::Panicked {
+                JoinOutcome::Panic {
                     message: Some("drop panic".to_owned()),
                 },
+                None,
                 Cancellation::NotObserved,
                 Exit::new(
                     ExitKind::Panicked {
@@ -718,9 +757,8 @@ mod tests {
             (
                 "readiness timeout overrides cancellation",
                 Some(RecordedOutcome::readiness_timed_out(deadline)),
-                JoinVerdict::Cancelled {
-                    phase: GracePhase::AfterGrace,
-                },
+                JoinOutcome::Cancelled,
+                Some(GracePhase::AfterGrace),
                 Cancellation::Observed,
                 Exit::new(
                     ExitKind::ReadinessTimedOut { deadline },
@@ -730,9 +768,10 @@ mod tests {
             (
                 "join panic overrides recorded completion",
                 Some(RecordedOutcome::returned(Ok(()))),
-                JoinVerdict::Panicked {
+                JoinOutcome::Panic {
                     message: Some("drop panic".to_owned()),
                 },
+                None,
                 Cancellation::NotObserved,
                 Exit::new(
                     ExitKind::Panicked {
@@ -746,9 +785,10 @@ mod tests {
                 Some(RecordedOutcome(ExitKind::Panicked {
                     message: Some("callback panic".to_owned()),
                 })),
-                JoinVerdict::Panicked {
+                JoinOutcome::Panic {
                     message: Some("drop panic".to_owned()),
                 },
+                None,
                 Cancellation::Observed,
                 Exit::new(
                     ExitKind::Panicked {
@@ -760,9 +800,8 @@ mod tests {
             (
                 "earlier recorded abort wins a tie",
                 Some(RecordedOutcome::aborted(GracePhase::WithinGrace)),
-                JoinVerdict::Cancelled {
-                    phase: GracePhase::AfterGrace,
-                },
+                JoinOutcome::Cancelled,
+                Some(GracePhase::AfterGrace),
                 Cancellation::Observed,
                 Exit::new(
                     ExitKind::Aborted {
@@ -774,9 +813,8 @@ mod tests {
             (
                 "join cancellation supplies a missing outcome",
                 None,
-                JoinVerdict::Cancelled {
-                    phase: GracePhase::AfterGrace,
-                },
+                JoinOutcome::Cancelled,
+                Some(GracePhase::AfterGrace),
                 Cancellation::Observed,
                 Exit::new(
                     ExitKind::Aborted {
@@ -788,7 +826,8 @@ mod tests {
             (
                 "missing outcome fails closed",
                 None,
-                JoinVerdict::Completed,
+                JoinOutcome::Ok { value: () },
+                None,
                 Cancellation::NotObserved,
                 Exit::new(
                     ExitKind::Aborted {
@@ -799,13 +838,90 @@ mod tests {
             ),
         ];
 
-        for (case, recorded, join, cancellation, expected) in cases {
+        for (case, recorded, join, hard_abort_phase, cancellation, expected) in cases {
             assert_eq!(
-                classify_exit(recorded, join, cancellation),
+                classify_exit(recorded, join, hard_abort_phase, cancellation),
                 expected,
                 "{case}"
             );
         }
+    }
+
+    #[test]
+    fn disposal_panic_uses_exit_precedence_and_preserves_cancellation() {
+        let classified = classify_disposal_panic(
+            Exit::new(ExitKind::Completed, Cancellation::Observed),
+            Some("destructor".to_owned()),
+        );
+        assert_eq!(
+            classified,
+            Exit::new(
+                ExitKind::Panicked {
+                    message: Some("destructor".to_owned())
+                },
+                Cancellation::Observed
+            )
+        );
+
+        let earlier = Exit::new(
+            ExitKind::Panicked {
+                message: Some("task".to_owned()),
+            },
+            Cancellation::NotObserved,
+        );
+        assert_eq!(
+            classify_disposal_panic(earlier.clone(), Some("destructor".to_owned())),
+            earlier
+        );
+    }
+
+    #[test]
+    fn stop_reasons_own_nested_and_root_exit_projection() {
+        assert!(StopReason::Finished.into_nested_result().is_ok());
+        assert!(StopReason::ShutdownRequested.into_nested_result().is_ok());
+        assert_eq!(
+            StopReason::ShutdownRequested.root_exit(),
+            Exit::new(ExitKind::Completed, Cancellation::Observed)
+        );
+        assert_eq!(StopReason::NeverStarted.root_exit(), Exit::never_started());
+
+        let trip = IntensityTrip {
+            max_restarts: 2,
+            observed_restarts: 3,
+            within: Duration::from_secs(10),
+        };
+        let nested = StopReason::IntensityTripped(trip.clone())
+            .into_nested_result()
+            .expect_err("an intensity trip fails a nested scope");
+        assert_eq!(nested.intensity_trip(), Some(&trip));
+        let root = StopReason::IntensityTripped(trip.clone()).root_exit();
+        let ExitKind::Failed(error) = root.kind() else {
+            panic!("an intensity trip fails the root")
+        };
+        assert_eq!(error.intensity_trip(), Some(&trip));
+
+        let failure = StartupFailure {
+            cause: StartupFailureCause::IdentityExhausted {
+                id: ChildId::from("nested"),
+            },
+        };
+        let nested = StopReason::StartupFailed(failure.clone())
+            .into_nested_result()
+            .expect_err("startup failure fails a nested scope");
+        assert_eq!(nested.startup_failure(), Some(&failure));
+        let root = StopReason::StartupFailed(failure.clone()).root_exit();
+        let ExitKind::Failed(error) = root.kind() else {
+            panic!("startup failure fails the root")
+        };
+        assert_eq!(error.startup_failure(), Some(&failure));
+
+        let never_started = StopReason::NeverStarted
+            .into_nested_result()
+            .expect_err("a never-started nested scope fails closed");
+        assert_eq!(
+            never_started.as_error().to_string(),
+            "nested scope never started"
+        );
     }
 
     #[test]
@@ -879,9 +995,8 @@ mod tests {
             assert_eq!(
                 classify_exit(
                     reconciled,
-                    JoinVerdict::Cancelled {
-                        phase: GracePhase::AfterGrace
-                    },
+                    JoinOutcome::Cancelled,
+                    Some(GracePhase::AfterGrace),
                     Cancellation::Observed
                 ),
                 expected,

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -811,6 +811,27 @@ mod tests {
                 ),
             ),
             (
+                "cancelled join without a hard abort fails closed to within grace",
+                None,
+                JoinOutcome::Cancelled,
+                None,
+                Cancellation::Observed,
+                Exit::new(
+                    ExitKind::Aborted {
+                        phase: GracePhase::WithinGrace,
+                    },
+                    Cancellation::Observed,
+                ),
+            ),
+            (
+                "hard abort phase is ignored when the join completed normally",
+                Some(RecordedOutcome::returned(Ok(()))),
+                JoinOutcome::Ok { value: () },
+                Some(GracePhase::AfterGrace),
+                Cancellation::Observed,
+                Exit::new(ExitKind::Completed, Cancellation::Observed),
+            ),
+            (
                 "join cancellation supplies a missing outcome",
                 None,
                 JoinOutcome::Cancelled,
@@ -862,6 +883,25 @@ mod tests {
                 Cancellation::Observed
             )
         );
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        for weaker in [
+            ExitKind::Failed(ExitError::message("failed")),
+            ExitKind::ReadinessTimedOut { deadline },
+        ] {
+            assert_eq!(
+                classify_disposal_panic(
+                    Exit::new(weaker, Cancellation::NotObserved),
+                    Some("destructor".to_owned()),
+                ),
+                Exit::new(
+                    ExitKind::Panicked {
+                        message: Some("destructor".to_owned())
+                    },
+                    Cancellation::NotObserved
+                )
+            );
+        }
 
         let earlier = Exit::new(
             ExitKind::Panicked {


### PR DESCRIPTION
Part of #151.

## Summary

- pass the runtime `JoinOutcome` into the exit classifier directly and remove the lossy `JoinVerdict` mirror
- let the classifier own cancelled-join grace-phase selection instead of rewriting it in the driver
- fold destructor panics through the same diagnostic precedence rule
- centralize nested-result and root-exit projection on `StopReason`
- route the root-driver crash folds in `join_driver` and `spawn_system` through `classify_exit`, keeping each site's cancellation choice explicit
- cover join precedence, destructor panic precedence, cancellation preservation, and structured stop-reason projection

## Test pins

- a cancelled join with no recorded hard-abort phase fails closed to `Aborted { WithinGrace }` (the ordinary teardown path)
- a recorded hard-abort phase is ignored when the join completed normally (hard abort losing the race to completion stays `Completed`)
- a destructor panic supersedes `Failed` and `ReadinessTimedOut` exits through the shared `OutcomeRank` precedence, alongside the existing panic-tie case

## Scope note

`discharge_child_terminality` still builds an `Exit` by hand. It is intentionally left untouched here because open PR #154 edits exactly those lines; routing that residual site through `classify_exit` is deferred to a follow-up.

## Validation

- `./tools/dev cargo test -p shelterwood exit::tests`
- `./tools/dev cargo test -p shelterwood driver::tests::same_batch_intensity_exit_suppresses_real_expedited_factory`
- `./tools/dev cargo test -p shelterwood driver::tests::same_batch_self_stop_preserves_fired_readiness_for_startup`
- `./tools/dev just ci` (501 tests plus docs, API reachability, enforcement checks, package verification, and Nix formatting)
