### PR TITLE
Implement Part 0.3 drain verdict lattice

### DIFF
--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -145,9 +145,11 @@ impl ScopeRuntime {
 
     pub(super) fn force_all(&mut self) {
         self.hard_forced = true;
-        if !self.lifecycle.is_draining() {
-            self.begin_drain(StopReason::ShutdownRequested);
-        }
+        // Unconditional: on an already-draining scope this is a pure monotone
+        // reason upgrade (no drain-entry side effects are replayed), and a
+        // hard-forced scope must terminalize as ShutdownRequested even if it
+        // was mid-drain for a lower-precedence reason.
+        self.begin_drain(StopReason::ShutdownRequested);
         let now = runtime::now();
         let children: Vec<_> = self.children.keys().collect();
         for key in children {

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -74,7 +74,7 @@ async fn latched_shutdown_upgrades_an_intensity_drain() {
     );
 }
 
-#[crate::runtime::test]
+#[crate::runtime::test(start_paused = true)]
 async fn force_uses_the_stop_funnel_for_every_ordered_child() {
     let mut tree = Tree::new();
     let first = tree

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -1,6 +1,80 @@
 use super::support::*;
 
 #[crate::runtime::test]
+async fn latched_shutdown_upgrades_an_intensity_drain() {
+    let mut tree = Tree::new();
+    tree.intensity(Intensity::new(0, Duration::from_secs(10)).expect("valid intensity"));
+    tree.add_task(
+        "worker",
+        TaskDef::new(|_| future::pending::<crate::ExitResult>()),
+    )
+    .expect("valid task");
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    root.set_state(ScopeState::Running);
+    root.set_startup(Ok(()));
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
+    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+    let mut children = ChildArena::default();
+    let key = children
+        .insert(child)
+        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+        .with_defaults(plan.defaults.clone())
+        .with_intensity_policy(plan.config.intensity)
+        .with_children(children)
+        .with_lifecycle(ScopeLifecycle::running())
+        .build();
+    plan.armed = false;
+    drop(plan);
+
+    scope.spawn_child(key);
+    let active = scope.children[key]
+        .active
+        .as_ref()
+        .expect("worker is active");
+    let incarnation = active.incarnation;
+    active.abort_handle.abort();
+
+    // Model a shutdown request that latches after this pass sampled the
+    // control plane but before the collected child exit is dispatched.
+    assert!(root.request_shutdown().is_some());
+    scope.handle_exit(
+        key,
+        incarnation,
+        Some(RecordedOutcome::returned(Err(ExitError::message(
+            "trip intensity",
+        )))),
+        crate::runtime::JoinOutcome::Ok { value: () },
+        Cancellation::NotObserved,
+        false,
+    );
+    assert!(matches!(
+        scope.lifecycle.draining_reason(),
+        Some(StopReason::IntensityTripped(_))
+    ));
+
+    // The request's next-pass follow-up owns the stronger verdict even
+    // though teardown was already started by the intensity trip.
+    assert!(root.take_shutdown_request(scope.epoch));
+    scope.begin_drain(StopReason::ShutdownRequested);
+    assert_eq!(
+        scope.lifecycle.draining_reason(),
+        Some(&StopReason::ShutdownRequested)
+    );
+}
+
+#[crate::runtime::test]
 async fn force_uses_the_stop_funnel_for_every_ordered_child() {
     let mut tree = Tree::new();
     let first = tree

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -74,6 +74,81 @@ async fn latched_shutdown_upgrades_an_intensity_drain() {
     );
 }
 
+#[crate::runtime::test]
+async fn force_upgrades_an_intensity_drain_to_shutdown_requested() {
+    let mut tree = Tree::new();
+    tree.intensity(Intensity::new(0, Duration::from_secs(10)).expect("valid intensity"));
+    tree.add_task(
+        "worker",
+        TaskDef::new(|_| future::pending::<crate::ExitResult>()),
+    )
+    .expect("valid task");
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    root.set_state(ScopeState::Running);
+    root.set_startup(Ok(()));
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
+    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+    let mut children = ChildArena::default();
+    let key = children
+        .insert(child)
+        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+        .with_defaults(plan.defaults.clone())
+        .with_intensity_policy(plan.config.intensity)
+        .with_children(children)
+        .with_lifecycle(ScopeLifecycle::running())
+        .build();
+    plan.armed = false;
+    drop(plan);
+
+    scope.spawn_child(key);
+    let active = scope.children[key]
+        .active
+        .as_ref()
+        .expect("worker is active");
+    let incarnation = active.incarnation;
+    active.abort_handle.abort();
+    scope.handle_exit(
+        key,
+        incarnation,
+        Some(RecordedOutcome::returned(Err(ExitError::message(
+            "trip intensity",
+        )))),
+        crate::runtime::JoinOutcome::Ok { value: () },
+        Cancellation::NotObserved,
+        false,
+    );
+    assert!(matches!(
+        scope.lifecycle.draining_reason(),
+        Some(StopReason::IntensityTripped(_))
+    ));
+
+    // Model the child driver collecting only the ancestor abort latch: force
+    // runs on a scope already draining for the trip, without a processed
+    // shutdown request having upgraded the reason first.
+    scope.force_all();
+    assert_eq!(
+        scope.lifecycle.draining_reason(),
+        Some(&StopReason::ShutdownRequested)
+    );
+    assert_eq!(
+        scope.finish_if_ready(),
+        Some(StopReason::ShutdownRequested),
+        "the same pass terminalizes with the forced verdict, not the stale trip"
+    );
+}
+
 #[crate::runtime::test(start_paused = true)]
 async fn force_uses_the_stop_funnel_for_every_ordered_child() {
     let mut tree = Tree::new();

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -130,7 +130,7 @@ impl StopLadder {
             {
                 self.grace_phase = GracePhase::AfterGrace;
             }
-            self.deadline = Some(now);
+            self.deadline = Some(self.deadline.map_or(now, |deadline| deadline.min(now)));
         }
         self.force_requested = true;
     }
@@ -666,6 +666,28 @@ enum StartupPhase {
     Failed,
 }
 
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum DrainReasonPrecedence {
+    Finished,
+    IntensityTripped,
+    StartupFailed,
+    ShutdownRequested,
+}
+
+impl DrainReasonPrecedence {
+    fn of(reason: &StopReason) -> Self {
+        match reason {
+            StopReason::Finished => Self::Finished,
+            StopReason::IntensityTripped(_) => Self::IntensityTripped,
+            StopReason::StartupFailed(_) => Self::StartupFailed,
+            StopReason::ShutdownRequested => Self::ShutdownRequested,
+            StopReason::NeverStarted => {
+                unreachable!("NeverStarted is not a live-incarnation drain reason")
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ScopeDrain {
     reason: StopReason,
@@ -788,12 +810,27 @@ impl ScopeLifecycle {
         Some(self.state.clone())
     }
 
+    /// Begins draining or monotonically upgrades an in-progress drain.
+    ///
+    /// The returned effect exists only for the initial transition: upgrades
+    /// change the eventual verdict without repeating teardown side effects.
     pub(crate) fn begin_drain(&mut self, reason: StopReason) -> Option<DrainEffect> {
+        let incoming_precedence = DrainReasonPrecedence::of(&reason);
         let startup = match self.state {
             ScopeState::Starting => StartupPhase::Pending,
             ScopeState::Running => StartupPhase::Complete,
             ScopeState::StartupFailed => StartupPhase::Failed,
-            ScopeState::Draining => return None,
+            ScopeState::Draining => {
+                let drain = self
+                    .drain
+                    .as_mut()
+                    .expect("the drain invariant supplies a reason while draining");
+                if incoming_precedence > DrainReasonPrecedence::of(&drain.reason) {
+                    drain.reason = reason;
+                }
+                self.assert_drain_invariant();
+                return None;
+            }
             ScopeState::Unstarted | ScopeState::Stopped { .. } => {
                 unreachable!("a scope incarnation owns only live lifecycle states")
             }
@@ -1081,6 +1118,28 @@ mod tests {
             ladder.advance(tidy),
             None,
             "a finished ladder stays finished"
+        );
+    }
+
+    #[test]
+    fn force_preserves_an_already_due_deadline() {
+        let start = Instant::now();
+        let grace = Duration::from_secs(30);
+        let mut ladder = StopLadder::new(Shutdown::Graceful { grace });
+
+        assert_eq!(ladder.advance(start), Some(StopAction::Cancel));
+        let due = ladder.deadline().expect("grace deadline");
+        ladder.force(due + Duration::from_secs(1));
+
+        assert_eq!(
+            ladder.deadline(),
+            Some(due),
+            "forcing after expiry cannot move the deadline later"
+        );
+        assert_eq!(
+            ladder.advance(due),
+            Some(StopAction::Escalate),
+            "the original due instant remains actionable"
         );
     }
 
@@ -1418,6 +1477,72 @@ mod tests {
             .expect("starting can begin draining");
         assert!(drain.startup_pending);
         assert_eq!(drain.state, ScopeState::Draining);
+    }
+
+    #[test]
+    fn scope_lifecycle_upgrades_drain_reasons_monotonically() {
+        let trip = crate::IntensityTrip {
+            max_restarts: 0,
+            observed_restarts: 1,
+            within: Duration::from_secs(10),
+        };
+        let startup_failure = crate::StartupFailure {
+            cause: crate::StartupFailureCause::IdentityExhausted {
+                id: crate::ChildId::from("worker"),
+            },
+        };
+        let mut lifecycle = ScopeLifecycle::running();
+
+        assert!(lifecycle.begin_drain(crate::StopReason::Finished).is_some());
+        assert_eq!(
+            lifecycle.draining_reason(),
+            Some(&crate::StopReason::Finished)
+        );
+
+        assert!(
+            lifecycle
+                .begin_drain(crate::StopReason::IntensityTripped(trip.clone()))
+                .is_none(),
+            "an upgrade does not repeat the enter-drain effect"
+        );
+        assert_eq!(
+            lifecycle.draining_reason(),
+            Some(&crate::StopReason::IntensityTripped(trip.clone()))
+        );
+
+        assert!(
+            lifecycle
+                .begin_drain(crate::StopReason::StartupFailed(startup_failure.clone()))
+                .is_none()
+        );
+        assert_eq!(
+            lifecycle.draining_reason(),
+            Some(&crate::StopReason::StartupFailed(startup_failure.clone()))
+        );
+
+        assert!(
+            lifecycle
+                .begin_drain(crate::StopReason::ShutdownRequested)
+                .is_none()
+        );
+        assert_eq!(
+            lifecycle.draining_reason(),
+            Some(&crate::StopReason::ShutdownRequested)
+        );
+
+        let lower_reasons = [
+            crate::StopReason::Finished,
+            crate::StopReason::IntensityTripped(trip),
+            crate::StopReason::StartupFailed(startup_failure),
+        ];
+        for reason in lower_reasons {
+            assert!(lifecycle.begin_drain(reason).is_none());
+            assert_eq!(
+                lifecycle.draining_reason(),
+                Some(&crate::StopReason::ShutdownRequested),
+                "a lower-precedence reason cannot replace shutdown"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace the scope drain's first-writer-wins reason with the Part 0.3 total precedence order: `ShutdownRequested > StartupFailed > IntensityTripped > Finished`
- upgrade in-progress drain verdicts monotonically without repeating teardown side effects
- make `StopLadder::force` retain the earliest deadline
- add coverage for the cross-pass `max_restarts = 0` shutdown/intensity race, every drain-reason upgrade, downgrade rejection, and already-due forced deadlines

## Why

Part 0.3 of #172 identifies a shared first-writer-wins root cause. If shutdown latched immediately after a driver pass sampled the control plane, a restartable exit could trip intensity first. The next pass observed shutdown, but `ScopeLifecycle::begin_drain` returned without changing the already-latched intensity verdict.

The same monotonicity requirement applies to forced stop deadlines: forcing an already-due ladder must not move its deadline later.

## Impact

Explicit shutdown now deterministically supersedes lower-precedence causes even when they begin teardown one pass earlier. Lower-precedence causes cannot overwrite a stronger verdict, and forcing a stop ladder can only preserve or shorten its deadline.

This implements move 0.3 from #172, including item 5 and the `StopLadder::force` bullet from item 10.

## Validation

- `./tools/dev just ci`
  - formatting and clippy with warnings denied
  - 520 nextest tests
  - doctests and rustdoc
  - API reachability and layering enforcement
  - packaged-crate verification
  - Nix formatting checks
