### PR TITLE
Adjudicate finding 6 and record the Part 0 spec contracts

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2008,6 +2008,18 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
   Part II §19's group restarts a bounded change. The ladder and the funnel
   together are the decision layer of §1's implementation shape: they only
   compute; the driver shell awaits.
+- The drain reason is a verdict lattice, not a first-writer-wins latch:
+  reasons carry the total precedence order `ShutdownRequested` >
+  `StartupFailed` > `IntensityTripped` > `Finished`, and a drain already
+  in progress upgrades its reason monotonically when a higher-precedence
+  cause arrives; nothing downgrades. An explicit shutdown request
+  therefore cannot lose its verdict to a lower-precedence cause that
+  latched one wake earlier: a restartable exit that trips intensity in
+  the same batch as a shutdown request still yields `ShutdownRequested`
+  as the scope's terminal reason. Ladder deadlines share the posture: a
+  forced escalation only ever moves a deadline *earlier* (`min`), never
+  later. (`NeverStarted` sits outside the order — it is the terminal
+  reason of a membership that never had an incarnation to drain.)
 - Mailbox shutdown policy — `Drain` (the default) or `Discard` — is part
   of the actor options. It is a two-variant choice about exactly one
   thing: the fate of the frozen accepted prefix (§5.2). The intake
@@ -2369,6 +2381,23 @@ the same fencing — there is no second, separately-fenced view [#362]):
    reader always sees a consistent-or-newer snapshot (the conformance test
    reads the snapshot *synchronously inside the event arm*, §13.14).
    Cumulative counters distinguish crash restarts from planned remove/add.
+
+**The consistent-cut guarantee.** The single publication path is
+transactional: every control-plane transition — scope state changes
+(`Draining`, `StartupFailed`, `Stopped`), member terminalization, dynamic
+entry release, residency withdrawal and `Removed` publication — commits
+atomically with respect to observation. No observer can see a cut
+mid-transition: not a terminal membership whose enclosing scope record is
+still live, not a released dynamic id whose member is still
+snapshot-resident, not a reservation accepted after `Draining` was
+published. The wait/observe helpers (`wait_for_child`, exit-awaiting
+surfaces — B.9) are observers in this sense: they read the published
+view, never the engine's internals, so their outcomes agree with what
+snapshots and lifecycle events show at the same cut. Concretely for
+dynamic removal: the removed id becomes reusable (and a repeated `remove`
+reports `AlreadyAbsent`) only at the commit that withdraws the member
+from residency and publishes its `Removed` edge — §2's
+resident-membership uniqueness holds at every observable cut.
 
 `tracing` spans emit from one choke point (the optional `metrics` surface
 is Part II §20). Everything else observational — peer monitoring, actor

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -343,6 +343,297 @@ async fn admission_conversion_panic_does_not_poison_dynamic_cleanup() {
     );
 }
 
+// Gate-free never-started terminalization (an `Admission` drop's annul) and
+// gated supervised terminalization (`terminalize_child`) are mutually
+// excluded per member by the reserved→resident transition: the annul decides
+// against `is_reserved` under the dynamic-state mutex, and promotion happens
+// under that same mutex before the member is admitted to residency. The three
+// tests below pin both serialization orders and the racing window between
+// them, so a competing terminalizer can never publish an exit that diverges
+// from the one the lifecycle stream carries.
+
+#[crate::runtime::test]
+async fn annulment_before_admission_owns_never_started_terminality() {
+    let (mut scope, _event_receiver, mut dynamic_event_receiver, _disposal_event_receiver, control) =
+        running_dynamic_fixture();
+    let root = Arc::clone(&scope.root);
+    let mut lifecycle = root.subscribe_lifecycle();
+    let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
+        .expect("running dynamic scope reserves the child");
+    let member = Arc::clone(&reservation.slot.member);
+    reservation
+        .slot
+        .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
+    let response = super::super::start_admission(
+        Arc::clone(&reservation.control),
+        Arc::clone(&reservation.slot),
+        None,
+    )
+    .expect("admission starts inside the runtime");
+    let Some(DriverEvent::Admission(request)) = dynamic_event_receiver.recv().await else {
+        panic!("admission enqueueing submits the request")
+    };
+
+    cancel_dynamic_reservation(reservation.control.as_ref(), &reservation.slot);
+    let annulled_stage = member.record().stage;
+    assert!(matches!(
+        &annulled_stage,
+        MemberStage::Terminal(exit) if matches!(exit.kind(), ExitKind::NeverStarted)
+    ));
+
+    scope.handle_admission(request);
+
+    assert!(matches!(
+        response.receive().await,
+        Some(Err(ReserveError::NotAdmitting(
+            crate::NotAdmittingCause::ReservationEnded
+        )))
+    ));
+    assert!(
+        scope.children.is_empty(),
+        "an annulled reservation is never admitted"
+    );
+    assert!(
+        control
+            .state
+            .lock()
+            .expect("dynamic-state mutex remains healthy")
+            .entries
+            .is_empty()
+    );
+    assert_eq!(
+        member.record().stage,
+        annulled_stage,
+        "the driver's rejection cannot displace the annul's terminal exit"
+    );
+    assert!(root.snapshot().child("worker").is_none());
+    while let Ok(LifecycleItem::Event(event)) = lifecycle.try_recv() {
+        assert!(
+            !matches!(
+                event.kind,
+                LifecycleEventKind::Added { .. } | LifecycleEventKind::Exited { .. }
+            ),
+            "a never-resident member has no supervised lifecycle edges"
+        );
+    }
+}
+
+#[crate::runtime::test]
+async fn annulment_after_promotion_is_inert_and_supervision_owns_the_exit() {
+    let (
+        mut scope,
+        mut event_receiver,
+        mut dynamic_event_receiver,
+        mut disposal_event_receiver,
+        control,
+    ) = running_dynamic_fixture();
+    let root = Arc::clone(&scope.root);
+    let mut lifecycle = root.subscribe_lifecycle();
+    let started = Latch::default();
+    let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
+        .expect("running dynamic scope reserves the child");
+    let member = Arc::clone(&reservation.slot.member);
+    reservation
+        .slot
+        .define(ChildConstruction::Task(TaskDef::new({
+            let started = started.clone();
+            move |context| {
+                let started = started.clone();
+                async move {
+                    started.fire();
+                    context.shutdown_token().cancelled().await;
+                    Ok(())
+                }
+            }
+        })));
+    let mut response = super::super::start_admission(
+        Arc::clone(&reservation.control),
+        Arc::clone(&reservation.slot),
+        None,
+    )
+    .expect("admission starts inside the runtime");
+    let Some(DriverEvent::Admission(request)) = dynamic_event_receiver.recv().await else {
+        panic!("admission enqueueing submits the request")
+    };
+    scope.handle_admission(request);
+    assert!(matches!(response.try_receive(), Some(Ok(()))));
+    assert!(matches!(
+        crate::runtime::timeout(Duration::from_secs(2), started.fired()).await,
+        crate::runtime::Timeout::Completed(())
+    ));
+
+    // The promoted entry is no longer reserved, so a late annul (a dropped
+    // `Admission` future racing its own completion) must not terminalize the
+    // now-supervised member.
+    cancel_dynamic_reservation(reservation.control.as_ref(), &reservation.slot);
+    assert!(
+        !matches!(member.record().stage, MemberStage::Terminal(_)),
+        "a late annul cannot compete with supervised terminalization"
+    );
+    assert!(
+        control
+            .state
+            .lock()
+            .expect("dynamic-state mutex remains healthy")
+            .entries
+            .get(member.id())
+            .is_some_and(|entry| !entry.is_reserved()),
+        "the resident registration survives the inert annul"
+    );
+
+    let removal_response =
+        super::super::remove_dynamic(&root, member.id(), Some(member.membership()));
+    let removal = match crate::runtime::timeout(
+        Duration::from_secs(2),
+        dynamic_event_receiver.recv(),
+    )
+    .await
+    {
+        crate::runtime::Timeout::Completed(Some(DriverEvent::Removal(removal))) => removal,
+        crate::runtime::Timeout::Completed(_) => panic!("the removal reaches the driver"),
+        crate::runtime::Timeout::Elapsed => panic!("the removal must reach the driver"),
+    };
+    scope.handle_removal(removal);
+    let exit = match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
+        crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {
+            child,
+            incarnation,
+            recorded,
+            join,
+            cancellation,
+            readiness_signal_seen,
+        }))) => (
+            child,
+            incarnation,
+            recorded,
+            join,
+            cancellation,
+            readiness_signal_seen,
+        ),
+        crate::runtime::Timeout::Completed(_) => panic!("the stopped child reports exit"),
+        crate::runtime::Timeout::Elapsed => panic!("the stopped child exit must arrive"),
+    };
+    scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4, exit.5);
+    let disposal =
+        match crate::runtime::timeout(Duration::from_secs(2), disposal_event_receiver.recv()).await
+        {
+            crate::runtime::Timeout::Completed(Some(event)) => event,
+            crate::runtime::Timeout::Completed(None) => panic!("the disposal lane remains open"),
+            crate::runtime::Timeout::Elapsed => panic!("retained construction disposal completes"),
+        };
+    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = disposal else {
+        panic!("the stop path reports retained construction disposal")
+    };
+    scope.handle_construction_disposed(child, panic);
+    assert_eq!(
+        removal_response.receive().await,
+        Some(RemoveOutcome::Removed)
+    );
+
+    // The adjudicated consistency property: the terminal record and the
+    // lifecycle stream publish the same exit, because supervision was the
+    // only terminalizer.
+    let MemberStage::Terminal(record_exit) = member.record().stage else {
+        panic!("the removed member publishes a terminal record");
+    };
+    let mut emitted_exit = None;
+    while let Ok(LifecycleItem::Event(event)) = lifecycle.try_recv() {
+        if let LifecycleEventKind::Exited { exit, .. } = event.kind {
+            assert!(
+                emitted_exit.replace(exit).is_none(),
+                "exactly one supervised exit is emitted"
+            );
+        }
+    }
+    assert_eq!(
+        emitted_exit.as_ref(),
+        Some(&record_exit),
+        "the lifecycle stream and the terminal record agree on the exit"
+    );
+}
+
+#[crate::runtime::test]
+async fn annulment_racing_admission_resolves_to_one_terminalization_owner() {
+    for _ in 0..64 {
+        let (
+            mut scope,
+            _event_receiver,
+            mut dynamic_event_receiver,
+            _disposal_event_receiver,
+            control,
+        ) = running_dynamic_fixture();
+        let root = Arc::clone(&scope.root);
+        let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
+            .expect("running dynamic scope reserves the child");
+        let member = Arc::clone(&reservation.slot.member);
+        reservation
+            .slot
+            .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
+        let response = super::super::start_admission(
+            Arc::clone(&reservation.control),
+            Arc::clone(&reservation.slot),
+            None,
+        )
+        .expect("admission starts inside the runtime");
+        let Some(DriverEvent::Admission(request)) = dynamic_event_receiver.recv().await else {
+            panic!("admission enqueueing submits the request")
+        };
+
+        let barrier = Arc::new(Barrier::new(2));
+        let annul = {
+            let barrier = Arc::clone(&barrier);
+            let annul_control = Arc::clone(&reservation.control);
+            let annul_slot = Arc::clone(&reservation.slot);
+            std::thread::spawn(move || {
+                barrier.wait();
+                cancel_dynamic_reservation(annul_control.as_ref(), &annul_slot);
+            })
+        };
+        barrier.wait();
+        scope.handle_admission(request);
+        annul.join().expect("the annul thread completes");
+
+        // Whichever side won the dynamic-state mutex, exactly one owner
+        // published terminality (or none, if the admission won): the record,
+        // the arena, and the control-plane entry always agree.
+        match response.receive().await {
+            Some(Ok(())) => {
+                assert!(
+                    !matches!(member.record().stage, MemberStage::Terminal(_)),
+                    "an admitted member is live; the losing annul is inert"
+                );
+                assert_eq!(scope.children.len(), 1);
+                assert!(
+                    control
+                        .state
+                        .lock()
+                        .expect("dynamic-state mutex remains healthy")
+                        .entries
+                        .get(member.id())
+                        .is_some_and(|entry| !entry.is_reserved())
+                );
+            }
+            Some(Err(ReserveError::NotAdmitting(crate::NotAdmittingCause::ReservationEnded))) => {
+                assert!(matches!(
+                    member.record().stage,
+                    MemberStage::Terminal(exit)
+                        if matches!(exit.kind(), ExitKind::NeverStarted)
+                ));
+                assert!(scope.children.is_empty());
+                assert!(
+                    control
+                        .state
+                        .lock()
+                        .expect("dynamic-state mutex remains healthy")
+                        .entries
+                        .is_empty()
+                );
+            }
+            other => panic!("the race admits exactly two outcomes, got {other:?}"),
+        }
+    }
+}
+
 #[crate::runtime::test]
 async fn fused_cancellation_overtaking_admission_rejects_before_conversion() {
     let (mut scope, _event_receiver, mut dynamic_event_receiver, _disposal_event_receiver, control) =


### PR DESCRIPTION
Step 1 of the Part 0 sequencing on #172: the remaining adjudications plus the two Part 0 spec sentences.

## Finding 6 — adjudicated: the overlap is unreachable in production

Traced every gate-free production caller of `MemberCell::terminalize`:

- The dynamic annul (`Admission` drop → `cancel_dynamic_reservation_parts`) decides against `is_reserved()` under the dynamic-state mutex, and the driver promotes reserved→resident under that same mutex *before* `admit_child` installs residency (driver.rs "arena insertion and promotion one state transition"). Promotion requires the entry to still exist, so an annul that wins removes the entry and the admission rejects; an annul that loses is inert. A gate-free terminalize on a *resident* member is therefore impossible from this path.
- Every other gate-free caller (`DynamicControl::close`, the admission rejection paths, plan/rollback never-started teardown) runs on the driver task itself, sequential with `terminalize_child`.
- The remaining callers of bare `terminalize` are `#[cfg(test)]`-only (`task.rs`, `stage_terminal_before_mailbox`).

The first review's position holds. Three new tests pin the exclusion so it is enforced rather than conventional:

- `annulment_before_admission_owns_never_started_terminality` — annul-first order: one owner, no supervised lifecycle edges.
- `annulment_after_promotion_is_inert_and_supervision_owns_the_exit` — promote-first order: annul is a no-op, and the terminal record and the lifecycle `Exited` event carry the same exit (the disputed consistency property, asserted on the production path).
- `annulment_racing_admission_resolves_to_one_terminalization_owner` — 64-iteration barrier race across the mutex window; both outcomes assert record/arena/control-plane agreement.

Residual note for 0.1: `terminalize_child` still emits its `exit` *argument* (cells.rs) rather than the winning exit the mailbox arbitration returned — harmless today given the exclusion, but the `ObservationTxn` should publish the canonical winning exit as #172 already prescribes, making the property structural instead of convention-guarded.

## SPEC amendments (the two Part 0 sentences)

- §10: drain reasons form a verdict lattice — `ShutdownRequested` > `StartupFailed` > `IntensityTripped` > `Finished`, monotone upgrades only, ladder deadlines only move earlier (0.3's contract; also the fix contract for item 5).
- §12: the consistent-cut guarantee — control-plane transitions commit atomically w.r.t. all observers, wait/observe helpers included, with the dynamic id-release rule stated (0.1/0.2's acceptance criterion; graduates the `wait_for_id_release` test-comment contract into public docs). Items 2/3/4 are the known code divergences from this contract until 0.1/0.2 land.

Part of #172.