### PR TITLE
Part 0.1/0.2: unify observation transactions and waits

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -188,6 +188,7 @@ pub(crate) struct MemberCell {
     membership: Membership,
     rebased_membership: OnceLock<Membership>,
     record: runtime::WatchSender<MemberRecord>,
+    observation_gate: RwLock<ObservationGate>,
     terminal_disposal_pending: AtomicBool,
     mailbox: Mutex<MemberMailbox>,
     options: OnceLock<ResolvedCommonOptions>,
@@ -242,6 +243,7 @@ impl MemberCell {
             membership,
             rebased_membership: OnceLock::new(),
             record,
+            observation_gate: RwLock::new(ObservationGate::new()),
             terminal_disposal_pending: AtomicBool::new(false),
             mailbox: Mutex::new(MemberMailbox::default()),
             options: OnceLock::new(),
@@ -308,7 +310,7 @@ impl MemberCell {
     /// contract documented there binds this path too.
     #[cfg(test)]
     pub(crate) fn update(&self, update: impl FnOnce(&mut MemberRecord)) {
-        self.record.send_modify(update);
+        self.with_observation_txn(|txn| self.update_locked(txn, update));
     }
 
     /// Applies a member transition and pulses the watch channel.
@@ -316,18 +318,77 @@ impl MemberCell {
     /// The driver also treats this channel as its control-plane wake bus: any
     /// field read by a loop precondition must be changed through a pulsing path
     /// like this one, never by a silent write outside an observation gate.
+    #[cfg(test)]
     pub(crate) fn transition(&self, transition: MemberTransition) {
-        self.record
-            .send_modify(|record| record.apply_transition(transition));
+        self.with_observation_txn(|txn| self.transition_locked(txn, transition));
     }
 
-    fn update_locked(&self, wakes: &mut ObservationWakes, update: impl FnOnce(&mut MemberRecord)) {
+    fn with_observation_txn<R>(&self, operation: impl FnOnce(&mut ObservationTxn<'_>) -> R) -> R {
+        let mut operation = Some(operation);
+        loop {
+            let gate = self.current_observation_gate();
+            let guard = gate.lock();
+            if gate.same_gate(&self.current_observation_gate()) {
+                let mut txn = ObservationTxn::new(guard);
+                return operation
+                    .take()
+                    .expect("member observation operation runs exactly once")(
+                    &mut txn
+                );
+            }
+            drop(guard);
+        }
+    }
+
+    fn current_observation_gate(&self) -> ObservationGate {
+        self.observation_gate
+            .read()
+            .expect("member observation gate handoff mutex poisoned")
+            .clone()
+    }
+
+    fn install_observation_gate_locked(&self, previous: &ObservationGate, gate: &ObservationGate) {
+        let mut installed = self
+            .observation_gate
+            .write()
+            .expect("member observation gate handoff mutex poisoned");
+        if installed.same_gate(previous) {
+            *installed = gate.clone();
+        } else {
+            assert!(
+                installed.same_gate(gate),
+                "a resident member must share its tree observation gate"
+            );
+        }
+    }
+
+    fn adopt_observation_gate(&self, gate: &ObservationGate, _txn: &mut ObservationTxn<'_>) {
+        loop {
+            let current = self.current_observation_gate();
+            if current.same_gate(gate) {
+                return;
+            }
+            let current_guard = current.lock();
+            if current.same_gate(&self.current_observation_gate()) {
+                self.install_observation_gate_locked(&current, gate);
+                drop(current_guard);
+                return;
+            }
+            drop(current_guard);
+        }
+    }
+
+    fn update_locked(&self, txn: &mut ObservationTxn<'_>, update: impl FnOnce(&mut MemberRecord)) {
         self.record.modify_silently(update);
-        wakes.pulse(&self.record);
+        txn.pulse(&self.record);
     }
 
-    fn transition_locked(&self, wakes: &mut ObservationWakes, transition: MemberTransition) {
-        self.update_locked(wakes, |record| record.apply_transition(transition));
+    pub(crate) fn transition_locked(
+        &self,
+        txn: &mut ObservationTxn<'_>,
+        transition: MemberTransition,
+    ) {
+        self.update_locked(txn, |record| record.apply_transition(transition));
     }
 
     pub(crate) fn set_options(&self, options: ResolvedCommonOptions) {
@@ -349,32 +410,34 @@ impl MemberCell {
     }
 
     pub(crate) fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
-        let terminal_exit = {
-            let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
-            match &mut *state {
-                MemberMailbox::Unattached => {
-                    *state = MemberMailbox::Attached(mailbox);
-                    None
+        self.with_observation_txn(|txn| {
+            let terminal_exit = {
+                let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
+                match &mut *state {
+                    MemberMailbox::Unattached => {
+                        *state = MemberMailbox::Attached(mailbox);
+                        None
+                    }
+                    MemberMailbox::Attached(_)
+                    | MemberMailbox::Terminal {
+                        control: Some(_), ..
+                    } => panic!("a member can own only one mailbox"),
+                    MemberMailbox::Terminal {
+                        control,
+                        exit,
+                        teardown,
+                    } => {
+                        debug_assert!(teardown.is_none());
+                        *teardown = mailbox.prepare_termination();
+                        *control = Some(mailbox);
+                        Some(exit.clone())
+                    }
                 }
-                MemberMailbox::Attached(_)
-                | MemberMailbox::Terminal {
-                    control: Some(_), ..
-                } => panic!("a member can own only one mailbox"),
-                MemberMailbox::Terminal {
-                    control,
-                    exit,
-                    teardown,
-                } => {
-                    debug_assert!(teardown.is_none());
-                    *teardown = mailbox.prepare_termination();
-                    *control = Some(mailbox);
-                    Some(exit.clone())
-                }
+            };
+            if let Some(terminal_exit) = terminal_exit {
+                self.publish_terminal_locked(terminal_exit, txn, None);
             }
-        };
-        if let Some(terminal_exit) = terminal_exit {
-            self.publish_terminal(terminal_exit);
-        }
+        });
     }
 
     pub(crate) fn mailbox(&self) -> Option<Arc<dyn MailboxControl>> {
@@ -386,32 +449,30 @@ impl MemberCell {
     }
 
     pub(crate) fn terminalize(&self, exit: Exit) {
-        self.terminalize_with_wakes(exit, None, None);
+        self.with_observation_txn(|txn| {
+            self.terminalize_locked(exit, txn);
+        });
     }
 
-    fn terminalize_locked(&self, exit: Exit, wakes: &mut ObservationWakes) {
-        self.terminalize_with_wakes(exit, Some(wakes), None);
+    pub(crate) fn terminalize_locked(&self, exit: Exit, txn: &mut ObservationTxn<'_>) -> Exit {
+        self.terminalize_in(exit, txn, None)
     }
 
     fn terminalize_child_locked(
         &self,
         exit: Exit,
         startup: StartupDisposition,
-        wakes: &mut ObservationWakes,
-    ) {
-        self.terminalize_with_wakes(
-            exit,
-            Some(wakes),
-            Some(startup == StartupDisposition::Aborted),
-        );
+        txn: &mut ObservationTxn<'_>,
+    ) -> Exit {
+        self.terminalize_in(exit, txn, Some(startup == StartupDisposition::Aborted))
     }
 
-    fn terminalize_with_wakes(
+    fn terminalize_in(
         &self,
         exit: Exit,
-        wakes: Option<&mut ObservationWakes>,
+        txn: &mut ObservationTxn<'_>,
         startup_aborted: Option<bool>,
-    ) {
+    ) -> Exit {
         let terminal_exit = {
             let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
             match &*state {
@@ -439,17 +500,14 @@ impl MemberCell {
                 }
             }
         };
-        self.publish_terminal_with_wakes(terminal_exit, wakes, startup_aborted);
+        self.publish_terminal_locked(terminal_exit.clone(), txn, startup_aborted);
+        terminal_exit
     }
 
-    fn publish_terminal(&self, terminal_exit: Exit) {
-        self.publish_terminal_with_wakes(terminal_exit, None, None);
-    }
-
-    fn publish_terminal_with_wakes(
+    fn publish_terminal_locked(
         &self,
         terminal_exit: Exit,
-        wakes: Option<&mut ObservationWakes>,
+        txn: &mut ObservationTxn<'_>,
         startup_aborted: Option<bool>,
     ) {
         let mut published = false;
@@ -476,39 +534,19 @@ impl MemberCell {
                 unreachable!("terminal publication requires terminal mailbox state")
             }
         };
-        if let Some(wakes) = wakes {
-            if let Some(teardown) = teardown {
-                wakes.defer(move || {
-                    if let Some(payload) = teardown.finish() {
-                        runtime::dispose_detached(payload);
-                    }
-                });
-            }
-            // A supervised terminal edge updates `startup_aborted` even if a
-            // competing terminalizer won the stage transition. Its record
-            // pulse remains required, but mailbox discharge must lead it: by
-            // flush time every record mutation is already visible, so an
-            // earlier pulse would expose `Terminal` before teardown finished.
-            if record_changed {
-                wakes.pulse(&self.record);
-            }
-            return;
-        }
-        let mut teardown_panic = None;
         if let Some(teardown) = teardown {
-            match runtime::catch_panic(|| teardown.finish()) {
-                Ok(Some(payload)) => runtime::dispose_detached(payload),
-                Ok(None) => {}
-                Err(payload) => teardown_panic = Some(payload),
-            }
+            txn.defer(move || {
+                if let Some(payload) = teardown.finish() {
+                    runtime::dispose_detached(payload);
+                }
+            });
         }
-        let pulse_panic = record_changed
-            .then(|| runtime::catch_panic(|| self.record.pulse()).err())
-            .flatten();
-        runtime::resume_preferred_panic(runtime::UnwindPanics {
-            primary: teardown_panic,
-            cleanup: pulse_panic,
-        });
+        // A supervised terminal edge updates `startup_aborted` even if a
+        // competing terminalizer won the stage transition. Its record pulse
+        // remains required, but mailbox discharge must lead it.
+        if record_changed {
+            txn.pulse(&self.record);
+        }
     }
 
     pub(crate) async fn wait_terminal(&self) -> Exit {
@@ -549,7 +587,10 @@ pub(crate) trait DynamicRoute: Send + Sync {
         scope: &Arc<ScopeCell>,
         id: ChildId,
         child_scope: Option<ScopeFlavor>,
+        txn: &mut ObservationTxn<'_>,
     ) -> Result<Arc<Self::Slot>, ReserveError>;
+
+    fn close_admission(&self, txn: &mut ObservationTxn<'_>);
 
     fn start_admission(
         self: Arc<Self>,
@@ -557,15 +598,22 @@ pub(crate) trait DynamicRoute: Send + Sync {
         fused_cancel: Option<Latch>,
     ) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError>;
 
-    fn cancel_reservation(&self, slot: &Self::Slot);
+    fn cancel_reservation(&self, slot: &Self::Slot, txn: &mut ObservationTxn<'_>);
 
-    fn signal_fused_cancel(&self, slot: &Self::Slot, latch: &Latch);
+    fn signal_fused_cancel(
+        &self,
+        scope: &Arc<ScopeCell>,
+        slot: &Self::Slot,
+        latch: &Latch,
+        txn: &mut ObservationTxn<'_>,
+    );
 
     fn remove(
         &self,
         scope: &Arc<ScopeCell>,
         id: &ChildId,
         exact: Option<Membership>,
+        txn: &mut ObservationTxn<'_>,
     ) -> runtime::OneShotReceiver<RemoveOutcome>;
 }
 
@@ -593,20 +641,36 @@ impl ObservationGate {
     }
 }
 
-/// Watch notifications accumulated by one observation-gate transaction.
+/// Capability for one observation-gate transaction.
 ///
-/// Tokio invokes registered wakers synchronously from a watch send. A public
-/// observation future may therefore install a waker that immediately reads a
-/// scope snapshot. Retained values are mutated while the gate is held, but
-/// their version pulses are collected here and run only after the gate has
-/// been released, so that reentrant read cannot self-deadlock.
-#[derive(Default)]
-pub(crate) struct ObservationWakes {
+/// Every retained control-plane writer takes this token, making an
+/// out-of-transaction mutation unavailable by construction. Tokio invokes
+/// registered wakers synchronously, so pulses and disposal work accumulate on
+/// the token and flush only after its gate guard has been released. The same
+/// drop path runs during unwind, preventing a poisoned transaction from
+/// stranding already-committed wakes.
+pub(crate) struct ObservationTxn<'a> {
+    guard: Option<MutexGuard<'a, ()>>,
     pulses: Vec<Box<dyn FnOnce()>>,
 }
 
-impl ObservationWakes {
-    fn defer(&mut self, operation: impl FnOnce() + 'static) {
+impl<'a> ObservationTxn<'a> {
+    fn new(guard: MutexGuard<'a, ()>) -> Self {
+        Self {
+            guard: Some(guard),
+            pulses: Vec::new(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn detached() -> Self {
+        Self {
+            guard: None,
+            pulses: Vec::new(),
+        }
+    }
+
+    pub(crate) fn defer(&mut self, operation: impl FnOnce() + 'static) {
         self.pulses.push(Box::new(operation));
     }
 
@@ -615,7 +679,8 @@ impl ObservationWakes {
         self.defer(move || sender.pulse());
     }
 
-    fn flush(&mut self) {
+    fn commit(&mut self) {
+        drop(self.guard.take());
         let mut panics = runtime::PanicAccumulator::default();
         for pulse in self.pulses.drain(..) {
             // One hostile waker must not prevent the remaining committed
@@ -625,17 +690,9 @@ impl ObservationWakes {
     }
 }
 
-struct ObservationPublication<'a> {
-    guard: Option<MutexGuard<'a, ()>>,
-    wakes: ObservationWakes,
-}
-
-impl Drop for ObservationPublication<'_> {
+impl Drop for ObservationTxn<'_> {
     fn drop(&mut self) {
-        // Reentrant observation is safe only after the serialized projection
-        // has become readable as one complete transaction.
-        drop(self.guard.take());
-        self.wakes.flush();
+        self.commit();
     }
 }
 
@@ -674,14 +731,16 @@ impl ResidentChild {
         }
     }
 
-    fn complete_removal(mut self, wakes: &mut ObservationWakes) {
-        let completion = self
-            .removal
+    fn disarm_removal(&mut self) -> ResidencyCompletion {
+        self.removal
             .take()
-            .expect("a resident completes removal exactly once");
+            .expect("a resident completes removal exactly once")
+    }
+
+    fn publish_removal(completion: ResidencyCompletion, txn: &mut ObservationTxn<'_>) {
         if let Some(parent) = completion.parent.upgrade() {
             parent.emit_locked(
-                wakes,
+                txn,
                 LifecycleEventKind::Removed {
                     id: completion.projection.member.id().clone(),
                     membership: completion.projection.member.membership(),
@@ -689,6 +748,11 @@ impl ResidentChild {
                 },
             );
         }
+    }
+
+    fn complete_removal(mut self, txn: &mut ObservationTxn<'_>) {
+        let completion = self.disarm_removal();
+        Self::publish_removal(completion, txn);
     }
 }
 
@@ -740,9 +804,11 @@ struct ScopeRequest {
 /// their individual locks do not make a multi-field transition atomic, so
 /// every recursive observation path continues to hold that one tree gate.
 ///
-/// Control requests, identity counters, lifecycle sequences, and the dynamic
-/// route remain independent synchronization planes. The member-record watch is
-/// intentionally also the driver's wake bus.
+/// Control requests, the dynamic route, records, residency, and hubs retain
+/// their narrow storage locks, but every mutation is subordinate to the tree
+/// gate and takes an [`ObservationTxn`] capability. Identity allocation and
+/// lifecycle sequence minting remain independent driver-only counters. The
+/// member-record watch is intentionally also the driver's wake bus.
 pub(crate) struct ScopeCell {
     pub(crate) member: Arc<MemberCell>,
     pub(crate) flavor: ScopeFlavor,
@@ -755,7 +821,7 @@ pub(crate) struct ScopeCell {
     // itself, so dropping a resident anywhere the gate is already held
     // self-deadlocks — not just inside a mutation callback. In-gate removal
     // paths must instead consume the resident through
-    // `complete_removal(wakes)`, which emits under the already-held gate.
+    // `complete_removal(txn)`, which emits under the already-held gate.
     // Letting the bare destructor run is reserved for the orphaned path,
     // where the parent `Weak` is dead and the drop emits nothing. Adding a
     // resident inside a mutation callback remains safe. Dropping a resident
@@ -805,6 +871,7 @@ impl ScopeCell {
         flavor: ScopeFlavor,
         child_identity: ScopeIdentity,
     ) -> Arc<Self> {
+        let observation_gate = member.current_observation_gate();
         let (record, _) = runtime::watch(ScopeRecord {
             state: ScopeState::Unstarted,
             startup: None,
@@ -820,7 +887,7 @@ impl ScopeCell {
             dynamic_route: Mutex::new(None),
             current_children: Mutex::new(Vec::new()),
             parent: Mutex::new(None),
-            observation_gate: RwLock::new(ObservationGate::new()),
+            observation_gate: RwLock::new(observation_gate),
             lifecycle_seq: AtomicU64::new(0),
             lifecycle: LifecycleHub::default(),
             snapshots: SnapshotHub::default(),
@@ -862,7 +929,7 @@ impl ScopeCell {
             .and_then(Weak::upgrade)
     }
 
-    fn set_parent(&self, parent: &Arc<ScopeCell>) {
+    fn set_parent(&self, parent: &Arc<ScopeCell>, _txn: &mut ObservationTxn<'_>) {
         *self
             .parent
             .lock()
@@ -921,7 +988,12 @@ impl ScopeCell {
             .clone()
     }
 
-    fn adopt_observation_gate(&self, parent: &ScopeCell, gate: &ObservationGate) {
+    fn adopt_observation_gate(
+        &self,
+        parent: &ScopeCell,
+        gate: &ObservationGate,
+        txn: &mut ObservationTxn<'_>,
+    ) {
         debug_assert!(
             !std::ptr::eq(self, parent),
             "a scope cannot adopt from itself"
@@ -953,13 +1025,28 @@ impl ScopeCell {
                 .expect("observation gate handoff mutex poisoned");
             if current.same_gate(&installed) {
                 *installed = gate.clone();
+                self.member.install_observation_gate_locked(&current, gate);
                 drop(installed);
-                self.adopt_descendant_observation_gates_locked(&current, gate);
+                self.adopt_descendant_observation_gates_locked(&current, gate, txn);
                 drop(current_guard);
                 return;
             }
             drop(installed);
             drop(current_guard);
+        }
+    }
+
+    pub(crate) fn adopt_child_observation_gate(
+        self: &Arc<Self>,
+        member: &MemberCell,
+        child: Option<&ScopeCell>,
+        txn: &mut ObservationTxn<'_>,
+    ) {
+        let gate = self.current_observation_gate();
+        if let Some(child) = child {
+            child.adopt_observation_gate(self, &gate, txn);
+        } else {
+            member.adopt_observation_gate(&gate, txn);
         }
     }
 
@@ -970,6 +1057,7 @@ impl ScopeCell {
         &self,
         previous: &ObservationGate,
         gate: &ObservationGate,
+        _txn: &mut ObservationTxn<'_>,
     ) {
         let descendants = self
             .current_children()
@@ -983,6 +1071,9 @@ impl ScopeCell {
                 .expect("observation gate handoff mutex poisoned");
             if installed.same_gate(previous) {
                 *installed = gate.clone();
+                descendant
+                    .member
+                    .install_observation_gate_locked(previous, gate);
             } else {
                 assert!(
                     installed.same_gate(gate),
@@ -990,7 +1081,7 @@ impl ScopeCell {
                 );
             }
             drop(installed);
-            descendant.adopt_descendant_observation_gates_locked(previous, gate);
+            descendant.adopt_descendant_observation_gates_locked(previous, gate, _txn);
         }
     }
 
@@ -999,7 +1090,7 @@ impl ScopeCell {
     /// detected and retried before the operation enters its critical section.
     pub(crate) fn with_observation_gate<R>(
         &self,
-        operation: impl FnOnce(&mut ObservationWakes) -> R,
+        operation: impl FnOnce(&mut ObservationTxn<'_>) -> R,
     ) -> R {
         let mut operation = Some(operation);
         loop {
@@ -1011,12 +1102,9 @@ impl ScopeCell {
                 let operation = operation
                     .take()
                     .expect("observation operation runs exactly once");
-                let mut publication = ObservationPublication {
-                    guard: Some(guard),
-                    wakes: ObservationWakes::default(),
-                };
-                let result = operation(&mut publication.wakes);
-                drop(publication);
+                let mut txn = ObservationTxn::new(guard);
+                let result = operation(&mut txn);
+                drop(txn);
                 return result;
             }
             drop(guard);
@@ -1024,14 +1112,32 @@ impl ScopeCell {
     }
 
     pub(crate) fn set_state(&self, state: ScopeState) {
-        self.with_observation_gate(|wakes| {
-            self.record.modify_silently(|record| {
-                record.state = state.clone();
-            });
-            wakes.pulse(&self.record);
-            wakes.pulse(&self.member.record);
-            self.emit_locked(wakes, LifecycleEventKind::ScopeState { state });
+        self.with_observation_gate(|txn| self.set_state_locked(state, txn));
+    }
+
+    pub(crate) fn set_state_and_startup(
+        &self,
+        state: ScopeState,
+        startup: Result<(), StartupError>,
+    ) {
+        self.with_observation_gate(|txn| {
+            self.set_startup_locked(startup, txn);
+            self.set_state_locked(state, txn);
         });
+    }
+
+    fn set_state_locked(&self, state: ScopeState, txn: &mut ObservationTxn<'_>) {
+        if matches!(state, ScopeState::Draining | ScopeState::StartupFailed)
+            && let Some(route) = self.dynamic_route_in(txn)
+        {
+            route.close_admission(txn);
+        }
+        self.record.modify_silently(|record| {
+            record.state = state.clone();
+        });
+        txn.pulse(&self.record);
+        txn.pulse(&self.member.record);
+        self.emit_locked(txn, LifecycleEventKind::ScopeState { state });
     }
 
     pub(crate) fn set_observation_config(&self, strategy: Strategy, intensity: Intensity) {
@@ -1063,12 +1169,15 @@ impl ScopeCell {
         });
     }
 
-    pub(crate) fn set_child_removing(&self, member: &MemberCell) {
-        self.update_child_record(
-            member,
-            |record| record.membership_status = MembershipStatus::Removing,
-            None,
-        );
+    pub(crate) fn set_child_removing_locked(
+        &self,
+        member: &MemberCell,
+        txn: &mut ObservationTxn<'_>,
+    ) {
+        member.update_locked(txn, |record| {
+            record.membership_status = MembershipStatus::Removing;
+        });
+        self.publish_snapshot_chain_locked(txn);
     }
 
     #[cfg(test)]
@@ -1141,7 +1250,7 @@ impl ScopeCell {
                 .find(|resident| resident.projection.member.membership() == member.membership())
                 .and_then(|resident| resident.projection.scope.as_ref())
                 .cloned();
-            member.terminalize_child_locked(exit.clone(), startup, wakes);
+            let terminal_exit = member.terminalize_child_locked(exit, startup, wakes);
             if record.last_incarnation.is_none()
                 && let Some(scope) = &nested
             {
@@ -1154,7 +1263,7 @@ impl ScopeCell {
                         id: member.id().clone(),
                         membership: member.membership(),
                         incarnation,
-                        exit: exit.clone(),
+                        exit: terminal_exit,
                     },
                 );
             } else {
@@ -1171,25 +1280,30 @@ impl ScopeCell {
         })
     }
 
+    #[cfg(test)]
     pub(crate) fn prune_child(&self, member: &MemberCell) -> bool {
-        self.with_observation_gate(|wakes| {
-            let membership = member.membership();
-            let resident = {
-                let mut children = self.current_children();
-                let index = children
-                    .iter()
-                    .position(|child| child.projection.member.membership() == membership);
-                index.map(|index| children.remove(index))
-            };
-            let Some(resident) = resident else {
-                return false;
-            };
-            debug_assert_eq!(resident.projection.member.membership(), membership);
-            // Dropping residency under the observation gate emits the matching
-            // Removed edge through its owned completion.
-            resident.complete_removal(wakes);
-            true
-        })
+        self.with_observation_gate(|wakes| self.prune_child_locked(member, wakes))
+    }
+
+    pub(crate) fn prune_child_locked(
+        &self,
+        member: &MemberCell,
+        txn: &mut ObservationTxn<'_>,
+    ) -> bool {
+        let membership = member.membership();
+        let resident = {
+            let mut children = self.current_children();
+            let index = children
+                .iter()
+                .position(|child| child.projection.member.membership() == membership);
+            index.map(|index| children.remove(index))
+        };
+        let Some(resident) = resident else {
+            return false;
+        };
+        debug_assert_eq!(resident.projection.member.membership(), membership);
+        resident.complete_removal(txn);
+        true
     }
 
     pub(crate) fn snapshot(&self) -> Arc<ScopeSnapshot> {
@@ -1198,7 +1312,7 @@ impl ScopeCell {
 
     pub(crate) fn subscribe_snapshots(&self) -> SnapshotReceiver {
         self.with_observation_gate(|wakes| {
-            let receiver = self.snapshots.subscribe(self.snapshot_locked());
+            let receiver = self.snapshots.subscribe(self.snapshot_locked(), wakes);
             if self.observation_closed.load(Ordering::Acquire) {
                 self.snapshots.close_deferred(wakes);
             }
@@ -1291,7 +1405,7 @@ impl ScopeCell {
         ancestors
     }
 
-    fn publish_snapshot_chain_locked(&self, wakes: &mut ObservationWakes) {
+    fn publish_snapshot_chain_locked(&self, wakes: &mut ObservationTxn<'_>) {
         self.snapshots
             .publish_deferred(wakes, || self.snapshot_locked());
         for ancestor in self.ancestors_locked() {
@@ -1301,7 +1415,7 @@ impl ScopeCell {
         }
     }
 
-    fn emit_locked(&self, wakes: &mut ObservationWakes, kind: LifecycleEventKind) {
+    fn emit_locked(&self, wakes: &mut ObservationTxn<'_>, kind: LifecycleEventKind) {
         // The resident-tree observation gate serializes every mint; the
         // atomic is the published watermark as well as the counter, avoiding
         // a second, provably uncontended lock on every lifecycle edge. The
@@ -1341,7 +1455,7 @@ impl ScopeCell {
         }
     }
 
-    fn close_observation_locked(&self, wakes: &mut ObservationWakes) {
+    fn close_observation_locked(&self, wakes: &mut ObservationTxn<'_>) {
         if self.observation_closed.swap(true, Ordering::AcqRel) {
             return;
         }
@@ -1365,6 +1479,10 @@ impl ScopeCell {
     }
 
     pub(crate) fn set_startup(&self, startup: Result<(), StartupError>) {
+        self.with_observation_gate(|txn| self.set_startup_locked(startup, txn));
+    }
+
+    fn set_startup_locked(&self, startup: Result<(), StartupError>, txn: &mut ObservationTxn<'_>) {
         let mut published = false;
         self.record.modify_silently(|record| {
             if record.startup.is_none() {
@@ -1373,10 +1491,8 @@ impl ScopeCell {
             }
         });
         if published {
-            // Preserve the original driver wake boundary before releasing the
-            // startup record itself.
-            self.member.record.pulse();
-            self.record.pulse();
+            txn.pulse(&self.member.record);
+            txn.pulse(&self.record);
         }
     }
 
@@ -1468,8 +1584,10 @@ impl ScopeCell {
     }
 
     pub(crate) fn request_shutdown(&self) -> Option<Epoch> {
-        let control = self.control.lock().expect("scope control mutex poisoned");
-        self.request_shutdown_locked(control)
+        self.with_observation_gate(|txn| {
+            let control = self.control.lock().expect("scope control mutex poisoned");
+            self.request_shutdown_locked(control, txn)
+        })
     }
 
     /// [`Self::request_shutdown`] for destructors: tolerates a poisoned
@@ -1478,14 +1596,20 @@ impl ScopeCell {
     /// so overwriting a poisoner's partial update is no worse than any other
     /// racing request.
     pub(crate) fn request_shutdown_ignoring_poison(&self) -> Option<Epoch> {
-        let control = self
-            .control
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        self.request_shutdown_locked(control)
+        self.with_observation_gate(|txn| {
+            let control = self
+                .control
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            self.request_shutdown_locked(control, txn)
+        })
     }
 
-    fn request_shutdown_locked(&self, mut control: MutexGuard<'_, ScopeControl>) -> Option<Epoch> {
+    fn request_shutdown_locked(
+        &self,
+        mut control: MutexGuard<'_, ScopeControl>,
+        txn: &mut ObservationTxn<'_>,
+    ) -> Option<Epoch> {
         let RequestTarget {
             epoch: target,
             pending_incarnation,
@@ -1500,9 +1624,9 @@ impl ScopeCell {
             });
         }
         drop(control);
-        self.member.record.pulse();
+        txn.pulse(&self.member.record);
         if pending_incarnation && let Some(parent) = self.parent() {
-            parent.member.record.pulse();
+            txn.pulse(&parent.member.record);
         }
         Some(target)
     }
@@ -1523,37 +1647,43 @@ impl ScopeCell {
     }
 
     pub(crate) fn take_shutdown_request(&self, epoch: Epoch) -> bool {
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        match control.shutdown.as_mut() {
-            Some(request) if request.epoch == epoch && !request.consumed => {
-                request.consumed = true;
-                true
+        self.with_observation_gate(|_txn| {
+            let mut control = self.control.lock().expect("scope control mutex poisoned");
+            match control.shutdown.as_mut() {
+                Some(request) if request.epoch == epoch && !request.consumed => {
+                    request.consumed = true;
+                    true
+                }
+                _ => false,
             }
-            _ => false,
-        }
+        })
     }
 
     pub(crate) fn force_shutdown(&self, epoch: Epoch) {
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        if control.epochs.is_current(epoch) {
-            control.force = Some(ScopeRequest {
-                epoch,
-                consumed: false,
-            });
-        }
-        drop(control);
-        self.member.record.pulse();
+        self.with_observation_gate(|txn| {
+            let mut control = self.control.lock().expect("scope control mutex poisoned");
+            if control.epochs.is_current(epoch) {
+                control.force = Some(ScopeRequest {
+                    epoch,
+                    consumed: false,
+                });
+            }
+            drop(control);
+            txn.pulse(&self.member.record);
+        });
     }
 
     pub(crate) fn take_force_request(&self, epoch: Epoch) -> bool {
-        let mut control = self.control.lock().expect("scope control mutex poisoned");
-        match control.force.as_mut() {
-            Some(request) if request.epoch == epoch && !request.consumed => {
-                request.consumed = true;
-                true
+        self.with_observation_gate(|_txn| {
+            let mut control = self.control.lock().expect("scope control mutex poisoned");
+            match control.force.as_mut() {
+                Some(request) if request.epoch == epoch && !request.consumed => {
+                    request.consumed = true;
+                    true
+                }
+                _ => false,
             }
-            _ => false,
-        }
+        })
     }
 
     pub(crate) fn incarnation_finished(&self, epoch: Epoch) -> bool {
@@ -1567,8 +1697,10 @@ impl ScopeCell {
             self.clear_residents_locked(wakes);
             for child in children {
                 if let Some(scope) = &child.scope {
-                    scope.adopt_observation_gate(self, &gate);
-                    scope.set_parent(self);
+                    scope.adopt_observation_gate(self, &gate, wakes);
+                    scope.set_parent(self, wakes);
+                } else {
+                    child.member.adopt_observation_gate(&gate, wakes);
                 }
                 child
                     .member
@@ -1582,53 +1714,90 @@ impl ScopeCell {
         });
     }
 
+    #[cfg(test)]
     pub(crate) fn admit_child(self: &Arc<Self>, child: ResidentProjection) {
-        self.with_observation_gate(|wakes| {
-            let gate = self.current_observation_gate();
-            if let Some(scope) = &child.scope {
-                scope.adopt_observation_gate(self, &gate);
-                scope.set_parent(self);
-            }
-            let id = child.member.id().clone();
-            let membership = child.member.membership();
-            child
-                .member
-                .transition_locked(wakes, MemberTransition::Admitted);
-            self.current_children()
-                .push(ResidentChild::new(self, child));
-            self.emit_locked(wakes, LifecycleEventKind::Added { id, membership });
-        });
+        self.with_observation_gate(|wakes| self.admit_child_locked(child, wakes));
+    }
+
+    pub(crate) fn admit_child_locked(
+        self: &Arc<Self>,
+        child: ResidentProjection,
+        txn: &mut ObservationTxn<'_>,
+    ) {
+        let gate = self.current_observation_gate();
+        if let Some(scope) = &child.scope {
+            scope.adopt_observation_gate(self, &gate, txn);
+            scope.set_parent(self, txn);
+        } else {
+            child.member.adopt_observation_gate(&gate, txn);
+        }
+        let id = child.member.id().clone();
+        let membership = child.member.membership();
+        child
+            .member
+            .transition_locked(txn, MemberTransition::Admitted);
+        self.current_children()
+            .push(ResidentChild::new(self, child));
+        self.emit_locked(txn, LifecycleEventKind::Added { id, membership });
     }
 
     pub(crate) fn clear_residents(&self) {
         self.with_observation_gate(|wakes| self.clear_residents_locked(wakes));
     }
 
-    fn clear_residents_locked(&self, wakes: &mut ObservationWakes) {
-        let residents = {
+    pub(crate) fn clear_residents_locked(&self, wakes: &mut ObservationTxn<'_>) {
+        let mut residents = {
             let mut children = self.current_children();
             std::mem::take(&mut *children)
         };
-        // Each owned residency emits Removed only after the state guard has
-        // been released, so the recursively projected set is already empty.
-        for resident in residents {
-            resident.complete_removal(wakes);
+        // Disarm every drop fallback before publishing any edge. If an emit
+        // unwinds, the untouched suffix no longer re-enters the non-reentrant
+        // observation gate from ResidentChild::drop.
+        let completions = residents
+            .iter_mut()
+            .map(ResidentChild::disarm_removal)
+            .collect::<Vec<_>>();
+        drop(residents);
+        for completion in completions {
+            ResidentChild::publish_removal(completion, wakes);
         }
     }
 
     pub(crate) fn set_dynamic_route(&self, route: Option<Arc<ErasedDynamicRoute>>) {
-        *self
-            .dynamic_route
-            .lock()
-            .expect("scope dynamic-route mutex poisoned") = route;
-        self.member.record.pulse();
+        self.with_observation_gate(|txn| {
+            self.set_dynamic_route_locked(route, txn);
+        });
     }
 
-    pub(crate) fn dynamic_route(&self) -> Option<Arc<ErasedDynamicRoute>> {
+    pub(crate) fn set_dynamic_route_locked(
+        &self,
+        route: Option<Arc<ErasedDynamicRoute>>,
+        txn: &mut ObservationTxn<'_>,
+    ) {
+        let previous = std::mem::replace(
+            &mut *self
+                .dynamic_route
+                .lock()
+                .expect("scope dynamic-route mutex poisoned"),
+            route,
+        );
+        txn.defer(move || drop(previous));
+        txn.pulse(&self.member.record);
+    }
+
+    pub(crate) fn dynamic_route_in(
+        &self,
+        _txn: &ObservationTxn<'_>,
+    ) -> Option<Arc<ErasedDynamicRoute>> {
         self.dynamic_route
             .lock()
             .expect("scope dynamic-route mutex poisoned")
             .clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn dynamic_route(&self) -> Option<Arc<ErasedDynamicRoute>> {
+        self.with_observation_gate(|txn| self.dynamic_route_in(txn))
     }
 
     pub(crate) fn signal(&self) -> &runtime::WatchSender<MemberRecord> {
@@ -1677,7 +1846,7 @@ impl ScopeCell {
     /// only then close the nested streams.
     fn publish_stopped_locked(
         &self,
-        wakes: &mut ObservationWakes,
+        wakes: &mut ObservationTxn<'_>,
         reason: StopReason,
         terminal_exit: Option<Exit>,
         epoch_owner: Option<MutexGuard<'_, ScopeControl>>,
@@ -1701,13 +1870,15 @@ impl ScopeCell {
     }
 
     pub(crate) fn terminalize_never_started(&self) {
-        self.with_observation_gate(|wakes| {
-            if self.observation_closed.load(Ordering::Acquire) {
-                return;
-            }
-            self.member.terminalize_locked(Exit::never_started(), wakes);
-            self.publish_stopped_locked(wakes, StopReason::NeverStarted, None, None);
-            self.close_observation_locked(wakes);
-        });
+        self.with_observation_gate(|txn| self.terminalize_never_started_locked(txn));
+    }
+
+    pub(crate) fn terminalize_never_started_locked(&self, txn: &mut ObservationTxn<'_>) {
+        if self.observation_closed.load(Ordering::Acquire) {
+            return;
+        }
+        self.member.terminalize_locked(Exit::never_started(), txn);
+        self.publish_stopped_locked(txn, StopReason::NeverStarted, None, None);
+        self.close_observation_locked(txn);
     }
 }

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -188,6 +188,10 @@ pub(crate) struct MemberCell {
     membership: Membership,
     rebased_membership: OnceLock<Membership>,
     record: runtime::WatchSender<MemberRecord>,
+    // Guards only a gate-pointer swap, so no torn state is possible; every
+    // access deliberately tolerates poisoning (mirroring
+    // `ObservationGate::lock`) so drop-path shutdown after a panicked assert
+    // cannot itself panic.
     observation_gate: RwLock<ObservationGate>,
     terminal_disposal_pending: AtomicBool,
     mailbox: Mutex<MemberMailbox>,
@@ -343,7 +347,7 @@ impl MemberCell {
     fn current_observation_gate(&self) -> ObservationGate {
         self.observation_gate
             .read()
-            .expect("member observation gate handoff mutex poisoned")
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
     }
 
@@ -356,7 +360,7 @@ impl MemberCell {
         let mut installed = self
             .observation_gate
             .write()
-            .expect("member observation gate handoff mutex poisoned");
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         if installed.same_gate(previous) {
             *installed = gate.clone();
         } else {
@@ -834,6 +838,10 @@ pub(crate) struct ScopeCell {
     // move removed residents into outer storage before the drop runs.
     current_children: Mutex<Vec<ResidentChild>>,
     parent: Mutex<Option<Weak<ScopeCell>>>,
+    // Guards only a gate-pointer swap, so no torn state is possible; every
+    // access deliberately tolerates poisoning (mirroring
+    // `ObservationGate::lock`) so drop-path shutdown after a panicked assert
+    // cannot itself panic.
     observation_gate: RwLock<ObservationGate>,
     lifecycle_seq: AtomicU64,
     lifecycle: LifecycleHub,
@@ -995,7 +1003,7 @@ impl ScopeCell {
     fn current_observation_gate(&self) -> ObservationGate {
         self.observation_gate
             .read()
-            .expect("observation gate handoff mutex poisoned")
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
     }
 
@@ -1033,7 +1041,7 @@ impl ScopeCell {
             let mut installed = self
                 .observation_gate
                 .write()
-                .expect("observation gate handoff mutex poisoned");
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             if current.same_gate(&installed) {
                 *installed = gate.clone();
                 self.member.install_observation_gate_locked(&current, gate);
@@ -1080,7 +1088,7 @@ impl ScopeCell {
                 let mut installed = scope
                     .observation_gate
                     .write()
-                    .expect("observation gate handoff mutex poisoned");
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
                 if installed.same_gate(previous) {
                     *installed = gate.clone();
                     descendant
@@ -1494,7 +1502,7 @@ impl ScopeCell {
         *self
             .observation_gate
             .write()
-            .expect("observation gate handoff mutex remains healthy") = gate;
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = gate;
     }
 
     #[cfg(test)]

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -347,6 +347,11 @@ impl MemberCell {
             .clone()
     }
 
+    #[cfg(test)]
+    pub(crate) fn observation_gate(&self) -> ObservationGate {
+        self.current_observation_gate()
+    }
+
     fn install_observation_gate_locked(&self, previous: &ObservationGate, gate: &ObservationGate) {
         let mut installed = self
             .observation_gate
@@ -1062,26 +1067,32 @@ impl ScopeCell {
         let descendants = self
             .current_children()
             .iter()
-            .filter_map(|resident| resident.projection.scope.as_ref().cloned())
+            .map(|resident| resident.projection.clone())
             .collect::<Vec<_>>();
         for descendant in descendants {
-            let mut installed = descendant
-                .observation_gate
-                .write()
-                .expect("observation gate handoff mutex poisoned");
-            if installed.same_gate(previous) {
-                *installed = gate.clone();
+            if let Some(scope) = descendant.scope {
+                let mut installed = scope
+                    .observation_gate
+                    .write()
+                    .expect("observation gate handoff mutex poisoned");
+                if installed.same_gate(previous) {
+                    *installed = gate.clone();
+                    descendant
+                        .member
+                        .install_observation_gate_locked(previous, gate);
+                } else {
+                    assert!(
+                        installed.same_gate(gate),
+                        "one resident tree must share one observation gate"
+                    );
+                }
+                drop(installed);
+                scope.adopt_descendant_observation_gates_locked(previous, gate, _txn);
+            } else {
                 descendant
                     .member
                     .install_observation_gate_locked(previous, gate);
-            } else {
-                assert!(
-                    installed.same_gate(gate),
-                    "one resident tree must share one observation gate"
-                );
             }
-            drop(installed);
-            descendant.adopt_descendant_observation_gates_locked(previous, gate, _txn);
         }
     }
 
@@ -1273,7 +1284,14 @@ impl ScopeCell {
                 // closes.
                 self.publish_snapshot_chain_locked(wakes);
             }
-            if let Some(scope) = nested {
+            if let Some(scope) = nested
+                && matches!(scope.record().state, ScopeState::Stopped { .. })
+            {
+                // A parent fallback can terminalize a live nested membership
+                // before cancellation drops the nested driver. Keep that
+                // scope's stream open until its own epilogue publishes the
+                // final Stopped record; otherwise waiters would receive a
+                // terminal stream carrying Starting/Running as its payload.
                 scope.close_observation_locked(wakes);
             }
             true
@@ -1561,8 +1579,14 @@ impl ScopeCell {
                 control.force = None;
             }
             let terminal = terminal_exit.is_some();
+            let membership_terminal =
+                matches!(self.member.record().stage, MemberStage::Terminal(_));
             self.publish_stopped_locked(wakes, reason, terminal_exit, Some(control));
-            if terminal {
+            if terminal || membership_terminal {
+                // A parent-driver fallback may have terminalized this nested
+                // membership while its live scope epilogue was still
+                // pending. The epilogue owns the final Stopped projection and
+                // closes observation only after publishing it.
                 self.close_observation_locked(wakes);
             }
         });

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -920,6 +920,12 @@ impl ScopeCell {
             .collect()
     }
 
+    pub(crate) fn has_resident_child(&self, member: &MemberCell) -> bool {
+        self.current_children()
+            .iter()
+            .any(|resident| resident.projection.member.membership() == member.membership())
+    }
+
     fn current_children(&self) -> MutexGuard<'_, Vec<ResidentChild>> {
         self.current_children
             .lock()

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -228,8 +228,11 @@ struct ScopeCompletion {
 impl Drop for ScopeRuntime {
     fn drop(&mut self) {
         let dynamic_entries = if let Some(dynamic) = &self.dynamic {
-            let entries = dynamic.close();
-            self.root.set_dynamic_route(None);
+            let entries = self.root.with_observation_gate(|txn| {
+                let entries = dynamic.close(txn);
+                self.root.set_dynamic_route_locked(None, txn);
+                entries
+            });
             Some(entries)
         } else {
             None
@@ -304,7 +307,9 @@ impl ScopeRuntime {
             } else {
                 NotAdmittingCause::NoLiveIncarnation
             };
-            let (definition, removed) = cancel_dynamic_reservation_parts(&control, &request.slot);
+            let (definition, removed) = self.root.with_observation_gate(|txn| {
+                cancel_dynamic_reservation_parts(&control, &request.slot, txn)
+            });
             reject_admission_after_disposal(
                 request,
                 definition,
@@ -314,7 +319,9 @@ impl ScopeRuntime {
             return;
         }
         if request.fused_cancel.as_ref().is_some_and(Latch::is_fired) {
-            let (definition, removed) = cancel_dynamic_reservation_parts(&control, &request.slot);
+            let (definition, removed) = self.root.with_observation_gate(|txn| {
+                cancel_dynamic_reservation_parts(&control, &request.slot, txn)
+            });
             reject_admission_after_disposal(
                 request,
                 definition,
@@ -327,7 +334,9 @@ impl ScopeRuntime {
         let (definition, resolved) = match request.slot.resolve_and_take_defined(&self.defaults) {
             Ok(Some(claimed)) => claimed,
             Ok(None) => {
-                let (_, removed) = cancel_dynamic_reservation_parts(&control, &request.slot);
+                let (_, removed) = self.root.with_observation_gate(|txn| {
+                    cancel_dynamic_reservation_parts(&control, &request.slot, txn)
+                });
                 reject_admission_after_disposal(
                     request,
                     None,
@@ -337,8 +346,9 @@ impl ScopeRuntime {
                 return;
             }
             Err(invalid) => {
-                let (definition, removed) =
-                    cancel_dynamic_reservation_parts(&control, &request.slot);
+                let (definition, removed) = self.root.with_observation_gate(|txn| {
+                    cancel_dynamic_reservation_parts(&control, &request.slot, txn)
+                });
                 reject_admission_after_disposal(
                     request,
                     definition,
@@ -354,32 +364,31 @@ impl ScopeRuntime {
         // so driver teardown can still close reservations and removals.
         let mut child = ChildRuntime::from_plan(plan, &self.root);
         child.initial = false;
-        let key = {
+        enum AdmissionInstall {
+            Admitted(ChildKey),
+            Rejected {
+                child: Box<ChildRuntime>,
+                removed: Option<DynamicEntry>,
+                error: ReserveError,
+            },
+        }
+        let root = Arc::clone(&self.root);
+        let installed = root.with_observation_gate(|txn| {
             let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
             let id = request.slot.member.id();
-            let matches_reservation = state.entries.get(id).is_some_and(|entry| {
+            let matches_reservation = state.entry(id).is_some_and(|entry| {
                 entry.slot.member.membership() == request.slot.member.membership()
                     && entry.is_reserved()
             });
             if !matches_reservation || request.fused_cancel.as_ref().is_some_and(Latch::is_fired) {
-                let removed = matches_reservation
-                    .then(|| state.entries.remove(id))
-                    .flatten();
+                let removed = matches_reservation.then(|| state.remove(id, txn)).flatten();
                 drop(state);
-                request.slot.terminalize_never_started();
-                // The entry's drop completes its removal response; preserve
-                // the same terminality-before-completion ordering as every
-                // other reservation-cancellation path. Definition disposal
-                // is also complete before either waiter regains ownership.
-                child.complete_terminality();
-                let ChildRuntime { construction, .. } = child;
-                reject_admission_after_disposal(
-                    request,
-                    Some(construction),
+                request.slot.terminalize_never_started_locked(txn);
+                return AdmissionInstall::Rejected {
+                    child: Box::new(child),
                     removed,
-                    ReserveError::NotAdmitting(NotAdmittingCause::ReservationEnded),
-                );
-                return;
+                    error: ReserveError::NotAdmitting(NotAdmittingCause::ReservationEnded),
+                };
             }
             // The control-plane lock makes arena insertion and promotion one
             // state transition: an exact remover sees either the reservation
@@ -388,29 +397,40 @@ impl ScopeRuntime {
             let key = match self.children.insert(child) {
                 Ok(key) => key,
                 Err(child) => {
-                    let removed = state.entries.remove(id);
+                    let removed = state.remove(id, txn);
                     drop(state);
-                    let mut child = *child;
-                    request.slot.terminalize_never_started();
-                    child.complete_terminality();
-                    let ChildRuntime { construction, .. } = child;
-                    reject_admission_after_disposal(
-                        request,
-                        Some(construction),
+                    request.slot.terminalize_never_started_locked(txn);
+                    return AdmissionInstall::Rejected {
+                        child,
                         removed,
-                        ReserveError::IdentityExhausted,
-                    );
-                    return;
+                        error: ReserveError::IdentityExhausted,
+                    };
                 }
             };
             let entry = state
-                .entries
-                .get_mut(id)
+                .entry_mut(id)
                 .expect("the matching reservation was just resolved");
-            entry.promote(key, request.fused_cancel.take());
-            key
+            entry.promote(key, request.fused_cancel.take(), txn);
+            root.admit_child_locked(resident_projection(&request.slot), txn);
+            AdmissionInstall::Admitted(key)
+        });
+        let key = match installed {
+            AdmissionInstall::Admitted(key) => key,
+            AdmissionInstall::Rejected {
+                mut child,
+                removed,
+                error,
+            } => {
+                // The entry's drop completes its removal response; preserve
+                // the same terminality-before-completion ordering as every
+                // other reservation-cancellation path. Definition disposal
+                // is also complete before either waiter regains ownership.
+                child.complete_terminality();
+                let ChildRuntime { construction, .. } = *child;
+                reject_admission_after_disposal(request, Some(construction), removed, error);
+                return;
+            }
         };
-        self.root.admit_child(resident_projection(&request.slot));
         #[cfg(test)]
         self.record_storage();
         request.complete(Ok(()));
@@ -567,7 +587,10 @@ async fn run_scope_incarnation(
 ) -> StopReason {
     let root = Arc::clone(&plan.root);
     if role.is_root() {
-        root.member.transition(MemberTransition::Running);
+        root.with_observation_gate(|txn| {
+            root.member
+                .transition_locked(txn, MemberTransition::Running);
+        });
     }
     // Both lanes are unbounded so their producers can publish synchronously.
     // Keep child lifecycle events separate from externally generated dynamic
@@ -606,7 +629,9 @@ async fn run_scope_incarnation(
         }
     }
     if let Some(control) = &dynamic {
-        control.register_initial(children.iter().map(|(key, child)| (&child.slot, key)));
+        root.with_observation_gate(|txn| {
+            control.register_initial(children.iter().map(|(key, child)| (&child.slot, key)), txn);
+        });
     }
     let next_ordered_start = children.keys().next();
     let mut scope = ScopeRuntime {

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -436,9 +436,13 @@ fn signal_fused_cancel_impl(
     latch: &Latch,
     txn: &mut ObservationTxn<'_>,
 ) {
-    if !latch.fire() {
+    // The fire linearizes inside the transaction so a racing `remove` sees a
+    // decided latch, but the waker-visible wake must not run under the gate.
+    if !latch.fire_silently() {
         return;
     }
+    let latch = latch.clone();
+    txn.defer(move || latch.notify());
     // A fused drop and an explicit `remove` dedup only within their own
     // source (each behind a once-firing latch), not against each other:
     // `mark_removing` also succeeds on an already-Removing entry, so the
@@ -517,7 +521,11 @@ fn remove_dynamic_impl(
     if member.record().membership_status != MembershipStatus::Removing {
         scope.set_child_removing_locked(&member, txn);
     }
-    if member.removal.fire() {
+    // The fire linearizes inside the transaction; the waker-visible wake is
+    // deferred past the gate release.
+    if member.removal.fire_silently() {
+        let removal = member.removal.clone();
+        txn.defer(move || removal.notify());
         // This latch dedups repeated `remove` calls, but not a concurrent
         // fused drop, which queues its own `RemovalRequest` for the same
         // membership (see `signal_fused_cancel_impl`). The driver's stop

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -8,7 +8,9 @@ use std::{
 use crate::{
     ChildId, Membership, ScopeState,
     admission::{NotAdmittingCause, RemoveOutcome, ReserveError},
-    cells::{DynamicRoute, ErasedDynamicRoute, ErasedDynamicSlot, MemberStage, ScopeCell},
+    cells::{
+        DynamicRoute, ErasedDynamicRoute, ErasedDynamicSlot, MemberStage, ObservationTxn, ScopeCell,
+    },
     engine::MembershipStatus,
     plan::{
         ChildConstruction, SlotCell, checked_id, concrete_dynamic_slot, concrete_dynamic_slot_ref,
@@ -136,12 +138,17 @@ impl DynamicEntry {
         self.key() == Some(key)
     }
 
-    pub(super) fn promote(&mut self, key: ChildKey, fused_cancel: Option<Latch>) {
+    pub(super) fn promote(
+        &mut self,
+        key: ChildKey,
+        fused_cancel: Option<Latch>,
+        _txn: &mut ObservationTxn<'_>,
+    ) {
         debug_assert!(self.is_reserved(), "only a reservation can become resident");
         self.state = DynamicMembershipState::Resident { key, fused_cancel };
     }
 
-    pub(super) fn mark_removing(&mut self) -> Option<ChildKey> {
+    pub(super) fn mark_removing(&mut self, _txn: &mut ObservationTxn<'_>) -> Option<ChildKey> {
         let key = self.key()?;
         self.state = DynamicMembershipState::Removing { key };
         Some(key)
@@ -161,7 +168,45 @@ impl DynamicEntry {
 
 pub(super) struct DynamicState {
     accepting: bool,
+    #[cfg(not(test))]
+    entries: HashMap<ChildId, DynamicEntry>,
+    #[cfg(test)]
     pub(super) entries: HashMap<ChildId, DynamicEntry>,
+}
+
+impl DynamicState {
+    pub(super) fn entry(&self, id: &ChildId) -> Option<&DynamicEntry> {
+        self.entries.get(id)
+    }
+
+    pub(super) fn entry_mut(&mut self, id: &ChildId) -> Option<&mut DynamicEntry> {
+        self.entries.get_mut(id)
+    }
+
+    fn insert(
+        &mut self,
+        id: ChildId,
+        entry: DynamicEntry,
+        _txn: &mut ObservationTxn<'_>,
+    ) -> Option<DynamicEntry> {
+        self.entries.insert(id, entry)
+    }
+
+    pub(super) fn remove(
+        &mut self,
+        id: &ChildId,
+        _txn: &mut ObservationTxn<'_>,
+    ) -> Option<DynamicEntry> {
+        self.entries.remove(id)
+    }
+
+    fn close_admission(&mut self, _txn: &mut ObservationTxn<'_>) {
+        self.accepting = false;
+    }
+
+    fn take_entries(&mut self, _txn: &mut ObservationTxn<'_>) -> HashMap<ChildId, DynamicEntry> {
+        std::mem::take(&mut self.entries)
+    }
 }
 
 pub(crate) struct DynamicControl {
@@ -183,26 +228,35 @@ impl DynamicControl {
     pub(super) fn register_initial<'a>(
         &self,
         slots: impl IntoIterator<Item = (&'a Arc<SlotCell>, ChildKey)>,
+        _txn: &mut ObservationTxn<'_>,
     ) {
         let mut state = self.state.lock().expect("dynamic-state mutex poisoned");
         for (slot, key) in slots {
-            state.entries.insert(
+            state.insert(
                 slot.member.id().clone(),
                 DynamicEntry::resident(Arc::clone(slot), key, None),
+                _txn,
             );
         }
     }
 
-    pub(super) fn close(&self) -> HashMap<ChildId, DynamicEntry> {
+    fn close_admission_in(&self, _txn: &mut ObservationTxn<'_>) {
+        self.state
+            .lock()
+            .expect("dynamic-state mutex poisoned")
+            .close_admission(_txn);
+    }
+
+    pub(super) fn close(&self, txn: &mut ObservationTxn<'_>) -> HashMap<ChildId, DynamicEntry> {
+        self.close_admission_in(txn);
         let mut state = self.state.lock().expect("dynamic-state mutex poisoned");
-        state.accepting = false;
-        let entries = std::mem::take(&mut state.entries);
+        let entries = state.take_entries(txn);
         drop(state);
         let mut retained = HashMap::new();
         for (id, entry) in entries {
             if entry.is_reserved() {
-                let definition = entry.slot.take_never_started();
-                dispose_definition_then(definition, move || drop(entry));
+                let definition = entry.slot.take_never_started_locked(txn);
+                txn.defer(move || dispose_definition_then(definition, move || drop(entry)));
             } else {
                 retained.insert(id, entry);
             }
@@ -215,6 +269,7 @@ impl DynamicControl {
 }
 
 pub(crate) struct DynamicReservation {
+    pub(crate) scope: Arc<ScopeCell>,
     pub(crate) slot: Arc<SlotCell>,
     pub(crate) control: Arc<ErasedDynamicRoute>,
 }
@@ -228,12 +283,23 @@ pub(crate) fn reserve_dynamic(
     if !runtime::is_available() {
         return Err(ReserveError::NoRuntime);
     }
+    scope.with_observation_gate(|txn| reserve_dynamic_in(scope, id, child_scope, txn))
+}
+
+pub(super) fn reserve_dynamic_in(
+    scope: &Arc<ScopeCell>,
+    id: ChildId,
+    child_scope: Option<ScopeFlavor>,
+    txn: &mut ObservationTxn<'_>,
+) -> Result<DynamicReservation, ReserveError> {
     if matches!(scope.member.record().stage, MemberStage::Terminal(_)) {
         return Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal));
     }
-    let control = scope.dynamic_route().ok_or(ReserveError::NotAdmitting(
-        NotAdmittingCause::NoLiveIncarnation,
-    ))?;
+    let control = scope
+        .dynamic_route_in(txn)
+        .ok_or(ReserveError::NotAdmitting(
+            NotAdmittingCause::NoLiveIncarnation,
+        ))?;
     match scope.record().state {
         ScopeState::Starting | ScopeState::Running => {}
         ScopeState::Draining => {
@@ -248,8 +314,12 @@ pub(crate) fn reserve_dynamic(
             ));
         }
     }
-    let slot = concrete_dynamic_slot(control.reserve(scope, id, child_scope)?);
-    Ok(DynamicReservation { slot, control })
+    let slot = concrete_dynamic_slot(control.reserve(scope, id, child_scope, txn)?);
+    Ok(DynamicReservation {
+        scope: Arc::clone(scope),
+        slot,
+        control,
+    })
 }
 
 fn reserve_dynamic_slot(
@@ -257,21 +327,21 @@ fn reserve_dynamic_slot(
     scope: &Arc<ScopeCell>,
     id: ChildId,
     child_scope: Option<ScopeFlavor>,
+    _txn: &mut ObservationTxn<'_>,
 ) -> Result<Arc<SlotCell>, ReserveError> {
     let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
     if !state.accepting {
         return Err(ReserveError::NotAdmitting(NotAdmittingCause::Draining));
     }
-    if let Some(existing) = state.entries.get(&id) {
+    if let Some(existing) = state.entry(&id) {
         if existing.removal_requested() {
             return Err(ReserveError::RemovalInProgress(id));
         }
         return Err(ReserveError::DuplicateId(id));
     }
     let slot = mint_reserved_slot(scope, &id, child_scope)?;
-    state
-        .entries
-        .insert(id, DynamicEntry::reserved(Arc::clone(&slot)));
+    scope.adopt_child_observation_gate(&slot.member, slot.scope.as_deref(), _txn);
+    state.insert(id, DynamicEntry::reserved(Arc::clone(&slot)), _txn);
     Ok(slot)
 }
 
@@ -309,45 +379,63 @@ fn start_dynamic_admission(
 pub(super) fn cancel_dynamic_reservation_parts(
     control: &DynamicControl,
     slot: &SlotCell,
+    txn: &mut ObservationTxn<'_>,
 ) -> (
     Option<runtime::Isolated<ChildConstruction>>,
     Option<DynamicEntry>,
 ) {
     let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
     let id = slot.member.id().clone();
-    let cancelled = state.entries.get(&id).is_some_and(|entry| {
+    let cancelled = state.entry(&id).is_some_and(|entry| {
         entry.slot.member.membership() == slot.member.membership() && entry.is_reserved()
     });
-    let removed = cancelled.then(|| state.entries.remove(&id)).flatten();
+    let removed = cancelled.then(|| state.remove(&id, txn)).flatten();
     drop(state);
     let definition = if cancelled {
-        slot.take_never_started()
+        slot.take_never_started_locked(txn)
     } else {
         None
     };
     (definition, removed)
 }
 
-pub(crate) fn cancel_dynamic_reservation(control: &ErasedDynamicRoute, slot: &Arc<SlotCell>) {
-    control.cancel_reservation(slot.as_ref());
+pub(crate) fn cancel_dynamic_reservation(
+    scope: &Arc<ScopeCell>,
+    control: &ErasedDynamicRoute,
+    slot: &Arc<SlotCell>,
+) {
+    scope.with_observation_gate(|txn| control.cancel_reservation(slot.as_ref(), txn));
 }
 
-fn cancel_dynamic_reservation_impl(control: &DynamicControl, slot: &SlotCell) {
-    let (definition, removed) = cancel_dynamic_reservation_parts(control, slot);
+fn cancel_dynamic_reservation_impl(
+    control: &DynamicControl,
+    slot: &SlotCell,
+    txn: &mut ObservationTxn<'_>,
+) {
+    let (definition, removed) = cancel_dynamic_reservation_parts(control, slot, txn);
     // The entry's drop completes its removal response; it must follow the
     // member's terminal publication and isolated definition disposal.
-    dispose_definition_then(definition, move || drop(removed));
+    txn.defer(move || dispose_definition_then(definition, move || drop(removed)));
 }
 
 pub(crate) fn signal_fused_cancel(
+    scope: &Arc<ScopeCell>,
     control: &ErasedDynamicRoute,
     slot: &Arc<SlotCell>,
     latch: &Latch,
 ) {
-    control.signal_fused_cancel(slot.as_ref(), latch);
+    scope.with_observation_gate(|txn| {
+        control.signal_fused_cancel(scope, slot.as_ref(), latch, txn);
+    });
 }
 
-fn signal_fused_cancel_impl(control: &DynamicControl, slot: &SlotCell, latch: &Latch) {
+fn signal_fused_cancel_impl(
+    control: &DynamicControl,
+    scope: &Arc<ScopeCell>,
+    slot: &SlotCell,
+    latch: &Latch,
+    txn: &mut ObservationTxn<'_>,
+) {
     if !latch.fire() {
         return;
     }
@@ -355,23 +443,24 @@ fn signal_fused_cancel_impl(control: &DynamicControl, slot: &SlotCell, latch: &L
     // source (each behind a once-firing latch), not against each other:
     // `mark_removing` also succeeds on an already-Removing entry, so the
     // same membership can queue one `RemovalRequest` per source. The
-    // duplicate is benign by construction — `handle_removal` re-enters
-    // `publish_dynamic_removal` behind the record's status guard and
-    // `begin_stop_child` behind its ladder/disposal idempotency guards.
+    // duplicate is benign by construction — the shared transaction retains
+    // one Removing phase/projection, and `begin_stop_child` is idempotent.
     let removal = {
         let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
         state
-            .entries
-            .get_mut(slot.member.id())
+            .entry_mut(slot.member.id())
             .filter(|entry| entry.slot.member.membership() == slot.member.membership())
-            .and_then(DynamicEntry::mark_removing)
+            .and_then(|entry| entry.mark_removing(txn))
             .map(|key| RemovalRequest {
                 membership: slot.member.membership(),
                 key,
             })
     };
     if let Some(removal) = removal {
-        queue_driver_event(control, DriverEvent::Removal(removal));
+        if slot.member.record().membership_status != MembershipStatus::Removing {
+            scope.set_child_removing_locked(&slot.member, txn);
+        }
+        defer_driver_event(txn, control, DriverEvent::Removal(removal));
     }
 }
 
@@ -380,16 +469,18 @@ pub(crate) fn remove_dynamic(
     id: &ChildId,
     exact: Option<Membership>,
 ) -> RemovalResponse {
-    if matches!(
-        scope.record().state,
-        ScopeState::Draining | ScopeState::Stopped { .. }
-    ) {
-        return completed_removal(RemoveOutcome::AlreadyAbsent);
-    }
-    let Some(control) = scope.dynamic_route() else {
-        return completed_removal(RemoveOutcome::AlreadyAbsent);
-    };
-    control.remove(scope, id, exact)
+    scope.with_observation_gate(|txn| {
+        if matches!(
+            scope.record().state,
+            ScopeState::Draining | ScopeState::Stopped { .. }
+        ) {
+            return completed_removal(RemoveOutcome::AlreadyAbsent);
+        }
+        let Some(control) = scope.dynamic_route_in(txn) else {
+            return completed_removal(RemoveOutcome::AlreadyAbsent);
+        };
+        control.remove(scope, id, exact, txn)
+    })
 }
 
 fn remove_dynamic_impl(
@@ -397,9 +488,10 @@ fn remove_dynamic_impl(
     scope: &Arc<ScopeCell>,
     id: &ChildId,
     exact: Option<Membership>,
+    txn: &mut ObservationTxn<'_>,
 ) -> RemovalResponse {
     let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-    let Some(entry) = state.entries.get_mut(id) else {
+    let Some(entry) = state.entry_mut(id) else {
         return completed_removal(RemoveOutcome::AlreadyAbsent);
     };
     if exact.is_some_and(|membership| membership != entry.slot.member.membership()) {
@@ -407,10 +499,10 @@ fn remove_dynamic_impl(
     }
     let response = entry.removal.payload_mut().subscribe();
     if entry.is_reserved() {
-        let entry = state.entries.remove(id).expect("entry was just resolved");
+        let entry = state.remove(id, txn).expect("entry was just resolved");
         drop(state);
-        let definition = entry.slot.take_never_started();
-        dispose_definition_then(definition, move || drop(entry));
+        let definition = entry.slot.take_never_started_locked(txn);
+        txn.defer(move || dispose_definition_then(definition, move || drop(entry)));
         return response;
     }
     // Terminal residents still have a driver registration. Route them
@@ -419,25 +511,19 @@ fn remove_dynamic_impl(
     let member = Arc::clone(&entry.slot.member);
     let membership = member.membership();
     let key = entry
-        .mark_removing()
+        .mark_removing(txn)
         .expect("a non-reservation has a resident child key");
-    // Dynamic-state protects admission/removal bookkeeping; the observation
-    // gate protects the public projection. Release the former before entering
-    // the latter. No path takes the two in the opposite order, so this is not
-    // breaking an existing cycle; it keeps an unbounded wait out of the
-    // bookkeeping mutex. Any thread may hold the gate across arbitrary
-    // observation work, and blocking there while holding dynamic state would
-    // stall every concurrent reservation, removal, and driver admission.
     drop(state);
     if member.record().membership_status != MembershipStatus::Removing {
-        scope.set_child_removing(&member);
+        scope.set_child_removing_locked(&member, txn);
     }
     if member.removal.fire() {
         // This latch dedups repeated `remove` calls, but not a concurrent
         // fused drop, which queues its own `RemovalRequest` for the same
         // membership (see `signal_fused_cancel_impl`). The driver's stop
         // path must therefore stay idempotent under a second delivery.
-        queue_driver_event(
+        defer_driver_event(
+            txn,
             control,
             DriverEvent::Removal(RemovalRequest { membership, key }),
         );
@@ -453,8 +539,13 @@ impl DynamicRoute for DynamicControl {
         scope: &Arc<ScopeCell>,
         id: ChildId,
         child_scope: Option<ScopeFlavor>,
+        txn: &mut ObservationTxn<'_>,
     ) -> Result<Arc<Self::Slot>, ReserveError> {
-        reserve_dynamic_slot(self, scope, id, child_scope).map(erase_dynamic_slot)
+        reserve_dynamic_slot(self, scope, id, child_scope, txn).map(erase_dynamic_slot)
+    }
+
+    fn close_admission(&self, txn: &mut ObservationTxn<'_>) {
+        self.close_admission_in(txn);
     }
 
     fn start_admission(
@@ -465,12 +556,18 @@ impl DynamicRoute for DynamicControl {
         start_dynamic_admission(self, concrete_dynamic_slot(slot), fused_cancel)
     }
 
-    fn cancel_reservation(&self, slot: &Self::Slot) {
-        cancel_dynamic_reservation_impl(self, concrete_dynamic_slot_ref(slot));
+    fn cancel_reservation(&self, slot: &Self::Slot, txn: &mut ObservationTxn<'_>) {
+        cancel_dynamic_reservation_impl(self, concrete_dynamic_slot_ref(slot), txn);
     }
 
-    fn signal_fused_cancel(&self, slot: &Self::Slot, latch: &Latch) {
-        signal_fused_cancel_impl(self, concrete_dynamic_slot_ref(slot), latch);
+    fn signal_fused_cancel(
+        &self,
+        scope: &Arc<ScopeCell>,
+        slot: &Self::Slot,
+        latch: &Latch,
+        txn: &mut ObservationTxn<'_>,
+    ) {
+        signal_fused_cancel_impl(self, scope, concrete_dynamic_slot_ref(slot), latch, txn);
     }
 
     fn remove(
@@ -478,8 +575,9 @@ impl DynamicRoute for DynamicControl {
         scope: &Arc<ScopeCell>,
         id: &ChildId,
         exact: Option<Membership>,
+        txn: &mut ObservationTxn<'_>,
     ) -> RemovalResponse {
-        remove_dynamic_impl(self, scope, id, exact)
+        remove_dynamic_impl(self, scope, id, exact, txn)
     }
 }
 
@@ -487,6 +585,13 @@ fn queue_driver_event(control: &DynamicControl, event: DriverEvent) {
     // Synchronous and runtime-independent: admission detaches at its first
     // poll, and removal may be signalled from a foreign thread.
     let _ = runtime::unbounded_mpsc_send(&control.requests, event);
+}
+
+fn defer_driver_event(txn: &mut ObservationTxn<'_>, control: &DynamicControl, event: DriverEvent) {
+    let requests = control.requests.clone();
+    txn.defer(move || {
+        let _ = runtime::unbounded_mpsc_send(&requests, event);
+    });
 }
 
 pub(super) struct AdmissionRequest {

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -131,14 +131,9 @@ pub(super) fn discharge_child_terminality(completion: ChildTerminality) {
             record.incarnation,
         )
     };
-    // `incarnation: None` also describes the gap between two incarnations.
-    // Only a membership that never ran needs a synthesized scope stop; a
-    // restarting scope already published its real reason in its last
-    // incarnation's epilogue, and replacing it here would make `wait_stopped`
-    // incorrectly report `NeverStarted`.
-    if never_started && let Some(scope) = &completion.slot.scope {
-        scope.terminalize_never_started();
-    }
+    // `terminalize_child` synthesizes the nested NeverStarted scope stop in
+    // the same observation transaction as the parent membership edge. A
+    // restarting scope already published its real prior-incarnation reason.
     completion.root.terminalize_child(
         &completion.slot.member,
         exit,
@@ -933,10 +928,13 @@ impl ScopeRuntime {
                 if decision.charge.tripped {
                     let trip = IntensityTrip::new(self.intensity_policy, decision.charge);
                     if self.lifecycle.is_starting() {
-                        self.root
-                            .set_startup(Err(StartupError::IntensityTripped(trip.clone())));
+                        self.begin_drain_with_startup(
+                            StopReason::IntensityTripped(trip.clone()),
+                            Err(StartupError::IntensityTripped(trip)),
+                        );
+                    } else {
+                        self.begin_drain(StopReason::IntensityTripped(trip));
                     }
-                    self.begin_drain(StopReason::IntensityTripped(trip));
                 } else {
                     if let Some(restart_at) = decision.restart_at {
                         child.restart_deadline = Some(
@@ -1041,11 +1039,6 @@ impl ScopeRuntime {
             startup,
         );
         if self.dynamic_membership_is_removing(key) {
-            // A foreign remover may have committed the control-plane state
-            // and be waiting for this thread's observation gate. Publish the
-            // Removing projection before pruning so the public lifecycle
-            // cannot skip directly from resident to Removed.
-            self.publish_dynamic_removal(key);
             self.finalize_removal(key);
         } else if terminal.startup == StartupDisposition::Aborted && !self.lifecycle.is_draining() {
             self.fail_startup(key, exit);

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -131,9 +131,17 @@ pub(super) fn discharge_child_terminality(completion: ChildTerminality) {
             record.incarnation,
         )
     };
-    // `terminalize_child` synthesizes the nested NeverStarted scope stop in
-    // the same observation transaction as the parent membership edge. A
-    // restarting scope already published its real prior-incarnation reason.
+    // Initial-child conversion precedes residency publication. If a later
+    // conversion unwinds, use the slot-owned gate for the converted prefix;
+    // `terminalize_child` cannot discover those slots through the parent's
+    // resident list yet. Once resident, the parent path synthesizes a nested
+    // NeverStarted scope stop in the same observation transaction as the
+    // membership edge. A restarting scope already published its real prior-
+    // incarnation reason.
+    if never_started && !completion.root.has_resident_child(&completion.slot.member) {
+        completion.slot.terminalize_never_started();
+        return;
+    }
     completion.root.terminalize_child(
         &completion.slot.member,
         exit,

--- a/crates/shelterwood/src/driver/events.rs
+++ b/crates/shelterwood/src/driver/events.rs
@@ -132,8 +132,7 @@ impl ScopeRuntime {
                 .state
                 .lock()
                 .expect("dynamic-state mutex poisoned")
-                .entries
-                .get(child.slot.member.id())
+                .entry(child.slot.member.id())
                 .filter(|entry| entry.slot.member.membership() == child.slot.member.membership())
                 .is_some_and(|entry| entry.restart_is_suppressed(key))
         });

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -16,32 +16,10 @@ impl ScopeRuntime {
                 .state
                 .lock()
                 .expect("dynamic-state mutex poisoned")
-                .entries
-                .get(child.slot.member.id())
+                .entry(child.slot.member.id())
                 .filter(|entry| entry.slot.member.membership() == child.slot.member.membership())
                 .is_some_and(|entry| entry.is_removing() && entry.matches_key(key))
         })
-    }
-
-    pub(super) fn publish_dynamic_removal(&self, key: ChildKey) {
-        let Some(member) = self
-            .children
-            .get(key)
-            .map(|child| Arc::clone(&child.slot.member))
-        else {
-            return;
-        };
-        // Idempotency hygiene rather than a load-bearing guard: an explicit
-        // removal publishes this projection before its request reaches the
-        // driver, and duplicate deliveries re-enter here after the first
-        // publication. Skipping the transition only avoids re-publishing an
-        // identical record under the observation gate; no public observable
-        // distinguishes that redundant publication, so tests pin the call
-        // sites (the fused-only removal path, where this write is the sole
-        // Removing-projection writer) rather than this check.
-        if member.record().membership_status != MembershipStatus::Removing {
-            self.root.set_child_removing(&member);
-        }
     }
 
     pub(super) fn handle_removal(&mut self, removal: RemovalRequest) {
@@ -57,26 +35,26 @@ impl ScopeRuntime {
         let Some(control) = &self.dynamic else {
             return;
         };
-        let tracked = {
+        let root = Arc::clone(&self.root);
+        let tracked = root.with_observation_gate(|txn| {
             let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-            state
-                .entries
-                .get_mut(member.id())
+            let tracked = state
+                .entry_mut(member.id())
                 .filter(|entry| entry.slot.member.membership() == membership)
-                .and_then(DynamicEntry::mark_removing)
-                .is_some_and(|tracked| tracked == key)
-        };
+                .and_then(|entry| entry.mark_removing(txn))
+                .is_some_and(|tracked| tracked == key);
+            if tracked && member.record().membership_status != MembershipStatus::Removing {
+                root.set_child_removing_locked(&member, txn);
+            }
+            tracked
+        });
         if !tracked {
             return;
         }
-        // A fused drop and an explicit `remove` each queue one
-        // `RemovalRequest` for the same membership, and `mark_removing`
-        // deliberately re-succeeds on an already-Removing entry, so a second
-        // delivery reaches this point. Every step below is idempotent:
-        // `publish_dynamic_removal` is guarded by the record's status
-        // flag, `begin_stop_child` by its ladder/disposal guards, and
-        // `finalize_removal` removes the entry it matched.
-        self.publish_dynamic_removal(key);
+        // A fused drop and an explicit `remove` can each queue one request for
+        // the same membership. The phase/projection transaction above,
+        // `begin_stop_child`'s ladder guards, and `finalize_removal`'s exact
+        // match keep that duplicate delivery idempotent.
         if self.children[key].is_terminal() {
             self.finalize_removal(key);
         } else {
@@ -93,15 +71,24 @@ impl ScopeRuntime {
         };
         let member = Arc::clone(&self.children[key].slot.member);
         let id = member.id().clone();
-        let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-        if state.entries.get(&id).is_some_and(|entry| {
-            entry.slot.member.membership() == member.membership()
-                && entry.matches_key(key)
-                && entry.is_removing()
-        }) {
-            let entry = state.entries.remove(&id).expect("entry was just resolved");
-            drop(state);
-            self.root.prune_child(&member);
+        let root = Arc::clone(&self.root);
+        let entry = root.with_observation_gate(|txn| {
+            let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
+            let matches = state.entry(&id).is_some_and(|entry| {
+                entry.slot.member.membership() == member.membership()
+                    && entry.matches_key(key)
+                    && entry.is_removing()
+            });
+            if !matches {
+                return None;
+            }
+            // Residency is withdrawn while the identifier remains claimed.
+            // A new reservation can therefore observe only the old resident
+            // or the committed Removed edge, never a reused-id overlap.
+            root.prune_child_locked(&member, txn);
+            state.remove(&id, txn)
+        });
+        if let Some(entry) = entry {
             self.reclaim_child(key);
             drop(entry);
         }
@@ -109,17 +96,26 @@ impl ScopeRuntime {
 
     pub(super) fn prune_terminal(&mut self, key: ChildKey) {
         let member = Arc::clone(&self.children[key].slot.member);
-        let mut removed = None;
-        if let Some(control) = &self.dynamic {
-            let id = member.id().clone();
-            let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-            if state.entries.get(&id).is_some_and(|entry| {
-                entry.slot.member.membership() == member.membership() && entry.matches_key(key)
-            }) {
-                removed = state.entries.remove(&id);
+        let root = Arc::clone(&self.root);
+        let removed = root.with_observation_gate(|txn| {
+            let mut state = self
+                .dynamic
+                .as_ref()
+                .map(|control| control.state.lock().expect("dynamic-state mutex poisoned"));
+            let matches = state.as_ref().is_some_and(|state| {
+                state.entry(member.id()).is_some_and(|entry| {
+                    entry.slot.member.membership() == member.membership() && entry.matches_key(key)
+                })
+            });
+            root.prune_child_locked(&member, txn);
+            if matches {
+                state
+                    .as_mut()
+                    .and_then(|state| state.remove(member.id(), txn))
+            } else {
+                None
             }
-        }
-        self.root.prune_child(&member);
+        });
         if self.root.flavor == ScopeFlavor::Dynamic {
             self.reclaim_child(key);
         }

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -37,12 +37,17 @@ impl ScopeRuntime {
         };
         let root = Arc::clone(&self.root);
         let tracked = root.with_observation_gate(|txn| {
-            let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-            let tracked = state
-                .entry_mut(member.id())
-                .filter(|entry| entry.slot.member.membership() == membership)
-                .and_then(|entry| entry.mark_removing(txn))
-                .is_some_and(|tracked| tracked == key);
+            let tracked = {
+                let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
+                state
+                    .entry_mut(member.id())
+                    .filter(|entry| entry.slot.member.membership() == membership)
+                    .and_then(|entry| entry.mark_removing(txn))
+                    .is_some_and(|tracked| tracked == key)
+            };
+            // The Removing projection publishes outside the dynamic-state
+            // mutex, like the sibling writers in `admission_control`; the
+            // observation gate alone serializes the mutation.
             if tracked && member.record().membership_status != MembershipStatus::Removing {
                 root.set_child_removing_locked(&member, txn);
             }

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -77,13 +77,35 @@ pub(crate) async fn shutdown_scope(
 
 impl ScopeRuntime {
     pub(super) fn begin_drain(&mut self, reason: StopReason) {
+        let startup = self
+            .lifecycle
+            .is_starting()
+            .then_some(Err(StartupError::ShutdownRequested));
+        self.begin_drain_transition(reason, startup);
+    }
+
+    pub(super) fn begin_drain_with_startup(
+        &mut self,
+        reason: StopReason,
+        startup: Result<(), StartupError>,
+    ) {
+        self.begin_drain_transition(reason, Some(startup));
+    }
+
+    fn begin_drain_transition(
+        &mut self,
+        reason: StopReason,
+        startup: Option<Result<(), StartupError>>,
+    ) {
         let Some(effect) = self.lifecycle.begin_drain(reason) else {
             return;
         };
-        if effect.startup_pending {
-            self.root.set_startup(Err(StartupError::ShutdownRequested));
+        if let Some(startup) = startup {
+            self.root.set_state_and_startup(effect.state, startup);
+        } else {
+            debug_assert!(!effect.startup_pending);
+            self.root.set_state(effect.state);
         }
-        self.root.set_state(effect.state);
         match self.root.flavor {
             ScopeFlavor::Ordered => {
                 self.ordered_stop_cursor = self.children.keys().next_back();

--- a/crates/shelterwood/src/driver/startup.rs
+++ b/crates/shelterwood/src/driver/startup.rs
@@ -106,8 +106,7 @@ impl ScopeRuntime {
         let Some(state) = self.lifecycle.complete_startup() else {
             return;
         };
-        self.root.set_state(state);
-        self.root.set_startup(Ok(()));
+        self.root.set_state_and_startup(state, Ok(()));
         if let Some(parent_ready) = self.role.parent_ready() {
             parent_ready.fire();
         }
@@ -146,8 +145,6 @@ impl ScopeRuntime {
         let Some(state) = self.lifecycle.fail_startup() else {
             return;
         };
-        self.root
-            .set_startup(Err(StartupError::StartupFailed(failure.clone())));
         if self.root.flavor == ScopeFlavor::Ordered {
             let later_children: Vec<_> = self.children.keys_after(key).collect();
             for later in later_children {
@@ -165,9 +162,13 @@ impl ScopeRuntime {
             }
         }
         if self.role.is_root() {
-            self.root.set_state(state);
+            self.root
+                .set_state_and_startup(state, Err(StartupError::StartupFailed(failure.clone())));
         } else {
-            self.begin_drain(StopReason::StartupFailed(failure));
+            self.begin_drain_with_startup(
+                StopReason::StartupFailed(failure.clone()),
+                Err(StartupError::StartupFailed(failure)),
+            );
         }
     }
 }

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -277,7 +277,11 @@ impl ReserveOnLifecycleWake {
         if result.is_none() {
             *result = Some(
                 reserve_dynamic(&self.scope, ChildId::from("reentrant"), None).map(|reservation| {
-                    cancel_dynamic_reservation(reservation.control.as_ref(), &reservation.slot);
+                    cancel_dynamic_reservation(
+                        &reservation.scope,
+                        reservation.control.as_ref(),
+                        &reservation.slot,
+                    );
                 }),
             );
             self.observed.fire();

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -184,6 +184,47 @@ async fn dropped_unpolled_scope_plan_terminalizes_nested_declarations() {
 }
 
 #[crate::runtime::test]
+async fn converted_nested_child_without_residency_closes_its_scope_on_drop() {
+    let mut outer = Tree::new();
+    let nested = outer
+        .add_subtree_once("nested", SubtreeOnceDef::new(Tree::new()))
+        .expect("valid nested scope");
+    let mut snapshots = nested.subscribe_snapshots();
+    let mut plan = outer.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let nested_index = plan
+        .children
+        .iter()
+        .position(|child| child.slot.member.id().as_str() == "nested")
+        .expect("nested child is present");
+    let nested_runtime = ChildRuntime::from_plan(plan.children.remove(nested_index), &root);
+
+    assert!(
+        root.snapshot().children.is_empty(),
+        "initial-child conversion precedes residency publication"
+    );
+    // Models an unwind while converting a later child: the converted prefix
+    // is dropped while its nested slot is not yet discoverable as a resident.
+    drop(nested_runtime);
+
+    assert!(matches!(
+        crate::runtime::timeout(Duration::from_secs(1), nested.wait_stopped()).await,
+        crate::runtime::Timeout::Completed(StopReason::NeverStarted)
+    ));
+    snapshots
+        .changed()
+        .await
+        .expect("the final nested snapshot is delivered before closure");
+    assert!(matches!(
+        snapshots.borrow_latest().state,
+        ScopeState::Stopped {
+            reason: StopReason::NeverStarted
+        }
+    ));
+    assert!(snapshots.changed().await.is_err());
+}
+
+#[crate::runtime::test]
 async fn scope_plan_conversion_panic_terminalizes_every_child() {
     let mut tree = Tree::new();
     for id in ["first", "second"] {

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -109,7 +109,7 @@ fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
             DynamicEntry::removing(slot, ChildKey(1), responses),
         );
 
-    let entries = control.close();
+    let entries = root.with_observation_gate(|txn| control.close(txn));
     assert!(
         response.try_receive().is_none(),
         "closing admission must not complete removal before teardown"
@@ -151,7 +151,7 @@ fn reserve_dynamic_rejects_an_empty_id_at_the_driver_boundary() {
 }
 
 #[test]
-fn dynamic_removal_releases_state_before_waiting_for_the_observation_gate() {
+fn dynamic_removal_waits_for_the_observation_gate_before_mutating_state() {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
     let child_id = ChildId::from("worker");
     let member = MemberCell::new(
@@ -183,10 +183,9 @@ fn dynamic_removal_releases_state_before_waiting_for_the_observation_gate() {
     let worker =
         std::thread::spawn(move || super::super::remove_dynamic(&removal_root, &removal_id, None));
 
-    // The capture report proves removal committed to the held observation
-    // gate for its removing transition. Dynamic state cannot change again
-    // until that gate is released, so a single acquisition attempt decides
-    // whether removal reached the gate while still holding the state.
+    // Capturing the gate attempt proves the remover has reached its commit
+    // boundary. No retained control-plane state may change until that one
+    // observation transaction begins.
     assert_eq!(
         captures
             .recv_timeout(CAPTURE_PROBE_WAIT)
@@ -196,33 +195,189 @@ fn dynamic_removal_releases_state_before_waiting_for_the_observation_gate() {
     let state = control
         .state
         .try_lock()
-        .expect("a removal waiting on observation must release dynamic state");
+        .expect("a removal waiting on observation has not acquired or mutated dynamic state");
     let entry = state
         .entries
         .get(&child_id)
         .expect("the removal keeps its resident registration");
-    assert!(entry.is_removing());
+    assert!(!entry.is_removing());
     assert!(entry.matches_key(key));
     drop(state);
+
+    drop(held_gate);
+    let response = worker.join().expect("removal transition completes");
+    drop(response);
 
     let route = root
         .dynamic_route()
         .expect("the fixture exposes its dynamic route");
     assert!(matches!(
-        route.reserve(&root, child_id.clone(), None),
+        root.with_observation_gate(|txn| route.reserve(&root, child_id.clone(), None, txn)),
         Err(crate::ReserveError::RemovalInProgress(id)) if id == child_id
     ));
+}
 
-    drop(held_gate);
-    let response = worker.join().expect("removal transition completes");
-    drop(response);
+#[crate::runtime::test]
+async fn final_removal_holds_the_id_until_removed_publication_commits() {
+    let (mut scope, _events, _dynamic_events, _disposal_events, control) =
+        running_dynamic_fixture();
+    let root = Arc::clone(&scope.root);
+    let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
+        .expect("running dynamic scope reserves the child");
+    let member = Arc::clone(&reservation.slot.member);
+    reservation
+        .slot
+        .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
+    let (definition, resolved) = reservation
+        .slot
+        .resolve_and_take_defined(&scope.defaults)
+        .expect("the definition has not been claimed")
+        .expect("the slot is defined");
+    let plan =
+        crate::plan::ChildPlan::with_options(Arc::clone(&reservation.slot), definition, resolved);
+    let mut child = ChildRuntime::from_plan(plan, &root);
+    child.initial = false;
+    let key = root.with_observation_gate(|txn| {
+        let key = match scope.children.insert(child) {
+            Ok(key) => key,
+            Err(_) => panic!("the empty arena accepts its first child"),
+        };
+        control
+            .state
+            .lock()
+            .expect("dynamic-state mutex poisoned")
+            .entries
+            .get_mut(member.id())
+            .expect("the reservation remains registered")
+            .promote(key, None, txn);
+        root.admit_child_locked(resident_projection(&reservation.slot), txn);
+        key
+    });
+    assert!(scope.children[key].terminalize(
+        &root,
+        Exit::never_started(),
+        None,
+        StartupDisposition::NotAborted,
+    ));
+    let mut removal = super::super::remove_dynamic(&root, member.id(), Some(member.membership()));
+    assert!(root.snapshot().child("worker").is_some());
+
+    let captures = root.probe_gate_captures();
+    let gate = root.observation_gate();
+    let held_gate = gate.lock();
+    std::thread::scope(|threads| {
+        let finalizer = threads.spawn(|| scope.finalize_removal(key));
+        assert_eq!(
+            captures
+                .recv_timeout(CAPTURE_PROBE_WAIT)
+                .expect("finalization reaches its commit gate within the bound"),
+            GateCapture::Observation
+        );
+        assert!(
+            control
+                .state
+                .lock()
+                .expect("dynamic-state mutex remains available")
+                .entries
+                .contains_key(member.id()),
+            "the old id remains claimed until residency withdrawal can commit"
+        );
+        drop(held_gate);
+        finalizer.join().expect("finalization completes");
+    });
+
+    assert!(root.snapshot().child("worker").is_none());
+    assert!(
+        !control
+            .state
+            .lock()
+            .expect("dynamic-state mutex remains healthy")
+            .entries
+            .contains_key(member.id()),
+        "id release follows the Removed publication"
+    );
+    assert_eq!(removal.try_receive(), Some(RemoveOutcome::Removed));
+
+    let replacement = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
+        .expect("the id is reusable after the Removed commit");
+    cancel_dynamic_reservation(
+        &replacement.scope,
+        replacement.control.as_ref(),
+        &replacement.slot,
+    );
+}
+
+#[test]
+fn draining_cannot_publish_across_an_inflight_reservation_transaction() {
+    let root = isolated_scope("root", ScopeFlavor::Dynamic);
+    root.member
+        .update(|record| record.stage = MemberStage::Running);
+    root.set_state(ScopeState::Running);
+    let (events, _receiver) = crate::runtime::unbounded_mpsc();
+    let control = DynamicControl::new(events);
+    root.set_dynamic_route(Some(control.clone()));
+
+    let state = control.state.lock().expect("dynamic-state mutex poisoned");
+    let (entered, observed) = std::sync::mpsc::channel();
+    std::thread::scope(|threads| {
+        let reserve_root = Arc::clone(&root);
+        let reserver = threads.spawn(move || {
+            reserve_root.with_observation_gate(|txn| {
+                entered
+                    .send(())
+                    .expect("the test waits for the reservation transaction");
+                super::super::admission_control::reserve_dynamic_in(
+                    &reserve_root,
+                    ChildId::from("worker"),
+                    None,
+                    txn,
+                )
+            })
+        });
+        observed
+            .recv_timeout(CAPTURE_PROBE_WAIT)
+            .expect("reservation acquires the observation gate");
+
+        let captures = root.probe_gate_captures();
+        let drain_root = Arc::clone(&root);
+        let drainer = threads.spawn(move || drain_root.set_state(ScopeState::Draining));
+        assert_eq!(
+            captures
+                .recv_timeout(CAPTURE_PROBE_WAIT)
+                .expect("draining reaches the occupied gate within the bound"),
+            GateCapture::Observation
+        );
+        assert_eq!(
+            root.record().state,
+            ScopeState::Running,
+            "draining cannot publish after the reservation has read the live phase"
+        );
+
+        drop(state);
+        let reservation = reserver
+            .join()
+            .expect("reservation transaction does not panic")
+            .expect("the earlier transaction reserves before draining");
+        drainer
+            .join()
+            .expect("draining completes after reservation");
+        assert_eq!(root.record().state, ScopeState::Draining);
+        cancel_dynamic_reservation(
+            &reservation.scope,
+            reservation.control.as_ref(),
+            &reservation.slot,
+        );
+    });
 }
 
 #[crate::runtime::test]
 async fn removal_from_a_foreign_thread_reaches_the_driver() {
-    let mut identity = ScopeIdentity::new();
+    let root = isolated_scope("root", ScopeFlavor::Dynamic);
     let child_id = ChildId::from("worker");
-    let membership = identity
+    let membership = root
+        .child_identity
+        .lock()
+        .expect("scope identity mutex poisoned")
         .mint_membership(&child_id)
         .expect("membership available");
     let member = MemberCell::new(child_id.clone(), membership);
@@ -241,12 +396,14 @@ async fn removal_from_a_foreign_thread_reaches_the_driver() {
         );
     let foreign_control = Arc::clone(&control);
     let foreign_slot = Arc::clone(&slot);
+    let foreign_root = Arc::clone(&root);
     std::thread::spawn(move || {
         assert!(
             !crate::runtime::is_available(),
             "Tokio context is not inherited by a foreign thread"
         );
         super::super::signal_fused_cancel(
+            &foreign_root,
             foreign_control.as_ref(),
             &foreign_slot,
             &Latch::default(),
@@ -374,7 +531,11 @@ async fn annulment_before_admission_owns_never_started_terminality() {
         panic!("admission enqueueing submits the request")
     };
 
-    cancel_dynamic_reservation(reservation.control.as_ref(), &reservation.slot);
+    cancel_dynamic_reservation(
+        &reservation.scope,
+        reservation.control.as_ref(),
+        &reservation.slot,
+    );
     let annulled_stage = member.record().stage;
     assert!(matches!(
         &annulled_stage,
@@ -465,7 +626,11 @@ async fn annulment_after_promotion_is_inert_and_supervision_owns_the_exit() {
     // The promoted entry is no longer reserved, so a late annul (a dropped
     // `Admission` future racing its own completion) must not terminalize the
     // now-supervised member.
-    cancel_dynamic_reservation(reservation.control.as_ref(), &reservation.slot);
+    cancel_dynamic_reservation(
+        &reservation.scope,
+        reservation.control.as_ref(),
+        &reservation.slot,
+    );
     assert!(
         !matches!(member.record().stage, MemberStage::Terminal(_)),
         "a late annul cannot compete with supervised terminalization"
@@ -584,9 +749,10 @@ async fn annulment_racing_admission_resolves_to_one_terminalization_owner() {
             let barrier = Arc::clone(&barrier);
             let annul_control = Arc::clone(&reservation.control);
             let annul_slot = Arc::clone(&reservation.slot);
+            let annul_scope = Arc::clone(&reservation.scope);
             std::thread::spawn(move || {
                 barrier.wait();
-                cancel_dynamic_reservation(annul_control.as_ref(), &annul_slot);
+                cancel_dynamic_reservation(&annul_scope, annul_control.as_ref(), &annul_slot);
             })
         };
         barrier.wait();
@@ -661,7 +827,12 @@ async fn fused_cancellation_overtaking_admission_rejects_before_conversion() {
     // `signal_fused_cancel` cannot queue a Removal for this membership;
     // the fired latch is the authoritative rejection evidence until the
     // queued Admission reaches the driver.
-    super::super::signal_fused_cancel(control.as_ref(), &reservation.slot, &fused_cancel);
+    super::super::signal_fused_cancel(
+        &reservation.scope,
+        control.as_ref(),
+        &reservation.slot,
+        &fused_cancel,
+    );
     assert!(fused_cancel.is_fired());
     assert!(
         crate::runtime::unbounded_mpsc_try_recv(&mut dynamic_event_receiver).is_none(),
@@ -753,7 +924,12 @@ async fn fused_cancellation_during_conversion_is_rejected_by_the_under_lock_rech
             }
             std::thread::yield_now();
         }
-        super::super::signal_fused_cancel(control.as_ref(), &reservation.slot, &fused_cancel);
+        super::super::signal_fused_cancel(
+            &reservation.scope,
+            control.as_ref(),
+            &reservation.slot,
+            &fused_cancel,
+        );
         // Release without unwinding: conversion must proceed into the
         // under-lock re-check, not observe a poisoned identity mutex.
         drop(identity);
@@ -850,7 +1026,12 @@ async fn exercise_double_removal(delivery: DuplicateRemovalDelivery) {
         .get(member.id())
         .and_then(DynamicEntry::key)
         .expect("the admission installs its child key");
-    super::super::signal_fused_cancel(control.as_ref(), &reservation.slot, &fused_cancel);
+    super::super::signal_fused_cancel(
+        &reservation.scope,
+        control.as_ref(),
+        &reservation.slot,
+        &fused_cancel,
+    );
     let mut removal_response =
         super::super::remove_dynamic(&root, member.id(), Some(member.membership()));
 
@@ -998,7 +1179,7 @@ async fn double_removal_is_idempotent_during_construction_disposal() {
 }
 
 #[crate::runtime::test]
-async fn fused_only_removal_publishes_removing_from_the_driver() {
+async fn fused_only_removal_commits_phase_and_projection_together() {
     let (
         mut scope,
         mut event_receiver,
@@ -1051,26 +1232,26 @@ async fn fused_only_removal_publishes_removing_from_the_driver() {
         .and_then(DynamicEntry::key)
         .expect("the admission installs its child key");
 
-    // A fused drop is the only removal source in this variant. Unlike an
-    // explicit `remove`, `signal_fused_cancel` marks the control-plane entry
-    // Removing and queues the Removal without touching the member record,
-    // so the driver-side `publish_dynamic_removal` call in `handle_removal`
-    // is the only writer of the public Removing projection on this path.
-    // The projection asserts after `handle_removal` pin that call; the
-    // explicit-remove variants cannot, because `remove_dynamic_impl`
-    // publishes the projection before its request reaches the driver.
+    // A fused drop is the only removal source in this variant. Its dynamic
+    // phase and public projection commit under one observation transaction,
+    // before the deferred driver request is delivered.
     assert_eq!(member.record().membership_status, MembershipStatus::Active);
-    super::super::signal_fused_cancel(control.as_ref(), &reservation.slot, &fused_cancel);
+    super::super::signal_fused_cancel(
+        &reservation.scope,
+        control.as_ref(),
+        &reservation.slot,
+        &fused_cancel,
+    );
     assert_eq!(
         member.record().membership_status,
-        MembershipStatus::Active,
-        "the fused source leaves the Removing projection to the driver"
+        MembershipStatus::Removing,
+        "the fused source commits the Removing projection with its phase"
     );
     assert!(matches!(
         root.snapshot()
             .child("worker")
             .map(|child| child.membership_status),
-        Some(MembershipStatus::Active)
+        Some(MembershipStatus::Removing)
     ));
     let removal = match crate::runtime::timeout(
         Duration::from_secs(2),
@@ -1277,12 +1458,12 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
         root.snapshot()
             .child("worker")
             .map(|child| child.membership_status),
-        Some(MembershipStatus::Active)
+        Some(MembershipStatus::Removing)
     ));
     assert_eq!(
         scope.dispatch_membership_status(key),
         MembershipStatus::Removing,
-        "exit dispatch follows the fused-cancel control plane before the public projection"
+        "exit dispatch and the public projection share the fused-cancel commit"
     );
 
     scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4, exit.5);

--- a/crates/shelterwood/src/driver/tests/events.rs
+++ b/crates/shelterwood/src/driver/tests/events.rs
@@ -92,7 +92,12 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
     // The fused admission handle drops only now: the cancellation latch
     // fires after the backoff was scheduled, and its Removal edge queues
     // behind the already-due restart deadline.
-    super::super::signal_fused_cancel(control.as_ref(), &reservation.slot, &fused_cancel);
+    super::super::signal_fused_cancel(
+        &reservation.scope,
+        control.as_ref(),
+        &reservation.slot,
+        &fused_cancel,
+    );
     assert!(fused_cancel.is_fired());
 
     let deadline = scope

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -240,6 +240,56 @@ async fn terminal_scope_waits_for_its_live_incarnation_to_stop() {
 }
 
 #[crate::runtime::test]
+async fn wait_for_child_reloads_after_its_predicate_closes_the_snapshot_stream() {
+    let scope = isolated_scope("scope", ScopeFlavor::Ordered);
+    let epoch = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("scope epoch is available");
+    scope.set_state(ScopeState::Running);
+    let child_id = ChildId::from("child");
+    let membership = scope
+        .child_identity
+        .lock()
+        .expect("scope identity mutex is healthy")
+        .mint_membership(&child_id)
+        .expect("child membership is available");
+    let child = MemberCell::new(child_id, membership);
+    let slot = SlotCell::new(Arc::clone(&child), None);
+    scope.set_admitted_children(vec![resident_projection(&slot)]);
+    let scope_ref = ScopeRef {
+        cell: Arc::clone(&scope),
+    };
+    let closing_scope = Arc::clone(&scope);
+    let mut first = true;
+
+    let result = scope_ref
+        .wait_for_child(
+            "child",
+            move |_| {
+                if std::mem::take(&mut first) {
+                    closing_scope.finish_root_incarnation(
+                        epoch,
+                        StopReason::Finished,
+                        Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+                    );
+                }
+                false
+            },
+            Duration::from_secs(1),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(crate::WaitError::ScopeTerminated {
+            state: ScopeState::Stopped {
+                reason: StopReason::Finished
+            }
+        })
+    ));
+}
+
+#[crate::runtime::test]
 async fn terminality_fallback_preserves_restart_window_scope_reason() {
     let parent = isolated_scope("parent", ScopeFlavor::Ordered);
     let nested = isolated_scope("nested", ScopeFlavor::Ordered);

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -207,6 +207,18 @@ async fn terminal_scope_waits_for_its_live_incarnation_to_stop() {
         StartupDisposition::NotAborted,
     ));
 
+    let nested_ref = ScopeRef {
+        cell: Arc::clone(&nested),
+    };
+    let mut snapshot_waiter =
+        Box::pin(nested_ref.wait_for_child("missing", |_| false, Duration::from_secs(10)));
+    let first_snapshot_poll =
+        std::future::poll_fn(|context| Poll::Ready(snapshot_waiter.as_mut().poll(context))).await;
+    assert!(
+        first_snapshot_poll.is_pending(),
+        "membership terminality must not close a live scope's snapshot stream"
+    );
+
     let mut waiter = Box::pin(nested.wait_stopped());
     let first_poll =
         std::future::poll_fn(|context| Poll::Ready(waiter.as_mut().poll(context))).await;
@@ -217,6 +229,14 @@ async fn terminal_scope_waits_for_its_live_incarnation_to_stop() {
 
     nested.finish_incarnation(epoch, StopReason::ShutdownRequested);
     assert_eq!(waiter.await, StopReason::ShutdownRequested);
+    assert!(matches!(
+        snapshot_waiter.await,
+        Err(crate::WaitError::ScopeTerminated {
+            state: ScopeState::Stopped {
+                reason: StopReason::ShutdownRequested
+            }
+        })
+    ));
 }
 
 #[crate::runtime::test]
@@ -512,12 +532,31 @@ fn admitted_subtree_rehomes_existing_descendants_to_one_gate() {
     let root = isolated_scope("root", ScopeFlavor::Ordered);
     let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
     let leaf = isolated_scope("leaf", ScopeFlavor::Ordered);
+    let raw_leaf_id = ChildId::from("raw-leaf");
+    let raw_leaf = MemberCell::new(
+        raw_leaf_id.clone(),
+        nested
+            .child_identity
+            .lock()
+            .expect("scope identity mutex poisoned")
+            .mint_membership(&raw_leaf_id)
+            .expect("raw leaf membership is available"),
+    );
     let leaf_slot = SlotCell::new(Arc::clone(&leaf.member), Some(Arc::clone(&leaf)));
-    nested.set_admitted_children(vec![resident_projection(&leaf_slot)]);
+    let raw_leaf_slot = SlotCell::new(Arc::clone(&raw_leaf), None);
+    nested.set_admitted_children(vec![
+        resident_projection(&leaf_slot),
+        resident_projection(&raw_leaf_slot),
+    ]);
     assert!(
         nested
             .observation_gate()
             .same_gate(&leaf.observation_gate())
+    );
+    assert!(
+        nested
+            .observation_gate()
+            .same_gate(&raw_leaf.observation_gate())
     );
 
     let nested_slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
@@ -526,6 +565,7 @@ fn admitted_subtree_rehomes_existing_descendants_to_one_gate() {
     let root_gate = root.observation_gate();
     assert!(root_gate.same_gate(&nested.observation_gate()));
     assert!(root_gate.same_gate(&leaf.observation_gate()));
+    assert!(root_gate.same_gate(&raw_leaf.observation_gate()));
 }
 
 #[test]

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -300,10 +300,11 @@ impl SnapshotReceiver {
         self.inner.borrow_cloned().snapshot
     }
 
-    /// Returns whether the published snapshot stream is terminal.
+    /// Borrows the newest snapshot and terminal flag from one retained state.
     #[must_use]
-    pub(crate) fn is_closed(&self) -> bool {
-        self.inner.borrow_cloned().closed
+    pub(crate) fn borrow_latest_and_closed(&self) -> (Arc<ScopeSnapshot>, bool) {
+        let state = self.inner.borrow_cloned();
+        (state.snapshot, state.closed)
     }
 
     /// Waits for and returns a newer snapshot.

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -300,6 +300,12 @@ impl SnapshotReceiver {
         self.inner.borrow_cloned().snapshot
     }
 
+    /// Returns whether the published snapshot stream is terminal.
+    #[must_use]
+    pub(crate) fn is_closed(&self) -> bool {
+        self.inner.borrow_cloned().closed
+    }
+
     /// Waits for and returns a newer snapshot.
     pub async fn changed(&mut self) -> Result<Arc<ScopeSnapshot>, SnapshotClosed> {
         loop {
@@ -342,7 +348,11 @@ struct SnapshotHubState {
 }
 
 impl SnapshotHub {
-    pub(crate) fn subscribe(&self, initial: Arc<ScopeSnapshot>) -> SnapshotReceiver {
+    pub(crate) fn subscribe(
+        &self,
+        initial: Arc<ScopeSnapshot>,
+        txn: &mut crate::cells::ObservationTxn<'_>,
+    ) -> SnapshotReceiver {
         if self.closed.load(Ordering::Acquire) {
             let (sender, inner) = runtime::watch(SnapshotHubState {
                 snapshot: initial,
@@ -368,12 +378,14 @@ impl SnapshotHub {
         // that first subscriber still observes closure; once installed,
         // `close` itself performs this publication and wakeup.
         if self.closed.load(Ordering::Acquire) {
-            sender.send_modify(|state| state.closed = true);
+            sender.modify_silently(|state| state.closed = true);
+            txn.pulse(sender);
         } else if sender.receiver_count() == 0 {
-            sender.send_modify(|state| {
+            sender.modify_silently(|state| {
                 state.snapshot = initial;
                 state.generation = state.generation.saturating_add(1);
             });
+            txn.pulse(sender);
         }
         let inner = sender.watcher();
         let seen_generation = inner.borrow_cloned().generation;
@@ -409,7 +421,7 @@ impl SnapshotHub {
 
     pub(crate) fn publish_deferred(
         &self,
-        wakes: &mut crate::cells::ObservationWakes,
+        wakes: &mut crate::cells::ObservationTxn<'_>,
         snapshot: impl FnOnce() -> Arc<ScopeSnapshot>,
     ) {
         if self.closed.load(Ordering::Acquire) {
@@ -445,7 +457,7 @@ impl SnapshotHub {
         }
     }
 
-    pub(crate) fn close_deferred(&self, wakes: &mut crate::cells::ObservationWakes) {
+    pub(crate) fn close_deferred(&self, wakes: &mut crate::cells::ObservationTxn<'_>) {
         if self.closed.swap(true, Ordering::AcqRel) {
             return;
         }
@@ -607,7 +619,7 @@ impl LifecycleHub {
 
     pub(crate) fn publish_deferred(
         &self,
-        wakes: &mut crate::cells::ObservationWakes,
+        wakes: &mut crate::cells::ObservationTxn<'_>,
         event: LifecycleEvent,
     ) {
         tracing::trace!(
@@ -669,7 +681,7 @@ impl LifecycleHub {
 
     pub(crate) fn publish_lagged_deferred(
         &self,
-        wakes: &mut crate::cells::ObservationWakes,
+        wakes: &mut crate::cells::ObservationTxn<'_>,
         dropped: u64,
     ) {
         if self.closed.load(Ordering::Acquire) {
@@ -697,7 +709,7 @@ impl LifecycleHub {
         }
     }
 
-    pub(crate) fn close_deferred(&self, wakes: &mut crate::cells::ObservationWakes) {
+    pub(crate) fn close_deferred(&self, wakes: &mut crate::cells::ObservationTxn<'_>) {
         if self.closed.swap(true, Ordering::AcqRel) {
             return;
         }
@@ -772,7 +784,9 @@ mod tests {
     #[crate::runtime::test]
     async fn snapshot_publication_that_linearizes_before_close_is_drained() {
         let hub = Arc::new(SnapshotHub::default());
-        let mut snapshots = hub.subscribe(snapshot(ScopeState::Unstarted));
+        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut snapshots = hub.subscribe(snapshot(ScopeState::Unstarted), &mut txn);
+        drop(txn);
         let (entered, wait_for_release) = std::sync::mpsc::channel();
         let (release, released) = std::sync::mpsc::channel();
 
@@ -811,9 +825,14 @@ mod tests {
         assert!(snapshots.changed().await.is_err());
         hub.publish(|| panic!("publication after close must remain lazy"));
 
-        let mut after_close = hub.subscribe(snapshot(ScopeState::Stopped {
-            reason: crate::StopReason::Finished,
-        }));
+        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut after_close = hub.subscribe(
+            snapshot(ScopeState::Stopped {
+                reason: crate::StopReason::Finished,
+            }),
+            &mut txn,
+        );
+        drop(txn);
         assert!(matches!(
             after_close.borrow_latest().state,
             ScopeState::Stopped {

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::{
     ChildId, DefaultsInheritance, Exit, Intensity, Readiness, ScopeDefaults, Strategy,
     admission::ReserveError,
-    cells::{ErasedDynamicSlot, MemberCell, ScopeCell},
+    cells::{ErasedDynamicSlot, MemberCell, ObservationTxn, ScopeCell},
     definition::DefinitionSource,
     identity::{IdError, ScopeIdentity},
     policy::{
@@ -130,22 +130,28 @@ impl SlotCell {
         }
     }
 
-    /// Publishes the canonical never-started terminal state for this slot.
-    ///
-    /// Member terminality closes any mailbox before the nested scope closes
-    /// its observation surfaces. Every static and dynamic path uses this
-    /// method so those edges cannot drift independently.
+    /// Publishes one never-started slot under the gate its observers use.
     pub(crate) fn terminalize_never_started(&self) {
-        self.member.terminalize(Exit::never_started());
         if let Some(scope) = &self.scope {
             scope.terminalize_never_started();
+        } else {
+            self.member.terminalize(Exit::never_started());
         }
     }
 
-    /// Claims an unlowered definition and publishes never-started terminality.
-    pub(crate) fn take_never_started(&self) -> Option<Isolated<ChildConstruction>> {
+    pub(crate) fn terminalize_never_started_locked(&self, txn: &mut ObservationTxn<'_>) {
+        self.member.terminalize_locked(Exit::never_started(), txn);
+        if let Some(scope) = &self.scope {
+            scope.terminalize_never_started_locked(txn);
+        }
+    }
+
+    pub(crate) fn take_never_started_locked(
+        &self,
+        txn: &mut ObservationTxn<'_>,
+    ) -> Option<Isolated<ChildConstruction>> {
         let definition = self.take_definition().ok().flatten();
-        self.terminalize_never_started();
+        self.terminalize_never_started_locked(txn);
         definition
     }
 
@@ -408,11 +414,13 @@ impl Drop for ScopePlan {
         for child in &self.children {
             child.slot.terminalize_never_started();
         }
-        // Lowering can publish the planned children before ScopeRuntime takes
-        // ownership. If construction then unwinds, the plan fallback also
-        // owns those residencies and their matching Removed edges.
-        self.root.clear_residents();
-        self.root.terminalize_never_started();
+        self.root.with_observation_gate(|txn| {
+            // Lowering can publish the planned children before ScopeRuntime
+            // takes ownership. The plan fallback commits residency withdrawal
+            // and root closure as one root-scope observation.
+            self.root.clear_residents_locked(txn);
+            self.root.terminalize_never_started_locked(txn);
+        });
     }
 }
 

--- a/crates/shelterwood/src/runtime/sync.rs
+++ b/crates/shelterwood/src/runtime/sync.rs
@@ -429,6 +429,7 @@ impl<T> WatchSender<T> {
         self.0.send_modify(|_| {});
     }
 
+    #[cfg(test)]
     pub(crate) fn send_modify(&self, update: impl FnOnce(&mut T)) {
         self.0.send_modify(update);
     }

--- a/crates/shelterwood/src/runtime/sync.rs
+++ b/crates/shelterwood/src/runtime/sync.rs
@@ -89,17 +89,38 @@ struct LatchState {
 
 impl Latch {
     pub(crate) fn fire(&self) -> bool {
-        if self
-            .state
-            .fired
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
-        {
-            self.state.notify.notify_waiters();
+        if self.fire_silently() {
+            self.notify();
             true
         } else {
             false
         }
+    }
+
+    /// Performs the one-shot transition without waking waiters.
+    ///
+    /// Splitting the transition from the wake lets an observation-gate
+    /// transaction linearize the fire inside its critical section while
+    /// deferring the waker-visible [`Self::notify`] until after the gate is
+    /// released. Deferral cannot strand a waiter: [`Self::fired`] rechecks
+    /// `is_fired` after creating its notification, so a waiter either
+    /// observes the committed transition directly or holds a notification
+    /// created before the deferred `notify_waiters`, which Tokio guarantees
+    /// to be observed even when it has not been polled yet.
+    pub(crate) fn fire_silently(&self) -> bool {
+        self.state
+            .fired
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    /// Wakes waiters after a [`Self::fire_silently`] transition.
+    ///
+    /// Idempotent and only meaningful once the latch is fired; callers that
+    /// won `fire_silently` inside an observation-gate transaction defer this
+    /// wake past the gate release.
+    pub(crate) fn notify(&self) {
+        self.state.notify.notify_waiters();
     }
 
     pub(crate) fn is_fired(&self) -> bool {

--- a/crates/shelterwood/src/scope.rs
+++ b/crates/shelterwood/src/scope.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use crate::{
-    cells::{MemberStage, ScopeCell},
+    cells::ScopeCell,
     exit::StopReason,
     identity::{ChildId, Membership},
     observe::{ChildSnapshot, LifecycleEvents, ScopeSnapshot, SnapshotReceiver, WaitError},
@@ -189,15 +189,18 @@ impl_scope_ref_async_surface! {
             {
                 return Ok(child.clone());
             }
-            // Inspect the current snapshot before rejecting even an already
-            // elapsed (including zero-duration) budget.
-            if expires.is_due(crate::runtime::now()) {
-                return Err(WaitError::TimedOut);
-            }
-            if matches!(self.cell.member.record().stage, MemberStage::Terminal(_)) {
+            // The published stream is the waiter's sole authority. Closure
+            // and its final snapshot commit together under ObservationTxn, so
+            // the terminal payload cannot come from an earlier cut.
+            if snapshots.is_closed() {
                 return Err(WaitError::ScopeTerminated {
                     state: snapshot.state.clone(),
                 });
+            }
+            // Precedence is predicate, final termination, then deadline on
+            // both the fast and awaited paths.
+            if expires.is_due(crate::runtime::now()) {
+                return Err(WaitError::TimedOut);
             }
             match crate::runtime::select_two(snapshots.changed(), async {
                 match expires.instant() {
@@ -207,27 +210,8 @@ impl_scope_ref_async_surface! {
             })
             .await
             {
-                crate::runtime::Either::Left(Ok(_)) => {}
-                crate::runtime::Either::Left(Err(_)) => {
-                    let snapshot = snapshots.borrow_latest();
-                    if let Some(child) = snapshot.child(id.as_str())
-                        && pred(child)
-                    {
-                        return Ok(child.clone());
-                    }
-                    return Err(WaitError::ScopeTerminated {
-                        state: snapshot.state.clone(),
-                    });
-                }
-                crate::runtime::Either::Right(()) => {
-                    let snapshot = snapshots.borrow_latest();
-                    if let Some(child) = snapshot.child(id.as_str())
-                        && pred(child)
-                    {
-                        return Ok(child.clone());
-                    }
-                    return Err(WaitError::TimedOut);
-                }
+                crate::runtime::Either::Left(Ok(_) | Err(_))
+                | crate::runtime::Either::Right(()) => continue,
             }
         }
     }

--- a/crates/shelterwood/src/scope.rs
+++ b/crates/shelterwood/src/scope.rs
@@ -183,7 +183,7 @@ impl_scope_ref_async_surface! {
         let mut snapshots = self.subscribe_snapshots();
 
         loop {
-            let snapshot = snapshots.borrow_latest();
+            let (snapshot, closed) = snapshots.borrow_latest_and_closed();
             if let Some(child) = snapshot.child(id.as_str())
                 && pred(child)
             {
@@ -192,7 +192,7 @@ impl_scope_ref_async_surface! {
             // The published stream is the waiter's sole authority. Closure
             // and its final snapshot commit together under ObservationTxn, so
             // the terminal payload cannot come from an earlier cut.
-            if snapshots.is_closed() {
+            if closed {
                 return Err(WaitError::ScopeTerminated {
                     state: snapshot.state.clone(),
                 });

--- a/crates/shelterwood/src/tree/admission.rs
+++ b/crates/shelterwood/src/tree/admission.rs
@@ -61,6 +61,7 @@ impl<H> PendingAdmission<H> {
 
     fn cancel_reservation(&self) {
         crate::driver::cancel_dynamic_reservation(
+            &self.reservation.scope,
             self.reservation.control.as_ref(),
             &self.reservation.slot,
         );
@@ -176,6 +177,7 @@ impl<H> Drop for Admission<H> {
                 let signal_panic = pending.fused_cancel.as_ref().and_then(|cancel| {
                     crate::runtime::catch_panic(|| {
                         crate::driver::signal_fused_cancel(
+                            &pending.reservation.scope,
                             pending.reservation.control.as_ref(),
                             &pending.reservation.slot,
                             cancel,
@@ -194,6 +196,7 @@ impl<H> Drop for Admission<H> {
                 if let Some(cancel) = &pending.fused_cancel {
                     let signal_panic = crate::runtime::catch_panic(|| {
                         crate::driver::signal_fused_cancel(
+                            &pending.reservation.scope,
                             pending.reservation.control.as_ref(),
                             &pending.reservation.slot,
                             cancel,

--- a/crates/shelterwood/src/tree/slots.rs
+++ b/crates/shelterwood/src/tree/slots.rs
@@ -87,6 +87,7 @@ impl Drop for DynamicSlotEndpoint {
     fn drop(&mut self) {
         if let Some(reservation) = &self.reservation {
             crate::driver::cancel_dynamic_reservation(
+                &reservation.scope,
                 reservation.control.as_ref(),
                 &reservation.slot,
             );

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -30,9 +30,10 @@ use shelterwood::{
 /// `ReserveError::RemovalInProgress`: a surviving entry whose member is
 /// already `removing`.
 ///
-/// Removal completion releases the entry before it withdraws residency, so
-/// an absent resident is a sound — slightly conservative — signal that the
-/// id is free again.
+/// Removal withdraws residency and publishes `Removed` while the old entry
+/// still claims the id, then releases the entry in the same observation
+/// transaction. An absent resident is therefore a sound signal that the id
+/// is free again.
 async fn wait_for_id_release(scope: &DynamicScopeRef, id: &str) {
     assert!(
         poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -805,6 +805,14 @@ async fn wait_for_child_handles_later_ids_terminal_children_timeouts_and_scope_t
         .shutdown(Duration::from_secs(1))
         .await
         .expect("root shuts down");
+    assert!(matches!(
+        scope
+            .wait_for_child("missing", |_| false, Duration::ZERO)
+            .await,
+        Err(WaitError::ScopeTerminated {
+            state: ScopeState::Stopped { .. }
+        })
+    ));
 
     let mut declaration = Tree::new();
     let never_spawned = declaration


### PR DESCRIPTION
Implements Part 0.1 and Part 0.2 of #172.

Stacked on #180; review and merge that PR first.

## What changed

- replace the separate observation-wake accumulator with an `ObservationTxn` capability that owns the tree gate and defers all pulses, disposal, and driver wakes until commit/unwind
- adopt member, nested-scope, record, hub, control-request, dynamic-entry, admission, terminalization, and residency mutations into that commit domain
- make dynamic draining/startup failure close admission atomically with the published scope state
- keep a removing identifier claimed until residency withdrawal and the `Removed` edge commit, then release it in the same transaction
- commit fused-cancel phase and its public `Removing` projection together
- publish the mailbox-arbitrated canonical exit through lifecycle events
- disarm all resident-removal fallbacks before recursive publication so unwind cannot re-enter the non-reentrant gate
- make `wait_for_child` read only its snapshot stream, with predicate → final termination → deadline precedence on both fast and awaited paths

## Regression coverage

- parks final removal at the observation gate and verifies the old identifier remains claimed
- parks a live reservation transaction and verifies draining cannot publish across it
- verifies an already-stopped scope beats a zero-duration timeout
- updates fused-removal and observation-gate tests for the single-commit contract

This subsumes findings 2, 3, 4, 6, and 7 from #172.

## Validation

- `./tools/dev just ci`
  - 522 nextest tests
  - doctests and rustdoc with warnings denied
  - API reachability, runtime/exit/layering enforcement, fixture coverage
  - packaged-crate verification and Nix formatting