### PR TITLE
Centralize raw readiness metadata

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -695,10 +695,12 @@ trait RawActor: Send + 'static {
   raw-actor wrapper, which owns the `Uninit(Args) → Running(A)` transition;
   `ActorDef` and `ActorOnceDef` construct that wrapper rather than relying on
   a blanket `impl<A: Actor> RawActor for A` (which cannot exist before
-  `init` produces `A`). The wrapper stores its declared readiness mode, the
-  engine reads it before `run` is first polled, and only `AfterInit` performs
-  the automatic post-init `mark_ready`; `Immediate` and `Manual` retain their
-  declared meanings. Raw decorators can wrap `Handler<A>` directly and may
+  `init` produces `A`). The wrapper supplies `AfterInit` as its type-level
+  readiness default; the engine resolves that default with any child-definition
+  override before constructing an incarnation, and only an effective
+  `AfterInit` mode performs the automatic post-init `mark_ready`. `Immediate`
+  and `Manual` retain their declared meanings. Raw decorators can wrap
+  `Handler<A>` directly and may
   await before delegation without changing readiness. Handler decorators use
   the zero-cost same-message `Context::for_actor` / `StopContext::for_actor`
   reborrow, sharing identity and incarnation-owned resources. Executable
@@ -1116,10 +1118,10 @@ enum Readiness { Immediate, AfterInit, Manual }   // mode only — the deadline 
   boundary. A decorator that awaited anything before delegating silently
   released the ordered-startup gate before the inner actor's init ran.)
 - Per-declaration override lives on the child options (§8) uniformly for
-  actor and task children — readiness is per instance, not per type [#368]
-  (e.g. "not ready
-  until an external handshake completes" must be declarable on one instance
-  of an ordinary handler actor). Subtree children are the stated
+  actor and task children. A raw actor type supplies the fallback mode, but
+  each child definition resolves its own effective mode [#368] (e.g. "not
+  ready until an external handshake completes" must be declarable for one
+  ordinary handler child without changing the handler type). Subtree children are the stated
   exception: their readiness is structural (below), so the subtree veneer
   carries no mode override — only the deadline.
 - The deadline is not part of the mode: it lives on the shared options

--- a/SPEC.md
+++ b/SPEC.md
@@ -1139,6 +1139,16 @@ enum Readiness { Immediate, AfterInit, Manual }   // mode only — the deadline 
   startup-failure exit cause (§7) — one type, for tasks and actors alike,
   produced by one engine-side timeout (not re-implemented per child kind
   and reunited by downcast).
+- An effective `Immediate` mode publishes readiness **at spawn**: the
+  engine marks the child ready when it launches the incarnation, before
+  the child's future is first polled — for a raw child, before its
+  factory has constructed the actor. Uniformly for tasks and raw actors,
+  a failure inside an effectively-immediate child — including a raw
+  construction panic — is therefore a **post-ready** exit for startup
+  classification (§7): an ordered sequence has already advanced past the
+  child, later siblings still start, and `wait_started()` does not
+  report a startup abort for it. A definition that wants construction
+  observed pre-ready declares a gated mode instead.
 - Ordered scopes start children sequentially; a gated child blocks the
   sequence until ready. A pre-ready exit follows the child's restart policy
   like any other exit (§7): while restarts remain eligible the sequence

--- a/SPEC.md
+++ b/SPEC.md
@@ -655,7 +655,8 @@ established in the construction-path types, before erasure:
 ```rust
 trait RawActor: Send + 'static {
     type Msg: Send + 'static;
-    fn readiness(&self) -> Readiness { Readiness::Immediate }   // §6
+    // Type-level definition metadata, read before incarnation construction.
+    fn readiness() -> Readiness { Readiness::Immediate }        // §6
     // Desugared per §4.1's Send-bound rule; implementors write `async fn`.
     fn run(&mut self, ctx: &mut RawContext<Self::Msg>)
         -> impl Future<Output = ExitResult> + Send;
@@ -1099,8 +1100,8 @@ enum Readiness { Immediate, AfterInit, Manual }   // mode only — the deadline 
 
 - `Actor` (blanket) children default to `AfterInit`: ready when `init`
   returns `Ok`.
-- Raw actors declare via `RawActor::readiness()`; decorators propagate with
-  a visible `self.inner.readiness()`. The trait default is `Immediate`, so
+- Raw actor types declare via `RawActor::readiness()`; decorators propagate
+  with a visible `R::readiness()`. The trait default is `Immediate`, so
   a decorator that omits propagation reports immediate readiness — an
   ordinary, testable bug (the sibling starts unblocked and ordered-startup
   tests see it), not the origin's silent mid-`init` gate release; §13.6's

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -306,20 +306,14 @@ impl<'a, A: Actor> StopContext<'a, A> {
 pub struct Handler<A: Actor> {
     args: Option<A::Args>,
     actor: Option<A>,
-    readiness: Readiness,
 }
 
 impl<A: Actor> Handler<A> {
     /// Wraps owned args using the callback-actor default `AfterInit` readiness.
     pub fn new(args: A::Args) -> Self {
-        Self::with_readiness(args, Readiness::AfterInit)
-    }
-
-    fn with_readiness(args: A::Args, readiness: Readiness) -> Self {
         Self {
             args: Some(args),
             actor: None,
-            readiness,
         }
     }
 }
@@ -327,8 +321,8 @@ impl<A: Actor> Handler<A> {
 impl<A: Actor> RawActor for Handler<A> {
     type Msg = A::Msg;
 
-    fn readiness(&self) -> Readiness {
-        self.readiness
+    fn readiness() -> Readiness {
+        Readiness::AfterInit
     }
 
     /// Runs one incarnation, leaning on the raw incarnation boundary for the
@@ -457,10 +451,9 @@ impl<A: Actor> ActorDef<A> {
 
     pub(crate) fn into_raw(self) -> RawDef<Handler<A>> {
         let factory = self.factory;
-        let readiness = self.options.readiness.unwrap_or(Readiness::AfterInit);
         let mut raw = RawDef::factory(move || {
             let args = factory();
-            Handler::with_readiness(args, readiness)
+            Handler::new(args)
         });
         raw.options = self.options;
         raw
@@ -505,8 +498,7 @@ impl<A: Actor> ActorOnceDef<A> {
     );
 
     pub(crate) fn into_raw(self) -> RawOnceDef<Handler<A>> {
-        let readiness = self.options.readiness.unwrap_or(Readiness::AfterInit);
-        let mut raw = RawOnceDef::new(Handler::with_readiness(self.args, readiness));
+        let mut raw = RawOnceDef::new(Handler::new(self.args));
         raw.options = self.options;
         raw
     }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -316,11 +316,6 @@ pub(crate) fn spawn_system(plan: ScopePlan) -> SystemRun {
 }
 
 enum ChildEvent {
-    Constructed {
-        child: ChildKey,
-        incarnation: Incarnation,
-        readiness: Readiness,
-    },
     Ready {
         child: ChildKey,
         incarnation: Incarnation,
@@ -369,7 +364,6 @@ struct ActiveChild {
     readiness: ReadinessGate,
     readiness_deadline: Option<DeadlineHandle>,
     ready_signal: CompletionGatedLatch,
-    construction_release: Latch,
     framework_abort: Option<Latch>,
     framework_abort_ack: Option<Latch>,
     stop_deadline: Option<DeadlineHandle>,
@@ -653,7 +647,7 @@ enum SpawnBody {
 
 struct SpawnDispatch {
     body: SpawnBody,
-    declared_readiness: Option<Readiness>,
+    declared_readiness: Readiness,
     construction_spent: bool,
     scope_child: bool,
 }
@@ -663,15 +657,12 @@ struct SpawnDispatch {
 /// - `shutdown`/`abort` are the child-facing cooperative ladder;
 /// - `framework_abort`/`framework_abort_ack` bound a nested scope driver's
 ///   recursive drain before its task is aborted;
-/// - `construction_release` prevents a raw actor from running before the
-///   driver has installed the readiness mode reported by construction;
 /// - `ready` also carries the completion edge that makes readiness and
 ///   self-stop watcher tasks finite.
 struct SpawnLatches {
     shutdown: Latch,
     abort: Latch,
     ready: CompletionGatedLatch,
-    construction_release: Latch,
     local_stop: Latch,
     framework_abort: Latch,
     framework_abort_ack: Latch,
@@ -703,11 +694,10 @@ struct ChildTaskLaunch {
     key: ChildKey,
     incarnation: Incarnation,
     body: SpawnBody,
-    readiness_override: Option<Readiness>,
+    readiness: Readiness,
     watch_readiness: bool,
     shutdown: Latch,
     ready: CompletionGatedLatch,
-    construction_release: Latch,
     local_stop: Latch,
 }
 
@@ -740,7 +730,7 @@ fn dispatch_child_construction(
                         mailbox_shutdown: child.options.mailbox_shutdown,
                     },
                 },
-                declared_readiness: None,
+                declared_readiness: child.options.readiness,
                 construction_spent,
                 scope_child: false,
             }
@@ -750,7 +740,7 @@ fn dispatch_child_construction(
                 factory: Arc::clone(&definition.factory),
                 context: TaskContext::new(id, incarnation, latches.task_context()),
             },
-            declared_readiness: Some(child.options.readiness),
+            declared_readiness: child.options.readiness,
             construction_spent: false,
             scope_child: false,
         },
@@ -759,7 +749,7 @@ fn dispatch_child_construction(
                 body: definition.take_body(),
                 context: TaskContext::new(id, incarnation, latches.task_context()),
             },
-            declared_readiness: Some(child.options.readiness),
+            declared_readiness: child.options.readiness,
             construction_spent: true,
             scope_child: false,
         },
@@ -800,7 +790,7 @@ fn dispatch_child_construction(
             };
             SpawnDispatch {
                 body,
-                declared_readiness: Some(Readiness::Manual),
+                declared_readiness: Readiness::Manual,
                 construction_spent,
                 scope_child: true,
             }
@@ -814,31 +804,18 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
         key,
         incarnation,
         body,
-        readiness_override,
+        readiness,
         watch_readiness,
         shutdown,
         ready,
-        construction_release,
         local_stop,
     } = launch;
     let (report, report_claim) = report_slot(shutdown, Some(local_stop.clone()), ready.clone());
-    let constructed_sender = events.clone();
     let handle = runtime::spawn(async move {
         let body = async move {
             match body {
                 SpawnBody::Raw { spawn, context } => {
                     let instance = spawn.construct();
-                    let readiness = readiness_override.unwrap_or_else(|| instance.readiness());
-                    let _ = runtime::mpsc_send(
-                        &constructed_sender,
-                        DriverEvent::Child(ChildEvent::Constructed {
-                            child: key,
-                            incarnation,
-                            readiness,
-                        }),
-                    )
-                    .await;
-                    construction_release.fired().await;
                     instance.run(context, readiness).await
                 }
                 SpawnBody::TaskRestartable { factory, context } => factory(context).await,
@@ -1085,15 +1062,12 @@ impl ScopeRuntime {
         // - ready and local_stop flow from application code back to helpers;
         // - ready's completion edge terminates those helpers when the child
         //   exits first and orders late retained readiness capabilities;
-        // - construction_release keeps a raw actor behind the driver-owned
-        //   readiness transition after its construction report is accepted;
         // - framework_abort/ack join nested-scope escalation before exit.
         // Each edge is level-triggered, so helper startup cannot lose a pulse.
         let latches = SpawnLatches {
             shutdown: Latch::default(),
             abort: Latch::default(),
             ready: CompletionGatedLatch::default(),
-            construction_release: Latch::default(),
             local_stop: Latch::default(),
             framework_abort: Latch::default(),
             framework_abort_ack: Latch::default(),
@@ -1130,19 +1104,16 @@ impl ScopeRuntime {
         );
 
         let mut readiness = ReadinessGate::new();
-        let readiness_effect = declared_readiness.and_then(|readiness_mode| {
-            let deadline = match child.options.readiness_deadline {
-                ReadinessDeadline::Bounded(duration) => Deadline::after(now, duration).instant(),
-                ReadinessDeadline::Unbounded | ReadinessDeadline::Inherit => None,
-            };
-            readiness.step(ReadinessEvent::Configure {
-                readiness: readiness_mode,
-                deadline,
-            })
+        let deadline = match child.options.readiness_deadline {
+            ReadinessDeadline::Bounded(duration) => Deadline::after(now, duration).instant(),
+            ReadinessDeadline::Unbounded | ReadinessDeadline::Inherit => None,
+        };
+        let readiness_effect = readiness.step(ReadinessEvent::Configure {
+            readiness: declared_readiness,
+            deadline,
         });
         let gated = readiness.needs_signal_watch();
 
-        let child_readiness_override = child.options.readiness_override;
         if construction_spent {
             // One-shot actor/task/subtree state has moved into `body`; the
             // retained construction is now framework-only spent metadata.
@@ -1155,11 +1126,10 @@ impl ScopeRuntime {
             key,
             incarnation,
             body,
-            readiness_override: child_readiness_override,
+            readiness: declared_readiness,
             watch_readiness: gated,
             shutdown: latches.shutdown.clone(),
             ready: latches.ready.clone(),
-            construction_release: latches.construction_release.clone(),
             local_stop: latches.local_stop.clone(),
         });
 
@@ -1175,7 +1145,6 @@ impl ScopeRuntime {
             readiness,
             readiness_deadline: None,
             ready_signal: latches.ready,
-            construction_release: latches.construction_release,
             framework_abort: scope_child.then_some(latches.framework_abort),
             framework_abort_ack: scope_child.then_some(latches.framework_abort_ack),
             stop_deadline: None,
@@ -1505,55 +1474,6 @@ impl ScopeRuntime {
             // remains. Hard escalation detaches that cleanup, but must not
             // rewrite the actor's recorded verdict.
             self.handle_construction_disposed(key, None);
-        }
-    }
-
-    fn handle_constructed(
-        &mut self,
-        key: ChildKey,
-        incarnation: Incarnation,
-        readiness: Readiness,
-    ) {
-        let effect = {
-            let Some(child) = self.children.get_mut(key) else {
-                return;
-            };
-            let Some(active) = child.active.as_mut() else {
-                return;
-            };
-            if active.incarnation != incarnation {
-                return;
-            }
-            if active.ladder.is_some() {
-                active.construction_release.fire();
-                return;
-            }
-            let deadline = match child.options.readiness_deadline {
-                ReadinessDeadline::Bounded(duration) => {
-                    Deadline::after(active.started_at, duration).instant()
-                }
-                ReadinessDeadline::Unbounded | ReadinessDeadline::Inherit => None,
-            };
-            active.readiness.step(ReadinessEvent::Configure {
-                readiness,
-                deadline,
-            })
-        };
-        let became_ready = effect
-            .map(|effect| self.apply_readiness_effect(key, incarnation, effect))
-            .unwrap_or(false);
-        if let Some(active) = self
-            .children
-            .get(key)
-            .and_then(|child| child.active.as_ref())
-            .filter(|active| active.incarnation == incarnation)
-        {
-            // Readiness state and all shell effects are installed before raw
-            // actor execution is released.
-            active.construction_release.fire();
-        }
-        if became_ready {
-            self.progress_startup();
         }
     }
 
@@ -2602,11 +2522,6 @@ async fn run_scope_incarnation(
                 Pending::Driver(DriverEvent::Admission(request)) => {
                     scope.handle_admission(request);
                 }
-                Pending::Driver(DriverEvent::Child(ChildEvent::Constructed {
-                    child,
-                    incarnation,
-                    readiness,
-                })) => scope.handle_constructed(child, incarnation, readiness),
                 Pending::Driver(DriverEvent::Child(ChildEvent::Ready { child, incarnation })) => {
                     scope.handle_ready(child, incarnation);
                 }
@@ -2710,9 +2625,7 @@ fn driver_event_class(event: &DriverEvent) -> ArbitrationClass {
     match event {
         DriverEvent::Child(ChildEvent::SelfStop { .. }) => ArbitrationClass::MembershipRemoval,
         DriverEvent::Removal(_) => ArbitrationClass::MembershipRemoval,
-        DriverEvent::Child(ChildEvent::Constructed { .. } | ChildEvent::Ready { .. }) => {
-            ArbitrationClass::ReadinessSignal
-        }
+        DriverEvent::Child(ChildEvent::Ready { .. }) => ArbitrationClass::ReadinessSignal,
         DriverEvent::Child(ChildEvent::Exited { .. } | ChildEvent::ConstructionDisposed { .. }) => {
             ArbitrationClass::ChildExit
         }

--- a/crates/shelterwood/src/driver/tests.rs
+++ b/crates/shelterwood/src/driver/tests.rs
@@ -140,7 +140,7 @@ struct PendingRaw;
 impl crate::RawActor for PendingRaw {
     type Msg = u8;
 
-    fn readiness(&self) -> Readiness {
+    fn readiness() -> Readiness {
         Readiness::Manual
     }
 

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -399,6 +399,10 @@ impl ReadinessGate {
     }
 
     /// Whether a retained signal watcher is needed for this incarnation.
+    ///
+    /// The `Unconfigured` case is unreachable from the driver, which
+    /// configures the gate at spawn now that readiness is definition-level;
+    /// it remains for the state machine's own completeness and unit tests.
     pub(crate) fn needs_signal_watch(self) -> bool {
         matches!(
             self.state,
@@ -451,6 +455,10 @@ impl ReadinessGate {
                 self.state = ReadinessState::Disarmed;
                 Some(ReadinessEffect::TimedOut { deadline })
             }
+            // The `Unconfigured` half of this arm is unreachable from the
+            // driver, which configures the gate at spawn now that readiness
+            // is definition-level; it remains for the state machine's own
+            // completeness and unit tests.
             (
                 ReadinessState::Unconfigured,
                 ReadinessEvent::Shutdown | ReadinessEvent::Exit { .. },

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -195,10 +195,20 @@ impl SlotCell {
         definition: &Isolated<ChildConstruction>,
         defaults: &ResolvedDefaults,
     ) -> Result<ResolvedCommonOptions, InvalidPolicy> {
-        let (options, mode) = match definition.get() {
-            ChildConstruction::Raw(definition) => (&definition.options, definition.mode()),
-            ChildConstruction::Task(definition) => (&definition.options, ChildMode::Restartable),
-            ChildConstruction::TaskOnce(definition) => (&definition.options, ChildMode::OneShot),
+        let (options, mode, default_readiness) = match definition.get() {
+            ChildConstruction::Raw(definition) => {
+                (&definition.options, definition.mode(), definition.readiness)
+            }
+            ChildConstruction::Task(definition) => (
+                &definition.options,
+                ChildMode::Restartable,
+                Readiness::Immediate,
+            ),
+            ChildConstruction::TaskOnce(definition) => (
+                &definition.options,
+                ChildMode::OneShot,
+                Readiness::Immediate,
+            ),
             ChildConstruction::Scope(definition) => {
                 if let DefinitionSource::OneShot(tree) = &definition.source {
                     let inherited = match definition.defaults {
@@ -208,10 +218,10 @@ impl SlotCell {
                     tree.validate_policies(&inherited)
                         .map_err(|invalid| invalid.prepend(self.member.id()))?;
                 }
-                (&definition.options, definition.mode())
+                (&definition.options, definition.mode(), Readiness::Immediate)
             }
         };
-        resolve_common(options, defaults, mode, Readiness::Immediate)
+        resolve_common(options, defaults, mode, default_readiness)
             .map_err(|invalid| invalid.prepend(self.member.id()))
     }
 }

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -756,7 +756,6 @@ pub(crate) struct ResolvedCommonOptions {
     pub(crate) mailbox: Mailbox,
     pub(crate) mailbox_shutdown: MailboxShutdown,
     pub(crate) readiness: Readiness,
-    pub(crate) readiness_override: Option<Readiness>,
     pub(crate) readiness_deadline: ReadinessDeadline,
     pub(crate) retention: Retention,
 }
@@ -787,7 +786,6 @@ pub(crate) fn resolve_common(
         mailbox: resolve_mailbox(options.mailbox, defaults.mailbox, defaults.queue_capacity),
         mailbox_shutdown: resolve(options.mailbox_shutdown, defaults.mailbox_shutdown),
         readiness: resolve(options.readiness, default_readiness),
-        readiness_override: options.readiness,
         readiness_deadline: resolve_readiness_deadline(
             options.readiness_deadline,
             defaults.readiness_deadline,
@@ -1348,7 +1346,6 @@ mod tests {
         assert_eq!(child.mailbox, inherited.mailbox);
         assert_eq!(child.mailbox_shutdown, inherited.mailbox_shutdown);
         assert_eq!(child.readiness, Readiness::Manual);
-        assert_eq!(child.readiness_override, None);
         assert_eq!(child.readiness_deadline, inherited.readiness_deadline);
         assert_eq!(child.retention, Retention::Retain);
 
@@ -1372,7 +1369,6 @@ mod tests {
         assert_eq!(overridden.mailbox, inherited.mailbox);
         assert_eq!(overridden.mailbox_shutdown, MailboxShutdown::Drain);
         assert_eq!(overridden.readiness, Readiness::Immediate);
-        assert_eq!(overridden.readiness_override, Some(Readiness::Immediate));
         assert_eq!(
             overridden.readiness_deadline,
             ReadinessDeadline::Bounded(Duration::from_nanos(1))

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -891,8 +891,11 @@ pub trait RawActor: Send + 'static {
     /// Message accepted by this actor.
     type Msg: Send + 'static;
 
-    /// Declares when this actor becomes ready. Read before `run` is polled.
-    fn readiness(&self) -> Readiness {
+    /// Declares when this actor type becomes ready.
+    ///
+    /// This is definition metadata: the framework reads it before constructing
+    /// an incarnation, so it cannot depend on per-incarnation actor state.
+    fn readiness() -> Readiness {
         Readiness::Immediate
     }
 
@@ -1618,6 +1621,7 @@ impl<R: RawActor> RawDef<R> {
 
     pub(crate) fn erase(self, mailbox: Arc<MailboxCell<R::Msg>>) -> RawConstruction {
         let factory = self.factory;
+        let readiness = self.options.readiness.unwrap_or_else(R::readiness);
         RawConstruction {
             source: DefinitionSource::Restartable(Arc::new(move || {
                 let actor = factory();
@@ -1627,6 +1631,7 @@ impl<R: RawActor> RawDef<R> {
                 })
             })),
             options: self.options,
+            readiness,
         }
     }
 }
@@ -1666,12 +1671,14 @@ impl<R: RawActor> RawOnceDef<R> {
     );
 
     pub(crate) fn erase(self, mailbox: Arc<MailboxCell<R::Msg>>) -> RawConstruction {
+        let readiness = self.options.readiness.unwrap_or_else(R::readiness);
         RawConstruction {
             source: DefinitionSource::OneShot(Box::new(RawInstance {
                 actor: self.actor,
                 mailbox,
             })),
             options: self.options,
+            readiness,
         }
     }
 }
@@ -1680,7 +1687,6 @@ pub(crate) type RawFuture = Pin<Box<dyn Future<Output = ExitResult> + Send + 'st
 type RawFactory = Arc<dyn Fn() -> Box<dyn ErasedRawInstance> + Send + Sync + 'static>;
 
 pub(crate) trait ErasedRawInstance: Send {
-    fn readiness(&self) -> Readiness;
     fn run(self: Box<Self>, context: RawRunContext, readiness: Readiness) -> RawFuture;
 }
 
@@ -1751,10 +1757,6 @@ impl<R: RawActor> Drop for RawIncarnationOwner<R> {
 }
 
 impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
-    fn readiness(&self) -> Readiness {
-        self.actor.readiness()
-    }
-
     fn run(self: Box<Self>, context: RawRunContext, readiness: Readiness) -> RawFuture {
         Box::pin(async move {
             let Self { actor, mailbox } = *self;
@@ -1811,6 +1813,7 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
 pub(crate) struct RawConstruction {
     pub(crate) source: DefinitionSource<RawFactory, Box<dyn ErasedRawInstance>>,
     pub(crate) options: CommonOptions,
+    pub(crate) readiness: Readiness,
 }
 
 impl RawConstruction {

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -238,8 +238,8 @@ struct AwaitingDecorator<R> {
 impl<R: RawActor> RawActor for AwaitingDecorator<R> {
     type Msg = R::Msg;
 
-    fn readiness(&self) -> Readiness {
-        self.inner.readiness()
+    fn readiness() -> Readiness {
+        R::readiness()
     }
 
     async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
@@ -357,8 +357,8 @@ struct ResumeProbeDecorator<R> {
 impl<R: RawActor> RawActor for ResumeProbeDecorator<R> {
     type Msg = R::Msg;
 
-    fn readiness(&self) -> Readiness {
-        self.inner.readiness()
+    fn readiness() -> Readiness {
+        R::readiness()
     }
 
     async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {

--- a/crates/shelterwood/tests/one_shot_resource_ownership.rs
+++ b/crates/shelterwood/tests/one_shot_resource_ownership.rs
@@ -1,4 +1,5 @@
 use std::{
+    panic::{AssertUnwindSafe, catch_unwind},
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -17,7 +18,6 @@ use shelterwood::{
 #[derive(Clone, Copy)]
 enum RawResourceMode {
     Normal,
-    ReadinessPanic,
     StartupFailure,
 }
 
@@ -29,22 +29,29 @@ struct ResourceRawActor {
 impl RawActor for ResourceRawActor {
     type Msg = ();
 
-    fn readiness(&self) -> Readiness {
-        match self.mode {
-            RawResourceMode::Normal => Readiness::Immediate,
-            RawResourceMode::ReadinessPanic => panic!("raw readiness panic"),
-            RawResourceMode::StartupFailure => Readiness::Manual,
-        }
-    }
-
     async fn run(&mut self, _context: &mut RawContext<Self::Msg>) -> ExitResult {
         match self.mode {
             RawResourceMode::Normal => Ok(()),
-            RawResourceMode::ReadinessPanic => unreachable!("readiness prevents run"),
             RawResourceMode::StartupFailure => {
                 Err(ExitError::message("raw actor failed before ready"))
             }
         }
+    }
+}
+
+struct ReadinessPanicRawActor {
+    _guard: ConsumeGuard,
+}
+
+impl RawActor for ReadinessPanicRawActor {
+    type Msg = ();
+
+    fn readiness() -> Readiness {
+        panic!("raw readiness panic")
+    }
+
+    async fn run(&mut self, _: &mut RawContext<Self::Msg>) -> ExitResult {
+        unreachable!("readiness metadata prevents admission")
     }
 }
 
@@ -69,21 +76,19 @@ async fn one_shot_raw_resource_drops_once_on_normal_exit() {
     count.assert_once();
 }
 
-#[tokio::test]
-async fn one_shot_raw_resource_drops_once_on_construction_panic() {
+#[test]
+fn one_shot_raw_resource_drops_once_on_readiness_definition_panic() {
     let count = ConsumeCount::default();
     let mut tree = Tree::new();
-    tree.add_raw_once(
-        "raw",
-        RawOnceDef::new(resource_raw_actor(&count, RawResourceMode::ReadinessPanic)),
-    )
-    .expect("valid actor");
-    let system = tree.spawn().expect("runtime is available");
-    assert!(system.wait_started().await.is_err());
-    system
-        .shutdown(Duration::from_secs(1))
-        .await
-        .expect("failed root rolls back");
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let _ = tree.add_raw_once(
+            "raw",
+            RawOnceDef::new(ReadinessPanicRawActor {
+                _guard: count.guard(),
+            }),
+        );
+    }));
+    assert!(result.is_err());
     count.assert_once();
 }
 
@@ -93,7 +98,9 @@ async fn one_shot_raw_resource_drops_once_on_startup_failure() {
     let mut tree = Tree::new();
     tree.add_raw_once(
         "raw",
-        RawOnceDef::new(resource_raw_actor(&count, RawResourceMode::StartupFailure)),
+        RawOnceDef::new(resource_raw_actor(&count, RawResourceMode::StartupFailure))
+            .readiness(Readiness::Manual)
+            .expect("manual raw readiness"),
     )
     .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -60,19 +60,16 @@ fn raw_readiness_override_rejects_after_init_eagerly() {
     assert_eq!(error, PolicyError::UnsupportedReadiness);
 }
 
-struct StatefulReadiness {
-    calls: Arc<AtomicUsize>,
-}
+static STATEFUL_READINESS_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+struct StatefulReadiness;
 
 impl RawActor for StatefulReadiness {
     type Msg = ();
 
-    fn readiness(&self) -> Readiness {
-        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
-            Readiness::Immediate
-        } else {
-            Readiness::Manual
-        }
+    fn readiness() -> Readiness {
+        STATEFUL_READINESS_CALLS.fetch_add(1, Ordering::SeqCst);
+        Readiness::Immediate
     }
 
     async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
@@ -82,49 +79,34 @@ impl RawActor for StatefulReadiness {
 }
 
 #[tokio::test]
-async fn raw_readiness_is_resolved_once_per_incarnation() {
-    let calls = Arc::new(AtomicUsize::new(0));
+async fn raw_readiness_is_definition_metadata_evaluated_once() {
+    STATEFUL_READINESS_CALLS.store(0, Ordering::SeqCst);
     let mut tree = Tree::new();
-    tree.add_raw_once(
-        "stateful-readiness",
-        RawOnceDef::new(StatefulReadiness {
-            calls: Arc::clone(&calls),
-        }),
-    )
-    .expect("valid actor");
+    tree.add_raw_once("stateful-readiness", RawOnceDef::new(StatefulReadiness))
+        .expect("valid actor");
+    assert_eq!(STATEFUL_READINESS_CALLS.load(Ordering::SeqCst), 1);
 
     let system = tree.spawn().expect("runtime is available");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
-    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(STATEFUL_READINESS_CALLS.load(Ordering::SeqCst), 1);
 }
+
+static RESTARTING_READINESS_CALLS: AtomicUsize = AtomicUsize::new(0);
 
 struct RestartingReadiness {
     generation: usize,
-    calls: Arc<AtomicUsize>,
 }
 
 impl RawActor for RestartingReadiness {
     type Msg = ();
 
-    fn readiness(&self) -> Readiness {
-        self.calls.fetch_add(1, Ordering::SeqCst);
-        if self.generation == 0 {
-            Readiness::Immediate
-        } else {
-            Readiness::Manual
-        }
+    fn readiness() -> Readiness {
+        RESTARTING_READINESS_CALLS.fetch_add(1, Ordering::SeqCst);
+        Readiness::Immediate
     }
 
     async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
-        let expected = if self.generation == 0 {
-            Readiness::Immediate
-        } else {
-            Readiness::Manual
-        };
-        assert_eq!(context.readiness(), expected);
-        if expected == Readiness::Manual {
-            context.mark_ready();
-        }
+        assert_eq!(context.readiness(), Readiness::Immediate);
         if self.generation == 0 {
             Err(ExitError::message("restart once"))
         } else {
@@ -134,18 +116,16 @@ impl RawActor for RestartingReadiness {
 }
 
 #[tokio::test]
-async fn raw_readiness_is_resolved_once_for_each_restartable_incarnation() {
+async fn restartable_raw_readiness_is_resolved_once_for_the_definition() {
+    RESTARTING_READINESS_CALLS.store(0, Ordering::SeqCst);
     let generations = Arc::new(AtomicUsize::new(0));
-    let calls = Arc::new(AtomicUsize::new(0));
     let mut tree = Tree::new();
     tree.add_raw(
         "restartable-readiness",
         RawDef::factory({
             let generations = Arc::clone(&generations);
-            let calls = Arc::clone(&calls);
             move || RestartingReadiness {
                 generation: generations.fetch_add(1, Ordering::SeqCst),
-                calls: Arc::clone(&calls),
             }
         }),
     )
@@ -154,18 +134,18 @@ async fn raw_readiness_is_resolved_once_for_each_restartable_incarnation() {
     let system = tree.spawn().expect("runtime is available");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert_eq!(generations.load(Ordering::SeqCst), 2);
-    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert_eq!(RESTARTING_READINESS_CALLS.load(Ordering::SeqCst), 1);
 }
 
-struct OverrideReadiness {
-    calls: Arc<AtomicUsize>,
-}
+static OVERRIDE_READINESS_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+struct OverrideReadiness;
 
 impl RawActor for OverrideReadiness {
     type Msg = ();
 
-    fn readiness(&self) -> Readiness {
-        self.calls.fetch_add(1, Ordering::SeqCst);
+    fn readiness() -> Readiness {
+        OVERRIDE_READINESS_CALLS.fetch_add(1, Ordering::SeqCst);
         panic!("an effective definition override must bypass actor readiness")
     }
 
@@ -179,21 +159,19 @@ impl RawActor for OverrideReadiness {
 
 #[tokio::test]
 async fn raw_readiness_override_does_not_evaluate_actor_readiness() {
-    let calls = Arc::new(AtomicUsize::new(0));
+    OVERRIDE_READINESS_CALLS.store(0, Ordering::SeqCst);
     let mut tree = Tree::new();
     tree.add_raw_once(
         "overridden-readiness",
-        RawOnceDef::new(OverrideReadiness {
-            calls: Arc::clone(&calls),
-        })
-        .readiness(Readiness::Manual)
-        .expect("manual readiness override"),
+        RawOnceDef::new(OverrideReadiness)
+            .readiness(Readiness::Manual)
+            .expect("manual readiness override"),
     )
     .expect("valid actor");
 
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("actor becomes ready");
-    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert_eq!(OVERRIDE_READINESS_CALLS.load(Ordering::SeqCst), 0);
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -209,7 +187,7 @@ struct ManualActor {
 impl RawActor for ManualActor {
     type Msg = usize;
 
-    fn readiness(&self) -> Readiness {
+    fn readiness() -> Readiness {
         Readiness::Manual
     }
 
@@ -477,7 +455,7 @@ struct DoublePanicActor;
 impl RawActor for DoublePanicActor {
     type Msg = ();
 
-    fn readiness(&self) -> Readiness {
+    fn readiness() -> Readiness {
         Readiness::Manual
     }
 

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -11,7 +11,7 @@ use crate::common::{
 };
 use shelterwood::{
     Backoff, Cancellation, ChildState, DynamicTree, ExitError, ExitKind, ExitResult, Jitter,
-    RawActor, RawContext, RawOnceDef, Readiness, ReadinessDeadline, RestartCondition,
+    RawActor, RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline, RestartCondition,
     RestartPolicy, ScopeState, Shutdown, StartupError, StartupFailureCause, SubtreeOnceDef,
     TaskDef, Tree,
 };
@@ -1061,4 +1061,68 @@ async fn nested_startup_rollback_includes_runtime_added_members() {
         .shutdown(Duration::from_secs(1))
         .await
         .expect("failed root rolls back");
+}
+
+struct NeverConstructed;
+
+impl RawActor for NeverConstructed {
+    type Msg = ();
+
+    async fn run(&mut self, _: &mut RawContext<Self::Msg>) -> ExitResult {
+        unreachable!("the factory panics before an incarnation exists")
+    }
+}
+
+#[tokio::test]
+async fn immediate_raw_construction_panic_classifies_post_ready() {
+    // Resolved-`Immediate` readiness publishes at spawn, before the raw
+    // factory runs (SPEC §6): a construction panic is a post-ready failure,
+    // so ordered startup has already advanced past the child and later
+    // siblings still start.
+    let sibling_started = Arc::new(AtomicBool::new(false));
+    let mut tree = Tree::new();
+    tree.add_raw(
+        "constructs-never",
+        RawDef::factory(|| -> NeverConstructed { panic!("raw construction panic") })
+            .restart(never()),
+    )
+    .expect("valid raw actor");
+    tree.add_task(
+        "sibling",
+        TaskDef::new({
+            let sibling_started = Arc::clone(&sibling_started);
+            move |context| {
+                sibling_started.store(true, Ordering::SeqCst);
+                async move {
+                    context.shutdown_token().cancelled().await;
+                    Ok(())
+                }
+            }
+        }),
+    )
+    .expect("valid sibling");
+
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("spawn-time readiness classifies the construction panic post-ready");
+    assert!(sibling_started.load(Ordering::SeqCst));
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            system
+                .scope()
+                .child("constructs-never")
+                .is_some_and(|child| matches!(
+                    &child.state,
+                    ChildState::Stopped { exit } if matches!(exit.kind(), ExitKind::Panicked { .. })
+                ))
+        })
+        .await,
+        "the terminal panic is an ordinary post-ready stop, not a startup abort"
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("clean shutdown");
 }

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -21,7 +21,7 @@ struct ReadyThenStop;
 impl RawActor for ReadyThenStop {
     type Msg = ();
 
-    fn readiness(&self) -> Readiness {
+    fn readiness() -> Readiness {
         Readiness::Manual
     }
 


### PR DESCRIPTION
Part of #151. Builds on #157 (merge first).

## Summary

- make raw readiness type-level definition metadata rather than per-incarnation state
- resolve readiness before constructing an incarnation and configure the driver gate synchronously before spawn
- remove the `Constructed` child event, construction-release latch, and duplicate resolved-policy override
- preserve explicit definition overrides without evaluating the raw type's declaration
- update the specification and add restart, override-bypass, and one-shot ownership regressions

## Reconciliation with #157

This branch now merges `agent/issue-151-readiness-field` and expresses definition-level
resolution on top of its single readiness field:

- Non-raw kinds keep #157's plan-level per-kind defaults exactly (task/task-once resolve
  `Immediate`, scope resolves `Manual` at `SlotCell::resolve`), and the scope dispatch arm
  consumes the resolved value instead of hardcoding `Manual`, so the default lives in one place.
- Raw children carry no `Option` and no per-incarnation fallback: the definition resolves its
  effective mode at erasure (`options.readiness.unwrap_or_else(R::readiness)`), plan resolution
  treats that value as the kind default, and `SpawnBody::Raw` keeps #157's readiness slot, now
  holding the already-resolved mode handed to the incarnation. #157's defaults-pinning unit test
  is updated accordingly (Raw pins the erasure-resolved value instead of `None`).

## Semantic change: spawn-time `Immediate` readiness

Deleting the `Constructed` round-trip moves the effective-`Immediate` ready edge to spawn,
**before the raw factory runs**. Observable consequence: in an ordered scope, a raw
construction panic under effective `Immediate` readiness was a **pre-ready** exit on main
(startup aborted, later siblings marked `NeverStarted`, `wait_started()` returned `Err`) and is
**post-ready** here (siblings start, `wait_started()` can return `Ok`). This is accepted
deliberately — it makes raw children uniform with tasks, whose `Immediate` gate already
released before the body ran. SPEC §6 is amended to pin the rule, and
`immediate_raw_construction_panic_classifies_post_ready` (tests/readiness.rs) pins the new
classification. Declaring a gated mode restores pre-ready observation of construction.

## Known gaps / minor notes

- The dynamic-add unwind path — a panicking `R::readiness()` during a `DynamicScopeRef` add now
  unwinds the *adding* actor at definition time — is currently untested; only the static
  `Tree::add_raw_once` unwind is pinned.
- The engine's `Unconfigured` readiness-gate paths (`needs_signal_watch`, the
  `(Unconfigured, Shutdown|Exit)` arm) are driver-unreachable now that the gate is configured at
  spawn; they are commented as retained for the state machine's own completeness and unit tests.

## Validation

- `./tools/dev cargo test -p shelterwood --test integration raw_readiness`
- `./tools/dev cargo test -p shelterwood --test integration raw_decorator`
- `./tools/dev cargo test -p shelterwood --test integration one_shot_raw_resource`
- `./tools/dev cargo test -p shelterwood --test integration ordered_startup_waits_for_manual_readiness`
- `./tools/dev cargo test -p shelterwood --test integration manual_readiness_override_on_a_wrapped_handler_stays_gated`
- `./tools/dev cargo test -p shelterwood --test integration immediate_raw_construction_panic_classifies_post_ready`
- `./tools/dev just ci` (501 tests plus docs, API reachability, enforcement checks, package verification, and Nix formatting)
