### PR TITLE
Polish correctness edges and test evidence

### DIFF
--- a/crates/shelterwood/src/admission.rs
+++ b/crates/shelterwood/src/admission.rs
@@ -1,5 +1,7 @@
 //! Dynamic membership admission errors and removal outcomes.
 
+use std::fmt;
+
 use crate::{identity::ChildId, policy::InvalidPolicy};
 
 /// A child reservation or dynamic admission error.
@@ -19,7 +21,7 @@ pub enum ReserveError {
     #[error("child id `{0}` is being removed")]
     RemovalInProgress(ChildId),
     /// The target dynamic scope is not admitting.
-    #[error("scope is not admitting: {0:?}")]
+    #[error("scope is not admitting: {0}")]
     NotAdmitting(NotAdmittingCause),
     /// The scope can mint no further membership identities.
     #[error("membership identity space is exhausted")]
@@ -45,6 +47,18 @@ pub enum NotAdmittingCause {
     ReservationEnded,
 }
 
+impl fmt::Display for NotAdmittingCause {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Terminal => "terminal",
+            Self::Draining => "draining",
+            Self::StartupFailed => "startup failed",
+            Self::NoLiveIncarnation => "no live incarnation",
+            Self::ReservationEnded => "reservation ended",
+        })
+    }
+}
+
 /// Outcome of an idempotent dynamic removal.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RemoveOutcome {
@@ -52,4 +66,28 @@ pub enum RemoveOutcome {
     Removed,
     /// No matching membership remained to remove.
     AlreadyAbsent,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NotAdmittingCause, ReserveError};
+
+    #[test]
+    fn not_admitting_display_is_stable_and_does_not_delegate_to_debug() {
+        let cases = [
+            (NotAdmittingCause::Terminal, "terminal"),
+            (NotAdmittingCause::Draining, "draining"),
+            (NotAdmittingCause::StartupFailed, "startup failed"),
+            (NotAdmittingCause::NoLiveIncarnation, "no live incarnation"),
+            (NotAdmittingCause::ReservationEnded, "reservation ended"),
+        ];
+
+        for (cause, expected) in cases {
+            assert_eq!(cause.to_string(), expected);
+            assert_eq!(
+                ReserveError::NotAdmitting(cause).to_string(),
+                format!("scope is not admitting: {expected}")
+            );
+        }
+    }
 }

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -18,8 +18,7 @@ use std::{
 };
 
 use crate::{
-    ChildId, Exit, Incarnation, Intensity, Membership, Readiness, RestartCount, Strategy,
-    TotalRestarts,
+    ChildId, Exit, Incarnation, Intensity, Membership, RestartCount, Strategy, TotalRestarts,
     admission::{RemoveOutcome, ReserveError},
     engine::{Epoch, MembershipStatus, RequestTarget, ScopeEpochs, ScopeState},
     exit::{StartupError, StopReason},
@@ -432,16 +431,8 @@ impl MemberCell {
             .expect("member options are resolved exactly once");
     }
 
-    fn options(&self) -> ResolvedCommonOptions {
-        self.options.get().cloned().unwrap_or_else(|| {
-            crate::policy::resolve_common(
-                &crate::policy::CommonOptions::default(),
-                &crate::policy::ResolvedDefaults::default(),
-                crate::policy::ChildMode::Restartable,
-                Readiness::Immediate,
-            )
-            .expect("library defaults must be valid")
-        })
+    fn options(&self) -> Option<ResolvedCommonOptions> {
+        self.options.get().cloned()
     }
 
     pub(crate) fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
@@ -1461,6 +1452,9 @@ impl ScopeCell {
     fn child_snapshot_locked(&self, child: &ResidentProjection) -> ChildSnapshot {
         let record = child.member.record();
         let options = child.member.options();
+        let (restart_policy, retention) = options.map_or((None, None), |options| {
+            (Some(options.restart), Some(options.retention))
+        });
         let terminal = matches!(record.stage, MemberStage::Terminal(_));
         let nested = child.scope.as_ref().and_then(|scope| {
             (record.incarnation.is_some() || terminal).then(|| scope.snapshot_locked())
@@ -1483,8 +1477,8 @@ impl ScopeCell {
             last_exit: record.last_exit,
             membership_status: record.membership_status,
             restart_count: record.restart_count,
-            restart_policy: options.restart,
-            retention: options.retention,
+            restart_policy,
+            retention,
             restart_at: record.restart_at,
             nested,
             scope_seq: child

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -196,6 +196,8 @@ pub(crate) struct MemberCell {
     observation_gate: RwLock<ObservationGate>,
     terminal_disposal_pending: AtomicBool,
     mailbox: Mutex<MemberMailbox>,
+    // Lowering resolves this before the member enters resident projection;
+    // snapshots treat a missing value as an internal admission-order bug.
     options: OnceLock<ResolvedCommonOptions>,
     pub(crate) removal: Latch,
 }
@@ -431,8 +433,11 @@ impl MemberCell {
             .expect("member options are resolved exactly once");
     }
 
-    fn options(&self) -> Option<ResolvedCommonOptions> {
-        self.options.get().cloned()
+    fn options(&self) -> ResolvedCommonOptions {
+        self.options
+            .get()
+            .cloned()
+            .expect("resident member options are resolved before snapshot publication")
     }
 
     pub(crate) fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
@@ -1452,9 +1457,6 @@ impl ScopeCell {
     fn child_snapshot_locked(&self, child: &ResidentProjection) -> ChildSnapshot {
         let record = child.member.record();
         let options = child.member.options();
-        let (restart_policy, retention) = options.map_or((None, None), |options| {
-            (Some(options.restart), Some(options.retention))
-        });
         let terminal = matches!(record.stage, MemberStage::Terminal(_));
         let nested = child.scope.as_ref().and_then(|scope| {
             (record.incarnation.is_some() || terminal).then(|| scope.snapshot_locked())
@@ -1477,8 +1479,8 @@ impl ScopeCell {
             last_exit: record.last_exit,
             membership_status: record.membership_status,
             restart_count: record.restart_count,
-            restart_policy,
-            retention,
+            restart_policy: options.restart,
+            retention: options.retention,
             restart_at: record.restart_at,
             nested,
             scope_seq: child

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -196,8 +196,13 @@ pub(crate) struct MemberCell {
     observation_gate: RwLock<ObservationGate>,
     terminal_disposal_pending: AtomicBool,
     mailbox: Mutex<MemberMailbox>,
-    // Lowering resolves this before the member enters resident projection;
-    // snapshots treat a missing value as an internal admission-order bug.
+    // Lowering resolves this before residency in both production routes:
+    // `ChildPlan::with_options` runs ahead of the planned
+    // `set_admitted_children` and ahead of the dynamic `admit_child_locked`.
+    // The enforcement point is snapshot construction rather than admission —
+    // that is the only read, and admitting an unresolved member is a useful
+    // fixture shape — so a missing value surfaces there as an internal
+    // admission-order bug.
     options: OnceLock<ResolvedCommonOptions>,
     pub(crate) removal: Latch,
 }

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -531,6 +531,7 @@ async fn scope_incarnation_exhaustion_closes_nested_observation() {
 async fn never_started_nested_terminal_publishes_one_final_parent_snapshot() {
     let parent = isolated_scope("parent", ScopeFlavor::Ordered);
     let nested = isolated_scope("nested", ScopeFlavor::Ordered);
+    resolve_fixture_options(&nested.member);
     let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
     parent.set_admitted_children(vec![resident_projection(&slot)]);
     let mut snapshots = parent.subscribe_snapshots();

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -1,6 +1,24 @@
 use super::support::*;
 
 #[test]
+#[should_panic(expected = "resident member options are resolved before snapshot publication")]
+fn snapshot_rejects_a_resident_whose_options_were_never_resolved() {
+    let root = isolated_scope("root", ScopeFlavor::Dynamic);
+    let child_id = ChildId::from("worker");
+    let member = MemberCell::new(
+        child_id.clone(),
+        root.child_identity
+            .lock()
+            .expect("scope identity mutex poisoned")
+            .mint_membership(&child_id)
+            .expect("child membership available"),
+    );
+
+    root.admit_child(ResidentProjection::new(member, None));
+    let _ = root.snapshot();
+}
+
+#[test]
 fn independent_systems_do_not_share_an_observation_critical_section() {
     let first = isolated_scope("first", ScopeFlavor::Ordered);
     let second = isolated_scope("second", ScopeFlavor::Ordered);
@@ -254,6 +272,7 @@ async fn wait_for_child_reloads_after_its_predicate_closes_the_snapshot_stream()
         .mint_membership(&child_id)
         .expect("child membership is available");
     let child = MemberCell::new(child_id, membership);
+    resolve_fixture_options(&child);
     let slot = SlotCell::new(Arc::clone(&child), None);
     scope.set_admitted_children(vec![resident_projection(&slot)]);
     let scope_ref = ScopeRef {
@@ -662,6 +681,8 @@ fn plain_resident_state_is_released_before_recursive_removed_publication() {
     let root = isolated_scope("root", ScopeFlavor::Ordered);
     let first = isolated_scope("first", ScopeFlavor::Dynamic);
     let second = isolated_scope("second", ScopeFlavor::Dynamic);
+    resolve_fixture_options(&first.member);
+    resolve_fixture_options(&second.member);
     let first_slot = SlotCell::new(Arc::clone(&first.member), Some(first));
     let second_slot = SlotCell::new(Arc::clone(&second.member), Some(second));
     let mut events = root.subscribe_lifecycle();
@@ -692,6 +713,7 @@ fn plain_parent_state_preserves_nested_snapshot_propagation() {
     let root = isolated_scope("root", ScopeFlavor::Ordered);
     let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
     let mut incarnations = IncarnationCounter::near_exhaustion(nested.member.membership());
+    resolve_fixture_options(&nested.member);
     let nested_slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
     root.set_admitted_children(vec![resident_projection(&nested_slot)]);
     // Start the nested member along the production admit-then-spawn order so

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -20,7 +20,7 @@ pub(super) use crate::{
     exit::RecordedOutcome,
     identity::{IncarnationCounter, ScopeIdentity},
     mailbox::MailboxCell,
-    plan::{BuilderCore, ChildConstruction, SlotCell},
+    plan::{BuilderCore, ChildConstruction, SlotCell, resolve_fixture_options},
     policy::ResolvedDefaults,
     runtime::{CompletionGatedLatch, Latch},
 };

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -1116,9 +1116,9 @@ mod tests {
             "forcing after expiry cannot move the deadline later"
         );
         assert_eq!(
-            ladder.advance(due),
+            ladder.advance(due + Duration::from_secs(1)),
             Some(StopAction::Escalate),
-            "the original due instant remains actionable"
+            "the already-due ladder remains actionable at the force instant"
         );
         assert_eq!(
             ladder.advance(ladder.deadline().expect("tidy deadline")),
@@ -1612,6 +1612,7 @@ mod tests {
         assert!(!epochs.request_is_pending(first));
         assert!(!epochs.request_is_pending(unminted));
         assert!(!epochs.finished(first));
+        assert!(!epochs.finished(unminted));
         assert!(!epochs.finish(unminted));
         assert_eq!(epochs.live_epoch(), Some(first));
         assert!(epochs.finish(first));
@@ -1635,8 +1636,10 @@ mod tests {
         assert_eq!(exhausted.live_epoch(), None);
         assert_eq!(exhausted.request_target(), None);
         assert_eq!(exhausted.begin(), None, "poisoning is permanent");
+        assert!(!exhausted.request_is_pending(last));
         assert!(!exhausted.request_is_pending(Epoch(u64::MAX)));
         assert!(exhausted.finished(last));
+        assert!(!exhausted.finished(Epoch(u64::MAX)));
         assert!(!exhausted.finish(Epoch(u64::MAX)));
     }
 

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -1265,6 +1265,14 @@ mod tests {
         );
     }
 
+    /// Pins the observable behaviour of a charge dated before one already in
+    /// the window; it cannot discriminate `charge`'s `checked_duration_since`
+    /// from the saturating `duration_since`. That guard is defence in depth:
+    /// the saturating form yields `Duration::ZERO` for a regressed clock, and
+    /// `Intensity::validate` rejects a zero `within`, so `ZERO > within` is
+    /// already false for every constructible policy. Replacing the checked
+    /// call with the saturating one leaves this assertion — and the rest of
+    /// the suite — green.
     #[test]
     fn intensity_clock_regression_retains_future_charges() {
         let start = Instant::now();
@@ -1280,7 +1288,7 @@ mod tests {
         let regressed = state.charge(policy, start);
         assert_eq!(
             regressed.in_window, 2,
-            "a regressed clock cannot age a charge from the apparent future"
+            "a charge from the apparent future stays in the window"
         );
         assert_eq!(regressed.total_restarts, TotalRestarts::ZERO.bump().bump());
     }

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -1120,6 +1120,13 @@ mod tests {
             Some(StopAction::Escalate),
             "the original due instant remains actionable"
         );
+        assert_eq!(
+            ladder.advance(ladder.deadline().expect("tidy deadline")),
+            Some(StopAction::HardAbort {
+                phase: GracePhase::AfterGrace
+            }),
+            "force arriving after grace expiry preserves after-grace provenance"
+        );
     }
 
     #[test]
@@ -1165,7 +1172,7 @@ mod tests {
     }
 
     #[test]
-    fn overflowing_grace_never_becomes_immediately_due() {
+    fn overflowing_grace_stays_pending_until_force_rescues_the_ladder() {
         let start = Instant::now();
         let mut ladder = StopLadder::new(Shutdown::Graceful {
             grace: Duration::MAX,
@@ -1174,6 +1181,17 @@ mod tests {
         assert_eq!(ladder.advance(start), Some(StopAction::Cancel));
         assert_eq!(ladder.deadline(), None);
         assert_eq!(ladder.advance(start), None);
+
+        let forced_at = start + Duration::from_secs(1);
+        ladder.force(forced_at);
+        assert_eq!(ladder.deadline(), Some(forced_at));
+        assert_eq!(ladder.advance(forced_at), Some(StopAction::Escalate));
+        assert_eq!(
+            ladder.advance(ladder.deadline().expect("forced tidy deadline")),
+            Some(StopAction::HardAbort {
+                phase: GracePhase::WithinGrace
+            })
+        );
     }
 
     #[test]
@@ -1200,6 +1218,17 @@ mod tests {
                 MembershipStatus::Active
             ),
             ExitDispatch::Terminal
+        );
+        let success = Exit::new(ExitKind::Completed, Cancellation::NotObserved);
+        assert_eq!(
+            dispatch_exit(
+                &success,
+                restart,
+                ScopeMode::Running,
+                MembershipStatus::Active
+            ),
+            ExitDispatch::Terminal,
+            "a running scope still honors a restart policy that declines this exit"
         );
         assert_eq!(
             dispatch_exit(
@@ -1234,6 +1263,26 @@ mod tests {
             aged.total_restarts,
             TotalRestarts::ZERO.bump().bump().bump()
         );
+    }
+
+    #[test]
+    fn intensity_clock_regression_retains_future_charges() {
+        let start = Instant::now();
+        let policy = Intensity::new(5, Duration::from_secs(10)).expect("valid intensity");
+        let mut state = IntensityState::default();
+
+        assert_eq!(
+            state
+                .charge(policy, start + Duration::from_secs(5))
+                .in_window,
+            1
+        );
+        let regressed = state.charge(policy, start);
+        assert_eq!(
+            regressed.in_window, 2,
+            "a regressed clock cannot age a charge from the apparent future"
+        );
+        assert_eq!(regressed.total_restarts, TotalRestarts::ZERO.bump().bump());
     }
 
     #[test]
@@ -1327,6 +1376,7 @@ mod tests {
     fn readiness_configuration_and_signal_deadline_race_are_engine_owned() {
         let deadline = Instant::now();
         let mut ready = ReadinessGate::new();
+        assert!(ready.needs_signal_watch());
         assert_eq!(
             ready.step(ReadinessEvent::Configure {
                 readiness: crate::Readiness::Manual,
@@ -1334,6 +1384,7 @@ mod tests {
             }),
             Some(ReadinessEffect::ArmDeadline { deadline })
         );
+        assert!(ready.needs_signal_watch());
         assert_eq!(
             ready.step(ReadinessEvent::Deadline {
                 now: deadline,
@@ -1341,6 +1392,7 @@ mod tests {
             }),
             Some(ReadinessEffect::BecameReady)
         );
+        assert!(!ready.needs_signal_watch());
         assert_eq!(
             ready.step(ReadinessEvent::Deadline {
                 now: deadline,
@@ -1377,6 +1429,17 @@ mod tests {
             }),
             Some(ReadinessEffect::TimedOut { deadline })
         );
+        assert!(!timed_out.needs_signal_watch());
+
+        let mut immediate = ReadinessGate::new();
+        assert_eq!(
+            immediate.step(ReadinessEvent::Configure {
+                readiness: crate::Readiness::Immediate,
+                deadline: None,
+            }),
+            Some(ReadinessEffect::BecameReady)
+        );
+        assert!(!immediate.needs_signal_watch());
 
         let mut shutdown = ReadinessGate::new();
         assert_eq!(
@@ -1390,6 +1453,7 @@ mod tests {
             shutdown.step(ReadinessEvent::Shutdown),
             Some(ReadinessEffect::Disarmed)
         );
+        assert!(!shutdown.needs_signal_watch());
     }
 
     #[test]
@@ -1545,6 +1609,9 @@ mod tests {
         );
         assert_eq!(epochs.begin(), None, "a live epoch cannot be replaced");
         let unminted = first.successor().expect("a successor epoch is available");
+        assert!(!epochs.request_is_pending(first));
+        assert!(!epochs.request_is_pending(unminted));
+        assert!(!epochs.finished(first));
         assert!(!epochs.finish(unminted));
         assert_eq!(epochs.live_epoch(), Some(first));
         assert!(epochs.finish(first));
@@ -1568,6 +1635,8 @@ mod tests {
         assert_eq!(exhausted.live_epoch(), None);
         assert_eq!(exhausted.request_target(), None);
         assert_eq!(exhausted.begin(), None, "poisoning is permanent");
+        assert!(!exhausted.request_is_pending(Epoch(u64::MAX)));
+        assert!(exhausted.finished(last));
         assert!(!exhausted.finish(Epoch(u64::MAX)));
     }
 

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -521,8 +521,10 @@ mod tests {
         let id = ChildId::from("worker");
         let first_grant = scope.mint_membership(&id).expect("membership available");
         let first = first_grant.membership();
+        assert!(!first.supersedes(first));
         let second_grant = scope.mint_membership(&id).expect("membership available");
         let second = second_grant.membership();
+        assert!(!second.supersedes(second));
         assert!(second.supersedes(first));
         assert!(!first.supersedes(second));
 
@@ -536,6 +538,8 @@ mod tests {
         let (_, mut generations) = first_grant.into_pair();
         let a = generations.mint().expect("incarnation available");
         let b = generations.mint().expect("incarnation available");
+        assert!(!a.supersedes(a));
+        assert!(!b.supersedes(b));
         assert!(b.supersedes(a));
         assert_eq!(a.membership(), first);
         assert!(
@@ -547,6 +551,43 @@ mod tests {
                     .expect("incarnation available")
             )
         );
+    }
+
+    #[test]
+    fn adopted_membership_orders_a_direct_mint_and_later_rebuild() {
+        let id = ChildId::from("worker");
+        let mut declaration = ScopeIdentity::new();
+        let provisional = declaration
+            .mint_membership(&id)
+            .expect("provisional membership available")
+            .membership();
+
+        let mut stable = ScopeIdentity::new();
+        assert!(matches!(
+            stable.adopt_or_mint_membership(&id, provisional),
+            Some(None)
+        ));
+        let direct = stable
+            .mint_membership(&id)
+            .expect("a direct mint follows the adopted generation")
+            .membership();
+
+        let mut rebuilt_declaration = ScopeIdentity::new();
+        let rebuilt = rebuilt_declaration
+            .mint_membership(&id)
+            .expect("rebuilt provisional membership available")
+            .membership();
+        let reconciled = stable
+            .adopt_or_mint_membership(&id, rebuilt)
+            .expect("stable identity is not exhausted")
+            .expect("an occupied stable identity mints a successor")
+            .membership();
+
+        assert!(direct.supersedes(provisional));
+        assert!(reconciled.supersedes(direct));
+        assert!(!direct.supersedes(reconciled));
+        assert!(!rebuilt.supersedes(reconciled));
+        assert!(!reconciled.supersedes(rebuilt));
     }
 
     #[test]

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -201,10 +201,12 @@ pub struct ChildSnapshot {
     pub membership_status: MembershipStatus,
     /// Cumulative scheduled-restart charges for this membership.
     pub restart_count: RestartCount,
-    /// Resolved restart policy.
-    pub restart_policy: RestartPolicy,
-    /// Resolved terminal-retention policy.
-    pub retention: Retention,
+    /// Resolved restart policy, or `None` while an admitted dynamic
+    /// reservation is still being lowered.
+    pub restart_policy: Option<RestartPolicy>,
+    /// Resolved terminal-retention policy, or `None` while an admitted
+    /// dynamic reservation is still being lowered.
+    pub retention: Option<Retention>,
     /// Absolute backoff deadline while restarting, or `None` when the exact
     /// point is too distant for the runtime clock to represent and arm.
     pub restart_at: Option<Instant>,

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -201,12 +201,10 @@ pub struct ChildSnapshot {
     pub membership_status: MembershipStatus,
     /// Cumulative scheduled-restart charges for this membership.
     pub restart_count: RestartCount,
-    /// Resolved restart policy, or `None` while an admitted dynamic
-    /// reservation is still being lowered.
-    pub restart_policy: Option<RestartPolicy>,
-    /// Resolved terminal-retention policy, or `None` while an admitted
-    /// dynamic reservation is still being lowered.
-    pub retention: Option<Retention>,
+    /// Resolved restart policy.
+    pub restart_policy: RestartPolicy,
+    /// Resolved terminal-retention policy.
+    pub retention: Retention,
     /// Absolute backoff deadline while restarting, or `None` when the exact
     /// point is too distant for the runtime clock to represent and arm.
     pub restart_at: Option<Instant>,

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -53,6 +53,20 @@ pub(crate) fn mint_reserved_slot(
     Ok(SlotCell::new(member, scope))
 }
 
+/// Installs a valid option set for a manually constructed resident fixture,
+/// preserving production lowering's resolve-before-residency ordering.
+#[cfg(test)]
+pub(crate) fn resolve_fixture_options(member: &MemberCell) {
+    let options = resolve_common(
+        &CommonOptions::default(),
+        &ResolvedDefaults::default(),
+        ChildMode::Restartable,
+        Readiness::Immediate,
+    )
+    .expect("fixture defaults are valid");
+    member.set_options(options);
+}
+
 enum DefinitionState {
     Undefined,
     Defined(Isolated<ChildConstruction>),

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -332,7 +332,8 @@ fn duration_from_nanos(nanos: f64) -> Duration {
         Duration::MAX
     } else {
         let nanos = rounded.max(0.0) as u128;
-        let seconds = u64::try_from(nanos / 1_000_000_000).unwrap_or(u64::MAX);
+        let seconds = u64::try_from(nanos / 1_000_000_000)
+            .expect("a bounded nanosecond count fits the duration range");
         let subsecond = u32::try_from(nanos % 1_000_000_000)
             .expect("nanosecond remainder is below one billion");
         Duration::new(seconds, subsecond)
@@ -520,7 +521,10 @@ impl Mailbox {
 
 impl Default for Mailbox {
     fn default() -> Self {
-        Self::Queue(NonZeroUsize::new(DEFAULT_MAILBOX_CAPACITY))
+        Self::Queue(Some(
+            NonZeroUsize::new(DEFAULT_MAILBOX_CAPACITY)
+                .expect("the library mailbox capacity is non-zero"),
+        ))
     }
 }
 

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -762,8 +762,9 @@ impl SharedOffloadState {
             return None;
         }
         debug_assert!(!state.polling, "offload work must have one poller");
-        state.polling = true;
-        state.future.take()
+        let future = state.future.take();
+        state.polling = future.is_some();
+        future
     }
 
     fn finish_poll(&self, future: OffloadFuture, outcome: OffloadPoll) -> Option<OffloadFuture> {
@@ -1984,7 +1985,7 @@ mod tests {
     };
 
     use super::{
-        Contained, EventQueue, OffloadResource, PanicSlot, QueuedEvent, RawResources,
+        Contained, EventQueue, OffloadPoll, OffloadResource, PanicSlot, QueuedEvent, RawResources,
         SharedOffloadFuture, SharedOffloadState,
     };
     use crate::runtime::{
@@ -2263,6 +2264,29 @@ mod tests {
         assert_eq!(
             panic_message(&payload),
             Some("unit offload destructor panic")
+        );
+    }
+
+    #[test]
+    fn absent_offload_future_does_not_claim_a_poller() {
+        let state = SharedOffloadState::new(
+            Box::pin(std::future::pending()),
+            Arc::new(PanicSlot::default()),
+            Signal::default(),
+            Latch::default(),
+        );
+        let future = state.take_for_poll().expect("fixture future is present");
+        let dispose = state.finish_poll(future, OffloadPoll::Finished);
+        state.dispose(dispose);
+
+        assert!(state.take_for_poll().is_none());
+        assert!(
+            !state
+                .state
+                .lock()
+                .expect("offload future mutex starts healthy")
+                .polling,
+            "a contract-violating re-poll with no future cannot leave a poller claimed"
         );
     }
 

--- a/crates/shelterwood/src/runtime/timer.rs
+++ b/crates/shelterwood/src/runtime/timer.rs
@@ -30,7 +30,11 @@ fn next_timer_deadline(
         return None;
     }
     let slice = requested.duration_since(current).min(MAX_TIMER_SLICE);
-    current.checked_add(slice)
+    Some(
+        current
+            .checked_add(slice)
+            .expect("a timer slice no later than the requested instant must fit"),
+    )
 }
 
 pub(crate) type BoxedSleep = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -8,14 +8,15 @@ use std::{
 
 use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until};
 use shelterwood::{
-    Actor, ActorDef, ActorOnceDef, ActorRef, Context, DynamicTree, ExitError, ExitResult, Handler,
-    Mailbox, RawActor, RawContext, RawOnceDef, Readiness, ScopeRef, SendErrorKind, StopContext,
-    TaskDef, Tree,
+    Actor, ActorDef, ActorOnceDef, ActorRef, ChildState, Context, DynamicTree, ExitError, ExitKind,
+    ExitResult, Handler, Mailbox, RawActor, RawContext, RawOnceDef, Readiness, Retention, ScopeRef,
+    SendErrorKind, StopContext, TaskDef, Tree,
 };
 
 #[derive(Clone)]
 struct BasicArgs {
     events: Arc<Mutex<Vec<&'static str>>>,
+    expected_id: &'static str,
 }
 
 enum BasicMessage {
@@ -24,6 +25,7 @@ enum BasicMessage {
 
 struct BasicActor {
     events: Arc<Mutex<Vec<&'static str>>>,
+    expected_id: &'static str,
 }
 
 impl Actor for BasicActor {
@@ -38,6 +40,7 @@ impl Actor for BasicActor {
             .push("init");
         Ok(Self {
             events: args.events,
+            expected_id: args.expected_id,
         })
     }
 
@@ -55,7 +58,7 @@ impl Actor for BasicActor {
     }
 
     async fn on_stop(&mut self, context: &mut StopContext<'_, Self>) {
-        assert_eq!(context.id().as_str(), "actor");
+        assert_eq!(context.id().as_str(), self.expected_id);
         self.events
             .lock()
             .expect("events mutex poisoned")
@@ -112,6 +115,7 @@ async fn handler_actor_runs_init_handle_and_stop_through_the_raw_wrapper() {
             "actor",
             ActorOnceDef::<BasicActor>::new(BasicArgs {
                 events: Arc::clone(&events),
+                expected_id: "actor",
             }),
         )
         .expect("valid actor");
@@ -135,6 +139,7 @@ async fn handler_decorator_reenters_the_inner_actor_context_across_callbacks() {
             ActorOnceDef::<Audited<BasicActor>>::new((
                 BasicArgs {
                     events: Arc::clone(&events),
+                    expected_id: "actor",
                 },
                 Arc::clone(&events),
             )),
@@ -310,6 +315,7 @@ async fn restartable_and_dynamic_actor_definition_surfaces_work() {
             count.fetch_add(1, Ordering::SeqCst);
             BasicArgs {
                 events: Arc::clone(&events_for_args),
+                expected_id: "initial",
             }
         }),
     )
@@ -317,6 +323,11 @@ async fn restartable_and_dynamic_actor_definition_surfaces_work() {
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("initial actor starts");
     assert_eq!(inits.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        *events.lock().expect("events mutex poisoned"),
+        ["init"],
+        "the restartable actor definition runs its actor initializer"
+    );
 
     let dynamic_events = Arc::new(Mutex::new(Vec::new()));
     let dynamic = system.scope();
@@ -325,7 +336,9 @@ async fn restartable_and_dynamic_actor_definition_surfaces_work() {
             "dynamic",
             ActorOnceDef::<BasicActor>::new(BasicArgs {
                 events: Arc::clone(&dynamic_events),
-            }),
+                expected_id: "dynamic",
+            })
+            .retention(Retention::Retain),
         )
         .await
         .expect("dynamic actor admitted");
@@ -342,6 +355,19 @@ async fn restartable_and_dynamic_actor_definition_surfaces_work() {
         .send(BasicMessage::Stop)
         .await
         .expect("dynamic actor live");
+    let stopped = dynamic
+        .wait_for_child("dynamic", |child| child.state.is_terminal(), POLL_TIMEOUT)
+        .await
+        .expect("the dynamic actor's requested stop reaches terminal publication");
+    assert!(matches!(
+        stopped.state,
+        ChildState::Stopped { ref exit } if matches!(exit.kind(), ExitKind::Completed)
+    ));
+    assert_eq!(
+        *dynamic_events.lock().expect("events mutex poisoned"),
+        ["init", "handle", "stop"],
+        "the dynamic actor completes its full stop path before the test proceeds"
+    );
     system
         .shutdown(Duration::from_secs(1))
         .await

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -372,6 +372,11 @@ async fn restartable_and_dynamic_actor_definition_surfaces_work() {
         .shutdown(Duration::from_secs(1))
         .await
         .expect("tree shuts down");
+    assert_eq!(
+        *events.lock().expect("events mutex poisoned"),
+        ["init", "stop"],
+        "the restartable actor definition completes its full shutdown path"
+    );
 }
 
 struct ResumeProbeDecorator<R> {

--- a/crates/shelterwood/tests/common/gates.rs
+++ b/crates/shelterwood/tests/common/gates.rs
@@ -1,20 +1,47 @@
 use std::sync::{Arc, Condvar, Mutex};
 
-use tokio::sync::Notify;
+use tokio::sync::Semaphore;
+
+#[derive(Debug)]
+struct ReleaseState {
+    permits: Semaphore,
+    releases: Mutex<()>,
+}
+
+impl Default for ReleaseState {
+    fn default() -> Self {
+        Self {
+            permits: Semaphore::new(0),
+            releases: Mutex::new(()),
+        }
+    }
+}
 
 /// A one-permit asynchronous gate used to sequence child progress.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct ReleaseGate(Arc<Notify>);
+pub(crate) struct ReleaseGate(Arc<ReleaseState>);
 
 impl ReleaseGate {
     /// Waits until the gate is released.
     pub(crate) async fn wait(&self) {
-        self.0.notified().await;
+        self.0
+            .permits
+            .acquire()
+            .await
+            .expect("test release gates are never closed")
+            .forget();
     }
 
     /// Releases one current or future waiter.
+    #[track_caller]
     pub(crate) fn release(&self) {
-        self.0.notify_one();
+        let _release = self.0.releases.lock().expect("release gate mutex poisoned");
+        assert_eq!(
+            self.0.permits.available_permits(),
+            0,
+            "a ReleaseGate cannot store more than one unclaimed release"
+        );
+        self.0.permits.add_permits(1);
     }
 }
 
@@ -81,5 +108,13 @@ mod tests {
         let gate = ReleaseGate::default();
         gate.release();
         gate.wait().await;
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot store more than one unclaimed release")]
+    fn release_gate_rejects_a_collapsed_double_release() {
+        let gate = ReleaseGate::default();
+        gate.release();
+        gate.release();
     }
 }

--- a/crates/shelterwood/tests/common/gates.rs
+++ b/crates/shelterwood/tests/common/gates.rs
@@ -1,29 +1,46 @@
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{
+    Arc, Condvar, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
 
 use tokio::sync::Semaphore;
 
 #[derive(Debug)]
 struct ReleaseState {
     permits: Semaphore,
-    releases: Mutex<()>,
+    // Demand and supply, owned by the gate rather than read back from
+    // `Semaphore::available_permits`. The semaphore reports *storage*, not
+    // intent: it hides a release the instant a waiter is enqueued and
+    // re-stores one when a waiter's `acquire` future is cancelled, so a check
+    // against it both misses and invents over-releases depending on when the
+    // waiting task happened to be polled.
+    waits: AtomicUsize,
+    releases: AtomicUsize,
 }
 
 impl Default for ReleaseState {
     fn default() -> Self {
         Self {
             permits: Semaphore::new(0),
-            releases: Mutex::new(()),
+            waits: AtomicUsize::new(0),
+            releases: AtomicUsize::new(0),
         }
     }
 }
 
 /// A one-permit asynchronous gate used to sequence child progress.
+///
+/// A release never collapses the way `Notify::notify_one` does — the extra
+/// permit is stored and the next waiter claims it — but running more than one
+/// release ahead of the waits that have begun is still a test bug, so the gate
+/// fails loudly instead of letting the surplus go unnoticed.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ReleaseGate(Arc<ReleaseState>);
 
 impl ReleaseGate {
     /// Waits until the gate is released.
     pub(crate) async fn wait(&self) {
+        self.0.waits.fetch_add(1, Ordering::SeqCst);
         self.0
             .permits
             .acquire()
@@ -35,11 +52,12 @@ impl ReleaseGate {
     /// Releases one current or future waiter.
     #[track_caller]
     pub(crate) fn release(&self) {
-        let _release = self.0.releases.lock().expect("release gate mutex poisoned");
-        assert_eq!(
-            self.0.permits.available_permits(),
-            0,
-            "a ReleaseGate cannot store more than one unclaimed release"
+        let issued = self.0.releases.fetch_add(1, Ordering::SeqCst) + 1;
+        let begun = self.0.waits.load(Ordering::SeqCst);
+        assert!(
+            issued <= begun + 1,
+            "a ReleaseGate cannot run more than one release ahead of its waiters \
+             ({issued} releases against {begun} waits)"
         );
         self.0.permits.add_permits(1);
     }
@@ -101,6 +119,12 @@ impl Drop for DestructorBlocker {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        future::Future,
+        sync::atomic::Ordering,
+        task::{Context, Waker},
+    };
+
     use super::ReleaseGate;
 
     #[tokio::test]
@@ -111,10 +135,52 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "cannot store more than one unclaimed release")]
-    fn release_gate_rejects_a_collapsed_double_release() {
+    #[should_panic(expected = "cannot run more than one release ahead of its waiters")]
+    fn release_gate_rejects_a_release_no_waiter_asked_for() {
         let gate = ReleaseGate::default();
         gate.release();
         gate.release();
+    }
+
+    #[tokio::test]
+    async fn release_gate_serves_every_wait_that_has_begun() {
+        let gate = ReleaseGate::default();
+        let first = tokio::spawn({
+            let gate = gate.clone();
+            async move { gate.wait().await }
+        });
+        let second = tokio::spawn({
+            let gate = gate.clone();
+            async move { gate.wait().await }
+        });
+        while gate.0.waits.load(Ordering::SeqCst) < 2 {
+            tokio::task::yield_now().await;
+        }
+
+        // Back-to-back releases for two already-parked waiters are ordinary
+        // usage: the check counts demand, not whichever permits the semaphore
+        // happens to be storing at this instant.
+        gate.release();
+        gate.release();
+
+        first.await.expect("first waiter joins");
+        second.await.expect("second waiter joins");
+    }
+
+    #[tokio::test]
+    async fn cancelling_a_wait_returns_its_release_to_the_gate() {
+        let gate = ReleaseGate::default();
+        let mut waiting = Box::pin(gate.wait());
+        let mut context = Context::from_waker(Waker::noop());
+        assert!(waiting.as_mut().poll(&mut context).is_pending());
+
+        gate.release();
+        // Tokio hands the permit to the parked waiter and takes it back when
+        // that future is dropped. The wait still counts as demand, so the
+        // replacement release is not an over-release.
+        drop(waiting);
+        gate.release();
+
+        gate.wait().await;
     }
 }

--- a/crates/shelterwood/tests/common/ownership.rs
+++ b/crates/shelterwood/tests/common/ownership.rs
@@ -86,12 +86,6 @@ impl PanicOnDrop {
     }
 }
 
-impl Default for PanicOnDrop {
-    fn default() -> Self {
-        Self::new("intentional destructor panic")
-    }
-}
-
 impl Drop for PanicOnDrop {
     fn drop(&mut self) {
         panic!("{}", self.0);

--- a/crates/shelterwood/tests/common/timing.rs
+++ b/crates/shelterwood/tests/common/timing.rs
@@ -37,7 +37,8 @@ pub(crate) async fn poll_until(
     .is_ok()
 }
 
-/// Asserts that a predicate remains false for a bounded quiet window.
+/// Asserts that a predicate is false at 1 ms samples across a bounded quiet
+/// window; it does not observe continuous truth between samples.
 pub(crate) async fn assert_quiet(duration: Duration, mut predicate: impl FnMut() -> bool) {
     const POLL_INTERVAL: Duration = Duration::from_millis(1);
 

--- a/crates/shelterwood/tests/defaults.rs
+++ b/crates/shelterwood/tests/defaults.rs
@@ -97,18 +97,27 @@ async fn default_child_shutdown_grace_is_five_seconds() {
         .await
         .expect("immediate task readiness");
 
+    let shutdown_started = tokio::time::Instant::now();
     let mut shutdown = Box::pin(system.shutdown(Duration::from_secs(60)));
     assert_quiet(Duration::from_millis(50), || {
         poll_once(shutdown.as_mut()).is_ready()
     })
     .await;
-    advance_time(Duration::from_millis(4500)).await;
-    // ~4.55s elapsed: still inside the shipped 5s grace.
+    advance_time(
+        (shutdown_started + Duration::from_millis(4500))
+            .saturating_duration_since(tokio::time::Instant::now()),
+    )
+    .await;
+    // 4.5s elapsed from the captured baseline: still inside the shipped 5s grace.
     assert_quiet(Duration::from_millis(50), || {
         poll_once(shutdown.as_mut()).is_ready()
     })
     .await;
-    advance_time(Duration::from_millis(600)).await;
+    advance_time(
+        (shutdown_started + Duration::from_millis(5100))
+            .saturating_duration_since(tokio::time::Instant::now()),
+    )
+    .await;
     assert!(
         poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             poll_once(shutdown.as_mut()).is_ready()

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -141,7 +141,7 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("actor starts");
 
-    actor.send(Message::Stop).await.expect("stop accepted");
+    let accepting_incarnation = actor.send(Message::Stop).await.expect("stop accepted");
     assert!(
         poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
             stop_entered.load(Ordering::SeqCst)
@@ -168,7 +168,11 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
         .try_send(Message::Value(3))
         .expect_err("frozen intake rejects fail-fast sends");
     assert_eq!(rejection.kind, SendErrorKind::NotRunning);
-    assert!(rejection.incarnation_observed.is_some());
+    assert_eq!(
+        rejection.incarnation_observed,
+        Some(accepting_incarnation),
+        "freeze rejection reports the exact incarnation that accepted the frozen prefix"
+    );
 
     let parked_actor = actor.clone();
     let parked_started = ReleaseGate::default();

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -105,6 +105,7 @@ impl RawActor for WaitingRaw {
 struct SignalledWaitingRaw {
     started: Arc<AtomicBool>,
     cancelled: Arc<AtomicBool>,
+    liveness: Option<(ReleaseGate, Arc<AtomicBool>)>,
 }
 
 impl RawActor for SignalledWaitingRaw {
@@ -112,19 +113,45 @@ impl RawActor for SignalledWaitingRaw {
 
     async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
         self.started.store(true, Ordering::SeqCst);
+        if let Some((gate, observed)) = &self.liveness {
+            let shutdown = context.shutdown_token();
+            tokio::select! {
+                biased;
+                () = shutdown.cancelled() => {
+                    self.cancelled.store(true, Ordering::SeqCst);
+                    return Ok(());
+                }
+                () = gate.wait() => observed.store(true, Ordering::SeqCst),
+            }
+        }
         context.shutdown_token().cancelled().await;
         self.cancelled.store(true, Ordering::SeqCst);
         Ok(())
     }
 }
 
-fn signalled_waiting_tree(started: Arc<AtomicBool>, cancelled: Arc<AtomicBool>) -> Tree {
+fn signalled_waiting_tree(
+    started: Arc<AtomicBool>,
+    cancelled: Arc<AtomicBool>,
+    liveness: Option<(ReleaseGate, Arc<AtomicBool>)>,
+) -> Tree {
     let mut tree = Tree::new();
     let (_, completion) = tree
         .add_task_once(
             "worker",
             TaskOnceDef::new(move |context| async move {
                 started.store(true, Ordering::SeqCst);
+                if let Some((gate, observed)) = liveness {
+                    let shutdown = context.shutdown_token();
+                    tokio::select! {
+                        biased;
+                        () = shutdown.cancelled() => {
+                            cancelled.store(true, Ordering::SeqCst);
+                            return Ok::<_, ExitError>(());
+                        }
+                        () = gate.wait() => observed.store(true, Ordering::SeqCst),
+                    }
+                }
                 context.shutdown_token().cancelled().await;
                 cancelled.store(true, Ordering::SeqCst);
                 Ok::<_, ExitError>(())
@@ -133,6 +160,17 @@ fn signalled_waiting_tree(started: Arc<AtomicBool>, cancelled: Arc<AtomicBool>) 
         .expect("valid signalled task");
     drop(completion);
     tree
+}
+
+async fn assert_positive_liveness(gate: &ReleaseGate, observed: &Arc<AtomicBool>) {
+    gate.release();
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            observed.load(Ordering::SeqCst)
+        })
+        .await,
+        "the detached child must execute work released after its admission future was dropped"
+    );
 }
 
 #[tokio::test]
@@ -683,6 +721,8 @@ async fn select_and_timeout_preserve_fused_and_split_admission_ownership() {
 
     let split_started = Arc::new(AtomicBool::new(false));
     let split_cancelled = Arc::new(AtomicBool::new(false));
+    let split_liveness_gate = ReleaseGate::default();
+    let split_liveness_seen = Arc::new(AtomicBool::new(false));
     let slot = scope
         .reserve_task("split-timeout")
         .expect("split reservation");
@@ -690,11 +730,26 @@ async fn select_and_timeout_preserve_fused_and_split_admission_ownership() {
     let mut split = Box::pin(slot.define(TaskDef::new({
         let split_started = Arc::clone(&split_started);
         let split_cancelled = Arc::clone(&split_cancelled);
+        let split_liveness_gate = split_liveness_gate.clone();
+        let split_liveness_seen = Arc::clone(&split_liveness_seen);
         move |context| {
             let split_started = Arc::clone(&split_started);
             let split_cancelled = Arc::clone(&split_cancelled);
+            let split_liveness_gate = split_liveness_gate.clone();
+            let split_liveness_seen = Arc::clone(&split_liveness_seen);
             async move {
                 split_started.store(true, Ordering::SeqCst);
+                let shutdown = context.shutdown_token();
+                tokio::select! {
+                    biased;
+                    () = shutdown.cancelled() => {
+                        split_cancelled.store(true, Ordering::SeqCst);
+                        return Ok(());
+                    }
+                    () = split_liveness_gate.wait() => {
+                        split_liveness_seen.store(true, Ordering::SeqCst);
+                    }
+                }
                 context.shutdown_token().cancelled().await;
                 split_cancelled.store(true, Ordering::SeqCst);
                 Ok(())
@@ -726,6 +781,7 @@ async fn select_and_timeout_preserve_fused_and_split_admission_ownership() {
         split_cancelled.load(Ordering::SeqCst)
     })
     .await;
+    assert_positive_liveness(&split_liveness_gate, &split_liveness_seen).await;
     assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
     assert!(split_cancelled.load(Ordering::SeqCst));
 
@@ -790,16 +846,33 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
 
     let split_started = Arc::new(AtomicBool::new(false));
     let split_cancelled = Arc::new(AtomicBool::new(false));
+    let split_liveness_gate = ReleaseGate::default();
+    let split_liveness_seen = Arc::new(AtomicBool::new(false));
     let slot = scope.reserve_task("split").expect("split reservation");
     let split_task = slot.task_ref();
     let mut split = Box::pin(slot.define(TaskDef::new({
         let split_started = Arc::clone(&split_started);
         let split_cancelled = Arc::clone(&split_cancelled);
+        let split_liveness_gate = split_liveness_gate.clone();
+        let split_liveness_seen = Arc::clone(&split_liveness_seen);
         move |context| {
             let split_started = Arc::clone(&split_started);
             let split_cancelled = Arc::clone(&split_cancelled);
+            let split_liveness_gate = split_liveness_gate.clone();
+            let split_liveness_seen = Arc::clone(&split_liveness_seen);
             async move {
                 split_started.store(true, Ordering::SeqCst);
+                let shutdown = context.shutdown_token();
+                tokio::select! {
+                    biased;
+                    () = shutdown.cancelled() => {
+                        split_cancelled.store(true, Ordering::SeqCst);
+                        return Ok(());
+                    }
+                    () = split_liveness_gate.wait() => {
+                        split_liveness_seen.store(true, Ordering::SeqCst);
+                    }
+                }
                 context.shutdown_token().cancelled().await;
                 split_cancelled.store(true, Ordering::SeqCst);
                 Ok(())
@@ -818,10 +891,13 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
         split_cancelled.load(Ordering::SeqCst)
     })
     .await;
+    assert_positive_liveness(&split_liveness_gate, &split_liveness_seen).await;
     assert_eq!(scope.remove_task(&split_task).await, RemoveOutcome::Removed);
 
     let split_after_started = Arc::new(AtomicBool::new(false));
     let split_after_cancelled = Arc::new(AtomicBool::new(false));
+    let split_after_liveness_gate = ReleaseGate::default();
+    let split_after_liveness_seen = Arc::new(AtomicBool::new(false));
     let slot = scope
         .reserve_task("split-after-admission")
         .expect("split reservation");
@@ -829,11 +905,26 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
     let mut split_after = Box::pin(slot.define(TaskDef::new({
         let split_after_started = Arc::clone(&split_after_started);
         let split_after_cancelled = Arc::clone(&split_after_cancelled);
+        let split_after_liveness_gate = split_after_liveness_gate.clone();
+        let split_after_liveness_seen = Arc::clone(&split_after_liveness_seen);
         move |context| {
             let split_after_started = Arc::clone(&split_after_started);
             let split_after_cancelled = Arc::clone(&split_after_cancelled);
+            let split_after_liveness_gate = split_after_liveness_gate.clone();
+            let split_after_liveness_seen = Arc::clone(&split_after_liveness_seen);
             async move {
                 split_after_started.store(true, Ordering::SeqCst);
+                let shutdown = context.shutdown_token();
+                tokio::select! {
+                    biased;
+                    () = shutdown.cancelled() => {
+                        split_after_cancelled.store(true, Ordering::SeqCst);
+                        return Ok(());
+                    }
+                    () = split_after_liveness_gate.wait() => {
+                        split_after_liveness_seen.store(true, Ordering::SeqCst);
+                    }
+                }
                 context.shutdown_token().cancelled().await;
                 split_after_cancelled.store(true, Ordering::SeqCst);
                 Ok(())
@@ -852,6 +943,7 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
         split_after_cancelled.load(Ordering::SeqCst)
     })
     .await;
+    assert_positive_liveness(&split_after_liveness_gate, &split_after_liveness_seen).await;
     assert_eq!(
         scope.remove_task(&split_after_task).await,
         RemoveOutcome::Removed
@@ -878,6 +970,7 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
             move || SignalledWaitingRaw {
                 started: Arc::clone(&actor_started),
                 cancelled: Arc::clone(&actor_cancelled),
+                liveness: None,
             }
         }),
     ));
@@ -909,6 +1002,7 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
         SubtreeOnceDef::new(signalled_waiting_tree(
             Arc::clone(&subtree_started),
             Arc::clone(&subtree_cancelled),
+            None,
         )),
     ));
     assert!(poll_once(fused_subtree.as_mut()).is_pending());
@@ -934,6 +1028,8 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
 
     let actor_started = Arc::new(AtomicBool::new(false));
     let actor_cancelled = Arc::new(AtomicBool::new(false));
+    let actor_liveness_gate = ReleaseGate::default();
+    let actor_liveness_seen = Arc::new(AtomicBool::new(false));
     let slot = scope
         .reserve_actor("split-actor")
         .expect("actor reservation succeeds");
@@ -941,6 +1037,10 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
     let mut split_actor = Box::pin(slot.define_once_raw(RawOnceDef::new(SignalledWaitingRaw {
         started: Arc::clone(&actor_started),
         cancelled: Arc::clone(&actor_cancelled),
+        liveness: Some((
+            actor_liveness_gate.clone(),
+            Arc::clone(&actor_liveness_seen),
+        )),
     })));
     assert!(poll_once(split_actor.as_mut()).is_pending());
     assert!(
@@ -954,18 +1054,27 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
         actor_cancelled.load(Ordering::SeqCst)
     })
     .await;
+    assert_positive_liveness(&actor_liveness_gate, &actor_liveness_seen).await;
     assert_eq!(scope.remove_actor(&actor).await, RemoveOutcome::Removed);
     assert!(actor_cancelled.load(Ordering::SeqCst));
 
     let subtree_started = Arc::new(AtomicBool::new(false));
     let subtree_cancelled = Arc::new(AtomicBool::new(false));
+    let subtree_liveness_gate = ReleaseGate::default();
+    let subtree_liveness_seen = Arc::new(AtomicBool::new(false));
     let slot = scope
         .reserve_subtree::<Tree>("split-subtree")
         .expect("subtree reservation succeeds");
     let subtree = slot.scope_ref();
-    let mut split_subtree = Box::pin(slot.define_once(SubtreeOnceDef::new(
-        signalled_waiting_tree(Arc::clone(&subtree_started), Arc::clone(&subtree_cancelled)),
-    )));
+    let mut split_subtree =
+        Box::pin(slot.define_once(SubtreeOnceDef::new(signalled_waiting_tree(
+            Arc::clone(&subtree_started),
+            Arc::clone(&subtree_cancelled),
+            Some((
+                subtree_liveness_gate.clone(),
+                Arc::clone(&subtree_liveness_seen),
+            )),
+        ))));
     assert!(poll_once(split_subtree.as_mut()).is_pending());
     assert!(
         poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
@@ -978,6 +1087,7 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
         subtree_cancelled.load(Ordering::SeqCst)
     })
     .await;
+    assert_positive_liveness(&subtree_liveness_gate, &subtree_liveness_seen).await;
     assert_eq!(scope.remove_scope(&subtree).await, RemoveOutcome::Removed);
     assert!(subtree_cancelled.load(Ordering::SeqCst));
 

--- a/crates/shelterwood/tests/events.rs
+++ b/crates/shelterwood/tests/events.rs
@@ -941,7 +941,6 @@ enum OverflowMessage {
 
 struct OverflowTimerActor {
     fired: Arc<AtomicUsize>,
-    interval: bool,
 }
 
 impl Actor for OverflowTimerActor {
@@ -959,7 +958,7 @@ impl Actor for OverflowTimerActor {
                 .set_timeout("never", OverflowMessage::Fired, Duration::MAX)
                 .expect("live actor arms its timeout");
         }
-        Ok(Self { fired, interval })
+        Ok(Self { fired })
     }
 
     async fn handle(
@@ -968,7 +967,6 @@ impl Actor for OverflowTimerActor {
         _: &mut Context<'_, Self>,
     ) -> ExitResult {
         self.fired.fetch_add(1, Ordering::SeqCst);
-        let _ = self.interval;
         Ok(())
     }
 }

--- a/crates/shelterwood/tests/mailbox.rs
+++ b/crates/shelterwood/tests/mailbox.rs
@@ -8,9 +8,14 @@ use std::{
 
 use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
 use shelterwood::{
-    CallErrorKind, ExitResult, Mailbox, MailboxShutdown, RawActor, RawContext, RawDef, Reply,
-    ReplyError, SendErrorKind, Tree,
+    CallErrorKind, ExitResult, Mailbox, MailboxShutdown, PolicyError, RawActor, RawContext, RawDef,
+    Reply, ReplyError, SendErrorKind, Tree,
 };
+
+#[test]
+fn zero_capacity_queue_is_rejected_at_the_integration_surface() {
+    assert_eq!(Mailbox::queue(0), Err(PolicyError::ZeroCapacity));
+}
 
 #[derive(Debug)]
 enum Message {

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -1323,10 +1323,12 @@ async fn end_to_end_snapshot_projects_kinds_policies_membership_status_and_stopp
     assert_eq!(nested_row.membership_status, MembershipStatus::Active);
     assert_eq!(nested_row.restart_count, RestartCount::ZERO);
     assert!(
-        nested_row.restart_policy.is_never(),
+        nested_row
+            .restart_policy
+            .is_some_and(RestartPolicy::is_never),
         "a one-shot subtree cannot restart"
     );
-    assert_eq!(nested_row.retention, Retention::Retain);
+    assert_eq!(nested_row.retention, Some(Retention::Retain));
     assert_eq!(nested_row.restart_at, None);
 
     let recursive = nested_row.nested.as_ref().expect("nested scope is live");
@@ -1341,8 +1343,8 @@ async fn end_to_end_snapshot_projects_kinds_policies_membership_status_and_stopp
     let worker_row = running
         .descendant(["nested", "worker"])
         .expect("recursion reaches the nested worker");
-    assert_eq!(worker_row.restart_policy, worker_policy);
-    assert_eq!(worker_row.retention, Retention::Retain);
+    assert_eq!(worker_row.restart_policy, Some(worker_policy));
+    assert_eq!(worker_row.retention, Some(Retention::Retain));
     assert_eq!(worker_row.membership_status, MembershipStatus::Active);
 
     let departing_row = running
@@ -1352,9 +1354,12 @@ async fn end_to_end_snapshot_projects_kinds_policies_membership_status_and_stopp
     assert!(matches!(departing_row.state, ChildState::Running));
     assert_eq!(
         departing_row.restart_policy,
-        RestartPolicy::new(RestartCondition::Never, Backoff::Immediate)
+        Some(RestartPolicy::new(
+            RestartCondition::Never,
+            Backoff::Immediate
+        ))
     );
-    assert_eq!(departing_row.retention, Retention::Remove);
+    assert_eq!(departing_row.retention, Some(Retention::Remove));
     assert_eq!(departing_row.membership_status, MembershipStatus::Active);
     assert!(departing_row.nested.is_none());
     assert!(departing_row.scope_seq.is_none());

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -1323,12 +1323,10 @@ async fn end_to_end_snapshot_projects_kinds_policies_membership_status_and_stopp
     assert_eq!(nested_row.membership_status, MembershipStatus::Active);
     assert_eq!(nested_row.restart_count, RestartCount::ZERO);
     assert!(
-        nested_row
-            .restart_policy
-            .is_some_and(RestartPolicy::is_never),
+        nested_row.restart_policy.is_never(),
         "a one-shot subtree cannot restart"
     );
-    assert_eq!(nested_row.retention, Some(Retention::Retain));
+    assert_eq!(nested_row.retention, Retention::Retain);
     assert_eq!(nested_row.restart_at, None);
 
     let recursive = nested_row.nested.as_ref().expect("nested scope is live");
@@ -1343,8 +1341,8 @@ async fn end_to_end_snapshot_projects_kinds_policies_membership_status_and_stopp
     let worker_row = running
         .descendant(["nested", "worker"])
         .expect("recursion reaches the nested worker");
-    assert_eq!(worker_row.restart_policy, Some(worker_policy));
-    assert_eq!(worker_row.retention, Some(Retention::Retain));
+    assert_eq!(worker_row.restart_policy, worker_policy);
+    assert_eq!(worker_row.retention, Retention::Retain);
     assert_eq!(worker_row.membership_status, MembershipStatus::Active);
 
     let departing_row = running
@@ -1354,12 +1352,9 @@ async fn end_to_end_snapshot_projects_kinds_policies_membership_status_and_stopp
     assert!(matches!(departing_row.state, ChildState::Running));
     assert_eq!(
         departing_row.restart_policy,
-        Some(RestartPolicy::new(
-            RestartCondition::Never,
-            Backoff::Immediate
-        ))
+        RestartPolicy::new(RestartCondition::Never, Backoff::Immediate)
     );
-    assert_eq!(departing_row.retention, Some(Retention::Remove));
+    assert_eq!(departing_row.retention, Retention::Remove);
     assert_eq!(departing_row.membership_status, MembershipStatus::Active);
     assert!(departing_row.nested.is_none());
     assert!(departing_row.scope_seq.is_none());


### PR DESCRIPTION
## Summary

Completes every item under #193's top-level items 40 and 41, plus adversarial review fixes.

### Item 40 — correctness-adjacent polish

- Stops `MemberCell::options()` from inventing library defaults on every unresolved read. Production lowering resolves options before resident snapshot publication; a missing value is now an explicit internal invariant failure, while the existing non-optional `ChildSnapshot::restart_policy` and `retention` API remains intact.
- Gives `NotAdmittingCause` a stable `Display` contract and makes `ReserveError::NotAdmitting` use it instead of leaking `Debug`.
- Fills the named engine test quadrants:
  - force after grace expiry preserves `AfterGrace`
  - force rescues an unrepresentable/infinite grace
  - `ScopeEpochs::request_is_pending` / `finished` in live and exhausted states
  - a running scope whose policy declines restart
  - intensity accounting under clock regression
  - every `needs_signal_watch` state
- Keeps `take_for_poll` from claiming `polling` when no offload future exists.
- Replaces the impossible fallback postures in runtime/policy duration and mailbox-default arithmetic with proof-carrying `expect` calls.

### Item 41 — test-suite polish

- Pins frozen-mailbox rejection to the exact accepting incarnation.
- Makes every split-admission drop test prove positive post-drop liveness before performing the removal that legitimately cancels the child.
- Integration-pins zero-capacity mailbox rejection.
- Pins membership/incarnation `supersedes` irreflexivity and the adopt → direct mint → rebuild ordering interleaving.
- Removes the vestigial overflow-timer interval field.
- Makes the actor surface test assert both event histories and await the dynamic actor's terminal publication.
- Computes default shutdown-grace timing from a captured virtual-time baseline.
- Replaces `ReleaseGate`'s silently collapsing stored notify with a one-permit semaphore plus a double-release assertion.
- Removes the dead `PanicOnDrop::default()` implementation.
- Documents that `assert_quiet` samples at 1 ms rather than observing continuous truth.

## Adversarial review fixes

- Preserves the normative non-optional snapshot policy fields instead of introducing an unnecessary public API break.
- Pins the resolve-before-residency invariant with a negative test and repairs manual driver fixtures that had relied on fabricated fallback values.
- Keeps the force-after-expiry test on monotonic clock inputs.
- Strengthens live/exhausted epoch assertions and verifies the restartable actor's complete shutdown callback history.

## Impact

Production behavior and the public snapshot API remain compatible. Missing option resolution is no longer masked by fabricated library defaults; it is treated as an internal admission-order bug. The remaining production changes tighten diagnostics and invariants without changing intended runtime behavior. Item 41 changes are test-only hardening.

## Commits

- `27a4866` — item 40
- `d8f7299` — item 41
- `17650bf` — adversarial review fixes

## Validation

- `./tools/dev cargo test -p shelterwood --lib` — 244 passed
- `./tools/dev cargo test -p shelterwood --test integration` — 299 passed
- `./tools/dev just ci` — passed, including nightly fmt, clippy with `-D warnings`, 547 nextest tests, doctests, rustdoc/API reachability, path/layering/enforcement checks, packaged-crate verification, and nixfmt

Closes #193