### PR TITLE
Fix latent driver hazards and pre-loop verdict precedence

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2023,7 +2023,9 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
   as the scope's terminal reason. A nested lowering failure before the
   driver loop follows the same rule: a stop request already latched for
   its epoch, or a fired ancestor-shutdown latch, upgrades the terminal
-  reason and pending startup result to `ShutdownRequested`. Ladder deadlines
+  reason and pending startup result to `ShutdownRequested` — and, like the
+  loop path, records the stop as observed, so the scope still exits at its
+  parent as a cancelled `Completed` (§11). Ladder deadlines
   share the posture: a forced escalation only ever moves a deadline
   *earlier* (`min`), never later. (`NeverStarted` sits outside the order — it
   is the terminal reason of a membership that never had an incarnation to

--- a/SPEC.md
+++ b/SPEC.md
@@ -2020,10 +2020,14 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
   therefore cannot lose its verdict to a lower-precedence cause that
   latched one wake earlier: a restartable exit that trips intensity in
   the same batch as a shutdown request still yields `ShutdownRequested`
-  as the scope's terminal reason. Ladder deadlines share the posture: a
-  forced escalation only ever moves a deadline *earlier* (`min`), never
-  later. (`NeverStarted` sits outside the order — it is the terminal
-  reason of a membership that never had an incarnation to drain.)
+  as the scope's terminal reason. A nested lowering failure before the
+  driver loop follows the same rule: a stop request already latched for
+  its epoch, or a fired ancestor-shutdown latch, upgrades the terminal
+  reason and pending startup result to `ShutdownRequested`. Ladder deadlines
+  share the posture: a forced escalation only ever moves a deadline
+  *earlier* (`min`), never later. (`NeverStarted` sits outside the order — it
+  is the terminal reason of a membership that never had an incarnation to
+  drain.)
 - Mailbox shutdown policy — `Drain` (the default) or `Discard` — is part
   of the actor options. It is a two-variant choice about exactly one
   thing: the fate of the frozen accepted prefix (§5.2). The intake

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -1095,6 +1095,10 @@ impl ScopeCell {
             if current.same_gate(gate) {
                 return;
             }
+            debug_assert!(
+                self.dynamic_route_in(txn).is_none(),
+                "a scope with a live dynamic route is never re-homed"
+            );
 
             #[cfg(test)]
             self.report_gate_capture(GateCapture::Adoption);
@@ -1137,7 +1141,10 @@ impl ScopeCell {
 
     /// Re-homes a resident subtree while its prior tree gate is held. The
     /// destination gate is also held, so observers cannot enter either tree
-    /// while the handoff is installed recursively.
+    /// while the handoff is installed recursively. Walking residents is
+    /// exhaustive here: a reserved dynamic slot requires the live route that
+    /// only a started driver installs, while gate adoption happens before
+    /// that driver can run, and no running scope is subsequently re-homed.
     fn adopt_descendant_observation_gates_locked(
         &self,
         previous: &ObservationGate,

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -601,9 +601,24 @@ async fn run_nested_tree_with_epoch(
             // through the same monotone verdict lattice as the loop path.
             // Peek rather than consume: `finish_incarnation` clears both
             // epoch-tagged request latches after publishing the verdict.
+            // The ancestor *abort* latch needs no separate arm: it is the
+            // framework-abort edge, fired only by `StopAction::AbortFramework`,
+            // and the stop ladder unconditionally passes through
+            // `StopAction::Cancel` — which fires this same ancestor shutdown
+            // latch — before it can reach that phase.
             if scope.has_stop_request(epoch.epoch()) || latches.ancestor.shutdown.is_fired() {
+                // Mirror the loop's `Pending::Shutdown` arm: firing the
+                // ancestor shutdown latch is what makes this scope's exit read
+                // `Cancellation::Observed` at its parent, as a requested stop
+                // must (§11). The latch is level-triggered, so re-firing an
+                // ancestor-driven stop is a no-op.
+                latches.ancestor.shutdown.fire();
                 epoch.lifecycle.begin_drain(StopReason::ShutdownRequested);
             }
+            // Both drain effects are deliberately discarded: this path
+            // publishes no `Draining` edge because nothing was ever started to
+            // drain, matching the pre-lattice behaviour of the `StartupFailed`
+            // verdict it generalizes.
             epoch
                 .lifecycle
                 .begin_drain(StopReason::StartupFailed(failure));

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -498,6 +498,11 @@ impl ScopeEpochGuard {
         self.lifecycle.clone()
     }
 
+    fn epoch(&self) -> Epoch {
+        self.epoch
+            .expect("an owned scope epoch remains available until transfer or finish")
+    }
+
     fn finish(mut self, reason: StopReason) {
         let epoch = self
             .epoch
@@ -564,7 +569,7 @@ async fn run_nested_tree_with_epoch(
     scope: Arc<ScopeCell>,
     inherited: ResolvedDefaults,
     latches: NestedScopeLatches,
-    epoch: ScopeEpochGuard,
+    mut epoch: ScopeEpochGuard,
 ) -> crate::ExitResult {
     let plan = match tree.lower(inherited, Some(Arc::clone(&scope))) {
         Ok(plan) => plan,
@@ -591,9 +596,36 @@ async fn run_nested_tree_with_epoch(
             // cancellation-safe disposal jobs.
             disposal.fired().await;
             let failure = StartupFailure { cause };
-            scope.set_startup(Err(StartupError::StartupFailed(failure.clone())));
-            epoch.finish(StopReason::StartupFailed(failure.clone()));
-            return Err(crate::ExitError::from_startup_failure(failure));
+            // A lowering failure occurs before the driver loop exists, but it
+            // still belongs to a live incarnation. Resolve every stop source
+            // through the same monotone verdict lattice as the loop path.
+            // Peek rather than consume: `finish_incarnation` clears both
+            // epoch-tagged request latches after publishing the verdict.
+            if scope.has_stop_request(epoch.epoch()) || latches.ancestor.shutdown.is_fired() {
+                epoch.lifecycle.begin_drain(StopReason::ShutdownRequested);
+            }
+            epoch
+                .lifecycle
+                .begin_drain(StopReason::StartupFailed(failure));
+            let reason = epoch
+                .lifecycle
+                .draining_reason()
+                .cloned()
+                .expect("pre-loop verdicts enter the drain lattice");
+            let startup = match &reason {
+                StopReason::ShutdownRequested => Err(StartupError::ShutdownRequested),
+                StopReason::StartupFailed(failure) => {
+                    Err(StartupError::StartupFailed(failure.clone()))
+                }
+                StopReason::Finished
+                | StopReason::IntensityTripped(_)
+                | StopReason::NeverStarted => {
+                    unreachable!("lowering resolves only failure or shutdown verdicts")
+                }
+            };
+            scope.set_startup(startup);
+            epoch.finish(reason.clone());
+            return reason.into_nested_result();
         }
     };
     run_scope_incarnation(plan.take_for_runtime(), ScopeRole::Nested(latches), epoch)

--- a/crates/shelterwood/src/driver/events.rs
+++ b/crates/shelterwood/src/driver/events.rs
@@ -214,6 +214,10 @@ impl ScopeRuntime {
         }
         child.restart_shutdown_pending = None;
         self.spawn_child(key);
+        // This path runs outside the ordered-startup loop. Revisit the
+        // aggregate in case the spawn became ready synchronously, just like a
+        // restart-deadline spawn below.
+        self.progress_startup();
     }
 
     pub(super) fn handle_deadline(&mut self, deadline: DeadlineKind) {

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -64,7 +64,11 @@ impl ScopeRuntime {
             self.finalize_removal(key);
         } else {
             self.begin_stop_child(key, None);
-            if self.children[key].is_terminal() {
+            if self
+                .children
+                .get(key)
+                .is_some_and(ChildRuntime::is_terminal)
+            {
                 self.finalize_removal(key);
             }
         }

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -383,6 +383,59 @@ async fn final_removal_holds_the_id_until_removed_publication_commits() {
     );
 }
 
+#[crate::runtime::test]
+async fn removal_tolerates_synchronous_reclaim_from_the_stop_funnel() {
+    let (mut scope, _events, _dynamic_events, _disposal_events, control) =
+        running_dynamic_fixture();
+    let root = Arc::clone(&scope.root);
+    let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
+        .expect("running dynamic scope reserves the child");
+    let member = Arc::clone(&reservation.slot.member);
+    reservation
+        .slot
+        .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
+    let (definition, resolved) = reservation
+        .slot
+        .resolve_and_take_defined(&scope.defaults)
+        .expect("the definition has not been claimed")
+        .expect("the slot is defined");
+    let plan =
+        crate::plan::ChildPlan::with_options(Arc::clone(&reservation.slot), definition, resolved);
+    let mut child = ChildRuntime::from_plan(plan, &root);
+    child.initial = false;
+    // Model the latent restart-gap shape: there is no active incarnation and
+    // no retained construction, so a hard-force stop can terminalize and
+    // reclaim this Removing member synchronously from `begin_stop_child`.
+    drop(child.construction.take());
+    let key = root.with_observation_gate(|txn| {
+        let key = scope
+            .insert_child(child)
+            .unwrap_or_else(|_| panic!("the empty arena accepts its first child"));
+        control
+            .state
+            .lock()
+            .expect("dynamic-state mutex poisoned")
+            .entries
+            .get_mut(member.id())
+            .expect("the reservation remains registered")
+            .promote(key, None, txn);
+        root.admit_child_locked(resident_projection(&reservation.slot), txn);
+        key
+    });
+    scope.hard_forced = true;
+
+    scope.handle_removal(RemovalRequest {
+        membership: member.membership(),
+        key,
+    });
+
+    assert!(
+        scope.children.get(key).is_none(),
+        "the stop funnel may reclaim the member before handle_removal returns"
+    );
+    assert!(root.snapshot().child("worker").is_none());
+}
+
 #[test]
 fn draining_cannot_publish_across_an_inflight_reservation_transaction() {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -517,7 +517,7 @@ async fn assert_pre_loop_stop_upgrades_a_nested_lowering_failure(source: PreLoop
         NestedScopeLatches {
             parent_ready: ready.clone(),
             ancestor: AncestorCommandLatches {
-                shutdown: ancestor_shutdown,
+                shutdown: ancestor_shutdown.clone(),
                 abort: Latch::default(),
                 abort_ack: Latch::default(),
             },
@@ -527,6 +527,10 @@ async fn assert_pre_loop_stop_upgrades_a_nested_lowering_failure(source: PreLoop
     .await;
 
     assert!(result.is_ok());
+    assert!(
+        ancestor_shutdown.is_fired(),
+        "the upgraded verdict fires the latch that reports the exit as cancelled"
+    );
     assert!(matches!(
         scope.record().startup,
         Some(Err(StartupError::ShutdownRequested))

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -467,6 +467,63 @@ async fn nested_membership_exhaustion_is_structured_and_fail_closed() {
 }
 
 #[crate::runtime::test]
+async fn pre_loop_shutdown_upgrades_a_nested_lowering_failure() {
+    let nested_id = ChildId::from("nested");
+    let mut parent_identity = ScopeIdentity::new();
+    let nested_membership = parent_identity
+        .mint_membership(&nested_id)
+        .expect("nested membership available");
+    let nested_member = MemberCell::new(nested_id, nested_membership);
+
+    let worker_id = ChildId::from("worker");
+    let mut child_identity = ScopeIdentity::near_exhaustion(worker_id.clone(), 7);
+    child_identity
+        .mint_membership(&worker_id)
+        .expect("last usable membership is minted before the rebuild");
+    let scope = ScopeCell::new(nested_member, ScopeFlavor::Ordered, child_identity);
+
+    let mut tree = Tree::new();
+    let worker = tree
+        .add_task(
+            worker_id,
+            TaskDef::new(|_| future::pending::<crate::ExitResult>()),
+        )
+        .expect("provisional declaration succeeds");
+    let _target = scope
+        .request_shutdown()
+        .expect("declaration-time shutdown targets the first epoch");
+    let ready = CompletionGatedLatch::default();
+    let result = run_nested_tree(
+        tree.into_core_for_test(),
+        Arc::clone(&scope),
+        crate::policy::ResolvedDefaults::default(),
+        NestedScopeLatches {
+            parent_ready: ready.clone(),
+            ancestor: AncestorCommandLatches {
+                shutdown: Latch::default(),
+                abort: Latch::default(),
+                abort_ack: Latch::default(),
+            },
+        },
+    )
+    .await;
+
+    assert!(result.is_ok());
+    assert!(matches!(
+        scope.record().startup,
+        Some(Err(StartupError::ShutdownRequested))
+    ));
+    assert!(matches!(
+        scope.record().state,
+        ScopeState::Stopped {
+            reason: StopReason::ShutdownRequested
+        }
+    ));
+    assert!(!ready.is_fired());
+    assert!(matches!(worker.wait().await.kind(), ExitKind::NeverStarted));
+}
+
+#[crate::runtime::test]
 async fn scope_incarnation_exhaustion_closes_nested_observation() {
     let parent = isolated_scope("parent", ScopeFlavor::Ordered);
     let mut identity = ScopeIdentity::new();

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -466,8 +466,14 @@ async fn nested_membership_exhaustion_is_structured_and_fail_closed() {
     assert!(matches!(worker.wait().await.kind(), ExitKind::NeverStarted));
 }
 
-#[crate::runtime::test]
-async fn pre_loop_shutdown_upgrades_a_nested_lowering_failure() {
+#[derive(Clone, Copy)]
+enum PreLoopStopSource {
+    ScopeShutdown,
+    ScopeForce,
+    AncestorShutdown,
+}
+
+async fn assert_pre_loop_stop_upgrades_a_nested_lowering_failure(source: PreLoopStopSource) {
     let nested_id = ChildId::from("nested");
     let mut parent_identity = ScopeIdentity::new();
     let nested_membership = parent_identity
@@ -489,22 +495,34 @@ async fn pre_loop_shutdown_upgrades_a_nested_lowering_failure() {
             TaskDef::new(|_| future::pending::<crate::ExitResult>()),
         )
         .expect("provisional declaration succeeds");
-    let _target = scope
-        .request_shutdown()
-        .expect("declaration-time shutdown targets the first epoch");
+    let epoch = ScopeEpochGuard::begin(&scope).expect("the first nested epoch is available");
+    let ancestor_shutdown = Latch::default();
+    match source {
+        PreLoopStopSource::ScopeShutdown => {
+            let target = scope
+                .request_shutdown()
+                .expect("declaration-time shutdown targets the live epoch");
+            assert_eq!(target, epoch.epoch());
+        }
+        PreLoopStopSource::ScopeForce => scope.force_shutdown(epoch.epoch()),
+        PreLoopStopSource::AncestorShutdown => {
+            ancestor_shutdown.fire();
+        }
+    }
     let ready = CompletionGatedLatch::default();
-    let result = run_nested_tree(
+    let result = super::super::run_nested_tree_with_epoch(
         tree.into_core_for_test(),
         Arc::clone(&scope),
         crate::policy::ResolvedDefaults::default(),
         NestedScopeLatches {
             parent_ready: ready.clone(),
             ancestor: AncestorCommandLatches {
-                shutdown: Latch::default(),
+                shutdown: ancestor_shutdown,
                 abort: Latch::default(),
                 abort_ack: Latch::default(),
             },
         },
+        epoch,
     )
     .await;
 
@@ -521,6 +539,22 @@ async fn pre_loop_shutdown_upgrades_a_nested_lowering_failure() {
     ));
     assert!(!ready.is_fired());
     assert!(matches!(worker.wait().await.kind(), ExitKind::NeverStarted));
+}
+
+#[crate::runtime::test]
+async fn pre_loop_shutdown_upgrades_a_nested_lowering_failure() {
+    assert_pre_loop_stop_upgrades_a_nested_lowering_failure(PreLoopStopSource::ScopeShutdown).await;
+}
+
+#[crate::runtime::test]
+async fn pre_loop_force_upgrades_a_nested_lowering_failure() {
+    assert_pre_loop_stop_upgrades_a_nested_lowering_failure(PreLoopStopSource::ScopeForce).await;
+}
+
+#[crate::runtime::test]
+async fn pre_loop_ancestor_shutdown_upgrades_a_nested_lowering_failure() {
+    assert_pre_loop_stop_upgrades_a_nested_lowering_failure(PreLoopStopSource::AncestorShutdown)
+        .await;
 }
 
 #[crate::runtime::test]

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -814,3 +814,33 @@ fn gate_handoff_waits_for_an_in_flight_observation_edge() {
             .same_gate(&nested.observation_gate())
     );
 }
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "a scope with a live dynamic route is never re-homed")]
+fn gate_handoff_rejects_a_scope_with_an_unadmitted_dynamic_reservation() {
+    let root = isolated_scope("root", ScopeFlavor::Ordered);
+    let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
+    nested
+        .member
+        .update(|record| record.stage = MemberStage::Running);
+    nested.set_state(ScopeState::Running);
+    let (events, _receiver) = crate::runtime::unbounded_mpsc();
+    let control = DynamicControl::new(events);
+    nested.set_dynamic_route(Some(control));
+    let _reservation = nested
+        .with_observation_gate(|txn| {
+            super::super::admission_control::reserve_dynamic_in(
+                &nested,
+                ChildId::from("reserved"),
+                None,
+                txn,
+            )
+        })
+        .expect("the synthetic running scope reserves a child");
+    let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
+
+    // Public layering cannot reach this adoption: a reservation requires a
+    // started driver, while a scope is parented before its driver starts.
+    root.set_admitted_children(vec![resident_projection(&slot)]);
+}

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -135,6 +135,62 @@ async fn pre_admission_restart_shutdown_does_not_expedite_the_following_incarnat
     assert!(scope.children[key].restart_shutdown_pending.is_none());
 }
 
+#[crate::runtime::test]
+async fn expedited_restart_progresses_synchronous_readiness() {
+    let mut tree = Tree::new();
+    tree.add_subtree("nested", SubtreeDef::factory(pending_tree))
+        .expect("valid subtree");
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let nested_cell = Arc::clone(
+        plan.children[0]
+            .slot
+            .scope
+            .as_ref()
+            .expect("nested scope cell"),
+    );
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
+    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+    let mut child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+    // Scope definitions currently resolve to Manual and expose no public
+    // readiness setter. Model that API invariant changing: the expedited
+    // restart must still release ordered startup when configuration produces
+    // an immediate readiness effect.
+    child.options.readiness = Readiness::Immediate;
+    child.spawned_once = true;
+    let mut children = ChildArena::default();
+    let key = children
+        .insert(child)
+        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+        .with_defaults(plan.defaults.clone())
+        .with_children(children)
+        .with_next_ordered_start(Some(key))
+        .build();
+    plan.take_for_runtime().finish_transfer();
+    let target = nested_cell
+        .request_shutdown()
+        .expect("the shutdown targets the pending nested incarnation");
+
+    scope.expedite_restart_shutdown(key, target);
+
+    assert!(scope.children[key].initial_ready);
+    assert!(
+        scope.lifecycle.startup_complete(),
+        "synchronous readiness from an expedited spawn advances aggregate startup"
+    );
+    assert_eq!(root.record().startup, Some(Ok(())));
+}
+
 /// A shutdown request against a nested scope's *first* (still pending)
 /// incarnation, published before the ordered start reaches that child, must
 /// not expedite-spawn it: only a member in the restart gap may bypass

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -542,15 +542,13 @@ impl LifecycleEvents {
             // reports lag when `len` exceeds the effective capacity; 128 is
             // already a power of two, so the effective capacity is exact.
             if self.events.len() > LIFECYCLE_EVENT_CAPACITY {
-                match self.events.try_receive() {
-                    runtime::BroadcastReceive::Lagged(overflow) => {
-                        dropped = dropped.saturating_add(overflow);
-                    }
-                    runtime::BroadcastReceive::Item(_)
-                    | runtime::BroadcastReceive::Empty
-                    | runtime::BroadcastReceive::Closed => {
-                        unreachable!("a lagging broadcast receiver reports its dropped prefix")
-                    }
+                let overflow = self.events.try_receive();
+                debug_assert!(
+                    matches!(&overflow, runtime::BroadcastReceive::Lagged(_)),
+                    "a lagging broadcast receiver should report its dropped prefix"
+                );
+                if let runtime::BroadcastReceive::Lagged(overflow) = overflow {
+                    dropped = dropped.saturating_add(overflow);
                 }
             }
             return Ok(LifecycleItem::Lagged { dropped });

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -953,7 +953,17 @@ impl<M> RawResources<M> {
     async fn join_offloads(&mut self) {
         for offload in &mut self.offloads {
             if let Some(task) = offload.task.take() {
-                task.join().await;
+                match task.join().await {
+                    runtime::JoinOutcome::Ok { value: () } | runtime::JoinOutcome::Cancelled => {}
+                    runtime::JoinOutcome::Panic { message } => {
+                        let message = message.unwrap_or_else(|| {
+                            "library-owned offload task panicked without a string payload"
+                                .to_owned()
+                        });
+                        tracing::error!(%message, "library-owned offload task panicked");
+                        self.panic.record(Box::new(message));
+                    }
+                }
             }
         }
         self.events.clear();
@@ -2290,6 +2300,30 @@ mod tests {
             "reclamation retains exactly the unfinished offloads"
         );
         assert!(!resources.offloads[0].finished.is_fired());
+    }
+
+    #[crate::runtime::test]
+    async fn joining_offloads_retains_a_framework_task_panic() {
+        let mut resources = RawResources::<()>::default();
+        resources.offloads.push(OffloadResource {
+            cancellation: Latch::default(),
+            finished: Latch::default(),
+            state: None,
+            task: Some(crate::runtime::spawn_actor_work(async {
+                panic!("unit framework offload panic");
+            })),
+        });
+
+        resources.join_offloads().await;
+
+        let payload = resources
+            .panic
+            .take()
+            .expect("the framework panic is retained for incarnation teardown");
+        assert_eq!(
+            panic_message(&payload),
+            Some("unit framework offload panic")
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/runtime/spawn.rs
+++ b/crates/shelterwood/src/runtime/spawn.rs
@@ -27,11 +27,11 @@ impl ActorWork {
         self.abort.abort();
     }
 
-    pub(crate) async fn join(mut self) {
+    pub(crate) async fn join(mut self) -> JoinOutcome<()> {
         let Some(handle) = self.handle.take() else {
-            return;
+            return JoinOutcome::Cancelled;
         };
-        let _ = join(handle).await;
+        join(handle).await
     }
 }
 

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -828,6 +828,48 @@ async fn locally_requested_subtree_shutdown_reads_cancelled() {
     );
 }
 
+/// The pre-driver lowering-failure path resolves the same verdict as the loop
+/// above, including the cancellation evidence: a stop request latched against
+/// the first (still pending) incarnation outranks the lowering failure, so the
+/// subtree exits `Completed`/`Observed` rather than `Failed`.
+#[tokio::test]
+async fn shutdown_latched_before_a_subtree_lowering_failure_reads_cancelled() {
+    let mut nested = Tree::new();
+    let _undefined = nested.reserve_task("missing").expect("reservation");
+    let mut root = Tree::new();
+    let sub = root
+        .add_subtree_once("nested", SubtreeOnceDef::new(nested))
+        .expect("valid subtree edge");
+    // Declaration-time request: it latches against the incarnation the nested
+    // driver has not minted yet, so lowering fails with the stop already held.
+    sub.request_shutdown();
+    let system = root.spawn().expect("runtime is available");
+    let startup = system
+        .wait_started()
+        .await
+        .expect_err("the nested stop aborts parent startup pre-ready");
+    let StartupError::StartupFailed(failure) = startup else {
+        panic!("unexpected startup error: {startup:?}");
+    };
+    let StartupFailureCause::Child { id, exit, .. } = &failure.cause else {
+        panic!("unexpected failure cause: {:?}", failure.cause);
+    };
+    assert_eq!(id.as_str(), "nested");
+    assert!(
+        matches!(exit.kind(), ExitKind::Completed),
+        "the latched stop outranks the lowering failure: {exit:?}"
+    );
+    assert_eq!(
+        exit.cancellation(),
+        Cancellation::Observed,
+        "a pre-loop stop request is still a stop request: {exit:?}"
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("the stopped root rolls back");
+}
+
 #[tokio::test(start_paused = true)]
 async fn restart_attempt_resets_after_a_ready_incarnation_settles() {
     let starts = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
## Summary

Addresses all six checklist items in #187:

- hardens removal against synchronous child reclaim and ensures expedited restarts revisit aggregate startup;
- degrades the public lifecycle lag path safely and retains unexpected framework offload panics for teardown diagnostics;
- routes pre-driver nested lowering verdicts through the drain-reason lattice, including the 2026-08-11 route-through-lattice adjudication and its SPEC update;
- documents and debug-asserts why reserved dynamic slots cannot cross observation-gate re-homes.

## Item-to-commit map

- **A — item 9, `handle_removal` stale key:** `36ad1e1` Guard removal after synchronous reclaim
- **B — item 9, expedited readiness:** `69fa7ec` Progress startup after expedited restart
- **C — item 10, lifecycle broadcast invariant:** `8ad6711` Degrade lifecycle lag invariant safely
- **D — item 10, discarded framework panic:** `22d233c` Retain framework offload task panics
- **E — pre-loop drain-lattice adjudication:** `f4f3190` Route pre-loop verdicts through drain lattice
- **F — reserved-slot observation gate invariant:** `5136eea` Assert reserved slots cannot cross gate re-homes

## Adversarial review follow-up

- `522c1b0` Cover every pre-loop stop source — proves item E independently for direct shutdown, forced shutdown, and fired ancestor-shutdown latches.

## Impact

The scope driver no longer risks indexing a synchronously reclaimed child, expedited restart readiness cannot strand startup, and lifecycle lag handling has a release-mode fallback instead of an unconditional panic. Framework-owned offload task panics are preserved as cleanup evidence. A shutdown that is already latched when nested lowering fails now wins according to SPEC §10, producing `ShutdownRequested` consistently for the scope state, startup result, and parent-visible exit.

## Root cause

These sites relied on non-local invariants: child reclaim could occur synchronously through the stop funnel, the expedited spawn path assumed nested scopes could never be immediately ready, lifecycle receive logic depended on Tokio broadcast details, and offload join discarded a supposedly unreachable panic. Separately, nested lowering failure minted `StartupFailed` before entering the driver loop, bypassing the monotone drain lattice and clearing latched shutdown evidence at epoch finish. Reserved dynamic entries were excluded from recursive gate adoption because public layering makes the state unreachable, but that invariant was not stated or asserted.

## Validation

- `./tools/dev just ci`
  - nightly rustfmt and clippy with warnings denied
  - 547 nextest tests passed
  - workspace doctests passed
  - rustdoc/API reachability/path/layering/enforcement checks passed
  - packaged-doc and crate-package checks passed
  - nix formatting check passed
- Focused regressions cover synchronous reclaim, expedited immediate readiness, framework panic retention, all three pre-loop stop sources, and the reserved-slot re-home assertion; the existing lifecycle overflow regression covers the lag merge path.

Closes #187
