### PR TITLE
Bound liveness and raw ownership overhead

### DIFF
--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -17,6 +17,9 @@ use std::{
     time::Instant,
 };
 
+#[cfg(test)]
+use std::sync::atomic::AtomicUsize;
+
 use crate::{
     ChildId, Exit, Incarnation, Intensity, Membership, Readiness, RestartCount, Strategy,
     TotalRestarts,
@@ -893,6 +896,8 @@ pub(crate) struct ScopeCell {
     snapshots: SnapshotHub,
     observation_closed: AtomicBool,
     #[cfg(test)]
+    ancestor_parent_reads: AtomicUsize,
+    #[cfg(test)]
     runtime_storage: Mutex<RuntimeStorage>,
     #[cfg(test)]
     gate_capture_probe: Mutex<Option<std::sync::mpsc::Sender<GateCapture>>>,
@@ -958,6 +963,8 @@ impl ScopeCell {
             snapshots: SnapshotHub::default(),
             observation_closed: AtomicBool::new(false),
             #[cfg(test)]
+            ancestor_parent_reads: AtomicUsize::new(0),
+            #[cfg(test)]
             runtime_storage: Mutex::new(RuntimeStorage::default()),
             #[cfg(test)]
             gate_capture_probe: Mutex::new(None),
@@ -993,11 +1000,18 @@ impl ScopeCell {
     }
 
     fn parent(&self) -> Option<Arc<ScopeCell>> {
+        #[cfg(test)]
+        self.ancestor_parent_reads.fetch_add(1, Ordering::Relaxed);
         self.parent
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .as_ref()
             .and_then(Weak::upgrade)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn take_ancestor_parent_reads(&self) -> usize {
+        self.ancestor_parent_reads.swap(0, Ordering::Relaxed)
     }
 
     fn set_parent(&self, parent: &Arc<ScopeCell>, txn: &mut ObservationTxn<'_>) {
@@ -1504,17 +1518,30 @@ impl ScopeCell {
         ancestors
     }
 
-    fn publish_snapshot_chain_locked(&self, wakes: &mut ObservationTxn<'_>) {
+    fn publish_snapshot_chain_through_locked(
+        &self,
+        wakes: &mut ObservationTxn<'_>,
+        ancestors: &[Arc<ScopeCell>],
+    ) {
         self.snapshots
             .publish_deferred(wakes, || self.snapshot_locked());
-        for ancestor in self.ancestors_locked() {
+        for ancestor in ancestors {
             ancestor
                 .snapshots
                 .publish_deferred(wakes, || ancestor.snapshot_locked());
         }
     }
 
+    fn publish_snapshot_chain_locked(&self, wakes: &mut ObservationTxn<'_>) {
+        let ancestors = self.ancestors_locked();
+        self.publish_snapshot_chain_through_locked(wakes, &ancestors);
+    }
+
     fn emit_locked(&self, wakes: &mut ObservationTxn<'_>, kind: LifecycleEventKind) {
+        // Parent links cannot change under the resident-tree observation gate.
+        // Resolve them once for snapshot and lifecycle propagation so one leaf
+        // edge does not repeatedly lock every ancestor's parent mutex.
+        let ancestors = self.ancestors_locked();
         // The resident-tree observation gate serializes every mint; the
         // atomic is the published watermark as well as the counter, avoiding
         // a second, provably uncontended lock on every lifecycle edge. The
@@ -1524,14 +1551,14 @@ impl ScopeCell {
             .lifecycle_seq
             .mint(Ordering::Release, Ordering::Relaxed);
         let Some(seq) = seq.map(LifecycleSeq::new) else {
-            self.publish_snapshot_chain_locked(wakes);
+            self.publish_snapshot_chain_through_locked(wakes, &ancestors);
             self.lifecycle.publish_lagged_deferred(wakes, 1);
-            for ancestor in self.ancestors_locked() {
+            for ancestor in &ancestors {
                 ancestor.lifecycle.publish_lagged_deferred(wakes, 1);
             }
             return;
         };
-        self.publish_snapshot_chain_locked(wakes);
+        self.publish_snapshot_chain_through_locked(wakes, &ancestors);
 
         let scope = self.member.membership();
         let mut event = LifecycleEvent {
@@ -1542,7 +1569,7 @@ impl ScopeCell {
         };
         self.lifecycle.publish_deferred(wakes, event.clone());
         let mut child_id = self.member.id().clone();
-        for ancestor in self.ancestors_locked() {
+        for ancestor in ancestors {
             event.scope_path.insert(0, child_id);
             child_id = ancestor.member.id().clone();
             ancestor.lifecycle.publish_deferred(wakes, event.clone());

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -1776,6 +1776,15 @@ impl ScopeCell {
     }
 
     pub(crate) fn take_control_events(&self) -> Vec<ScopeControlEvent> {
+        if self
+            .control
+            .lock()
+            .expect("scope control mutex poisoned")
+            .events
+            .is_empty()
+        {
+            return Vec::new();
+        }
         self.with_observation_gate(|_txn| {
             self.control
                 .lock()
@@ -1804,6 +1813,15 @@ impl ScopeCell {
     }
 
     pub(crate) fn take_shutdown_request(&self, epoch: Epoch) -> bool {
+        let pending = self
+            .control
+            .lock()
+            .expect("scope control mutex poisoned")
+            .shutdown
+            .is_some_and(|request| request.epoch == epoch && !request.consumed);
+        if !pending {
+            return false;
+        }
         self.with_observation_gate(|_txn| {
             let mut control = self.control.lock().expect("scope control mutex poisoned");
             match control.shutdown.as_mut() {
@@ -1831,6 +1849,15 @@ impl ScopeCell {
     }
 
     pub(crate) fn take_force_request(&self, epoch: Epoch) -> bool {
+        let pending = self
+            .control
+            .lock()
+            .expect("scope control mutex poisoned")
+            .force
+            .is_some_and(|request| request.epoch == epoch && !request.consumed);
+        if !pending {
+            return false;
+        }
         self.with_observation_gate(|_txn| {
             let mut control = self.control.lock().expect("scope control mutex poisoned");
             match control.force.as_mut() {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -789,7 +789,7 @@ async fn run_scope_incarnation(
         let control_batch_full = dynamic_event_receiver.as_mut().is_some_and(|receiver| {
             collect_driver_events(receiver, event_batch_limit, &mut pending)
         });
-        // Disposal completions drain after the primary and dynamic lanes, and `arbitrate`
+        // Disposal completions collect after the primary and dynamic lanes, and `arbitrate`
         // sorts stably, so a `ConstructionDisposed` always trails every
         // same-class `Exited` collected in the same wake — even one produced
         // later. A disposal is therefore a batch-tail event: the exit it
@@ -799,9 +799,14 @@ async fn run_scope_incarnation(
         // That is a widening of an order that was already reachable, not a new
         // one: disposal runs on the blocking pool, so its completion never had
         // a fixed position relative to concurrent exits.
-        while let Some(event) = runtime::unbounded_mpsc_try_recv(&mut disposal_event_receiver) {
-            pending.push(Pending::Driver(event).classified());
-        }
+        // Apply the same per-wake cap as the other unbounded lanes. Otherwise
+        // a disposal flood can monopolize this loop before a shutdown request
+        // is observed (and before its timeout begins).
+        let disposal_batch_full = collect_driver_events(
+            &mut disposal_event_receiver,
+            event_batch_limit,
+            &mut pending,
+        );
         let now = runtime::now();
         while let Some(deadline) = scope.deadlines.pop_due(now) {
             pending.push(Pending::Deadline(deadline).classified());
@@ -946,8 +951,8 @@ async fn run_scope_incarnation(
         // runtime, immediately collecting the next batch would prevent the
         // child, timer, and helper tasks whose events this loop prioritizes
         // from running at all. Give those producers one scheduler turn before
-        // returning to either saturated lane.
-        if primary_batch_full || control_batch_full {
+        // returning to any saturated lane.
+        if primary_batch_full || control_batch_full || disposal_batch_full {
             runtime::yield_now().await;
         }
     }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -21,8 +21,8 @@ use child::ChildRuntime;
 #[cfg(test)]
 use child::{ChildTerminality, discharge_child_terminality, report_slot};
 use events::{
-    ChildEvent, DeadlineKind, DriverEvent, MIN_EVENT_BATCH_LIMIT, Pending, collect_driver_events,
-    restart_shutdown_work,
+    ChildEvent, DeadlineKind, DriverEvent, EventLanes, MIN_EVENT_BATCH_LIMIT, Pending,
+    collect_event_lanes, restart_shutdown_work,
 };
 use removal::RemovalRequest;
 pub(crate) use shutdown::shutdown_scope;
@@ -784,26 +784,12 @@ async fn run_scope_incarnation(
             // cannot publish Running after the stop boundary.
             pending.push(Pending::Force.classified());
         }
-        let primary_batch_full =
-            collect_driver_events(&mut event_receiver, event_batch_limit, &mut pending);
-        let control_batch_full = dynamic_event_receiver.as_mut().is_some_and(|receiver| {
-            collect_driver_events(receiver, event_batch_limit, &mut pending)
-        });
-        // Disposal completions collect after the primary and dynamic lanes, and `arbitrate`
-        // sorts stably, so a `ConstructionDisposed` always trails every
-        // same-class `Exited` collected in the same wake — even one produced
-        // later. A disposal is therefore a batch-tail event: the exit it
-        // trails may begin a drain first, after which
-        // `handle_construction_disposed` sees `is_draining` and routes the
-        // disposed child through stop progression instead of `fail_startup`.
-        // That is a widening of an order that was already reachable, not a new
-        // one: disposal runs on the blocking pool, so its completion never had
-        // a fixed position relative to concurrent exits.
-        // Apply the same per-wake cap as the other unbounded lanes. Otherwise
-        // a disposal flood can monopolize this loop before a shutdown request
-        // is observed (and before its timeout begins).
-        let disposal_batch_full = collect_driver_events(
-            &mut disposal_event_receiver,
+        let lane_batch_full = collect_event_lanes(
+            EventLanes {
+                primary: &mut event_receiver,
+                control: dynamic_event_receiver.as_mut(),
+                disposal: &mut disposal_event_receiver,
+            },
             event_batch_limit,
             &mut pending,
         );
@@ -952,7 +938,7 @@ async fn run_scope_incarnation(
         // child, timer, and helper tasks whose events this loop prioritizes
         // from running at all. Give those producers one scheduler turn before
         // returning to any saturated lane.
-        if primary_batch_full || control_batch_full || disposal_batch_full {
+        if lane_batch_full {
             runtime::yield_now().await;
         }
     }

--- a/crates/shelterwood/src/driver/events.rs
+++ b/crates/shelterwood/src/driver/events.rs
@@ -72,6 +72,58 @@ impl Pending {
     }
 }
 
+/// The three unbounded lanes one driver wake collects from, in collection
+/// order.
+pub(super) struct EventLanes<'a> {
+    pub(super) primary: &'a mut runtime::UnboundedMpscReceiver<DriverEvent>,
+    pub(super) control: Option<&'a mut runtime::UnboundedMpscReceiver<DriverEvent>>,
+    pub(super) disposal: &'a mut runtime::UnboundedMpscReceiver<DriverEvent>,
+}
+
+/// Collects one bounded batch from every unbounded lane and reports whether
+/// *any* of them still had a queued suffix, which is the driver's signal to
+/// yield a scheduler turn before collecting again.
+///
+/// Lane order is a contract, not an implementation detail. Child lifecycle
+/// events lead so a large externally generated admission prefix cannot strand
+/// the exit that completes shutdown. Disposal completions trail, and
+/// `arbitrate` sorts stably, so a `ConstructionDisposed` always follows every
+/// same-class `Exited` collected in the same wake — even one produced later.
+/// A disposal is therefore a batch-tail event: the exit it trails may begin a
+/// drain first, after which `handle_construction_disposed` sees `is_draining`
+/// and routes the disposed child through stop progression instead of
+/// `fail_startup`. That is a widening of an order that was already reachable,
+/// not a new one: disposal runs on the blocking pool, so its completion never
+/// had a fixed position relative to concurrent exits.
+///
+/// Every lane — disposal included — is capped. An uncapped lane can monopolize
+/// a wake before the loop returns to the top and observes a shutdown request
+/// (whose timeout does not start until `Draining` is published). The cap adds
+/// one ordering surface: a deferred suffix is processed one wake later, so it
+/// sorts against that wake's batch rather than this one's. For the disposal
+/// lane that widens the same axis once more — the next wake's shutdown/force
+/// checks run before its collection, and `ScopeShutdown` sorts ahead of
+/// `ChildExit`, so a deferred disposal can observe a drain that a same-wake
+/// exit had not yet begun. Same rationale: a blocking-pool completion never
+/// had a fixed position relative to a request that can arrive on any wake.
+///
+/// The disposal cap only bites for a dynamic scope whose initial plan is small
+/// relative to its admitted population. At most one construction disposal is in
+/// flight per child (`pending_terminal` admits one), so an ordered scope's
+/// disposal lane can never reach the `plan.children.len() * 3` limit.
+pub(super) fn collect_event_lanes(
+    lanes: EventLanes<'_>,
+    limit: usize,
+    pending: &mut Vec<(ArbitrationClass, Pending)>,
+) -> bool {
+    let primary_batch_full = collect_driver_events(lanes.primary, limit, pending);
+    let control_batch_full = lanes
+        .control
+        .is_some_and(|receiver| collect_driver_events(receiver, limit, pending));
+    let disposal_batch_full = collect_driver_events(lanes.disposal, limit, pending);
+    primary_batch_full || control_batch_full || disposal_batch_full
+}
+
 pub(super) fn collect_driver_events(
     receiver: &mut runtime::UnboundedMpscReceiver<DriverEvent>,
     limit: usize,

--- a/crates/shelterwood/src/driver/tests/events.rs
+++ b/crates/shelterwood/src/driver/tests/events.rs
@@ -1,34 +1,83 @@
 use super::support::*;
 
+fn disposed(child: ChildKey) -> DriverEvent {
+    DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic: None })
+}
+
+fn disposed_child(pending: &Pending) -> ChildKey {
+    match pending {
+        Pending::Driver(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, .. })) => {
+            *child
+        }
+        _ => panic!("this fixture only queues construction disposals"),
+    }
+}
+
+/// Pins the wiring the driver's per-wake collection depends on: the disposal
+/// lane is collected last, through the same cap as the other two, and its
+/// saturation reaches the caller so the loop yields a scheduler turn instead
+/// of returning to a lane that still has a queued suffix. Without the cap a
+/// disposal flood monopolizes the wake, deferring the shutdown check at the
+/// top of the loop — and with it the start of the shutdown timeout.
 #[test]
-fn disposal_event_collection_caps_a_saturated_lane() {
-    let (sender, mut receiver) = crate::runtime::unbounded_mpsc();
-    let queued = super::super::MIN_EVENT_BATCH_LIMIT * 2;
-    for _ in 0..queued {
-        sender
-            .send(DriverEvent::Child(ChildEvent::ConstructionDisposed {
-                child: ChildKey(0),
-                panic: None,
-            }))
+fn every_event_lane_is_capped_and_a_saturated_lane_forces_a_yield() {
+    let limit = super::super::MIN_EVENT_BATCH_LIMIT;
+    let primary_key = ChildKey(1);
+    let control_key = ChildKey(2);
+    let disposal_key = ChildKey(3);
+    let (primary, mut primary_receiver) = crate::runtime::unbounded_mpsc();
+    let (control, mut control_receiver) = crate::runtime::unbounded_mpsc();
+    let (disposal, mut disposal_receiver) = crate::runtime::unbounded_mpsc();
+    primary
+        .send(disposed(primary_key))
+        .expect("the primary lane remains open");
+    control
+        .send(disposed(control_key))
+        .expect("the control lane remains open");
+    for _ in 0..limit * 2 {
+        disposal
+            .send(disposed(disposal_key))
             .expect("the disposal lane remains open");
     }
 
     let mut pending = Vec::new();
+    let saturated = super::super::collect_event_lanes(
+        super::super::EventLanes {
+            primary: &mut primary_receiver,
+            control: Some(&mut control_receiver),
+            disposal: &mut disposal_receiver,
+        },
+        limit,
+        &mut pending,
+    );
+
     assert!(
-        super::super::collect_driver_events(
-            &mut receiver,
-            super::super::MIN_EVENT_BATCH_LIMIT,
-            &mut pending,
-        ),
-        "a disposal suffix reports saturation so the driver yields"
+        saturated,
+        "a saturated disposal lane reports through to the driver's yield"
     );
     assert_eq!(
         pending.len(),
-        super::super::MIN_EVENT_BATCH_LIMIT + 1,
-        "the one-event saturation probe joins the bounded batch"
+        limit + 3,
+        "the disposal lane contributes one bounded batch plus its saturation probe"
+    );
+    assert_eq!(
+        disposed_child(&pending[0].1),
+        primary_key,
+        "child lifecycle events lead the wake"
+    );
+    assert_eq!(
+        disposed_child(&pending[1].1),
+        control_key,
+        "dynamic control traffic collects after the primary lane"
     );
     assert!(
-        crate::runtime::unbounded_mpsc_try_recv(&mut receiver).is_some(),
+        pending[2..]
+            .iter()
+            .all(|entry| disposed_child(&entry.1) == disposal_key),
+        "disposal completions trail both lifecycle lanes so they stay batch-tail events"
+    );
+    assert!(
+        crate::runtime::unbounded_mpsc_try_recv(&mut disposal_receiver).is_some(),
         "the disposal suffix remains for a later scheduler turn"
     );
 }

--- a/crates/shelterwood/src/driver/tests/events.rs
+++ b/crates/shelterwood/src/driver/tests/events.rs
@@ -1,5 +1,38 @@
 use super::support::*;
 
+#[test]
+fn disposal_event_collection_caps_a_saturated_lane() {
+    let (sender, mut receiver) = crate::runtime::unbounded_mpsc();
+    let queued = super::super::MIN_EVENT_BATCH_LIMIT * 2;
+    for _ in 0..queued {
+        sender
+            .send(DriverEvent::Child(ChildEvent::ConstructionDisposed {
+                child: ChildKey(0),
+                panic: None,
+            }))
+            .expect("the disposal lane remains open");
+    }
+
+    let mut pending = Vec::new();
+    assert!(
+        super::super::collect_driver_events(
+            &mut receiver,
+            super::super::MIN_EVENT_BATCH_LIMIT,
+            &mut pending,
+        ),
+        "a disposal suffix reports saturation so the driver yields"
+    );
+    assert_eq!(
+        pending.len(),
+        super::super::MIN_EVENT_BATCH_LIMIT + 1,
+        "the one-event saturation probe joins the bounded batch"
+    );
+    assert!(
+        crate::runtime::unbounded_mpsc_try_recv(&mut receiver).is_some(),
+        "the disposal suffix remains for a later scheduler turn"
+    );
+}
+
 /// Exercises the `DeadlineKind::Restart` suppression gate on its own:
 /// the restart deadline is scheduled first (no stop source latched at
 /// exit time), then the fused cancellation lands before the deadline's

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -715,6 +715,37 @@ fn plain_parent_state_preserves_nested_snapshot_propagation() {
 }
 
 #[test]
+fn lifecycle_emit_resolves_the_ancestor_chain_once() {
+    let root = isolated_scope("root", ScopeFlavor::Ordered);
+    let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
+    let nested_slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
+    root.set_admitted_children(vec![resident_projection(&nested_slot)]);
+    let mut root_events = root.subscribe_lifecycle();
+
+    let _ = nested.take_ancestor_parent_reads();
+    let _ = root.take_ancestor_parent_reads();
+    nested.emit(LifecycleEventKind::ScopeState {
+        state: ScopeState::Running,
+    });
+
+    assert_eq!(
+        nested.take_ancestor_parent_reads(),
+        1,
+        "the emitting scope reads its parent link once"
+    );
+    assert_eq!(
+        root.take_ancestor_parent_reads(),
+        1,
+        "each ancestor reads its parent link once while building the chain"
+    );
+    assert!(matches!(
+        root_events.try_recv(),
+        Ok(LifecycleItem::Event(event))
+            if matches!(event.kind, LifecycleEventKind::ScopeState { state: ScopeState::Running })
+    ));
+}
+
+#[test]
 fn pre_admission_observer_retries_after_gate_handoff() {
     let root = isolated_scope("root", ScopeFlavor::Ordered);
     let nested = isolated_scope("nested", ScopeFlavor::Dynamic);

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -1,6 +1,26 @@
 use super::support::*;
 
 #[test]
+fn empty_control_peeks_skip_the_tree_observation_gate() {
+    let root = isolated_scope("root", ScopeFlavor::Ordered);
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("the scope has a live epoch");
+    let captures = root.probe_gate_captures();
+
+    assert!(!root.take_shutdown_request(epoch));
+    assert!(!root.take_force_request(epoch));
+    assert!(root.take_control_events().is_empty());
+    assert!(
+        matches!(
+            captures.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ),
+        "an idle driver wake only peeks under the control mutex"
+    );
+}
+
+#[test]
 fn pre_admission_restart_shutdown_is_published_when_the_scope_gets_a_parent() {
     let mut tree = Tree::new();
     tree.add_subtree("nested", SubtreeDef::factory(Tree::new))

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -308,6 +308,12 @@ impl<T> Contained<T> {
         }
     }
 
+    fn get(&self) -> &T {
+        self.value
+            .as_ref()
+            .expect("contained ownership is consumed once")
+    }
+
     fn into_inner(mut self) -> T {
         self.value
             .take()
@@ -535,13 +541,18 @@ impl<M> TimerStore<M> {
     ) where
         K: Hash + Eq + Send + 'static,
     {
-        self.remove(&key);
-        let hash = self.hash_key(&key);
+        // Hash and equality are user code. Keep incoming ownership behind the
+        // disposal boundary until those callbacks finish so a callback panic
+        // cannot unwind through a hostile key or message destructor.
+        let key = Contained::new(key, self.disposal.clone());
+        let message = Contained::new(message, self.disposal.clone());
+        self.remove(key.get());
+        let hash = self.hash_key(key.get());
         self.keyed.entry(hash).or_default().push(TimerEntry {
-            key: Box::new(key),
+            key: Box::new(key.into_inner()),
             deadline,
             arming_order,
-            message,
+            message: message.into_inner(),
             period,
         });
         let previous = self.armings.insert(arming_order, hash);
@@ -593,6 +604,19 @@ impl<M> TimerStore<M> {
         };
         self.dispose_entry(entry);
         true
+    }
+
+    fn clear_and_dispose<K>(&mut self, key: K, message: M)
+    where
+        K: Hash + Eq + Send + 'static,
+    {
+        // A zero-period interval still invokes user Hash/Eq while it owns the
+        // rejected inputs. Keep both values contained through that lookup.
+        let key = Contained::new(key, self.disposal.clone());
+        let message = Contained::new(message, self.disposal.clone());
+        self.remove(key.get());
+        drop(key);
+        drop(message);
     }
 
     fn dispose_entry(&self, entry: TimerEntry<M>) {
@@ -1223,9 +1247,7 @@ impl<M: Send + 'static> RawContext<M> {
             return Err(Rejected::new((key, message)));
         }
         if period.is_zero() {
-            let _ = self.clear_timer(&key);
-            self.resources.disposal.dispose(key);
-            self.resources.disposal.dispose(message);
+            self.resources.timers.clear_and_dispose(key, message);
             return Ok(());
         }
         self.replace_timer(
@@ -2445,6 +2467,11 @@ mod tests {
 mod timer_store_tests {
     use std::{
         collections::HashSet,
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
         time::{Duration, Instant},
     };
 
@@ -2460,6 +2487,38 @@ mod timer_store_tests {
     impl std::hash::Hash for CollidingKey {
         fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
             0_u8.hash(state);
+        }
+    }
+
+    struct PanickingHashKey(Arc<AtomicUsize>);
+
+    impl PartialEq for PanickingHashKey {
+        fn eq(&self, _other: &Self) -> bool {
+            true
+        }
+    }
+
+    impl Eq for PanickingHashKey {}
+
+    impl std::hash::Hash for PanickingHashKey {
+        fn hash<H: std::hash::Hasher>(&self, _state: &mut H) {
+            panic!("timer key hash panic");
+        }
+    }
+
+    impl Drop for PanickingHashKey {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            panic!("timer key destructor panic");
+        }
+    }
+
+    struct PanickingTimerMessage(Arc<AtomicUsize>);
+
+    impl Drop for PanickingTimerMessage {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            panic!("timer message destructor panic");
         }
     }
 
@@ -2553,6 +2612,77 @@ mod timer_store_tests {
                     .expect("replacement remains registered")
             ),
             "replacement"
+        );
+        assert!(timers.is_empty());
+    }
+
+    #[test]
+    fn timer_input_cleanup_stays_contained_when_hash_panics() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut timers = TimerStore::default();
+
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            timers.replace(
+                PanickingHashKey(Arc::clone(&drops)),
+                None,
+                order(1),
+                TimerMessage::Once(PanickingTimerMessage(Arc::clone(&drops))),
+                None,
+            );
+        }))
+        .expect_err("the user key hash panic escapes the timer operation");
+
+        assert_eq!(
+            panic.downcast_ref::<&'static str>().copied(),
+            Some("timer key hash panic"),
+            "the callback panic remains primary"
+        );
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            2,
+            "both hostile incoming destructors run behind independent boundaries"
+        );
+        let cleanup = timers
+            .disposal
+            .panic
+            .take()
+            .expect("the first destructor panic is retained as cleanup evidence");
+        assert!(
+            matches!(
+                cleanup.downcast_ref::<&'static str>().copied(),
+                Some("timer message destructor panic" | "timer key destructor panic")
+            ),
+            "a hostile incoming destructor is recorded"
+        );
+        assert!(timers.is_empty());
+    }
+
+    #[test]
+    fn zero_period_timer_cleanup_stays_contained_when_hash_panics() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut timers = TimerStore::default();
+
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            timers.clear_and_dispose(
+                PanickingHashKey(Arc::clone(&drops)),
+                PanickingTimerMessage(Arc::clone(&drops)),
+            );
+        }))
+        .expect_err("the user key hash panic escapes the clear operation");
+
+        assert_eq!(
+            panic.downcast_ref::<&'static str>().copied(),
+            Some("timer key hash panic"),
+            "the callback panic remains primary"
+        );
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            2,
+            "both zero-period inputs are destroyed behind containment"
+        );
+        assert!(
+            timers.disposal.panic.take().is_some(),
+            "a hostile input destructor is retained as cleanup evidence"
         );
         assert!(timers.is_empty());
     }

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -933,11 +933,15 @@ impl<M> RawResources<M> {
 
     /// Drops ledger entries for offloads that already finished, keeping a
     /// long-lived incarnation's ledger O(in-flight) rather than
-    /// O(offloads-ever-issued). Invoked at the two cheap points that bound
-    /// steady-state retention: when a new offload starts and when the loop
-    /// goes idle.
+    /// O(offloads-ever-issued). Invoked when a new offload starts, before each
+    /// ready-selection turn, and when the loop goes idle. The selection point
+    /// is what bounds retention for an actor whose mailbox never empties.
     fn reclaim_finished(&mut self) {
         self.offloads.retain(|offload| !offload.finished.is_fired());
+    }
+
+    fn begin_ready_selection(&mut self) {
+        self.reclaim_finished();
     }
 
     fn resume_pending_panic(&self) {
@@ -1221,8 +1225,8 @@ impl<M: Send + 'static> RawContext<M> {
     /// admits at most one mailbox delivery before its captured completion
     /// prefix. Its population therefore stays proportional to the caller's
     /// in-flight count even under sustained mailbox traffic. Bookkeeping for
-    /// finished offloads is reclaimed when a new offload starts and when the
-    /// loop goes idle.
+    /// finished offloads is reclaimed when a new offload starts, on every
+    /// input-selection turn, and when the loop goes idle.
     pub fn offload<F, T, C>(
         &mut self,
         work: F,
@@ -1468,6 +1472,10 @@ impl<M: Send + 'static> RawContext<M> {
     /// [`try_recv`](Self::try_recv) bypasses this selector and drains the
     /// accepted prefix directly according to the caller's shutdown policy.
     fn next_ready(&mut self) -> Option<M> {
+        // A permanently busy actor never reaches `wait_for_event`; reclaim at
+        // its other guaranteed re-entry point so completed task handles do not
+        // accumulate for the lifetime of the incarnation.
+        self.resources.begin_ready_selection();
         loop {
             self.resources.resume_pending_panic();
             self.begin_ready_batch();
@@ -2267,7 +2275,7 @@ mod tests {
     }
 
     #[test]
-    fn finished_offload_ledger_entries_are_reclaimed_eagerly() {
+    fn ready_selection_reclaims_finished_offload_ledger_entries() {
         let mut resources = RawResources::<()>::default();
         for finished in [true, false, true] {
             let completion = Latch::default();
@@ -2282,7 +2290,7 @@ mod tests {
             });
         }
 
-        resources.reclaim_finished();
+        resources.begin_ready_selection();
 
         assert_eq!(
             resources.offloads.len(),

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -255,9 +255,10 @@ impl PanicSlot {
 
 /// The one cleanup route for values owned by a raw incarnation.
 ///
-/// Every container stores user payloads in [`Contained`], and offload futures
-/// use the same funnel explicitly when ownership sits behind a mutex. A
-/// destructor panic is retained as cleanup evidence and wakes an idle actor;
+/// Collection drains and offload futures route user payloads through this
+/// funnel. Collections keep their resident elements raw and dispose each one
+/// explicitly when draining, avoiding a cloned disposal handle per element.
+/// A destructor panic is retained as cleanup evidence and wakes an idle actor;
 /// it never unwinds through another user destructor.
 #[derive(Clone)]
 struct RawDisposal {
@@ -307,12 +308,6 @@ impl<T> Contained<T> {
         }
     }
 
-    fn get(&self) -> &T {
-        self.value
-            .as_ref()
-            .expect("contained ownership is consumed once")
-    }
-
     fn into_inner(mut self) -> T {
         self.value
             .take()
@@ -348,7 +343,7 @@ struct EventQueue<M> {
     // Insertion and the snapshot share this lock, so FIFO order itself is the
     // sequence and there is no integer counter whose saturation could blur a
     // boundary.
-    queue: Mutex<VecDeque<Contained<QueuedEvent<M>>>>,
+    queue: Mutex<VecDeque<QueuedEvent<M>>>,
     signal: Signal,
     disposal: RawDisposal,
 }
@@ -370,7 +365,6 @@ impl<M> EventQueue<M> {
     }
 
     fn push(&self, event: QueuedEvent<M>) {
-        let event = Contained::new(event, self.disposal.clone());
         self.queue
             .lock()
             .expect("actor event queue mutex poisoned")
@@ -380,7 +374,6 @@ impl<M> EventQueue<M> {
 
     #[cfg(test)]
     fn insert_with(&self, event: QueuedEvent<M>, before_insert: impl FnOnce()) {
-        let event = Contained::new(event, self.disposal.clone());
         let mut queue = self.queue.lock().expect("actor event queue mutex poisoned");
         before_insert();
         queue.push_back(event);
@@ -406,14 +399,14 @@ impl<M> EventQueue<M> {
     }
 
     #[cfg(test)]
-    fn pop(&self) -> Option<Contained<QueuedEvent<M>>> {
+    fn pop(&self) -> Option<QueuedEvent<M>> {
         self.queue
             .lock()
             .expect("actor event queue mutex poisoned")
             .pop_front()
     }
 
-    fn pop_through(&self, remaining: &mut usize) -> Option<Contained<QueuedEvent<M>>> {
+    fn pop_through(&self, remaining: &mut usize) -> Option<QueuedEvent<M>> {
         if *remaining == 0 {
             None
         } else {
@@ -433,11 +426,25 @@ impl<M> EventQueue<M> {
     }
 
     fn clear(&self) {
-        let queue = {
+        let mut queue = {
             let mut queue = self.queue.lock().expect("actor event queue mutex poisoned");
             std::mem::take(&mut *queue)
         };
-        drop(queue);
+        while let Some(event) = queue.pop_front() {
+            self.disposal.dispose(event);
+        }
+    }
+}
+
+impl<M> Drop for EventQueue<M> {
+    fn drop(&mut self) {
+        let queue = self
+            .queue
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while let Some(event) = queue.pop_front() {
+            self.disposal.dispose(event);
+        }
     }
 }
 
@@ -457,12 +464,12 @@ impl ArmingOrder {
 struct KeyHash(u64);
 
 struct TimerEntry<M> {
-    key: Contained<Box<dyn Any + Send>>,
+    key: Box<dyn Any + Send>,
     /// `None` when the requested delay overflows the clock: a deadline that
     /// never arrives, mirroring the offload path — never "due now".
     deadline: Option<Instant>,
     arming_order: ArmingOrder,
-    message: Contained<TimerMessage<M>>,
+    message: TimerMessage<M>,
     period: Option<Duration>,
 }
 
@@ -510,9 +517,12 @@ impl<M> TimerStore<M> {
     }
 
     fn clear(&mut self) {
-        self.keyed.clear();
+        let keyed = std::mem::take(&mut self.keyed);
         self.armings.clear();
         self.deadlines.clear();
+        for entry in keyed.into_values().flatten() {
+            self.dispose_entry(entry);
+        }
     }
 
     fn replace<K>(
@@ -525,12 +535,10 @@ impl<M> TimerStore<M> {
     ) where
         K: Hash + Eq + Send + 'static,
     {
-        let key = Contained::new(key, self.disposal.clone());
-        let message = Contained::new(message, self.disposal.clone());
-        let _ = self.remove(key.get());
-        let hash = self.hash_key(key.get());
+        self.remove(&key);
+        let hash = self.hash_key(&key);
         self.keyed.entry(hash).or_default().push(TimerEntry {
-            key: Contained::new(Box::new(key.into_inner()), self.disposal.clone()),
+            key: Box::new(key),
             deadline,
             arming_order,
             message,
@@ -543,7 +551,7 @@ impl<M> TimerStore<M> {
         }
     }
 
-    fn remove<K>(&mut self, key: &K) -> Option<TimerEntry<M>>
+    fn take<K>(&mut self, key: &K) -> Option<TimerEntry<M>>
     where
         K: Hash + Eq + 'static,
     {
@@ -557,7 +565,7 @@ impl<M> TimerStore<M> {
                 {
                     probes += 1;
                 }
-                entry.key.get().downcast_ref::<K>() == Some(key)
+                entry.key.downcast_ref::<K>() == Some(key)
             })?;
             #[cfg(test)]
             {
@@ -574,6 +582,23 @@ impl<M> TimerStore<M> {
             self.deadlines.remove(&(deadline, entry.arming_order));
         }
         Some(entry)
+    }
+
+    fn remove<K>(&mut self, key: &K) -> bool
+    where
+        K: Hash + Eq + 'static,
+    {
+        let Some(entry) = self.take(key) else {
+            return false;
+        };
+        self.dispose_entry(entry);
+        true
+    }
+
+    fn dispose_entry(&self, entry: TimerEntry<M>) {
+        let TimerEntry { key, message, .. } = entry;
+        self.disposal.dispose(key);
+        self.disposal.dispose(message);
     }
 
     fn remove_arming(&mut self, arming_order: ArmingOrder) -> Option<TimerEntry<M>> {
@@ -631,6 +656,12 @@ impl<M> TimerStore<M> {
 
     fn next_deadline(&self) -> Option<Instant> {
         self.deadlines.first().map(|(deadline, _)| *deadline)
+    }
+}
+
+impl<M> Drop for TimerStore<M> {
+    fn drop(&mut self) {
+        self.clear();
     }
 }
 
@@ -871,7 +902,7 @@ impl OffloadResource {
 
 struct RawResources<M> {
     accepting: bool,
-    continuations: VecDeque<Contained<M>>,
+    continuations: VecDeque<M>,
     // Set after returning a continuation and cleared after an external
     // mailbox/offload/timer item. `next_ready` uses it to prohibit two local
     // continuations from leading while an external source remains eligible.
@@ -924,7 +955,9 @@ impl<M> RawResources<M> {
         for offload in &mut self.offloads {
             offload.cancel();
         }
-        self.continuations.clear();
+        while let Some(message) = self.continuations.pop_front() {
+            self.disposal.dispose(message);
+        }
         self.timers.clear();
         self.ready_batch = None;
         self.events.clear();
@@ -1154,9 +1187,7 @@ impl<M: Send + 'static> RawContext<M> {
         if self.is_stopping() || !self.resources.accepting {
             return Err(Rejected::new(message));
         }
-        self.resources
-            .continuations
-            .push_back(Contained::new(message, self.resources.disposal.clone()));
+        self.resources.continuations.push_back(message);
         Ok(())
     }
 
@@ -1192,11 +1223,9 @@ impl<M: Send + 'static> RawContext<M> {
             return Err(Rejected::new((key, message)));
         }
         if period.is_zero() {
-            let key = Contained::new(key, self.resources.disposal.clone());
-            let message = Contained::new(message, self.resources.disposal.clone());
-            let _ = self.clear_timer(key.get());
-            drop(key);
-            drop(message);
+            let _ = self.clear_timer(&key);
+            self.resources.disposal.dispose(key);
+            self.resources.disposal.dispose(message);
             return Ok(());
         }
         self.replace_timer(
@@ -1213,7 +1242,7 @@ impl<M: Send + 'static> RawContext<M> {
     where
         K: Hash + Eq + Send + 'static,
     {
-        self.resources.timers.remove(key).is_some()
+        self.resources.timers.remove(key)
     }
 
     /// Starts incarnation-owned async work with one total deadline budget.
@@ -1491,7 +1520,7 @@ impl<M: Send + 'static> RawContext<M> {
                 batch.record_continuation_delivery();
                 self.resources.continuation_needs_external = true;
                 self.resources.ready_batch = Some(batch);
-                return Some(message.into_inner());
+                return Some(message);
             }
 
             if !batch.mailbox_complete {
@@ -1511,7 +1540,7 @@ impl<M: Send + 'static> RawContext<M> {
                     .events
                     .pop_through(&mut batch.offloads_remaining)
                 {
-                    if let Some(message) = Self::materialize_event(event) {
+                    if let Some(message) = self.materialize_event(event) {
                         self.resources.continuation_needs_external = false;
                         self.resources.ready_batch = Some(batch);
                         return Some(message);
@@ -1542,7 +1571,7 @@ impl<M: Send + 'static> RawContext<M> {
                 batch.record_continuation_delivery();
                 self.resources.continuation_needs_external = true;
                 self.resources.ready_batch = Some(batch);
-                return Some(message.into_inner());
+                return Some(message);
             }
             batch.continuations_remaining = 0;
 
@@ -1572,11 +1601,11 @@ impl<M: Send + 'static> RawContext<M> {
         }
     }
 
-    fn materialize_event(event: Contained<QueuedEvent<M>>) -> Option<M> {
-        if event.get().cancellation.is_fired() {
+    fn materialize_event(&self, event: QueuedEvent<M>) -> Option<M> {
+        if event.cancellation.is_fired() {
+            self.resources.disposal.dispose(event);
             return None;
         }
-        let event = event.into_inner();
         Some((event.make_message)())
     }
 
@@ -1619,7 +1648,7 @@ impl<M: Send + 'static> RawContext<M> {
         if let Some(period) = entry.period {
             let deadline = crate::deadline::Deadline::after(runtime::now(), period).instant();
             entry.deadline = deadline;
-            let TimerMessage::Interval(message, clone_message) = entry.message.get() else {
+            let TimerMessage::Interval(message, clone_message) = &entry.message else {
                 unreachable!("an interval timer must own a message factory")
             };
             let message = clone_message(message);
@@ -1632,7 +1661,9 @@ impl<M: Send + 'static> RawContext<M> {
             .timers
             .remove_arming(arming)
             .expect("a due one-shot timer remains registered");
-        let TimerMessage::Once(message) = entry.message.into_inner() else {
+        let TimerEntry { key, message, .. } = entry;
+        self.resources.disposal.dispose(key);
+        let TimerMessage::Once(message) = message else {
             unreachable!("a non-interval timer must own a one-shot message")
         };
         Some(message)
@@ -1992,8 +2023,8 @@ mod tests {
     };
 
     use super::{
-        Contained, EventQueue, OffloadResource, PanicSlot, QueuedEvent, RawResources,
-        SharedOffloadFuture, SharedOffloadState,
+        ArmingOrder, EventQueue, OffloadResource, PanicSlot, QueuedEvent, RawResources,
+        SharedOffloadFuture, SharedOffloadState, TimerMessage,
     };
     use crate::runtime::{
         Latch, PanicPayload, Signal, UnwindPanics, resume_preferred_panic,
@@ -2007,8 +2038,7 @@ mod tests {
         }
     }
 
-    fn value(event: Contained<QueuedEvent<usize>>) -> usize {
-        let event = event.into_inner();
+    fn value(event: QueuedEvent<usize>) -> usize {
         (event.make_message)()
     }
 
@@ -2301,6 +2331,27 @@ mod tests {
     }
 
     #[test]
+    fn resident_raw_collections_do_not_clone_disposal_per_element() {
+        let mut resources = RawResources::<()>::default();
+        let baseline = Arc::strong_count(&resources.panic);
+
+        resources.continuations.push_back(());
+        resources.events.push(QueuedEvent {
+            cancellation: Latch::default(),
+            make_message: Box::new(|| ()),
+        });
+        resources
+            .timers
+            .replace(7_u8, None, ArmingOrder(1), TimerMessage::Once(()), None);
+
+        assert_eq!(
+            Arc::strong_count(&resources.panic),
+            baseline,
+            "continuations, events, and timers store raw elements without disposal clones"
+        );
+    }
+
+    #[test]
     fn raw_resources_drop_cancels_every_offload_after_one_destructor_panics() {
         let drops = Arc::new(AtomicUsize::new(0));
         let mut resources = RawResources::<()>::default();
@@ -2349,21 +2400,35 @@ mod tests {
     }
 
     #[test]
-    fn freeze_contains_each_user_payload_destructor_independently() {
+    fn freeze_drains_each_raw_collection_with_independent_containment() {
         let drops = Arc::new(AtomicUsize::new(0));
         let mut resources = RawResources::<PanickingDrop>::default();
         for _ in 0..2 {
-            resources.continuations.push_back(Contained::new(
-                PanickingDrop(Arc::clone(&drops)),
-                resources.disposal.clone(),
-            ));
+            resources
+                .continuations
+                .push_back(PanickingDrop(Arc::clone(&drops)));
         }
+        let event_payload = PanickingDrop(Arc::clone(&drops));
+        resources.events.push(QueuedEvent {
+            cancellation: Latch::default(),
+            make_message: Box::new(move || {
+                drop(event_payload);
+                unreachable!("a disposed event is never materialized")
+            }),
+        });
+        resources.timers.replace(
+            1_u8,
+            None,
+            ArmingOrder(1),
+            TimerMessage::Once(PanickingDrop(Arc::clone(&drops))),
+            None,
+        );
 
         assert_eq!(resources.freeze(), 2);
         assert_eq!(
             drops.load(Ordering::SeqCst),
-            2,
-            "one hostile destructor cannot skip the remaining payloads"
+            4,
+            "one hostile destructor cannot skip later collection elements or drains"
         );
         let payload = resources
             .panic
@@ -2399,7 +2464,7 @@ mod timer_store_tests {
     }
 
     fn once(entry: super::TimerEntry<&'static str>) -> &'static str {
-        let TimerMessage::Once(message) = entry.message.into_inner() else {
+        let TimerMessage::Once(message) = entry.message else {
             panic!("expected a live one-shot timer")
         };
         message
@@ -2476,7 +2541,7 @@ mod timer_store_tests {
         assert_eq!(
             once(
                 timers
-                    .remove(&CollidingKey(2))
+                    .take(&CollidingKey(2))
                     .expect("colliding peer remains registered")
             ),
             "second"
@@ -2484,7 +2549,7 @@ mod timer_store_tests {
         assert_eq!(
             once(
                 timers
-                    .remove(&CollidingKey(1))
+                    .take(&CollidingKey(1))
                     .expect("replacement remains registered")
             ),
             "replacement"
@@ -2519,7 +2584,7 @@ mod timer_store_tests {
             );
         }
         for key in keys.into_iter().rev() {
-            assert!(timers.remove(&key).is_some());
+            assert!(timers.remove(&key));
         }
 
         assert!(timers.is_empty());

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -454,6 +454,55 @@ impl<M> Drop for EventQueue<M> {
     }
 }
 
+/// Incarnation-owned storage for `continue_with` messages.
+///
+/// Elements are stored raw — the queue owns one disposal handle instead of one
+/// per element — so every drain must route its payloads through that funnel.
+/// `Drop` re-drains unconditionally: a `freeze` that never ran, or that failed
+/// partway through an earlier cleanup step, must not leave queued user
+/// messages to be destroyed outside the disposal boundary.
+struct ContinuationQueue<M> {
+    queue: VecDeque<M>,
+    disposal: RawDisposal,
+}
+
+impl<M> ContinuationQueue<M> {
+    fn new(disposal: RawDisposal) -> Self {
+        Self {
+            queue: VecDeque::new(),
+            disposal,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.queue.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    fn push_back(&mut self, message: M) {
+        self.queue.push_back(message);
+    }
+
+    fn pop_front(&mut self) -> Option<M> {
+        self.queue.pop_front()
+    }
+
+    fn clear(&mut self) {
+        while let Some(message) = self.queue.pop_front() {
+            self.disposal.dispose(message);
+        }
+    }
+}
+
+impl<M> Drop for ContinuationQueue<M> {
+    fn drop(&mut self) {
+        self.clear();
+    }
+}
+
 enum TimerMessage<M> {
     Once(M),
     Interval(M, fn(&M) -> M),
@@ -926,7 +975,7 @@ impl OffloadResource {
 
 struct RawResources<M> {
     accepting: bool,
-    continuations: VecDeque<M>,
+    continuations: ContinuationQueue<M>,
     // Set after returning a continuation and cleared after an external
     // mailbox/offload/timer item. `next_ready` uses it to prohibit two local
     // continuations from leading while an external source remains eligible.
@@ -953,7 +1002,7 @@ impl<M> Default for RawResources<M> {
         let event_watcher = events.signal.watcher();
         Self {
             accepting: true,
-            continuations: VecDeque::new(),
+            continuations: ContinuationQueue::new(disposal.clone()),
             continuation_needs_external: false,
             timers: TimerStore::new(disposal.clone()),
             timer_orders: PoisonedCounter::new(),
@@ -979,9 +1028,7 @@ impl<M> RawResources<M> {
         for offload in &mut self.offloads {
             offload.cancel();
         }
-        while let Some(message) = self.continuations.pop_front() {
-            self.disposal.dispose(message);
-        }
+        self.continuations.clear();
         self.timers.clear();
         self.ready_batch = None;
         self.events.clear();
@@ -993,12 +1040,13 @@ impl<M> RawResources<M> {
     /// O(offloads-ever-issued). Invoked when a new offload starts, before each
     /// ready-selection turn, and when the loop goes idle. The selection point
     /// is what bounds retention for an actor whose mailbox never empties.
+    ///
+    /// The scan is therefore O(in-flight offloads) per delivered input, by
+    /// design: the ledger is already bounded by the caller's own in-flight
+    /// count, so a per-turn walk of it is proportional to work the actor
+    /// itself has outstanding.
     fn reclaim_finished(&mut self) {
         self.offloads.retain(|offload| !offload.finished.is_fired());
-    }
-
-    fn begin_ready_selection(&mut self) {
-        self.reclaim_finished();
     }
 
     fn resume_pending_panic(&self) {
@@ -1525,8 +1573,9 @@ impl<M: Send + 'static> RawContext<M> {
     fn next_ready(&mut self) -> Option<M> {
         // A permanently busy actor never reaches `wait_for_event`; reclaim at
         // its other guaranteed re-entry point so completed task handles do not
-        // accumulate for the lifetime of the incarnation.
-        self.resources.begin_ready_selection();
+        // accumulate for the lifetime of the incarnation. This is the point
+        // that bounds ledger retention.
+        self.resources.reclaim_finished();
         loop {
             self.resources.resume_pending_panic();
             self.begin_ready_batch();
@@ -1696,8 +1745,10 @@ impl<M: Send + 'static> RawContext<M> {
     }
 
     async fn wait_for_event(&mut self) {
-        // The loop is about to go idle: reclaim finished offload bookkeeping
-        // now so steady-state retention never waits for the next offload.
+        // Retention is already bounded by the reclaim in `next_ready`, which
+        // ran on this task with no await in between. This is a same-instant
+        // backstop for the one case that reclaim could not have seen: an
+        // offload finishing on another thread between the two calls.
         self.resources.reclaim_finished();
         let sleep = self.next_timer_deadline().map_or_else(
             || Box::pin(std::future::pending()) as runtime::BoxedSleep,
@@ -2045,13 +2096,69 @@ mod tests {
     };
 
     use super::{
-        ArmingOrder, EventQueue, OffloadResource, PanicSlot, QueuedEvent, RawResources,
-        SharedOffloadFuture, SharedOffloadState, TimerMessage,
+        ArmingOrder, EventQueue, OffloadResource, PanicSlot, QueuedEvent, RawContext, RawResources,
+        RawRunContext, SharedOffloadFuture, SharedOffloadState, TimerMessage,
     };
-    use crate::runtime::{
-        Latch, PanicPayload, Signal, UnwindPanics, resume_preferred_panic,
-        resume_preferred_panic_outside_unwind,
+    use crate::{
+        ChildId, MailboxShutdown, Readiness,
+        cells::{MailboxControl, MemberCell, ScopeCell},
+        identity::ScopeIdentity,
+        mailbox::{ActorRef, MailboxCell},
+        policy::{ResolvedDefaults, ScopeFlavor},
+        runtime::{
+            CompletionGatedLatch, Latch, PanicPayload, Signal, UnwindPanics,
+            resume_preferred_panic, resume_preferred_panic_outside_unwind,
+        },
+        scope::ScopeRef,
     };
+
+    /// Builds a live raw incarnation context whose mailbox is configured and
+    /// bound, so `next_ready` can take the busy path without a driver.
+    fn bound_raw_context() -> (RawContext<u8>, ActorRef<u8>) {
+        let mut identity = ScopeIdentity::new();
+        let id = ChildId::from("raw-actor");
+        let member = MemberCell::new(
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
+        );
+        let mailbox = MailboxCell::new(id.clone());
+        member.attach_mailbox(mailbox.clone());
+        MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox);
+        let incarnation = member
+            .take_incarnation_counter()
+            .mint()
+            .expect("incarnation available");
+        MailboxControl::bind(&*mailbox, incarnation);
+
+        let mut scope_identity = ScopeIdentity::new();
+        let scope_id = ChildId::from("scope");
+        let scope_member = MemberCell::new(
+            scope_id.clone(),
+            scope_identity
+                .mint_membership(&scope_id)
+                .expect("membership available"),
+        );
+        let scope = ScopeCell::new(scope_member, ScopeFlavor::Ordered, ScopeIdentity::new());
+
+        let myself = ActorRef::new(Arc::clone(&member), Arc::clone(&mailbox));
+        let context = RawContext::new(
+            RawRunContext {
+                id,
+                incarnation,
+                member,
+                scope: ScopeRef { cell: scope },
+                shutdown: Latch::default(),
+                abort: Latch::default(),
+                ready: CompletionGatedLatch::default(),
+                local_stop: Latch::default(),
+                mailbox_shutdown: MailboxShutdown::Drain,
+            },
+            myself.clone(),
+            mailbox,
+            Readiness::Immediate,
+        );
+        (context, myself)
+    }
 
     fn marker(value: usize) -> QueuedEvent<usize> {
         QueuedEvent {
@@ -2122,6 +2229,20 @@ mod tests {
         fn drop(&mut self) {
             self.0.fetch_add(1, Ordering::SeqCst);
             panic!("contained raw payload destructor panic");
+        }
+    }
+
+    struct CountedDrop {
+        drops: Arc<AtomicUsize>,
+        panic_on_drop: bool,
+    }
+
+    impl Drop for CountedDrop {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::SeqCst);
+            if self.panic_on_drop {
+                panic!("queued continuation destructor panic");
+            }
         }
     }
 
@@ -2327,7 +2448,7 @@ mod tests {
     }
 
     #[test]
-    fn ready_selection_reclaims_finished_offload_ledger_entries() {
+    fn finished_offload_ledger_entries_are_reclaimed() {
         let mut resources = RawResources::<()>::default();
         for finished in [true, false, true] {
             let completion = Latch::default();
@@ -2342,7 +2463,7 @@ mod tests {
             });
         }
 
-        resources.begin_ready_selection();
+        resources.reclaim_finished();
 
         assert_eq!(
             resources.offloads.len(),
@@ -2350,6 +2471,81 @@ mod tests {
             "reclamation retains exactly the unfinished offloads"
         );
         assert!(!resources.offloads[0].finished.is_fired());
+    }
+
+    /// `freeze` is the drain that normally empties the continuation queue, but
+    /// it is not a guaranteed one: `Drop for RawResources` skips it once the
+    /// incarnation is already frozen, and runs it under `catch_panic` so an
+    /// earlier cleanup step failing can cut it short. Either way the queue's
+    /// own destructor must still route its payloads through the disposal
+    /// funnel instead of letting them unwind out of incarnation cleanup.
+    #[test]
+    fn a_skipped_freeze_still_contains_queued_continuation_destructors() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut resources = RawResources::<CountedDrop>::default();
+        let panic = Arc::clone(&resources.panic);
+        resources.accepting = false;
+        for panic_on_drop in [true, false] {
+            resources.continuations.push_back(CountedDrop {
+                drops: Arc::clone(&drops),
+                panic_on_drop,
+            });
+        }
+
+        catch_unwind(AssertUnwindSafe(|| drop(resources)))
+            .expect("a hostile continuation destructor never escapes incarnation cleanup");
+
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            2,
+            "one hostile destructor cannot skip the rest of the queue"
+        );
+        assert_eq!(
+            panic.take().as_ref().and_then(panic_message),
+            Some("queued continuation destructor panic"),
+            "the contained destructor panic is retained as cleanup evidence"
+        );
+    }
+
+    /// The ledger's retention bound rests on the reclaim point inside
+    /// `next_ready`, not on the one in `wait_for_event`: an actor whose
+    /// mailbox never empties returns from every receive without going idle,
+    /// so the idle reclaim never runs and finished task handles would
+    /// otherwise accumulate for the lifetime of the incarnation.
+    #[test]
+    fn a_busy_receive_turn_reclaims_finished_offload_ledger_entries() {
+        let (mut context, actor) = bound_raw_context();
+        actor
+            .try_send(1)
+            .expect("a bound mailbox accepts the message");
+        actor
+            .try_send(2)
+            .expect("a bound mailbox keeps the actor busy");
+        for finished in [true, false, true] {
+            let completion = Latch::default();
+            if finished {
+                completion.fire();
+            }
+            context.resources.offloads.push(OffloadResource {
+                cancellation: Latch::default(),
+                finished: completion,
+                state: None,
+                task: None,
+            });
+        }
+
+        assert_eq!(
+            context.try_recv(),
+            Some(1),
+            "a readable mailbox returns from ready selection without going idle"
+        );
+
+        assert_eq!(
+            context.resources.offloads.len(),
+            1,
+            "the ready-selection turn reclaimed both finished ledger entries"
+        );
+        assert!(!context.resources.offloads[0].finished.is_fired());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Cap disposal-completion collection with the driver's existing per-wake batch/yield policy so a disposal flood cannot defer shutdown observation.
- Resolve an observation edge's ancestor chain once and reuse it for snapshot and lifecycle propagation.
- Reclaim finished offload ledger entries before every ready-selection turn, including permanently busy actors.
- Peek shutdown, force, and control-event state under the control mutex before acquiring the tree observation gate.
- Store continuations, queued events, and timers as raw elements; apply independent disposal containment when cancelling, clearing, freezing, or dropping those collections.

## Root cause and impact

The driver treated two unbounded event lanes fairly but drained the disposal lane without a cap, so completion floods could monopolize a wake before shutdown entered `Draining` and started its timeout. Lifecycle emission repeatedly rebuilt the same ancestor list, adding parent-mutex traffic to every edge. Finished offload handles were only reclaimed when another offload started or the actor idled, allowing a permanently busy actor's ledger to grow with history. Idle control polls acquired the tree-wide gate even when no control state existed. Finally, raw input collections embedded a cloned `RawDisposal` in every element (including three clones per timer arm), imposing refcount and storage cost on the steady-state path.

These changes bound driver scheduling, ledger retention, ancestor traversal, and gate traffic while preserving ordering, wake, ownership-transfer, and destructor-panic containment semantics.

## Checklist and commit map

- [x] Disposal fairness — `6d2346a Cap disposal completion batches`
- [x] Observation emit cost — `105ec2e Reuse observation ancestor chains`
- [x] Offload ledger retention — `dcbf068 Reclaim offload ledger on busy turns`
- [x] Control peek-before-gate residual — `f9214d6 Peek control state before tree gate`
- [x] `Contained` drain-clone residual — `36a9883 Move raw collection containment to drains`
- [x] Adversarial review: contain raw timer inputs across user key callbacks — `13e6411 Contain timer inputs across key callbacks`

## Validation

- `./tools/dev cargo test -p shelterwood timer_store_tests` — 5 timer-store tests passed
- `./tools/dev cargo test -p shelterwood` — 245 unit tests, 297 integration tests, and 3 doctests passed
- `./tools/dev just ci` — passed formatting, clippy with warnings denied, 546 nextest tests, 3 doctests, documentation/API reachability, runtime/exit/layering/enforcement checks, packaged-crate verification, and Nix formatting

Closes #188