### PR TITLE
Part 0.4: carry control subjects into the driver

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -8,6 +8,7 @@
 
 use std::{
     any::Any,
+    collections::VecDeque,
     fmt,
     sync::{
         Arc, Mutex, MutexGuard, OnceLock, RwLock, Weak,
@@ -797,12 +798,23 @@ struct ScopeControl {
     epochs: ScopeEpochs,
     shutdown: Option<ScopeRequest>,
     force: Option<ScopeRequest>,
+    events: VecDeque<ScopeControlEvent>,
 }
 
 #[derive(Clone, Copy, Debug)]
 struct ScopeRequest {
     epoch: Epoch,
     consumed: bool,
+}
+
+/// One fact published by a scope control-plane transaction for its driver.
+///
+/// The payload is restart-stable identity rather than a mutable driver key.
+/// The driver resolves it through its incrementally maintained membership
+/// index, so stale events miss instead of addressing a replacement child.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ScopeControlEvent {
+    RestartShutdown { membership: Membership },
 }
 
 /// Shared scope state follows two distinct synchronization regimes.
@@ -948,11 +960,24 @@ impl ScopeCell {
             .and_then(Weak::upgrade)
     }
 
-    fn set_parent(&self, parent: &Arc<ScopeCell>, _txn: &mut ObservationTxn<'_>) {
+    fn set_parent(&self, parent: &Arc<ScopeCell>, txn: &mut ObservationTxn<'_>) {
         *self
             .parent
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::downgrade(parent));
+        let control = self.control.lock().expect("scope control mutex poisoned");
+        let pending_shutdown = control.shutdown.is_some_and(|request| {
+            !request.consumed && control.epochs.request_is_pending(request.epoch)
+        });
+        drop(control);
+        if pending_shutdown {
+            parent.publish_control_event_locked(
+                ScopeControlEvent::RestartShutdown {
+                    membership: self.member.membership(),
+                },
+                txn,
+            );
+        }
     }
 
     #[cfg(test)]
@@ -1652,27 +1677,47 @@ impl ScopeCell {
             epoch: target,
             pending_incarnation,
         } = control.epochs.request_target()?;
-        if control
+        let published = control
             .shutdown
-            .is_none_or(|request| request.epoch < target)
-        {
+            .is_none_or(|request| request.epoch < target);
+        if published {
             control.shutdown = Some(ScopeRequest {
                 epoch: target,
                 consumed: false,
             });
         }
         drop(control);
-        txn.pulse(&self.member.record);
-        if pending_incarnation && let Some(parent) = self.parent() {
-            txn.pulse(&parent.member.record);
+        if published {
+            txn.pulse(&self.member.record);
+            if pending_incarnation && let Some(parent) = self.parent() {
+                parent.publish_control_event_locked(
+                    ScopeControlEvent::RestartShutdown {
+                        membership: self.member.membership(),
+                    },
+                    txn,
+                );
+            }
         }
         Some(target)
     }
 
-    pub(crate) fn has_pending_incarnation_shutdown(&self) -> bool {
-        let control = self.control.lock().expect("scope control mutex poisoned");
-        control.shutdown.is_some_and(|request| {
-            !request.consumed && control.epochs.request_is_pending(request.epoch)
+    fn publish_control_event_locked(&self, event: ScopeControlEvent, txn: &mut ObservationTxn<'_>) {
+        self.control
+            .lock()
+            .expect("scope control mutex poisoned")
+            .events
+            .push_back(event);
+        txn.pulse(&self.member.record);
+    }
+
+    pub(crate) fn take_control_events(&self) -> Vec<ScopeControlEvent> {
+        self.with_observation_gate(|_txn| {
+            self.control
+                .lock()
+                .expect("scope control mutex poisoned")
+                .events
+                .drain(..)
+                .collect()
         })
     }
 

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -814,7 +814,10 @@ struct ScopeRequest {
 /// index, so stale events miss instead of addressing a replacement child.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ScopeControlEvent {
-    RestartShutdown { membership: Membership },
+    RestartShutdown {
+        membership: Membership,
+        target: Epoch,
+    },
 }
 
 /// Shared scope state follows two distinct synchronization regimes.
@@ -966,14 +969,15 @@ impl ScopeCell {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::downgrade(parent));
         let control = self.control.lock().expect("scope control mutex poisoned");
-        let pending_shutdown = control.shutdown.is_some_and(|request| {
+        let pending_shutdown = control.shutdown.filter(|request| {
             !request.consumed && control.epochs.request_is_pending(request.epoch)
         });
         drop(control);
-        if pending_shutdown {
+        if let Some(request) = pending_shutdown {
             parent.publish_control_event_locked(
                 ScopeControlEvent::RestartShutdown {
                     membership: self.member.membership(),
+                    target: request.epoch,
                 },
                 txn,
             );
@@ -1693,6 +1697,7 @@ impl ScopeCell {
                 parent.publish_control_event_locked(
                     ScopeControlEvent::RestartShutdown {
                         membership: self.member.membership(),
+                        target,
                     },
                     txn,
                 );
@@ -1718,6 +1723,15 @@ impl ScopeCell {
                 .events
                 .drain(..)
                 .collect()
+        })
+    }
+
+    pub(crate) fn has_pending_incarnation_shutdown(&self, target: Epoch) -> bool {
+        let control = self.control.lock().expect("scope control mutex poisoned");
+        control.shutdown.is_some_and(|request| {
+            request.epoch == target
+                && !request.consumed
+                && control.epochs.request_is_pending(target)
         })
     }
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -8,6 +8,7 @@ mod shutdown;
 mod startup;
 
 use std::{
+    collections::HashMap,
     sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
@@ -19,9 +20,10 @@ use storage::{ChildArena, ChildKey, Obligation};
 use child::ChildRuntime;
 #[cfg(test)]
 use child::{ChildTerminality, discharge_child_terminality, report_slot};
+#[cfg(test)]
+use events::restart_shutdown_work;
 use events::{
     ChildEvent, DeadlineKind, DriverEvent, MIN_EVENT_BATCH_LIMIT, Pending, collect_driver_events,
-    restart_shutdown_work,
 };
 use removal::RemovalRequest;
 pub(crate) use shutdown::shutdown_scope;
@@ -33,7 +35,7 @@ use crate::{
     admission::{NotAdmittingCause, ReserveError},
     cells::{
         MailboxControl, MemberStage, MemberTransition, ResidentProjection, ScopeCell,
-        StartupDisposition,
+        ScopeControlEvent, StartupDisposition,
     },
     deadline::Deadline,
     engine::{
@@ -200,6 +202,10 @@ struct ScopeRuntime {
     intensity_policy: crate::Intensity,
     intensity: IntensityState,
     children: ChildArena<ChildRuntime>,
+    // The index and count are maintained only at child installation/completion.
+    // Driver wakes resolve a subject directly and test completion in O(1).
+    child_keys: HashMap<Membership, ChildKey>,
+    incomplete_children: usize,
     events: runtime::UnboundedMpscSender<DriverEvent>,
     disposal_events: runtime::UnboundedMpscSender<DriverEvent>,
     deadlines: DeadlineQueue<DeadlineKind>,
@@ -278,6 +284,27 @@ impl Drop for ScopeRuntime {
 }
 
 impl ScopeRuntime {
+    pub(super) fn insert_child(
+        &mut self,
+        child: ChildRuntime,
+    ) -> Result<ChildKey, Box<ChildRuntime>> {
+        let membership = child.slot.member.membership();
+        let incomplete = !child.is_terminal() || child.is_disposing();
+        let key = self.children.insert(child)?;
+        let replaced = self.child_keys.insert(membership, key);
+        assert!(
+            replaced.is_none(),
+            "one live membership maps to exactly one child key"
+        );
+        if incomplete {
+            self.incomplete_children = self
+                .incomplete_children
+                .checked_add(1)
+                .expect("an in-memory child count fits in usize");
+        }
+        Ok(key)
+    }
+
     #[cfg(test)]
     fn record_storage(&self) {
         self.root.record_runtime_storage(RuntimeStorage {
@@ -394,7 +421,7 @@ impl ScopeRuntime {
             // state transition: an exact remover sees either the reservation
             // or a resident carrying its live arena key, never an unindexed
             // admitted intermediate.
-            let key = match self.children.insert(child) {
+            let key = match self.insert_child(child) {
                 Ok(key) => key,
                 Err(child) => {
                     let removed = state.remove(id, txn);
@@ -634,12 +661,22 @@ async fn run_scope_incarnation(
         });
     }
     let next_ordered_start = children.keys().next();
+    let child_keys = children
+        .iter()
+        .map(|(key, child)| (child.slot.member.membership(), key))
+        .collect();
+    let incomplete_children = children
+        .values()
+        .filter(|child| !child.is_terminal() || child.is_disposing())
+        .count();
     let mut scope = ScopeRuntime {
         root: Arc::clone(&root),
         defaults: plan.defaults.clone(),
         intensity_policy: plan.config.intensity,
         intensity: IntensityState::default(),
         children,
+        child_keys,
+        incomplete_children,
         events,
         disposal_events,
         deadlines: DeadlineQueue::default(),
@@ -700,8 +737,10 @@ async fn run_scope_incarnation(
         if root.take_shutdown_request(scope.epoch) {
             pending.push(Pending::Shutdown.classified());
         }
-        for child in scope.pending_restart_shutdowns() {
-            pending.push(restart_shutdown_work(child));
+        for event in root.take_control_events() {
+            if let Some(work) = scope.control_event_work(event) {
+                pending.push(work);
+            }
         }
         if !scope.ancestor_shutdown_seen
             && scope

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -858,7 +858,9 @@ async fn run_scope_incarnation(
                     }
                     scope.begin_drain(StopReason::ShutdownRequested);
                 }
-                Pending::RestartShutdown(child) => scope.expedite_restart_shutdown(child),
+                Pending::RestartShutdown { child, target } => {
+                    scope.expedite_restart_shutdown(child, target);
+                }
                 Pending::AncestorShutdown => {
                     scope.begin_drain(StopReason::ShutdownRequested);
                 }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -294,7 +294,7 @@ impl ScopeRuntime {
         child: ChildRuntime,
     ) -> Result<ChildKey, Box<ChildRuntime>> {
         let membership = child.slot.member.membership();
-        let incomplete = !child.is_terminal() || child.is_disposing();
+        let incomplete = child.is_incomplete();
         let key = self.children.insert(child)?;
         let replaced = self.child_keys.insert(membership, key);
         assert!(
@@ -612,6 +612,21 @@ async fn run_scope(plan: ScopePlan, role: ScopeRole) -> StopReason {
     run_scope_incarnation(plan, role, epoch).await
 }
 
+/// Derives the membership index and incompleteness count for a freshly
+/// assembled child arena. Production construction and the test builder both
+/// call this, so the derived state cannot drift between them.
+fn index_children(children: &ChildArena<ChildRuntime>) -> (HashMap<Membership, ChildKey>, usize) {
+    let child_keys = children
+        .iter()
+        .map(|(key, child)| (child.slot.member.membership(), key))
+        .collect();
+    let incomplete_children = children
+        .values()
+        .filter(|child| child.is_incomplete())
+        .count();
+    (child_keys, incomplete_children)
+}
+
 async fn run_scope_incarnation(
     mut plan: ScopePlan,
     role: ScopeRole,
@@ -666,14 +681,7 @@ async fn run_scope_incarnation(
         });
     }
     let next_ordered_start = children.keys().next();
-    let child_keys = children
-        .iter()
-        .map(|(key, child)| (child.slot.member.membership(), key))
-        .collect();
-    let incomplete_children = children
-        .values()
-        .filter(|child| !child.is_terminal() || child.is_disposing())
-        .count();
+    let (child_keys, incomplete_children) = index_children(&children);
     let mut scope = ScopeRuntime {
         root: Arc::clone(&root),
         defaults: plan.defaults.clone(),

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -20,10 +20,9 @@ use storage::{ChildArena, ChildKey, Obligation};
 use child::ChildRuntime;
 #[cfg(test)]
 use child::{ChildTerminality, discharge_child_terminality, report_slot};
-#[cfg(test)]
-use events::restart_shutdown_work;
 use events::{
     ChildEvent, DeadlineKind, DriverEvent, MIN_EVENT_BATCH_LIMIT, Pending, collect_driver_events,
+    restart_shutdown_work,
 };
 use removal::RemovalRequest;
 pub(crate) use shutdown::shutdown_scope;
@@ -206,6 +205,12 @@ struct ScopeRuntime {
     // Driver wakes resolve a subject directly and test completion in O(1).
     child_keys: HashMap<Membership, ChildKey>,
     incomplete_children: usize,
+    // Retained restart-shutdown facts whose subjects became inactive mid-batch.
+    // `handle_exit` queues them here instead of expediting synchronously so the
+    // retry re-enters arbitration on the next wake: an exit collected in the
+    // same batch must first get the chance to trip intensity or fail startup.
+    // Duplicates are harmless — expediting is idempotent.
+    restart_shutdown_retries: Vec<(ChildKey, Epoch)>,
     events: runtime::UnboundedMpscSender<DriverEvent>,
     disposal_events: runtime::UnboundedMpscSender<DriverEvent>,
     deadlines: DeadlineQueue<DeadlineKind>,
@@ -677,6 +682,7 @@ async fn run_scope_incarnation(
         children,
         child_keys,
         incomplete_children,
+        restart_shutdown_retries: Vec::new(),
         events,
         disposal_events,
         deadlines: DeadlineQueue::default(),
@@ -741,6 +747,12 @@ async fn run_scope_incarnation(
             if let Some(work) = scope.control_event_work(event) {
                 pending.push(work);
             }
+        }
+        // Retries queued at the tail of a previous batch's exit handling
+        // re-enter arbitration here, so a same-wake exit sorts ahead of them
+        // and the execution-time suppression re-check observes its drain.
+        for (child, target) in std::mem::take(&mut scope.restart_shutdown_retries) {
+            pending.push(restart_shutdown_work(child, target));
         }
         if !scope.ancestor_shutdown_seen
             && scope

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -536,6 +536,25 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
 }
 
 impl ScopeRuntime {
+    pub(super) fn terminalize_child(
+        &mut self,
+        key: ChildKey,
+        exit: Exit,
+        exited_incarnation: Option<Incarnation>,
+        startup: StartupDisposition,
+    ) -> bool {
+        let changed = self.children[key].terminalize(&self.root, exit, exited_incarnation, startup);
+        debug_assert!(
+            self.children[key].is_terminal() && !self.children[key].is_disposing(),
+            "terminal completion leaves no disposal outstanding"
+        );
+        self.incomplete_children = self
+            .incomplete_children
+            .checked_sub(1)
+            .expect("a child completes terminality exactly once");
+        changed
+    }
+
     pub(super) fn spawn_child(&mut self, key: ChildKey) {
         let Some(child) = self.children.get(key) else {
             return;
@@ -1040,12 +1059,7 @@ impl ScopeRuntime {
         } else {
             StartupDisposition::NotAborted
         };
-        self.children[key].terminalize(
-            &self.root,
-            exit.clone(),
-            terminal.exited_incarnation,
-            startup,
-        );
+        self.terminalize_child(key, exit.clone(), terminal.exited_incarnation, startup);
         if self.dynamic_membership_is_removing(key) {
             self.finalize_removal(key);
         } else if terminal.startup == StartupDisposition::Aborted && !self.lifecycle.is_draining() {

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -984,7 +984,12 @@ impl ScopeRuntime {
             // fact now that the old incarnation is inactive; otherwise the
             // one-shot event would be consumed while `spawn_child` still
             // rejects the active child and the requested expedite is lost.
-            self.expedite_restart_shutdown(key, target);
+            // Queue the retry rather than expediting synchronously: it
+            // re-enters arbitration on the next wake, so a later exit
+            // collected in this same batch first gets the chance to trip
+            // intensity or fail startup, and the execution-time suppression
+            // re-check then observes that drain.
+            self.restart_shutdown_retries.push((key, target));
         }
     }
 

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -160,6 +160,7 @@ pub(super) struct ChildRuntime {
     pub(super) incarnations: IncarnationCounter,
     pub(super) restarts: RestartState,
     pub(super) restart_deadline: Option<DeadlineHandle>,
+    pub(super) restart_shutdown_pending: bool,
     pub(super) active: Option<ActiveChild>,
     pub(super) initial_ready: bool,
     pub(super) initial: bool,
@@ -208,6 +209,7 @@ impl ChildRuntime {
             incarnations,
             restarts: RestartState::new(),
             restart_deadline: None,
+            restart_shutdown_pending: false,
             active: None,
             initial_ready: false,
             initial: true,
@@ -971,6 +973,18 @@ impl ScopeRuntime {
                     }
                 }
             }
+        }
+        if self
+            .children
+            .get(key)
+            .is_some_and(|child| child.restart_shutdown_pending)
+        {
+            // A subject-carrying control event can beat the corresponding
+            // child exit into an earlier driver batch. Retry the retained
+            // fact now that the old incarnation is inactive; otherwise the
+            // one-shot event would be consumed while `spawn_child` still
+            // rejects the active child and the requested expedite is lost.
+            self.expedite_restart_shutdown(key);
         }
     }
 

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -160,7 +160,7 @@ pub(super) struct ChildRuntime {
     pub(super) incarnations: IncarnationCounter,
     pub(super) restarts: RestartState,
     pub(super) restart_deadline: Option<DeadlineHandle>,
-    pub(super) restart_shutdown_pending: bool,
+    pub(super) restart_shutdown_pending: Option<Epoch>,
     pub(super) active: Option<ActiveChild>,
     pub(super) initial_ready: bool,
     pub(super) initial: bool,
@@ -209,7 +209,7 @@ impl ChildRuntime {
             incarnations,
             restarts: RestartState::new(),
             restart_deadline: None,
-            restart_shutdown_pending: false,
+            restart_shutdown_pending: None,
             active: None,
             initial_ready: false,
             initial: true,
@@ -974,17 +974,17 @@ impl ScopeRuntime {
                 }
             }
         }
-        if self
+        if let Some(target) = self
             .children
             .get(key)
-            .is_some_and(|child| child.restart_shutdown_pending)
+            .and_then(|child| child.restart_shutdown_pending)
         {
             // A subject-carrying control event can beat the corresponding
             // child exit into an earlier driver batch. Retry the retained
             // fact now that the old incarnation is inactive; otherwise the
             // one-shot event would be consumed while `spawn_child` still
             // rejects the active child and the requested expedite is lost.
-            self.expedite_restart_shutdown(key);
+            self.expedite_restart_shutdown(key, target);
         }
     }
 

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -225,6 +225,14 @@ impl ChildRuntime {
         matches!(self.slot.member.record().stage, MemberStage::Terminal(_))
     }
 
+    /// Reports whether this child still counts against scope completeness:
+    /// it has not published a terminal stage, or its terminal disposal is
+    /// still outstanding. Every `incomplete_children` adjustment and the
+    /// `child_keys` index derivation consult exactly this predicate.
+    pub(super) fn is_incomplete(&self) -> bool {
+        !self.is_terminal() || self.is_disposing()
+    }
+
     pub(super) fn terminalize(
         &mut self,
         root: &ScopeCell,
@@ -547,7 +555,7 @@ impl ScopeRuntime {
     ) -> bool {
         let changed = self.children[key].terminalize(&self.root, exit, exited_incarnation, startup);
         debug_assert!(
-            self.children[key].is_terminal() && !self.children[key].is_disposing(),
+            !self.children[key].is_incomplete(),
             "terminal completion leaves no disposal outstanding"
         );
         self.incomplete_children = self

--- a/crates/shelterwood/src/driver/events.rs
+++ b/crates/shelterwood/src/driver/events.rs
@@ -178,9 +178,25 @@ impl ScopeRuntime {
         // Collection and execution are separated by arbitration. Recheck
         // every level-triggered stop source so teardown/removal latched in the
         // same batch suppresses user construction immediately.
-        if !self.restart_is_suppressed(key) {
-            self.spawn_child(key);
+        if self.restart_is_suppressed(key) {
+            if let Some(child) = self.children.get_mut(key) {
+                child.restart_shutdown_pending = false;
+            }
+            return;
         }
+        let Some(child) = self.children.get_mut(key) else {
+            return;
+        };
+        if child.is_terminal() || child.is_disposing() {
+            child.restart_shutdown_pending = false;
+            return;
+        }
+        if child.active.is_some() {
+            child.restart_shutdown_pending = true;
+            return;
+        }
+        child.restart_shutdown_pending = false;
+        self.spawn_child(key);
     }
 
     pub(super) fn handle_deadline(&mut self, deadline: DeadlineKind) {

--- a/crates/shelterwood/src/driver/events.rs
+++ b/crates/shelterwood/src/driver/events.rs
@@ -45,7 +45,7 @@ pub(super) enum DeadlineKind {
 }
 pub(super) enum Pending {
     Shutdown,
-    RestartShutdown(ChildKey),
+    RestartShutdown { child: ChildKey, target: Epoch },
     AncestorShutdown,
     AncestorAbort,
     Force,
@@ -59,7 +59,7 @@ impl Pending {
             Self::Shutdown | Self::AncestorShutdown | Self::AncestorAbort | Self::Force => {
                 ArbitrationClass::ScopeShutdown
             }
-            Self::RestartShutdown(_) => ArbitrationClass::BackoffDue,
+            Self::RestartShutdown { .. } => ArbitrationClass::BackoffDue,
             Self::Driver(event) => driver_event_class(event),
             Self::Deadline(DeadlineKind::Readiness { .. }) => ArbitrationClass::ReadinessDeadline,
             Self::Deadline(DeadlineKind::Restart { .. }) => ArbitrationClass::BackoffDue,
@@ -94,12 +94,12 @@ pub(super) fn collect_driver_events(
     true
 }
 
-pub(super) fn restart_shutdown_work(child: ChildKey) -> (ArbitrationClass, Pending) {
+pub(super) fn restart_shutdown_work(child: ChildKey, target: Epoch) -> (ArbitrationClass, Pending) {
     // This starts a pending incarnation, so it is restart work, not a
     // scope-shutdown transition. A child exit collected in the same wake must
     // first get the chance to trip intensity or fail startup; the
     // execution-time suppression check then observes that drain.
-    Pending::RestartShutdown(child).classified()
+    Pending::RestartShutdown { child, target }.classified()
 }
 
 pub(super) fn driver_event_class(event: &DriverEvent) -> ArbitrationClass {
@@ -166,36 +166,41 @@ impl ScopeRuntime {
         event: ScopeControlEvent,
     ) -> Option<(ArbitrationClass, Pending)> {
         match event {
-            ScopeControlEvent::RestartShutdown { membership } => self
+            ScopeControlEvent::RestartShutdown { membership, target } => self
                 .child_keys
                 .get(&membership)
                 .copied()
-                .map(restart_shutdown_work),
+                .map(|child| restart_shutdown_work(child, target)),
         }
     }
 
-    pub(super) fn expedite_restart_shutdown(&mut self, key: ChildKey) {
+    pub(super) fn expedite_restart_shutdown(&mut self, key: ChildKey, target: Epoch) {
         // Collection and execution are separated by arbitration. Recheck
         // every level-triggered stop source so teardown/removal latched in the
         // same batch suppresses user construction immediately.
         if self.restart_is_suppressed(key) {
             if let Some(child) = self.children.get_mut(key) {
-                child.restart_shutdown_pending = false;
+                child.restart_shutdown_pending = None;
             }
             return;
         }
+        let target_is_pending = self
+            .children
+            .get(key)
+            .and_then(|child| child.slot.scope.as_ref())
+            .is_some_and(|scope| scope.has_pending_incarnation_shutdown(target));
         let Some(child) = self.children.get_mut(key) else {
             return;
         };
-        if child.is_terminal() || child.is_disposing() {
-            child.restart_shutdown_pending = false;
+        if !target_is_pending || child.is_terminal() || child.is_disposing() {
+            child.restart_shutdown_pending = None;
             return;
         }
         if child.active.is_some() {
-            child.restart_shutdown_pending = true;
+            child.restart_shutdown_pending = Some(target);
             return;
         }
-        child.restart_shutdown_pending = false;
+        child.restart_shutdown_pending = None;
         self.spawn_child(key);
     }
 

--- a/crates/shelterwood/src/driver/events.rs
+++ b/crates/shelterwood/src/driver/events.rs
@@ -161,24 +161,17 @@ impl ScopeRuntime {
             || self.dispatch_membership_status(key) == MembershipStatus::Removing
     }
 
-    pub(super) fn pending_restart_shutdowns(&self) -> Vec<ChildKey> {
-        self.children
-            .keys()
-            .filter(|key| {
-                let child = &self.children[*key];
-                // Only a nested scope can hold a pending-incarnation stop, and
-                // only its own control plane can answer whether one exists.
-                // Both are cheap, so they gate the dynamic-state lookup.
-                child.active.is_none()
-                    && matches!(child.slot.member.record().stage, MemberStage::Restarting)
-                    && child
-                        .slot
-                        .scope
-                        .as_ref()
-                        .is_some_and(|scope| scope.has_pending_incarnation_shutdown())
-                    && !self.restart_is_suppressed(*key)
-            })
-            .collect()
+    pub(super) fn control_event_work(
+        &self,
+        event: ScopeControlEvent,
+    ) -> Option<(ArbitrationClass, Pending)> {
+        match event {
+            ScopeControlEvent::RestartShutdown { membership } => self
+                .child_keys
+                .get(&membership)
+                .copied()
+                .map(restart_shutdown_work),
+        }
     }
 
     pub(super) fn expedite_restart_shutdown(&mut self, key: ChildKey) {

--- a/crates/shelterwood/src/driver/events.rs
+++ b/crates/shelterwood/src/driver/events.rs
@@ -200,6 +200,18 @@ impl ScopeRuntime {
             child.restart_shutdown_pending = Some(target);
             return;
         }
+        if !child.spawned_once {
+            // Only a member in the restart gap may be expedited. The wake-start
+            // scan this path replaced required `MemberStage::Restarting`; with
+            // no active incarnation and the terminal/disposing cases excluded
+            // above, `spawned_once` is that stage bit — false means the member
+            // is still `Admitted` and has never run. Expediting it would let a
+            // shutdown request against the first (pending) incarnation start an
+            // ordered child before its in-order turn. Leave the request latched
+            // on the nested cell: the first incarnation claims it when
+            // `progress_startup` reaches the child.
+            return;
+        }
         child.restart_shutdown_pending = None;
         self.spawn_child(key);
     }

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -134,6 +134,12 @@ impl ScopeRuntime {
         let Some(mut child) = self.children.remove(key) else {
             return;
         };
+        let removed = self.child_keys.remove(&child.slot.member.membership());
+        debug_assert_eq!(
+            removed,
+            Some(key),
+            "reclaimed memberships leave the key index"
+        );
         if let Some(deadline) = child.restart_deadline.take() {
             self.deadlines.cancel(deadline);
         }

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -134,6 +134,14 @@ impl ScopeRuntime {
         let Some(mut child) = self.children.remove(key) else {
             return;
         };
+        // Reclaim never adjusts `incomplete_children`: every reclaim path runs
+        // after terminal completion, which already decremented the count. An
+        // early reclaim would leak the count and stall scope completion, so
+        // fail loudly instead.
+        debug_assert!(
+            !child.is_incomplete(),
+            "reclaim runs only after terminal completion"
+        );
         let removed = self.child_keys.remove(&child.slot.member.membership());
         debug_assert_eq!(
             removed,

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -132,7 +132,7 @@ impl ScopeRuntime {
             let waiting = self
                 .children
                 .get(key)
-                .is_some_and(|child| !child.is_terminal() || child.is_disposing());
+                .is_some_and(ChildRuntime::is_incomplete);
             if waiting {
                 self.ordered_stop_progressing = false;
                 return;
@@ -150,7 +150,7 @@ impl ScopeRuntime {
             let Some(child) = self.children.get(key) else {
                 continue;
             };
-            if child.is_terminal() && !child.is_disposing() {
+            if !child.is_incomplete() {
                 continue;
             }
             self.begin_stop_child(key, None);

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -203,15 +203,11 @@ impl ScopeRuntime {
     }
 
     pub(super) fn finish_if_ready(&mut self) -> Option<StopReason> {
-        let all_terminal = self
-            .children
-            .values()
-            .all(|child| child.is_terminal() && !child.is_disposing());
         self.lifecycle.finish_if_ready(
             self.root.flavor,
             ChildCompletionState {
                 has_children: !self.children.is_empty(),
-                all_terminal,
+                all_terminal: self.incomplete_children == 0,
             },
         )
     }

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -238,7 +238,7 @@ async fn final_removal_holds_the_id_until_removed_publication_commits() {
     let mut child = ChildRuntime::from_plan(plan, &root);
     child.initial = false;
     let key = root.with_observation_gate(|txn| {
-        let key = match scope.children.insert(child) {
+        let key = match scope.insert_child(child) {
             Ok(key) => key,
             Err(_) => panic!("the empty arena accepts its first child"),
         };
@@ -253,8 +253,8 @@ async fn final_removal_holds_the_id_until_removed_publication_commits() {
         root.admit_child_locked(resident_projection(&reservation.slot), txn);
         key
     });
-    assert!(scope.children[key].terminalize(
-        &root,
+    assert!(scope.terminalize_child(
+        key,
         Exit::never_started(),
         None,
         StartupDisposition::NotAborted,

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -314,6 +314,15 @@ fn forced_ordered_drain_advances_an_inactive_suffix_iteratively() {
         scope.ordered_stop_inspections, CHILDREN,
         "the reverse cursor inspects each ordered child exactly once"
     );
+    assert_eq!(
+        scope.incomplete_children, 0,
+        "terminal completion decrements the incremental count exactly once"
+    );
+    assert_eq!(
+        scope.finish_if_ready(),
+        Some(StopReason::ShutdownRequested),
+        "shutdown completion is decided from the maintained count"
+    );
 }
 #[crate::runtime::test]
 async fn system_shutdown_joins_root_driver_teardown() {

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -31,6 +31,82 @@ fn pre_admission_restart_shutdown_is_published_when_the_scope_gets_a_parent() {
 }
 
 #[crate::runtime::test]
+async fn restart_shutdown_arriving_before_exit_is_retried_after_the_child_becomes_inactive() {
+    let mut tree = Tree::new();
+    tree.add_subtree(
+        "nested",
+        SubtreeDef::factory(pending_tree).restart(RestartPolicy::new(
+            RestartCondition::Always,
+            Backoff::fixed(Duration::from_secs(60), crate::Jitter::None)
+                .expect("non-zero restart backoff"),
+        )),
+    )
+    .expect("valid subtree");
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
+    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+    let mut children = ChildArena::default();
+    let key = children
+        .insert(child)
+        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+        .with_defaults(plan.defaults.clone())
+        .with_lifecycle(ScopeLifecycle::running())
+        .with_children(children)
+        .build();
+    plan.armed = false;
+    drop(plan);
+
+    scope.spawn_child(key);
+    let first = scope.children[key]
+        .active
+        .as_ref()
+        .expect("the first incarnation is active")
+        .incarnation;
+    scope.expedite_restart_shutdown(key);
+    assert!(
+        scope.children[key].restart_shutdown_pending,
+        "the early event remains owned until the active incarnation exits"
+    );
+    scope.children[key]
+        .active
+        .as_ref()
+        .expect("the first incarnation is active")
+        .abort_handle
+        .abort();
+
+    scope.handle_exit(
+        key,
+        first,
+        Some(RecordedOutcome::returned(Err(ExitError::message(
+            "restart the nested scope",
+        )))),
+        crate::runtime::JoinOutcome::Ok { value: () },
+        Cancellation::NotObserved,
+        false,
+    );
+
+    let restarted = scope.children[key]
+        .active
+        .as_ref()
+        .expect("the retained event starts the next incarnation immediately");
+    assert_ne!(restarted.incarnation, first);
+    assert!(scope.children[key].restart_deadline.is_none());
+    assert!(!scope.children[key].restart_shutdown_pending);
+}
+
+#[crate::runtime::test]
 async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
     let factories = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let mut tree = Tree::new();

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -122,11 +122,18 @@ async fn pre_admission_restart_shutdown_does_not_expedite_the_following_incarnat
         false,
     );
 
+    // Drive the deferred retry the exit queued: the consumed target must not
+    // expedite the following incarnation.
+    for (child, target) in std::mem::take(&mut scope.restart_shutdown_retries) {
+        scope.expedite_restart_shutdown(child, target);
+    }
+
     assert!(
         scope.children[key].active.is_none(),
         "the consumed request must not bypass the following incarnation's backoff"
     );
     assert!(scope.children[key].restart_deadline.is_some());
+    assert!(scope.children[key].restart_shutdown_pending.is_none());
 }
 
 /// A shutdown request against a nested scope's *first* (still pending)
@@ -317,10 +324,18 @@ async fn restart_shutdown_arriving_before_exit_is_retried_after_the_child_become
         false,
     );
 
+    // Exit handling queues the retry rather than expediting mid-batch; the
+    // driver loop drains it into the next wake's arbitration.
+    let retries = std::mem::take(&mut scope.restart_shutdown_retries);
+    assert_eq!(retries, vec![(key, target)]);
+    for (child, target) in retries {
+        scope.expedite_restart_shutdown(child, target);
+    }
+
     let restarted = scope.children[key]
         .active
         .as_ref()
-        .expect("the retained event starts the next incarnation immediately");
+        .expect("the retained event starts the next incarnation on the following wake");
     assert_ne!(restarted.incarnation, first);
     assert!(scope.children[key].restart_deadline.is_none());
     assert!(scope.children[key].restart_shutdown_pending.is_none());
@@ -476,6 +491,181 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
         0,
         "the production guard must suppress the expedited factory after intensity drain"
     );
+}
+
+/// The retained-fact twin of the test above: a restart-shutdown fact retained
+/// while its subject was active is retried when the subject's exit is handled
+/// — but the retry must re-enter arbitration rather than expedite mid-batch,
+/// so an intensity-tripping exit collected in the same wake drains the scope
+/// before the retry can start a doomed incarnation.
+#[crate::runtime::test]
+async fn same_batch_intensity_exit_suppresses_retained_expedite_retry() {
+    let factories = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    tree.intensity(Intensity::new(1, Duration::from_secs(10)).expect("valid intensity"));
+    tree.add_subtree(
+        "nested",
+        SubtreeDef::factory({
+            let factories = Arc::clone(&factories);
+            move || {
+                factories.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Tree::new()
+            }
+        })
+        .restart(RestartPolicy::new(
+            RestartCondition::Always,
+            Backoff::fixed(Duration::from_secs(60), crate::Jitter::None)
+                .expect("non-zero restart backoff"),
+        )),
+    )
+    .expect("valid subtree");
+    tree.add_task("trip", TaskDef::new(|_| future::pending()))
+        .expect("valid task");
+
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
+    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+    let mut children = ChildArena::default();
+    plan.children.reverse();
+    while let Some(child) = plan.children.pop() {
+        children
+            .insert(ChildRuntime::from_plan(child, &root))
+            .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+    }
+    let nested = children
+        .keys()
+        .find(|key| children[*key].slot.member.id().as_str() == "nested")
+        .expect("nested child key");
+    let trip = children
+        .keys()
+        .find(|key| children[*key].slot.member.id().as_str() == "trip")
+        .expect("tripping child key");
+    let next_ordered_start = children.keys().next();
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+        .with_defaults(plan.defaults.clone())
+        .with_intensity_policy(plan.config.intensity)
+        .with_children(children)
+        .with_lifecycle(ScopeLifecycle::running())
+        .with_next_ordered_start(next_ordered_start)
+        .build();
+    plan.armed = false;
+    drop(plan);
+
+    let target = scope.children[nested]
+        .slot
+        .scope
+        .as_ref()
+        .expect("nested scope cell")
+        .request_shutdown()
+        .expect("the shutdown targets the pending nested incarnation");
+    scope.spawn_child(nested);
+    let nested_first = scope.children[nested]
+        .active
+        .as_ref()
+        .expect("the first nested incarnation is active")
+        .incarnation;
+    // The subject-carrying event runs while the child is still active, so the
+    // fact is retained for the exit-time retry.
+    scope.expedite_restart_shutdown(nested, target);
+    assert_eq!(
+        scope.children[nested].restart_shutdown_pending,
+        Some(target)
+    );
+    scope.children[nested]
+        .active
+        .as_ref()
+        .expect("the first nested incarnation is active")
+        .abort_handle
+        .abort();
+
+    scope.spawn_child(trip);
+    let trip_incarnation = scope.children[trip]
+        .active
+        .as_ref()
+        .expect("tripping child is active")
+        .incarnation;
+    scope.children[trip]
+        .active
+        .as_ref()
+        .expect("tripping child is active")
+        .abort_handle
+        .abort();
+
+    let nested_exit = DriverEvent::Child(ChildEvent::Exited {
+        child: nested,
+        incarnation: nested_first,
+        recorded: Some(RecordedOutcome::returned(Err(ExitError::message(
+            "restart the nested scope",
+        )))),
+        join: crate::runtime::JoinOutcome::Ok { value: () },
+        cancellation: Cancellation::NotObserved,
+        readiness_signal_seen: false,
+    });
+    let trip_exit = DriverEvent::Child(ChildEvent::Exited {
+        child: trip,
+        incarnation: trip_incarnation,
+        recorded: Some(RecordedOutcome::returned(Err(ExitError::message(
+            "trip intensity",
+        )))),
+        join: crate::runtime::JoinOutcome::Ok { value: () },
+        cancellation: Cancellation::NotObserved,
+        readiness_signal_seen: false,
+    });
+    let mut pending = [
+        Pending::Driver(nested_exit).classified(),
+        Pending::Driver(trip_exit).classified(),
+    ];
+    arbitrate(&mut pending);
+    for (_, event) in pending {
+        match event {
+            Pending::Driver(DriverEvent::Child(ChildEvent::Exited {
+                child,
+                incarnation,
+                recorded,
+                join,
+                cancellation,
+                readiness_signal_seen,
+            })) => scope.handle_exit(
+                child,
+                incarnation,
+                recorded,
+                join,
+                cancellation,
+                readiness_signal_seen,
+            ),
+            _ => unreachable!("the fixture queues only the two exits"),
+        }
+    }
+
+    // The nested exit deferred its retry through arbitration, so the trip
+    // exit from the same batch drained the scope first.
+    assert!(scope.lifecycle.is_draining());
+    let retries = std::mem::take(&mut scope.restart_shutdown_retries);
+    assert_eq!(retries, vec![(nested, target)]);
+    for (child, target) in retries {
+        scope.expedite_restart_shutdown(child, target);
+    }
+
+    crate::runtime::yield_now().await;
+    crate::runtime::yield_now().await;
+
+    assert_eq!(
+        factories.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "the deferred retry must not start a doomed incarnation after intensity drain"
+    );
+    assert!(scope.children[nested].active.is_none());
+    assert!(scope.children[nested].restart_shutdown_pending.is_none());
 }
 
 /// A `mark_ready(); stop()` child reports its local stop and exit on

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -129,6 +129,119 @@ async fn pre_admission_restart_shutdown_does_not_expedite_the_following_incarnat
     assert!(scope.children[key].restart_deadline.is_some());
 }
 
+/// A shutdown request against a nested scope's *first* (still pending)
+/// incarnation, published before the ordered start reaches that child, must
+/// not expedite-spawn it: only a member in the restart gap may bypass
+/// `progress_startup`'s in-order gating. The request stays latched on the
+/// nested cell and is claimed when the child starts at its ordered turn.
+#[crate::runtime::test]
+async fn early_restart_shutdown_does_not_expedite_a_never_started_ordered_child() {
+    let factories = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    tree.add_task(
+        "a",
+        TaskDef::new(|_| future::pending::<crate::ExitResult>())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness is valid")
+            .readiness_deadline(ReadinessDeadline::Unbounded),
+    )
+    .expect("valid task");
+    tree.add_subtree(
+        "nested",
+        SubtreeDef::factory({
+            let factories = Arc::clone(&factories);
+            move || {
+                factories.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Tree::new()
+            }
+        }),
+    )
+    .expect("valid subtree");
+
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let nested_cell = Arc::clone(
+        plan.children[1]
+            .slot
+            .scope
+            .as_ref()
+            .expect("nested scope cell"),
+    );
+    let target = nested_cell
+        .request_shutdown()
+        .expect("the pre-admission shutdown targets the first epoch");
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
+    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+    let mut children = ChildArena::default();
+    plan.children.reverse();
+    while let Some(child) = plan.children.pop() {
+        children
+            .insert(ChildRuntime::from_plan(child, &root))
+            .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+    }
+    let first = children.keys().next().expect("first ordered child");
+    let nested = children
+        .keys()
+        .find(|key| children[*key].slot.member.id().as_str() == "nested")
+        .expect("nested child key");
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+        .with_defaults(plan.defaults.clone())
+        .with_children(children)
+        .with_next_ordered_start(Some(first))
+        .build();
+    plan.armed = false;
+    drop(plan);
+
+    // Ordered startup spawns "a" and parks on its (never-fired) readiness.
+    scope.progress_startup();
+    assert!(scope.children[first].active.is_some());
+    assert!(!scope.children[first].initial_ready);
+
+    let event = root
+        .take_control_events()
+        .pop()
+        .expect("parent adoption publishes the pre-admission request");
+    let Some((
+        _,
+        Pending::RestartShutdown {
+            child,
+            target: event_target,
+        },
+    )) = scope.control_event_work(event)
+    else {
+        panic!("the control event resolves to restart-shutdown work");
+    };
+    assert_eq!(child, nested);
+    assert_eq!(event_target, target);
+    scope.expedite_restart_shutdown(child, event_target);
+
+    crate::runtime::yield_now().await;
+    crate::runtime::yield_now().await;
+
+    assert_eq!(
+        factories.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "a never-started ordered child must not be expedite-spawned before its turn"
+    );
+    assert!(scope.children[nested].active.is_none());
+    assert!(!scope.children[nested].spawned_once);
+    assert!(scope.children[nested].restart_shutdown_pending.is_none());
+    assert_eq!(
+        nested_cell.begin_incarnation(ScopeState::Starting),
+        Some(target),
+        "the request stays latched for the first incarnation's ordered turn"
+    );
+}
+
 #[crate::runtime::test]
 async fn restart_shutdown_arriving_before_exit_is_retried_after_the_child_becomes_inactive() {
     let mut tree = Tree::new();

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -13,7 +13,9 @@ fn pre_admission_restart_shutdown_is_published_when_the_scope_gets_a_parent() {
         .as_ref()
         .expect("nested scope cell");
 
-    assert!(nested.request_shutdown().is_some());
+    let target = nested
+        .request_shutdown()
+        .expect("the pre-admission shutdown targets the first epoch");
     assert!(root.take_control_events().is_empty());
     root.set_admitted_children(
         plan.children
@@ -26,8 +28,105 @@ fn pre_admission_restart_shutdown_is_published_when_the_scope_gets_a_parent() {
         root.take_control_events(),
         vec![ScopeControlEvent::RestartShutdown {
             membership: nested.member.membership(),
+            target,
         }]
     );
+}
+
+#[crate::runtime::test]
+async fn pre_admission_restart_shutdown_does_not_expedite_the_following_incarnation() {
+    let mut tree = Tree::new();
+    tree.add_subtree(
+        "nested",
+        SubtreeDef::factory(pending_tree).restart(RestartPolicy::new(
+            RestartCondition::Always,
+            Backoff::fixed(Duration::from_secs(60), crate::Jitter::None)
+                .expect("non-zero restart backoff"),
+        )),
+    )
+    .expect("valid subtree");
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let nested = Arc::clone(
+        plan.children[0]
+            .slot
+            .scope
+            .as_ref()
+            .expect("nested scope cell"),
+    );
+    let target = nested
+        .request_shutdown()
+        .expect("the pre-admission shutdown targets the first epoch");
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
+    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+    let mut children = ChildArena::default();
+    let key = children
+        .insert(child)
+        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+        .with_defaults(plan.defaults.clone())
+        .with_lifecycle(ScopeLifecycle::running())
+        .with_children(children)
+        .build();
+    plan.armed = false;
+    drop(plan);
+
+    scope.spawn_child(key);
+    let first = scope.children[key]
+        .active
+        .as_ref()
+        .expect("the first incarnation is active")
+        .incarnation;
+    assert_eq!(
+        nested.begin_incarnation(ScopeState::Starting),
+        Some(target),
+        "the first nested incarnation claims the pre-admission target"
+    );
+    assert!(nested.take_shutdown_request(target));
+    let event = root
+        .take_control_events()
+        .pop()
+        .expect("parent adoption publishes the pre-admission request");
+    let Some((_, Pending::RestartShutdown { child, target })) = scope.control_event_work(event)
+    else {
+        panic!("the control event resolves to restart-shutdown work");
+    };
+    assert_eq!(child, key);
+    scope.expedite_restart_shutdown(child, target);
+    nested.finish_incarnation(target, StopReason::ShutdownRequested);
+    scope.children[key]
+        .active
+        .as_ref()
+        .expect("the first incarnation is active")
+        .abort_handle
+        .abort();
+
+    scope.handle_exit(
+        key,
+        first,
+        Some(RecordedOutcome::returned(Err(ExitError::message(
+            "restart the nested scope",
+        )))),
+        crate::runtime::JoinOutcome::Ok { value: () },
+        Cancellation::NotObserved,
+        false,
+    );
+
+    assert!(
+        scope.children[key].active.is_none(),
+        "the consumed request must not bypass the following incarnation's backoff"
+    );
+    assert!(scope.children[key].restart_deadline.is_some());
 }
 
 #[crate::runtime::test]
@@ -68,15 +167,23 @@ async fn restart_shutdown_arriving_before_exit_is_retried_after_the_child_become
     plan.armed = false;
     drop(plan);
 
+    let target = scope.children[key]
+        .slot
+        .scope
+        .as_ref()
+        .expect("nested scope cell")
+        .request_shutdown()
+        .expect("the shutdown targets the pending nested incarnation");
     scope.spawn_child(key);
     let first = scope.children[key]
         .active
         .as_ref()
         .expect("the first incarnation is active")
         .incarnation;
-    scope.expedite_restart_shutdown(key);
-    assert!(
+    scope.expedite_restart_shutdown(key, target);
+    assert_eq!(
         scope.children[key].restart_shutdown_pending,
+        Some(target),
         "the early event remains owned until the active incarnation exits"
     );
     scope.children[key]
@@ -103,7 +210,7 @@ async fn restart_shutdown_arriving_before_exit_is_retried_after_the_child_become
         .expect("the retained event starts the next incarnation immediately");
     assert_ne!(restarted.incarnation, first);
     assert!(scope.children[key].restart_deadline.is_none());
-    assert!(!scope.children[key].restart_shutdown_pending);
+    assert!(scope.children[key].restart_shutdown_pending.is_none());
 }
 
 #[crate::runtime::test]
@@ -172,20 +279,29 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
         },
         None,
     );
-    let _ = scope.children[nested]
+    let target = scope.children[nested]
         .slot
         .scope
         .as_ref()
         .expect("nested scope cell")
-        .request_shutdown();
+        .request_shutdown()
+        .expect("the shutdown targets the pending nested incarnation");
     let event = root
         .take_control_events()
         .pop()
         .expect("the request publishes one subject-carrying control event");
-    let Some((_, Pending::RestartShutdown(subject))) = scope.control_event_work(event) else {
+    let Some((
+        _,
+        Pending::RestartShutdown {
+            child: subject,
+            target: event_target,
+        },
+    )) = scope.control_event_work(event)
+    else {
         panic!("the control event resolves to restart-shutdown work");
     };
     assert_eq!(subject, nested);
+    assert_eq!(event_target, target);
 
     scope.spawn_child(trip);
     let incarnation = scope.children[trip]
@@ -210,13 +326,15 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
         readiness_signal_seen: false,
     });
     let mut pending = [
-        restart_shutdown_work(nested),
+        restart_shutdown_work(nested, target),
         Pending::Driver(exit).classified(),
     ];
     arbitrate(&mut pending);
     for (_, event) in pending {
         match event {
-            Pending::RestartShutdown(child) => scope.expedite_restart_shutdown(child),
+            Pending::RestartShutdown { child, target } => {
+                scope.expedite_restart_shutdown(child, target);
+            }
             Pending::Driver(DriverEvent::Child(ChildEvent::Exited {
                 child,
                 incarnation,

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -1,5 +1,35 @@
 use super::support::*;
 
+#[test]
+fn pre_admission_restart_shutdown_is_published_when_the_scope_gets_a_parent() {
+    let mut tree = Tree::new();
+    tree.add_subtree("nested", SubtreeDef::factory(Tree::new))
+        .expect("valid subtree");
+    let plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let nested = plan.children[0]
+        .slot
+        .scope
+        .as_ref()
+        .expect("nested scope cell");
+
+    assert!(nested.request_shutdown().is_some());
+    assert!(root.take_control_events().is_empty());
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+
+    assert_eq!(
+        root.take_control_events(),
+        vec![ScopeControlEvent::RestartShutdown {
+            membership: nested.member.membership(),
+        }]
+    );
+}
+
 #[crate::runtime::test]
 async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
     let factories = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -72,7 +102,14 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
         .as_ref()
         .expect("nested scope cell")
         .request_shutdown();
-    assert_eq!(scope.pending_restart_shutdowns(), vec![nested]);
+    let event = root
+        .take_control_events()
+        .pop()
+        .expect("the request publishes one subject-carrying control event");
+    let Some((_, Pending::RestartShutdown(subject))) = scope.control_event_work(event) else {
+        panic!("the control event resolves to restart-shutdown work");
+    };
+    assert_eq!(subject, nested);
 
     scope.spawn_child(trip);
     let incarnation = scope.children[trip]

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -31,7 +31,7 @@ pub(super) use super::super::{
     MemberTransition, NestedScopeLatches, Pending, RemovalRequest, RemovalResponses,
     ResidentProjection, RuntimeStorage, ScopeCell, ScopeControlEvent, ScopeEpochGuard, ScopeFlavor,
     ScopeRole, ScopeRuntime, StartupDisposition, cancel_dynamic_reservation,
-    discharge_child_terminality, report_slot, reserve_dynamic, resident_projection,
+    discharge_child_terminality, index_children, report_slot, reserve_dynamic, resident_projection,
     restart_shutdown_work, run_nested_factory, run_nested_tree, run_scope_incarnation,
     storage::Obligation,
 };
@@ -108,21 +108,13 @@ impl ScopeRuntimeBuilder {
     }
 
     pub(super) fn build(self) -> ScopeRuntime {
-        let incomplete_children = self
-            .children
-            .values()
-            .filter(|child| !child.is_terminal() || child.is_disposing())
-            .count();
+        let (child_keys, incomplete_children) = index_children(&self.children);
         ScopeRuntime {
             root: self.root,
             defaults: self.defaults,
             intensity_policy: self.intensity_policy,
             intensity: super::super::IntensityState::default(),
-            child_keys: self
-                .children
-                .iter()
-                .map(|(key, child)| (child.slot.member.membership(), key))
-                .collect(),
+            child_keys,
             incomplete_children,
             restart_shutdown_retries: Vec::new(),
             children: self.children,

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -124,6 +124,7 @@ impl ScopeRuntimeBuilder {
                 .map(|(key, child)| (child.slot.member.membership(), key))
                 .collect(),
             incomplete_children,
+            restart_shutdown_retries: Vec::new(),
             children: self.children,
             events: self.events,
             disposal_events: self.disposal_events,

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -29,10 +29,11 @@ pub(super) use super::super::{
     AncestorCommandLatches, ChildArena, ChildEvent, ChildKey, ChildRuntime, ChildTerminality,
     DriverEvent, DynamicControl, DynamicEntry, GateCapture, MemberCell, MemberStage,
     MemberTransition, NestedScopeLatches, Pending, RemovalRequest, RemovalResponses,
-    ResidentProjection, RuntimeStorage, ScopeCell, ScopeEpochGuard, ScopeFlavor, ScopeRole,
-    ScopeRuntime, StartupDisposition, cancel_dynamic_reservation, discharge_child_terminality,
-    report_slot, reserve_dynamic, resident_projection, restart_shutdown_work, run_nested_factory,
-    run_nested_tree, run_scope_incarnation, storage::Obligation,
+    ResidentProjection, RuntimeStorage, ScopeCell, ScopeControlEvent, ScopeEpochGuard, ScopeFlavor,
+    ScopeRole, ScopeRuntime, StartupDisposition, cancel_dynamic_reservation,
+    discharge_child_terminality, report_slot, reserve_dynamic, resident_projection,
+    restart_shutdown_work, run_nested_factory, run_nested_tree, run_scope_incarnation,
+    storage::Obligation,
 };
 
 pub(super) struct ScopeRuntimeBuilder {
@@ -107,11 +108,22 @@ impl ScopeRuntimeBuilder {
     }
 
     pub(super) fn build(self) -> ScopeRuntime {
+        let incomplete_children = self
+            .children
+            .values()
+            .filter(|child| !child.is_terminal() || child.is_disposing())
+            .count();
         ScopeRuntime {
             root: self.root,
             defaults: self.defaults,
             intensity_policy: self.intensity_policy,
             intensity: super::super::IntensityState::default(),
+            child_keys: self
+                .children
+                .iter()
+                .map(|(key, child)| (child.slot.member.membership(), key))
+                .collect(),
+            incomplete_children,
             children: self.children,
             events: self.events,
             disposal_events: self.disposal_events,


### PR DESCRIPTION
## Why

Part 0.4 of #172 requires driver wakes to carry their subject instead of rediscovering rare control-plane facts through full-arena scans. Item 11 also requires shutdown completion to stop rescanning every child on every pass.

Stacked on #181.

## What

- publish pending-incarnation restart shutdowns as transactional control events carrying exact `Membership`
- resolve event subjects through an incrementally maintained membership-to-`ChildKey` index, so stale subjects safely miss
- republish a pre-admission pending request when parent adoption commits
- replace `pending_restart_shutdowns()` and its per-child record clone/lock scan
- maintain an incremental incomplete-child count and use it for O(1) shutdown completion checks
- cover subject publication, pre-admission adoption, same-batch arbitration, and exact terminal-count completion

This completes Part 0.4 and subsumes item 11 from #172.

## Test plan

- `./tools/dev cargo test -p shelterwood driver::tests::`
- pending restart-shutdown integration tests
- `./tools/dev just ci`
  - clippy with warnings denied
  - 523 nextest tests
  - doctests and rustdoc
  - API reachability and layering enforcement
  - packaged-crate verification
  - Nix formatting check
