### PR TITLE
Remove the admission request forwarder

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -471,9 +471,6 @@ pub(crate) trait DynamicRoute: Send + Sync {
         id: &ChildId,
         exact: Option<Membership>,
     ) -> runtime::OneShotReceiver<RemoveOutcome>;
-
-    #[cfg(test)]
-    fn request_forwarder_probe(&self) -> (Latch, Latch);
 }
 
 /// Shared critical section for one resident tree's observation projection.

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -159,6 +159,8 @@ enum DriverEvent {
     Removal(RemovalRequest),
 }
 
+const MIN_EVENT_BATCH_LIMIT: usize = 64;
+
 #[derive(Clone, Copy)]
 struct RemovalRequest {
     membership: Membership,
@@ -2379,15 +2381,24 @@ async fn run_scope_incarnation(
         root.member
             .update(|record| record.stage = MemberStage::Running);
     }
-    // The queue is unbounded so every producer can publish synchronously,
-    // including foreign-thread removal and detached admission. Preserve the
-    // old bounded lane's per-wake collection ceiling so a producer flood
-    // cannot defer shutdown signals or deadlines indefinitely.
-    let event_batch_limit = plan.children.len().saturating_mul(3).max(64);
+    // Both lanes are unbounded so their producers can publish synchronously.
+    // Keep child lifecycle events separate from externally generated dynamic
+    // control traffic: a large admission prefix must not strand the exit that
+    // completes shutdown. Bound each lane's per-wake collection so traffic
+    // cannot defer signals or deadlines indefinitely.
+    let event_batch_limit = plan
+        .children
+        .len()
+        .saturating_mul(3)
+        .max(MIN_EVENT_BATCH_LIMIT);
     let (events, mut event_receiver) = runtime::unbounded_mpsc();
     let (disposal_events, mut disposal_event_receiver) = runtime::unbounded_mpsc();
-    let dynamic =
-        (plan.root.flavor == ScopeFlavor::Dynamic).then(|| DynamicControl::new(events.clone()));
+    let (dynamic, mut dynamic_event_receiver) = if plan.root.flavor == ScopeFlavor::Dynamic {
+        let (dynamic_events, receiver) = runtime::unbounded_mpsc();
+        (Some(DynamicControl::new(dynamic_events)), Some(receiver))
+    } else {
+        (None, None)
+    };
     // Transfer children one at a time. The not-yet-converted suffix remains
     // owned by ScopePlan, while ChildRuntime::from_plan arms the current
     // child's obligation before fallible setup. Thus a panic at any point has
@@ -2496,13 +2507,11 @@ async fn run_scope_incarnation(
             // cannot publish Running after the stop boundary.
             pending.push(Pending::Force.classified());
         }
-        for _ in 0..event_batch_limit {
-            let Some(event) = runtime::unbounded_mpsc_try_recv(&mut event_receiver) else {
-                break;
-            };
-            pending.push(Pending::Driver(event).classified());
+        collect_driver_events(&mut event_receiver, event_batch_limit, &mut pending);
+        if let Some(receiver) = dynamic_event_receiver.as_mut() {
+            collect_driver_events(receiver, event_batch_limit, &mut pending);
         }
-        // Disposal completions drain after the main lane, and `arbitrate`
+        // Disposal completions drain after the primary and dynamic lanes, and `arbitrate`
         // sorts stably, so a `ConstructionDisposed` always trails every
         // same-class `Exited` collected in the same wake — even one produced
         // later. A disposal is therefore a batch-tail event: the exit it
@@ -2554,6 +2563,7 @@ async fn run_scope_incarnation(
                     parent_shutdown: ancestor_command,
                 },
                 &mut event_receiver,
+                dynamic_event_receiver.as_mut(),
                 scope.deadlines.next(),
             )
             .await
@@ -2570,7 +2580,12 @@ async fn run_scope_incarnation(
                 runtime::ScopeWake::Message(Some(event)) => {
                     pending.push(Pending::Driver(event).classified());
                 }
-                runtime::ScopeWake::Message(None) => continue,
+                runtime::ScopeWake::ControlMessage(Some(event)) => {
+                    pending.push(Pending::Driver(event).classified());
+                }
+                runtime::ScopeWake::Message(None) | runtime::ScopeWake::ControlMessage(None) => {
+                    continue;
+                }
             }
         }
 
@@ -2698,6 +2713,19 @@ impl Pending {
 
     fn classified(self) -> (ArbitrationClass, Self) {
         (self.class(), self)
+    }
+}
+
+fn collect_driver_events(
+    receiver: &mut runtime::UnboundedMpscReceiver<DriverEvent>,
+    limit: usize,
+    pending: &mut Vec<(ArbitrationClass, Pending)>,
+) {
+    for _ in 0..limit {
+        let Some(event) = runtime::unbounded_mpsc_try_recv(receiver) else {
+            break;
+        };
+        pending.push(Pending::Driver(event).classified());
     }
 }
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2507,10 +2507,11 @@ async fn run_scope_incarnation(
             // cannot publish Running after the stop boundary.
             pending.push(Pending::Force.classified());
         }
-        collect_driver_events(&mut event_receiver, event_batch_limit, &mut pending);
-        if let Some(receiver) = dynamic_event_receiver.as_mut() {
-            collect_driver_events(receiver, event_batch_limit, &mut pending);
-        }
+        let primary_batch_full =
+            collect_driver_events(&mut event_receiver, event_batch_limit, &mut pending);
+        let control_batch_full = dynamic_event_receiver.as_mut().is_some_and(|receiver| {
+            collect_driver_events(receiver, event_batch_limit, &mut pending)
+        });
         // Disposal completions drain after the primary and dynamic lanes, and `arbitrate`
         // sorts stably, so a `ConstructionDisposed` always trails every
         // same-class `Exited` collected in the same wake — even one produced
@@ -2684,6 +2685,15 @@ async fn run_scope_incarnation(
             });
             return reason;
         }
+
+        // A full lane may still have a queued suffix. On a current-thread
+        // runtime, immediately collecting the next batch would prevent the
+        // child, timer, and helper tasks whose events this loop prioritizes
+        // from running at all. Give those producers one scheduler turn before
+        // returning to either saturated lane.
+        if primary_batch_full || control_batch_full {
+            runtime::yield_now().await;
+        }
     }
 }
 
@@ -2720,13 +2730,15 @@ fn collect_driver_events(
     receiver: &mut runtime::UnboundedMpscReceiver<DriverEvent>,
     limit: usize,
     pending: &mut Vec<(ArbitrationClass, Pending)>,
-) {
+) -> bool {
+    let before = pending.len();
     for _ in 0..limit {
         let Some(event) = runtime::unbounded_mpsc_try_recv(receiver) else {
             break;
         };
         pending.push(Pending::Driver(event).classified());
     }
+    pending.len() - before == limit
 }
 
 fn restart_shutdown_work(child: ChildKey) -> (ArbitrationClass, Pending) {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -550,7 +550,7 @@ struct ScopeRuntime {
     intensity_policy: crate::Intensity,
     intensity: IntensityState,
     children: ChildArena<ChildRuntime>,
-    events: runtime::MpscSender<DriverEvent>,
+    events: runtime::UnboundedMpscSender<DriverEvent>,
     disposal_events: runtime::UnboundedMpscSender<DriverEvent>,
     deadlines: DeadlineQueue<DeadlineKind>,
     jitter: runtime::JitterRng,
@@ -699,7 +699,7 @@ impl SpawnLatches {
 }
 
 struct ChildTaskLaunch {
-    events: runtime::MpscSender<DriverEvent>,
+    events: runtime::UnboundedMpscSender<DriverEvent>,
     key: ChildKey,
     incarnation: Incarnation,
     body: SpawnBody,
@@ -829,15 +829,14 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
                 SpawnBody::Raw { spawn, context } => {
                     let instance = spawn.construct();
                     let readiness = readiness_override.unwrap_or_else(|| instance.readiness());
-                    let _ = runtime::mpsc_send(
+                    let _ = runtime::unbounded_mpsc_send(
                         &constructed_sender,
                         DriverEvent::Child(ChildEvent::Constructed {
                             child: key,
                             incarnation,
                             readiness,
                         }),
-                    )
-                    .await;
+                    );
                     construction_release.fired().await;
                     instance.run(context, readiness).await
                 }
@@ -880,7 +879,7 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
         // ownership and immediate post-join availability without ever
         // blocking this runtime worker.
         let report = report_claim.receive();
-        let _ = runtime::mpsc_send(
+        let _ = runtime::unbounded_mpsc_send(
             &exit_sender,
             DriverEvent::Child(ChildEvent::Exited {
                 child: key,
@@ -890,8 +889,7 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
                 cancellation: report.cancellation,
                 readiness_signal_seen: report.readiness_signal_seen,
             }),
-        )
-        .await;
+        );
     });
 
     let completion = ready.clone();
@@ -903,14 +901,13 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
                 runtime::select_two(ready.fired(), ready_completion.completed()).await,
                 runtime::Either::Left(())
             ) {
-                let _ = runtime::mpsc_send(
+                let _ = runtime::unbounded_mpsc_send(
                     &ready_sender,
                     DriverEvent::Child(ChildEvent::Ready {
                         child: key,
                         incarnation,
                     }),
-                )
-                .await;
+                );
             }
         });
     }
@@ -920,14 +917,13 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
             runtime::select_two(local_stop.fired(), completion.completed()).await,
             runtime::Either::Left(())
         ) {
-            let _ = runtime::mpsc_send(
+            let _ = runtime::unbounded_mpsc_send(
                 &events,
                 DriverEvent::Child(ChildEvent::SelfStop {
                     child: key,
                     incarnation,
                 }),
-            )
-            .await;
+            );
         }
     });
 
@@ -2383,8 +2379,12 @@ async fn run_scope_incarnation(
         root.member
             .update(|record| record.stage = MemberStage::Running);
     }
-    let capacity = plan.children.len().saturating_mul(3).max(64);
-    let (events, mut event_receiver) = runtime::bounded_mpsc(capacity);
+    // The queue is unbounded so every producer can publish synchronously,
+    // including foreign-thread removal and detached admission. Preserve the
+    // old bounded lane's per-wake collection ceiling so a producer flood
+    // cannot defer shutdown signals or deadlines indefinitely.
+    let event_batch_limit = plan.children.len().saturating_mul(3).max(64);
+    let (events, mut event_receiver) = runtime::unbounded_mpsc();
     let (disposal_events, mut disposal_event_receiver) = runtime::unbounded_mpsc();
     let dynamic =
         (plan.root.flavor == ScopeFlavor::Dynamic).then(|| DynamicControl::new(events.clone()));
@@ -2496,10 +2496,13 @@ async fn run_scope_incarnation(
             // cannot publish Running after the stop boundary.
             pending.push(Pending::Force.classified());
         }
-        while let Some(event) = runtime::mpsc_try_recv(&mut event_receiver) {
+        for _ in 0..event_batch_limit {
+            let Some(event) = runtime::unbounded_mpsc_try_recv(&mut event_receiver) else {
+                break;
+            };
             pending.push(Pending::Driver(event).classified());
         }
-        // Disposal completions drain after the bounded lane, and `arbitrate`
+        // Disposal completions drain after the main lane, and `arbitrate`
         // sorts stably, so a `ConstructionDisposed` always trails every
         // same-class `Exited` collected in the same wake — even one produced
         // later. A disposal is therefore a batch-tail event: the exit it

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2385,7 +2385,13 @@ async fn run_scope_incarnation(
     // Keep child lifecycle events separate from externally generated dynamic
     // control traffic: a large admission prefix must not strand the exit that
     // completes shutdown. Bound each lane's per-wake collection so traffic
-    // cannot defer signals or deadlines indefinitely.
+    // cannot defer signals or deadlines indefinitely. The cap adds one
+    // ordering surface: when a wake finds more than a full batch of primary
+    // events, the deferred suffix (an intensity-tripping exit, say) is
+    // processed one wake after control-lane admissions enqueued earlier.
+    // `arbitrate` promises order only within a batch, and cross-pass
+    // wall-clock inversion was already reachable through the forwarder, so
+    // no promised order is violated.
     let event_batch_limit = plan
         .children
         .len()
@@ -2731,14 +2737,21 @@ fn collect_driver_events(
     limit: usize,
     pending: &mut Vec<(ArbitrationClass, Pending)>,
 ) -> bool {
-    let before = pending.len();
     for _ in 0..limit {
         let Some(event) = runtime::unbounded_mpsc_try_recv(receiver) else {
-            break;
+            return false;
         };
         pending.push(Pending::Driver(event).classified());
     }
-    pending.len() - before == limit
+    // Collecting exactly `limit` events does not by itself show a capped
+    // lane. Probe once more so a lane that drained right at the limit skips
+    // the full-batch yield; a probed event joins this batch rather than
+    // being deferred a wake.
+    let Some(event) = runtime::unbounded_mpsc_try_recv(receiver) else {
+        return false;
+    };
+    pending.push(Pending::Driver(event).classified());
+    true
 }
 
 fn restart_shutdown_work(child: ChildKey) -> (ArbitrationClass, Pending) {
@@ -2764,7 +2777,7 @@ fn driver_event_class(event: &DriverEvent) -> ArbitrationClass {
 }
 
 #[cfg(test)]
-pub(crate) use tests::exercise_saturated_fused_drop_before_exit;
+pub(crate) use tests::exercise_queued_fused_drop_before_exit_dispatch;
 
 #[cfg(test)]
 mod tests;

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -164,14 +164,14 @@ pub(super) struct DynamicState {
 }
 
 pub(crate) struct DynamicControl {
-    events: runtime::UnboundedMpscSender<DriverEvent>,
+    requests: runtime::UnboundedMpscSender<DriverEvent>,
     pub(super) state: Mutex<DynamicState>,
 }
 
 impl DynamicControl {
-    pub(super) fn new(events: runtime::UnboundedMpscSender<DriverEvent>) -> Arc<Self> {
+    pub(super) fn new(requests: runtime::UnboundedMpscSender<DriverEvent>) -> Arc<Self> {
         Arc::new(Self {
-            events,
+            requests,
             state: Mutex::new(DynamicState {
                 accepting: true,
                 entries: HashMap::new(),
@@ -485,7 +485,7 @@ impl DynamicRoute for DynamicControl {
 fn queue_driver_event(control: &DynamicControl, event: DriverEvent) {
     // Synchronous and runtime-independent: admission detaches at its first
     // poll, and removal may be signalled from a foreign thread.
-    let _ = runtime::unbounded_mpsc_send(&control.events, event);
+    let _ = runtime::unbounded_mpsc_send(&control.requests, event);
 }
 
 pub(super) struct AdmissionRequest {

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -164,70 +164,19 @@ pub(super) struct DynamicState {
 }
 
 pub(crate) struct DynamicControl {
-    events: runtime::MpscSender<DriverEvent>,
+    events: runtime::UnboundedMpscSender<DriverEvent>,
     pub(super) state: Mutex<DynamicState>,
-    requests: runtime::UnboundedMpscSender<DriverEvent>,
-    pub(super) request_forwarder_close: Latch,
-    #[cfg(test)]
-    pub(super) request_forwarder_ended: Latch,
 }
 
 impl DynamicControl {
-    pub(super) fn new(events: runtime::MpscSender<DriverEvent>) -> Arc<Self> {
-        let (requests, mut request_receiver) = runtime::unbounded_mpsc();
-        let forward_events = events.clone();
-        let request_forwarder_close = Latch::default();
-        let close_forwarder = request_forwarder_close.clone();
-        #[cfg(test)]
-        let request_forwarder_ended = Latch::default();
-        #[cfg(test)]
-        let forwarder_ended = request_forwarder_ended.clone();
-        let control = Arc::new(Self {
+    pub(super) fn new(events: runtime::UnboundedMpscSender<DriverEvent>) -> Arc<Self> {
+        Arc::new(Self {
             events,
             state: Mutex::new(DynamicState {
                 accepting: true,
                 entries: HashMap::new(),
             }),
-            requests,
-            request_forwarder_close,
-            #[cfg(test)]
-            request_forwarder_ended,
-        });
-        // Off-runtime construction (unit tests only) safely skips the
-        // forwarder: `reserve_dynamic`/`start_admission` fail closed with
-        // `NoRuntime` before anything can enqueue, and a live driver — the
-        // only other producer — exists only inside the runtime.
-        if runtime::is_available() {
-            runtime::spawn(async move {
-                loop {
-                    let request = match runtime::select_two(
-                        close_forwarder.fired(),
-                        runtime::unbounded_mpsc_recv(&mut request_receiver),
-                    )
-                    .await
-                    {
-                        runtime::Either::Left(()) | runtime::Either::Right(None) => break,
-                        runtime::Either::Right(Some(request)) => request,
-                    };
-                    // A failed admission send drops its response obligation,
-                    // completing it with `Terminal`. Explicit closure drops
-                    // this request and the queued suffix for the same result.
-                    if matches!(
-                        runtime::select_two(
-                            close_forwarder.fired(),
-                            runtime::mpsc_send(&forward_events, request),
-                        )
-                        .await,
-                        runtime::Either::Left(())
-                    ) {
-                        break;
-                    }
-                }
-                #[cfg(test)]
-                forwarder_ended.fire();
-            });
-        }
-        control
+        })
     }
 
     pub(super) fn register_initial<'a>(
@@ -248,10 +197,6 @@ impl DynamicControl {
         state.accepting = false;
         let entries = std::mem::take(&mut state.entries);
         drop(state);
-        // Reservation handles may retain this control after scope teardown.
-        // Stop the sole per-scope forwarder explicitly instead of waiting for
-        // every clone of its unbounded sender to disappear.
-        self.request_forwarder_close.fire();
         let mut retained = HashMap::new();
         for (id, entry) in entries {
             if entry.is_reserved() {
@@ -354,12 +299,9 @@ fn start_dynamic_admission(
             let _ = sender.send(Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal)));
         }),
     };
-    // The driver channel is bounded and a split admission may be dropped
-    // right after this first poll (drop detaches), so the send cannot live in
-    // the caller-held future. One persistent forwarder per scope drains this
-    // unbounded FIFO, keeping pending-admission memory proportional to the
-    // requests without a second mutex-protected channel implementation.
-    let _ = runtime::unbounded_mpsc_send(&control.requests, DriverEvent::Admission(request));
+    // Queue synchronously so dropping a split-admission future immediately
+    // after its first poll cannot cancel the admitted request.
+    queue_driver_event(&control, DriverEvent::Admission(request));
     Ok(response)
 }
 
@@ -538,25 +480,12 @@ impl DynamicRoute for DynamicControl {
     ) -> RemovalResponse {
         remove_dynamic_impl(self, scope, id, exact)
     }
-
-    #[cfg(test)]
-    fn request_forwarder_probe(&self) -> (Latch, Latch) {
-        (
-            self.request_forwarder_close.clone(),
-            self.request_forwarder_ended.clone(),
-        )
-    }
 }
 
 fn queue_driver_event(control: &DynamicControl, event: DriverEvent) {
-    let Err(event) = runtime::mpsc_try_send(&control.events, event) else {
-        return;
-    };
-    // The unbounded send is synchronous and runtime-independent, so a drop or
-    // removal from a foreign thread cannot lose the edge when the bounded
-    // driver lane is full. The per-scope forwarder applies backpressure only
-    // on that saturated fallback; the normal removal path stays allocation-free.
-    let _ = runtime::unbounded_mpsc_send(&control.requests, event);
+    // Synchronous and runtime-independent: admission detaches at its first
+    // poll, and removal may be signalled from a foreign thread.
+    let _ = runtime::unbounded_mpsc_send(&control.events, event);
 }
 
 pub(super) struct AdmissionRequest {

--- a/crates/shelterwood/src/driver/tests.rs
+++ b/crates/shelterwood/src/driver/tests.rs
@@ -2982,7 +2982,7 @@ async fn admission_conversion_panic_does_not_poison_dynamic_cleanup() {
     );
 }
 
-pub(crate) async fn exercise_saturated_fused_drop_before_exit<A>(
+pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
     make_admission: impl FnOnce(super::DynamicReservation) -> A,
 ) where
     A: Future,
@@ -3101,7 +3101,7 @@ pub(crate) async fn exercise_saturated_fused_drop_before_exit<A>(
             }),
         )
         .is_ok(),
-        "the driver lane remains open"
+        "the open lane queues a predecessor edge ahead of the fused removal"
     );
     drop(admission);
     assert!(
@@ -3398,6 +3398,31 @@ async fn queued_admissions_yield_to_shutdown_without_forwarder_tasks() {
     ));
     drop(shutdown);
     assert_eq!(system.wait().await, StopReason::ShutdownRequested);
+
+    // The driver tore down with a control backlog still queued, so every
+    // stranded admission's completion obligation must resolve rather than
+    // hang its caller. Pin both ends of the queue: the head is rejected
+    // while the drain runs, the tail at latest by the obligation's
+    // receiver-drop fallback once the driver's lane closes.
+    let tail = admissions.pop().expect("the backlog has a tail");
+    let head = admissions.swap_remove(0);
+    for (position, admission) in [("head", head), ("tail", tail)] {
+        let outcome = match crate::runtime::timeout(Duration::from_secs(2), admission).await {
+            crate::runtime::Timeout::Completed(outcome) => outcome,
+            crate::runtime::Timeout::Elapsed => {
+                panic!("the {position}-of-queue admission obligation completes at teardown")
+            }
+        };
+        assert!(
+            matches!(
+                outcome,
+                Err(ReserveError::NotAdmitting(
+                    crate::NotAdmittingCause::Draining | crate::NotAdmittingCause::Terminal
+                ))
+            ),
+            "the {position}-of-queue admission reports the stopped scope"
+        );
+    }
 }
 
 #[crate::runtime::test]

--- a/crates/shelterwood/src/driver/tests.rs
+++ b/crates/shelterwood/src/driver/tests.rs
@@ -1,3 +1,4 @@
+
 use std::{
     future::{self, Future},
     panic::{AssertUnwindSafe, catch_unwind},
@@ -818,7 +819,7 @@ async fn force_uses_the_stop_funnel_for_every_ordered_child() {
             .map(|child| resident_projection(&child.slot))
             .collect(),
     );
-    let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
     let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let mut children = ChildArena::default();
     plan.children.reverse();
@@ -947,7 +948,7 @@ fn forced_ordered_drain_advances_an_inactive_suffix_iteratively() {
             .map(|child| resident_projection(&child.slot))
             .collect(),
     );
-    let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
     let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let mut children = ChildArena::default();
     plan.children.reverse();
@@ -1030,7 +1031,7 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
             .map(|child| resident_projection(&child.slot))
             .collect(),
     );
-    let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
     let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let mut children = ChildArena::default();
     plan.children.reverse();
@@ -1180,7 +1181,7 @@ async fn same_batch_self_stop_preserves_fired_readiness_for_startup() {
             .map(|child| resident_projection(&child.slot))
             .collect(),
     );
-    let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
     let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     let mut children = ChildArena::default();
@@ -2716,7 +2717,7 @@ fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
     );
     let slot = SlotCell::new(Arc::clone(&member), None);
     root.set_admitted_children(vec![resident_projection(&slot)]);
-    let (events, _receiver) = crate::runtime::bounded_mpsc(1);
+    let (events, _receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events);
     let (sender, mut response) = crate::runtime::oneshot();
     let mut responses = RemovalResponses::default();
@@ -2747,32 +2748,19 @@ fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
 }
 
 #[crate::runtime::test]
-async fn retained_unadmitted_slot_does_not_retain_the_request_forwarder() {
+async fn retained_unadmitted_slot_does_not_block_driver_teardown() {
     let system = DynamicTree::new().spawn().expect("runtime is available");
     system.wait_started().await.expect("root starts");
     let scope = system.scope();
     let slot = scope
         .reserve_task("retained")
         .expect("unadmitted reservation is retained");
-    let control = scope
-        .as_scope()
-        .cell
-        .dynamic_route()
-        .expect("the live dynamic scope exposes its control");
-    let (forwarder_close, forwarder_ended) = control.request_forwarder_probe();
-
     system
         .shutdown(Duration::from_secs(1))
         .await
         .expect("driver teardown completes");
 
-    assert!(forwarder_close.is_fired());
-    assert!(matches!(
-        crate::runtime::timeout(Duration::from_secs(1), forwarder_ended.fired()).await,
-        crate::runtime::Timeout::Completed(())
-    ));
     drop(slot);
-    drop(control);
 }
 
 #[test]
@@ -2799,7 +2787,7 @@ fn dynamic_removal_releases_state_before_waiting_for_the_observation_gate() {
     );
     let slot = SlotCell::new(Arc::clone(&member), None);
     root.set_admitted_children(vec![resident_projection(&slot)]);
-    let (events, _receiver) = crate::runtime::bounded_mpsc(1);
+    let (events, _receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events);
     let key = ChildKey(1);
     control
@@ -2854,29 +2842,16 @@ fn dynamic_removal_releases_state_before_waiting_for_the_observation_gate() {
 }
 
 #[crate::runtime::test]
-async fn saturated_removal_from_a_foreign_thread_reaches_the_driver() {
+async fn removal_from_a_foreign_thread_reaches_the_driver() {
     let mut identity = ScopeIdentity::new();
-    let first_id = ChildId::from("first");
-    let second_id = ChildId::from("second");
-    let first = identity
-        .mint_membership(&first_id)
-        .expect("first membership available");
-    let second = identity
-        .mint_membership(&second_id)
-        .expect("second membership available");
-    let member = MemberCell::new(second_id.clone(), second);
+    let child_id = ChildId::from("worker");
+    let membership = identity
+        .mint_membership(&child_id)
+        .expect("membership available");
+    let member = MemberCell::new(child_id.clone(), membership);
     let slot = SlotCell::new(Arc::clone(&member), None);
-    let second_key = ChildKey(2);
-    let (events, mut event_receiver) = crate::runtime::bounded_mpsc(1);
-    assert!(
-        events
-            .try_send(DriverEvent::Removal(RemovalRequest {
-                membership: first,
-                key: ChildKey(1),
-            }))
-            .is_ok(),
-        "the fixture saturates the bounded driver lane"
-    );
+    let key = ChildKey(1);
+    let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events);
     control
         .state
@@ -2884,8 +2859,8 @@ async fn saturated_removal_from_a_foreign_thread_reaches_the_driver() {
         .expect("dynamic-state mutex poisoned")
         .entries
         .insert(
-            second_id,
-            DynamicEntry::resident(Arc::clone(&slot), second_key, Some(Latch::default())),
+            child_id,
+            DynamicEntry::resident(Arc::clone(&slot), key, Some(Latch::default())),
         );
     let foreign_control = Arc::clone(&control);
     let foreign_slot = Arc::clone(&slot);
@@ -2899,24 +2874,17 @@ async fn saturated_removal_from_a_foreign_thread_reaches_the_driver() {
     .join()
     .expect("foreign-thread removal signaling succeeds");
 
-    let Some(DriverEvent::Removal(observed_first)) = event_receiver.recv().await else {
-        panic!("the saturated event remains first");
+    let event = match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
+        crate::runtime::Timeout::Completed(event) => event.expect("the driver lane remains open"),
+        crate::runtime::Timeout::Elapsed => {
+            panic!("the off-runtime removal edge must not be lost")
+        }
     };
-    assert_eq!(observed_first.membership, first);
-    let second_event =
-        match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
-            crate::runtime::Timeout::Completed(event) => {
-                event.expect("the control forwarder remains open")
-            }
-            crate::runtime::Timeout::Elapsed => {
-                panic!("the off-runtime removal edge must not be lost")
-            }
-        };
-    let DriverEvent::Removal(observed_second) = second_event else {
-        panic!("the forwarded event is the requested removal");
+    let DriverEvent::Removal(observed) = event else {
+        panic!("the queued event is the requested removal");
     };
-    assert_eq!(observed_second.membership, second);
-    assert_eq!(observed_second.key, second_key);
+    assert_eq!(observed.membership, membership);
+    assert_eq!(observed.key, key);
 }
 
 #[crate::runtime::test]
@@ -2930,7 +2898,7 @@ async fn admission_conversion_panic_does_not_poison_dynamic_cleanup() {
     root.set_state(ScopeState::Running);
     root.set_startup(Ok(()));
 
-    let (events, mut event_receiver) = crate::runtime::bounded_mpsc(1);
+    let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
     let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events.clone());
     root.set_dynamic_route(Some(control.clone()));
@@ -2973,7 +2941,7 @@ async fn admission_conversion_panic_does_not_poison_dynamic_cleanup() {
     )
     .expect("admission starts inside the runtime");
     let Some(DriverEvent::Admission(request)) = event_receiver.recv().await else {
-        panic!("the admission forwarder submits the request")
+        panic!("admission enqueueing submits the request")
     };
 
     assert!(
@@ -3028,7 +2996,7 @@ pub(crate) async fn exercise_saturated_fused_drop_before_exit<A>(
     root.set_state(ScopeState::Running);
     root.set_startup(Ok(()));
 
-    let (events, mut event_receiver) = crate::runtime::bounded_mpsc(1);
+    let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
     let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events.clone());
     root.set_dynamic_route(Some(control.clone()));
@@ -3091,7 +3059,7 @@ pub(crate) async fn exercise_saturated_fused_drop_before_exit<A>(
         "first poll submits the fused admission"
     );
     let Some(DriverEvent::Admission(request)) = event_receiver.recv().await else {
-        panic!("the admission forwarder submits the request")
+        panic!("admission enqueueing submits the request")
     };
     scope.handle_admission(request);
 
@@ -3125,14 +3093,15 @@ pub(crate) async fn exercise_saturated_fused_drop_before_exit<A>(
     };
     let key = exit.0;
     assert!(
-        scope
-            .events
-            .try_send(DriverEvent::Removal(RemovalRequest {
+        crate::runtime::unbounded_mpsc_send(
+            &scope.events,
+            DriverEvent::Removal(RemovalRequest {
                 membership: root.member.membership(),
                 key: ChildKey(u64::MAX - 1),
-            }))
-            .is_ok(),
-        "the fixture saturates the bounded driver lane"
+            }),
+        )
+        .is_ok(),
+        "the driver lane remains open"
     );
     drop(admission);
     assert!(
@@ -3174,21 +3143,18 @@ pub(crate) async fn exercise_saturated_fused_drop_before_exit<A>(
             crate::runtime::Timeout::Elapsed => panic!("the fused removal edge is forwarded"),
         };
     let DriverEvent::Removal(removal) = forwarded else {
-        panic!("the forwarded event is the fused removal")
+        panic!("the queued event is the fused removal")
     };
     assert_eq!(removal.membership, membership);
     assert_eq!(removal.key, key);
     scope.handle_removal(removal);
     let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
-        crate::runtime::unbounded_mpsc_recv(&mut disposal_event_receiver).await
+        disposal_event_receiver.recv().await
     else {
         panic!("removal joins retained construction disposal")
     };
     scope.handle_construction_disposed(child, panic);
     assert!(scope.children.get(key).is_none());
-
-    control.request_forwarder_close.fire();
-    control.request_forwarder_ended.fired().await;
 }
 
 /// Exercises the `DeadlineKind::Restart` suppression gate on its own:
@@ -3207,7 +3173,7 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
     root.set_state(ScopeState::Running);
     root.set_startup(Ok(()));
 
-    let (events, mut event_receiver) = crate::runtime::bounded_mpsc(64);
+    let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
     let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events.clone());
     root.set_dynamic_route(Some(control.clone()));
@@ -3265,7 +3231,7 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
     )
     .expect("the running scope accepts the admission");
     let Some(DriverEvent::Admission(request)) = event_receiver.recv().await else {
-        panic!("the admission forwarder submits the request")
+        panic!("admission enqueueing submits the request")
     };
     scope.handle_admission(request);
     assert!(matches!(response.try_receive(), Some(Ok(()))));
@@ -3334,30 +3300,28 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
             crate::runtime::Timeout::Elapsed => panic!("the fused removal edge is forwarded"),
         };
     let DriverEvent::Removal(removal) = forwarded else {
-        panic!("the forwarded event is the fused removal");
+        panic!("the queued event is the fused removal");
     };
     assert_eq!(removal.membership, membership);
     assert_eq!(removal.key, key);
     scope.handle_removal(removal);
     let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
-        crate::runtime::unbounded_mpsc_recv(&mut disposal_event_receiver).await
+        disposal_event_receiver.recv().await
     else {
         panic!("removal joins retained construction disposal")
     };
     scope.handle_construction_disposed(child, panic);
     assert!(scope.children.get(key).is_none());
-
-    control.request_forwarder_close.fire();
-    control.request_forwarder_ended.fired().await;
 }
 
 #[crate::runtime::test]
-async fn saturated_admissions_share_one_forwarder_task_and_all_resolve() {
-    const ADMISSIONS: usize = 64;
+async fn queued_admissions_spawn_no_forwarder_tasks_and_all_resolve() {
+    const ADMISSIONS: usize = super::MIN_EVENT_BATCH_LIMIT + 1;
 
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
-    let (events, event_receiver) = crate::runtime::bounded_mpsc(1);
-    let control = DynamicControl::new(events);
+    let (control_events, mut control_receiver) = crate::runtime::unbounded_mpsc();
+    let (critical_events, mut critical_receiver) = crate::runtime::unbounded_mpsc();
+    let control = DynamicControl::new(control_events);
     let child_id = ChildId::from("worker");
     let member = MemberCell::new(
         child_id.clone(),
@@ -3378,19 +3342,62 @@ async fn saturated_admissions_share_one_forwarder_task_and_all_resolve() {
         );
     }
 
-    // Let the forwarder run until it parks on the saturated driver
-    // channel; pending admissions must not each hold a live sender task.
-    for _ in 0..64 {
-        crate::runtime::yield_now().await;
-    }
-    assert!(
-        crate::runtime::alive_task_count() <= baseline + 1,
-        "saturated admissions share one forwarder task instead of spawning one each"
+    assert_eq!(
+        crate::runtime::alive_task_count(),
+        baseline,
+        "synchronous admission enqueueing spawns no transport tasks"
     );
 
-    // Ending the driver channel answers every queued admission through
-    // its response obligation.
-    drop(event_receiver);
+    let incarnation = root
+        .child_identity
+        .lock()
+        .expect("scope identity mutex poisoned")
+        .incarnation_counter(member.membership())
+        .mint()
+        .expect("incarnation available");
+    assert!(
+        crate::runtime::unbounded_mpsc_send(
+            &critical_events,
+            DriverEvent::Child(ChildEvent::Exited {
+                child: ChildKey(1),
+                incarnation,
+                recorded: Some(RecordedOutcome::returned(Ok(()))),
+                join: JoinVerdict::Completed,
+                cancellation: Cancellation::NotObserved,
+                readiness_signal_seen: false,
+            }),
+        )
+        .is_ok()
+    );
+
+    let mut pending = Vec::new();
+    super::collect_driver_events(
+        &mut critical_receiver,
+        super::MIN_EVENT_BATCH_LIMIT,
+        &mut pending,
+    );
+    super::collect_driver_events(
+        &mut control_receiver,
+        super::MIN_EVENT_BATCH_LIMIT,
+        &mut pending,
+    );
+    arbitrate(&mut pending);
+    assert!(matches!(
+        pending.first(),
+        Some((
+            _,
+            Pending::Driver(DriverEvent::Child(ChildEvent::Exited { .. }))
+        ))
+    ));
+    assert!(matches!(
+        control_receiver.try_recv(),
+        Ok(DriverEvent::Admission(_))
+    ));
+
+    // Ending both the collected batch and queued suffix answers every
+    // admission through its response obligation.
+    drop(pending);
+    drop(control_receiver);
     for response in responses {
         assert!(matches!(
             response.receive().await,
@@ -3399,16 +3406,6 @@ async fn saturated_admissions_share_one_forwarder_task_and_all_resolve() {
             )))
         ));
     }
-
-    let mut alive = crate::runtime::alive_task_count();
-    for _ in 0..1_024 {
-        if alive == baseline {
-            break;
-        }
-        crate::runtime::yield_now().await;
-        alive = crate::runtime::alive_task_count();
-    }
-    assert_eq!(alive, baseline, "the forwarder exits once its queue drains");
 }
 
 #[crate::runtime::test]
@@ -3477,7 +3474,7 @@ async fn incarnation_exhaustion_uses_post_disposal_retention_routing() {
             .map(|child| resident_projection(&child.slot))
             .collect(),
     );
-    let (events, mut event_receiver) = crate::runtime::bounded_mpsc(1);
+    let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
     let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     let mut children = ChildArena::default();
@@ -3533,14 +3530,15 @@ async fn incarnation_exhaustion_uses_post_disposal_retention_routing() {
     );
 
     assert!(
-        scope
-            .events
-            .try_send(DriverEvent::Child(ChildEvent::Ready {
+        crate::runtime::unbounded_mpsc_send(
+            &scope.events,
+            DriverEvent::Child(ChildEvent::Ready {
                 child: key,
                 incarnation: first,
-            }))
-            .is_ok(),
-        "the bounded driver queue is deliberately saturated"
+            }),
+        )
+        .is_ok(),
+        "the driver lane remains open"
     );
 
     scope.spawn_child(key);
@@ -3600,7 +3598,7 @@ async fn first_spawn_exhaustion_stops_without_reporting_a_startup_abort() {
             .map(|child| resident_projection(&child.slot))
             .collect(),
     );
-    let (events, _event_receiver) = crate::runtime::bounded_mpsc(64);
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
     let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     let mut children = ChildArena::default();
@@ -3717,7 +3715,7 @@ async fn latched_shutdown_keeps_the_startup_verdict_for_its_follow_up_event() {
             .map(|child| resident_projection(&child.slot))
             .collect(),
     );
-    let (events, mut event_receiver) = crate::runtime::bounded_mpsc(64);
+    let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
     let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     let mut children = ChildArena::default();
@@ -3810,7 +3808,7 @@ async fn latched_shutdown_keeps_the_startup_verdict_for_its_follow_up_event() {
     assert!(scope.children[key].restart_deadline.is_none());
 
     let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
-        crate::runtime::unbounded_mpsc_recv(&mut disposal_event_receiver).await
+        disposal_event_receiver.recv().await
     else {
         panic!("only construction disposal was armed")
     };

--- a/crates/shelterwood/src/driver/tests.rs
+++ b/crates/shelterwood/src/driver/tests.rs
@@ -1,7 +1,7 @@
-
 use std::{
     future::{self, Future},
     panic::{AssertUnwindSafe, catch_unwind},
+    pin::Pin,
     sync::{
         Arc, Barrier, Condvar, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -3315,97 +3315,89 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
 }
 
 #[crate::runtime::test]
-async fn queued_admissions_spawn_no_forwarder_tasks_and_all_resolve() {
-    const ADMISSIONS: usize = super::MIN_EVENT_BATCH_LIMIT + 1;
+async fn queued_admissions_yield_to_shutdown_without_forwarder_tasks() {
+    const ADMISSIONS: usize = super::MIN_EVENT_BATCH_LIMIT * 8 + 1;
 
-    let root = isolated_scope("root", ScopeFlavor::Dynamic);
-    let (control_events, mut control_receiver) = crate::runtime::unbounded_mpsc();
-    let (critical_events, mut critical_receiver) = crate::runtime::unbounded_mpsc();
-    let control = DynamicControl::new(control_events);
-    let child_id = ChildId::from("worker");
-    let member = MemberCell::new(
-        child_id.clone(),
-        root.child_identity
-            .lock()
-            .expect("scope identity mutex poisoned")
-            .mint_membership(&child_id)
-            .expect("child membership available"),
-    );
-    let slot = SlotCell::new(Arc::clone(&member), None);
+    let release_holder = Latch::default();
+    let mut tree = DynamicTree::new();
+    let exiting = tree
+        .add_task(
+            "exiting",
+            TaskDef::new(|context| async move {
+                context.shutdown_token().cancelled().await;
+                Ok(())
+            }),
+        )
+        .expect("exiting task is valid");
+    tree.add_task(
+        "holder",
+        TaskDef::new({
+            let release_holder = release_holder.clone();
+            move |context| {
+                let release_holder = release_holder.clone();
+                async move {
+                    context.shutdown_token().cancelled().await;
+                    release_holder.fired().await;
+                    Ok(())
+                }
+            }
+        }),
+    )
+    .expect("holding task is valid");
 
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
     let baseline = crate::runtime::alive_task_count();
-    let mut responses = Vec::with_capacity(ADMISSIONS);
-    for _ in 0..ADMISSIONS {
-        responses.push(
-            super::start_admission(control.clone(), Arc::clone(&slot), None)
-                .expect("runtime is available"),
+    let mut admissions = Vec::with_capacity(ADMISSIONS);
+    for index in 0..ADMISSIONS {
+        let mut admission = scope.add_task(
+            format!("queued-{index}"),
+            TaskDef::new(|_| future::pending()),
         );
+        assert!(
+            Pin::new(&mut admission)
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending(),
+            "first poll synchronously queues admission {index}"
+        );
+        admissions.push(admission);
     }
-
     assert_eq!(
         crate::runtime::alive_task_count(),
         baseline,
         "synchronous admission enqueueing spawns no transport tasks"
     );
 
-    let incarnation = root
-        .child_identity
-        .lock()
-        .expect("scope identity mutex poisoned")
-        .incarnation_counter(member.membership())
-        .mint()
-        .expect("incarnation available");
+    // Latch shutdown without yielding to the already-woken driver. Its first
+    // batch begins draining and rejects one control prefix; the full-batch
+    // yield must then let `exiting` run and publish its primary-lane exit.
+    let mut shutdown = Box::pin(scope.shutdown_and_wait(Duration::from_secs(2)));
     assert!(
-        crate::runtime::unbounded_mpsc_send(
-            &critical_events,
-            DriverEvent::Child(ChildEvent::Exited {
-                child: ChildKey(1),
-                incarnation,
-                recorded: Some(RecordedOutcome::returned(Ok(()))),
-                join: JoinVerdict::Completed,
-                cancellation: Cancellation::NotObserved,
-                readiness_signal_seen: false,
-            }),
-        )
-        .is_ok()
+        shutdown
+            .as_mut()
+            .poll(&mut Context::from_waker(Waker::noop()))
+            .is_pending(),
+        "shutdown waits for both declared children"
+    );
+    assert!(matches!(
+        crate::runtime::timeout(Duration::from_secs(1), exiting.wait()).await,
+        crate::runtime::Timeout::Completed(_)
+    ));
+    assert!(
+        Pin::new(admissions.last_mut().expect("an admission exists"))
+            .poll(&mut Context::from_waker(Waker::noop()))
+            .is_pending(),
+        "the primary exit is handled before the control suffix is drained"
     );
 
-    let mut pending = Vec::new();
-    super::collect_driver_events(
-        &mut critical_receiver,
-        super::MIN_EVENT_BATCH_LIMIT,
-        &mut pending,
-    );
-    super::collect_driver_events(
-        &mut control_receiver,
-        super::MIN_EVENT_BATCH_LIMIT,
-        &mut pending,
-    );
-    arbitrate(&mut pending);
+    release_holder.fire();
     assert!(matches!(
-        pending.first(),
-        Some((
-            _,
-            Pending::Driver(DriverEvent::Child(ChildEvent::Exited { .. }))
-        ))
+        crate::runtime::timeout(Duration::from_secs(1), shutdown.as_mut()).await,
+        crate::runtime::Timeout::Completed(Ok(()))
     ));
-    assert!(matches!(
-        control_receiver.try_recv(),
-        Ok(DriverEvent::Admission(_))
-    ));
-
-    // Ending both the collected batch and queued suffix answers every
-    // admission through its response obligation.
-    drop(pending);
-    drop(control_receiver);
-    for response in responses {
-        assert!(matches!(
-            response.receive().await,
-            Some(Err(crate::ReserveError::NotAdmitting(
-                crate::NotAdmittingCause::Terminal
-            )))
-        ));
-    }
+    drop(shutdown);
+    assert_eq!(system.wait().await, StopReason::ShutdownRequested);
 }
 
 #[crate::runtime::test]

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -1289,6 +1289,7 @@ pub(crate) enum ScopeWake<T> {
     Signal,
     ParentShutdown,
     Message(Option<T>),
+    ControlMessage(Option<T>),
     Deadline,
 }
 
@@ -1300,6 +1301,7 @@ pub(crate) struct ScopeWait<S, C> {
 pub(crate) async fn wait_scope<S, C, T>(
     wait: ScopeWait<S, C>,
     receiver: &mut UnboundedMpscReceiver<T>,
+    control_receiver: Option<&mut UnboundedMpscReceiver<T>>,
     deadline: Option<std::time::Instant>,
 ) -> ScopeWake<T>
 where
@@ -1319,12 +1321,21 @@ where
             std::future::pending::<()>().await;
         }
     };
+    let control_message = async move {
+        if let Some(receiver) = control_receiver {
+            receiver.recv().await
+        } else {
+            std::future::pending().await
+        }
+    };
     tokio::pin!(deadline);
+    tokio::pin!(control_message);
     tokio::select! {
         biased;
         () = &mut signal => ScopeWake::Signal,
         () = &mut parent_shutdown => ScopeWake::ParentShutdown,
         message = receiver.recv() => ScopeWake::Message(message),
+        message = &mut control_message => ScopeWake::ControlMessage(message),
         () = &mut deadline => ScopeWake::Deadline,
     }
 }
@@ -1458,10 +1469,35 @@ mod tests {
             },
             &mut receiver,
             None,
+            None,
         )
         .await;
 
         assert!(matches!(wake, super::ScopeWake::Signal));
+    }
+
+    #[tokio::test]
+    async fn scope_wait_prefers_a_primary_event_over_a_control_backlog() {
+        let (sender, mut receiver) = super::unbounded_mpsc();
+        let (control_sender, mut control_receiver) = super::unbounded_mpsc();
+        for value in 0..128 {
+            assert!(super::unbounded_mpsc_send(&control_sender, value).is_ok());
+        }
+        assert!(super::unbounded_mpsc_send(&sender, 999).is_ok());
+
+        let wake = super::wait_scope(
+            super::ScopeWait {
+                signal: std::future::pending(),
+                parent_shutdown: std::future::pending(),
+            },
+            &mut receiver,
+            Some(&mut control_receiver),
+            None,
+        )
+        .await;
+
+        assert!(matches!(wake, super::ScopeWake::Message(Some(999))));
+        assert_eq!(control_receiver.try_recv(), Ok(0));
     }
 
     struct RecursivelyPanickingPayload;

--- a/crates/shelterwood/src/runtime.rs
+++ b/crates/shelterwood/src/runtime.rs
@@ -1270,37 +1270,15 @@ where
     }
 }
 
-pub(crate) type MpscSender<T> = mpsc::Sender<T>;
-pub(crate) type MpscReceiver<T> = mpsc::Receiver<T>;
 pub(crate) type UnboundedMpscSender<T> = mpsc::UnboundedSender<T>;
 pub(crate) type UnboundedMpscReceiver<T> = mpsc::UnboundedReceiver<T>;
-
-pub(crate) fn bounded_mpsc<T>(capacity: usize) -> (MpscSender<T>, MpscReceiver<T>) {
-    mpsc::channel(capacity)
-}
 
 pub(crate) fn unbounded_mpsc<T>() -> (UnboundedMpscSender<T>, UnboundedMpscReceiver<T>) {
     mpsc::unbounded_channel()
 }
 
-pub(crate) async fn mpsc_send<T>(sender: &MpscSender<T>, value: T) -> Result<(), T> {
-    sender.send(value).await.map_err(|error| error.0)
-}
-
-pub(crate) fn mpsc_try_send<T>(sender: &MpscSender<T>, value: T) -> Result<(), T> {
-    sender.try_send(value).map_err(|error| error.into_inner())
-}
-
-pub(crate) fn mpsc_try_recv<T>(receiver: &mut MpscReceiver<T>) -> Option<T> {
-    receiver.try_recv().ok()
-}
-
 pub(crate) fn unbounded_mpsc_send<T>(sender: &UnboundedMpscSender<T>, value: T) -> Result<(), T> {
     sender.send(value).map_err(|error| error.0)
-}
-
-pub(crate) async fn unbounded_mpsc_recv<T>(receiver: &mut UnboundedMpscReceiver<T>) -> Option<T> {
-    receiver.recv().await
 }
 
 pub(crate) fn unbounded_mpsc_try_recv<T>(receiver: &mut UnboundedMpscReceiver<T>) -> Option<T> {
@@ -1321,7 +1299,7 @@ pub(crate) struct ScopeWait<S, C> {
 
 pub(crate) async fn wait_scope<S, C, T>(
     wait: ScopeWait<S, C>,
-    receiver: &mut MpscReceiver<T>,
+    receiver: &mut UnboundedMpscReceiver<T>,
     deadline: Option<std::time::Instant>,
 ) -> ScopeWake<T>
 where
@@ -1471,7 +1449,7 @@ mod tests {
 
     #[tokio::test]
     async fn scope_wait_prefers_signal_when_both_control_futures_are_ready() {
-        let (_sender, mut receiver) = super::bounded_mpsc::<()>(1);
+        let (_sender, mut receiver) = super::unbounded_mpsc::<()>();
 
         let wake = super::wait_scope(
             super::ScopeWait {

--- a/crates/shelterwood/src/tree.rs
+++ b/crates/shelterwood/src/tree.rs
@@ -1587,8 +1587,8 @@ mod tests {
     }
 
     #[crate::runtime::test]
-    async fn saturated_fused_drop_before_exit_suppresses_restart_accounting() {
-        crate::driver::exercise_saturated_fused_drop_before_exit(|reservation| {
+    async fn queued_fused_drop_before_exit_dispatch_suppresses_restart_accounting() {
+        crate::driver::exercise_queued_fused_drop_before_exit_dispatch(|reservation| {
             Admission::new(reservation, (), AdmissionOwnership::Fused)
         })
         .await;


### PR DESCRIPTION
Part of #151.

## Summary

- delete the per-scope admission request forwarder task and its shutdown/probe latches
- enqueue admissions and removals synchronously into an unbounded dynamic-control lane, including fused drops from foreign threads
- keep child lifecycle events on a separate primary lane so an arbitrary admission prefix cannot strand readiness, self-stop, or exit processing
- cap per-wake collection from each lane and make idle waiting prefer signals and primary events before dynamic traffic or deadlines
- simplify the runtime channel facade and add regressions with more than a full admission batch ahead of a child exit

## Validation

- `./tools/dev cargo test -p shelterwood --lib` (202 passed)
- `./tools/dev just ci` (500 tests plus docs, API reachability, enforcement checks, package verification, and Nix formatting)