### PR TITLE
Part 0.5/0.6: make disposal and mailbox intake structural

### DIFF
--- a/crates/shelterwood/src/mailbox/cell.rs
+++ b/crates/shelterwood/src/mailbox/cell.rs
@@ -282,7 +282,9 @@ impl WaiterId {
 /// FIFO registrations with direct removal by a send operation.
 ///
 /// Monotonic keys are insertion order, so the first map entry is the oldest
-/// waiter. Keys are never reused, making stale cancellation ids harmless.
+/// waiter. Keys are never reused within one queue instance; a queue is only
+/// replaced when it is empty or by the absorbing Terminal state, so no
+/// registration outlives its queue and stale cancellation ids remain harmless.
 /// `u64::MAX` is a poison key and is never minted; exhaustion remains poisoned
 /// instead of wrapping back into the live id domain.
 pub(super) struct WaiterQueue<M> {

--- a/crates/shelterwood/src/mailbox/cell.rs
+++ b/crates/shelterwood/src/mailbox/cell.rs
@@ -25,6 +25,35 @@ enum BindingStatus {
     Terminal(Option<Incarnation>),
 }
 
+enum MailboxBinding<M> {
+    Unbound(WaiterQueue<M>),
+    Bound(BoundState<M>),
+    Frozen {
+        incarnation: Incarnation,
+        waiters: WaiterQueue<M>,
+    },
+    Terminal(Option<Incarnation>),
+}
+
+/// A bound mailbox either has no parked senders or is explicitly blocked.
+/// Only the blocked variant can own waiters, and it is constructed only when
+/// a queue mailbox has reached capacity.
+enum BoundState<M> {
+    Available(Incarnation),
+    Full {
+        incarnation: Incarnation,
+        waiters: WaiterQueue<M>,
+    },
+}
+
+impl<M> BoundState<M> {
+    fn incarnation(&self) -> Incarnation {
+        match self {
+            Self::Available(incarnation) | Self::Full { incarnation, .. } => *incarnation,
+        }
+    }
+}
+
 /// Which mailbox binding states may yield accepted messages.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ReceiveMode {
@@ -151,11 +180,81 @@ impl<M> SendOperation<M> {
 
 pub(super) struct MailboxState<M> {
     kind: Option<MailboxKind>,
-    status: BindingStatus,
+    binding: MailboxBinding<M>,
     last_bound: Option<Incarnation>,
     pub(super) queue: VecDeque<Envelope<M>>,
     latest: Option<Envelope<M>>,
-    pub(super) waiters: WaiterQueue<M>,
+}
+
+impl<M> MailboxState<M> {
+    fn status(&self) -> BindingStatus {
+        match &self.binding {
+            MailboxBinding::Unbound(_) => BindingStatus::Unbound,
+            MailboxBinding::Bound(bound) => BindingStatus::Bound(bound.incarnation()),
+            MailboxBinding::Frozen { incarnation, .. } => BindingStatus::Frozen(*incarnation),
+            MailboxBinding::Terminal(incarnation) => BindingStatus::Terminal(*incarnation),
+        }
+    }
+
+    fn park(&mut self, operation: &Arc<SendOperation<M>>) {
+        match &mut self.binding {
+            MailboxBinding::Unbound(waiters)
+            | MailboxBinding::Frozen { waiters, .. }
+            | MailboxBinding::Bound(BoundState::Full { waiters, .. }) => {
+                waiters.park(operation);
+            }
+            MailboxBinding::Bound(BoundState::Available(incarnation)) => {
+                let Some(MailboxKind::Queue(capacity)) = self.kind else {
+                    unreachable!("only a capacity-bound queue can park while bound")
+                };
+                debug_assert_eq!(self.queue.len(), capacity.get());
+                let incarnation = *incarnation;
+                let mut waiters = WaiterQueue::default();
+                waiters.park(operation);
+                self.binding = MailboxBinding::Bound(BoundState::Full {
+                    incarnation,
+                    waiters,
+                });
+            }
+            MailboxBinding::Terminal(_) => {
+                unreachable!("terminal submissions return their payload directly")
+            }
+        }
+    }
+
+    fn remove_waiter(&mut self, registration: WaiterId) -> Option<Arc<SendOperation<M>>> {
+        let mut available = None;
+        let removed = match &mut self.binding {
+            MailboxBinding::Unbound(waiters) | MailboxBinding::Frozen { waiters, .. } => {
+                waiters.remove(registration)
+            }
+            MailboxBinding::Bound(BoundState::Full {
+                incarnation,
+                waiters,
+            }) => {
+                let removed = waiters.remove(registration);
+                if removed.is_some() && waiters.is_empty() {
+                    available = Some(*incarnation);
+                }
+                removed
+            }
+            MailboxBinding::Bound(BoundState::Available(_)) | MailboxBinding::Terminal(_) => None,
+        };
+        if let Some(incarnation) = available {
+            self.binding = MailboxBinding::Bound(BoundState::Available(incarnation));
+        }
+        removed
+    }
+
+    #[cfg(test)]
+    pub(super) fn waiters(&self) -> Option<&WaiterQueue<M>> {
+        match &self.binding {
+            MailboxBinding::Unbound(waiters)
+            | MailboxBinding::Frozen { waiters, .. }
+            | MailboxBinding::Bound(BoundState::Full { waiters, .. }) => Some(waiters),
+            MailboxBinding::Bound(BoundState::Available(_)) | MailboxBinding::Terminal(_) => None,
+        }
+    }
 }
 
 pub(super) enum Submission<M> {
@@ -252,6 +351,22 @@ impl<M> WaiterQueue<M> {
             self.direct_removals = self.direct_removals.saturating_add(1);
         }
         Some(operation)
+    }
+}
+
+/// A completed locked acceptance whose user payload must be destroyed only
+/// after the mailbox mutex is released.
+#[must_use = "finish accepted delivery after releasing the mailbox lock"]
+struct Acceptance<M> {
+    incarnation: Incarnation,
+    displaced: Option<Envelope<M>>,
+}
+
+impl<M> Acceptance<M> {
+    fn finish(self, changed: &Signal) -> Incarnation {
+        changed.pulse();
+        drop(self.displaced);
+        self.incarnation
     }
 }
 
@@ -413,11 +528,10 @@ impl<M: Send + 'static> MailboxCell<M> {
             actor_id,
             state: Mutex::new(MailboxState {
                 kind: None,
-                status: BindingStatus::Unbound,
+                binding: MailboxBinding::Unbound(WaiterQueue::default()),
                 last_bound: None,
                 queue: VecDeque::new(),
                 latest: None,
-                waiters: WaiterQueue::default(),
             }),
             accepted: AtomicU64::new(0),
             changed: Signal::default(),
@@ -426,67 +540,42 @@ impl<M: Send + 'static> MailboxCell<M> {
 
     pub(super) fn submit(&self, message: M) -> Submission<M> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
-        match state.status {
+        match state.status() {
             BindingStatus::Terminal(final_incarnation) => Submission::Terminated {
                 message,
                 final_incarnation,
             },
             BindingStatus::Bound(incarnation) => {
-                let can_accept = match state.kind {
-                    Some(MailboxKind::Queue(capacity)) => {
-                        state.waiters.is_empty() && state.queue.len() < capacity.get()
+                match accept_locked(&mut state, message, &self.accepted) {
+                    Ok(acceptance) => {
+                        drop(state);
+                        Submission::Accepted(acceptance.finish(&self.changed))
                     }
-                    Some(MailboxKind::Latest) => true,
-                    None => false,
-                };
-                if can_accept {
-                    let accepted_sequence = self.mint_accepted_sequence();
-                    let displaced = match state.kind {
-                        Some(MailboxKind::Queue(_)) => {
-                            state.queue.push_back(Envelope {
-                                message,
-                                accepted_sequence,
-                            });
-                            None
-                        }
-                        Some(MailboxKind::Latest) => state.latest.replace(Envelope {
-                            message,
-                            accepted_sequence,
-                        }),
-                        None => unreachable!(),
-                    };
-                    drop(state);
-                    self.changed.pulse();
-                    drop(displaced);
-                    Submission::Accepted(incarnation)
-                } else {
-                    let operation = SendOperation::new(message);
-                    operation.observe(incarnation);
-                    state.waiters.park(&operation);
-                    Submission::Parked(operation)
+                    Err(message) => {
+                        let operation = SendOperation::new(message);
+                        operation.observe(incarnation);
+                        state.park(&operation);
+                        Submission::Parked(operation)
+                    }
                 }
             }
             BindingStatus::Frozen(incarnation) => {
                 let operation = SendOperation::new(message);
                 operation.observe(incarnation);
-                state.waiters.park(&operation);
+                state.park(&operation);
                 Submission::Parked(operation)
             }
             BindingStatus::Unbound => {
                 let operation = SendOperation::new(message);
-                state.waiters.park(&operation);
+                state.park(&operation);
                 Submission::Parked(operation)
             }
         }
     }
 
-    fn mint_accepted_sequence(&self) -> AcceptedSequence {
-        mint_accepted_sequence(&self.accepted)
-    }
-
     pub(super) fn try_send(&self, message: M) -> Result<Incarnation, SendError<M>> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
-        match state.status {
+        match state.status() {
             BindingStatus::Terminal(final_incarnation) => Err(SendError {
                 actor_id: self.actor_id.clone(),
                 incarnation_observed: final_incarnation,
@@ -505,45 +594,28 @@ impl<M: Send + 'static> MailboxCell<M> {
                 message,
                 kind: SendErrorKind::NotRunning,
             }),
-            BindingStatus::Bound(incarnation) => match state.kind {
-                Some(MailboxKind::Queue(capacity))
-                    if !state.waiters.is_empty() || state.queue.len() >= capacity.get() =>
-                {
-                    Err(SendError {
+            BindingStatus::Bound(incarnation) => {
+                if state.kind.is_none() {
+                    return Err(SendError {
+                        actor_id: self.actor_id.clone(),
+                        incarnation_observed: None,
+                        message,
+                        kind: SendErrorKind::NotRunning,
+                    });
+                }
+                match accept_locked(&mut state, message, &self.accepted) {
+                    Ok(acceptance) => {
+                        drop(state);
+                        Ok(acceptance.finish(&self.changed))
+                    }
+                    Err(message) => Err(SendError {
                         actor_id: self.actor_id.clone(),
                         incarnation_observed: Some(incarnation),
                         message,
                         kind: SendErrorKind::Full,
-                    })
+                    }),
                 }
-                Some(MailboxKind::Queue(_)) => {
-                    let accepted_sequence = self.mint_accepted_sequence();
-                    state.queue.push_back(Envelope {
-                        message,
-                        accepted_sequence,
-                    });
-                    drop(state);
-                    self.changed.pulse();
-                    Ok(incarnation)
-                }
-                Some(MailboxKind::Latest) => {
-                    let accepted_sequence = self.mint_accepted_sequence();
-                    let displaced = state.latest.replace(Envelope {
-                        message,
-                        accepted_sequence,
-                    });
-                    drop(state);
-                    self.changed.pulse();
-                    drop(displaced);
-                    Ok(incarnation)
-                }
-                None => Err(SendError {
-                    actor_id: self.actor_id.clone(),
-                    incarnation_observed: None,
-                    message,
-                    kind: SendErrorKind::NotRunning,
-                }),
-            },
+            }
         }
     }
 
@@ -554,7 +626,7 @@ impl<M: Send + 'static> MailboxCell<M> {
         accepted_through: Option<AcceptedSequence>,
     ) -> Option<M> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
-        let eligible = match state.status {
+        let eligible = match state.status() {
             BindingStatus::Bound(current) => current == incarnation,
             BindingStatus::Frozen(current) => {
                 mode == ReceiveMode::IncludeFrozen && current == incarnation
@@ -585,7 +657,7 @@ impl<M: Send + 'static> MailboxCell<M> {
             }
             None => None,
         };
-        let promotion = if message.is_some() && matches!(state.status, BindingStatus::Bound(_)) {
+        let promotion = if message.is_some() && matches!(state.status(), BindingStatus::Bound(_)) {
             promote_waiters(&mut state, &self.accepted)
         } else {
             Promotion::default()
@@ -599,7 +671,7 @@ impl<M: Send + 'static> MailboxCell<M> {
     }
 
     pub(super) fn current_observation(&self) -> Option<Incarnation> {
-        match self.state.lock().expect("mailbox mutex poisoned").status {
+        match self.state.lock().expect("mailbox mutex poisoned").status() {
             BindingStatus::Bound(incarnation) | BindingStatus::Frozen(incarnation) => {
                 Some(incarnation)
             }
@@ -619,7 +691,7 @@ impl<M: Send + 'static> MailboxCell<M> {
 impl<M> MailboxCell<M> {
     pub(super) fn withdraw(&self, operation: &Arc<SendOperation<M>>) -> Withdrawal<M> {
         let mut mailbox = self.state.lock().expect("mailbox mutex poisoned");
-        let current_observation = match mailbox.status {
+        let current_observation = match mailbox.status() {
             BindingStatus::Bound(incarnation) | BindingStatus::Frozen(incarnation) => {
                 Some(incarnation)
             }
@@ -673,10 +745,10 @@ impl<M> MailboxCell<M> {
             }
         };
         if let Some(registration) = registration {
-            if let Some(removed) = mailbox.waiters.remove(registration) {
+            if let Some(removed) = mailbox.remove_waiter(registration) {
                 debug_assert!(Arc::ptr_eq(&removed, operation));
             } else {
-                debug_assert!(matches!(mailbox.status, BindingStatus::Terminal(_)));
+                debug_assert!(matches!(mailbox.status(), BindingStatus::Terminal(_)));
             }
         }
         result
@@ -702,7 +774,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
 
     fn bind(&self, incarnation: Incarnation) {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
-        if matches!(state.status, BindingStatus::Terminal(_)) {
+        if matches!(state.status(), BindingStatus::Terminal(_)) {
             return;
         }
         debug_assert!(
@@ -710,18 +782,45 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             "mailbox must be configured before its first bind"
         );
         debug_assert!(
-            matches!(state.status, BindingStatus::Unbound),
+            matches!(state.status(), BindingStatus::Unbound),
             "mailbox must close the prior incarnation before rebinding"
         );
-        state.status = BindingStatus::Bound(incarnation);
+        let binding = std::mem::replace(
+            &mut state.binding,
+            MailboxBinding::Bound(BoundState::Available(incarnation)),
+        );
+        let MailboxBinding::Unbound(mut waiters) = binding else {
+            unreachable!("the bind-order contract requires an unbound mailbox")
+        };
         state.last_bound = Some(incarnation);
         // Binding is an observation edge for every operation that remained
         // parked through it, including FIFO overflow that cannot be promoted
         // into the current capacity. Withdrawal takes the mailbox lock before
         // the operation lock, so a concurrent timeout sees either the prior
         // evidence or this incarnation consistently with which edge won.
-        state.waiters.observe_all(incarnation);
-        let promotion = promote_waiters(&mut state, &self.accepted);
+        waiters.observe_all(incarnation);
+        let kind = state.kind.expect("a bound mailbox is configured");
+        let promotion = {
+            let MailboxState { queue, latest, .. } = &mut *state;
+            promote_waiter_queue(
+                kind,
+                incarnation,
+                &mut waiters,
+                queue,
+                latest,
+                &self.accepted,
+            )
+        };
+        if !waiters.is_empty() {
+            let MailboxKind::Queue(capacity) = kind else {
+                unreachable!("a latest mailbox finishes all waiting submissions")
+            };
+            debug_assert_eq!(state.queue.len(), capacity.get());
+            state.binding = MailboxBinding::Bound(BoundState::Full {
+                incarnation,
+                waiters,
+            });
+        }
         drop(state);
         self.changed.pulse();
         promotion.finish_isolated();
@@ -729,23 +828,42 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
 
     fn freeze(&self, incarnation: Incarnation) {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
-        if state.status == BindingStatus::Bound(incarnation) {
-            state.status = BindingStatus::Frozen(incarnation);
-            drop(state);
-            self.changed.pulse();
+        if state.status() != BindingStatus::Bound(incarnation) {
+            return;
         }
+        let last_bound = state.last_bound;
+        let binding = std::mem::replace(&mut state.binding, MailboxBinding::Terminal(last_bound));
+        let waiters = match binding {
+            MailboxBinding::Bound(BoundState::Available(_)) => WaiterQueue::default(),
+            MailboxBinding::Bound(BoundState::Full { waiters, .. }) => waiters,
+            _ => unreachable!("the status check selected a bound mailbox"),
+        };
+        state.binding = MailboxBinding::Frozen {
+            incarnation,
+            waiters,
+        };
+        drop(state);
+        self.changed.pulse();
     }
 
     fn close(&self, incarnation: Incarnation) -> Option<MailboxDisposal> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         if !matches!(
-            state.status,
+            state.status(),
             BindingStatus::Bound(current) | BindingStatus::Frozen(current)
                 if current == incarnation
         ) {
             return None;
         }
-        state.status = BindingStatus::Unbound;
+        let last_bound = state.last_bound;
+        let binding = std::mem::replace(&mut state.binding, MailboxBinding::Terminal(last_bound));
+        let waiters = match binding {
+            MailboxBinding::Bound(BoundState::Available(_)) => WaiterQueue::default(),
+            MailboxBinding::Bound(BoundState::Full { waiters, .. })
+            | MailboxBinding::Frozen { waiters, .. } => waiters,
+            _ => unreachable!("the status check selected a live mailbox"),
+        };
+        state.binding = MailboxBinding::Unbound(waiters);
         let queue = std::mem::take(&mut state.queue);
         let latest = state.latest.take();
         drop(state);
@@ -759,14 +877,23 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
 
     fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>> {
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
-        if matches!(state.status, BindingStatus::Terminal(_)) {
+        if matches!(state.status(), BindingStatus::Terminal(_)) {
             return None;
         }
         let final_incarnation = state.last_bound;
-        state.status = BindingStatus::Terminal(final_incarnation);
+        let binding = std::mem::replace(
+            &mut state.binding,
+            MailboxBinding::Terminal(final_incarnation),
+        );
+        let waiters = match binding {
+            MailboxBinding::Unbound(waiters)
+            | MailboxBinding::Frozen { waiters, .. }
+            | MailboxBinding::Bound(BoundState::Full { waiters, .. }) => waiters,
+            MailboxBinding::Bound(BoundState::Available(_)) => WaiterQueue::default(),
+            MailboxBinding::Terminal(_) => unreachable!("terminality was checked above"),
+        };
         let queue = std::mem::take(&mut state.queue);
         let latest = state.latest.take();
-        let waiters = std::mem::take(&mut state.waiters);
         let termination = Termination {
             waiters,
             final_incarnation,
@@ -788,7 +915,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         let state = self.state.lock().expect("mailbox mutex poisoned");
         state.kind.is_some()
             && matches!(
-                state.status,
+                state.status(),
                 BindingStatus::Unbound | BindingStatus::Terminal(_)
             )
     }
@@ -805,24 +932,90 @@ fn mint_accepted_sequence(accepted: &AtomicU64) -> AcceptedSequence {
     )
 }
 
+fn accept_locked<M>(
+    state: &mut MailboxState<M>,
+    message: M,
+    accepted: &AtomicU64,
+) -> Result<Acceptance<M>, M> {
+    let incarnation = match &state.binding {
+        MailboxBinding::Bound(BoundState::Available(incarnation)) => *incarnation,
+        MailboxBinding::Unbound(_)
+        | MailboxBinding::Bound(BoundState::Full { .. })
+        | MailboxBinding::Frozen { .. }
+        | MailboxBinding::Terminal(_) => return Err(message),
+    };
+    let kind = match state.kind {
+        Some(MailboxKind::Queue(capacity)) if state.queue.len() < capacity.get() => {
+            MailboxKind::Queue(capacity)
+        }
+        Some(MailboxKind::Latest) => MailboxKind::Latest,
+        Some(MailboxKind::Queue(_)) | None => return Err(message),
+    };
+    let accepted_sequence = mint_accepted_sequence(accepted);
+    let displaced = match kind {
+        MailboxKind::Queue(_) => {
+            state.queue.push_back(Envelope {
+                message,
+                accepted_sequence,
+            });
+            None
+        }
+        MailboxKind::Latest => state.latest.replace(Envelope {
+            message,
+            accepted_sequence,
+        }),
+    };
+    Ok(Acceptance {
+        incarnation,
+        displaced,
+    })
+}
+
 fn promote_waiters<M: Send + 'static>(
     state: &mut MailboxState<M>,
     accepted_sequence: &AtomicU64,
 ) -> Promotion<M> {
-    let mut promotion = Promotion::default();
     let Some(kind) = state.kind else {
-        return promotion;
+        return Promotion::default();
     };
-    let BindingStatus::Bound(incarnation) = state.status else {
-        return promotion;
+    let MailboxBinding::Bound(BoundState::Full {
+        incarnation,
+        waiters,
+    }) = &mut state.binding
+    else {
+        return Promotion::default();
     };
+    let incarnation = *incarnation;
+    let promotion = promote_waiter_queue(
+        kind,
+        incarnation,
+        waiters,
+        &mut state.queue,
+        &mut state.latest,
+        accepted_sequence,
+    );
+    if waiters.is_empty() {
+        state.binding = MailboxBinding::Bound(BoundState::Available(incarnation));
+    }
+    promotion
+}
+
+fn promote_waiter_queue<M: Send + 'static>(
+    kind: MailboxKind,
+    incarnation: Incarnation,
+    waiters: &mut WaiterQueue<M>,
+    queue: &mut VecDeque<Envelope<M>>,
+    latest: &mut Option<Envelope<M>>,
+    accepted_sequence: &AtomicU64,
+) -> Promotion<M> {
+    let mut promotion = Promotion::default();
     let available = match kind {
-        MailboxKind::Queue(capacity) => capacity.get().saturating_sub(state.queue.len()),
+        MailboxKind::Queue(capacity) => capacity.get().saturating_sub(queue.len()),
         MailboxKind::Latest => usize::MAX,
     };
     let mut accepted = 0usize;
     while accepted < available {
-        let Some((registration, operation)) = state.waiters.pop_front() else {
+        let Some((registration, operation)) = waiters.pop_front() else {
             break;
         };
         operation.clear_registration(registration);
@@ -835,12 +1028,12 @@ fn promote_waiters<M: Send + 'static>(
         }
         let accepted_sequence = mint_accepted_sequence(accepted_sequence);
         match kind {
-            MailboxKind::Queue(_) => state.queue.push_back(Envelope {
+            MailboxKind::Queue(_) => queue.push_back(Envelope {
                 message,
                 accepted_sequence,
             }),
             MailboxKind::Latest => {
-                if let Some(displaced) = state.latest.replace(Envelope {
+                if let Some(displaced) = latest.replace(Envelope {
                     message,
                     accepted_sequence,
                 }) {
@@ -993,6 +1186,50 @@ pub(super) mod tests {
     }
 
     #[test]
+    fn bound_waiters_exist_only_in_the_full_state() {
+        let (mailbox, _) = actor();
+        MailboxControl::configure(
+            &*mailbox,
+            Mailbox::queue(1).expect("non-zero queue capacity"),
+        );
+        let mut identity = ScopeIdentity::new();
+        let membership = identity
+            .mint_membership(&ChildId::from("actor"))
+            .expect("membership available");
+        let incarnation = identity
+            .incarnation_counter(membership)
+            .mint()
+            .expect("incarnation available");
+        MailboxControl::bind(&*mailbox, incarnation);
+
+        assert!(matches!(
+            mailbox.submit(1),
+            super::Submission::Accepted(bound) if bound == incarnation
+        ));
+        let operation = match mailbox.submit(2) {
+            super::Submission::Parked(operation) => operation,
+            super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+                panic!("a sender parks behind the full queue")
+            }
+        };
+        assert!(matches!(
+            &mailbox.state.lock().expect("mailbox mutex poisoned").binding,
+            super::MailboxBinding::Bound(super::BoundState::Full { waiters, .. })
+                if !waiters.is_empty()
+        ));
+
+        assert!(matches!(
+            mailbox.withdraw(&operation),
+            super::Withdrawal::Withdrawn { message: 2, .. }
+        ));
+        assert!(matches!(
+            mailbox.state.lock().expect("mailbox mutex poisoned").binding,
+            super::MailboxBinding::Bound(super::BoundState::Available(bound))
+                if bound == incarnation
+        ));
+    }
+
+    #[test]
     fn cancelling_many_parked_sends_unlinks_one_registration_each() {
         const SENDS: usize = 16_384;
 
@@ -1008,7 +1245,8 @@ pub(super) mod tests {
                 .state
                 .lock()
                 .expect("mailbox mutex poisoned")
-                .waiters
+                .waiters()
+                .expect("an unbound mailbox owns its parked waiters")
                 .len(),
             SENDS
         );
@@ -1029,9 +1267,12 @@ pub(super) mod tests {
         }
 
         let state = mailbox.state.lock().expect("mailbox mutex poisoned");
-        assert!(state.waiters.is_empty());
+        let waiters = state
+            .waiters()
+            .expect("an unbound mailbox retains its empty waiter queue");
+        assert!(waiters.is_empty());
         assert_eq!(
-            state.waiters.direct_removals, SENDS,
+            waiters.direct_removals, SENDS,
             "mass cancellation must do one direct unlink per parked send"
         );
     }
@@ -1132,8 +1373,8 @@ pub(super) mod tests {
                 .state
                 .lock()
                 .expect("mailbox mutex remains healthy")
-                .waiters
-                .is_empty()
+                .waiters()
+                .is_none()
         );
     }
 

--- a/crates/shelterwood/src/mailbox/cell.rs
+++ b/crates/shelterwood/src/mailbox/cell.rs
@@ -777,20 +777,23 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         if matches!(state.status(), BindingStatus::Terminal(_)) {
             return;
         }
-        debug_assert!(
-            state.kind.is_some(),
-            "mailbox must be configured before its first bind"
-        );
-        debug_assert!(
-            matches!(state.status(), BindingStatus::Unbound),
-            "mailbox must close the prior incarnation before rebinding"
-        );
+        // Driver-contract violations release the lock before panicking so the
+        // failure stays on the driver thread instead of poisoning the mutex
+        // under every sender.
+        let Some(kind) = state.kind else {
+            drop(state);
+            panic!("mailbox must be configured before its first bind");
+        };
+        if !matches!(state.status(), BindingStatus::Unbound) {
+            drop(state);
+            panic!("mailbox must close the prior incarnation before rebinding");
+        }
         let binding = std::mem::replace(
             &mut state.binding,
             MailboxBinding::Bound(BoundState::Available(incarnation)),
         );
         let MailboxBinding::Unbound(mut waiters) = binding else {
-            unreachable!("the bind-order contract requires an unbound mailbox")
+            unreachable!("the bind-order contract was checked above")
         };
         state.last_bound = Some(incarnation);
         // Binding is an observation edge for every operation that remained
@@ -799,7 +802,6 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         // the operation lock, so a concurrent timeout sees either the prior
         // evidence or this incarnation consistently with which edge won.
         waiters.observe_all(incarnation);
-        let kind = state.kind.expect("a bound mailbox is configured");
         let promotion = {
             let MailboxState { queue, latest, .. } = &mut *state;
             promote_waiter_queue(
@@ -1152,7 +1154,6 @@ pub(super) mod tests {
         assert!(future.as_mut().poll(&mut context).is_pending());
     }
 
-    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "mailbox must be configured before its first bind")]
     fn binding_before_configuration_trips_the_driver_contract() {
@@ -1167,7 +1168,6 @@ pub(super) mod tests {
         MailboxControl::bind(&*mailbox, incarnation);
     }
 
-    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "mailbox must close the prior incarnation before rebinding")]
     fn rebinding_before_close_trips_the_driver_contract() {

--- a/crates/shelterwood/src/mailbox/futures.rs
+++ b/crates/shelterwood/src/mailbox/futures.rs
@@ -699,6 +699,6 @@ mod tests {
         assert_eq!(drops.load(Ordering::SeqCst), 1);
         let state = mailbox.state.lock().expect("mailbox mutex poisoned");
         assert!(state.queue.is_empty());
-        assert!(state.waiters.is_empty());
+        assert!(state.waiters().is_some_and(|waiters| waiters.is_empty()));
     }
 }

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -252,6 +252,68 @@ impl PanicSlot {
     }
 }
 
+/// The one cleanup route for values owned by a raw incarnation.
+///
+/// Every container stores user payloads in [`Contained`], and offload futures
+/// use the same funnel explicitly when ownership sits behind a mutex. A
+/// destructor panic is retained as cleanup evidence and wakes an idle actor;
+/// it never unwinds through another user destructor.
+#[derive(Clone)]
+struct RawDisposal {
+    panic: Arc<PanicSlot>,
+    signal: Signal,
+}
+
+impl RawDisposal {
+    fn record(&self, payload: PanicPayload) {
+        self.panic.record(payload);
+        if let Err(payload) = catch_panic(|| self.signal.pulse()) {
+            self.panic.record(payload);
+        }
+    }
+
+    fn dispose<T>(&self, value: T) {
+        if let Err(payload) = catch_panic(|| drop(value)) {
+            self.record(payload);
+        }
+    }
+}
+
+#[must_use = "contained user ownership must be consumed or disposed"]
+struct Contained<T> {
+    value: Option<T>,
+    disposal: RawDisposal,
+}
+
+impl<T> Contained<T> {
+    fn new(value: T, disposal: RawDisposal) -> Self {
+        Self {
+            value: Some(value),
+            disposal,
+        }
+    }
+
+    fn get(&self) -> &T {
+        self.value
+            .as_ref()
+            .expect("contained ownership is consumed once")
+    }
+
+    fn into_inner(mut self) -> T {
+        self.value
+            .take()
+            .expect("contained ownership is consumed once")
+    }
+}
+
+impl<T> Drop for Contained<T> {
+    fn drop(&mut self) {
+        if let Some(value) = self.value.take() {
+            self.disposal.dispose(value);
+        }
+    }
+}
+
 /// Incarnation-internal completion storage for offload continuations.
 ///
 /// The queue is deliberately unbounded, but sustained traffic cannot grow it
@@ -272,21 +334,33 @@ struct EventQueue<M> {
     // Insertion and the snapshot share this lock, so FIFO order itself is the
     // sequence and there is no integer counter whose saturation could blur a
     // boundary.
-    queue: Mutex<VecDeque<QueuedEvent<M>>>,
+    queue: Mutex<VecDeque<Contained<QueuedEvent<M>>>>,
     signal: Signal,
+    disposal: RawDisposal,
 }
 
 impl<M> Default for EventQueue<M> {
     fn default() -> Self {
-        Self {
-            queue: Mutex::new(VecDeque::new()),
-            signal: Signal::default(),
-        }
+        let signal = Signal::default();
+        let disposal = RawDisposal {
+            panic: Arc::new(PanicSlot::default()),
+            signal: signal.clone(),
+        };
+        Self::new(disposal)
     }
 }
 
 impl<M> EventQueue<M> {
+    fn new(disposal: RawDisposal) -> Self {
+        Self {
+            queue: Mutex::new(VecDeque::new()),
+            signal: disposal.signal.clone(),
+            disposal,
+        }
+    }
+
     fn push(&self, event: QueuedEvent<M>) {
+        let event = Contained::new(event, self.disposal.clone());
         self.queue
             .lock()
             .expect("actor event queue mutex poisoned")
@@ -296,6 +370,7 @@ impl<M> EventQueue<M> {
 
     #[cfg(test)]
     fn insert_with(&self, event: QueuedEvent<M>, before_insert: impl FnOnce()) {
+        let event = Contained::new(event, self.disposal.clone());
         let mut queue = self.queue.lock().expect("actor event queue mutex poisoned");
         before_insert();
         queue.push_back(event);
@@ -321,14 +396,14 @@ impl<M> EventQueue<M> {
     }
 
     #[cfg(test)]
-    fn pop(&self) -> Option<QueuedEvent<M>> {
+    fn pop(&self) -> Option<Contained<QueuedEvent<M>>> {
         self.queue
             .lock()
             .expect("actor event queue mutex poisoned")
             .pop_front()
     }
 
-    fn pop_through(&self, remaining: &mut usize) -> Option<QueuedEvent<M>> {
+    fn pop_through(&self, remaining: &mut usize) -> Option<Contained<QueuedEvent<M>>> {
         if *remaining == 0 {
             None
         } else {
@@ -377,12 +452,12 @@ impl ArmingOrder {
 struct KeyHash(u64);
 
 struct TimerEntry<M> {
-    key: Box<dyn Any + Send>,
+    key: Contained<Box<dyn Any + Send>>,
     /// `None` when the requested delay overflows the clock: a deadline that
     /// never arrives, mirroring the offload path — never "due now".
     deadline: Option<Instant>,
     arming_order: ArmingOrder,
-    message: TimerMessage<M>,
+    message: Contained<TimerMessage<M>>,
     period: Option<Duration>,
 }
 
@@ -397,24 +472,33 @@ struct TimerStore<M> {
     keyed: HashMap<KeyHash, Vec<TimerEntry<M>>>,
     armings: HashMap<ArmingOrder, KeyHash>,
     deadlines: BTreeSet<(Instant, ArmingOrder)>,
+    disposal: RawDisposal,
     #[cfg(test)]
     lookup_probes: usize,
 }
 
 impl<M> Default for TimerStore<M> {
     fn default() -> Self {
+        let signal = Signal::default();
+        Self::new(RawDisposal {
+            panic: Arc::new(PanicSlot::default()),
+            signal,
+        })
+    }
+}
+
+impl<M> TimerStore<M> {
+    fn new(disposal: RawDisposal) -> Self {
         Self {
             key_hasher: RandomState::new(),
             keyed: HashMap::new(),
             armings: HashMap::new(),
             deadlines: BTreeSet::new(),
+            disposal,
             #[cfg(test)]
             lookup_probes: 0,
         }
     }
-}
-
-impl<M> TimerStore<M> {
     fn hash_key<K: Hash + 'static>(&self, key: &K) -> KeyHash {
         KeyHash(self.key_hasher.hash_one((TypeId::of::<K>(), key)))
     }
@@ -439,10 +523,12 @@ impl<M> TimerStore<M> {
     ) where
         K: Hash + Eq + Send + 'static,
     {
-        let _ = self.remove(&key);
-        let hash = self.hash_key(&key);
+        let key = Contained::new(key, self.disposal.clone());
+        let message = Contained::new(message, self.disposal.clone());
+        let _ = self.remove(key.get());
+        let hash = self.hash_key(key.get());
         self.keyed.entry(hash).or_default().push(TimerEntry {
-            key: Box::new(key),
+            key: Contained::new(Box::new(key.into_inner()), self.disposal.clone()),
             deadline,
             arming_order,
             message,
@@ -469,7 +555,7 @@ impl<M> TimerStore<M> {
                 {
                     probes += 1;
                 }
-                entry.key.downcast_ref::<K>() == Some(key)
+                entry.key.get().downcast_ref::<K>() == Some(key)
             })?;
             #[cfg(test)]
             {
@@ -646,8 +732,7 @@ struct SharedOffloadState {
     // an idle future or marks an in-progress poll so that the poller disposes
     // it, always after releasing the lock.
     state: Mutex<OffloadFutureState>,
-    panic: Arc<PanicSlot>,
-    signal: Signal,
+    disposal: RawDisposal,
     finished: Latch,
 }
 
@@ -664,8 +749,7 @@ impl SharedOffloadState {
                 polling: false,
                 cancelled: false,
             }),
-            panic,
-            signal,
+            disposal: RawDisposal { panic, signal },
             finished,
         })
     }
@@ -693,19 +777,15 @@ impl SharedOffloadState {
     }
 
     fn record(&self, payload: PanicPayload) {
-        self.panic.record(payload);
         // Dropping a losing or cancelled operation can panic after its body
         // has stopped running, so every retained panic must wake the actor's
         // control plane independently of ordinary event delivery.
-        self.signal.pulse();
+        self.disposal.record(payload);
     }
 
     fn dispose(&self, future: Option<OffloadFuture>) {
         if let Some(future) = future {
-            match catch_panic(|| drop(future)) {
-                Ok(()) => {}
-                Err(payload) => self.record(payload),
-            }
+            self.disposal.dispose(future);
         }
     }
 
@@ -789,7 +869,7 @@ impl OffloadResource {
 
 struct RawResources<M> {
     accepting: bool,
-    continuations: VecDeque<M>,
+    continuations: VecDeque<Contained<M>>,
     // Set after returning a continuation and cleared after an external
     // mailbox/offload/timer item. `next_ready` uses it to prohibit two local
     // continuations from leading while an external source remains eligible.
@@ -799,23 +879,31 @@ struct RawResources<M> {
     ready_batch: Option<ReadyBatch>,
     events: Arc<EventQueue<M>>,
     panic: Arc<PanicSlot>,
+    disposal: RawDisposal,
     event_watcher: SignalWatcher,
     offloads: Vec<OffloadResource>,
 }
 
 impl<M> Default for RawResources<M> {
     fn default() -> Self {
-        let events = Arc::new(EventQueue::default());
+        let signal = Signal::default();
+        let panic = Arc::new(PanicSlot::default());
+        let disposal = RawDisposal {
+            panic: Arc::clone(&panic),
+            signal,
+        };
+        let events = Arc::new(EventQueue::new(disposal.clone()));
         let event_watcher = events.signal.watcher();
         Self {
             accepting: true,
             continuations: VecDeque::new(),
             continuation_needs_external: false,
-            timers: TimerStore::default(),
+            timers: TimerStore::new(disposal.clone()),
             next_timer_order: ArmingOrder::ZERO,
             ready_batch: None,
             events,
-            panic: Arc::new(PanicSlot::default()),
+            panic,
+            disposal,
             event_watcher,
             offloads: Vec::new(),
         }
@@ -1060,7 +1148,9 @@ impl<M: Send + 'static> RawContext<M> {
         if self.is_stopping() || !self.resources.accepting {
             return Err(Rejected::new(message));
         }
-        self.resources.continuations.push_back(message);
+        self.resources
+            .continuations
+            .push_back(Contained::new(message, self.resources.disposal.clone()));
         Ok(())
     }
 
@@ -1096,7 +1186,11 @@ impl<M: Send + 'static> RawContext<M> {
             return Err(Rejected::new((key, message)));
         }
         if period.is_zero() {
-            let _ = self.clear_timer(&key);
+            let key = Contained::new(key, self.resources.disposal.clone());
+            let message = Contained::new(message, self.resources.disposal.clone());
+            let _ = self.clear_timer(key.get());
+            drop(key);
+            drop(message);
             return Ok(());
         }
         self.replace_timer(
@@ -1267,6 +1361,8 @@ impl<M: Send + 'static> RawContext<M> {
         if self.is_stopping() || !self.resources.accepting {
             return Err(Rejected::new((work, continuation)));
         }
+        let work = Contained::new(work, self.resources.disposal.clone());
+        let continuation = Contained::new(continuation, self.resources.disposal.clone());
         // Completed offloads no longer need their resources.
         self.resources.reclaim_finished();
 
@@ -1283,7 +1379,7 @@ impl<M: Send + 'static> RawContext<M> {
             drop(work);
             events.push(QueuedEvent {
                 cancellation: cancellation.clone(),
-                make_message: Box::new(move || continuation(Err(DeadlineElapsed))),
+                make_message: Box::new(move || continuation.into_inner()(Err(DeadlineElapsed))),
             });
             finished.fire();
             self.resources.offloads.push(OffloadResource {
@@ -1301,7 +1397,7 @@ impl<M: Send + 'static> RawContext<M> {
         let event_cancellation = cancellation.clone();
         let operation = async move {
             let completion = async move {
-                let work = CatchUnwindFuture::new(work);
+                let work = CatchUnwindFuture::new(work.into_inner());
                 if let Some(expires_at) = expires_at {
                     match runtime::select_two(work, runtime::sleep_until(expires_at)).await {
                         runtime::Either::Left(result) => result.map(Ok),
@@ -1316,7 +1412,7 @@ impl<M: Send + 'static> RawContext<M> {
                 runtime::Either::Right(Ok(result)) => {
                     events.push(QueuedEvent {
                         cancellation: event_cancellation,
-                        make_message: Box::new(move || continuation(result)),
+                        make_message: Box::new(move || continuation.into_inner()(result)),
                     });
                 }
                 runtime::Either::Right(Err(payload)) => {
@@ -1385,7 +1481,7 @@ impl<M: Send + 'static> RawContext<M> {
                 batch.record_continuation_delivery();
                 self.resources.continuation_needs_external = true;
                 self.resources.ready_batch = Some(batch);
-                return Some(message);
+                return Some(message.into_inner());
             }
 
             if !batch.mailbox_complete {
@@ -1436,7 +1532,7 @@ impl<M: Send + 'static> RawContext<M> {
                 batch.record_continuation_delivery();
                 self.resources.continuation_needs_external = true;
                 self.resources.ready_batch = Some(batch);
-                return Some(message);
+                return Some(message.into_inner());
             }
             batch.continuations_remaining = 0;
 
@@ -1466,8 +1562,12 @@ impl<M: Send + 'static> RawContext<M> {
         }
     }
 
-    fn materialize_event(event: QueuedEvent<M>) -> Option<M> {
-        (!event.cancellation.is_fired()).then(event.make_message)
+    fn materialize_event(event: Contained<QueuedEvent<M>>) -> Option<M> {
+        if event.get().cancellation.is_fired() {
+            return None;
+        }
+        let event = event.into_inner();
+        Some((event.make_message)())
     }
 
     fn begin_ready_batch(&mut self) {
@@ -1509,7 +1609,7 @@ impl<M: Send + 'static> RawContext<M> {
         if let Some(period) = entry.period {
             let deadline = crate::deadline::Deadline::after(runtime::now(), period).instant();
             entry.deadline = deadline;
-            let TimerMessage::Interval(message, clone_message) = &entry.message else {
+            let TimerMessage::Interval(message, clone_message) = entry.message.get() else {
                 unreachable!("an interval timer must own a message factory")
             };
             let message = clone_message(message);
@@ -1522,7 +1622,7 @@ impl<M: Send + 'static> RawContext<M> {
             .timers
             .remove_arming(arming)
             .expect("a due one-shot timer remains registered");
-        let TimerMessage::Once(message) = entry.message else {
+        let TimerMessage::Once(message) = entry.message.into_inner() else {
             unreachable!("a non-interval timer must own a one-shot message")
         };
         Some(message)
@@ -1778,13 +1878,11 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
                     None
                 }
             };
-            let freeze_panic = catch_panic(|| {
-                mailbox.freeze(incarnation);
-                owner.raw().freeze_resources();
-            })
-            .err();
+            let mailbox_freeze_panic = catch_panic(|| mailbox.freeze(incarnation)).err();
+            let resource_freeze_panic = catch_panic(|| owner.raw().freeze_resources()).err();
             let mut cleanup_panic = owner.raw().take_resource_panic();
-            keep_first_panic(&mut cleanup_panic, freeze_panic);
+            keep_first_panic(&mut cleanup_panic, mailbox_freeze_panic);
+            keep_first_panic(&mut cleanup_panic, resource_freeze_panic);
 
             let joined = CatchUnwindFuture::new(owner.raw().join_resources()).await;
             keep_first_panic(&mut cleanup_panic, joined.err());
@@ -1884,8 +1982,8 @@ mod tests {
     };
 
     use super::{
-        EventQueue, OffloadResource, PanicSlot, QueuedEvent, RawResources, SharedOffloadFuture,
-        SharedOffloadState,
+        Contained, EventQueue, OffloadResource, PanicSlot, QueuedEvent, RawResources,
+        SharedOffloadFuture, SharedOffloadState,
     };
     use crate::runtime::{
         Latch, PanicPayload, Signal, UnwindPanics, resume_preferred_panic,
@@ -1899,7 +1997,8 @@ mod tests {
         }
     }
 
-    fn value(event: QueuedEvent<usize>) -> usize {
+    fn value(event: Contained<QueuedEvent<usize>>) -> usize {
+        let event = event.into_inner();
         (event.make_message)()
     }
 
@@ -1953,6 +2052,15 @@ mod tests {
         release: Arc<Barrier>,
         drops: Arc<AtomicUsize>,
         panic_on_drop: bool,
+    }
+
+    struct PanickingDrop(Arc<AtomicUsize>);
+
+    impl Drop for PanickingDrop {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            panic!("contained raw payload destructor panic");
+        }
     }
 
     impl Future for BlockingPollDrop {
@@ -2229,6 +2337,33 @@ mod tests {
             "repeat cancellation is inert"
         );
     }
+
+    #[test]
+    fn freeze_contains_each_user_payload_destructor_independently() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut resources = RawResources::<PanickingDrop>::default();
+        for _ in 0..2 {
+            resources.continuations.push_back(Contained::new(
+                PanickingDrop(Arc::clone(&drops)),
+                resources.disposal.clone(),
+            ));
+        }
+
+        assert_eq!(resources.freeze(), 2);
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            2,
+            "one hostile destructor cannot skip the remaining payloads"
+        );
+        let payload = resources
+            .panic
+            .take()
+            .expect("the first cleanup panic is retained");
+        assert_eq!(
+            panic_message(&payload),
+            Some("contained raw payload destructor panic")
+        );
+    }
 }
 
 #[cfg(test)]
@@ -2254,7 +2389,7 @@ mod timer_store_tests {
     }
 
     fn once(entry: super::TimerEntry<&'static str>) -> &'static str {
-        let TimerMessage::Once(message) = entry.message else {
+        let TimerMessage::Once(message) = entry.message.into_inner() else {
             panic!("expected a live one-shot timer")
         };
         message

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -264,6 +264,19 @@ struct RawDisposal {
     signal: Signal,
 }
 
+/// Test-only: mints an orphan disposal whose panic slot and signal nothing
+/// observes. Production wiring threads one shared disposal per incarnation
+/// through the container constructors.
+#[cfg(test)]
+impl Default for RawDisposal {
+    fn default() -> Self {
+        Self {
+            panic: Arc::new(PanicSlot::default()),
+            signal: Signal::default(),
+        }
+    }
+}
+
 impl RawDisposal {
     fn record(&self, payload: PanicPayload) {
         self.panic.record(payload);
@@ -339,14 +352,10 @@ struct EventQueue<M> {
     disposal: RawDisposal,
 }
 
+#[cfg(test)]
 impl<M> Default for EventQueue<M> {
     fn default() -> Self {
-        let signal = Signal::default();
-        let disposal = RawDisposal {
-            panic: Arc::new(PanicSlot::default()),
-            signal: signal.clone(),
-        };
-        Self::new(disposal)
+        Self::new(RawDisposal::default())
     }
 }
 
@@ -477,13 +486,10 @@ struct TimerStore<M> {
     lookup_probes: usize,
 }
 
+#[cfg(test)]
 impl<M> Default for TimerStore<M> {
     fn default() -> Self {
-        let signal = Signal::default();
-        Self::new(RawDisposal {
-            panic: Arc::new(PanicSlot::default()),
-            signal,
-        })
+        Self::new(RawDisposal::default())
     }
 }
 

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -1380,7 +1380,7 @@ impl<M: Send + 'static> RawContext<M> {
             armed: true,
         });
         let events = Arc::clone(&self.resources.events);
-        let panic = Arc::clone(&self.resources.panic);
+        let disposal = self.resources.disposal.clone();
         if deadline.is_zero() {
             drop(work);
             events.push(QueuedEvent {
@@ -1422,8 +1422,7 @@ impl<M: Send + 'static> RawContext<M> {
                     });
                 }
                 runtime::Either::Right(Err(payload)) => {
-                    panic.record(payload);
-                    events.signal.pulse();
+                    disposal.record(payload);
                 }
             }
         };

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -19,6 +19,32 @@ enum ZeroMessage {
 
 struct ZeroDeadlineActor;
 
+struct ZeroDeadlinePanickingDrop {
+    polled: Arc<AtomicBool>,
+    drops: Arc<AtomicUsize>,
+}
+
+impl std::future::Future for ZeroDeadlinePanickingDrop {
+    type Output = usize;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        self.polled.store(true, Ordering::SeqCst);
+        std::task::Poll::Pending
+    }
+}
+
+impl Drop for ZeroDeadlinePanickingDrop {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+        panic!("zero-budget offload destructor panic");
+    }
+}
+
+struct ZeroDeadlinePanickingDropActor;
+
 impl Actor for ZeroDeadlineActor {
     type Msg = ZeroMessage;
     type Args = Arc<AtomicBool>;
@@ -52,6 +78,33 @@ impl Actor for ZeroDeadlineActor {
     }
 }
 
+impl Actor for ZeroDeadlinePanickingDropActor {
+    type Msg = ZeroMessage;
+    type Args = (Arc<AtomicBool>, Arc<AtomicUsize>);
+
+    async fn init(
+        (polled, drops): Self::Args,
+        context: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        context
+            .offload(
+                ZeroDeadlinePanickingDrop { polled, drops },
+                |_| ZeroMessage::Done,
+                Duration::ZERO,
+            )
+            .expect("live offload accepted");
+        Ok(Self)
+    }
+
+    async fn handle(
+        &mut self,
+        ZeroMessage::Done: Self::Msg,
+        _: &mut Context<'_, Self>,
+    ) -> ExitResult {
+        panic!("cleanup panic must precede continuation delivery");
+    }
+}
+
 #[tokio::test]
 async fn zero_budget_offload_never_polls_work_and_times_out_on_actor_task() {
     let polled = Arc::new(AtomicBool::new(false));
@@ -64,6 +117,40 @@ async fn zero_budget_offload_never_polls_work_and_times_out_on_actor_task() {
     let system = tree.spawn().expect("runtime is available");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert!(!polled.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn zero_budget_offload_contains_and_classifies_its_work_destructor_panic() {
+    let polled = Arc::new(AtomicBool::new(false));
+    let drops = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    tree.add_actor_once(
+        "zero-drop-panic",
+        ActorOnceDef::<ZeroDeadlinePanickingDropActor>::new((
+            Arc::clone(&polled),
+            Arc::clone(&drops),
+        ))
+        .readiness(Readiness::Manual),
+    )
+    .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+
+    let message = startup_panic_message(
+        system
+            .wait_started()
+            .await
+            .expect_err("the contained pre-ready panic fails startup"),
+    );
+    assert_eq!(
+        message.as_deref(),
+        Some("zero-budget offload destructor panic")
+    );
+    assert!(!polled.load(Ordering::SeqCst));
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed root shuts down");
 }
 
 enum RestartMessage {


### PR DESCRIPTION
## Why

Part 0.5/0.6 of #172 moves two cleanup and intake invariants from repeated call-site convention into types:

- every raw-incarnation-owned user value must be destroyed through one panic-contained cleanup route
- bound mailbox waiters may exist only when a queue is full, and acceptance must have one implementation with displaced payloads destroyed after unlocking

Stacked on #182.

## What

### Part 0.5

- add one contained raw-payload owner backed by a shared disposal/panic sink
- route continuations, queued offload events, timer keys/messages, and offload work through it
- contain the zero-budget offload work destructor and classify its panic as cleanup
- make bulk freeze independently contain every discarded payload
- split mailbox freeze and raw-resource freeze into separate epilogue panic boundaries

### Part 0.6

- replace independent mailbox status/waiter fields with typed binding states
- make `BoundState::Full` the only bound state that can own waiters
- centralize `submit` and `try_send` acceptance in `accept_locked`
- return latest-value displacement in a must-finish bundle whose completion happens after the mutex is released
- preserve promotion, withdrawal, freeze/rebind, and terminal teardown semantics

This completes Part 0.5/0.6 and subsumes all item 8 bullets plus item 32's acceptance/invariant bullets from #172.

## Test plan

- focused raw disposal and zero-budget offload tests
- focused mailbox state/acceptance tests
- `./tools/dev just ci`
  - clippy with warnings denied
  - 526 nextest tests
  - doctests and rustdoc
  - API reachability and layering enforcement
  - packaged-crate verification
  - Nix formatting check
