### PR TITLE
Resolve lifecycle and admission review residuals

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -1026,9 +1026,6 @@ impl ScopeCell {
     pub(crate) fn set_state(&self, state: ScopeState) {
         self.with_observation_gate(|wakes| {
             self.record.modify_silently(|record| {
-                if state == ScopeState::Starting {
-                    record.total_restarts = TotalRestarts::ZERO;
-                }
                 record.state = state.clone();
             });
             wakes.pulse(&self.record);
@@ -1383,11 +1380,10 @@ impl ScopeCell {
         }
     }
 
-    pub(crate) fn begin_incarnation(&self) -> Option<Epoch> {
+    pub(crate) fn begin_incarnation(&self, state: ScopeState) -> Option<Epoch> {
         self.with_observation_gate(|wakes| {
             let mut control = self.control.lock().expect("scope control mutex poisoned");
             let epoch = control.epochs.begin()?;
-            let state = ScopeState::Starting;
             self.record.modify_silently(|record| {
                 record.total_restarts = TotalRestarts::ZERO;
                 record.state = state.clone();

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -1381,11 +1381,16 @@ impl ScopeCell {
     }
 
     pub(crate) fn begin_incarnation(&self, state: ScopeState) -> Option<Epoch> {
+        debug_assert!(
+            matches!(state, ScopeState::Starting),
+            "a fresh incarnation publishes its lifecycle machine's initial state"
+        );
         self.with_observation_gate(|wakes| {
             let mut control = self.control.lock().expect("scope control mutex poisoned");
             let epoch = control.epochs.begin()?;
             self.record.modify_silently(|record| {
                 record.total_restarts = TotalRestarts::ZERO;
+                record.startup = None;
                 record.state = state.clone();
             });
             // Hold epoch ownership through its observation projection. A

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -12,9 +12,9 @@ mod storage;
 use storage::{ChildArena, ChildKey, Obligation};
 
 use crate::{
-    Cancellation, ChildId, Exit, ExitKind, GracePhase, Incarnation, IntensityTrip, JitterSample,
-    Membership, Readiness, ReadinessDeadline, ScopeState, ShutdownStraggler, ShutdownTimeout,
-    StartupFailure, StartupFailureCause,
+    Cancellation, ChildId, Exit, GracePhase, Incarnation, IntensityTrip, JitterSample, Membership,
+    Readiness, ReadinessDeadline, ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure,
+    StartupFailureCause,
     admission::{NotAdmittingCause, ReserveError},
     cells::{
         MailboxControl, MemberStage, MemberTransition, ResidentProjection, ScopeCell,
@@ -392,10 +392,10 @@ fn discharge_child_terminality(completion: ChildTerminality) {
         (Exit::never_started(), None)
     } else {
         (
-            Exit::new(
-                ExitKind::Aborted {
-                    phase: GracePhase::WithinGrace,
-                },
+            classify_exit(
+                None,
+                runtime::JoinOutcome::Cancelled,
+                None,
                 Cancellation::Observed,
             ),
             record.incarnation,
@@ -2155,7 +2155,8 @@ impl ScopeRuntime {
     }
 }
 
-/// Owns a scope epoch until a `ScopeRuntime` has taken over its teardown.
+/// Owns a scope epoch and its matching initial lifecycle until a
+/// `ScopeRuntime` has taken over teardown.
 ///
 /// Nested lowering can await isolated disposal before a driver exists. If
 /// that setup future is cancelled or unwinds, dropping this guard retires the
@@ -2164,15 +2165,24 @@ impl ScopeRuntime {
 struct ScopeEpochGuard {
     scope: Arc<ScopeCell>,
     epoch: Option<Epoch>,
+    lifecycle: Option<ScopeLifecycle>,
 }
 
 impl ScopeEpochGuard {
     fn begin(scope: &Arc<ScopeCell>) -> Option<Self> {
-        let epoch = scope.begin_incarnation()?;
+        let lifecycle = ScopeLifecycle::starting();
+        let epoch = scope.begin_incarnation(lifecycle.state())?;
         Some(Self {
             scope: Arc::clone(scope),
             epoch: Some(epoch),
+            lifecycle: Some(lifecycle),
         })
+    }
+
+    fn take_lifecycle(&mut self) -> ScopeLifecycle {
+        self.lifecycle
+            .take()
+            .expect("an owned scope lifecycle transfers at most once")
     }
 
     fn finish(mut self, reason: StopReason) {
@@ -2292,7 +2302,7 @@ async fn run_scope(plan: ScopePlan, role: ScopeRole) -> StopReason {
 async fn run_scope_incarnation(
     mut plan: ScopePlan,
     role: ScopeRole,
-    epoch: ScopeEpochGuard,
+    mut epoch: ScopeEpochGuard,
 ) -> StopReason {
     let root = Arc::clone(&plan.root);
     if role.is_root() {
@@ -2348,7 +2358,7 @@ async fn run_scope_incarnation(
         disposal_events,
         deadlines: DeadlineQueue::default(),
         jitter: runtime::JitterRng::from_system_entropy(),
-        lifecycle: ScopeLifecycle::starting(),
+        lifecycle: epoch.take_lifecycle(),
         next_ordered_start,
         role,
         dynamic,

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -2165,7 +2165,7 @@ impl ScopeRuntime {
 struct ScopeEpochGuard {
     scope: Arc<ScopeCell>,
     epoch: Option<Epoch>,
-    lifecycle: Option<ScopeLifecycle>,
+    lifecycle: ScopeLifecycle,
 }
 
 impl ScopeEpochGuard {
@@ -2175,14 +2175,12 @@ impl ScopeEpochGuard {
         Some(Self {
             scope: Arc::clone(scope),
             epoch: Some(epoch),
-            lifecycle: Some(lifecycle),
+            lifecycle,
         })
     }
 
-    fn take_lifecycle(&mut self) -> ScopeLifecycle {
-        self.lifecycle
-            .take()
-            .expect("an owned scope lifecycle transfers at most once")
+    fn lifecycle(&self) -> ScopeLifecycle {
+        self.lifecycle.clone()
     }
 
     fn finish(mut self, reason: StopReason) {
@@ -2302,7 +2300,7 @@ async fn run_scope(plan: ScopePlan, role: ScopeRole) -> StopReason {
 async fn run_scope_incarnation(
     mut plan: ScopePlan,
     role: ScopeRole,
-    mut epoch: ScopeEpochGuard,
+    epoch: ScopeEpochGuard,
 ) -> StopReason {
     let root = Arc::clone(&plan.root);
     if role.is_root() {
@@ -2358,7 +2356,7 @@ async fn run_scope_incarnation(
         disposal_events,
         deadlines: DeadlineQueue::default(),
         jitter: runtime::JitterRng::from_system_entropy(),
-        lifecycle: epoch.take_lifecycle(),
+        lifecycle: epoch.lifecycle(),
         next_ordered_start,
         role,
         dynamic,

--- a/crates/shelterwood/src/driver/tests.rs
+++ b/crates/shelterwood/src/driver/tests.rs
@@ -430,6 +430,31 @@ fn stale_scope_driver_cannot_stop_a_newer_live_incarnation_projection() {
     assert!(scope.incarnation_finished(second));
 }
 
+#[test]
+fn a_new_incarnation_owns_an_unpublished_startup_verdict() {
+    let scope = isolated_scope("scope", ScopeFlavor::Ordered);
+    let first = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("first scope epoch is available");
+    scope.set_startup(Ok(()));
+    assert!(matches!(scope.record().startup, Some(Ok(()))));
+    scope.finish_incarnation(first, StopReason::Finished);
+
+    let second = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("second scope epoch is available");
+    assert!(
+        scope.record().startup.is_none(),
+        "the first incarnation's verdict does not outlive its epoch"
+    );
+    scope.set_startup(Err(StartupError::ShutdownRequested));
+    assert!(
+        matches!(scope.record().startup, Some(Err(_))),
+        "the write-once startup latch reopens per incarnation"
+    );
+    scope.finish_incarnation(second, StopReason::Finished);
+}
+
 #[crate::runtime::test]
 async fn terminal_scope_waits_for_its_live_incarnation_to_stop() {
     let parent = isolated_scope("parent", ScopeFlavor::Ordered);

--- a/crates/shelterwood/src/driver/tests.rs
+++ b/crates/shelterwood/src/driver/tests.rs
@@ -60,7 +60,7 @@ fn running_dynamic_fixture() -> (
 ) {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
     let epoch = root
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
     root.member
         .update(|record| record.stage = MemberStage::Running);
@@ -408,11 +408,11 @@ fn observation_gate_poison_does_not_wedge_later_observation() {
 fn stale_scope_driver_cannot_stop_a_newer_live_incarnation_projection() {
     let scope = isolated_scope("scope", ScopeFlavor::Ordered);
     let first = scope
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("first scope epoch is available");
     scope.finish_incarnation(first, StopReason::Finished);
     let second = scope
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("second scope epoch is available");
     scope.set_state(ScopeState::Running);
 
@@ -438,7 +438,7 @@ async fn terminal_scope_waits_for_its_live_incarnation_to_stop() {
     parent.set_admitted_children(vec![resident_projection(&slot)]);
 
     let epoch = nested
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("nested scope epoch is available");
     let mut incarnations = ScopeIdentity::new().incarnation_counter(nested.member.membership());
     let incarnation = incarnations.mint().expect("child incarnation is available");
@@ -713,7 +713,9 @@ fn pre_driver_epoch_guard_releases_on_cancellation_and_unwind() {
 #[test]
 fn a_declined_epoch_still_publishes_its_owned_terminal_exit() {
     let scope = isolated_scope("scope", ScopeFlavor::Ordered);
-    let epoch = scope.begin_incarnation().expect("scope epoch is available");
+    let epoch = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("scope epoch is available");
     // The orderly finisher retires the epoch without a terminal exit, so
     // a second owner still holds the only membership verdict.
     scope.finish_incarnation(epoch, StopReason::Finished);
@@ -920,7 +922,7 @@ async fn force_uses_the_stop_funnel_for_every_ordered_child() {
     let mut plan = tree.lower_for_test();
     let root = Arc::clone(&plan.root);
     let epoch = root
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
     root.set_admitted_children(
         plan.children
@@ -1049,7 +1051,7 @@ fn forced_ordered_drain_advances_an_inactive_suffix_iteratively() {
     let mut plan = tree.lower_for_test();
     let root = Arc::clone(&plan.root);
     let epoch = root
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
     root.set_admitted_children(
         plan.children
@@ -1132,7 +1134,7 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
     let mut plan = tree.lower_for_test();
     let root = Arc::clone(&plan.root);
     let epoch = root
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
     root.set_admitted_children(
         plan.children
@@ -1282,7 +1284,7 @@ async fn same_batch_self_stop_preserves_fired_readiness_for_startup() {
     let mut plan = tree.lower_for_test();
     let root = Arc::clone(&plan.root);
     let epoch = root
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
     root.set_admitted_children(
         plan.children
@@ -2078,7 +2080,7 @@ async fn terminal_stop_paths_share_one_complete_observation_transition() {
         let scope = isolated_scope("root", ScopeFlavor::Ordered);
         let epoch = matches!(path, TerminalStopPath::LiveEpoch).then(|| {
             scope
-                .begin_incarnation()
+                .begin_incarnation(ScopeState::Starting)
                 .expect("test scope epoch is available")
         });
         let handle = ScopeRef {
@@ -2143,7 +2145,7 @@ impl Wake for ObserveScopeOnStartupWake {
 fn stopped_publication_keeps_mailbox_panic_primary_and_finishes_observation() {
     let scope = isolated_scope("root", ScopeFlavor::Ordered);
     let epoch = scope
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
     let handle = ScopeRef {
         cell: Arc::clone(&scope),
@@ -2725,7 +2727,7 @@ fn terminal_startup_wake_follows_member_and_incarnation_publication() {
     );
     let scope = ScopeCell::new(member, ScopeFlavor::Ordered, ScopeIdentity::new());
     let epoch = scope
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
     let probe = Arc::new(ObserveScopeOnStartupWake {
         scope: Arc::clone(&scope),
@@ -2998,7 +3000,7 @@ async fn removal_from_a_foreign_thread_reaches_the_driver() {
 async fn admission_conversion_panic_does_not_poison_dynamic_cleanup() {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
     let epoch = root
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
     root.member
         .update(|record| record.stage = MemberStage::Running);
@@ -3622,7 +3624,7 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
 {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
     let epoch = root
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
     root.member
         .update(|record| record.stage = MemberStage::Running);
@@ -3747,6 +3749,17 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
             .is_some_and(|entry| entry.is_removing() && entry.matches_key(key)),
         "fused drop marks the indexed membership removing before its queued edge advances"
     );
+    assert!(matches!(
+        root.snapshot()
+            .child("worker")
+            .map(|child| child.membership_status),
+        Some(MembershipStatus::Active)
+    ));
+    assert_eq!(
+        scope.dispatch_membership_status(key),
+        MembershipStatus::Removing,
+        "exit dispatch follows the fused-cancel control plane before the public projection"
+    );
 
     scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4, exit.5);
     assert!(scope.children[key].restart_deadline.is_none());
@@ -3799,7 +3812,7 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
 async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_scheduling() {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
     let epoch = root
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
     root.member
         .update(|record| record.stage = MemberStage::Running);
@@ -4181,7 +4194,7 @@ async fn incarnation_exhaustion_uses_post_disposal_retention_routing() {
     let mut plan = tree.lower_for_test();
     let root = Arc::clone(&plan.root);
     let epoch = root
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
     root.set_admitted_children(
         plan.children
@@ -4305,7 +4318,7 @@ async fn first_spawn_exhaustion_stops_without_reporting_a_startup_abort() {
     let mut plan = tree.lower_for_test();
     let root = Arc::clone(&plan.root);
     let epoch = root
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
     root.set_admitted_children(
         plan.children
@@ -4422,7 +4435,7 @@ async fn latched_shutdown_keeps_the_startup_verdict_for_its_follow_up_event() {
     let mut plan = tree.lower_for_test();
     let root = Arc::clone(&plan.root);
     let epoch = root
-        .begin_incarnation()
+        .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
     root.set_admitted_children(
         plan.children

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -705,6 +705,10 @@ impl ScopeLifecycle {
         }
     }
 
+    pub(crate) fn state(&self) -> ScopeState {
+        self.state.clone()
+    }
+
     #[cfg(test)]
     pub(crate) fn running() -> Self {
         Self {

--- a/crates/shelterwood/tests/one_shot_resource_ownership.rs
+++ b/crates/shelterwood/tests/one_shot_resource_ownership.rs
@@ -93,6 +93,35 @@ fn one_shot_raw_resource_drops_once_on_readiness_definition_panic() {
 }
 
 #[tokio::test]
+async fn dynamic_one_shot_raw_resource_drops_once_on_readiness_definition_panic() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+    let count = ConsumeCount::default();
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        drop(scope.add_raw_once(
+            "raw",
+            RawOnceDef::new(ReadinessPanicRawActor {
+                _guard: count.guard(),
+            }),
+        ));
+    }));
+
+    assert!(result.is_err());
+    count.assert_once();
+    drop(
+        scope
+            .reserve_task("raw")
+            .expect("the panicking dynamic definition releases its id"),
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root stops");
+}
+
+#[tokio::test]
 async fn one_shot_raw_resource_drops_once_on_startup_failure() {
     let count = ConsumeCount::default();
     let mut tree = Tree::new();


### PR DESCRIPTION
## Summary

- make the pre-driver epoch guard own the matching initial `ScopeLifecycle` and pass that machine state into scope-incarnation publication
- remove the dead `ScopeCell::set_state(Starting)` restart reset
- route child-terminal fallback aborts through the canonical `classify_exit` path
- pin the fused-cancel control-plane/public-snapshot projection window
- pin dynamic one-shot raw readiness panics, including single resource drop and reservation reuse

## Why

Issue #170 recorded the remaining adjacent gaps from the #151 review round. Scope incarnation startup still hand-paired two copies of `Starting`, one fallback exit path bypassed canonical classification, and two already-documented edge behaviors lacked regression coverage.

## Impact

Scope startup now projects the exact state owned by its lifecycle machine, fallback abort classification shares the same precedence rules as other join paths, and the fused-cancel plus dynamic-definition unwind contracts are protected by deterministic tests.

## Validation

- `./tools/dev just ci`
  - nightly rustfmt and clippy with warnings denied
  - 513 nextest tests
  - doctests and rustdoc/API reachability
  - runtime/exit/layering enforcement checks
  - packaged-crate verification and Nix formatting

Closes #170