### PR TITLE
Centralize member record transitions

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -116,22 +116,62 @@ pub(crate) struct MemberRecord {
 }
 
 impl MemberRecord {
+    /// Applies one driver-requested transition.
+    ///
+    /// Every watch-channel writer routes stage changes through here (see
+    /// [`MemberCell::transition`] for the wake-bus contract), so each arm
+    /// asserts the source stages its driver call sites can actually present.
     fn apply_transition(&mut self, transition: MemberTransition) {
         match transition {
-            MemberTransition::Admitted => self.stage = MemberStage::Admitted,
+            MemberTransition::Admitted => {
+                debug_assert!(
+                    matches!(self.stage, MemberStage::Reserved),
+                    "admission must consume a fresh reservation, not {:?}",
+                    self.stage
+                );
+                self.stage = MemberStage::Admitted;
+            }
             MemberTransition::Starting { incarnation } => {
+                debug_assert!(
+                    matches!(self.stage, MemberStage::Admitted | MemberStage::Restarting),
+                    "a spawn must start an admitted or restarting member, not {:?}",
+                    self.stage
+                );
                 self.stage = MemberStage::Starting;
                 self.incarnation = Some(incarnation);
                 self.last_incarnation = Some(incarnation);
                 self.restart_at = None;
             }
-            MemberTransition::Running => self.stage = MemberStage::Running,
-            MemberTransition::Stopping => self.stage = MemberStage::Stopping,
+            MemberTransition::Running => {
+                debug_assert!(
+                    matches!(self.stage, MemberStage::Starting | MemberStage::Reserved),
+                    "readiness must promote a starting member (or the root scope's own \
+                     never-admitted reservation), not {:?}",
+                    self.stage
+                );
+                self.stage = MemberStage::Running;
+            }
+            MemberTransition::Stopping => {
+                debug_assert!(
+                    matches!(self.stage, MemberStage::Starting | MemberStage::Running),
+                    "a stop ladder must begin on a starting or running member, not {:?}",
+                    self.stage
+                );
+                self.stage = MemberStage::Stopping;
+            }
             MemberTransition::RestartScheduled {
                 exit,
                 restart_count,
                 restart_at,
             } => {
+                debug_assert!(
+                    matches!(
+                        self.stage,
+                        MemberStage::Starting | MemberStage::Running | MemberStage::Stopping
+                    ),
+                    "a restart must be scheduled from an active incarnation's exit, not {:?}",
+                    self.stage
+                );
                 self.stage = MemberStage::Restarting;
                 self.incarnation = None;
                 self.last_exit = Some(exit);
@@ -264,14 +304,18 @@ impl MemberCell {
 
     /// Mutates a member record and pulses the watch channel.
     ///
-    /// The driver also treats this channel as its control-plane wake bus: any
-    /// field read by a loop precondition must be changed through a pulsing path
-    /// like this one, never by a silent write outside an observation gate.
+    /// Test-only escape hatch around [`Self::transition`]; the wake-bus
+    /// contract documented there binds this path too.
     #[cfg(test)]
     pub(crate) fn update(&self, update: impl FnOnce(&mut MemberRecord)) {
         self.record.send_modify(update);
     }
 
+    /// Applies a member transition and pulses the watch channel.
+    ///
+    /// The driver also treats this channel as its control-plane wake bus: any
+    /// field read by a loop precondition must be changed through a pulsing path
+    /// like this one, never by a silent write outside an observation gate.
     pub(crate) fn transition(&self, transition: MemberTransition) {
         self.record
             .send_modify(|record| record.apply_transition(transition));

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -81,6 +81,21 @@ pub(crate) enum MemberStage {
     Terminal(Exit),
 }
 
+/// One non-terminal member-record transition owned by the cell layer.
+pub(crate) enum MemberTransition {
+    Admitted,
+    Starting {
+        incarnation: Incarnation,
+    },
+    Running,
+    Stopping,
+    RestartScheduled {
+        exit: Exit,
+        restart_count: RestartCount,
+        restart_at: Option<Instant>,
+    },
+}
+
 /// Whether a terminal child incarnation failed during aggregate startup.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum StartupDisposition {
@@ -98,6 +113,33 @@ pub(crate) struct MemberRecord {
     pub(crate) restart_at: Option<Instant>,
     pub(crate) removing: bool,
     pub(crate) startup_aborted: bool,
+}
+
+impl MemberRecord {
+    fn apply_transition(&mut self, transition: MemberTransition) {
+        match transition {
+            MemberTransition::Admitted => self.stage = MemberStage::Admitted,
+            MemberTransition::Starting { incarnation } => {
+                self.stage = MemberStage::Starting;
+                self.incarnation = Some(incarnation);
+                self.last_incarnation = Some(incarnation);
+                self.restart_at = None;
+            }
+            MemberTransition::Running => self.stage = MemberStage::Running,
+            MemberTransition::Stopping => self.stage = MemberStage::Stopping,
+            MemberTransition::RestartScheduled {
+                exit,
+                restart_count,
+                restart_at,
+            } => {
+                self.stage = MemberStage::Restarting;
+                self.incarnation = None;
+                self.last_exit = Some(exit);
+                self.restart_count = restart_count;
+                self.restart_at = restart_at;
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -225,13 +267,23 @@ impl MemberCell {
     /// The driver also treats this channel as its control-plane wake bus: any
     /// field read by a loop precondition must be changed through a pulsing path
     /// like this one, never by a silent write outside an observation gate.
+    #[cfg(test)]
     pub(crate) fn update(&self, update: impl FnOnce(&mut MemberRecord)) {
         self.record.send_modify(update);
+    }
+
+    pub(crate) fn transition(&self, transition: MemberTransition) {
+        self.record
+            .send_modify(|record| record.apply_transition(transition));
     }
 
     fn update_locked(&self, wakes: &mut ObservationWakes, update: impl FnOnce(&mut MemberRecord)) {
         self.record.modify_silently(update);
         wakes.pulse(&self.record);
+    }
+
+    fn transition_locked(&self, wakes: &mut ObservationWakes, transition: MemberTransition) {
+        self.update_locked(wakes, |record| record.apply_transition(transition));
     }
 
     pub(crate) fn set_options(&self, options: ResolvedCommonOptions) {
@@ -957,7 +1009,7 @@ impl ScopeCell {
         });
     }
 
-    pub(crate) fn transition_child(
+    fn update_child_record(
         &self,
         member: &MemberCell,
         update: impl FnOnce(&mut MemberRecord),
@@ -973,6 +1025,29 @@ impl ScopeCell {
         });
     }
 
+    pub(crate) fn set_child_removing(&self, member: &MemberCell) {
+        self.update_child_record(member, |record| record.removing = true, None);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn transition_child(
+        &self,
+        member: &MemberCell,
+        update: impl FnOnce(&mut MemberRecord),
+        event: Option<LifecycleEventKind>,
+    ) {
+        self.update_child_record(member, update, event);
+    }
+
+    pub(crate) fn transition_child_stage(
+        &self,
+        member: &MemberCell,
+        transition: MemberTransition,
+        event: Option<LifecycleEventKind>,
+    ) {
+        self.update_child_record(member, |record| record.apply_transition(transition), event);
+    }
+
     #[cfg(test)]
     pub(crate) fn emit(&self, event: LifecycleEventKind) {
         self.with_observation_gate(|wakes| self.emit_locked(wakes, event));
@@ -982,7 +1057,7 @@ impl ScopeCell {
         &self,
         member: &MemberCell,
         total_restarts: TotalRestarts,
-        update: impl FnOnce(&mut MemberRecord),
+        transition: MemberTransition,
         exited: LifecycleEventKind,
         scheduled: LifecycleEventKind,
     ) {
@@ -991,7 +1066,7 @@ impl ScopeCell {
                 scope.total_restarts = total_restarts;
             });
             wakes.pulse(&self.record);
-            member.update_locked(wakes, update);
+            member.transition_locked(wakes, transition);
             self.emit_locked(wakes, exited);
             self.emit_locked(wakes, scheduled);
         });
@@ -1438,7 +1513,7 @@ impl ScopeCell {
                 }
                 child
                     .member
-                    .update_locked(wakes, |record| record.stage = MemberStage::Admitted);
+                    .transition_locked(wakes, MemberTransition::Admitted);
                 let id = child.member.id().clone();
                 let membership = child.member.membership();
                 self.current_children()
@@ -1459,7 +1534,7 @@ impl ScopeCell {
             let membership = child.member.membership();
             child
                 .member
-                .update_locked(wakes, |record| record.stage = MemberStage::Admitted);
+                .transition_locked(wakes, MemberTransition::Admitted);
             self.current_children()
                 .push(ResidentChild::new(self, child));
             self.emit_locked(wakes, LifecycleEventKind::Added { id, membership });

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -16,7 +16,10 @@ use crate::{
     Membership, Readiness, ReadinessDeadline, ScopeState, ShutdownStraggler, ShutdownTimeout,
     StartupFailure, StartupFailureCause,
     admission::{NotAdmittingCause, ReserveError},
-    cells::{MailboxControl, MemberStage, ResidentProjection, ScopeCell, StartupDisposition},
+    cells::{
+        MailboxControl, MemberStage, MemberTransition, ResidentProjection, ScopeCell,
+        StartupDisposition,
+    },
     deadline::Deadline,
     engine::{
         ArbitrationClass, ChildCompletionState, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch,
@@ -960,8 +963,7 @@ impl ScopeRuntime {
             return;
         };
         if !member.record().removing {
-            self.root
-                .transition_child(&member, |record| record.removing = true, None);
+            self.root.set_child_removing(&member);
         }
     }
 
@@ -1114,14 +1116,9 @@ impl ScopeRuntime {
             );
             mailbox.bind(incarnation);
         }
-        self.root.transition_child(
+        self.root.transition_child_stage(
             &child.slot.member,
-            |record| {
-                record.stage = MemberStage::Starting;
-                record.incarnation = Some(incarnation);
-                record.last_incarnation = Some(incarnation);
-                record.restart_at = None;
-            },
+            MemberTransition::Starting { incarnation },
             Some(LifecycleEventKind::Started {
                 id: child.slot.member.id().clone(),
                 membership: child.slot.member.membership(),
@@ -1233,9 +1230,9 @@ impl ScopeRuntime {
                 if !self.lifecycle.startup_complete() {
                     child.initial_ready = true;
                 }
-                self.root.transition_child(
+                self.root.transition_child_stage(
                     &child.slot.member,
-                    |record| record.stage = MemberStage::Running,
+                    MemberTransition::Running,
                     Some(LifecycleEventKind::Ready {
                         id: child.slot.member.id().clone(),
                         membership: child.slot.member.membership(),
@@ -1315,11 +1312,8 @@ impl ScopeRuntime {
                 }
                 return;
             }
-            self.root.transition_child(
-                &child.slot.member,
-                |record| record.stage = MemberStage::Stopping,
-                None,
-            );
+            self.root
+                .transition_child_stage(&child.slot.member, MemberTransition::Stopping, None);
             if let Some(mailbox) = &child.mailbox {
                 mailbox.freeze(active.incarnation);
             }
@@ -1726,16 +1720,13 @@ impl ScopeRuntime {
                 self.root.publish_child_restart(
                     &child.slot.member,
                     decision.charge.total_restarts,
-                    |record| {
-                        record.incarnation = None;
-                        record.last_exit = Some(exit.clone());
-                        record.restart_count = decision.restart_count;
-                        // Publish the derived schedule even when intensity
-                        // prevents spawning it. `None` means the exact clock
-                        // point cannot be represented and armed; no substitute
-                        // restart is scheduled.
-                        record.restart_at = decision.restart_at;
-                        record.stage = MemberStage::Restarting;
+                    MemberTransition::RestartScheduled {
+                        exit: exit.clone(),
+                        restart_count: decision.restart_count,
+                        // Publish the derived schedule even when intensity prevents spawning it.
+                        // `None` means the exact clock point cannot be represented and armed; no
+                        // substitute restart is scheduled.
+                        restart_at: decision.restart_at,
                     },
                     LifecycleEventKind::Exited {
                         id: child.slot.member.id().clone(),
@@ -2380,8 +2371,7 @@ async fn run_scope_incarnation(
 ) -> StopReason {
     let root = Arc::clone(&plan.root);
     if role.is_root() {
-        root.member
-            .update(|record| record.stage = MemberStage::Running);
+        root.member.transition(MemberTransition::Running);
     }
     let capacity = plan.children.len().saturating_mul(3).max(64);
     let (events, mut event_receiver) = runtime::bounded_mpsc(capacity);

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -487,7 +487,7 @@ fn remove_dynamic_impl(
     // stall every concurrent reservation, removal, and driver admission.
     drop(state);
     if !member.record().removing {
-        scope.transition_child(&member, |record| record.removing = true, None);
+        scope.set_child_removing(&member);
     }
     if member.removal.fire() {
         // This latch dedups repeated `remove` calls, but not a concurrent

--- a/crates/shelterwood/src/driver/tests.rs
+++ b/crates/shelterwood/src/driver/tests.rs
@@ -13,7 +13,7 @@ use crate::{
     ActorRef, Backoff, Cancellation, ChildId, ChildState, DynamicTree, Exit, ExitError, ExitKind,
     GracePhase, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Mailbox,
     RawOnceDef, Readiness, ReadinessDeadline, RemoveOutcome, ReserveError, RestartCondition,
-    RestartPolicy, Retention, ScopeRef, ScopeState, SendErrorKind, StartupError,
+    RestartCount, RestartPolicy, Retention, ScopeRef, ScopeState, SendErrorKind, StartupError,
     StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
     engine::{Epoch, ScopeLifecycle, StopLadder, arbitrate},
     exit::{JoinVerdict, RecordedOutcome},
@@ -26,11 +26,12 @@ use crate::{
 
 use super::{
     AncestorCommandLatches, ChildArena, ChildEvent, ChildKey, ChildRuntime, DriverEvent,
-    DynamicControl, DynamicEntry, GateCapture, MemberCell, MemberStage, NestedScopeLatches,
-    Pending, RemovalRequest, RemovalResponses, ResidentProjection, RuntimeStorage, ScopeCell,
-    ScopeEpochGuard, ScopeFlavor, ScopeRole, ScopeRuntime, StartupDisposition,
-    cancel_dynamic_reservation, report_slot, reserve_dynamic, resident_projection,
-    restart_shutdown_work, run_nested_factory, run_nested_tree, run_scope_incarnation,
+    DynamicControl, DynamicEntry, GateCapture, MemberCell, MemberStage, MemberTransition,
+    NestedScopeLatches, Pending, RemovalRequest, RemovalResponses, ResidentProjection,
+    RuntimeStorage, ScopeCell, ScopeEpochGuard, ScopeFlavor, ScopeRole, ScopeRuntime,
+    StartupDisposition, cancel_dynamic_reservation, report_slot, reserve_dynamic,
+    resident_projection, restart_shutdown_work, run_nested_factory, run_nested_tree,
+    run_scope_incarnation,
 };
 
 /// Bounds every gate-capture probe wait. The probe sender lives inside
@@ -3436,6 +3437,47 @@ async fn system_shutdown_joins_root_driver_teardown() {
 }
 
 #[test]
+fn member_transitions_own_their_complete_record_projection() {
+    let mut identity = ScopeIdentity::new();
+    let id = ChildId::from("worker");
+    let membership = identity.mint_membership(&id).expect("membership available");
+    let member = MemberCell::new(id, membership);
+    let mut incarnations = identity.incarnation_counter(membership);
+    let incarnation = incarnations.mint().expect("incarnation available");
+
+    member.transition(MemberTransition::Admitted);
+    assert_eq!(member.record().stage, MemberStage::Admitted);
+
+    member.transition(MemberTransition::Starting { incarnation });
+    let record = member.record();
+    assert_eq!(record.stage, MemberStage::Starting);
+    assert_eq!(record.incarnation, Some(incarnation));
+    assert_eq!(record.last_incarnation, Some(incarnation));
+    assert_eq!(record.restart_at, None);
+
+    member.transition(MemberTransition::Running);
+    assert_eq!(member.record().stage, MemberStage::Running);
+    member.transition(MemberTransition::Stopping);
+    assert_eq!(member.record().stage, MemberStage::Stopping);
+
+    let exit = Exit::new(ExitKind::Completed, Cancellation::NotObserved);
+    let restart_count = RestartCount::ZERO.bump();
+    let restart_at = crate::runtime::now();
+    member.transition(MemberTransition::RestartScheduled {
+        exit: exit.clone(),
+        restart_count,
+        restart_at: Some(restart_at),
+    });
+    let record = member.record();
+    assert_eq!(record.stage, MemberStage::Restarting);
+    assert_eq!(record.incarnation, None);
+    assert_eq!(record.last_incarnation, Some(incarnation));
+    assert_eq!(record.last_exit, Some(exit));
+    assert_eq!(record.restart_count, restart_count);
+    assert_eq!(record.restart_at, Some(restart_at));
+}
+
+#[test]
 fn incarnation_mint_exhaustion_has_no_terminal_side_effects() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
@@ -3445,9 +3487,10 @@ fn incarnation_mint_exhaustion_has_no_terminal_side_effects() {
         ExitKind::Failed(ExitError::message("last completed incarnation")),
         Cancellation::NotObserved,
     );
-    member.update(|record| {
-        record.stage = MemberStage::Restarting;
-        record.last_exit = Some(previous.clone());
+    member.transition(MemberTransition::RestartScheduled {
+        exit: previous.clone(),
+        restart_count: RestartCount::ZERO,
+        restart_at: None,
     });
     let mut counter = IncarnationCounter::near_exhaustion(membership);
 

--- a/crates/shelterwood/src/driver/tests.rs
+++ b/crates/shelterwood/src/driver/tests.rs
@@ -3475,6 +3475,21 @@ fn member_transitions_own_their_complete_record_projection() {
     assert_eq!(record.last_exit, Some(exit));
     assert_eq!(record.restart_count, restart_count);
     assert_eq!(record.restart_at, Some(restart_at));
+
+    let second = incarnations.mint().expect("restart incarnation available");
+    member.transition(MemberTransition::Starting {
+        incarnation: second,
+    });
+    let record = member.record();
+    assert_eq!(record.stage, MemberStage::Starting);
+    assert_eq!(record.incarnation, Some(second));
+    assert_eq!(record.last_incarnation, Some(second));
+    assert_eq!(record.restart_at, None);
+    assert_eq!(
+        record.last_exit,
+        Some(Exit::new(ExitKind::Completed, Cancellation::NotObserved))
+    );
+    assert_eq!(record.restart_count, restart_count);
 }
 
 #[test]

--- a/crates/shelterwood/src/driver/tests.rs
+++ b/crates/shelterwood/src/driver/tests.rs
@@ -738,12 +738,13 @@ fn plain_parent_state_preserves_nested_snapshot_propagation() {
     let root = isolated_scope("root", ScopeFlavor::Ordered);
     let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
     let mut incarnations = IncarnationCounter::near_exhaustion(nested.member.membership());
-    nested.member.update(|record| {
-        record.incarnation = incarnations.mint();
-        record.stage = MemberStage::Starting;
-    });
     let nested_slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
     root.set_admitted_children(vec![resident_projection(&nested_slot)]);
+    // Start the nested member along the production admit-then-spawn order so
+    // the transition-source assertions in `apply_transition` hold here too.
+    nested.member.transition(MemberTransition::Starting {
+        incarnation: incarnations.mint().expect("incarnation available"),
+    });
     let snapshots = root.subscribe_snapshots();
     let intensity = Intensity::new(7, Duration::from_secs(11)).expect("valid intensity");
 
@@ -3502,6 +3503,14 @@ fn incarnation_mint_exhaustion_has_no_terminal_side_effects() {
         ExitKind::Failed(ExitError::message("last completed incarnation")),
         Cancellation::NotObserved,
     );
+    // Walk the record along the production path so the transition-source
+    // assertions in `apply_transition` cover this setup too.
+    let mut setup_incarnations = identity.incarnation_counter(membership);
+    let spent = setup_incarnations
+        .mint()
+        .expect("setup incarnation available");
+    member.transition(MemberTransition::Admitted);
+    member.transition(MemberTransition::Starting { incarnation: spent });
     member.transition(MemberTransition::RestartScheduled {
         exit: previous.clone(),
         restart_count: RestartCount::ZERO,


### PR DESCRIPTION
Part of #151.

## Summary

- define semantic non-terminal `MemberTransition` values in the cell layer
- make each transition own its complete `MemberRecord` projection, including incarnation and restart metadata
- replace driver-side field-edit closures for admission, spawn, readiness, stop, restart scheduling, and root running state
- expose a separate projection update for removal rather than leaving a general production record mutator
- retain terminal publication's specialized mailbox/observation transaction
- add a table-like transition regression covering every non-terminal projection

## Validation

- `./tools/dev cargo test -p shelterwood member_transitions_own_their_complete_record_projection`
- `./tools/dev cargo test -p shelterwood incarnation_mint_exhaustion_has_no_terminal_side_effects`
- `./tools/dev cargo test -p shelterwood --test integration dynamic_add_resolves_at_admission_and_removal_is_exact`
- `./tools/dev cargo test -p shelterwood --test integration one_shot_completion_reports_abort_verdict`
- `./tools/dev just ci` (500 tests plus docs, API reachability, enforcement checks, package verification, and Nix formatting)