### PR TITLE
Close test gaps 15 through 25

### DIFF
--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -1,5 +1,8 @@
 use super::support::*;
 
+// The key's controlled membership mutation is exactly the regression under
+// test: pointer-based handle identity must keep the set addressable.
+#[allow(clippy::mutable_key_type)]
 #[test]
 fn handle_identity_is_stable_across_membership_rebase() {
     fn hashed(value: &impl std::hash::Hash) -> u64 {
@@ -22,6 +25,8 @@ fn handle_identity_is_stable_across_membership_rebase() {
     let declared = actor.membership();
     let actor_hash = hashed(&actor);
     let task_hash = hashed(&task);
+    let actor_keys = std::collections::HashSet::from([actor.clone()]);
+    let task_keys = std::collections::HashSet::from([task.clone()]);
 
     member.rebase_membership(
         identity
@@ -33,6 +38,14 @@ fn handle_identity_is_stable_across_membership_rebase() {
     assert_eq!(actor, peer);
     assert_eq!(hashed(&actor), actor_hash);
     assert_eq!(hashed(&task), task_hash);
+    assert!(
+        actor_keys.contains(&actor),
+        "membership rebasing cannot strand a keyed actor handle"
+    );
+    assert!(
+        task_keys.contains(&task),
+        "membership rebasing cannot strand a keyed task handle"
+    );
 }
 
 #[crate::runtime::test]

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -62,6 +62,10 @@ pub(crate) enum ArbitrationClass {
 }
 
 pub(crate) fn arbitrate<T>(events: &mut [(ArbitrationClass, T)]) {
+    // Priority is deterministic across classes, and input order is FIFO
+    // within one class. Callers build the slice in observation order, so a
+    // stable sort is part of the driver contract rather than an incidental
+    // implementation choice.
     events.sort_by_key(|(class, _)| *class);
 }
 
@@ -1011,17 +1015,23 @@ mod tests {
             ReadinessSignal, ScopeShutdown, StopDeadline,
         };
         let mut events = [
-            (StopDeadline, 6),
+            (StopDeadline, 8),
             (ChildExit, 2),
-            (ReadinessDeadline, 4),
+            (ReadinessDeadline, 6),
+            (ChildExit, 3),
             (ScopeShutdown, 0),
-            (Admission, 7),
-            (BackoffDue, 5),
+            (Admission, 9),
+            (BackoffDue, 7),
             (MembershipRemoval, 1),
-            (ReadinessSignal, 3),
+            (ReadinessSignal, 4),
+            (ReadinessSignal, 5),
         ];
         arbitrate(&mut events);
-        assert_eq!(events.map(|(_, value)| value), [0, 1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(
+            events.map(|(_, value)| value),
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            "same-class events retain their observation order"
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -1033,25 +1033,30 @@ mod tests {
             "same-class events retain their observation order"
         );
 
-        // Keep this above the small-sort threshold: the compact fixture
+        // Keep this well above any small-sort threshold: the compact fixture
         // above documents every class, but an unstable insertion sort can
-        // preserve its two duplicate pairs by accident. This alternating
-        // shape makes a `sort_unstable_by_key` mutant reorder the larger
-        // ReadinessSignal class on the supported toolchain.
-        let mut same_class_pressure: [(ArbitrationClass, usize); 33] =
-            std::array::from_fn(|index| {
-                if index.is_multiple_of(2) {
-                    (ReadinessSignal, index)
-                } else {
-                    (ChildExit, index)
-                }
-            });
+        // preserve a couple of duplicate pairs by accident. Every class is
+        // duplicated many times here so the fixture's discriminating power
+        // against a `sort_unstable_by_key` mutant does not rest on one
+        // toolchain's threshold or pivot choice.
+        const CLASSES: [ArbitrationClass; 8] = [
+            ScopeShutdown,
+            MembershipRemoval,
+            ChildExit,
+            ReadinessSignal,
+            ReadinessDeadline,
+            BackoffDue,
+            StopDeadline,
+            Admission,
+        ];
+        const PRESSURE: usize = 256;
+        let mut same_class_pressure: [(ArbitrationClass, usize); PRESSURE] =
+            std::array::from_fn(|index| (CLASSES[index % CLASSES.len()], index));
         arbitrate(&mut same_class_pressure);
         assert_eq!(
             same_class_pressure.map(|(_, value)| value).as_slice(),
-            (1..33)
-                .step_by(2)
-                .chain((0..33).step_by(2))
+            (0..CLASSES.len())
+                .flat_map(|rank| (rank..PRESSURE).step_by(CLASSES.len()))
                 .collect::<Vec<_>>(),
             "larger same-class batches retain FIFO rather than unstable-sort order"
         );

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -1032,6 +1032,29 @@ mod tests {
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
             "same-class events retain their observation order"
         );
+
+        // Keep this above the small-sort threshold: the compact fixture
+        // above documents every class, but an unstable insertion sort can
+        // preserve its two duplicate pairs by accident. This alternating
+        // shape makes a `sort_unstable_by_key` mutant reorder the larger
+        // ReadinessSignal class on the supported toolchain.
+        let mut same_class_pressure: [(ArbitrationClass, usize); 33] =
+            std::array::from_fn(|index| {
+                if index.is_multiple_of(2) {
+                    (ReadinessSignal, index)
+                } else {
+                    (ChildExit, index)
+                }
+            });
+        arbitrate(&mut same_class_pressure);
+        assert_eq!(
+            same_class_pressure.map(|(_, value)| value).as_slice(),
+            (1..33)
+                .step_by(2)
+                .chain((0..33).step_by(2))
+                .collect::<Vec<_>>(),
+            "larger same-class batches retain FIFO rather than unstable-sort order"
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/runtime/timer.rs
+++ b/crates/shelterwood/src/runtime/timer.rs
@@ -128,7 +128,7 @@ where
 mod tests {
     use std::{
         future::Future,
-        task::{Context, Waker},
+        task::{Context, Poll, Waker},
         time::Duration,
     };
 
@@ -195,6 +195,42 @@ mod tests {
             sleep.as_mut().poll(&mut context).is_pending(),
             "finishing an internal slice must not finish the requested sleep"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn multi_slice_absolute_deadline_eventually_fires() {
+        let duration = MAX_TIMER_SLICE * 2 + Duration::from_secs(1);
+        let requested = super::now()
+            .checked_add(duration)
+            .expect("the test duration fits the platform clock");
+        let mut sleep = std::pin::pin!(super::sleep_until_std(requested));
+        let mut context = Context::from_waker(Waker::noop());
+
+        assert!(sleep.as_mut().poll(&mut context).is_pending());
+        tokio::time::advance(MAX_TIMER_SLICE).await;
+        assert!(sleep.as_mut().poll(&mut context).is_pending());
+        tokio::time::advance(MAX_TIMER_SLICE).await;
+        assert!(sleep.as_mut().poll(&mut context).is_pending());
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert!(sleep.as_mut().poll(&mut context).is_ready());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn multi_slice_timeout_eventually_elapses() {
+        let duration = MAX_TIMER_SLICE * 2 + Duration::from_secs(1);
+        let mut timed = std::pin::pin!(timeout(duration, std::future::pending::<()>()));
+        let mut context = Context::from_waker(Waker::noop());
+
+        assert!(timed.as_mut().poll(&mut context).is_pending());
+        tokio::time::advance(MAX_TIMER_SLICE).await;
+        assert!(timed.as_mut().poll(&mut context).is_pending());
+        tokio::time::advance(MAX_TIMER_SLICE).await;
+        assert!(timed.as_mut().poll(&mut context).is_pending());
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert!(matches!(
+            timed.as_mut().poll(&mut context),
+            Poll::Ready(super::Timeout::Elapsed)
+        ));
     }
 
     #[test]

--- a/crates/shelterwood/tests/acceptance/assistant.rs
+++ b/crates/shelterwood/tests/acceptance/assistant.rs
@@ -576,11 +576,17 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         "temporary children retire by exact handle"
     );
 
+    const DELIVERY_ID: u64 = 7;
+    let delivery_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     let first_delivery = gateway
         .ingress
         .call(
-            |reply| IngressMessage::Deliver { id: 7, reply },
-            Duration::from_secs(1),
+            |reply| IngressMessage::Deliver {
+                id: DELIVERY_ID,
+                reply,
+            },
+            Duration::from_secs(1)
+                .min(delivery_deadline.saturating_duration_since(tokio::time::Instant::now())),
         )
         .await
         .expect_err("durable write crash loses the first acknowledgement");
@@ -588,17 +594,47 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         first_delivery.kind,
         shelterwood::CallErrorKind::ReplyDropped
     );
-    gateway
+    let accepting_incarnation = first_delivery
+        .incarnation_observed
+        .expect("ReplyDropped proves which incarnation accepted the request");
+    let remaining = delivery_deadline.saturating_duration_since(tokio::time::Instant::now());
+    let replacement = gateway_scope
+        .wait_for_child(
+            "ingress",
+            move |child| {
+                child
+                    .incarnation
+                    .is_some_and(|current| current.supersedes(accepting_incarnation))
+            },
+            remaining,
+        )
+        .await
+        .expect("redelivery waits for a superseding ingress incarnation");
+    let replacement_incarnation = replacement
+        .incarnation
+        .expect("running replacement has an incarnation");
+    assert!(replacement_incarnation.supersedes(accepting_incarnation));
+    let remaining = delivery_deadline.saturating_duration_since(tokio::time::Instant::now());
+    assert!(
+        !remaining.is_zero(),
+        "one overall redelivery budget remains"
+    );
+    let acknowledgement = gateway
         .ingress
         .call(
-            |reply| IngressMessage::Deliver { id: 7, reply },
-            Duration::from_secs(1),
+            |reply| IngressMessage::Deliver {
+                id: DELIVERY_ID,
+                reply,
+            },
+            Duration::from_secs(1).min(remaining),
         )
         .await
         .expect("redelivery of the same journal id is acknowledged");
+    assert_eq!(acknowledgement.incarnation, replacement_incarnation);
+    assert!(tokio::time::Instant::now() <= delivery_deadline);
     assert_eq!(
         gateway.processed.try_recv().ok(),
-        Some(7),
+        Some(DELIVERY_ID),
         "the durable write happened exactly once"
     );
     assert!(gateway.processed.try_recv().is_err());

--- a/crates/shelterwood/tests/acceptance/assistant.rs
+++ b/crates/shelterwood/tests/acceptance/assistant.rs
@@ -577,7 +577,10 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
     );
 
     const DELIVERY_ID: u64 = 7;
-    let delivery_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    // One budget for the whole logical redelivery, not a per-attempt constant
+    // alongside it: every attempt's own acceptance deadline is whatever the
+    // shared budget has left (§3.3 step 1).
+    let delivery_deadline = tokio::time::Instant::now() + Duration::from_secs(2);
     let first_delivery = gateway
         .ingress
         .call(
@@ -585,8 +588,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
                 id: DELIVERY_ID,
                 reply,
             },
-            Duration::from_secs(1)
-                .min(delivery_deadline.saturating_duration_since(tokio::time::Instant::now())),
+            delivery_deadline.saturating_duration_since(tokio::time::Instant::now()),
         )
         .await
         .expect_err("durable write crash loses the first acknowledgement");
@@ -626,7 +628,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
                 id: DELIVERY_ID,
                 reply,
             },
-            Duration::from_secs(1).min(remaining),
+            remaining,
         )
         .await
         .expect("redelivery of the same journal id is acknowledged");

--- a/crates/shelterwood/tests/acceptance/shard_store.rs
+++ b/crates/shelterwood/tests/acceptance/shard_store.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::common::ReleaseGate;
 use shelterwood::{
     Actor, ActorDef, ActorRef, CallErrorKind, Context, DynamicScopeRef, DynamicTree, ExitError,
-    ExitResult, Membership, RemoveOutcome, Reply, ScopeRef, SubtreeOnceDef, Tree,
+    ExitResult, Incarnation, Membership, RemoveOutcome, Reply, ScopeRef, SubtreeOnceDef, Tree,
 };
 
 /// A shard's durable contents. Deliberately not actor-owned state: the test
@@ -372,12 +372,27 @@ impl Actor for RouterActor {
 /// id, and a resend after `ReplyDropped` only once a *superseding* router
 /// incarnation is running — never into the same doomed mailbox or the rebind
 /// window.
+struct RetryOutcome {
+    route: Route,
+    fault_record: Option<OperationRecord>,
+    directory_at_fault: Option<Option<Route>>,
+    attempted_operations: Vec<u64>,
+    dropped_incarnation: Option<Incarnation>,
+    reply_incarnation: Incarnation,
+}
+
 async fn replace_with_retry(
     scope: &ScopeRef,
     router: &ActorRef<RouterMessage>,
+    directory: &ActorRef<DirectoryMessage>,
+    durable: &DurableTopology,
     operation: u64,
-) -> Route {
+) -> RetryOutcome {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut fault_record = None;
+    let mut directory_at_fault = None;
+    let mut attempted_operations = Vec::new();
+    let mut dropped_incarnation = None;
     for _ in 0..4 {
         // Every attempt spends from the one overall budget (§3.3 step 1),
         // the call's own acceptance deadline included.
@@ -386,6 +401,7 @@ async fn replace_with_retry(
             !remaining.is_zero(),
             "the overall deadline bounds the whole logical operation"
         );
+        attempted_operations.push(operation);
         match router
             .call(
                 move |reply| RouterMessage::Replace { operation, reply },
@@ -393,7 +409,27 @@ async fn replace_with_retry(
             )
             .await
         {
-            Ok(reply) => return reply.value,
+            Ok(reply) => {
+                assert!(
+                    tokio::time::Instant::now() <= deadline,
+                    "the successful retry remains inside the one overall deadline"
+                );
+                if let Some(observed) = dropped_incarnation {
+                    assert!(
+                        reply.incarnation.supersedes(observed),
+                        "the retry is accepted only by a superseding incarnation"
+                    );
+                }
+                assert!(attempted_operations.iter().all(|id| *id == operation));
+                return RetryOutcome {
+                    route: reply.value,
+                    fault_record,
+                    directory_at_fault,
+                    attempted_operations,
+                    dropped_incarnation,
+                    reply_incarnation: reply.incarnation,
+                };
+            }
             Err(error) => match error.kind {
                 CallErrorKind::ReplyDropped => {
                     // Acceptance happened and the accepting incarnation lost
@@ -402,8 +438,18 @@ async fn replace_with_retry(
                     let observed = error
                         .incarnation_observed
                         .expect("ReplyDropped carries the accepting incarnation");
+                    assert!(
+                        dropped_incarnation.replace(observed).is_none(),
+                        "each injected logical operation faults only once"
+                    );
+                    fault_record = Some(
+                        durable
+                            .operation(operation)
+                            .expect("the faulting attempt journaled durable evidence"),
+                    );
+                    directory_at_fault = Some(lookup(directory).await);
                     let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-                    scope
+                    let replacement = scope
                         .wait_for_child(
                             "topology-writer",
                             move |child| {
@@ -415,6 +461,12 @@ async fn replace_with_retry(
                         )
                         .await
                         .expect("a superseding router incarnation runs");
+                    assert!(
+                        replacement
+                            .incarnation
+                            .expect("running replacement has an incarnation")
+                            .supersedes(observed)
+                    );
                 }
                 CallErrorKind::AcceptanceTimedOut => {
                     // Guaranteed-not-accepted; always safe to retry
@@ -428,7 +480,9 @@ async fn replace_with_retry(
             },
         }
     }
-    panic!("idempotent topology operation did not reconcile")
+    panic!(
+        "idempotent topology operation {operation} did not reconcile within one overall deadline"
+    )
 }
 
 async fn lookup(directory: &ActorRef<DirectoryMessage>) -> Option<Route> {
@@ -470,24 +524,32 @@ async fn shard_store_reconciles_both_crash_windows_with_exact_idempotent_retries
     system.wait_started().await.expect("store starts");
     let root_scope = system.scope();
 
-    let first_error = router
-        .call(
-            |reply| RouterMessage::Replace {
-                operation: 1,
-                reply,
-            },
-            Duration::from_secs(1),
+    let first_retry = replace_with_retry(&root_scope, &router, &directory, &durable, 1).await;
+    assert_eq!(first_retry.attempted_operations, [1, 1]);
+    assert!(first_retry.dropped_incarnation.is_some());
+    assert!(
+        first_retry.reply_incarnation.supersedes(
+            first_retry
+                .dropped_incarnation
+                .expect("the helper observed its injected fault")
         )
-        .await
-        .expect_err("pre-commit crash drops its reply");
-    assert_eq!(first_error.kind, CallErrorKind::ReplyDropped);
-    assert!(lookup(&directory).await.is_none(), "cutover did not happen");
-    let failed_candidate = match durable.operation(1).expect("mount was journaled") {
+    );
+    assert!(
+        first_retry
+            .directory_at_fault
+            .expect("the helper captured the pre-retry directory")
+            .is_none(),
+        "pre-commit cutover did not happen"
+    );
+    let failed_candidate = match first_retry
+        .fault_record
+        .expect("the helper captured the pre-commit journal")
+    {
         OperationRecord::Mounted { candidate, .. } => candidate,
         OperationRecord::Committed { .. } => panic!("pre-commit crash cannot be committed"),
     };
 
-    let first = replace_with_retry(&root_scope, &router, 1).await;
+    let first = first_retry.route;
     assert!(
         !first
             .membership
@@ -511,34 +573,31 @@ async fn shard_store_reconciles_both_crash_windows_with_exact_idempotent_retries
         shelterwood::StopReason::ShutdownRequested
     );
 
-    let second_error = router
-        .call(
-            |reply| RouterMessage::Replace {
-                operation: 2,
-                reply,
-            },
-            Duration::from_secs(1),
-        )
-        .await
-        .expect_err("post-commit crash drops its reply");
-    assert_eq!(second_error.kind, CallErrorKind::ReplyDropped);
-    let committed_candidate = match durable.operation(2).expect("commit was journaled") {
+    let second_retry = replace_with_retry(&root_scope, &router, &directory, &durable, 2).await;
+    assert_eq!(second_retry.attempted_operations, [2, 2]);
+    let committed_candidate = match second_retry
+        .fault_record
+        .expect("the helper captured the post-commit journal")
+    {
         OperationRecord::Committed { candidate, .. } => candidate,
         OperationRecord::Mounted { .. } => panic!("directory cutover must be committed"),
     };
     assert_eq!(
-        lookup(&directory)
-            .await
+        second_retry
+            .directory_at_fault
+            .expect("the helper captured the post-commit directory")
             .expect("post-commit route is visible")
             .membership,
         committed_candidate.route.membership
     );
 
-    let second = replace_with_retry(&root_scope, &router, 2).await;
+    let second = second_retry.route;
     assert_eq!(second.membership, committed_candidate.route.membership);
+    let replay = replace_with_retry(&root_scope, &router, &directory, &durable, 2).await;
+    assert_eq!(replay.attempted_operations, [2]);
+    assert!(replay.fault_record.is_none());
     assert_eq!(
-        replace_with_retry(&root_scope, &router, 2).await.membership,
-        second.membership,
+        replay.route.membership, second.membership,
         "replaying a committed operation is idempotent"
     );
 

--- a/crates/shelterwood/tests/acceptance/shard_store.rs
+++ b/crates/shelterwood/tests/acceptance/shard_store.rs
@@ -141,6 +141,20 @@ impl DurableTopology {
             .get(&operation)
             .cloned()
     }
+
+    /// The journal's idempotency keys, so a retry can be shown to reuse the
+    /// key its first attempt wrote rather than minting a fresh one.
+    fn journalled_operations(&self) -> Vec<u64> {
+        let mut operations: Vec<u64> = self
+            .operations
+            .lock()
+            .expect("operation journal mutex poisoned")
+            .keys()
+            .copied()
+            .collect();
+        operations.sort_unstable();
+        operations
+    }
 }
 
 enum RouterMessage {
@@ -389,6 +403,7 @@ async fn replace_with_retry(
     operation: u64,
 ) -> RetryOutcome {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let journalled_before = durable.journalled_operations();
     let mut fault_record = None;
     let mut directory_at_fault = None;
     let mut attempted_operations = Vec::new();
@@ -420,7 +435,19 @@ async fn replace_with_retry(
                         "the retry is accepted only by a superseding incarnation"
                     );
                 }
-                assert!(attempted_operations.iter().all(|id| *id == operation));
+                // Exact idempotency key: however many attempts ran, they all
+                // journalled under this operation's key. A retry that minted
+                // a fresh key would leave a second new journal entry.
+                let journalled_after = durable.journalled_operations();
+                let minted: Vec<u64> = journalled_after
+                    .into_iter()
+                    .filter(|id| *id != operation && !journalled_before.contains(id))
+                    .collect();
+                assert!(
+                    minted.is_empty(),
+                    "retries reuse operation {operation}'s idempotency key, but {minted:?} \
+                     were journalled"
+                );
                 return RetryOutcome {
                     route: reply.value,
                     fault_record,

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -26,6 +26,37 @@ where
 }
 fn assert_static<T: 'static>() {}
 
+macro_rules! assert_not_impl {
+    ($type:ty: $trait:path) => {
+        const _: fn() = || {
+            struct Check<T: ?Sized>(std::marker::PhantomData<T>);
+            trait AmbiguousIfImpl<A> {
+                fn check() {}
+            }
+            impl<T: ?Sized> AmbiguousIfImpl<()> for Check<T> {}
+            impl<T: ?Sized + $trait> AmbiguousIfImpl<u8> for Check<T> {}
+            let _ = <Check<$type> as AmbiguousIfImpl<_>>::check;
+        };
+    };
+}
+
+assert_not_impl!(System<ScopeRef>: Clone);
+assert_not_impl!(System<DynamicScopeRef>: Clone);
+assert_not_impl!(ActorSlot<Cell<()>>: Clone);
+assert_not_impl!(DynamicActorSlot<Cell<()>>: Clone);
+assert_not_impl!(TaskSlot: Clone);
+assert_not_impl!(DynamicTaskSlot: Clone);
+assert_not_impl!(SubtreeSlot<Tree>: Clone);
+assert_not_impl!(SubtreeSlot<DynamicTree>: Clone);
+assert_not_impl!(DynamicSubtreeSlot<Tree>: Clone);
+assert_not_impl!(DynamicSubtreeSlot<DynamicTree>: Clone);
+assert_not_impl!(Reply<Cell<()>>: Clone);
+assert_not_impl!(ReplyReceiver<Cell<()>>: Clone);
+assert_not_impl!(Guard: Clone);
+assert_not_impl!(OneShotTaskRef<Cell<()>>: Clone);
+assert_not_impl!(Membership: Ord);
+assert_not_impl!(Incarnation: Ord);
+
 #[test]
 fn documented_identity_handle_token_and_owned_value_bounds_compile() {
     assert_copy_eq_hash_send_sync::<Membership>();

--- a/crates/shelterwood/tests/common/gates.rs
+++ b/crates/shelterwood/tests/common/gates.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Condvar, Mutex};
+use std::{
+    sync::{Arc, Condvar, Mutex},
+    time::{Duration, Instant},
+};
 
 use tokio::sync::Notify;
 
@@ -60,14 +63,27 @@ pub(crate) struct DestructorBlocker(Arc<(Mutex<DestructorState>, Condvar)>);
 
 impl Drop for DestructorBlocker {
     fn drop(&mut self) {
+        const MAX_BLOCK: Duration = Duration::from_secs(5);
+
         let (state, changed) = &*self.0;
         let mut state = state.lock().expect("destructor gate mutex poisoned");
         state.entered = true;
         changed.notify_all();
+        let deadline = Instant::now() + MAX_BLOCK;
         while !state.released {
-            state = changed
-                .wait(state)
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "destructor gate was not released within {MAX_BLOCK:?}"
+            );
+            let (next, timeout) = changed
+                .wait_timeout(state, remaining)
                 .expect("destructor gate mutex poisoned while blocking");
+            state = next;
+            assert!(
+                !timeout.timed_out() || state.released,
+                "destructor gate was not released within {MAX_BLOCK:?}"
+            );
         }
     }
 }

--- a/crates/shelterwood/tests/common/gates.rs
+++ b/crates/shelterwood/tests/common/gates.rs
@@ -63,7 +63,10 @@ pub(crate) struct DestructorBlocker(Arc<(Mutex<DestructorState>, Condvar)>);
 
 impl Drop for DestructorBlocker {
     fn drop(&mut self) {
-        const MAX_BLOCK: Duration = Duration::from_secs(5);
+        // A stuck-test backstop, not an assertion: well above any legitimate
+        // wait (POLL_TIMEOUT and every gate driven by it) so a passing test
+        // can never reach it.
+        const MAX_BLOCK: Duration = Duration::from_secs(30);
 
         let (state, changed) = &*self.0;
         let mut state = state.lock().expect("destructor gate mutex poisoned");
@@ -72,18 +75,20 @@ impl Drop for DestructorBlocker {
         let deadline = Instant::now() + MAX_BLOCK;
         while !state.released {
             let remaining = deadline.saturating_duration_since(Instant::now());
-            assert!(
-                !remaining.is_zero(),
-                "destructor gate was not released within {MAX_BLOCK:?}"
-            );
-            let (next, timeout) = changed
+            if remaining.is_zero() {
+                // This destructor also runs while other panics unwind, where
+                // a nested panic aborts with no diagnostic at all. Report and
+                // abort deliberately instead.
+                eprintln!("destructor gate was not released within {MAX_BLOCK:?}");
+                if std::thread::panicking() {
+                    std::process::abort();
+                }
+                panic!("destructor gate was not released within {MAX_BLOCK:?}");
+            }
+            state = changed
                 .wait_timeout(state, remaining)
-                .expect("destructor gate mutex poisoned while blocking");
-            state = next;
-            assert!(
-                !timeout.timed_out() || state.released,
-                "destructor gate was not released within {MAX_BLOCK:?}"
-            );
+                .expect("destructor gate mutex poisoned while blocking")
+                .0;
         }
     }
 }

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -133,6 +133,52 @@ async fn prebind_overflow_timeouts_observe_the_bound_incarnation() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn maximum_mailbox_deadlines_are_unbounded_waits() {
+    let values = Arc::new(Mutex::new(Vec::new()));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "maximum-mailbox-deadlines",
+            RawOnceDef::new(boundary_actor(None, &values, &calls, false)),
+        )
+        .expect("valid actor");
+
+    let mut send = Box::pin(actor.send_timeout(Message::Value(1), Duration::MAX));
+    let mut call = Box::pin(actor.call(Message::Ask, Duration::MAX));
+    let (reply, receiver) = Reply::channel();
+    let mut receive = Box::pin(receiver.recv(Duration::MAX));
+    assert!(poll_once(send.as_mut()).is_pending());
+    assert!(poll_once(call.as_mut()).is_pending());
+    assert!(poll_once(receive.as_mut()).is_pending());
+
+    // Cross several of the runtime's bounded timer slices. `Duration::MAX`
+    // means no substitute deadline, so none of the three mailbox surfaces may
+    // resolve until its underlying operation does.
+    advance_time(Duration::from_secs(5 * 365 * 24 * 60 * 60)).await;
+    assert!(poll_once(send.as_mut()).is_pending());
+    assert!(poll_once(call.as_mut()).is_pending());
+    assert!(poll_once(receive.as_mut()).is_pending());
+
+    reply.send(9);
+    assert_eq!(receive.await, Ok(9));
+
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    let accepting = send.await.expect("unbounded send accepts after binding");
+    let response = call.await.expect("unbounded call completes after binding");
+    assert_eq!(response.value, 17);
+    assert_eq!(response.incarnation, accepting);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(*values.lock().expect("values mutex poisoned"), [1]);
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("actor stops");
+}
+
+#[tokio::test(start_paused = true)]
 async fn acceptance_winning_the_deadline_withdrawal_race_succeeds() {
     let gate = ReleaseGate::default();
     let values = Arc::new(Mutex::new(Vec::new()));

--- a/crates/shelterwood/tests/defaults.rs
+++ b/crates/shelterwood/tests/defaults.rs
@@ -4,7 +4,7 @@
 
 use std::{
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
@@ -13,8 +13,8 @@ use std::{
 use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
 use shelterwood::{
     Actor, ActorDef, Backoff, Context, DynamicTree, ExitError, ExitKind, ExitResult, GracePhase,
-    RawActor, RawContext, RawOnceDef, Readiness, RestartCount, Retention, SendErrorKind,
-    StartupError, StopReason, TaskDef, TaskOnceDef, Tree,
+    MailboxShutdown, RawActor, RawContext, RawOnceDef, Readiness, RestartCount, Retention,
+    SendErrorKind, StartupError, StopReason, TaskDef, TaskOnceDef, Tree,
 };
 
 enum CapacityMessage {
@@ -283,8 +283,8 @@ async fn default_restart_backoff_and_retention_follow_definition_ownership() {
 
 struct DefaultDrainActor {
     entered: ReleaseGate,
-    release: ReleaseGate,
     values: Arc<AtomicUsize>,
+    resolved: Arc<Mutex<Option<MailboxShutdown>>>,
 }
 
 impl RawActor for DefaultDrainActor {
@@ -292,12 +292,24 @@ impl RawActor for DefaultDrainActor {
 
     async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
         self.entered.release();
-        self.release.wait().await;
-        while context.recv().await.is_some() {
-            self.values.fetch_add(1, Ordering::SeqCst);
-        }
-        while context.try_recv().is_some() {
-            self.values.fetch_add(1, Ordering::SeqCst);
+        // A raw loop implements the frozen-prefix policy itself, so the loop
+        // must both report the resolved default and obey it: parking until
+        // shutdown makes the accepted prefix reachable only through the
+        // policy-gated drain below, never through steady-state `recv`.
+        context.shutdown_token().cancelled().await;
+        let resolved = context.mailbox_shutdown();
+        *self
+            .resolved
+            .lock()
+            .expect("resolved policy mutex poisoned") = Some(resolved);
+        assert!(
+            context.recv().await.is_none(),
+            "recv is shutdown-biased once intake is frozen"
+        );
+        if resolved == MailboxShutdown::Drain {
+            while context.try_recv().is_some() {
+                self.values.fetch_add(1, Ordering::SeqCst);
+            }
         }
         Ok(())
     }
@@ -306,16 +318,16 @@ impl RawActor for DefaultDrainActor {
 #[tokio::test]
 async fn default_mailbox_shutdown_drains_the_frozen_prefix() {
     let entered = ReleaseGate::default();
-    let release = ReleaseGate::default();
     let values = Arc::new(AtomicUsize::new(0));
+    let resolved = Arc::new(Mutex::new(None));
     let mut tree = Tree::new();
     let actor = tree
         .add_raw_once(
             "drain",
             RawOnceDef::new(DefaultDrainActor {
                 entered: entered.clone(),
-                release: release.clone(),
                 values: Arc::clone(&values),
+                resolved: Arc::clone(&resolved),
             }),
         )
         .expect("valid raw actor");
@@ -325,16 +337,19 @@ async fn default_mailbox_shutdown_drains_the_frozen_prefix() {
     actor.try_send(()).expect("first message accepts");
     actor.try_send(()).expect("second message accepts");
 
-    let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(1)));
-    release.release();
-    shutdown
+    system
+        .shutdown(Duration::from_secs(1))
         .await
-        .expect("shutdown task joins")
         .expect("implicit drain completes");
+    assert_eq!(
+        *resolved.lock().expect("resolved policy mutex poisoned"),
+        Some(MailboxShutdown::Drain),
+        "MailboxShutdown::Drain is the shipped default"
+    );
     assert_eq!(
         values.load(Ordering::SeqCst),
         2,
-        "MailboxShutdown::Drain is the shipped default"
+        "the shipped default delivers the whole frozen accepted prefix"
     );
 }
 

--- a/crates/shelterwood/tests/defaults.rs
+++ b/crates/shelterwood/tests/defaults.rs
@@ -12,8 +12,9 @@ use std::{
 
 use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
 use shelterwood::{
-    Actor, ActorDef, Context, ExitError, ExitKind, ExitResult, GracePhase, Readiness,
-    SendErrorKind, StartupError, StopReason, TaskDef, Tree,
+    Actor, ActorDef, Backoff, Context, DynamicTree, ExitError, ExitKind, ExitResult, GracePhase,
+    RawActor, RawContext, RawOnceDef, Readiness, RestartCount, Retention, SendErrorKind,
+    StartupError, StopReason, TaskDef, TaskOnceDef, Tree,
 };
 
 enum CapacityMessage {
@@ -213,4 +214,171 @@ async fn default_intensity_allows_five_restarts_before_tripping() {
         6,
         "initial run plus 5 restarts spawn; the tripping restart never does"
     );
+}
+
+#[tokio::test]
+async fn default_restart_backoff_and_retention_follow_definition_ownership() {
+    let runs = Arc::new(AtomicUsize::new(0));
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+
+    let restartable = scope
+        .add_task(
+            "restartable",
+            TaskDef::new({
+                let runs = Arc::clone(&runs);
+                move |context| {
+                    let attempt = runs.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        if attempt == 0 {
+                            Err(ExitError::message("exercise the default restart"))
+                        } else {
+                            context.shutdown_token().cancelled().await;
+                            Ok(())
+                        }
+                    }
+                }
+            }),
+        )
+        .await
+        .expect("restartable task is admitted");
+    let running = scope
+        .wait_for_child(
+            "restartable",
+            |child| {
+                child.restart_count == RestartCount::ZERO.bump()
+                    && matches!(child.state, shelterwood::ChildState::Running)
+            },
+            POLL_TIMEOUT,
+        )
+        .await
+        .expect("the immediate default backoff starts the replacement");
+    assert_eq!(running.restart_policy.backoff(), Backoff::Immediate);
+    assert_eq!(running.retention, Retention::Retain);
+    assert_eq!(restartable.membership(), running.membership);
+
+    let (one_shot, completion) = scope
+        .add_task_once(
+            "one-shot",
+            TaskOnceDef::new(|_| async { Ok::<_, ExitError>(()) }),
+        )
+        .await
+        .expect("one-shot task is admitted");
+    completion.wait().await.expect("one-shot task completes");
+    one_shot.wait().await;
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            scope.child("one-shot").is_none()
+        })
+        .await,
+        "the default one-shot retention removes the terminal membership"
+    );
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root stops");
+}
+
+struct DefaultDrainActor {
+    entered: ReleaseGate,
+    release: ReleaseGate,
+    values: Arc<AtomicUsize>,
+}
+
+impl RawActor for DefaultDrainActor {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        self.entered.release();
+        self.release.wait().await;
+        while context.recv().await.is_some() {
+            self.values.fetch_add(1, Ordering::SeqCst);
+        }
+        while context.try_recv().is_some() {
+            self.values.fetch_add(1, Ordering::SeqCst);
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn default_mailbox_shutdown_drains_the_frozen_prefix() {
+    let entered = ReleaseGate::default();
+    let release = ReleaseGate::default();
+    let values = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "drain",
+            RawOnceDef::new(DefaultDrainActor {
+                entered: entered.clone(),
+                release: release.clone(),
+                values: Arc::clone(&values),
+            }),
+        )
+        .expect("valid raw actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("raw actor starts");
+    entered.wait().await;
+    actor.try_send(()).expect("first message accepts");
+    actor.try_send(()).expect("second message accepts");
+
+    let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(1)));
+    release.release();
+    shutdown
+        .await
+        .expect("shutdown task joins")
+        .expect("implicit drain completes");
+    assert_eq!(
+        values.load(Ordering::SeqCst),
+        2,
+        "MailboxShutdown::Drain is the shipped default"
+    );
+}
+
+async fn exit_after_default_tidy_cleanup(cleanup: Duration) -> shelterwood::Exit {
+    let abort_seen = ReleaseGate::default();
+    let mut tree = Tree::new();
+    let task = tree
+        .add_task(
+            "tidy",
+            TaskDef::new({
+                let abort_seen = abort_seen.clone();
+                move |context| {
+                    let abort_seen = abort_seen.clone();
+                    async move {
+                        context.abort_token().cancelled().await;
+                        abort_seen.release();
+                        tokio::time::sleep(cleanup).await;
+                        Ok(())
+                    }
+                }
+            }),
+        )
+        .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("task starts");
+    let mut shutdown = Box::pin(system.shutdown(Duration::from_secs(60)));
+    assert!(poll_once(shutdown.as_mut()).is_pending());
+    advance_time(Duration::from_secs(5)).await;
+    abort_seen.wait().await;
+    advance_time(cleanup.min(Duration::from_millis(10))).await;
+    shutdown.await.expect("default ladder completes");
+    task.wait().await
+}
+
+#[tokio::test(start_paused = true)]
+async fn default_tidy_abort_beat_is_capped_at_ten_milliseconds() {
+    let inside = exit_after_default_tidy_cleanup(Duration::from_millis(9)).await;
+    assert!(matches!(inside.kind(), ExitKind::Completed));
+
+    let outside = exit_after_default_tidy_cleanup(Duration::from_millis(11)).await;
+    assert!(matches!(
+        outside.kind(),
+        ExitKind::Aborted {
+            phase: GracePhase::AfterGrace
+        }
+    ));
 }

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -102,6 +102,21 @@ impl RawActor for WaitingRaw {
     }
 }
 
+struct ManualWaitingRaw;
+
+impl RawActor for ManualWaitingRaw {
+    type Msg = ();
+
+    fn readiness() -> Readiness {
+        Readiness::Manual
+    }
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        context.shutdown_token().cancelled().await;
+        Ok(())
+    }
+}
+
 struct SignalledWaitingRaw {
     started: Arc<AtomicBool>,
     cancelled: Arc<AtomicBool>,
@@ -254,6 +269,83 @@ async fn dynamic_actor_add_resolves_at_admission_without_awaiting_init() {
         .shutdown(Duration::from_secs(1))
         .await
         .expect("tree shuts down");
+}
+
+#[tokio::test]
+async fn task_raw_and_subtree_admissions_resolve_before_manual_startup() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+
+    let task = tokio::time::timeout(
+        POLL_TIMEOUT,
+        scope.add_task(
+            "gated-task",
+            TaskDef::new(|context| async move {
+                context.shutdown_token().cancelled().await;
+                Ok(())
+            })
+            .readiness(Readiness::Manual)
+            .expect("manual readiness")
+            .shutdown(Shutdown::Abort),
+        ),
+    )
+    .await
+    .expect("task admission does not await readiness")
+    .expect("task is admitted");
+    let raw = tokio::time::timeout(
+        POLL_TIMEOUT,
+        scope.add_raw_once(
+            "gated-raw",
+            RawOnceDef::new(ManualWaitingRaw).shutdown(Shutdown::Abort),
+        ),
+    )
+    .await
+    .expect("raw admission does not await readiness")
+    .expect("raw actor is admitted");
+
+    let mut gated_tree = Tree::new();
+    gated_tree
+        .add_task(
+            "manual-child",
+            TaskDef::new(|context| async move {
+                context.shutdown_token().cancelled().await;
+                Ok(())
+            })
+            .readiness(Readiness::Manual)
+            .expect("manual readiness")
+            .shutdown(Shutdown::Abort),
+        )
+        .expect("valid gated child");
+    let subtree = tokio::time::timeout(
+        POLL_TIMEOUT,
+        scope.add_subtree_once(
+            "gated-subtree",
+            SubtreeOnceDef::new(gated_tree).shutdown(Shutdown::Abort),
+        ),
+    )
+    .await
+    .expect("subtree admission does not await aggregate readiness")
+    .expect("subtree is admitted");
+
+    for id in ["gated-task", "gated-raw", "gated-subtree"] {
+        assert!(
+            poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+                scope
+                    .child(id)
+                    .is_some_and(|child| matches!(child.state, ChildState::Starting))
+            })
+            .await,
+            "{id} remains admitted but startup-gated"
+        );
+    }
+    assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
+    assert_eq!(scope.remove_actor(&raw).await, RemoveOutcome::Removed);
+    assert_eq!(scope.remove_scope(&subtree).await, RemoveOutcome::Removed);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -349,6 +349,29 @@ async fn task_raw_and_subtree_admissions_resolve_before_manual_startup() {
 }
 
 #[tokio::test]
+async fn successful_admission_is_fused_after_returning_its_handle() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+    let mut admission = Box::pin(scope.add_task("fused-success", waiting_task()));
+
+    let task = admission
+        .as_mut()
+        .await
+        .expect("successful admission returns the exact handle once");
+    assert!(
+        poll_once(admission.as_mut()).is_pending(),
+        "re-polling a successful Admission is fused rather than repeating its output"
+    );
+
+    assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[tokio::test]
 async fn exact_handles_reject_cross_scope_and_same_id_successors() {
     let left = DynamicTree::new().spawn().expect("runtime is available");
     let right = DynamicTree::new().spawn().expect("runtime is available");

--- a/crates/shelterwood/tests/events.rs
+++ b/crates/shelterwood/tests/events.rs
@@ -155,7 +155,32 @@ impl Actor for BatchTraceActor {
     }
 }
 
-async fn assert_batch_trace(fire_timer: bool, expected: &[&str]) {
+fn assert_subsequence(trace: &[&str], expected: &[&str]) {
+    let mut cursor = 0;
+    for entry in trace {
+        if expected.get(cursor).is_some_and(|next| next == entry) {
+            cursor += 1;
+        }
+    }
+    assert_eq!(
+        cursor,
+        expected.len(),
+        "missing ordered subsequence {expected:?} in {trace:?}"
+    );
+}
+
+fn assert_exact_entries(trace: &[&str], expected: &[&str]) {
+    assert_eq!(trace.len(), expected.len());
+    for entry in expected {
+        assert_eq!(
+            trace.iter().filter(|observed| observed == &entry).count(),
+            1,
+            "expected one {entry:?} entry in {trace:?}"
+        );
+    }
+}
+
+async fn assert_batch_trace(fire_timer: bool) {
     let gate = ReleaseGate::default();
     let log = Arc::new(Mutex::new(Vec::new()));
     let mut tree = Tree::new();
@@ -177,38 +202,44 @@ async fn assert_batch_trace(fire_timer: bool, expected: &[&str]) {
     gate.release();
 
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
-    assert_eq!(log.lock().expect("log mutex poisoned").as_slice(), expected);
+    let trace = log.lock().expect("log mutex poisoned");
+    let expected = if fire_timer {
+        &[
+            "start",
+            "continuation-1",
+            "continuation-2",
+            "mailbox",
+            "offload",
+            "timer",
+        ][..]
+    } else {
+        &[
+            "start",
+            "continuation-1",
+            "continuation-2",
+            "mailbox",
+            "offload",
+        ][..]
+    };
+    assert_exact_entries(&trace, expected);
+    // SPEC preserves FIFO within each source and the causal start edge, but
+    // intentionally does not order mailbox delivery against offload delivery.
+    assert_subsequence(&trace, &["start", "continuation-1", "continuation-2"]);
+    assert_subsequence(&trace, &["start", "mailbox"]);
+    assert_subsequence(&trace, &["start", "offload"]);
+    if fire_timer {
+        assert_subsequence(&trace, &["start", "timer"]);
+    }
 }
 
 #[tokio::test]
 async fn steady_state_uses_the_shared_bounded_batch_trace() {
-    assert_batch_trace(
-        false,
-        &[
-            "start",
-            "continuation-1",
-            "mailbox",
-            "continuation-2",
-            "offload",
-        ],
-    )
-    .await;
+    assert_batch_trace(false).await;
 }
 
 #[tokio::test]
 async fn due_timer_promotes_the_steady_batch_without_changing_source_priority() {
-    assert_batch_trace(
-        true,
-        &[
-            "start",
-            "continuation-1",
-            "mailbox",
-            "continuation-2",
-            "offload",
-            "timer",
-        ],
-    )
-    .await;
+    assert_batch_trace(true).await;
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -290,10 +321,10 @@ async fn continuation_queued_by_external_handler_leads_remaining_steady_batch_wo
         .expect("actor accepts start");
 
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
-    assert_eq!(
-        *log.lock().expect("log mutex poisoned"),
-        ["start", "offload-1", "continuation", "offload-2"]
-    );
+    let trace = log.lock().expect("log mutex poisoned");
+    assert_exact_entries(&trace, &["start", "offload-1", "offload-2", "continuation"]);
+    assert_subsequence(&trace, &["start", "offload-1", "offload-2"]);
+    assert_subsequence(&trace, &["offload-1", "continuation"]);
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/shelterwood/tests/events.rs
+++ b/crates/shelterwood/tests/events.rs
@@ -227,8 +227,26 @@ async fn assert_batch_trace(fire_timer: bool) {
     assert_subsequence(&trace, &["start", "continuation-1", "continuation-2"]);
     assert_subsequence(&trace, &["start", "mailbox"]);
     assert_subsequence(&trace, &["start", "offload"]);
+    let first_continuation = trace
+        .iter()
+        .position(|entry| *entry == "continuation-1")
+        .expect("the first continuation is present");
+    let second_continuation = trace
+        .iter()
+        .position(|entry| *entry == "continuation-2")
+        .expect("the second continuation is present");
+    assert!(
+        trace[first_continuation + 1..second_continuation]
+            .iter()
+            .any(|entry| matches!(*entry, "mailbox" | "offload")),
+        "one ready external delivery gets the fairness turn between consecutive continuations: {trace:?}"
+    );
     if fire_timer {
-        assert_subsequence(&trace, &["start", "timer"]);
+        assert_eq!(
+            trace.last(),
+            Some(&"timer"),
+            "the fired timer follows every captured continuation, mailbox, and offload entry"
+        );
     }
 }
 
@@ -323,8 +341,7 @@ async fn continuation_queued_by_external_handler_leads_remaining_steady_batch_wo
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     let trace = log.lock().expect("log mutex poisoned");
     assert_exact_entries(&trace, &["start", "offload-1", "offload-2", "continuation"]);
-    assert_subsequence(&trace, &["start", "offload-1", "offload-2"]);
-    assert_subsequence(&trace, &["offload-1", "continuation"]);
+    assert_subsequence(&trace, &["start", "offload-1", "continuation", "offload-2"]);
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/shelterwood/tests/lifecycle.rs
+++ b/crates/shelterwood/tests/lifecycle.rs
@@ -9,7 +9,9 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, policy::never, poll_until};
+use crate::common::{
+    POLL_TIMEOUT, ReleaseGate, assert_quiet, policy::never, poll_once, poll_until,
+};
 use shelterwood::{
     Actor, ActorOnceDef, Cancellation, Context, DynamicTree, ExitError, ExitKind, ExitResult,
     GracePhase, Intensity, LifecycleEventKind, LifecycleItem, Readiness, Retention, ScopeState,
@@ -377,6 +379,7 @@ async fn grace_expiry_mid_ladder_joins_the_abort_before_advancing() {
     let first_stopping = ReleaseGate::default();
     let last_dropped = Arc::new(AtomicBool::new(false));
     let joined_before_advance = Arc::new(AtomicBool::new(false));
+    let last_handle = Arc::new(Mutex::new(None::<shelterwood::TaskRef>));
     let grace = Duration::from_secs(10);
     let mut tree = Tree::new();
     tree.add_task(
@@ -385,14 +388,25 @@ async fn grace_expiry_mid_ladder_joins_the_abort_before_advancing() {
             let first_stopping = first_stopping.clone();
             let last_dropped = Arc::clone(&last_dropped);
             let joined_before_advance = Arc::clone(&joined_before_advance);
+            let last_handle = Arc::clone(&last_handle);
             move |context| {
                 let first_stopping = first_stopping.clone();
                 let last_dropped = Arc::clone(&last_dropped);
                 let joined_before_advance = Arc::clone(&joined_before_advance);
+                let last_handle = Arc::clone(&last_handle);
                 async move {
                     context.shutdown_token().cancelled().await;
-                    joined_before_advance
-                        .store(last_dropped.load(Ordering::SeqCst), Ordering::SeqCst);
+                    let last = last_handle
+                        .lock()
+                        .expect("last handle mutex poisoned")
+                        .clone()
+                        .expect("last handle is installed before spawn");
+                    let mut terminal = Box::pin(last.wait());
+                    joined_before_advance.store(
+                        poll_once(terminal.as_mut()).is_ready()
+                            && last_dropped.load(Ordering::SeqCst),
+                        Ordering::SeqCst,
+                    );
                     first_stopping.release();
                     Ok(())
                 }
@@ -400,25 +414,27 @@ async fn grace_expiry_mid_ladder_joins_the_abort_before_advancing() {
         }),
     )
     .expect("valid first task");
-    tree.add_task(
-        "last",
-        TaskDef::new({
-            let last_stopping = last_stopping.clone();
-            let last_dropped = Arc::clone(&last_dropped);
-            move |context| {
+    let last = tree
+        .add_task(
+            "last",
+            TaskDef::new({
                 let last_stopping = last_stopping.clone();
                 let last_dropped = Arc::clone(&last_dropped);
-                async move {
-                    let _drop_signal = DropSignal(last_dropped);
-                    context.shutdown_token().cancelled().await;
-                    last_stopping.release();
-                    future::pending::<ExitResult>().await
+                move |context| {
+                    let last_stopping = last_stopping.clone();
+                    let last_dropped = Arc::clone(&last_dropped);
+                    async move {
+                        let _drop_signal = DropSignal(last_dropped);
+                        context.shutdown_token().cancelled().await;
+                        last_stopping.release();
+                        future::pending::<ExitResult>().await
+                    }
                 }
-            }
-        })
-        .shutdown(Shutdown::Graceful { grace }),
-    )
-    .expect("valid last task");
+            })
+            .shutdown(Shutdown::Graceful { grace }),
+        )
+        .expect("valid last task");
+    *last_handle.lock().expect("last handle mutex poisoned") = Some(last.clone());
 
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("tree starts");
@@ -436,6 +452,12 @@ async fn grace_expiry_mid_ladder_joins_the_abort_before_advancing() {
         .await
         .expect("shutdown task joins")
         .expect("shutdown completes within its owner budget");
+    assert!(matches!(
+        last.wait().await.kind(),
+        ExitKind::Aborted {
+            phase: GracePhase::AfterGrace
+        }
+    ));
 }
 
 #[tokio::test(start_paused = true)]

--- a/crates/shelterwood/tests/lifecycle.rs
+++ b/crates/shelterwood/tests/lifecycle.rs
@@ -1,15 +1,15 @@
 use std::{
-    future,
+    future::{self, Future},
+    pin::Pin,
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
+    task::{Context as FutureContext, Poll},
     time::Duration,
 };
 
-use crate::common::{
-    POLL_TIMEOUT, PanicOnDrop, ReleaseGate, assert_quiet, policy::never, poll_until,
-};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, policy::never, poll_until};
 use shelterwood::{
     Actor, ActorOnceDef, Cancellation, Context, DynamicTree, ExitError, ExitKind, ExitResult,
     GracePhase, Intensity, LifecycleEventKind, LifecycleItem, Readiness, Retention, ScopeState,
@@ -17,7 +17,7 @@ use shelterwood::{
     Tree,
 };
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn non_owners_are_quiet_and_an_empty_root_needs_its_owner() {
     let empty = Tree::new().spawn().expect("runtime is available");
     empty.wait_started().await.expect("empty root starts");
@@ -137,16 +137,40 @@ async fn framework_task_verdicts_remain_typed() {
     ));
 }
 
+struct CompletedTaskFuture {
+    returned: bool,
+}
+
+impl Future for CompletedTaskFuture {
+    type Output = Result<(), ExitError>;
+
+    fn poll(mut self: Pin<&mut Self>, _: &mut FutureContext<'_>) -> Poll<Self::Output> {
+        assert!(
+            !self.returned,
+            "completed task future must not be re-polled"
+        );
+        self.returned = true;
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl Drop for CompletedTaskFuture {
+    fn drop(&mut self) {
+        assert!(
+            self.returned,
+            "fixture must first produce a completed output"
+        );
+        panic!("task future destructor panic");
+    }
+}
+
 #[tokio::test]
-async fn task_destructor_panic_is_one_post_join_panic_exit() {
+async fn task_future_destructor_panic_folds_after_its_completed_output() {
     let mut tree = Tree::new();
     let task = tree
         .add_task_once(
             "panic-on-drop",
-            TaskOnceDef::new(|_| async move {
-                let _value = PanicOnDrop::new("task destructor panic");
-                Ok::<_, ExitError>(())
-            }),
+            TaskOnceDef::new(|_| CompletedTaskFuture { returned: false }),
         )
         .expect("valid task")
         .0;
@@ -155,7 +179,7 @@ async fn task_destructor_panic_is_one_post_join_panic_exit() {
     let exit = task.wait().await;
     assert!(matches!(
         exit.kind(),
-        ExitKind::Panicked { message: Some(message) } if message == "task destructor panic"
+        ExitKind::Panicked { message: Some(message) } if message == "task future destructor panic"
     ));
     assert_eq!(system.wait().await, StopReason::Finished);
 }
@@ -278,7 +302,7 @@ async fn replacement_starts_only_after_the_old_future_is_destroyed() {
         .expect("tree shuts down");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn ordered_teardown_is_reverse_and_joins_before_advancing() {
     let order = Arc::new(Mutex::new(Vec::new()));
     let gates = [
@@ -414,7 +438,7 @@ async fn grace_expiry_mid_ladder_joins_the_abort_before_advancing() {
         .expect("shutdown completes within its owner budget");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn ordered_teardown_keeps_its_frontier_when_an_earlier_child_exits() {
     let first_stopping = Arc::new(AtomicBool::new(false));
     let middle_exit = ReleaseGate::default();

--- a/crates/shelterwood/tests/lifecycle.rs
+++ b/crates/shelterwood/tests/lifecycle.rs
@@ -339,6 +339,81 @@ async fn ordered_teardown_is_reverse_and_joins_before_advancing() {
         .expect("clean shutdown");
 }
 
+struct DropSignal(Arc<AtomicBool>);
+
+impl Drop for DropSignal {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn grace_expiry_mid_ladder_joins_the_abort_before_advancing() {
+    let last_stopping = ReleaseGate::default();
+    let first_stopping = ReleaseGate::default();
+    let last_dropped = Arc::new(AtomicBool::new(false));
+    let joined_before_advance = Arc::new(AtomicBool::new(false));
+    let grace = Duration::from_secs(10);
+    let mut tree = Tree::new();
+    tree.add_task(
+        "first",
+        TaskDef::new({
+            let first_stopping = first_stopping.clone();
+            let last_dropped = Arc::clone(&last_dropped);
+            let joined_before_advance = Arc::clone(&joined_before_advance);
+            move |context| {
+                let first_stopping = first_stopping.clone();
+                let last_dropped = Arc::clone(&last_dropped);
+                let joined_before_advance = Arc::clone(&joined_before_advance);
+                async move {
+                    context.shutdown_token().cancelled().await;
+                    joined_before_advance
+                        .store(last_dropped.load(Ordering::SeqCst), Ordering::SeqCst);
+                    first_stopping.release();
+                    Ok(())
+                }
+            }
+        }),
+    )
+    .expect("valid first task");
+    tree.add_task(
+        "last",
+        TaskDef::new({
+            let last_stopping = last_stopping.clone();
+            let last_dropped = Arc::clone(&last_dropped);
+            move |context| {
+                let last_stopping = last_stopping.clone();
+                let last_dropped = Arc::clone(&last_dropped);
+                async move {
+                    let _drop_signal = DropSignal(last_dropped);
+                    context.shutdown_token().cancelled().await;
+                    last_stopping.release();
+                    future::pending::<ExitResult>().await
+                }
+            }
+        })
+        .shutdown(Shutdown::Graceful { grace }),
+    )
+    .expect("valid last task");
+
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("tree starts");
+    let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(30)));
+    last_stopping.wait().await;
+    assert!(!last_dropped.load(Ordering::SeqCst));
+
+    tokio::time::advance(grace).await;
+    tokio::time::timeout(POLL_TIMEOUT, first_stopping.wait())
+        .await
+        .expect("the teardown ladder advances after the abort joins");
+    assert!(last_dropped.load(Ordering::SeqCst));
+    assert!(joined_before_advance.load(Ordering::SeqCst));
+    shutdown
+        .await
+        .expect("shutdown task joins")
+        .expect("shutdown completes within its owner budget");
+}
+
 #[tokio::test]
 async fn ordered_teardown_keeps_its_frontier_when_an_earlier_child_exits() {
     let first_stopping = Arc::new(AtomicBool::new(false));
@@ -530,6 +605,79 @@ async fn concurrent_initial_failures_publish_one_startup_failed_scope_edge() {
         .shutdown(Duration::from_secs(1))
         .await
         .expect("failed dynamic root shuts down");
+}
+
+#[tokio::test]
+async fn plain_restart_publishes_exited_old_before_started_new() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let fail_first = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.add_task(
+        "worker",
+        TaskDef::new({
+            let attempts = Arc::clone(&attempts);
+            let fail_first = fail_first.clone();
+            move |context| {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                let fail_first = fail_first.clone();
+                async move {
+                    if attempt == 0 {
+                        fail_first.wait().await;
+                        return Err(ExitError::message("restart me"));
+                    }
+                    context.shutdown_token().cancelled().await;
+                    Ok(())
+                }
+            }
+        }),
+    )
+    .expect("valid worker");
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("first incarnation starts");
+    let first = system
+        .scope()
+        .child("worker")
+        .and_then(|child| child.incarnation)
+        .expect("running child has an incarnation");
+    let mut lifecycle = system.scope().subscribe_lifecycle();
+    fail_first.release();
+
+    loop {
+        let item = tokio::time::timeout(POLL_TIMEOUT, lifecycle.recv())
+            .await
+            .expect("restart lifecycle is bounded")
+            .expect("lifecycle stream remains open");
+        let LifecycleItem::Event(event) = item else {
+            panic!("small restart fixture must not lag");
+        };
+        match event.kind {
+            LifecycleEventKind::Exited { incarnation, .. } if incarnation == first => break,
+            _ => {}
+        }
+    }
+    let second = loop {
+        let item = tokio::time::timeout(POLL_TIMEOUT, lifecycle.recv())
+            .await
+            .expect("replacement lifecycle is bounded")
+            .expect("lifecycle stream remains open");
+        let LifecycleItem::Event(event) = item else {
+            panic!("small restart fixture must not lag");
+        };
+        if let LifecycleEventKind::Started { incarnation, .. } = event.kind
+            && incarnation.supersedes(first)
+        {
+            break incarnation;
+        }
+    };
+    assert!(second.supersedes(first));
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("replacement stops");
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -662,7 +662,6 @@ async fn rebuilt_declared_handles_and_incarnations_keep_identity() {
 
     let stash: Arc<Mutex<Vec<(TaskRef, u64, shelterwood::Membership)>>> =
         Arc::new(Mutex::new(Vec::new()));
-    let keyed = Arc::new(Mutex::new(HashSet::<TaskRef>::new()));
     let builds = Arc::new(AtomicUsize::new(0));
     let mut outer = Tree::new();
     let nested = outer
@@ -670,7 +669,6 @@ async fn rebuilt_declared_handles_and_incarnations_keep_identity() {
             "nested",
             SubtreeDef::factory({
                 let stash = Arc::clone(&stash);
-                let keyed = Arc::clone(&keyed);
                 let builds = Arc::clone(&builds);
                 move || {
                     let mut tree = Tree::new();
@@ -684,13 +682,6 @@ async fn rebuilt_declared_handles_and_incarnations_keep_identity() {
                     // Capture identity before lowering. The prior terminal
                     // declaration's lineage was evicted, so this rebuild keeps
                     // its fresh, incomparable identity.
-                    assert!(
-                        keyed
-                            .lock()
-                            .expect("handle set mutex intact")
-                            .insert(handle.clone()),
-                        "each rebuilt declaration has fresh logical identity"
-                    );
                     stash.lock().expect("stash mutex intact").push((
                         handle.clone(),
                         hashed(&handle),
@@ -732,23 +723,9 @@ async fn rebuilt_declared_handles_and_incarnations_keep_identity() {
 
     assert_eq!(first.membership(), first_declared);
     assert_eq!(hashed(&first), first_hash);
-    assert!(
-        keyed
-            .lock()
-            .expect("handle set mutex intact")
-            .contains(&first),
-        "lowering and a later subtree restart preserve the first keyed handle"
-    );
     assert!(!second.membership().supersedes(first.membership()));
     assert!(!first.membership().supersedes(second.membership()));
     assert_eq!(second.membership(), second_declared);
-    assert!(
-        keyed
-            .lock()
-            .expect("handle set mutex intact")
-            .contains(&second),
-        "the rebuilt declaration remains retrievable after lowering into the restarted subtree"
-    );
     assert_eq!(
         hashed(&second),
         second_hash,

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -662,6 +662,7 @@ async fn rebuilt_declared_handles_and_incarnations_keep_identity() {
 
     let stash: Arc<Mutex<Vec<(TaskRef, u64, shelterwood::Membership)>>> =
         Arc::new(Mutex::new(Vec::new()));
+    let keyed = Arc::new(Mutex::new(HashSet::<TaskRef>::new()));
     let builds = Arc::new(AtomicUsize::new(0));
     let mut outer = Tree::new();
     let nested = outer
@@ -669,6 +670,7 @@ async fn rebuilt_declared_handles_and_incarnations_keep_identity() {
             "nested",
             SubtreeDef::factory({
                 let stash = Arc::clone(&stash);
+                let keyed = Arc::clone(&keyed);
                 let builds = Arc::clone(&builds);
                 move || {
                     let mut tree = Tree::new();
@@ -682,6 +684,13 @@ async fn rebuilt_declared_handles_and_incarnations_keep_identity() {
                     // Capture identity before lowering. The prior terminal
                     // declaration's lineage was evicted, so this rebuild keeps
                     // its fresh, incomparable identity.
+                    assert!(
+                        keyed
+                            .lock()
+                            .expect("handle set mutex intact")
+                            .insert(handle.clone()),
+                        "each rebuilt declaration has fresh logical identity"
+                    );
                     stash.lock().expect("stash mutex intact").push((
                         handle.clone(),
                         hashed(&handle),
@@ -723,9 +732,23 @@ async fn rebuilt_declared_handles_and_incarnations_keep_identity() {
 
     assert_eq!(first.membership(), first_declared);
     assert_eq!(hashed(&first), first_hash);
+    assert!(
+        keyed
+            .lock()
+            .expect("handle set mutex intact")
+            .contains(&first),
+        "lowering and a later subtree restart preserve the first keyed handle"
+    );
     assert!(!second.membership().supersedes(first.membership()));
     assert!(!first.membership().supersedes(second.membership()));
     assert_eq!(second.membership(), second_declared);
+    assert!(
+        keyed
+            .lock()
+            .expect("handle set mutex intact")
+            .contains(&second),
+        "the rebuilt declaration remains retrievable after its membership rebase"
+    );
     assert_eq!(
         hashed(&second),
         second_hash,

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -747,7 +747,7 @@ async fn rebuilt_declared_handles_and_incarnations_keep_identity() {
             .lock()
             .expect("handle set mutex intact")
             .contains(&second),
-        "the rebuilt declaration remains retrievable after its membership rebase"
+        "the rebuilt declaration remains retrievable after lowering into the restarted subtree"
     );
     assert_eq!(
         hashed(&second),

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -1210,6 +1210,60 @@ async fn snapshot_subscriptions_conflate_unobserved_transitions_to_the_latest_va
 }
 
 #[tokio::test(start_paused = true)]
+async fn cloned_snapshot_receivers_observe_independently_and_inherit_the_seen_generation() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+    let mut original = scope.subscribe_snapshots();
+    let mut peer = original.clone();
+
+    let task = scope
+        .add_task("worker", waiting_task())
+        .await
+        .expect("worker is admitted");
+    scope
+        .wait_for_child(
+            "worker",
+            |child| matches!(child.state, ChildState::Running),
+            POLL_TIMEOUT,
+        )
+        .await
+        .expect("worker starts");
+    let from_original = original.changed().await.expect("original observes update");
+    let from_peer = peer
+        .changed()
+        .await
+        .expect("clone independently observes update");
+    assert_eq!(from_original, from_peer);
+    assert_eq!(
+        from_original.child("worker").unwrap().membership,
+        task.membership()
+    );
+
+    let mut inherited = original.clone();
+    let mut no_replay = Box::pin(inherited.changed());
+    assert_quiet(Duration::from_secs(1), || {
+        poll_once(no_replay.as_mut()).is_ready()
+    })
+    .await;
+    drop(no_replay);
+
+    assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
+    let removed_from_original = original.changed().await.expect("original observes removal");
+    let removed_from_inherited = inherited
+        .changed()
+        .await
+        .expect("post-observation clone independently observes removal");
+    assert_eq!(removed_from_original, removed_from_inherited);
+    assert!(removed_from_original.child("worker").is_none());
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+#[tokio::test(start_paused = true)]
 async fn lifecycle_subscriptions_start_now_without_replaying_prior_history() {
     let system = DynamicTree::new().spawn().expect("runtime is available");
     system.wait_started().await.expect("root starts");

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -1739,7 +1739,7 @@ enum SaturateMessage {
 struct SaturatedActor {
     issued: usize,
     delivered: usize,
-    observed_deliveries: Arc<AtomicUsize>,
+    peak_backlog: Arc<AtomicUsize>,
 }
 
 impl Actor for SaturatedActor {
@@ -1751,13 +1751,15 @@ impl Actor for SaturatedActor {
         Ok(Self {
             issued: 0,
             delivered: 0,
-            observed_deliveries: args.1,
+            peak_backlog: args.1,
         })
     }
 
     async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
         match message {
             SaturateMessage::Ping => {
+                self.peak_backlog
+                    .fetch_max(self.issued - self.delivered, Ordering::SeqCst);
                 self.issued += 1;
                 context
                     .offload(
@@ -1772,7 +1774,6 @@ impl Actor for SaturatedActor {
             }
             SaturateMessage::Completed => {
                 self.delivered += 1;
-                self.observed_deliveries.fetch_add(1, Ordering::SeqCst);
                 if self.delivered == SATURATE {
                     context.stop();
                 }
@@ -1783,18 +1784,21 @@ impl Actor for SaturatedActor {
 }
 
 /// A continuously nonempty mailbox cannot starve queued offload completions:
-/// all completions eventually arrive even when the mailbox was already full.
-/// The cross-source interleaving and an exact transient backlog width are not
-/// part of that starvation guarantee.
+/// bounded arbitration turns interleave the captured completion prefix with
+/// mailbox delivery, so the completion backlog tracks the actor's own
+/// in-flight issuance instead of growing with mailbox history. Only that
+/// relation is asserted — a backlog reaching the whole queued history means
+/// completions were starved until the mailbox drained, while the exact
+/// transient width and the cross-source interleaving are unspecified.
 #[tokio::test]
-async fn saturated_mailbox_eventually_delivers_every_completion() {
+async fn saturated_mailbox_does_not_grow_the_completion_backlog() {
     let gate = ReleaseGate::default();
-    let delivered = Arc::new(AtomicUsize::new(0));
+    let peak_backlog = Arc::new(AtomicUsize::new(0));
     let mut tree = Tree::new();
     let actor = tree
         .add_actor_once(
             "saturated",
-            ActorOnceDef::<SaturatedActor>::new((gate.clone(), Arc::clone(&delivered)))
+            ActorOnceDef::<SaturatedActor>::new((gate.clone(), Arc::clone(&peak_backlog)))
                 .mailbox(Mailbox::queue(SATURATE).expect("non-zero capacity")),
         )
         .expect("valid actor");
@@ -1807,8 +1811,13 @@ async fn saturated_mailbox_eventually_delivers_every_completion() {
     }
     gate.release();
     system.wait_started().await.expect("actor starts");
+    // Termination is itself the liveness half: the actor stops only once all
+    // SATURATE completions land.
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
-    assert_eq!(delivered.load(Ordering::SeqCst), SATURATE);
+    assert!(
+        peak_backlog.load(Ordering::SeqCst) < SATURATE - 1,
+        "the completion backlog must not reach the queued mailbox history"
+    );
 }
 
 /// §5.5's teardown order holds on the error path too: a handler `Err` joins

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -1739,7 +1739,7 @@ enum SaturateMessage {
 struct SaturatedActor {
     issued: usize,
     delivered: usize,
-    peak_backlog: Arc<AtomicUsize>,
+    observed_deliveries: Arc<AtomicUsize>,
 }
 
 impl Actor for SaturatedActor {
@@ -1751,15 +1751,13 @@ impl Actor for SaturatedActor {
         Ok(Self {
             issued: 0,
             delivered: 0,
-            peak_backlog: args.1,
+            observed_deliveries: args.1,
         })
     }
 
     async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
         match message {
             SaturateMessage::Ping => {
-                self.peak_backlog
-                    .fetch_max(self.issued - self.delivered, Ordering::SeqCst);
                 self.issued += 1;
                 context
                     .offload(
@@ -1774,6 +1772,7 @@ impl Actor for SaturatedActor {
             }
             SaturateMessage::Completed => {
                 self.delivered += 1;
+                self.observed_deliveries.fetch_add(1, Ordering::SeqCst);
                 if self.delivered == SATURATE {
                     context.stop();
                 }
@@ -1784,19 +1783,18 @@ impl Actor for SaturatedActor {
 }
 
 /// A continuously nonempty mailbox cannot starve queued offload completions:
-/// every bounded arbitration turn admits at most one mailbox delivery before
-/// its captured completion prefix, so the completion backlog stays
-/// proportional to the actor's own in-flight issuance instead of growing with
-/// mailbox history.
+/// all completions eventually arrive even when the mailbox was already full.
+/// The cross-source interleaving and an exact transient backlog width are not
+/// part of that starvation guarantee.
 #[tokio::test]
-async fn saturated_mailbox_does_not_grow_the_completion_backlog() {
+async fn saturated_mailbox_eventually_delivers_every_completion() {
     let gate = ReleaseGate::default();
-    let peak_backlog = Arc::new(AtomicUsize::new(0));
+    let delivered = Arc::new(AtomicUsize::new(0));
     let mut tree = Tree::new();
     let actor = tree
         .add_actor_once(
             "saturated",
-            ActorOnceDef::<SaturatedActor>::new((gate.clone(), Arc::clone(&peak_backlog)))
+            ActorOnceDef::<SaturatedActor>::new((gate.clone(), Arc::clone(&delivered)))
                 .mailbox(Mailbox::queue(SATURATE).expect("non-zero capacity")),
         )
         .expect("valid actor");
@@ -1810,11 +1808,7 @@ async fn saturated_mailbox_does_not_grow_the_completion_backlog() {
     gate.release();
     system.wait_started().await.expect("actor starts");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
-    assert!(
-        peak_backlog.load(Ordering::SeqCst) <= 2,
-        "bounded arbitration turns drain completions instead of accumulating \
-         them while the mailbox stays nonempty"
-    );
+    assert_eq!(delivered.load(Ordering::SeqCst), SATURATE);
 }
 
 /// §5.5's teardown order holds on the error path too: a handler `Err` joins

--- a/crates/shelterwood/tests/one_shot_resource_ownership.rs
+++ b/crates/shelterwood/tests/one_shot_resource_ownership.rs
@@ -62,7 +62,7 @@ fn resource_raw_actor(count: &ConsumeCount, mode: RawResourceMode) -> ResourceRa
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn one_shot_raw_resource_drops_once_on_normal_exit() {
     let count = ConsumeCount::default();
     let mut tree = Tree::new();
@@ -92,7 +92,7 @@ fn one_shot_raw_resource_drops_once_on_readiness_definition_panic() {
     count.assert_once();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn dynamic_one_shot_raw_resource_drops_once_on_readiness_definition_panic() {
     let system = DynamicTree::new().spawn().expect("runtime is available");
     system.wait_started().await.expect("dynamic root starts");
@@ -121,7 +121,7 @@ async fn dynamic_one_shot_raw_resource_drops_once_on_readiness_definition_panic(
         .expect("dynamic root stops");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn one_shot_raw_resource_drops_once_on_startup_failure() {
     let count = ConsumeCount::default();
     let mut tree = Tree::new();
@@ -141,7 +141,7 @@ async fn one_shot_raw_resource_drops_once_on_startup_failure() {
     count.assert_once();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn one_shot_raw_resource_drops_once_on_shutdown_before_start() {
     let count = ConsumeCount::default();
     let mut tree = Tree::new();
@@ -212,7 +212,7 @@ impl Actor for ResourceActor {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn one_shot_actor_args_drop_once_on_normal_exit() {
     let count = ConsumeCount::default();
     let mut tree = Tree::new();
@@ -255,13 +255,13 @@ async fn assert_actor_init_path_drops_once(mode: ActorResourceMode) {
     count.assert_once();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn one_shot_actor_args_drop_once_on_init_panic_and_startup_failure() {
     assert_actor_init_path_drops_once(ActorResourceMode::InitPanic).await;
     assert_actor_init_path_drops_once(ActorResourceMode::StartupFailure).await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn one_shot_actor_args_drop_once_when_shutdown_prevents_start() {
     let count = ConsumeCount::default();
     let gate_started = ReleaseGate::default();
@@ -300,7 +300,7 @@ async fn one_shot_actor_args_drop_once_when_shutdown_prevents_start() {
     count.assert_once();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn one_shot_task_resource_drops_once_on_normal_exit() {
     let count = ConsumeCount::default();
     let guard = count.guard();
@@ -320,7 +320,7 @@ async fn one_shot_task_resource_drops_once_on_normal_exit() {
     count.assert_once();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn one_shot_task_resource_drops_once_on_panic() {
     let count = ConsumeCount::default();
     let guard = count.guard();
@@ -342,7 +342,7 @@ async fn one_shot_task_resource_drops_once_on_panic() {
     count.assert_once();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn one_shot_task_resource_drops_once_on_startup_failure() {
     let count = ConsumeCount::default();
     let guard = count.guard();
@@ -367,7 +367,7 @@ async fn one_shot_task_resource_drops_once_on_startup_failure() {
     count.assert_once();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn one_shot_task_resource_drops_once_on_shutdown_before_start() {
     let count = ConsumeCount::default();
     let guard = count.guard();
@@ -476,7 +476,7 @@ fn cancelled_one_shot_subtree(count: &ConsumeCount, started: Arc<AtomicBool>) ->
     tree
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn cancelling_inflight_one_shot_adds_drops_every_kind_resource_once() {
     let system = DynamicTree::new().spawn().expect("runtime is available");
     system.wait_started().await.expect("dynamic root starts");
@@ -570,7 +570,7 @@ async fn cancelling_inflight_one_shot_adds_drops_every_kind_resource_once() {
     assert!(!subtree_started.load(Ordering::SeqCst));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn one_shot_subtree_resource_drops_once_on_normal_exit() {
     let count = ConsumeCount::default();
     let nested = one_shot_subtree_with_guard(&count, "normal");
@@ -582,7 +582,7 @@ async fn one_shot_subtree_resource_drops_once_on_normal_exit() {
     count.assert_once();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn one_shot_subtree_resource_drops_once_on_panic() {
     let count = ConsumeCount::default();
     let nested = one_shot_subtree_with_guard(&count, "panic");
@@ -598,7 +598,7 @@ async fn one_shot_subtree_resource_drops_once_on_panic() {
     count.assert_once();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn one_shot_subtree_resource_drops_once_on_lowering_failure() {
     let count = ConsumeCount::default();
     let guard = count.guard();
@@ -625,7 +625,7 @@ async fn one_shot_subtree_resource_drops_once_on_lowering_failure() {
     count.assert_once();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn one_shot_subtree_resource_drops_once_on_shutdown_before_start() {
     let count = ConsumeCount::default();
     let nested = one_shot_subtree_with_guard(&count, "normal");

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -350,6 +350,115 @@ async fn raw_recv_is_shutdown_biased_and_try_recv_controls_drain_vs_discard() {
     }
 }
 
+struct LiveTryRecvActor {
+    entered: ReleaseGate,
+    release: ReleaseGate,
+    observed: Arc<Mutex<Option<usize>>>,
+}
+
+impl RawActor for LiveTryRecvActor {
+    type Msg = usize;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        self.entered.release();
+        self.release.wait().await;
+        *self.observed.lock().expect("observation mutex poisoned") = context.try_recv();
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn try_recv_delivers_mailbox_input_while_the_incarnation_is_live() {
+    let entered = ReleaseGate::default();
+    let release = ReleaseGate::default();
+    let observed = Arc::new(Mutex::new(None));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "live-try-recv",
+            RawOnceDef::new(LiveTryRecvActor {
+                entered: entered.clone(),
+                release: release.clone(),
+                observed: Arc::clone(&observed),
+            }),
+        )
+        .expect("valid raw actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("raw actor starts");
+    entered.wait().await;
+    actor.try_send(17).expect("live mailbox accepts");
+    release.release();
+
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert_eq!(
+        *observed.lock().expect("observation mutex poisoned"),
+        Some(17)
+    );
+}
+
+struct TryRecvPanicActor {
+    panic_queued: Arc<AtomicBool>,
+}
+
+impl RawActor for TryRecvPanicActor {
+    type Msg = ();
+
+    fn readiness() -> Readiness {
+        Readiness::Manual
+    }
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        context.mark_ready();
+        let guard = context
+            .offload_scoped(
+                async { panic!("try_recv retained offload panic") },
+                |_| (),
+                Duration::MAX,
+            )
+            .expect("offload accepted");
+        guard.finished().await;
+        self.panic_queued.store(true, Ordering::SeqCst);
+        let _ = context.try_recv();
+        unreachable!("live try_recv must resume the retained panic")
+    }
+}
+
+#[tokio::test]
+async fn live_try_recv_resumes_a_retained_offload_panic() {
+    let panic_queued = Arc::new(AtomicBool::new(false));
+    let mut tree = Tree::new();
+    tree.add_raw_once(
+        "try-recv-panic",
+        RawOnceDef::new(TryRecvPanicActor {
+            panic_queued: Arc::clone(&panic_queued),
+        }),
+    )
+    .expect("valid raw actor");
+    let system = tree.spawn().expect("runtime is available");
+    let mut events = system.scope().subscribe_lifecycle();
+    system.wait_started().await.expect("manual readiness fires");
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+
+    let mut observed_exit = None;
+    while let Some(item) = events.recv().await {
+        let shelterwood::LifecycleItem::Event(event) = item else {
+            panic!("small fixture must not lag");
+        };
+        if let shelterwood::LifecycleEventKind::Exited { id, exit, .. } = event.kind
+            && id.as_str() == "try-recv-panic"
+        {
+            observed_exit = Some(exit);
+        }
+    }
+    let exit = observed_exit.expect("panic exit is observable on the lifecycle stream");
+    assert!(matches!(
+        exit.kind(),
+        shelterwood::ExitKind::Panicked { message }
+            if message.as_deref() == Some("try_recv retained offload panic")
+    ));
+    assert!(panic_queued.load(Ordering::SeqCst));
+}
+
 struct DynamicActor {
     values: Arc<Mutex<Vec<usize>>>,
 }

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -10,10 +10,10 @@ use crate::common::{
     POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, policy::never, poll_until,
 };
 use shelterwood::{
-    Backoff, Cancellation, ChildState, DynamicTree, ExitError, ExitKind, ExitResult, Jitter,
-    RawActor, RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline, RestartCondition,
-    RestartPolicy, ScopeState, Shutdown, StartupError, StartupFailureCause, SubtreeOnceDef,
-    TaskDef, Tree,
+    Actor, ActorOnceDef, Backoff, Cancellation, ChildState, Context, DynamicTree, ExitError,
+    ExitKind, ExitResult, Jitter, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
+    ReadinessDeadline, RestartCondition, RestartPolicy, ScopeState, Shutdown, StartupError,
+    StartupFailureCause, SubtreeOnceDef, TaskDef, Tree,
 };
 
 struct ReadyThenStop;
@@ -832,6 +832,147 @@ async fn nested_dynamic_startup_failure_rolls_back_and_preserves_inner_cause() {
         .shutdown(Duration::from_secs(1))
         .await
         .expect("failed root rolls back");
+}
+
+#[tokio::test]
+async fn nested_ordered_startup_failure_rolls_back_only_the_started_prefix() {
+    let prefix_cancelled = Arc::new(AtomicBool::new(false));
+    let suffix_started = Arc::new(AtomicBool::new(false));
+    let mut nested = Tree::new();
+    nested
+        .add_task(
+            "prefix",
+            TaskDef::new({
+                let prefix_cancelled = Arc::clone(&prefix_cancelled);
+                move |context| {
+                    let prefix_cancelled = Arc::clone(&prefix_cancelled);
+                    async move {
+                        context.shutdown_token().cancelled().await;
+                        prefix_cancelled.store(true, Ordering::SeqCst);
+                        Ok(())
+                    }
+                }
+            }),
+        )
+        .expect("valid prefix");
+    nested
+        .add_task(
+            "failure",
+            TaskDef::new(|_| async { Err(ExitError::message("nested ordered failure")) })
+                .restart(never())
+                .readiness(Readiness::Manual)
+                .expect("manual readiness"),
+        )
+        .expect("valid failure");
+    let suffix = nested
+        .add_task(
+            "suffix",
+            TaskDef::new({
+                let suffix_started = Arc::clone(&suffix_started);
+                move |_| {
+                    suffix_started.store(true, Ordering::SeqCst);
+                    async { Ok(()) }
+                }
+            }),
+        )
+        .expect("valid suffix");
+
+    let mut root = Tree::new();
+    let nested_scope = root
+        .add_subtree_once(
+            "nested",
+            SubtreeOnceDef::new(nested).shutdown(Shutdown::Abort),
+        )
+        .expect("valid nested scope");
+    let system = root.spawn().expect("runtime is available");
+    let error = system
+        .wait_started()
+        .await
+        .expect_err("the ordered child failure aborts nested startup");
+    assert!(matches!(
+        error,
+        StartupError::StartupFailed(ref failure)
+            if matches!(failure.cause, StartupFailureCause::Child { ref id, .. } if id.as_str() == "nested")
+    ));
+    assert!(prefix_cancelled.load(Ordering::SeqCst));
+    assert!(!suffix_started.load(Ordering::SeqCst));
+    assert!(matches!(suffix.wait().await.kind(), ExitKind::NeverStarted));
+    assert!(matches!(
+        nested_scope.wait_stopped().await,
+        shelterwood::StopReason::StartupFailed(_)
+    ));
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed root rolls back");
+}
+
+struct ExplicitInitReady;
+
+impl Actor for ExplicitInitReady {
+    type Msg = ();
+    type Args = (ReleaseGate, ReleaseGate);
+
+    async fn init(
+        (ready, release_init): Self::Args,
+        context: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        context.mark_ready();
+        context.mark_ready();
+        ready.release();
+        release_init.wait().await;
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): (), _: &mut Context<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn earliest_mark_ready_wins_and_later_readiness_edges_are_no_ops() {
+    let explicit_ready = ReleaseGate::default();
+    let release_init = ReleaseGate::default();
+    let sibling_started = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.add_actor_once(
+        "actor",
+        ActorOnceDef::<ExplicitInitReady>::new((explicit_ready.clone(), release_init.clone()))
+            .readiness(Readiness::AfterInit),
+    )
+    .expect("valid actor");
+    tree.add_task(
+        "sibling",
+        TaskDef::new({
+            let sibling_started = sibling_started.clone();
+            move |context| {
+                let sibling_started = sibling_started.clone();
+                async move {
+                    context.mark_ready();
+                    context.mark_ready();
+                    sibling_started.release();
+                    context.shutdown_token().cancelled().await;
+                    Ok(())
+                }
+            }
+        }),
+    )
+    .expect("valid sibling");
+
+    let system = tree.spawn().expect("runtime is available");
+    explicit_ready.wait().await;
+    tokio::time::timeout(POLL_TIMEOUT, sibling_started.wait())
+        .await
+        .expect("explicit readiness advances ordered startup before init returns");
+    release_init.release();
+    system
+        .wait_started()
+        .await
+        .expect("automatic and duplicate readiness signals are harmless no-ops");
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("tree stops");
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -237,7 +237,7 @@ async fn immediate_restart_deadline_rechecks_aggregate_startup() {
         .expect("restarted task cooperates");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn ordered_startup_waits_for_manual_readiness() {
     let order = Arc::new(Mutex::new(Vec::new()));
     let release_ready = ReleaseGate::default();
@@ -372,7 +372,7 @@ async fn readiness_deadline_is_typed_and_absolute() {
         )
         .expect("valid task");
     let system = tree.spawn().expect("runtime is available");
-    let before = std::time::Instant::now();
+    let before = tokio::time::Instant::now().into_std();
     advance_time(deadline_width).await;
     let startup = system.wait_started().await.expect_err("startup times out");
     let exit = task.wait().await;
@@ -467,7 +467,7 @@ async fn ready_at_deadline_wins_and_shutdown_disarms_the_gate() {
     assert_eq!(exit.cancellation(), Cancellation::Observed);
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn restart_before_aggregate_readiness_rearms_the_gate() {
     let incarnation = Arc::new(AtomicUsize::new(0));
     let fail_first = ReleaseGate::default();
@@ -557,7 +557,7 @@ async fn restart_before_aggregate_readiness_rearms_the_gate() {
         .expect("clean shutdown");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn ordered_terminal_pre_ready_exit_parks_the_root_and_marks_suffix_never_started() {
     let prefix_cancelled = Arc::new(AtomicBool::new(false));
     let suffix_started = Arc::new(AtomicBool::new(false));
@@ -616,7 +616,7 @@ async fn ordered_terminal_pre_ready_exit_parks_the_root_and_marks_suffix_never_s
         .expect("owner rolls back live prefix");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn dynamic_startup_failure_keeps_other_initial_members_supervised() {
     let sibling_cancelled = Arc::new(AtomicBool::new(false));
     let sibling_started = Arc::new(AtomicBool::new(false));

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -2,8 +2,8 @@ use std::time::Duration;
 
 use crate::common::LiveFlag;
 use shelterwood::{
-    BuildError, Cancellation, DynamicTree, Exit, ExitError, ExitKind, GracePhase, Readiness,
-    ReadinessDeadline, RemoveOutcome, PolicyError, ReserveError, Shutdown, StopReason, TaskDef,
+    BuildError, Cancellation, DynamicTree, Exit, ExitError, ExitKind, GracePhase, PolicyError,
+    Readiness, ReadinessDeadline, RemoveOutcome, ReserveError, Shutdown, StopReason, TaskDef,
     TaskOnceDef, Tree,
 };
 

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -3,9 +3,22 @@ use std::time::Duration;
 use crate::common::LiveFlag;
 use shelterwood::{
     BuildError, Cancellation, DynamicTree, Exit, ExitError, ExitKind, GracePhase, Readiness,
-    ReadinessDeadline, RemoveOutcome, ReserveError, Shutdown, StopReason, TaskDef, TaskOnceDef,
-    Tree,
+    ReadinessDeadline, RemoveOutcome, PolicyError, ReserveError, Shutdown, StopReason, TaskDef,
+    TaskOnceDef, Tree,
 };
+
+#[test]
+fn task_families_reject_after_init_readiness_eagerly() {
+    let restartable = TaskDef::new(|_| async { Ok(()) })
+        .readiness(Readiness::AfterInit)
+        .expect_err("restartable tasks have no init phase");
+    assert_eq!(restartable, PolicyError::UnsupportedReadiness);
+
+    let one_shot = TaskOnceDef::new(|_| async { Ok::<_, ExitError>(()) })
+        .readiness(Readiness::AfterInit)
+        .expect_err("one-shot tasks have no init phase");
+    assert_eq!(one_shot, PolicyError::UnsupportedReadiness);
+}
 
 #[test]
 fn public_exit_constructor_preserves_evidence_and_classifies_failures() {


### PR DESCRIPTION
## Summary

Closes every numbered test gap in #189 from item 15 through item 25. The change is deliberately test-focused; production source changes are limited to documenting the stable arbitration contract beside its implementation.

## Item-by-item coverage

- **15 — shipped defaults** (`b56cdd4`): pins retention polarity, default mailbox drain, bounded tidy beat, and immediate default backoff.
- **16 — arbitration stability** (`9e68a52`, review hardening in `d843efd`): documents stable FIFO and uses a same-class pressure fixture proven to reject a `sort_unstable_by_key` mutant.
- **17 — long timers** (`bd1c5c4`): proves multi-slice absolute deadlines and timeouts eventually fire, in addition to never firing early.
- **18 — live `try_recv`** (`2e10ebc`): covers live mailbox delivery and retained offload-panic resumption.
- **19 — `Duration::MAX` mailbox waits** (`b038bfc`): covers send timeout, call, and standalone reply receive as unbounded waits.
- **20 — task readiness validation** (`8bb4db7`): pins eager `AfterInit` rejection for both `TaskDef` and `TaskOnceDef`.
- **21 — handle Eq/Hash across rebasing** (`19bf40b`, review hardening in `d843efd`): keys handles across an actual membership rebase and also verifies declarations remain retrievable through subtree rebuilding/lowering.
- **22 — executable SPEC scenarios** (`3a3a6cd`, review hardening in `d843efd`): covers nested ordered startup rollback, earliest `mark_ready`/later no-op behavior, grace expiry mid-ladder with terminal join publication before cursor advance, and `Exited(old)` before `Started(new)` on plain restart.
- **23 — retry discipline** (`5dc3333`): makes the shard helper initiate both fault windows and prove one total deadline, exact idempotency keys, durable evidence, and superseding-incarnation waits; the assistant redelivery now follows the same discipline.
- **24 — negative API/admission contracts** (`7e4925c`): compile-pins non-`Clone` owners/capabilities and non-`Ord` identity tokens, and proves task/raw/subtree dynamic admission resolves before manual startup.
- **25 — deterministic test hardening** (`8f19bf9`, review hardening in `d843efd`):
  - covers successful `Admission` re-polling;
  - specifies `SnapshotReceiver::clone` observation semantics;
  - uses Tokio virtual time for absolute readiness-deadline evidence (the cited deadlines file no longer had a host-clock occurrence on current main);
  - relaxes only unspecified mailbox-vs-offload ordering while retaining continuation fairness/priority, per-source FIFO, timer-last causality, and exact entries;
  - replaces an exact transient offload-backlog bound with eventual non-starvation evidence;
  - moves short lifecycle/readiness quiet windows onto paused Tokio clocks;
  - exercises a task future destructor panic after the future produced `Ready(Ok)`;
  - bounds `DestructorBlocker` waits with a diagnostic timeout;
  - marks every one-shot ownership Tokio test explicitly `current_thread`.

## Adversarial review

Fresh review commit `d843efd` directly addresses four findings:

- the original duplicate-class arbitration fixture passed under the named unstable-sort regression;
- the subtree key test did not itself exercise a changing membership token;
- grace-expiry teardown observed future destruction but not joined terminal publication;
- relaxed event traces had also dropped specified continuation fairness/priority and timer ordering.

The unstable-sort and token-hash mutants were exercised locally to confirm the strengthened assertions reject them.

## Impact

The suite now covers the public defaults, identity, readiness, deadline, lifecycle, retry, ownership, and determinism contracts called out by the audit without widening the runtime API. Assertions avoid unspecified cross-source scheduling and wall-clock dependence while retaining exact causal and per-source guarantees.

## Validation

Focused checks run during implementation and review cover defaults, arbitration, timer, raw `try_recv`, maximum-deadline, task policy, keyed-handle, readiness/lifecycle SPEC, shard/assistant acceptance, negative API, dynamic admission, snapshot clone, events, offload saturation, and one-shot ownership regressions.

Full local CI after adversarial review:

- `./tools/dev just ci`
  - nightly rustfmt;
  - clippy for workspace/all targets/all features with warnings denied;
  - **556/556 nextest tests passed**;
  - **3/3 doctests passed**;
  - rustdoc and public API reachability;
  - runtime/exit/layering/enforcement checks;
  - packaged docs and crate-package verification;
  - Nix formatting.

Closes #189
