### PR TITLE
Ship the layering use parser to the Nix sandbox

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,14 +13,15 @@
       src = ./.;
       # Repository docs and their packaged doctest copies are compared in the
       # clean build sandbox, so keep Markdown alongside Cargo sources; the
-      # enforcement scripts under tools/ run there too (.sh), and nextest
-      # reads its timeout config.
+      # enforcement scripts under tools/ run there too (.sh plus the .awk
+      # use parser), and nextest reads its timeout config.
       extraSourceFilter =
         path: type:
         type == "regular"
         && (
           builtins.match ".*\\.md" (toString path) != null
           || builtins.match ".*\\.sh" (toString path) != null
+          || builtins.match ".*\\.awk" (toString path) != null
           || builtins.match ".*/\\.config/nextest\\.toml" (toString path) != null
         );
       extraChecks =


### PR DESCRIPTION
Main's tip CI failed after #155: the `api-enforcement` flake check runs `tools/check-layering-paths.sh` inside the clean Nix sandbox, but `extraSourceFilter` admitted only `.md`/`.sh`/nextest config, so the new `tools/check-layering-uses.awk` was absent and awk aborted (`cannot open source file`). The PR-level lane and the local `just ci` mirror run from the working tree, which is why every pre-merge check stayed green — only the full flake check on main caught it.

One-line fix: admit `.awk` files in `extraSourceFilter`.

Validation: `just ci-nix` (the authoritative clean Nix lane, including `api-enforcement`) exits 0 with this change; it reproduces the failure without it.