### PR TITLE
Part 0.7/0.8: make ownership and counters structural

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -327,13 +327,14 @@ structured error payloads. Both tokens are views of §3.1's one fencing primitiv
 `Incarnation::membership()` projects an incarnation's owning membership,
 and equality between an incarnation's projection and a held membership
 token is the "same slot?" question answered exactly. `supersedes` on
-`Membership` is replacement order for one child id under one stable owning
-scope: it answers whether `a` is a later membership for the same logical
-slot than `b` (§3.4). Different child ids and different owning scopes are
-incomparable and return `false` in both directions (fail closed, §3.1's
-rule; never a panic). Equality is exact identity; there is deliberately no
-total `Ord` — comparison outside one stable `(scope, child-id)` domain has no
-meaning.
+`Membership` orders tokens only while one stable owning scope retains the
+same child-id lineage, such as declaration reconciliation before the prior
+membership terminalizes. Terminalization evicts that lineage (§3.4), so a
+later remove-and-re-add is deliberately incomparable in both directions.
+Different child ids and different owning scopes are likewise incomparable and
+return `false` in both directions (fail closed, §3.1's rule; never a panic).
+Equality is exact identity; there is deliberately no total `Ord` — comparison
+outside one retained `(scope, child-id, lineage)` domain has no meaning.
 
 Consequences (normative):
 
@@ -461,14 +462,17 @@ An `ActorRef` follows incarnations of **its** membership, never a same-id
 replacement membership. This boundary is kept (it is what makes identity
 exact), but it MUST be discoverable: removal-then-re-add under the same id
 yields a fresh membership whose handles come from the new insertion, and the
-old handles report terminal. The replacement membership supersedes its
-removed predecessor. The ordering domain belongs to the stable scope cell,
-not to a temporary builder: an initially declared child and its later runtime
-replacement compare, as do corresponding descendants rebuilt across
-incarnations of one nested scope membership. Different ids and different
-owning scope memberships remain incomparable. A small routing/registry adapter
-for planned handoff (a `ServiceRef`/route-cell that the application repoints at
-cutover) is non-core (§24) — it must not weaken exact membership identity.
+old handles report terminal. Terminalization evicts the retained child-id
+lineage: the replacement and removed membership are deliberately incomparable
+in both directions. The same fail-closed rule applies to an initially declared
+child and its later runtime replacement, and to corresponding descendants
+rebuilt across incarnations of one nested scope membership. A stable scope may
+order a provisional declaration only while it still retains the same live
+lineage; a temporary builder never defines the ordering domain. Different ids
+and different owning scope memberships remain incomparable. A small
+routing/registry adapter for planned handoff (a `ServiceRef`/route-cell that the
+application repoints at cutover) is non-core (§24) — it must not weaken exact
+membership identity.
 
 ## 4. Construction and restart [#360]
 
@@ -2463,10 +2467,11 @@ integration toolkit for the driver shell and the end-to-end invariants.
    child with the same id (and, by construction, colliding internal
    coordinates), then present scope A's handle to scope B and require
    rejection. Replay remove→re-add under one id and assert the stale handle
-   fails while the replacement is untouched and supersedes it; assert that
-   different ids and different owning scopes are incomparable. Repeat the
-   ordering check for a declared child replaced at runtime and for a
-   corresponding descendant rebuilt after a nested-scope restart. Exhaustion
+   fails while the replacement is untouched and incomparable with it; assert
+   that different ids and different owning scopes are also incomparable.
+   Repeat the fail-closed comparison check for a declared child replaced at
+   runtime and for a corresponding descendant rebuilt after a nested-scope
+   restart. Exhaustion
    mints nothing (§3.1): drive a counter to saturation and assert no duplicate
    token is ever issued — an unmintable incarnation terminalizes the
    membership as under `Never`; an unmintable membership is the enumerated

--- a/crates/shelterwood/doctests/docs/observation.md
+++ b/crates/shelterwood/doctests/docs/observation.md
@@ -95,8 +95,9 @@ For planned replacement, retain the exact handle returned by admission, remove
 that membership, await `RemoveOutcome::Removed`, then add the replacement. An
 add racing an in-progress same-id removal fails with `RemovalInProgress`; await
 the removal and retry. The replacement's membership is distinct rather than a
-new incarnation of the old one, and it supersedes the removed same-id
-membership. Different ids and different owning scopes remain incomparable.
+new incarnation of the old one. Terminalization evicts the old id lineage, so
+the replacement and removed membership are deliberately incomparable in both
+directions, just like different ids and different owning scopes.
 
 ## Pre-spawn observation
 

--- a/crates/shelterwood/doctests/docs/retry-and-ordering.md
+++ b/crates/shelterwood/doctests/docs/retry-and-ordering.md
@@ -39,21 +39,20 @@ idempotent `ReplyDropped` loop.
 
 Membership and incarnation answer different questions. An `ActorRef` follows
 restarts of one membership. After remove and re-add under the same child id,
-the replacement has a new `Membership` that supersedes the removed membership,
-while the old handle remains pinned to the removed one and never retargets.
-Membership ordering is narrow: only replacements of the same child id in the
-same stable scope compare. Different child ids and memberships owned by
-different scopes remain incomparable.
+the replacement has a new `Membership`, while the old handle remains pinned to
+the removed one and never retargets. Terminalization evicts that child id's
+retained identity lineage, so the removed membership and its later replacement
+are deliberately incomparable in both directions. This fail-closed rule also
+applies to different child ids and memberships owned by different scopes.
 
-The stable scope identity also spans declaration and runtime boundaries.
-Replacing an initially declared child dynamically therefore supersedes that
-declared membership, and a corresponding descendant produced after a nested
-scope restart supersedes its predecessor. A rebuilt declaration's handle
-observes that rebased membership, but the handle's own `Eq`/`Hash` identity
-is the slot itself: a handle stashed in a map before lowering remains
-addressable afterward. Read `membership()` when the exact token matters.
-Within one membership, `Incarnation::supersedes` remains the correct restart
-ordering test.
+Declaration lowering may rebase a provisional token while the stable scope
+still retains that id's lineage. Once the membership terminalizes, however, a
+runtime replacement or a corresponding descendant produced after a nested
+scope restart starts a fresh lineage and is incomparable with its predecessor.
+A handle's own `Eq`/`Hash` identity is the slot itself: a handle stashed in a
+map before lowering remains addressable afterward. Read `membership()` when
+the exact token matters. Within one membership, `Incarnation::supersedes`
+remains the correct restart ordering test.
 
 ## Latest-value mailboxes and calls
 

--- a/crates/shelterwood/src/cancellation.rs
+++ b/crates/shelterwood/src/cancellation.rs
@@ -3,7 +3,7 @@
 use crate::runtime::{self, Latch};
 
 /// A library-owned cancellation token.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct CancellationToken {
     primary: Latch,
     secondary: Option<Latch>,
@@ -14,14 +14,6 @@ impl CancellationToken {
         Self {
             primary: latch,
             secondary: None,
-        }
-    }
-
-    pub(crate) fn child(&self, cancellation: Latch) -> Self {
-        debug_assert!(self.secondary.is_none());
-        Self {
-            primary: self.primary.clone(),
-            secondary: Some(cancellation),
         }
     }
 
@@ -41,19 +33,50 @@ impl CancellationToken {
     }
 }
 
+/// Internal capability that alone may derive a locally cancellable token.
+#[derive(Clone, Debug)]
+pub(crate) struct ParentCancellationToken {
+    primary: Latch,
+}
+
+impl ParentCancellationToken {
+    pub(crate) fn from_latch(primary: Latch) -> Self {
+        Self { primary }
+    }
+
+    pub(crate) fn token(&self) -> CancellationToken {
+        CancellationToken::from_latch(self.primary.clone())
+    }
+
+    pub(crate) fn child(&self, cancellation: Latch) -> CancellationToken {
+        CancellationToken {
+            primary: self.primary.clone(),
+            secondary: Some(cancellation),
+        }
+    }
+
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.primary.is_fired()
+    }
+
+    pub(crate) async fn cancelled(&self) {
+        self.primary.fired().await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
     use crate::runtime::{self, JoinOutcome, Latch, Timeout};
 
-    use super::CancellationToken;
+    use super::ParentCancellationToken;
 
     #[crate::runtime::test]
     async fn local_cancellation_cancels_only_the_derived_token() {
         let primary = Latch::default();
         let local = Latch::default();
-        let supervisor = CancellationToken::from_latch(primary.clone());
+        let supervisor = ParentCancellationToken::from_latch(primary.clone());
         let operation = supervisor.child(local.clone());
 
         assert!(local.fire());
@@ -70,7 +93,7 @@ mod tests {
     async fn supervisor_cancellation_cancels_the_derived_token() {
         let primary = Latch::default();
         let local = Latch::default();
-        let supervisor = CancellationToken::from_latch(primary.clone());
+        let supervisor = ParentCancellationToken::from_latch(primary.clone());
         let operation = supervisor.child(local.clone());
 
         assert!(primary.fire());
@@ -88,7 +111,8 @@ mod tests {
         for _ in 0..128 {
             let primary = Latch::default();
             let local = Latch::default();
-            let operation = CancellationToken::from_latch(primary.clone()).child(local.clone());
+            let operation =
+                ParentCancellationToken::from_latch(primary.clone()).child(local.clone());
             let waiter = runtime::spawn(async move {
                 operation.cancelled().await;
             });

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -12,23 +12,23 @@ use std::{
     fmt,
     sync::{
         Arc, Mutex, MutexGuard, OnceLock, RwLock, Weak,
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, Ordering},
     },
     time::Instant,
 };
 
 use crate::{
-    ChildId, Exit, Incarnation, Intensity, Mailbox, Membership, Readiness, RestartCount, Strategy,
+    ChildId, Exit, Incarnation, Intensity, Membership, Readiness, RestartCount, Strategy,
     TotalRestarts,
     admission::{RemoveOutcome, ReserveError},
     engine::{Epoch, MembershipStatus, RequestTarget, ScopeEpochs, ScopeState},
     exit::{StartupError, StopReason},
-    identity::ScopeIdentity,
+    identity::{AtomicPoisonedCounter, IncarnationCounter, MintedMembership, ScopeIdentity},
     observe::{
         ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
         LifecycleHub, LifecycleSeq, ScopeKind, ScopeSnapshot, SnapshotHub, SnapshotReceiver,
     },
-    policy::{ResolvedCommonOptions, ScopeFlavor},
+    policy::{ResolvedCommonOptions, ResolvedMailbox, ScopeFlavor},
     runtime::{self, Latch},
 };
 
@@ -52,7 +52,7 @@ pub(crate) trait MailboxTermination: Send {
 pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
     /// Installs the declaration-time mailbox policy before the first bind.
     /// Reconfiguration may only repeat the same resolved policy.
-    fn configure(&self, mailbox: Mailbox);
+    fn configure(&self, mailbox: ResolvedMailbox);
     /// Makes one incarnation live after configuration and prior-close cleanup.
     /// A bind after terminal preparation is deliberately ignored because
     /// terminality wins that race permanently.
@@ -188,6 +188,7 @@ pub(crate) struct MemberCell {
     id: ChildId,
     membership: Membership,
     rebased_membership: OnceLock<Membership>,
+    incarnations: Mutex<Option<IncarnationCounter>>,
     record: runtime::WatchSender<MemberRecord>,
     // Guards only a gate-pointer swap, so no torn state is possible; every
     // access deliberately tolerates poisoning (mirroring
@@ -232,7 +233,8 @@ impl fmt::Debug for MemberMailbox {
 }
 
 impl MemberCell {
-    pub(crate) fn new(id: ChildId, membership: Membership) -> Arc<Self> {
+    pub(crate) fn new(id: ChildId, identity: MintedMembership) -> Arc<Self> {
+        let (membership, incarnations) = identity.into_pair();
         let (record, _) = runtime::watch(MemberRecord {
             stage: MemberStage::Reserved,
             incarnation: None,
@@ -247,6 +249,7 @@ impl MemberCell {
             id,
             membership,
             rebased_membership: OnceLock::new(),
+            incarnations: Mutex::new(Some(incarnations)),
             record,
             observation_gate: RwLock::new(ObservationGate::new()),
             terminal_disposal_pending: AtomicBool::new(false),
@@ -267,7 +270,8 @@ impl MemberCell {
             .unwrap_or(self.membership)
     }
 
-    pub(crate) fn rebase_membership(&self, membership: Membership) {
+    pub(crate) fn rebase_membership(&self, identity: MintedMembership) {
+        let (membership, incarnations) = identity.into_pair();
         let record = self.record();
         assert!(
             matches!(record.stage, MemberStage::Reserved)
@@ -278,6 +282,27 @@ impl MemberCell {
         self.rebased_membership
             .set(membership)
             .expect("a reservation can be rebased at most once");
+        *self
+            .incarnations
+            .lock()
+            .expect("incarnation counter mutex poisoned") = Some(incarnations);
+    }
+
+    pub(crate) fn take_incarnation_counter(&self) -> IncarnationCounter {
+        self.incarnations
+            .lock()
+            .expect("incarnation counter mutex poisoned")
+            .take()
+            .expect("a membership's incarnation counter is issued to one runtime")
+    }
+
+    #[cfg(test)]
+    pub(crate) fn lock_incarnation_counter(
+        &self,
+    ) -> std::sync::MutexGuard<'_, Option<IncarnationCounter>> {
+        self.incarnations
+            .lock()
+            .expect("incarnation counter mutex starts healthy")
     }
 
     pub(crate) fn record(&self) -> MemberRecord {
@@ -608,7 +633,12 @@ pub(crate) trait DynamicRoute: Send + Sync {
         fused_cancel: Option<Latch>,
     ) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError>;
 
-    fn cancel_reservation(&self, slot: &Self::Slot, txn: &mut ObservationTxn<'_>);
+    fn cancel_reservation(
+        &self,
+        scope: &Arc<ScopeCell>,
+        slot: &Self::Slot,
+        txn: &mut ObservationTxn<'_>,
+    );
 
     fn signal_fused_cancel(
         &self,
@@ -858,7 +888,7 @@ pub(crate) struct ScopeCell {
     // `ObservationGate::lock`) so drop-path shutdown after a panicked assert
     // cannot itself panic.
     observation_gate: RwLock<ObservationGate>,
-    lifecycle_seq: AtomicU64,
+    lifecycle_seq: AtomicPoisonedCounter,
     lifecycle: LifecycleHub,
     snapshots: SnapshotHub,
     observation_closed: AtomicBool,
@@ -894,6 +924,13 @@ pub(crate) struct RuntimeStorage {
 }
 
 impl ScopeCell {
+    pub(crate) fn evict_child_identity(&self, member: &MemberCell) {
+        self.child_identity
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .evict(member.id(), member.membership());
+    }
+
     pub(crate) fn new(
         member: Arc<MemberCell>,
         flavor: ScopeFlavor,
@@ -916,7 +953,7 @@ impl ScopeCell {
             current_children: Mutex::new(Vec::new()),
             parent: Mutex::new(None),
             observation_gate: RwLock::new(observation_gate),
-            lifecycle_seq: AtomicU64::new(0),
+            lifecycle_seq: AtomicPoisonedCounter::new(),
             lifecycle: LifecycleHub::default(),
             snapshots: SnapshotHub::default(),
             observation_closed: AtomicBool::new(false),
@@ -1305,6 +1342,7 @@ impl ScopeCell {
                 .and_then(|resident| resident.projection.scope.as_ref())
                 .cloned();
             let terminal_exit = member.terminalize_child_locked(exit, startup, wakes);
+            self.evict_child_identity(member);
             if record.last_incarnation.is_none()
                 && let Some(scope) = &nested
             {
@@ -1484,13 +1522,8 @@ impl ScopeCell {
         // gate could reorder events but never duplicate a sequence value.
         let seq = self
             .lifecycle_seq
-            .try_update(Ordering::Release, Ordering::Relaxed, |current| {
-                current.checked_add(1).filter(|seq| *seq != u64::MAX)
-            })
-            .ok()
-            .map(|previous| previous.saturating_add(1));
+            .mint(Ordering::Release, Ordering::Relaxed);
         let Some(seq) = seq.map(LifecycleSeq::new) else {
-            self.lifecycle_seq.store(u64::MAX, Ordering::Release);
             self.publish_snapshot_chain_locked(wakes);
             self.lifecycle.publish_lagged_deferred(wakes, 1);
             for ancestor in self.ancestors_locked() {
@@ -1536,7 +1569,7 @@ impl ScopeCell {
 
     #[cfg(test)]
     pub(crate) fn set_lifecycle_sequence(&self, current: u64) {
-        self.lifecycle_seq.store(current, Ordering::Relaxed);
+        self.lifecycle_seq.set(current, Ordering::Relaxed);
     }
 
     pub(crate) fn set_startup(&self, startup: Result<(), StartupError>) {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -29,8 +29,7 @@ pub(crate) use shutdown::shutdown_scope;
 
 use crate::{
     Cancellation, ChildId, Exit, GracePhase, Incarnation, IntensityTrip, JitterSample, Membership,
-    Readiness, ReadinessDeadline, ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure,
-    StartupFailureCause,
+    Readiness, ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure, StartupFailureCause,
     admission::{NotAdmittingCause, ReserveError},
     cells::{
         MailboxControl, MemberStage, MemberTransition, ResidentProjection, ScopeCell,
@@ -50,7 +49,8 @@ use crate::{
     identity::IncarnationCounter,
     observe::LifecycleEventKind,
     plan::{
-        BuilderCore, ChildConstruction, ChildPlan, LowerError, ScopeFactory, ScopePlan, SlotCell,
+        BuilderCore, ChildConstruction, ChildPlan, LowerError, RuntimeScopePlan, ScopeFactory,
+        ScopePlan, SlotCell,
     },
     policy::{DefaultsInheritance, ResolvedDefaults, ScopeFlavor},
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
@@ -340,7 +340,7 @@ impl ScopeRuntime {
                 NotAdmittingCause::NoLiveIncarnation
             };
             let (definition, removed) = self.root.with_observation_gate(|txn| {
-                cancel_dynamic_reservation_parts(&control, &request.slot, txn)
+                cancel_dynamic_reservation_parts(&self.root, &control, &request.slot, txn)
             });
             reject_admission_after_disposal(
                 request,
@@ -352,7 +352,7 @@ impl ScopeRuntime {
         }
         if request.fused_cancel.as_ref().is_some_and(Latch::is_fired) {
             let (definition, removed) = self.root.with_observation_gate(|txn| {
-                cancel_dynamic_reservation_parts(&control, &request.slot, txn)
+                cancel_dynamic_reservation_parts(&self.root, &control, &request.slot, txn)
             });
             reject_admission_after_disposal(
                 request,
@@ -367,7 +367,7 @@ impl ScopeRuntime {
             Ok(Some(claimed)) => claimed,
             Ok(None) => {
                 let (_, removed) = self.root.with_observation_gate(|txn| {
-                    cancel_dynamic_reservation_parts(&control, &request.slot, txn)
+                    cancel_dynamic_reservation_parts(&self.root, &control, &request.slot, txn)
                 });
                 reject_admission_after_disposal(
                     request,
@@ -379,7 +379,7 @@ impl ScopeRuntime {
             }
             Err(invalid) => {
                 let (definition, removed) = self.root.with_observation_gate(|txn| {
-                    cancel_dynamic_reservation_parts(&control, &request.slot, txn)
+                    cancel_dynamic_reservation_parts(&self.root, &control, &request.slot, txn)
                 });
                 reject_admission_after_disposal(
                     request,
@@ -416,6 +416,7 @@ impl ScopeRuntime {
                 let removed = matches_reservation.then(|| state.remove(id, txn)).flatten();
                 drop(state);
                 request.slot.terminalize_never_started_locked(txn);
+                root.evict_child_identity(&request.slot.member);
                 return AdmissionInstall::Rejected {
                     child: Box::new(child),
                     removed,
@@ -432,6 +433,7 @@ impl ScopeRuntime {
                     let removed = state.remove(id, txn);
                     drop(state);
                     request.slot.terminalize_never_started_locked(txn);
+                    root.evict_child_identity(&request.slot.member);
                     return AdmissionInstall::Rejected {
                         child,
                         removed,
@@ -596,7 +598,7 @@ async fn run_nested_tree_with_epoch(
             return Err(crate::ExitError::from_startup_failure(failure));
         }
     };
-    run_scope_incarnation(plan, ScopeRole::Nested(latches), epoch)
+    run_scope_incarnation(plan.take_for_runtime(), ScopeRole::Nested(latches), epoch)
         .await
         .into_nested_result()
 }
@@ -604,12 +606,12 @@ async fn run_nested_tree_with_epoch(
 async fn run_scope(plan: ScopePlan, role: ScopeRole) -> StopReason {
     let root = Arc::clone(&plan.root);
     let Some(epoch) = ScopeEpochGuard::begin(&root) else {
-        // Dropping the still-armed plan terminalizes every never-started
+        // Dropping the still-owned plan terminalizes every never-started
         // declaration and the root; no aliased driver epoch is created.
         drop(plan);
         return StopReason::NeverStarted;
     };
-    run_scope_incarnation(plan, role, epoch).await
+    run_scope_incarnation(plan.take_for_runtime(), role, epoch).await
 }
 
 /// Derives the membership index and incompleteness count for a freshly
@@ -628,7 +630,7 @@ fn index_children(children: &ChildArena<ChildRuntime>) -> (HashMap<Membership, C
 }
 
 async fn run_scope_incarnation(
-    mut plan: ScopePlan,
+    mut plan: RuntimeScopePlan,
     role: ScopeRole,
     epoch: ScopeEpochGuard,
 ) -> StopReason {
@@ -713,8 +715,7 @@ async fn run_scope_incarnation(
         // the raw epoch directly into ScopeRuntime's synchronous epilogue.
         epoch: epoch.transfer(),
     };
-    plan.armed = false;
-    drop(plan);
+    plan.finish_transfer();
 
     // ScopeRuntime owns teardown before the route becomes public. If either
     // route notification or initial-child publication unwinds, its epilogue

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -240,7 +240,7 @@ impl Drop for ScopeRuntime {
     fn drop(&mut self) {
         let dynamic_entries = if let Some(dynamic) = &self.dynamic {
             let entries = self.root.with_observation_gate(|txn| {
-                let entries = dynamic.close(txn);
+                let entries = dynamic.close(&self.root, txn);
                 self.root.set_dynamic_route_locked(None, txn);
                 entries
             });

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -666,7 +666,7 @@ async fn run_scope_incarnation(
         (None, None)
     };
     // Transfer children one at a time. The not-yet-converted suffix remains
-    // owned by ScopePlan, while ChildRuntime::from_plan arms the current
+    // owned by RuntimeScopePlan, while ChildRuntime::from_plan arms the current
     // child's obligation before fallible setup. Thus a panic at any point has
     // exactly one terminality owner for every child.
     let mut children = ChildArena::default();

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -415,8 +415,7 @@ impl ScopeRuntime {
             if !matches_reservation || request.fused_cancel.as_ref().is_some_and(Latch::is_fired) {
                 let removed = matches_reservation.then(|| state.remove(id, txn)).flatten();
                 drop(state);
-                request.slot.terminalize_never_started_locked(txn);
-                root.evict_child_identity(&request.slot.member);
+                request.slot.terminalize_never_started_locked(&root, txn);
                 return AdmissionInstall::Rejected {
                     child: Box::new(child),
                     removed,
@@ -432,8 +431,7 @@ impl ScopeRuntime {
                 Err(child) => {
                     let removed = state.remove(id, txn);
                     drop(state);
-                    request.slot.terminalize_never_started_locked(txn);
-                    root.evict_child_identity(&request.slot.member);
+                    request.slot.terminalize_never_started_locked(&root, txn);
                     return AdmissionInstall::Rejected {
                         child,
                         removed,

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -377,6 +377,7 @@ fn start_dynamic_admission(
 }
 
 pub(super) fn cancel_dynamic_reservation_parts(
+    scope: &ScopeCell,
     control: &DynamicControl,
     slot: &SlotCell,
     txn: &mut ObservationTxn<'_>,
@@ -396,6 +397,9 @@ pub(super) fn cancel_dynamic_reservation_parts(
     } else {
         None
     };
+    if cancelled {
+        scope.evict_child_identity(&slot.member);
+    }
     (definition, removed)
 }
 
@@ -404,15 +408,16 @@ pub(crate) fn cancel_dynamic_reservation(
     control: &ErasedDynamicRoute,
     slot: &Arc<SlotCell>,
 ) {
-    scope.with_observation_gate(|txn| control.cancel_reservation(slot.as_ref(), txn));
+    scope.with_observation_gate(|txn| control.cancel_reservation(scope, slot.as_ref(), txn));
 }
 
 fn cancel_dynamic_reservation_impl(
+    scope: &ScopeCell,
     control: &DynamicControl,
     slot: &SlotCell,
     txn: &mut ObservationTxn<'_>,
 ) {
-    let (definition, removed) = cancel_dynamic_reservation_parts(control, slot, txn);
+    let (definition, removed) = cancel_dynamic_reservation_parts(scope, control, slot, txn);
     // The entry's drop completes its removal response; it must follow the
     // member's terminal publication and isolated definition disposal.
     txn.defer(move || dispose_definition_then(definition, move || drop(removed)));
@@ -564,8 +569,13 @@ impl DynamicRoute for DynamicControl {
         start_dynamic_admission(self, concrete_dynamic_slot(slot), fused_cancel)
     }
 
-    fn cancel_reservation(&self, slot: &Self::Slot, txn: &mut ObservationTxn<'_>) {
-        cancel_dynamic_reservation_impl(self, concrete_dynamic_slot_ref(slot), txn);
+    fn cancel_reservation(
+        &self,
+        scope: &Arc<ScopeCell>,
+        slot: &Self::Slot,
+        txn: &mut ObservationTxn<'_>,
+    ) {
+        cancel_dynamic_reservation_impl(scope, self, concrete_dynamic_slot_ref(slot), txn);
     }
 
     fn signal_fused_cancel(

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -247,7 +247,11 @@ impl DynamicControl {
             .close_admission(_txn);
     }
 
-    pub(super) fn close(&self, txn: &mut ObservationTxn<'_>) -> HashMap<ChildId, DynamicEntry> {
+    pub(super) fn close(
+        &self,
+        scope: &ScopeCell,
+        txn: &mut ObservationTxn<'_>,
+    ) -> HashMap<ChildId, DynamicEntry> {
         self.close_admission_in(txn);
         let mut state = self.state.lock().expect("dynamic-state mutex poisoned");
         let entries = state.take_entries(txn);
@@ -255,7 +259,7 @@ impl DynamicControl {
         let mut retained = HashMap::new();
         for (id, entry) in entries {
             if entry.is_reserved() {
-                let definition = entry.slot.take_never_started_locked(txn);
+                let definition = take_terminal_reservation(scope, &entry.slot, txn);
                 txn.defer(move || dispose_definition_then(definition, move || drop(entry)));
             } else {
                 retained.insert(id, entry);
@@ -266,6 +270,16 @@ impl DynamicControl {
         // removal without waking a remover before those observation edges.
         retained
     }
+}
+
+fn take_terminal_reservation(
+    scope: &ScopeCell,
+    slot: &SlotCell,
+    txn: &mut ObservationTxn<'_>,
+) -> Option<runtime::Isolated<ChildConstruction>> {
+    let definition = slot.take_never_started_locked(txn);
+    scope.evict_child_identity(&slot.member);
+    definition
 }
 
 pub(crate) struct DynamicReservation {
@@ -392,14 +406,9 @@ pub(super) fn cancel_dynamic_reservation_parts(
     });
     let removed = cancelled.then(|| state.remove(&id, txn)).flatten();
     drop(state);
-    let definition = if cancelled {
-        slot.take_never_started_locked(txn)
-    } else {
-        None
-    };
-    if cancelled {
-        scope.evict_child_identity(&slot.member);
-    }
+    let definition = cancelled
+        .then(|| take_terminal_reservation(scope, slot, txn))
+        .flatten();
     (definition, removed)
 }
 
@@ -510,7 +519,7 @@ fn remove_dynamic_impl(
     if entry.is_reserved() {
         let entry = state.remove(id, txn).expect("entry was just resolved");
         drop(state);
-        let definition = entry.slot.take_never_started_locked(txn);
+        let definition = take_terminal_reservation(scope, &entry.slot, txn);
         txn.defer(move || dispose_definition_then(definition, move || drop(entry)));
         return response;
     }

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -277,9 +277,7 @@ fn take_terminal_reservation(
     slot: &SlotCell,
     txn: &mut ObservationTxn<'_>,
 ) -> Option<runtime::Isolated<ChildConstruction>> {
-    let definition = slot.take_never_started_locked(txn);
-    scope.evict_child_identity(&slot.member);
-    definition
+    slot.take_never_started_locked(scope, txn)
 }
 
 pub(crate) struct DynamicReservation {

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -139,7 +139,10 @@ pub(super) fn discharge_child_terminality(completion: ChildTerminality) {
     // membership edge. A restarting scope already published its real prior-
     // incarnation reason.
     if never_started && !completion.root.has_resident_child(&completion.slot.member) {
-        completion.slot.terminalize_never_started();
+        // Every terminalization evicts the lineage; the slot-owned path
+        // passes the owning scope so a restart's rebuild adopts a fresh,
+        // incomparable membership instead of an ordered successor.
+        completion.slot.terminalize_never_started(&completion.root);
         return;
     }
     completion.root.terminalize_child(

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -190,11 +190,7 @@ impl ChildRuntime {
             },
             discharge_child_terminality,
         );
-        let incarnations = scope
-            .child_identity
-            .lock()
-            .expect("scope identity mutex poisoned")
-            .incarnation_counter(slot.member.membership());
+        let incarnations = slot.member.take_incarnation_counter();
         let mailbox = slot.member.mailbox();
         if let Some(mailbox) = &mailbox {
             mailbox.configure(options.mailbox);
@@ -643,8 +639,10 @@ impl ScopeRuntime {
 
         let mut readiness = ReadinessGate::new();
         let deadline = match child.options.readiness_deadline {
-            ReadinessDeadline::Bounded(duration) => Deadline::after(now, duration).instant(),
-            ReadinessDeadline::Unbounded | ReadinessDeadline::Inherit => None,
+            crate::policy::ResolvedReadinessDeadline::Bounded(duration) => {
+                Deadline::after(now, duration).instant()
+            }
+            crate::policy::ResolvedReadinessDeadline::Unbounded => None,
         };
         let readiness_effect = readiness.step(ReadinessEvent::Configure {
             readiness: declared_readiness,

--- a/crates/shelterwood/src/driver/storage.rs
+++ b/crates/shelterwood/src/driver/storage.rs
@@ -5,6 +5,8 @@ use std::{
     ops::{Bound, Index, IndexMut},
 };
 
+use crate::identity::PoisonedCounter;
+
 /// An exactly-once synchronous completion.
 ///
 /// The orderly path consumes the payload with [`Self::complete`]. If that
@@ -58,28 +60,23 @@ pub(super) struct ChildArena<T> {
     children: BTreeMap<ChildKey, T>,
     // `u64::MAX` is poison and is never minted. Once exhausted, every later
     // insertion fails closed instead of wrapping into the live key domain.
-    next_key: u64,
+    keys: PoisonedCounter,
 }
 
 impl<T> Default for ChildArena<T> {
     fn default() -> Self {
         Self {
             children: BTreeMap::new(),
-            next_key: 0,
+            keys: PoisonedCounter::new(),
         }
     }
 }
 
 impl<T> ChildArena<T> {
     pub(super) fn insert(&mut self, child: T) -> Result<ChildKey, Box<T>> {
-        let Some(next) = self.next_key.checked_add(1) else {
+        let Some(next) = self.keys.mint() else {
             return Err(Box::new(child));
         };
-        if next == u64::MAX {
-            self.next_key = u64::MAX;
-            return Err(Box::new(child));
-        }
-        self.next_key = next;
         let key = ChildKey(next);
         let replaced = self.children.insert(key, child);
         debug_assert!(replaced.is_none(), "monotonic child keys are never reused");
@@ -171,6 +168,8 @@ mod tests {
         },
     };
 
+    use crate::identity::PoisonedCounter;
+
     use super::{ChildArena, ChildKey, Obligation};
 
     fn count_fallback(fallbacks: Arc<AtomicUsize>) {
@@ -229,7 +228,7 @@ mod tests {
     fn child_key_exhaustion_poison_is_never_minted() {
         let mut arena = ChildArena {
             children: BTreeMap::new(),
-            next_key: u64::MAX - 2,
+            keys: PoisonedCounter::near_exhaustion(),
         };
         let last = arena.insert("worker").expect("the last usable key mints");
         assert_eq!(last, ChildKey(u64::MAX - 1));
@@ -238,7 +237,7 @@ mod tests {
         let child = *arena
             .insert(child)
             .expect_err("the poison key is never minted");
-        assert_eq!(arena.next_key, u64::MAX);
+        assert!(arena.keys.is_poisoned());
         assert!(arena.get(ChildKey(u64::MAX)).is_none());
         assert!(
             arena.insert(child).is_err(),

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -78,7 +78,7 @@ async fn task_aborted_scope_driver_resolves_startup() {
     let scope = Arc::clone(&plan.root);
     let epoch = ScopeEpochGuard::begin(&scope).expect("test scope epoch is available");
     let driver = crate::runtime::spawn(run_scope_incarnation(
-        plan,
+        plan.take_for_runtime(),
         ScopeRole::Nested(NestedScopeLatches {
             parent_ready: CompletionGatedLatch::default(),
             ancestor: AncestorCommandLatches {
@@ -243,17 +243,14 @@ async fn scope_plan_conversion_panic_terminalizes_every_child() {
 
     assert!(
         catch_unwind(AssertUnwindSafe(|| {
-            let _identity = root
-                .child_identity
-                .lock()
-                .expect("scope identity mutex starts healthy");
+            let _incarnations = children[1].lock_incarnation_counter();
             panic!("inject child conversion failure");
         }))
         .is_err()
     );
 
     let mut driver = Box::pin(run_scope_incarnation(
-        plan,
+        plan.take_for_runtime(),
         ScopeRole::Nested(NestedScopeLatches {
             parent_ready: CompletionGatedLatch::default(),
             ancestor: AncestorCommandLatches {
@@ -365,7 +362,11 @@ async fn initial_added_wake_observes_the_keyed_dynamic_route() {
             .is_pending()
     );
 
-    let driver = crate::runtime::spawn(run_scope_incarnation(plan, ScopeRole::Root, epoch));
+    let driver = crate::runtime::spawn(run_scope_incarnation(
+        plan.take_for_runtime(),
+        ScopeRole::Root,
+        epoch,
+    ));
     let abort = driver.abort_handle();
     assert!(matches!(
         crate::runtime::timeout(Duration::from_secs(1), probe.observed.fired()).await,

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -303,6 +303,95 @@ async fn scope_plan_conversion_panic_terminalizes_every_child() {
     );
 }
 
+#[crate::runtime::test]
+async fn conversion_unwind_evicts_never_started_child_identities() {
+    let mut tree = Tree::new();
+    for id in ["first", "second"] {
+        tree.add_task(id, TaskDef::new(|_| future::pending()))
+            .expect("valid task");
+    }
+    let plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let children: Vec<_> = plan
+        .children
+        .iter()
+        .map(|child| Arc::clone(&child.slot.member))
+        .collect();
+    let terminalized: Vec<_> = children
+        .iter()
+        .map(|member| (member.id().clone(), member.membership()))
+        .collect();
+    let epoch = ScopeEpochGuard::begin(&root).expect("test scope epoch is available");
+
+    // Converting "second" panics after "first" was converted, so "first"
+    // reaches its Obligation fallback never started and not yet resident,
+    // while "second" unwinds out of its own conversion.
+    assert!(
+        catch_unwind(AssertUnwindSafe(|| {
+            let _incarnations = children[1].lock_incarnation_counter();
+            panic!("inject child conversion failure");
+        }))
+        .is_err()
+    );
+    let mut driver = Box::pin(run_scope_incarnation(
+        plan.take_for_runtime(),
+        ScopeRole::Nested(NestedScopeLatches {
+            parent_ready: CompletionGatedLatch::default(),
+            ancestor: AncestorCommandLatches {
+                shutdown: Latch::default(),
+                abort: Latch::default(),
+                abort_ack: Latch::default(),
+            },
+        }),
+        epoch,
+    ));
+    assert!(
+        catch_unwind(AssertUnwindSafe(|| {
+            let mut context = Context::from_waker(Waker::noop());
+            let _ = driver.as_mut().poll(&mut context);
+        }))
+        .is_err()
+    );
+    drop(driver);
+    for child in &children {
+        assert!(
+            matches!(child.record().stage, MemberStage::Terminal(_)),
+            "every transferred or pending child must terminalize"
+        );
+    }
+
+    // The supervisor restart rebuilds the declarations against the same
+    // stable scope. Terminalization must have evicted each lineage, so the
+    // rebuild adopts fresh, incomparable memberships; a retained lineage
+    // would mint an ordered successor that supersedes its terminalized
+    // predecessor.
+    let mut rebuild = BuilderCore::new(ScopeFlavor::Ordered);
+    for id in ["first", "second"] {
+        let slot = rebuild
+            .reserve(id, None)
+            .expect("re-added id is reservable");
+        slot.define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
+    }
+    let replacement = rebuild
+        .lower(ResolvedDefaults::default(), Some(Arc::clone(&root)))
+        .expect("the restart rebuild lowers");
+    for child in &replacement.children {
+        let (_, predecessor) = terminalized
+            .iter()
+            .find(|(id, _)| id == child.slot.member.id())
+            .expect("the rebuild redeclares every terminalized id");
+        let replacement = child.slot.member.membership();
+        assert!(
+            !replacement.supersedes(*predecessor),
+            "a re-minted membership must not supersede its terminalized predecessor"
+        );
+        assert!(
+            !predecessor.supersedes(replacement),
+            "a terminalized predecessor must not order against its replacement"
+        );
+    }
+}
+
 struct ReserveOnLifecycleWake {
     scope: Arc<ScopeCell>,
     result: Mutex<Option<Result<(), ReserveError>>>,

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -109,7 +109,7 @@ fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
             DynamicEntry::removing(slot, ChildKey(1), responses),
         );
 
-    let entries = root.with_observation_gate(|txn| control.close(txn));
+    let entries = root.with_observation_gate(|txn| control.close(&root, txn));
     assert!(
         response.try_receive().is_none(),
         "closing admission must not complete removal before teardown"
@@ -122,6 +122,82 @@ fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
     );
     drop(entries);
     assert_eq!(response.try_receive(), Some(RemoveOutcome::Removed));
+}
+
+#[test]
+fn dynamic_close_evicts_a_terminal_reservation_before_readd() {
+    let root = isolated_scope("root", ScopeFlavor::Dynamic);
+    root.member
+        .update(|record| record.stage = MemberStage::Running);
+    root.set_state(ScopeState::Running);
+    let child_id = ChildId::from("worker");
+    let (events, _receiver) = crate::runtime::unbounded_mpsc();
+    let control = DynamicControl::new(events);
+    root.set_dynamic_route(Some(control.clone()));
+
+    let first = root
+        .with_observation_gate(|txn| {
+            super::super::admission_control::reserve_dynamic_in(&root, child_id.clone(), None, txn)
+        })
+        .expect("the first incarnation reserves the child");
+    let first_membership = first.slot.member.membership();
+    let retained = root.with_observation_gate(|txn| control.close(&root, txn));
+    assert!(
+        retained.is_empty(),
+        "reservations are terminalized on close"
+    );
+
+    let (restart_events, _restart_receiver) = crate::runtime::unbounded_mpsc();
+    let restart_control = DynamicControl::new(restart_events);
+    root.set_dynamic_route(Some(restart_control));
+    let replacement = root
+        .with_observation_gate(|txn| {
+            super::super::admission_control::reserve_dynamic_in(&root, child_id, None, txn)
+        })
+        .expect("the restarted scope can reserve the id again");
+    let replacement_membership = replacement.slot.member.membership();
+    assert!(!first_membership.supersedes(replacement_membership));
+    assert!(!replacement_membership.supersedes(first_membership));
+    cancel_dynamic_reservation(
+        &replacement.scope,
+        replacement.control.as_ref(),
+        &replacement.slot,
+    );
+}
+
+#[test]
+fn removing_a_reservation_evicts_its_identity_before_readd() {
+    let root = isolated_scope("root", ScopeFlavor::Dynamic);
+    root.member
+        .update(|record| record.stage = MemberStage::Running);
+    root.set_state(ScopeState::Running);
+    let child_id = ChildId::from("worker");
+    let (events, _receiver) = crate::runtime::unbounded_mpsc();
+    let control = DynamicControl::new(events);
+    root.set_dynamic_route(Some(control));
+
+    let first = root
+        .with_observation_gate(|txn| {
+            super::super::admission_control::reserve_dynamic_in(&root, child_id.clone(), None, txn)
+        })
+        .expect("the first reservation succeeds");
+    let first_membership = first.slot.member.membership();
+    let mut removal = super::super::remove_dynamic(&root, &child_id, Some(first_membership));
+    assert_eq!(removal.try_receive(), Some(RemoveOutcome::Removed));
+
+    let replacement = root
+        .with_observation_gate(|txn| {
+            super::super::admission_control::reserve_dynamic_in(&root, child_id, None, txn)
+        })
+        .expect("the removed reservation releases the id");
+    let replacement_membership = replacement.slot.member.membership();
+    assert!(!first_membership.supersedes(replacement_membership));
+    assert!(!replacement_membership.supersedes(first_membership));
+    cancel_dynamic_reservation(
+        &replacement.scope,
+        replacement.control.as_ref(),
+        &replacement.slot,
+    );
 }
 
 #[crate::runtime::test]

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -381,6 +381,7 @@ async fn removal_from_a_foreign_thread_reaches_the_driver() {
         .mint_membership(&child_id)
         .expect("membership available");
     let member = MemberCell::new(child_id.clone(), membership);
+    let membership = member.membership();
     let slot = SlotCell::new(Arc::clone(&member), None);
     let key = ChildKey(1);
     let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
@@ -464,17 +465,14 @@ async fn admission_conversion_panic_does_not_poison_dynamic_cleanup() {
 
     assert!(
         catch_unwind(AssertUnwindSafe(|| {
-            let _identity = root
-                .child_identity
-                .lock()
-                .expect("scope identity mutex starts healthy");
+            let _incarnations = member.lock_incarnation_counter();
             panic!("inject admission conversion failure");
         }))
         .is_err()
     );
     assert!(
         catch_unwind(AssertUnwindSafe(|| scope.handle_admission(request))).is_err(),
-        "the poisoned child identity injects the conversion panic"
+        "the poisoned issued counter injects the conversion panic"
     );
     assert!(matches!(
         response.receive().await,
@@ -906,10 +904,7 @@ async fn fused_cancellation_during_conversion_is_rejected_by_the_under_lock_rech
     let defaults = ResolvedDefaults::default();
     let mut definition_claimed = false;
     std::thread::scope(|threads| {
-        let identity = root
-            .child_identity
-            .lock()
-            .expect("scope identity mutex starts healthy");
+        let incarnations = member.lock_incarnation_counter();
         let driver_scope = &mut scope;
         let driver = threads.spawn(move || driver_scope.handle_admission(request));
         // The definition leaves the slot after the pre-conversion latch
@@ -932,7 +927,7 @@ async fn fused_cancellation_during_conversion_is_rejected_by_the_under_lock_rech
         );
         // Release without unwinding: conversion must proceed into the
         // under-lock re-check, not observe a poisoned identity mutex.
-        drop(identity);
+        drop(incarnations);
         driver
             .join()
             .expect("conversion proceeds after the identity mutex is released");

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -6,7 +6,7 @@ fn member_transitions_own_their_complete_record_projection() {
     let id = ChildId::from("worker");
     let membership = identity.mint_membership(&id).expect("membership available");
     let member = MemberCell::new(id, membership);
-    let mut incarnations = identity.incarnation_counter(membership);
+    let mut incarnations = member.take_incarnation_counter();
     let incarnation = incarnations.mint().expect("incarnation available");
 
     member.transition(MemberTransition::Admitted);
@@ -68,7 +68,7 @@ fn incarnation_mint_exhaustion_has_no_terminal_side_effects() {
     );
     // Walk the record along the production path so the transition-source
     // assertions in `apply_transition` cover this setup too.
-    let mut setup_incarnations = identity.incarnation_counter(membership);
+    let mut setup_incarnations = member.take_incarnation_counter();
     let spent = setup_incarnations
         .mint()
         .expect("setup incarnation available");
@@ -79,7 +79,7 @@ fn incarnation_mint_exhaustion_has_no_terminal_side_effects() {
         restart_count: RestartCount::ZERO,
         restart_at: None,
     });
-    let mut counter = IncarnationCounter::near_exhaustion(membership);
+    let mut counter = IncarnationCounter::near_exhaustion(member.membership());
 
     assert!(counter.mint().is_some());
     assert!(counter.mint().is_none());
@@ -121,8 +121,7 @@ async fn incarnation_exhaustion_uses_post_disposal_retention_routing() {
         .with_lifecycle(ScopeLifecycle::running())
         .with_next_ordered_start(Some(key))
         .build();
-    plan.armed = false;
-    drop(plan);
+    plan.take_for_runtime().finish_transfer();
 
     scope.children[key].incarnations =
         IncarnationCounter::near_exhaustion(scope.children[key].slot.member.membership());
@@ -227,8 +226,7 @@ async fn first_spawn_exhaustion_stops_without_reporting_a_startup_abort() {
         .with_children(children)
         .with_next_ordered_start(Some(key))
         .build();
-    plan.armed = false;
-    drop(plan);
+    plan.take_for_runtime().finish_transfer();
 
     // Burn the counter's last usable generation without touching the
     // member record: the child is still an unspawned initial member, so
@@ -326,8 +324,7 @@ async fn latched_shutdown_keeps_the_startup_verdict_for_its_follow_up_event() {
         .with_children(children)
         .with_next_ordered_start(Some(key))
         .build();
-    plan.armed = false;
-    drop(plan);
+    plan.take_for_runtime().finish_transfer();
 
     assert!(scope.children[key].initial);
     scope.spawn_child(key);
@@ -485,7 +482,7 @@ async fn scope_incarnation_exhaustion_closes_nested_observation() {
     parent.set_admitted_children(vec![resident_projection(&slot)]);
     let mut snapshots = scope.subscribe_snapshots();
     let mut events = scope.subscribe_lifecycle();
-    let mut counter = IncarnationCounter::near_exhaustion(membership);
+    let mut counter = IncarnationCounter::near_exhaustion(member.membership());
     let first = counter.mint().expect("last incarnation mints");
     member.update(|record| {
         record.stage = MemberStage::Restarting;

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -186,7 +186,7 @@ async fn terminal_scope_waits_for_its_live_incarnation_to_stop() {
     let epoch = nested
         .begin_incarnation(ScopeState::Starting)
         .expect("nested scope epoch is available");
-    let mut incarnations = ScopeIdentity::new().incarnation_counter(nested.member.membership());
+    let mut incarnations = IncarnationCounter::fixture(nested.member.membership());
     let incarnation = incarnations.mint().expect("child incarnation is available");
     nested.member.update(|record| {
         record.stage = MemberStage::Running;
@@ -296,7 +296,7 @@ async fn terminality_fallback_preserves_restart_window_scope_reason() {
     let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
     parent.set_admitted_children(vec![resident_projection(&slot)]);
 
-    let mut incarnations = ScopeIdentity::new().incarnation_counter(nested.member.membership());
+    let mut incarnations = IncarnationCounter::fixture(nested.member.membership());
     let last_incarnation = incarnations.mint().expect("child incarnation is available");
     nested.member.update(|record| {
         record.stage = MemberStage::Restarting;
@@ -360,7 +360,11 @@ async fn blocked_initial_scope_factory_owns_its_stop_epilogue() {
     let plan = tree.lower_for_test();
     let root = Arc::clone(&plan.root);
     let epoch = ScopeEpochGuard::begin(&root).expect("parent epoch is available");
-    let driver = crate::runtime::spawn(run_scope_incarnation(plan, ScopeRole::Root, epoch));
+    let driver = crate::runtime::spawn(run_scope_incarnation(
+        plan.take_for_runtime(),
+        ScopeRole::Root,
+        epoch,
+    ));
     let abort = driver.abort_handle();
 
     assert!(matches!(
@@ -419,7 +423,11 @@ async fn blocked_restart_scope_factory_supersedes_the_stale_stopped_projection()
     let plan = tree.lower_for_test();
     let root = Arc::clone(&plan.root);
     let epoch = ScopeEpochGuard::begin(&root).expect("parent epoch is available");
-    let driver = crate::runtime::spawn(run_scope_incarnation(plan, ScopeRole::Root, epoch));
+    let driver = crate::runtime::spawn(run_scope_incarnation(
+        plan.take_for_runtime(),
+        ScopeRole::Root,
+        epoch,
+    ));
     let abort = driver.abort_handle();
 
     assert!(matches!(

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -108,8 +108,7 @@ async fn force_upgrades_an_intensity_drain_to_shutdown_requested() {
         .with_children(children)
         .with_lifecycle(ScopeLifecycle::running())
         .build();
-    plan.armed = false;
-    drop(plan);
+    plan.take_for_runtime().finish_transfer();
 
     scope.spawn_child(key);
     let active = scope.children[key]

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -35,8 +35,7 @@ async fn latched_shutdown_upgrades_an_intensity_drain() {
         .with_children(children)
         .with_lifecycle(ScopeLifecycle::running())
         .build();
-    plan.armed = false;
-    drop(plan);
+    plan.take_for_runtime().finish_transfer();
 
     scope.spawn_child(key);
     let active = scope.children[key]
@@ -185,8 +184,7 @@ async fn force_uses_the_stop_funnel_for_every_ordered_child() {
         .with_children(children)
         .with_lifecycle(ScopeLifecycle::running())
         .build();
-    plan.armed = false;
-    drop(plan);
+    plan.take_for_runtime().finish_transfer();
 
     for key in &keys {
         scope.spawn_child(*key);
@@ -302,8 +300,7 @@ fn forced_ordered_drain_advances_an_inactive_suffix_iteratively() {
         .with_lifecycle(ScopeLifecycle::running())
         .with_hard_forced(true)
         .build();
-    plan.armed = false;
-    drop(plan);
+    plan.take_for_runtime().finish_transfer();
 
     scope.begin_drain(StopReason::ShutdownRequested);
 

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -204,8 +204,7 @@ async fn early_restart_shutdown_does_not_expedite_a_never_started_ordered_child(
         .with_children(children)
         .with_next_ordered_start(Some(first))
         .build();
-    plan.armed = false;
-    drop(plan);
+    plan.take_for_runtime().finish_transfer();
 
     // Ordered startup spawns "a" and parks on its (never-fired) readiness.
     scope.progress_startup();
@@ -555,8 +554,7 @@ async fn same_batch_intensity_exit_suppresses_retained_expedite_retry() {
         .with_lifecycle(ScopeLifecycle::running())
         .with_next_ordered_start(next_ordered_start)
         .build();
-    plan.armed = false;
-    drop(plan);
+    plan.take_for_runtime().finish_transfer();
 
     let target = scope.children[nested]
         .slot

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -78,8 +78,7 @@ async fn pre_admission_restart_shutdown_does_not_expedite_the_following_incarnat
         .with_lifecycle(ScopeLifecycle::running())
         .with_children(children)
         .build();
-    plan.armed = false;
-    drop(plan);
+    plan.take_for_runtime().finish_transfer();
 
     scope.spawn_child(key);
     let first = scope.children[key]
@@ -284,8 +283,7 @@ async fn restart_shutdown_arriving_before_exit_is_retried_after_the_child_become
         .with_lifecycle(ScopeLifecycle::running())
         .with_children(children)
         .build();
-    plan.armed = false;
-    drop(plan);
+    plan.take_for_runtime().finish_transfer();
 
     let target = scope.children[key]
         .slot
@@ -396,8 +394,7 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
         .with_lifecycle(ScopeLifecycle::running())
         .with_next_ordered_start(next_ordered_start)
         .build();
-    plan.armed = false;
-    drop(plan);
+    plan.take_for_runtime().finish_transfer();
 
     root.transition_child(
         &scope.children[nested].slot.member,
@@ -710,8 +707,7 @@ async fn same_batch_self_stop_preserves_fired_readiness_for_startup() {
         .with_children(children)
         .with_next_ordered_start(Some(key))
         .build();
-    plan.armed = false;
-    drop(plan);
+    plan.take_for_runtime().finish_transfer();
 
     scope.spawn_child(key);
     let active = scope.children[key]

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -20,7 +20,7 @@ pub(super) use crate::{
     exit::RecordedOutcome,
     identity::{IncarnationCounter, ScopeIdentity},
     mailbox::MailboxCell,
-    plan::{ChildConstruction, SlotCell},
+    plan::{BuilderCore, ChildConstruction, SlotCell},
     policy::ResolvedDefaults,
     runtime::{CompletionGatedLatch, Latch},
 };

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -11,6 +11,7 @@ use crate::{
     RestartCount, RestartPolicy, Shutdown, TotalRestarts,
     deadline::Deadline,
     exit::StopReason,
+    identity::PoisonedCounter,
     policy::{ScopeFlavor, tidy_abort_beat},
 };
 
@@ -715,99 +716,95 @@ pub(crate) struct ChildCompletionState {
 /// requests use [`ScopeEpochs`] and do not encode this phase a second time.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ScopeLifecycle {
-    state: ScopeState,
-    drain: Option<ScopeDrain>,
+    state: ScopeLifecycleState,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ScopeLifecycleState {
+    Starting,
+    Running,
+    StartupFailed,
+    Draining(ScopeDrain),
 }
 
 impl ScopeLifecycle {
     pub(crate) fn starting() -> Self {
         Self {
-            state: ScopeState::Starting,
-            drain: None,
+            state: ScopeLifecycleState::Starting,
         }
     }
 
     pub(crate) fn state(&self) -> ScopeState {
-        self.state.clone()
+        match &self.state {
+            ScopeLifecycleState::Starting => ScopeState::Starting,
+            ScopeLifecycleState::Running => ScopeState::Running,
+            ScopeLifecycleState::StartupFailed => ScopeState::StartupFailed,
+            ScopeLifecycleState::Draining(_) => ScopeState::Draining,
+        }
     }
 
     #[cfg(test)]
     pub(crate) fn running() -> Self {
         Self {
-            state: ScopeState::Running,
-            drain: None,
+            state: ScopeLifecycleState::Running,
         }
     }
 
-    /// The old `ScopePhase` enum made "draining without a reason"
-    /// unrepresentable; with split fields the equivalence is checked after
-    /// every transition instead.
-    fn assert_drain_invariant(&self) {
-        debug_assert_eq!(
-            self.state == ScopeState::Draining,
-            self.drain.is_some(),
-            "a scope is draining iff a drain reason is recorded"
-        );
-    }
-
     pub(crate) fn is_starting(&self) -> bool {
-        self.state == ScopeState::Starting
+        matches!(self.state, ScopeLifecycleState::Starting)
     }
 
     pub(crate) fn startup_complete(&self) -> bool {
         matches!(
-            (&self.state, &self.drain),
-            (ScopeState::Running, None)
-                | (
-                    ScopeState::Draining,
-                    Some(ScopeDrain {
-                        startup: StartupPhase::Complete,
-                        ..
-                    })
-                )
+            &self.state,
+            ScopeLifecycleState::Running
+                | ScopeLifecycleState::Draining(ScopeDrain {
+                    startup: StartupPhase::Complete,
+                    ..
+                })
         )
     }
 
     pub(crate) fn startup_failed(&self) -> bool {
         matches!(
-            (&self.state, &self.drain),
-            (ScopeState::StartupFailed, None)
-                | (
-                    ScopeState::Draining,
-                    Some(ScopeDrain {
-                        startup: StartupPhase::Failed,
-                        ..
-                    })
-                )
+            &self.state,
+            ScopeLifecycleState::StartupFailed
+                | ScopeLifecycleState::Draining(ScopeDrain {
+                    startup: StartupPhase::Failed,
+                    ..
+                })
         )
     }
 
     pub(crate) fn is_draining(&self) -> bool {
-        self.state == ScopeState::Draining
+        matches!(self.state, ScopeLifecycleState::Draining(_))
     }
 
     pub(crate) fn draining_reason(&self) -> Option<&StopReason> {
-        self.drain.as_ref().map(|drain| &drain.reason)
+        match &self.state {
+            ScopeLifecycleState::Draining(drain) => Some(&drain.reason),
+            ScopeLifecycleState::Starting
+            | ScopeLifecycleState::Running
+            | ScopeLifecycleState::StartupFailed => None,
+        }
     }
 
     pub(crate) fn complete_startup(&mut self) -> Option<ScopeState> {
-        if self.state != ScopeState::Starting {
+        if !matches!(self.state, ScopeLifecycleState::Starting) {
             return None;
         }
-        self.state = ScopeState::Running;
-        self.assert_drain_invariant();
-        Some(self.state.clone())
+        self.state = ScopeLifecycleState::Running;
+        Some(self.state())
     }
 
     /// Records only the first startup failure, so simultaneous failing
     /// initial children cannot publish the transition twice.
     pub(crate) fn fail_startup(&mut self) -> Option<ScopeState> {
-        if self.state != ScopeState::Starting {
+        if !matches!(self.state, ScopeLifecycleState::Starting) {
             return None;
         }
-        self.state = ScopeState::StartupFailed;
-        self.assert_drain_invariant();
-        Some(self.state.clone())
+        self.state = ScopeLifecycleState::StartupFailed;
+        Some(self.state())
     }
 
     /// Begins draining or monotonically upgrades an in-progress drain.
@@ -816,32 +813,22 @@ impl ScopeLifecycle {
     /// change the eventual verdict without repeating teardown side effects.
     pub(crate) fn begin_drain(&mut self, reason: StopReason) -> Option<DrainEffect> {
         let incoming_precedence = DrainReasonPrecedence::of(&reason);
-        let startup = match self.state {
-            ScopeState::Starting => StartupPhase::Pending,
-            ScopeState::Running => StartupPhase::Complete,
-            ScopeState::StartupFailed => StartupPhase::Failed,
-            ScopeState::Draining => {
-                let drain = self
-                    .drain
-                    .as_mut()
-                    .expect("the drain invariant supplies a reason while draining");
+        let startup = match &mut self.state {
+            ScopeLifecycleState::Starting => StartupPhase::Pending,
+            ScopeLifecycleState::Running => StartupPhase::Complete,
+            ScopeLifecycleState::StartupFailed => StartupPhase::Failed,
+            ScopeLifecycleState::Draining(drain) => {
                 if incoming_precedence > DrainReasonPrecedence::of(&drain.reason) {
                     drain.reason = reason;
                 }
-                self.assert_drain_invariant();
                 return None;
-            }
-            ScopeState::Unstarted | ScopeState::Stopped { .. } => {
-                unreachable!("a scope incarnation owns only live lifecycle states")
             }
         };
         let startup_pending = startup == StartupPhase::Pending;
-        self.state = ScopeState::Draining;
-        self.drain = Some(ScopeDrain { reason, startup });
-        self.assert_drain_invariant();
+        self.state = ScopeLifecycleState::Draining(ScopeDrain { reason, startup });
         Some(DrainEffect {
             startup_pending,
-            state: self.state.clone(),
+            state: self.state(),
         })
     }
 
@@ -889,7 +876,7 @@ impl Ord for DeadlineEntry {
 pub(crate) struct DeadlineQueue<K> {
     // Keys are both registration identity and equal-deadline arming order.
     // They are never reused, so a stale handle can only miss.
-    next_key: u64,
+    registration_ids: PoisonedCounter,
     entries: BinaryHeap<DeadlineEntry>,
     registrations: BTreeMap<DeadlineHandle, K>,
 }
@@ -907,7 +894,7 @@ struct DeadlineEntry {
 impl<K> Default for DeadlineQueue<K> {
     fn default() -> Self {
         Self {
-            next_key: 0,
+            registration_ids: PoisonedCounter::new(),
             entries: BinaryHeap::new(),
             registrations: BTreeMap::new(),
         }
@@ -950,16 +937,10 @@ impl<K> DeadlineQueue<K> {
     }
 
     fn next_handle(&mut self) -> DeadlineHandle {
-        let Some(next) = self.next_key.checked_add(1) else {
-            panic!("deadline key space exhausted");
-        };
-        // Reserve the maximum value as poison. Once reached, the counter stays
-        // poisoned and every later push fails instead of wrapping or reusing.
-        if next == u64::MAX {
-            self.next_key = u64::MAX;
-            panic!("deadline key space exhausted");
-        }
-        self.next_key = next;
+        let next = self
+            .registration_ids
+            .mint()
+            .expect("deadline key space exhausted");
         DeadlineHandle(next)
     }
 
@@ -1014,6 +995,7 @@ mod tests {
     use crate::{
         Cancellation, Exit, ExitKind, GracePhase, Intensity, JitterSample, RestartAttempt,
         RestartCondition, RestartCount, RestartPolicy, Shutdown, TotalRestarts,
+        identity::PoisonedCounter,
         policy::{Backoff, ScopeFlavor},
     };
 
@@ -1675,7 +1657,7 @@ mod tests {
     fn deadline_key_exhaustion_never_mints_poison_or_reuses_a_key() {
         let now = Instant::now();
         let mut deadlines = DeadlineQueue {
-            next_key: u64::MAX - 2,
+            registration_ids: PoisonedCounter::near_exhaustion(),
             ..DeadlineQueue::default()
         };
         let last = deadlines.push(now, "last usable");
@@ -1684,7 +1666,7 @@ mod tests {
 
         let first_exhausted = catch_unwind(AssertUnwindSafe(|| deadlines.push(now, "poison")));
         assert!(first_exhausted.is_err(), "the poison key is never minted");
-        assert_eq!(deadlines.next_key, u64::MAX);
+        assert!(deadlines.registration_ids.is_poisoned());
         assert!(
             !deadlines
                 .registrations

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -547,10 +547,7 @@ impl Epoch {
     /// The next mintable epoch. `None` reserves `u64::MAX` as the poison so
     /// no observable epoch can alias permanent exhaustion.
     fn successor(self) -> Option<Self> {
-        self.0
-            .checked_add(1)
-            .filter(|next| *next != u64::MAX)
-            .map(Self)
+        PoisonedCounter::minted_after(self.0).map(Self)
     }
 }
 

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -630,7 +630,10 @@ mod tests {
     fn child_startup_failure_display_summarizes_every_exit_kind() {
         let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
-        let membership = identity.mint_membership(&id).expect("membership available");
+        let membership = identity
+            .mint_membership(&id)
+            .expect("membership available")
+            .membership();
         let deadline = Instant::now() + Duration::from_secs(1);
         let cases = [
             (

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -13,7 +13,7 @@ use std::{
 #[cfg(test)]
 use std::cell::Cell;
 
-static NEXT_LINEAGE: AtomicU64 = AtomicU64::new(0);
+static NEXT_LINEAGE: AtomicPoisonedCounter = AtomicPoisonedCounter::new();
 
 #[cfg(test)]
 thread_local! {
@@ -78,7 +78,8 @@ impl Membership {
     /// stable owning scope.
     ///
     /// Tokens for different child ids or owning scopes are incomparable and
-    /// return `false`.
+    /// return `false`. Terminalization evicts the retained id lineage, so a
+    /// later remove-and-re-add is deliberately incomparable in both directions.
     #[must_use]
     pub fn supersedes(self, other: Self) -> bool {
         self.0.supersedes(other.0)
@@ -114,7 +115,6 @@ impl Incarnation {
 struct Generation(u64);
 
 impl Generation {
-    const ZERO: Self = Self(0);
     const POISON: Self = Self(u64::MAX);
 
     fn new(value: u64) -> Option<Self> {
@@ -156,24 +156,101 @@ impl Fence {
 ///
 /// `u64::MAX` is poison and is never returned. Once the last usable value has
 /// been minted, no successor can be minted.
+#[derive(Clone, Debug)]
+pub(crate) struct PoisonedCounter {
+    current: u64,
+}
+
+impl PoisonedCounter {
+    pub(crate) const fn new() -> Self {
+        Self { current: 0 }
+    }
+
+    fn from_current(current: u64) -> Self {
+        debug_assert_ne!(current, u64::MAX);
+        Self { current }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn near_exhaustion() -> Self {
+        Self {
+            current: u64::MAX - 2,
+        }
+    }
+
+    pub(crate) fn mint(&mut self) -> Option<u64> {
+        // Saturation is the poison transition itself: MAX is never returned,
+        // and retaining it makes every later mint fail closed.
+        let next = self.current.saturating_add(1);
+        self.current = next;
+        (next != u64::MAX).then_some(next)
+    }
+
+    pub(crate) fn current(&self) -> u64 {
+        self.current
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_poisoned(&self) -> bool {
+        self.current == u64::MAX
+    }
+}
+
+/// A thread-safe [`PoisonedCounter`] with the same fail-closed domain.
+#[derive(Debug)]
+pub(crate) struct AtomicPoisonedCounter(AtomicU64);
+
+impl AtomicPoisonedCounter {
+    pub(crate) const fn new() -> Self {
+        Self(AtomicU64::new(0))
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn near_exhaustion() -> Self {
+        Self(AtomicU64::new(u64::MAX - 2))
+    }
+
+    pub(crate) fn mint(&self, success: Ordering, failure: Ordering) -> Option<u64> {
+        let previous = self
+            .0
+            .try_update(success, failure, |current| {
+                // Saturation atomically installs the permanent poison value;
+                // MAX is interpreted below and never returned to a caller.
+                Some(current.saturating_add(1))
+            })
+            .expect("a poisoned counter update never rejects");
+        let next = previous.saturating_add(1);
+        (next != u64::MAX).then_some(next)
+    }
+
+    pub(crate) fn load(&self, ordering: Ordering) -> u64 {
+        self.0.load(ordering)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set(&self, value: u64, ordering: Ordering) {
+        self.0.store(value, ordering);
+    }
+}
+
 #[derive(Debug)]
 struct FenceCounter {
     lineage: Lineage,
-    current: Generation,
+    generations: PoisonedCounter,
 }
 
 impl FenceCounter {
     fn new(lineage: Lineage) -> Self {
         Self {
             lineage,
-            current: Generation::ZERO,
+            generations: PoisonedCounter::new(),
         }
     }
 
     fn from_fence(fence: Fence) -> Self {
         Self {
             lineage: fence.lineage,
-            current: fence.generation,
+            generations: PoisonedCounter::from_current(fence.generation.get()),
         }
     }
 
@@ -185,21 +262,29 @@ impl FenceCounter {
     fn near_exhaustion(lineage: u64) -> Self {
         Self {
             lineage: Lineage(lineage),
-            current: Generation(u64::MAX - 2),
+            generations: PoisonedCounter::near_exhaustion(),
         }
     }
 
     fn mint(&mut self) -> Option<Fence> {
-        let next = self.current.get().checked_add(1)?;
-        let Some(generation) = Generation::new(next) else {
-            self.current = Generation::POISON;
-            return None;
-        };
-        self.current = generation;
+        let generation = Generation::new(self.generations.mint()?)?;
         Some(Fence {
             lineage: self.lineage,
             generation,
         })
+    }
+
+    fn issued(&self) -> Fence {
+        let generation = if self.generations.current == u64::MAX {
+            u64::MAX - 1
+        } else {
+            self.generations.current
+        };
+        Fence {
+            lineage: self.lineage,
+            generation: Generation::new(generation)
+                .expect("a live identity cannot expose its poison generation"),
+        }
     }
 }
 
@@ -210,12 +295,39 @@ pub(crate) struct IncarnationCounter {
     counter: FenceCounter,
 }
 
+/// An inseparable identity grant: the counter for an incarnation lineage is
+/// allocated exactly once as its first membership method returns.
+#[derive(Debug)]
+pub(crate) struct MintedMembership {
+    membership: Membership,
+    incarnation_counter: IncarnationCounter,
+}
+
+impl MintedMembership {
+    #[cfg(test)]
+    pub(crate) fn membership(&self) -> Membership {
+        self.membership
+    }
+
+    pub(crate) fn into_pair(self) -> (Membership, IncarnationCounter) {
+        (self.membership, self.incarnation_counter)
+    }
+}
+
 impl IncarnationCounter {
     pub(crate) fn mint(&mut self) -> Option<Incarnation> {
         self.counter.mint().map(|fence| Incarnation {
             membership: self.membership,
             generation: fence.generation,
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fixture(membership: Membership) -> Self {
+        Self {
+            membership,
+            counter: FenceCounter::sequence(),
+        }
     }
 
     #[cfg(test)]
@@ -245,13 +357,7 @@ impl ScopeIdentity {
     }
 
     fn fresh_counter() -> Option<FenceCounter> {
-        let lineage = NEXT_LINEAGE
-            .try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
-                let next = current.checked_add(1)?;
-                (next != u64::MAX).then_some(next)
-            })
-            .ok()?
-            + 1;
+        let lineage = NEXT_LINEAGE.mint(Ordering::Relaxed, Ordering::Relaxed)?;
         Some(FenceCounter::new(Lineage(lineage)))
     }
 
@@ -267,8 +373,8 @@ impl ScopeIdentity {
         }
     }
 
-    pub(crate) fn mint_membership(&mut self, id: &ChildId) -> Option<Membership> {
-        match self.memberships.entry(id.clone()) {
+    pub(crate) fn mint_membership(&mut self, id: &ChildId) -> Option<MintedMembership> {
+        let membership = match self.memberships.entry(id.clone()) {
             Entry::Occupied(mut entry) => entry.get_mut().mint().map(Membership),
             Entry::Vacant(entry) => {
                 let mut counter = Self::fresh_counter()?;
@@ -276,7 +382,14 @@ impl ScopeIdentity {
                 entry.insert(counter);
                 Some(membership)
             }
-        }
+        }?;
+        Some(MintedMembership {
+            membership,
+            incarnation_counter: IncarnationCounter {
+                membership,
+                counter: FenceCounter::sequence(),
+            },
+        })
     }
 
     /// Reconciles a declaration-time membership with this stable scope.
@@ -289,40 +402,102 @@ impl ScopeIdentity {
         &mut self,
         id: &ChildId,
         provisional: Membership,
-    ) -> Option<Membership> {
+    ) -> Option<Option<MintedMembership>> {
         match self.memberships.entry(id.clone()) {
-            Entry::Occupied(mut entry) => entry.get_mut().mint().map(Membership),
+            Entry::Occupied(mut entry) => {
+                let membership = entry.get_mut().mint().map(Membership)?;
+                Some(Some(MintedMembership {
+                    membership,
+                    incarnation_counter: IncarnationCounter {
+                        membership,
+                        counter: FenceCounter::sequence(),
+                    },
+                }))
+            }
             Entry::Vacant(entry) => {
                 debug_assert_ne!(provisional.0.generation, Generation::POISON);
                 entry.insert(FenceCounter::from_fence(provisional.0));
-                Some(provisional)
+                Some(None)
             }
         }
     }
 
-    pub(crate) fn incarnation_counter(&self, membership: Membership) -> IncarnationCounter {
-        // Membership already supplies the complete incarnation lineage. The
-        // per-membership counter therefore needs only an ordered generation.
-        IncarnationCounter {
-            membership,
-            counter: FenceCounter::sequence(),
+    pub(crate) fn evict(&mut self, id: &ChildId, membership: Membership) {
+        let Entry::Occupied(entry) = self.memberships.entry(id.clone()) else {
+            return;
+        };
+        if entry.get().issued() == membership.0 {
+            entry.remove();
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::Ordering;
+
     use crate::ChildId;
 
-    use super::{FenceCounter, Generation, IncarnationCounter, ScopeIdentity};
+    use super::{
+        AtomicPoisonedCounter, FenceCounter, Generation, IncarnationCounter, PoisonedCounter,
+        ScopeIdentity,
+    };
+
+    #[test]
+    fn shared_counter_primitive_poison_is_never_minted() {
+        let mut local = PoisonedCounter::near_exhaustion();
+        assert_eq!(local.mint(), Some(u64::MAX - 1));
+        assert_eq!(local.mint(), None);
+        assert_eq!(local.mint(), None);
+        assert!(local.is_poisoned());
+
+        let atomic = AtomicPoisonedCounter(std::sync::atomic::AtomicU64::new(u64::MAX - 2));
+        assert_eq!(
+            atomic.mint(Ordering::Relaxed, Ordering::Relaxed),
+            Some(u64::MAX - 1)
+        );
+        assert_eq!(atomic.mint(Ordering::Relaxed, Ordering::Relaxed), None);
+        assert_eq!(atomic.mint(Ordering::Relaxed, Ordering::Relaxed), None);
+        assert_eq!(atomic.load(Ordering::Relaxed), u64::MAX);
+    }
+
+    #[test]
+    fn eviction_makes_readds_incomparable_and_stale_eviction_is_harmless() {
+        let id = ChildId::from("worker");
+        let mut scope = ScopeIdentity::new();
+        let first = scope
+            .mint_membership(&id)
+            .expect("first identity available")
+            .membership();
+        scope.evict(&id, first);
+        let second = scope
+            .mint_membership(&id)
+            .expect("re-added identity available")
+            .membership();
+        assert!(!first.supersedes(second));
+        assert!(!second.supersedes(first));
+
+        scope.evict(&id, first);
+        let third = scope
+            .mint_membership(&id)
+            .expect("stale eviction preserved the current domain")
+            .membership();
+        assert!(third.supersedes(second));
+    }
 
     #[test]
     fn cross_scope_tokens_fail_closed() {
         let mut left = ScopeIdentity::new();
         let mut right = ScopeIdentity::new();
         let id = ChildId::from("worker");
-        let left_member = left.mint_membership(&id).expect("membership available");
-        let right_member = right.mint_membership(&id).expect("membership available");
+        let left_member = left
+            .mint_membership(&id)
+            .expect("membership available")
+            .membership();
+        let right_member = right
+            .mint_membership(&id)
+            .expect("membership available")
+            .membership();
 
         assert_ne!(left_member, right_member);
         assert!(!left_member.supersedes(right_member));
@@ -333,26 +508,30 @@ mod tests {
     fn membership_and_incarnation_order_is_scoped_by_owner_and_id() {
         let mut scope = ScopeIdentity::new();
         let id = ChildId::from("worker");
-        let first = scope.mint_membership(&id).expect("membership available");
-        let second = scope.mint_membership(&id).expect("membership available");
+        let first_grant = scope.mint_membership(&id).expect("membership available");
+        let first = first_grant.membership();
+        let second_grant = scope.mint_membership(&id).expect("membership available");
+        let second = second_grant.membership();
         assert!(second.supersedes(first));
         assert!(!first.supersedes(second));
 
         let other = scope
             .mint_membership(&ChildId::from("other"))
-            .expect("other membership available");
+            .expect("other membership available")
+            .membership();
         assert!(!other.supersedes(first));
         assert!(!first.supersedes(other));
 
-        let mut generations = scope.incarnation_counter(first);
+        let (_, mut generations) = first_grant.into_pair();
         let a = generations.mint().expect("incarnation available");
         let b = generations.mint().expect("incarnation available");
         assert!(b.supersedes(a));
         assert_eq!(a.membership(), first);
         assert!(
             !b.supersedes(
-                scope
-                    .incarnation_counter(second)
+                second_grant
+                    .into_pair()
+                    .1
                     .mint()
                     .expect("incarnation available")
             )
@@ -366,29 +545,32 @@ mod tests {
         let mut first_builder = ScopeIdentity::new();
         let first = first_builder
             .mint_membership(&id)
-            .expect("first provisional membership available");
+            .expect("first provisional membership available")
+            .membership();
         let other = first_builder
             .mint_membership(&other_id)
-            .expect("other provisional membership available");
+            .expect("other provisional membership available")
+            .membership();
         let mut rebuilt_builder = ScopeIdentity::new();
         let rebuilt = rebuilt_builder
             .mint_membership(&id)
-            .expect("rebuilt provisional membership available");
+            .expect("rebuilt provisional membership available")
+            .membership();
 
         let mut stable = ScopeIdentity::new();
-        assert_eq!(
+        assert!(matches!(
             stable.adopt_or_mint_membership(&id, first),
-            Some(first),
-            "first lowering preserves pre-spawn identity"
-        );
-        assert_eq!(
+            Some(None)
+        ));
+        assert!(matches!(
             stable.adopt_or_mint_membership(&other_id, other),
-            Some(other),
-            "each id adopts its own provisional lineage"
-        );
+            Some(None)
+        ));
         let successor = stable
             .adopt_or_mint_membership(&id, rebuilt)
-            .expect("stable identity mints a rebuilt successor");
+            .expect("stable identity is not exhausted")
+            .expect("stable identity mints a rebuilt successor")
+            .membership();
 
         assert!(successor.supersedes(first));
         assert!(!first.supersedes(successor));
@@ -407,7 +589,8 @@ mod tests {
         let mut scope = ScopeIdentity::near_exhaustion(id.clone(), TEST_LINEAGE);
         let last = scope
             .mint_membership(&id)
-            .expect("last usable membership is minted");
+            .expect("last usable membership is minted")
+            .membership();
         assert!(scope.mint_membership(&id).is_none());
         assert!(scope.mint_membership(&id).is_none());
 
@@ -418,7 +601,8 @@ mod tests {
 
         let unrelated = scope
             .mint_membership(&ChildId::from("other"))
-            .expect("one exhausted id does not poison an unrelated domain");
+            .expect("one exhausted id does not poison an unrelated domain")
+            .membership();
         assert!(!unrelated.supersedes(last));
         assert!(!last.supersedes(unrelated));
     }
@@ -433,10 +617,11 @@ mod tests {
         let mut builder = ScopeIdentity::new();
         let provisional = builder
             .mint_membership(&id)
-            .expect("provisional membership available");
+            .expect("provisional membership available")
+            .membership();
 
-        assert_eq!(stable.adopt_or_mint_membership(&id, provisional), None);
-        assert_eq!(stable.adopt_or_mint_membership(&id, provisional), None);
+        assert!(stable.adopt_or_mint_membership(&id, provisional).is_none());
+        assert!(stable.adopt_or_mint_membership(&id, provisional).is_none());
         assert!(
             stable.mint_membership(&ChildId::from("other")).is_some(),
             "exhaustion remains local to one child id"
@@ -448,7 +633,8 @@ mod tests {
         let mut scope = ScopeIdentity::new();
         let membership = scope
             .mint_membership(&ChildId::from("worker"))
-            .expect("membership available");
+            .expect("membership available")
+            .membership();
         let mut incarnations = IncarnationCounter::near_exhaustion(membership);
         let last = incarnations
             .mint()

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -171,6 +171,16 @@ impl PoisonedCounter {
         Self { current }
     }
 
+    /// Returns the next mintable value under the shared poison rule.
+    ///
+    /// State-owning callers install `u64::MAX` when this returns `None`; state
+    /// machines that represent poison out of band use the same decision and
+    /// retain their explicit exhausted variant.
+    pub(crate) fn minted_after(current: u64) -> Option<u64> {
+        let next = current.saturating_add(1);
+        (next != u64::MAX).then_some(next)
+    }
+
     #[cfg(test)]
     pub(crate) const fn near_exhaustion() -> Self {
         Self {
@@ -181,9 +191,9 @@ impl PoisonedCounter {
     pub(crate) fn mint(&mut self) -> Option<u64> {
         // Saturation is the poison transition itself: MAX is never returned,
         // and retaining it makes every later mint fail closed.
-        let next = self.current.saturating_add(1);
-        self.current = next;
-        (next != u64::MAX).then_some(next)
+        let minted = Self::minted_after(self.current);
+        self.current = minted.unwrap_or(u64::MAX);
+        minted
     }
 
     pub(crate) fn current(&self) -> u64 {
@@ -216,11 +226,10 @@ impl AtomicPoisonedCounter {
             .try_update(success, failure, |current| {
                 // Saturation atomically installs the permanent poison value;
                 // MAX is interpreted below and never returned to a caller.
-                Some(current.saturating_add(1))
+                Some(PoisonedCounter::minted_after(current).unwrap_or(u64::MAX))
             })
             .expect("a poisoned counter update never rejects");
-        let next = previous.saturating_add(1);
-        (next != u64::MAX).then_some(next)
+        PoisonedCounter::minted_after(previous)
     }
 
     pub(crate) fn load(&self, ordering: Ordering) -> u64 {
@@ -394,10 +403,12 @@ impl ScopeIdentity {
 
     /// Reconciles a declaration-time membership with this stable scope.
     ///
-    /// The first declaration of an id donates its already-minted lineage so
-    /// pre-spawn handles retain their identity. Later declarations of that id
-    /// (including declarations produced after a scope restart) mint from the
-    /// retained counter and therefore supersede their predecessors.
+    /// The first declaration of an untracked id donates its already-minted
+    /// lineage so pre-spawn handles retain their identity. If the scope still
+    /// tracks that lineage, a later provisional declaration mints its ordered
+    /// successor. Terminalization evicts the lineage, so an ordinary later
+    /// remove-and-re-add or post-restart rebuild donates a fresh, incomparable
+    /// identity instead.
     pub(crate) fn adopt_or_mint_membership(
         &mut self,
         id: &ChildId,
@@ -539,7 +550,7 @@ mod tests {
     }
 
     #[test]
-    fn stable_scope_adopts_the_first_declaration_then_orders_rebuilds() {
+    fn stable_scope_adopts_the_first_declaration_then_orders_a_retained_lineage() {
         let id = ChildId::from("worker");
         let other_id = ChildId::from("other");
         let mut first_builder = ScopeIdentity::new();

--- a/crates/shelterwood/src/mailbox/cell.rs
+++ b/crates/shelterwood/src/mailbox/cell.rs
@@ -2,16 +2,15 @@ use std::{
     collections::{BTreeMap, VecDeque},
     fmt,
     num::NonZeroUsize,
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::{Arc, Mutex, atomic::Ordering},
     task::Waker,
 };
 
 use crate::{
-    ChildId, Incarnation, Mailbox,
+    ChildId, Incarnation,
     cells::{MailboxControl, MailboxDisposal, MailboxTermination},
+    identity::{AtomicPoisonedCounter, PoisonedCounter},
+    policy::ResolvedMailbox,
     runtime::{PanicAccumulator, PanicPayload, Signal, SignalWatcher, resume_panic},
 };
 
@@ -270,13 +269,8 @@ pub(super) enum Submission<M> {
 struct WaiterId(u64);
 
 impl WaiterId {
-    const ZERO: Self = Self(0);
+    #[cfg(test)]
     const POISON: Self = Self(u64::MAX);
-
-    fn checked_next(self) -> Option<Self> {
-        let next = self.0.checked_add(1)?;
-        (next != Self::POISON.0).then_some(Self(next))
-    }
 }
 
 /// FIFO registrations with direct removal by a send operation.
@@ -289,7 +283,7 @@ impl WaiterId {
 /// instead of wrapping back into the live id domain.
 pub(super) struct WaiterQueue<M> {
     entries: BTreeMap<WaiterId, Arc<SendOperation<M>>>,
-    next_id: WaiterId,
+    ids: PoisonedCounter,
     #[cfg(test)]
     direct_removals: usize,
 }
@@ -298,7 +292,7 @@ impl<M> Default for WaiterQueue<M> {
     fn default() -> Self {
         Self {
             entries: BTreeMap::new(),
-            next_id: WaiterId::ZERO,
+            ids: PoisonedCounter::new(),
             #[cfg(test)]
             direct_removals: 0,
         }
@@ -316,11 +310,11 @@ impl<M> WaiterQueue<M> {
     }
 
     fn push_back(&mut self, operation: Arc<SendOperation<M>>) -> WaiterId {
-        let Some(next) = self.next_id.checked_next() else {
-            self.next_id = WaiterId::POISON;
-            panic!("mailbox waiter identity space exhausted");
-        };
-        self.next_id = next;
+        let next = WaiterId(
+            self.ids
+                .mint()
+                .expect("mailbox waiter identity space exhausted"),
+        );
         let replaced = self.entries.insert(next, operation);
         debug_assert!(replaced.is_none());
         next
@@ -511,7 +505,7 @@ impl<M: Send + 'static> Drop for MailboxTeardown<M> {
 pub(crate) struct MailboxCell<M> {
     pub(super) actor_id: ChildId,
     pub(super) state: Mutex<MailboxState<M>>,
-    accepted: AtomicU64,
+    accepted: AtomicPoisonedCounter,
     changed: Signal,
 }
 
@@ -535,7 +529,7 @@ impl<M: Send + 'static> MailboxCell<M> {
                 queue: VecDeque::new(),
                 latest: None,
             }),
-            accepted: AtomicU64::new(0),
+            accepted: AtomicPoisonedCounter::new(),
             changed: Signal::default(),
         })
     }
@@ -758,14 +752,10 @@ impl<M> MailboxCell<M> {
 }
 
 impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
-    fn configure(&self, mailbox: Mailbox) {
+    fn configure(&self, mailbox: ResolvedMailbox) {
         let kind = match mailbox {
-            Mailbox::Queue(Some(capacity)) => MailboxKind::Queue(capacity),
-            Mailbox::Queue(None) => MailboxKind::Queue(
-                NonZeroUsize::new(crate::policy::DEFAULT_MAILBOX_CAPACITY)
-                    .expect("library mailbox capacity is non-zero"),
-            ),
-            Mailbox::Latest => MailboxKind::Latest,
+            ResolvedMailbox::Queue(capacity) => MailboxKind::Queue(capacity),
+            ResolvedMailbox::Latest => MailboxKind::Latest,
         };
         let mut state = self.state.lock().expect("mailbox mutex poisoned");
         match state.kind {
@@ -925,21 +915,18 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
     }
 }
 
-fn mint_accepted_sequence(accepted: &AtomicU64) -> AcceptedSequence {
+fn mint_accepted_sequence(accepted: &AtomicPoisonedCounter) -> AcceptedSequence {
     AcceptedSequence(
         accepted
-            .try_update(Ordering::Release, Ordering::Relaxed, |accepted| {
-                Some(accepted.saturating_add(1))
-            })
-            .expect("accepted sequence updates never reject")
-            .saturating_add(1),
+            .mint(Ordering::Release, Ordering::Relaxed)
+            .expect("mailbox accepted-sequence space exhausted"),
     )
 }
 
 fn accept_locked<M>(
     state: &mut MailboxState<M>,
     message: M,
-    accepted: &AtomicU64,
+    accepted: &AtomicPoisonedCounter,
 ) -> Result<Acceptance<M>, M> {
     let incarnation = match &state.binding {
         MailboxBinding::Bound(BoundState::Available(incarnation)) => *incarnation,
@@ -977,7 +964,7 @@ fn accept_locked<M>(
 
 fn promote_waiters<M: Send + 'static>(
     state: &mut MailboxState<M>,
-    accepted_sequence: &AtomicU64,
+    accepted_sequence: &AtomicPoisonedCounter,
 ) -> Promotion<M> {
     let Some(kind) = state.kind else {
         return Promotion::default();
@@ -1010,7 +997,7 @@ fn promote_waiter_queue<M: Send + 'static>(
     waiters: &mut WaiterQueue<M>,
     queue: &mut VecDeque<Envelope<M>>,
     latest: &mut Option<Envelope<M>>,
-    accepted_sequence: &AtomicU64,
+    accepted_sequence: &AtomicPoisonedCounter,
 ) -> Promotion<M> {
     let mut promotion = Promotion::default();
     let available = match kind {
@@ -1116,10 +1103,11 @@ pub(super) mod tests {
     };
 
     use crate::{
-        ChildId, Mailbox, SendErrorKind,
+        ChildId, SendErrorKind,
         cells::{MailboxControl, MemberCell},
         identity::ScopeIdentity,
         mailbox::ActorRef,
+        policy::{ResolvedDefaults, ResolvedMailbox},
     };
 
     use super::MailboxCell;
@@ -1161,10 +1149,10 @@ pub(super) mod tests {
     fn binding_before_configuration_trips_the_driver_contract() {
         let (mailbox, _) = actor();
         let mut identity = ScopeIdentity::new();
-        let membership = identity
+        let (_, mut incarnations) = identity
             .mint_membership(&ChildId::from("actor"))
-            .expect("membership available");
-        let mut incarnations = identity.incarnation_counter(membership);
+            .expect("membership available")
+            .into_pair();
         let incarnation = incarnations.mint().expect("incarnation available");
 
         MailboxControl::bind(&*mailbox, incarnation);
@@ -1174,12 +1162,12 @@ pub(super) mod tests {
     #[should_panic(expected = "mailbox must close the prior incarnation before rebinding")]
     fn rebinding_before_close_trips_the_driver_contract() {
         let (mailbox, _) = actor();
-        MailboxControl::configure(&*mailbox, Mailbox::default());
+        MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox);
         let mut identity = ScopeIdentity::new();
-        let membership = identity
+        let (_, mut incarnations) = identity
             .mint_membership(&ChildId::from("actor"))
-            .expect("membership available");
-        let mut incarnations = identity.incarnation_counter(membership);
+            .expect("membership available")
+            .into_pair();
         let first = incarnations.mint().expect("first incarnation available");
         let second = incarnations.mint().expect("second incarnation available");
 
@@ -1192,16 +1180,16 @@ pub(super) mod tests {
         let (mailbox, _) = actor();
         MailboxControl::configure(
             &*mailbox,
-            Mailbox::queue(1).expect("non-zero queue capacity"),
+            ResolvedMailbox::Queue(
+                std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
+            ),
         );
         let mut identity = ScopeIdentity::new();
-        let membership = identity
+        let (_, mut incarnations) = identity
             .mint_membership(&ChildId::from("actor"))
-            .expect("membership available");
-        let incarnation = identity
-            .incarnation_counter(membership)
-            .mint()
-            .expect("incarnation available");
+            .expect("membership available")
+            .into_pair();
+        let incarnation = incarnations.mint().expect("incarnation available");
         MailboxControl::bind(&*mailbox, incarnation);
 
         assert!(matches!(
@@ -1292,13 +1280,14 @@ pub(super) mod tests {
         park_with(&mut first, &first_panicking);
         park_with(&mut second, &second_panicking);
         park_with(&mut third, &counting);
-        MailboxControl::configure(&*mailbox, Mailbox::default());
+        MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox);
         let mut generations = {
             let mut identity = ScopeIdentity::new();
-            let membership = identity
+            let (_, generations) = identity
                 .mint_membership(&ChildId::from("actor"))
-                .expect("membership available");
-            identity.incarnation_counter(membership)
+                .expect("membership available")
+                .into_pair();
+            generations
         };
         let incarnation = generations.mint().expect("incarnation available");
 
@@ -1431,7 +1420,7 @@ pub(super) mod tests {
     #[test]
     fn waiter_identity_exhaustion_poison_is_never_minted() {
         let mut waiters = super::WaiterQueue {
-            next_id: super::WaiterId(u64::MAX - 2),
+            ids: crate::identity::PoisonedCounter::near_exhaustion(),
             ..super::WaiterQueue::default()
         };
         let last = waiters.push_back(super::SendOperation::new(1_u8));
@@ -1444,7 +1433,7 @@ pub(super) mod tests {
             .is_err(),
             "the poison key is never minted"
         );
-        assert_eq!(waiters.next_id, super::WaiterId::POISON);
+        assert!(waiters.ids.is_poisoned());
         assert!(!waiters.entries.contains_key(&super::WaiterId::POISON));
         assert!(
             catch_unwind(AssertUnwindSafe(|| {
@@ -1452,6 +1441,28 @@ pub(super) mod tests {
             }))
             .is_err(),
             "the exhausted domain stays poisoned"
+        );
+    }
+
+    #[test]
+    fn accepted_sequence_exhaustion_poison_is_never_minted() {
+        let accepted = crate::identity::AtomicPoisonedCounter::near_exhaustion();
+        assert_eq!(
+            super::mint_accepted_sequence(&accepted),
+            super::AcceptedSequence(u64::MAX - 1)
+        );
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                super::mint_accepted_sequence(&accepted);
+            }))
+            .is_err()
+        );
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                super::mint_accepted_sequence(&accepted);
+            }))
+            .is_err(),
+            "the accepted-sequence domain stays poisoned"
         );
     }
 }

--- a/crates/shelterwood/src/mailbox/futures.rs
+++ b/crates/shelterwood/src/mailbox/futures.rs
@@ -634,7 +634,7 @@ mod tests {
     };
 
     use crate::{
-        ChildId, Mailbox,
+        ChildId,
         cells::{MailboxControl, MemberCell},
         identity::ScopeIdentity,
     };
@@ -644,12 +644,15 @@ mod tests {
     #[test]
     fn an_accepted_send_reports_acceptance_on_every_poll() {
         let (mailbox, actor) = actor();
-        MailboxControl::configure(&*mailbox, Mailbox::default());
+        MailboxControl::configure(
+            &*mailbox,
+            crate::policy::ResolvedDefaults::default().mailbox,
+        );
         let mut identity = ScopeIdentity::new();
-        let membership = identity
+        let (_, mut incarnations) = identity
             .mint_membership(&ChildId::from("actor"))
-            .expect("membership available");
-        let mut incarnations = identity.incarnation_counter(membership);
+            .expect("membership available")
+            .into_pair();
         let incarnation = incarnations.mint().expect("incarnation available");
         MailboxControl::bind(&*mailbox, incarnation);
 

--- a/crates/shelterwood/src/mailbox/futures.rs
+++ b/crates/shelterwood/src/mailbox/futures.rs
@@ -158,9 +158,9 @@ impl<M> fmt::Debug for ActorRef<M> {
     }
 }
 
-// Handle identity is the slot cell, not the membership token: lowering a
-// rebuilt nested declaration rebases the token behind live pre-spawn handles,
-// and a token-value hash would strand entries keyed before the rebase.
+// Handle identity is the slot cell, not the membership token: declaration
+// lowering can rebase a provisional token behind live pre-spawn handles, and
+// a token-value hash would strand entries keyed before that rebase.
 impl<M> PartialEq for ActorRef<M> {
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.member, &other.member)

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -311,9 +311,9 @@ impl SnapshotReceiver {
     pub async fn changed(&mut self) -> Result<Arc<ScopeSnapshot>, SnapshotClosed> {
         loop {
             let state = self.inner.borrow_cloned();
-            if state.generation != self.seen_generation {
+            if state.generation.current() != self.seen_generation {
                 let state = self.inner.borrow_and_update_cloned();
-                self.seen_generation = state.generation;
+                self.seen_generation = state.generation.current();
                 return Ok(state.snapshot);
             }
             if state.closed {
@@ -344,7 +344,7 @@ pub(crate) struct SnapshotHub {
 #[derive(Clone, Debug)]
 struct SnapshotHubState {
     snapshot: Arc<ScopeSnapshot>,
-    generation: u64,
+    generation: crate::identity::PoisonedCounter,
     closed: bool,
 }
 
@@ -357,7 +357,7 @@ impl SnapshotHub {
         if self.closed.load(Ordering::Acquire) {
             let (sender, inner) = runtime::watch(SnapshotHubState {
                 snapshot: initial,
-                generation: 0,
+                generation: crate::identity::PoisonedCounter::new(),
                 closed: true,
             });
             drop(sender);
@@ -369,7 +369,7 @@ impl SnapshotHub {
         let sender = self.sender.get_or_init(|| {
             runtime::watch(SnapshotHubState {
                 snapshot: Arc::clone(&initial),
-                generation: 0,
+                generation: crate::identity::PoisonedCounter::new(),
                 closed: false,
             })
             .0
@@ -384,12 +384,15 @@ impl SnapshotHub {
         } else if sender.receiver_count() == 0 {
             sender.modify_silently(|state| {
                 state.snapshot = initial;
-                state.generation = state.generation.saturating_add(1);
+                state
+                    .generation
+                    .mint()
+                    .expect("snapshot generation space exhausted");
             });
             txn.pulse(sender);
         }
         let inner = sender.watcher();
-        let seen_generation = inner.borrow_cloned().generation;
+        let seen_generation = inner.borrow_cloned().generation.current();
         SnapshotReceiver {
             inner,
             seen_generation,
@@ -414,7 +417,10 @@ impl SnapshotHub {
                     return false;
                 }
                 state.snapshot = snapshot();
-                state.generation = state.generation.saturating_add(1);
+                state
+                    .generation
+                    .mint()
+                    .expect("snapshot generation space exhausted");
                 true
             });
         }
@@ -440,7 +446,10 @@ impl SnapshotHub {
                 return;
             }
             state.snapshot = snapshot();
-            state.generation = state.generation.saturating_add(1);
+            state
+                .generation
+                .mint()
+                .expect("snapshot generation space exhausted");
             modified = true;
         });
         if modified {
@@ -577,6 +586,9 @@ struct LifecycleChannels {
 
 #[derive(Clone, Copy, Debug, Default)]
 struct LifecycleSignal {
+    // A diagnostic-only loss total. Saturation deliberately preserves the
+    // strongest possible "at least this many" report; it never routes an
+    // event or identifies storage.
     explicit_lag: u64,
     closed: bool,
 }
@@ -860,7 +872,8 @@ mod tests {
         let mut identity = ScopeIdentity::new();
         let membership = identity
             .mint_membership(&crate::ChildId::from("scope"))
-            .expect("membership available");
+            .expect("membership available")
+            .membership();
         let hub = LifecycleHub::default();
         let mut events = hub.subscribe();
         hub.close();
@@ -887,7 +900,8 @@ mod tests {
         let mut identity = ScopeIdentity::new();
         let membership = identity
             .mint_membership(&crate::ChildId::from("scope"))
-            .expect("membership available");
+            .expect("membership available")
+            .membership();
         let event = |seq| LifecycleEvent {
             scope_path: Vec::new(),
             scope: membership,
@@ -924,7 +938,8 @@ mod tests {
         let mut identity = ScopeIdentity::new();
         let membership = identity
             .mint_membership(&crate::ChildId::from("scope"))
-            .expect("membership available");
+            .expect("membership available")
+            .membership();
         let event = |seq| LifecycleEvent {
             scope_path: Vec::new(),
             scope: membership,

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -320,7 +320,7 @@ impl BuilderCore {
                 .lock()
                 .expect("scope identity mutex poisoned");
             for slot in &self.slots {
-                let Some(membership) =
+                let Some(rebased) =
                     identity.adopt_or_mint_membership(slot.member.id(), slot.member.membership())
                 else {
                     let id = slot.member.id().clone();
@@ -328,8 +328,8 @@ impl BuilderCore {
                     let disposal = self.begin_failed_disposal();
                     return Err(LowerError::IdentityExhausted { id, disposal });
                 };
-                if membership != slot.member.membership() {
-                    slot.member.rebase_membership(membership);
+                if let Some(identity) = rebased {
+                    slot.member.rebase_membership(identity);
                 }
             }
         }
@@ -358,7 +358,7 @@ impl BuilderCore {
             config: self.config.clone(),
             defaults,
             children,
-            armed: true,
+            terminality: Some(ScopePlanTerminality),
         })
     }
 
@@ -384,6 +384,7 @@ impl BuilderCore {
     fn terminalize(&self) {
         for slot in &self.slots {
             slot.terminalize_never_started();
+            self.root.evict_child_identity(&slot.member);
         }
         self.root.terminalize_never_started();
     }
@@ -403,24 +404,78 @@ pub(crate) struct ScopePlan {
     pub(crate) config: ScopeConfig,
     pub(crate) defaults: ResolvedDefaults,
     pub(crate) children: Vec<ChildPlan>,
-    pub(crate) armed: bool,
+    terminality: Option<ScopePlanTerminality>,
+}
+
+struct ScopePlanTerminality;
+
+pub(crate) struct RuntimeScopePlan {
+    pub(crate) root: Arc<ScopeCell>,
+    pub(crate) config: ScopeConfig,
+    pub(crate) defaults: ResolvedDefaults,
+    pub(crate) children: Vec<ChildPlan>,
+    terminality: Option<ScopePlanTerminality>,
+}
+
+fn terminalize_plan(
+    root: &ScopeCell,
+    children: &[ChildPlan],
+    terminality: &mut Option<ScopePlanTerminality>,
+) {
+    if terminality.take().is_some() {
+        for child in children {
+            child.slot.terminalize_never_started();
+            root.evict_child_identity(&child.slot.member);
+        }
+        root.with_observation_gate(|txn| {
+            // Lowering can publish the planned children before ScopeRuntime
+            // takes ownership. The plan fallback commits residency withdrawal
+            // and root closure as one root-scope observation.
+            root.clear_residents_locked(txn);
+            root.terminalize_never_started_locked(txn);
+        });
+    }
+}
+
+impl ScopePlan {
+    /// Consumes declaration ownership and transfers its terminality obligation
+    /// to the runtime plan. There is no independently mutable disarm bit: a
+    /// caller either owns the declaration plan or has consumed it here.
+    pub(crate) fn take_for_runtime(mut self) -> RuntimeScopePlan {
+        RuntimeScopePlan {
+            root: Arc::clone(&self.root),
+            config: self.config.clone(),
+            defaults: self.defaults.clone(),
+            children: std::mem::take(&mut self.children),
+            terminality: self.terminality.take(),
+        }
+    }
 }
 
 impl Drop for ScopePlan {
     fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-        for child in &self.children {
-            child.slot.terminalize_never_started();
-        }
-        self.root.with_observation_gate(|txn| {
-            // Lowering can publish the planned children before ScopeRuntime
-            // takes ownership. The plan fallback commits residency withdrawal
-            // and root closure as one root-scope observation.
-            self.root.clear_residents_locked(txn);
-            self.root.terminalize_never_started_locked(txn);
-        });
+        terminalize_plan(&self.root, &self.children, &mut self.terminality);
+    }
+}
+
+impl RuntimeScopePlan {
+    /// Finishes the transfer after every child has installed its own
+    /// terminality obligation. Consuming `self` makes a partial handoff
+    /// impossible to mistake for a completed one.
+    pub(crate) fn finish_transfer(mut self) {
+        assert!(
+            self.children.is_empty(),
+            "runtime transfer completes only after every child owns terminality"
+        );
+        self.terminality
+            .take()
+            .expect("runtime plan transfer completes exactly once");
+    }
+}
+
+impl Drop for RuntimeScopePlan {
+    fn drop(&mut self) {
+        terminalize_plan(&self.root, &self.children, &mut self.terminality);
     }
 }
 

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -253,6 +253,11 @@ pub(crate) struct BuilderCore {
     pub(crate) config: ScopeConfig,
     pub(crate) slots: Vec<Arc<SlotCell>>,
     ids: HashMap<ChildId, Arc<SlotCell>>,
+    /// The stable scope whose identity map `lower(root_override)` adopts the
+    /// slots' lineages into. Eviction must target the map a lineage actually
+    /// entered: before adoption begins the lineages live in `root`'s map,
+    /// afterwards they live here.
+    adopting_root: Option<Arc<ScopeCell>>,
     armed: bool,
 }
 
@@ -281,6 +286,7 @@ impl BuilderCore {
             config: ScopeConfig::default(),
             slots: Vec::new(),
             ids: HashMap::new(),
+            adopting_root: None,
             armed: true,
         }
     }
@@ -327,6 +333,10 @@ impl BuilderCore {
             }
         };
         if !Arc::ptr_eq(&root, &self.root) {
+            // From the first adoption on, a failed or unwound lowering must
+            // evict the terminalized slots from the override's identity map,
+            // not this builder's throwaway root.
+            self.adopting_root = Some(Arc::clone(&root));
             let mut identity = root
                 .child_identity
                 .lock()
@@ -394,8 +404,13 @@ impl BuilderCore {
     }
 
     fn terminalize(&self) {
+        // A failed `lower(root_override)` may have adopted only a prefix of
+        // these lineages into the override's map before the error or unwind.
+        // Slots past the failure point never left `self.root`'s map, so their
+        // eviction from the override is a fence-mismatch no-op (fail closed).
+        let identity_root = self.adopting_root.as_ref().unwrap_or(&self.root);
         for slot in &self.slots {
-            slot.terminalize_never_started(&self.root);
+            slot.terminalize_never_started(identity_root);
         }
         self.root.terminalize_never_started();
     }
@@ -570,9 +585,11 @@ mod tests {
     };
 
     use crate::{
-        Backoff, DefaultsInheritance, ExitError, Readiness, RestartCondition, RestartPolicy,
-        Retention, Shutdown, TaskOnceDef,
+        Backoff, ChildId, DefaultsInheritance, ExitError, Readiness, RestartCondition,
+        RestartPolicy, Retention, Shutdown, TaskOnceDef,
+        cells::{MemberCell, ScopeCell},
         definition::DefinitionSource,
+        identity::ScopeIdentity,
         policy::{CommonOptions, ResolvedDefaults, ScopeFlavor},
         raw::RawConstruction,
         runtime::{self, Timeout},
@@ -580,7 +597,7 @@ mod tests {
     };
 
     use super::{
-        BuilderCore, ChildConstruction, ChildPlan, ScopeConstruction, SlotCell,
+        BuilderCore, ChildConstruction, ChildPlan, LowerError, ScopeConstruction, SlotCell,
         concrete_dynamic_slot, concrete_dynamic_slot_ref, erase_dynamic_slot,
     };
 
@@ -773,6 +790,69 @@ mod tests {
             "removal cannot claim between policy resolution and admission"
         );
         drop(claim);
+    }
+
+    #[crate::runtime::test]
+    async fn failed_override_lowering_evicts_adopted_lineages_from_the_override() {
+        // A stable scope whose identity domain for "exhausted" has no
+        // generations left, so adoption of that id must fail after the
+        // preceding slot's lineage was already adopted.
+        let root_id = ChildId::from("$root");
+        let mut root_identity = ScopeIdentity::new();
+        let root_membership = root_identity
+            .mint_membership(&root_id)
+            .expect("fresh scope identity must mint its root membership");
+        let member = MemberCell::new(root_id, root_membership);
+        let exhausted_id = ChildId::from("exhausted");
+        let mut child_identity = ScopeIdentity::near_exhaustion(exhausted_id.clone(), 7);
+        let _ = child_identity
+            .mint_membership(&exhausted_id)
+            .expect("the final generation is mintable");
+        let stable = ScopeCell::new(member, ScopeFlavor::Ordered, child_identity);
+
+        let mut builder = BuilderCore::new(ScopeFlavor::Ordered);
+        let adopted = builder
+            .reserve("adopted", None)
+            .expect("reservation succeeds");
+        adopted.define(ChildConstruction::Task(configured_task()));
+        let adopted_membership = adopted.member.membership();
+        let failing = builder
+            .reserve("exhausted", None)
+            .expect("reservation succeeds");
+        failing.define(ChildConstruction::Task(configured_task()));
+
+        let Err(error) = builder.lower(ResolvedDefaults::default(), Some(Arc::clone(&stable)))
+        else {
+            panic!("the exhausted id fails adoption");
+        };
+        let LowerError::IdentityExhausted { id, disposal } = error else {
+            panic!("partial adoption fails with identity exhaustion");
+        };
+        assert_eq!(id.as_str(), "exhausted");
+        disposal.fired().await;
+
+        // A restart-style rebuild reconciles against the same stable scope.
+        // The terminalized slot's lineage must have been evicted from the
+        // override's identity map — not the failed builder's throwaway root —
+        // so the re-added id donates a fresh lineage that is incomparable in
+        // both directions instead of minting an ordered successor.
+        let mut rebuild = BuilderCore::new(ScopeFlavor::Ordered);
+        let readded = rebuild
+            .reserve("adopted", None)
+            .expect("re-added id is reservable");
+        readded.define(ChildConstruction::Task(configured_task()));
+        let replacement = rebuild
+            .lower(ResolvedDefaults::default(), Some(stable))
+            .expect("the rebuild lowers");
+        let readded_membership = replacement.children[0].slot.member.membership();
+        assert!(
+            !readded_membership.supersedes(adopted_membership),
+            "a rebuilt membership must not supersede its terminalized predecessor"
+        );
+        assert!(
+            !adopted_membership.supersedes(readded_membership),
+            "a terminalized predecessor must not order against its replacement"
+        );
     }
 
     struct DropFlag(Arc<AtomicBool>);

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -130,28 +130,40 @@ impl SlotCell {
         }
     }
 
-    /// Publishes one never-started slot under the gate its observers use.
-    pub(crate) fn terminalize_never_started(&self) {
+    /// Publishes one never-started slot under the gate its observers use and
+    /// evicts its lineage from `owner`'s identity map. Every terminalization
+    /// evicts the lineage (SPEC §3.4): a later same-id declaration must mint
+    /// an incomparable membership, never an ordered successor of the
+    /// terminal predecessor. Taking the owning scope here keeps the pairing
+    /// structural instead of repeated at each call site.
+    pub(crate) fn terminalize_never_started(&self, owner: &ScopeCell) {
         if let Some(scope) = &self.scope {
             scope.terminalize_never_started();
         } else {
             self.member.terminalize(Exit::never_started());
         }
+        owner.evict_child_identity(&self.member);
     }
 
-    pub(crate) fn terminalize_never_started_locked(&self, txn: &mut ObservationTxn<'_>) {
+    pub(crate) fn terminalize_never_started_locked(
+        &self,
+        owner: &ScopeCell,
+        txn: &mut ObservationTxn<'_>,
+    ) {
         self.member.terminalize_locked(Exit::never_started(), txn);
         if let Some(scope) = &self.scope {
             scope.terminalize_never_started_locked(txn);
         }
+        owner.evict_child_identity(&self.member);
     }
 
     pub(crate) fn take_never_started_locked(
         &self,
+        owner: &ScopeCell,
         txn: &mut ObservationTxn<'_>,
     ) -> Option<Isolated<ChildConstruction>> {
         let definition = self.take_definition().ok().flatten();
-        self.terminalize_never_started_locked(txn);
+        self.terminalize_never_started_locked(owner, txn);
         definition
     }
 
@@ -383,8 +395,7 @@ impl BuilderCore {
 
     fn terminalize(&self) {
         for slot in &self.slots {
-            slot.terminalize_never_started();
-            self.root.evict_child_identity(&slot.member);
+            slot.terminalize_never_started(&self.root);
         }
         self.root.terminalize_never_started();
     }
@@ -424,8 +435,7 @@ fn terminalize_plan(
 ) {
     if terminality.take().is_some() {
         for child in children {
-            child.slot.terminalize_never_started();
-            root.evict_child_identity(&child.slot.member);
+            child.slot.terminalize_never_started(root);
         }
         root.with_observation_gate(|txn| {
             // Lowering can publish the planned children before ScopeRuntime

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -20,6 +20,9 @@ impl RestartAttempt {
     pub const ZERO: Self = Self(0);
 
     /// Returns the next attempt, saturating at the numeric limit.
+    ///
+    /// This is bounded policy arithmetic, not an identity: equal saturated
+    /// values cannot alias a resource or route an event.
     #[must_use]
     pub const fn bump(self) -> Self {
         Self(self.0.saturating_add(1))
@@ -41,6 +44,9 @@ impl RestartCount {
     pub const ZERO: Self = Self(0);
 
     /// Returns the next count, saturating at the numeric limit.
+    ///
+    /// This public diagnostic total deliberately stays monotone at exhaustion;
+    /// it is never used as identity or a storage key.
     #[must_use]
     pub const fn bump(self) -> Self {
         Self(self.0.saturating_add(1))
@@ -62,6 +68,9 @@ impl TotalRestarts {
     pub const ZERO: Self = Self(0);
 
     /// Returns the next total, saturating at the numeric limit.
+    ///
+    /// This public diagnostic total deliberately stays monotone at exhaustion;
+    /// it is never used as identity or a storage key.
     #[must_use]
     pub const fn bump(self) -> Self {
         Self(self.0.saturating_add(1))
@@ -438,13 +447,6 @@ impl ReadinessDeadline {
             Self::Inherit | Self::Bounded(_) | Self::Unbounded => Ok(()),
         }
     }
-
-    fn validate_resolved(self) -> Result<(), PolicyError> {
-        match self {
-            Self::Inherit => Err(PolicyError::UnresolvedReadinessDeadline),
-            value => value.validate_declared(),
-        }
-    }
 }
 
 /// The scope-wide restart budget.
@@ -591,9 +593,6 @@ pub enum PolicyError {
     /// An exponential maximum preceded its base delay.
     #[error("backoff maximum must not be shorter than its base")]
     BackoffMaximumBeforeBase,
-    /// An inherited readiness deadline remained unresolved at execution.
-    #[error("readiness deadline must be resolved before execution")]
-    UnresolvedReadinessDeadline,
     /// A readiness mode is not meaningful for this child kind.
     #[error("readiness mode is not supported by this child kind")]
     UnsupportedReadiness,
@@ -668,11 +667,23 @@ pub(crate) struct CommonOptions {
 pub(crate) struct ResolvedDefaults {
     pub(crate) child_restart: RestartPolicy,
     pub(crate) child_shutdown: Shutdown,
-    pub(crate) mailbox: Mailbox,
+    pub(crate) mailbox: ResolvedMailbox,
     /// Nearest resolved queue capacity, retained across defaults of other kinds.
     pub(crate) queue_capacity: NonZeroUsize,
     pub(crate) mailbox_shutdown: MailboxShutdown,
-    pub(crate) readiness_deadline: ReadinessDeadline,
+    pub(crate) readiness_deadline: ResolvedReadinessDeadline,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ResolvedMailbox {
+    Queue(NonZeroUsize),
+    Latest,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ResolvedReadinessDeadline {
+    Bounded(Duration),
+    Unbounded,
 }
 
 impl Default for ResolvedDefaults {
@@ -682,10 +693,10 @@ impl Default for ResolvedDefaults {
         Self {
             child_restart: RestartPolicy::default(),
             child_shutdown: Shutdown::default(),
-            mailbox: Mailbox::Queue(Some(queue_capacity)),
+            mailbox: ResolvedMailbox::Queue(queue_capacity),
             queue_capacity,
             mailbox_shutdown: MailboxShutdown::default(),
-            readiness_deadline: ReadinessDeadline::Bounded(DEFAULT_READINESS_DEADLINE),
+            readiness_deadline: ResolvedReadinessDeadline::Bounded(DEFAULT_READINESS_DEADLINE),
         }
     }
 }
@@ -702,10 +713,10 @@ impl ResolvedDefaults {
                 None | Some(Mailbox::Queue(None) | Mailbox::Latest) => self.queue_capacity,
             },
             mailbox_shutdown: resolve(values.mailbox_shutdown, self.mailbox_shutdown),
-            readiness_deadline: resolve_readiness_deadline(
-                resolve(values.readiness_deadline, self.readiness_deadline),
-                self.readiness_deadline,
-            ),
+            readiness_deadline: values
+                .readiness_deadline
+                .map(|value| resolve_readiness_deadline(value, self.readiness_deadline))
+                .unwrap_or(self.readiness_deadline),
         };
         // Validating the resolved value covers every selected override. The
         // inherited value was checked above even when an override replaces it.
@@ -717,9 +728,12 @@ impl ResolvedDefaults {
         self.child_restart
             .validate()
             .map_err(|error| InvalidPolicy::new(PolicyField::RestartBackoff, error))?;
-        self.readiness_deadline
-            .validate_resolved()
-            .map_err(|error| InvalidPolicy::new(PolicyField::ReadinessDeadline, error))
+        match self.readiness_deadline {
+            ResolvedReadinessDeadline::Bounded(duration) if duration.is_zero() => Err(
+                InvalidPolicy::new(PolicyField::ReadinessDeadline, PolicyError::ZeroDuration),
+            ),
+            ResolvedReadinessDeadline::Bounded(_) | ResolvedReadinessDeadline::Unbounded => Ok(()),
+        }
     }
 }
 
@@ -729,23 +743,25 @@ fn resolve<T: Copy>(value: Option<T>, inherited: T) -> T {
 
 fn resolve_readiness_deadline(
     value: ReadinessDeadline,
-    inherited: ReadinessDeadline,
-) -> ReadinessDeadline {
+    inherited: ResolvedReadinessDeadline,
+) -> ResolvedReadinessDeadline {
     match value {
         ReadinessDeadline::Inherit => inherited,
-        value => value,
+        ReadinessDeadline::Bounded(duration) => ResolvedReadinessDeadline::Bounded(duration),
+        ReadinessDeadline::Unbounded => ResolvedReadinessDeadline::Unbounded,
     }
 }
 
 fn resolve_mailbox(
     value: Option<Mailbox>,
-    inherited: Mailbox,
+    inherited: ResolvedMailbox,
     inherited_queue_capacity: NonZeroUsize,
-) -> Mailbox {
+) -> ResolvedMailbox {
     match value {
         None => inherited,
-        Some(Mailbox::Queue(None)) => Mailbox::Queue(Some(inherited_queue_capacity)),
-        Some(value) => value,
+        Some(Mailbox::Queue(None)) => ResolvedMailbox::Queue(inherited_queue_capacity),
+        Some(Mailbox::Queue(Some(capacity))) => ResolvedMailbox::Queue(capacity),
+        Some(Mailbox::Latest) => ResolvedMailbox::Latest,
     }
 }
 
@@ -753,13 +769,13 @@ fn resolve_mailbox(
 pub(crate) struct ResolvedCommonOptions {
     pub(crate) restart: RestartPolicy,
     pub(crate) shutdown: Shutdown,
-    pub(crate) mailbox: Mailbox,
+    pub(crate) mailbox: ResolvedMailbox,
     pub(crate) mailbox_shutdown: MailboxShutdown,
     /// Effective definition readiness. Every kind arrives here already
     /// resolved: raw actors fold their type-level default into the definition
     /// at erasure, so no per-incarnation fallback remains.
     pub(crate) readiness: Readiness,
-    pub(crate) readiness_deadline: ReadinessDeadline,
+    pub(crate) readiness_deadline: ResolvedReadinessDeadline,
     pub(crate) retention: Retention,
 }
 
@@ -811,9 +827,9 @@ mod tests {
     use super::{
         Backoff, BackoffFactor, ChildMode, CommonOptions, Intensity, InvalidPolicy, Jitter,
         JitterSample, Mailbox, MailboxShutdown, PolicyError, PolicyField, Readiness,
-        ReadinessDeadline, ResolvedDefaults, RestartAttempt, RestartCondition, RestartCount,
-        RestartPolicy, Retention, ScopeDefaults, Shutdown, TotalRestarts, resolve_common,
-        tidy_abort_beat,
+        ReadinessDeadline, ResolvedDefaults, ResolvedMailbox, ResolvedReadinessDeadline,
+        RestartAttempt, RestartCondition, RestartCount, RestartPolicy, Retention, ScopeDefaults,
+        Shutdown, TotalRestarts, resolve_common, tidy_abort_beat,
     };
 
     fn assert_constructor_matches_literal<T>(
@@ -845,7 +861,7 @@ mod tests {
         );
         assert_eq!(
             ResolvedDefaults::default().readiness_deadline,
-            ReadinessDeadline::Bounded(Duration::from_secs(30))
+            ResolvedReadinessDeadline::Bounded(Duration::from_secs(30))
         );
         assert_eq!(
             Intensity::default(),
@@ -1268,7 +1284,10 @@ mod tests {
                 ..ScopeDefaults::default()
             })
             .expect("valid defaults");
-        assert_eq!(library_queue.mailbox, Mailbox::default());
+        assert_eq!(
+            library_queue.mailbox,
+            ResolvedMailbox::Queue(NonZeroUsize::new(64).expect("capacity is non-zero"))
+        );
 
         let outer_queue = library
             .overlay(&ScopeDefaults {
@@ -1282,7 +1301,7 @@ mod tests {
                 ..ScopeDefaults::default()
             })
             .expect("valid defaults");
-        assert_eq!(latest.mailbox, Mailbox::Latest);
+        assert_eq!(latest.mailbox, ResolvedMailbox::Latest);
 
         let deferred_queue = latest
             .overlay(&ScopeDefaults {
@@ -1292,7 +1311,7 @@ mod tests {
             .expect("valid defaults");
         assert_eq!(
             deferred_queue.mailbox,
-            Mailbox::queue(10).expect("non-zero capacity")
+            ResolvedMailbox::Queue(NonZeroUsize::new(10).expect("capacity is non-zero"))
         );
         assert_eq!(deferred_queue.child_restart, latest.child_restart);
         assert_eq!(deferred_queue.child_shutdown, latest.child_shutdown);
@@ -1303,7 +1322,10 @@ mod tests {
                 ..ScopeDefaults::default()
             })
             .expect("valid reset defaults");
-        assert_eq!(reset_queue.mailbox, Mailbox::default());
+        assert_eq!(
+            reset_queue.mailbox,
+            ResolvedMailbox::Queue(NonZeroUsize::new(64).expect("capacity is non-zero"))
+        );
     }
 
     #[test]
@@ -1374,7 +1396,7 @@ mod tests {
         assert_eq!(overridden.readiness, Readiness::Immediate);
         assert_eq!(
             overridden.readiness_deadline,
-            ReadinessDeadline::Bounded(Duration::from_nanos(1))
+            ResolvedReadinessDeadline::Bounded(Duration::from_nanos(1))
         );
         assert_eq!(overridden.retention, Retention::Remove);
     }
@@ -1502,14 +1524,14 @@ mod tests {
         );
 
         let unresolved = ResolvedDefaults {
-            readiness_deadline: ReadinessDeadline::Inherit,
+            readiness_deadline: ResolvedReadinessDeadline::Bounded(Duration::ZERO),
             ..ResolvedDefaults::default()
         };
         assert_eq!(
             unresolved.overlay(&ScopeDefaults::default()),
             Err(InvalidPolicy::new(
                 PolicyField::ReadinessDeadline,
-                PolicyError::UnresolvedReadinessDeadline
+                PolicyError::ZeroDuration
             ))
         );
     }
@@ -1535,7 +1557,7 @@ mod tests {
             Ok(())
         );
         assert_eq!(
-            ReadinessDeadline::Bounded(Duration::from_nanos(1)).validate_resolved(),
+            ReadinessDeadline::Bounded(Duration::from_nanos(1)).validate_declared(),
             Ok(())
         );
         assert_eq!(

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -15,9 +15,10 @@ use std::{
 use crate::{
     ActorRef, ChildId, ExitResult, Incarnation, Mailbox, MailboxShutdown, PolicyError, Readiness,
     ReadinessDeadline, RestartPolicy, Retention, Shutdown,
-    cancellation::CancellationToken,
+    cancellation::{CancellationToken, ParentCancellationToken},
     cells::{MailboxControl, MemberCell},
     definition::DefinitionSource,
+    identity::PoisonedCounter,
     mailbox::{AcceptedSequence, MailboxCell, MailboxReceiver},
     policy::{ChildMode, CommonOptions},
     runtime::{
@@ -449,12 +450,7 @@ enum TimerMessage<M> {
 struct ArmingOrder(u64);
 
 impl ArmingOrder {
-    const ZERO: Self = Self(0);
     const MAX: Self = Self(u64::MAX);
-
-    fn saturating_next(self) -> Self {
-        Self(self.0.saturating_add(1))
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -881,7 +877,7 @@ struct RawResources<M> {
     // continuations from leading while an external source remains eligible.
     continuation_needs_external: bool,
     timers: TimerStore<M>,
-    next_timer_order: ArmingOrder,
+    timer_orders: PoisonedCounter,
     ready_batch: Option<ReadyBatch>,
     events: Arc<EventQueue<M>>,
     panic: Arc<PanicSlot>,
@@ -905,7 +901,7 @@ impl<M> Default for RawResources<M> {
             continuations: VecDeque::new(),
             continuation_needs_external: false,
             timers: TimerStore::new(disposal.clone()),
-            next_timer_order: ArmingOrder::ZERO,
+            timer_orders: PoisonedCounter::new(),
             ready_batch: None,
             events,
             panic,
@@ -1019,7 +1015,7 @@ pub struct RawContext<M> {
     incarnation: Incarnation,
     myself: ActorRef<M>,
     scope: ScopeRef,
-    shutdown: CancellationToken,
+    shutdown: ParentCancellationToken,
     abort: CancellationToken,
     ready: CompletionGatedLatch,
     local_stop: Latch,
@@ -1051,7 +1047,7 @@ impl<M: Send + 'static> RawContext<M> {
             incarnation: run.incarnation,
             myself,
             scope: run.scope,
-            shutdown: CancellationToken::from_latch(run.shutdown),
+            shutdown: ParentCancellationToken::from_latch(run.shutdown),
             abort: CancellationToken::from_latch(run.abort),
             ready: run.ready,
             local_stop: run.local_stop,
@@ -1089,7 +1085,7 @@ impl<M: Send + 'static> RawContext<M> {
     /// Returns the cooperative shutdown token.
     #[must_use]
     pub fn shutdown_token(&self) -> CancellationToken {
-        self.shutdown.clone()
+        self.shutdown.token()
     }
 
     /// Returns the escalation token.
@@ -1340,16 +1336,17 @@ impl<M: Send + 'static> RawContext<M> {
     ) where
         K: Hash + Eq + Send + 'static,
     {
-        self.resources.next_timer_order = self.resources.next_timer_order.saturating_next();
+        let arming_order = ArmingOrder(
+            self.resources
+                .timer_orders
+                .mint()
+                .expect("timer arming-order space exhausted"),
+        );
         let now = runtime::now();
         let deadline = crate::deadline::Deadline::after(now, after).instant();
-        self.resources.timers.replace(
-            key,
-            deadline,
-            self.resources.next_timer_order,
-            message,
-            period,
-        );
+        self.resources
+            .timers
+            .replace(key, deadline, arming_order, message, period);
     }
 
     fn start_offload<F, T, C>(

--- a/crates/shelterwood/src/scope.rs
+++ b/crates/shelterwood/src/scope.rs
@@ -239,9 +239,9 @@ impl fmt::Debug for ScopeRef {
     }
 }
 
-// Handle identity is the slot cell, not the membership token: lowering a
-// rebuilt nested declaration rebases the token behind live pre-spawn handles,
-// and a token-value hash would strand entries keyed before the rebase.
+// Handle identity is the slot cell, not the membership token: declaration
+// lowering can rebase a provisional token behind live pre-spawn handles, and
+// a token-value hash would strand entries keyed before that rebase.
 impl PartialEq for ScopeRef {
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.cell, &other.cell)

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -239,9 +239,9 @@ impl fmt::Debug for TaskRef {
     }
 }
 
-// Handle identity is the slot cell, not the membership token: lowering a
-// rebuilt nested declaration rebases the token behind live pre-spawn handles,
-// and a token-value hash would strand entries keyed before the rebase.
+// Handle identity is the slot cell, not the membership token: declaration
+// lowering can rebase a provisional token behind live pre-spawn handles, and
+// a token-value hash would strand entries keyed before that rebase.
 impl PartialEq for TaskRef {
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.cell, &other.cell)

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -333,8 +333,10 @@ mod tests {
     fn task_context() -> (TaskContext, Latch, Latch, CompletionGatedLatch) {
         let id = ChildId::from("task");
         let mut identity = ScopeIdentity::new();
-        let membership = identity.mint_membership(&id).expect("membership available");
-        let mut incarnations = identity.incarnation_counter(membership);
+        let (_, mut incarnations) = identity
+            .mint_membership(&id)
+            .expect("membership available")
+            .into_pair();
         let incarnation = incarnations.mint().expect("incarnation available");
         let shutdown = Latch::default();
         let abort = Latch::default();

--- a/crates/shelterwood/src/tree/dynamic_api.rs
+++ b/crates/shelterwood/src/tree/dynamic_api.rs
@@ -13,7 +13,9 @@ use super::{
     Admission, DynamicActorSlot, DynamicSubtreeSlot, DynamicTaskSlot, Removal, Subtree, SubtreeDef,
     SubtreeOnceDef,
     builders::dispose_rejected,
-    slots::{ActorSlotCore, DynamicSlotEndpoint, SubtreeSlotCore, TaskSlotCore},
+    slots::{
+        ActorSlotCore, AdmissionOwnership, DynamicSlotEndpoint, SubtreeSlotCore, TaskSlotCore,
+    },
     system::sealed,
 };
 
@@ -25,6 +27,43 @@ impl ScopeRef {
 }
 
 impl DynamicScopeRef {
+    fn reserve_actor_with<M: Send + 'static>(
+        &self,
+        id: impl Into<ChildId>,
+        ownership: AdmissionOwnership,
+    ) -> Result<DynamicActorSlot<M>, ReserveError> {
+        crate::driver::reserve_dynamic(&self.0.cell, id.into(), None).map(|reservation| {
+            let mailbox = MailboxCell::new(reservation.slot.member.id().clone());
+            reservation.slot.member.attach_mailbox(mailbox.clone());
+            DynamicActorSlot {
+                core: ActorSlotCore::new(DynamicSlotEndpoint::new(reservation, ownership), mailbox),
+            }
+        })
+    }
+
+    fn reserve_task_with(
+        &self,
+        id: impl Into<ChildId>,
+        ownership: AdmissionOwnership,
+    ) -> Result<DynamicTaskSlot, ReserveError> {
+        crate::driver::reserve_dynamic(&self.0.cell, id.into(), None).map(|reservation| {
+            DynamicTaskSlot {
+                core: TaskSlotCore::new(DynamicSlotEndpoint::new(reservation, ownership)),
+            }
+        })
+    }
+
+    fn reserve_subtree_with<T: Subtree>(
+        &self,
+        id: impl Into<ChildId>,
+        ownership: AdmissionOwnership,
+    ) -> Result<DynamicSubtreeSlot<T>, ReserveError> {
+        crate::driver::reserve_dynamic(&self.0.cell, id.into(), Some(<T as sealed::Sealed>::FLAVOR))
+            .map(|reservation| DynamicSubtreeSlot {
+                core: SubtreeSlotCore::new(DynamicSlotEndpoint::new(reservation, ownership)),
+            })
+    }
+
     /// Requests shutdown and waits for this scope to stop.
     pub async fn shutdown_and_wait(&self, timeout: Duration) -> Result<(), ShutdownTimeout> {
         self.0.shutdown_and_wait(timeout).await
@@ -37,13 +76,7 @@ impl DynamicScopeRef {
         &self,
         id: impl Into<ChildId>,
     ) -> Result<DynamicActorSlot<M>, ReserveError> {
-        crate::driver::reserve_dynamic(&self.0.cell, id.into(), None).map(|reservation| {
-            let mailbox = MailboxCell::new(reservation.slot.member.id().clone());
-            reservation.slot.member.attach_mailbox(mailbox.clone());
-            DynamicActorSlot {
-                core: ActorSlotCore::new(DynamicSlotEndpoint::split(reservation), mailbox),
-            }
-        })
+        self.reserve_actor_with(id, AdmissionOwnership::Split)
     }
 
     /// Adds a restartable callback-oriented actor, resolving at admission.
@@ -52,11 +85,8 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: ActorDef<A>,
     ) -> Admission<ActorRef<A::Msg>> {
-        match self.reserve_actor(id) {
-            Ok(mut slot) => {
-                slot.core.endpoint.fuse();
-                slot.core.define_raw(definition.into_raw())
-            }
+        match self.reserve_actor_with(id, AdmissionOwnership::Fused) {
+            Ok(slot) => slot.core.define_raw(definition.into_raw()),
             Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
@@ -67,11 +97,8 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: ActorOnceDef<A>,
     ) -> Admission<ActorRef<A::Msg>> {
-        match self.reserve_actor(id) {
-            Ok(mut slot) => {
-                slot.core.endpoint.fuse();
-                slot.core.define_once_raw(definition.into_raw())
-            }
+        match self.reserve_actor_with(id, AdmissionOwnership::Fused) {
+            Ok(slot) => slot.core.define_once_raw(definition.into_raw()),
             Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
@@ -82,11 +109,8 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: RawDef<R>,
     ) -> Admission<ActorRef<R::Msg>> {
-        match self.reserve_actor(id) {
-            Ok(mut slot) => {
-                slot.core.endpoint.fuse();
-                slot.core.define_raw(definition)
-            }
+        match self.reserve_actor_with(id, AdmissionOwnership::Fused) {
+            Ok(slot) => slot.core.define_raw(definition),
             Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
@@ -97,11 +121,8 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: RawOnceDef<R>,
     ) -> Admission<ActorRef<R::Msg>> {
-        match self.reserve_actor(id) {
-            Ok(mut slot) => {
-                slot.core.endpoint.fuse();
-                slot.core.define_once_raw(definition)
-            }
+        match self.reserve_actor_with(id, AdmissionOwnership::Fused) {
+            Ok(slot) => slot.core.define_once_raw(definition),
             Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
@@ -110,20 +131,13 @@ impl DynamicScopeRef {
     ///
     /// Returns [`ReserveError::NoRuntime`] outside an ambient Tokio runtime.
     pub fn reserve_task(&self, id: impl Into<ChildId>) -> Result<DynamicTaskSlot, ReserveError> {
-        crate::driver::reserve_dynamic(&self.0.cell, id.into(), None).map(|reservation| {
-            DynamicTaskSlot {
-                core: TaskSlotCore::new(DynamicSlotEndpoint::split(reservation)),
-            }
-        })
+        self.reserve_task_with(id, AdmissionOwnership::Split)
     }
 
     /// Adds a restartable task, resolving at admission rather than startup.
     pub fn add_task(&self, id: impl Into<ChildId>, definition: TaskDef) -> Admission<TaskRef> {
-        match self.reserve_task(id) {
-            Ok(mut slot) => {
-                slot.core.endpoint.fuse();
-                slot.core.define(definition)
-            }
+        match self.reserve_task_with(id, AdmissionOwnership::Fused) {
+            Ok(slot) => slot.core.define(definition),
             Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
@@ -134,11 +148,8 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: TaskOnceDef<T>,
     ) -> Admission<(TaskRef, OneShotTaskRef<T>)> {
-        match self.reserve_task(id) {
-            Ok(mut slot) => {
-                slot.core.endpoint.fuse();
-                slot.core.define_once(definition)
-            }
+        match self.reserve_task_with(id, AdmissionOwnership::Fused) {
+            Ok(slot) => slot.core.define_once(definition),
             Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
@@ -150,10 +161,7 @@ impl DynamicScopeRef {
         &self,
         id: impl Into<ChildId>,
     ) -> Result<DynamicSubtreeSlot<T>, ReserveError> {
-        crate::driver::reserve_dynamic(&self.0.cell, id.into(), Some(<T as sealed::Sealed>::FLAVOR))
-            .map(|reservation| DynamicSubtreeSlot {
-                core: SubtreeSlotCore::new(DynamicSlotEndpoint::split(reservation)),
-            })
+        self.reserve_subtree_with(id, AdmissionOwnership::Split)
     }
 
     /// Adds a restartable subtree, resolving at admission.
@@ -162,11 +170,8 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: SubtreeDef<T>,
     ) -> Admission<T::Ref> {
-        match self.reserve_subtree::<T>(id) {
-            Ok(mut slot) => {
-                slot.core.endpoint.fuse();
-                slot.core.define(definition)
-            }
+        match self.reserve_subtree_with::<T>(id, AdmissionOwnership::Fused) {
+            Ok(slot) => slot.core.define(definition),
             Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
@@ -177,11 +182,8 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: SubtreeOnceDef<T>,
     ) -> Admission<T::Ref> {
-        match self.reserve_subtree::<T>(id) {
-            Ok(mut slot) => {
-                slot.core.endpoint.fuse();
-                slot.core.define_once(definition)
-            }
+        match self.reserve_subtree_with::<T>(id, AdmissionOwnership::Fused) {
+            Ok(slot) => slot.core.define_once(definition),
             Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }

--- a/crates/shelterwood/src/tree/slots.rs
+++ b/crates/shelterwood/src/tree/slots.rs
@@ -48,15 +48,11 @@ pub(super) struct DynamicSlotEndpoint {
 }
 
 impl DynamicSlotEndpoint {
-    pub(super) fn split(reservation: DynamicReservation) -> Self {
+    pub(super) fn new(reservation: DynamicReservation, ownership: AdmissionOwnership) -> Self {
         Self {
             reservation: Some(reservation),
-            ownership: AdmissionOwnership::Split,
+            ownership,
         }
-    }
-
-    pub(super) fn fuse(&mut self) {
-        self.ownership = AdmissionOwnership::Fused;
     }
 
     fn reservation(&self) -> &DynamicReservation {

--- a/crates/shelterwood/tests/acceptance/assistant.rs
+++ b/crates/shelterwood/tests/acceptance/assistant.rs
@@ -646,7 +646,8 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .add_subtree_once("session", SubtreeOnceDef::new(replacement_data.tree))
         .await
         .expect("same id is reusable after removal completes");
-    assert!(replacement.membership().supersedes(session_membership));
+    assert!(!replacement.membership().supersedes(session_membership));
+    assert!(!session_membership.supersedes(replacement.membership()));
     sessions
         .wait_for_child(
             "session",

--- a/crates/shelterwood/tests/acceptance/shard_store.rs
+++ b/crates/shelterwood/tests/acceptance/shard_store.rs
@@ -489,9 +489,15 @@ async fn shard_store_reconciles_both_crash_windows_with_exact_idempotent_retries
 
     let first = replace_with_retry(&root_scope, &router, 1).await;
     assert!(
-        first
+        !first
             .membership
             .supersedes(failed_candidate.route.membership)
+    );
+    assert!(
+        !failed_candidate
+            .route
+            .membership
+            .supersedes(first.membership)
     );
     assert_eq!(
         lookup(&directory)

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -285,7 +285,8 @@ async fn exact_handles_reject_cross_scope_and_same_id_successors() {
         .add_task("same", waiting_task())
         .await
         .expect("replacement admission");
-    assert!(replacement.membership().supersedes(left_task.membership()));
+    assert!(!replacement.membership().supersedes(left_task.membership()));
+    assert!(!left_task.membership().supersedes(replacement.membership()));
     assert_eq!(
         left_scope.remove_task(&left_task).await,
         RemoveOutcome::AlreadyAbsent
@@ -346,7 +347,7 @@ async fn nested_declared_membership_is_superseded_by_its_runtime_replacement() {
         .await
         .expect("runtime replacement is admitted");
 
-    assert!(replacement.membership().supersedes(declared_membership));
+    assert!(!replacement.membership().supersedes(declared_membership));
     assert!(!declared_membership.supersedes(replacement.membership()));
     assert!(
         !replacement
@@ -405,7 +406,8 @@ async fn nested_actor_replacement_keeps_mailbox_evidence_in_each_exact_membershi
         .await
         .expect("runtime replacement is admitted");
     let replacement_incarnation = replacement.try_send(()).expect("replacement actor accepts");
-    assert!(replacement.membership().supersedes(declared.membership()));
+    assert!(!replacement.membership().supersedes(declared.membership()));
+    assert!(!declared.membership().supersedes(replacement.membership()));
     assert_eq!(
         replacement_incarnation.membership(),
         replacement.membership()
@@ -440,7 +442,8 @@ async fn exact_scope_removal_does_not_touch_a_same_id_successor() {
         .add_subtree_once("nested", SubtreeOnceDef::new(waiting_tree()))
         .await
         .expect("second subtree admitted");
-    assert!(second.membership().supersedes(first.membership()));
+    assert!(!second.membership().supersedes(first.membership()));
+    assert!(!first.membership().supersedes(second.membership()));
     assert_eq!(
         root.remove_scope(&first).await,
         RemoveOutcome::AlreadyAbsent

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -309,7 +309,7 @@ async fn exact_handles_reject_cross_scope_and_same_id_successors() {
 }
 
 #[tokio::test]
-async fn nested_declared_membership_is_superseded_by_its_runtime_replacement() {
+async fn nested_declared_membership_is_incomparable_with_its_runtime_replacement() {
     let mut nested = DynamicTree::new();
     let declared = nested
         .add_task("worker", waiting_task())

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -679,8 +679,9 @@ async fn rebuilt_declared_handles_and_incarnations_keep_identity() {
                         tree.add_task("worker", waiting_task())
                             .expect("valid waiting task")
                     };
-                    // Capture identity before lowering rebases a rebuilt
-                    // declaration onto the stable scope.
+                    // Capture identity before lowering. The prior terminal
+                    // declaration's lineage was evicted, so this rebuild keeps
+                    // its fresh, incomparable identity.
                     stash.lock().expect("stash mutex intact").push((
                         handle.clone(),
                         hashed(&handle),

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -631,10 +631,8 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
         }
     };
     let first_child = first_child.expect("first incarnation admits its child");
-    assert!(
-        second_child.supersedes(first_child),
-        "corresponding descendants retain ordering across a scope restart"
-    );
+    assert!(!second_child.supersedes(first_child));
+    assert!(!first_child.supersedes(second_child));
     assert_eq!(nested.membership(), scope_membership);
     assert_eq!(nested.snapshot().total_restarts, TotalRestarts::ZERO);
     assert!(nested.snapshot().lifecycle_seq >= starting.seq);
@@ -654,7 +652,7 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
 }
 
 #[tokio::test]
-async fn rebased_declared_handles_and_incarnations_keep_identity() {
+async fn rebuilt_declared_handles_and_incarnations_keep_identity() {
     fn hashed(value: &impl std::hash::Hash) -> u64 {
         use std::hash::Hasher;
         let mut hasher = std::hash::DefaultHasher::new();
@@ -724,15 +722,13 @@ async fn rebased_declared_handles_and_incarnations_keep_identity() {
 
     assert_eq!(first.membership(), first_declared);
     assert_eq!(hashed(&first), first_hash);
-    assert!(
-        second.membership().supersedes(first.membership()),
-        "the rebuilt declaration is rebased onto the stable scope"
-    );
-    assert_ne!(second.membership(), second_declared);
+    assert!(!second.membership().supersedes(first.membership()));
+    assert!(!first.membership().supersedes(second.membership()));
+    assert_eq!(second.membership(), second_declared);
     assert_eq!(
         hashed(&second),
         second_hash,
-        "handle identity survives the rebase that refreshed its membership"
+        "handle identity survives declaration lowering"
     );
     assert_eq!(second.membership(), admissions[1]);
     assert_eq!(starts[1].0, second.membership());

--- a/docs/observation.md
+++ b/docs/observation.md
@@ -95,8 +95,9 @@ For planned replacement, retain the exact handle returned by admission, remove
 that membership, await `RemoveOutcome::Removed`, then add the replacement. An
 add racing an in-progress same-id removal fails with `RemovalInProgress`; await
 the removal and retry. The replacement's membership is distinct rather than a
-new incarnation of the old one, and it supersedes the removed same-id
-membership. Different ids and different owning scopes remain incomparable.
+new incarnation of the old one. Terminalization evicts the old id lineage, so
+the replacement and removed membership are deliberately incomparable in both
+directions, just like different ids and different owning scopes.
 
 ## Pre-spawn observation
 

--- a/docs/retry-and-ordering.md
+++ b/docs/retry-and-ordering.md
@@ -39,21 +39,20 @@ idempotent `ReplyDropped` loop.
 
 Membership and incarnation answer different questions. An `ActorRef` follows
 restarts of one membership. After remove and re-add under the same child id,
-the replacement has a new `Membership` that supersedes the removed membership,
-while the old handle remains pinned to the removed one and never retargets.
-Membership ordering is narrow: only replacements of the same child id in the
-same stable scope compare. Different child ids and memberships owned by
-different scopes remain incomparable.
+the replacement has a new `Membership`, while the old handle remains pinned to
+the removed one and never retargets. Terminalization evicts that child id's
+retained identity lineage, so the removed membership and its later replacement
+are deliberately incomparable in both directions. This fail-closed rule also
+applies to different child ids and memberships owned by different scopes.
 
-The stable scope identity also spans declaration and runtime boundaries.
-Replacing an initially declared child dynamically therefore supersedes that
-declared membership, and a corresponding descendant produced after a nested
-scope restart supersedes its predecessor. A rebuilt declaration's handle
-observes that rebased membership, but the handle's own `Eq`/`Hash` identity
-is the slot itself: a handle stashed in a map before lowering remains
-addressable afterward. Read `membership()` when the exact token matters.
-Within one membership, `Incarnation::supersedes` remains the correct restart
-ordering test.
+Declaration lowering may rebase a provisional token while the stable scope
+still retains that id's lineage. Once the membership terminalizes, however, a
+runtime replacement or a corresponding descendant produced after a nested
+scope restart starts a fresh lineage and is incomparable with its predecessor.
+A handle's own `Eq`/`Hash` identity is the slot itself: a handle stashed in a
+map before lowering remains addressable afterward. Read `membership()` when
+the exact token matters. Within one membership, `Incarnation::supersedes`
+remains the correct restart ordering test.
 
 ## Latest-value mailboxes and calls
 


### PR DESCRIPTION
Implements the remaining Part 0 work from #172.

Stacked on #184.

## Part 0.7 — structural ownership

- make membership minting carry the sole incarnation counter and evict exact terminal identities
- select fused versus split dynamic admission ownership when constructing the slot
- transfer scope plans into the runtime through a consuming handoff
- represent internal scope lifecycle state with only live, reachable variants
- reserve parent-capable cancellation tokens for internal construction
- resolve mailbox and readiness policies into types that cannot retain inherited or incomplete states

Terminalized remove/re-add identities are deliberately incomparable, matching the Part 0 adjudication's fail-closed rule.

## Part 0.8 — poisoned monotonic counters

- share local and atomic poisoned-counter primitives across identity fencing, mailbox acceptance and waiters, timers, lifecycle sequencing, arena/deadline handles, and snapshot generations
- permanently poison counters at exhaustion so the maximum value is never minted
- document the remaining diagnostic-only counters that intentionally saturate

## Validation

- `./tools/dev just ci`
- 530 tests passed