### PR TITLE
Simplify supervision internals after Part 0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,13 @@ resolver = "3"
 [workspace.metadata]
 name = "shelterwood"
 
+# Enforced in every lane that compiles the workspace -- plain `cargo check`
+# included -- rather than by appending a flag to one CI clippy invocation.
+# `-D warnings` escalates these to errors in `just lint` and the Nix
+# `cargo-clippy` check, so the template's check definition stays unforked.
+[workspace.lints.rust]
+unreachable_pub = "warn"
+
 [workspace.dependencies]
 fastrand = "2.5.0"
 serde_json = "1.0.151"

--- a/crates/shelterwood/Cargo.toml
+++ b/crates/shelterwood/Cargo.toml
@@ -10,6 +10,9 @@ homepage = "https://github.com/ralexstokes/shelterwood"
 repository = "https://github.com/ralexstokes/shelterwood"
 autotests = false
 
+[lints]
+workspace = true
+
 [dependencies]
 fastrand.workspace = true
 thiserror.workspace = true

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -2,7 +2,7 @@
 //! wrapper, which encapsulates the callback loop's error-path freeze-and-join
 //! discipline.
 
-use std::{fmt, future::Future, hash::Hash, marker::PhantomData, sync::Arc, time::Duration};
+use std::{fmt, future::Future, hash::Hash, marker::PhantomData, time::Duration};
 
 use crate::{
     ActorRef, Blocking, ChildId, DeadlineElapsed, ExitError, ExitResult, Guard, Incarnation,
@@ -402,7 +402,7 @@ async fn fail_after_teardown<M: Send + 'static>(
     Err(error)
 }
 
-type ArgsFactory<A> = Arc<dyn Fn() -> <A as Actor>::Args + Send + Sync + 'static>;
+type ArgsFactory<A> = Box<dyn Fn() -> <A as Actor>::Args + Send + Sync + 'static>;
 
 /// Restartable handler-actor definition.
 pub struct ActorDef<A: Actor> {
@@ -434,7 +434,7 @@ impl<A: Actor> ActorDef<A> {
     /// Creates a restartable definition from a fresh per-incarnation args source.
     pub fn factory(factory: impl Fn() -> A::Args + Send + Sync + 'static) -> Self {
         Self {
-            factory: Arc::new(factory),
+            factory: Box::new(factory),
             options: CommonOptions::default(),
         }
     }

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -883,11 +883,6 @@ pub(crate) struct ScopeCell {
     // move removed residents into outer storage before the drop runs.
     current_children: Mutex<Vec<ResidentChild>>,
     parent: Mutex<Option<Weak<ScopeCell>>>,
-    // Guards only a gate-pointer swap, so no torn state is possible; every
-    // access deliberately tolerates poisoning (mirroring
-    // `ObservationGate::lock`) so drop-path shutdown after a panicked assert
-    // cannot itself panic.
-    observation_gate: RwLock<ObservationGate>,
     lifecycle_seq: AtomicPoisonedCounter,
     lifecycle: LifecycleHub,
     snapshots: SnapshotHub,
@@ -936,7 +931,6 @@ impl ScopeCell {
         flavor: ScopeFlavor,
         child_identity: ScopeIdentity,
     ) -> Arc<Self> {
-        let observation_gate = member.current_observation_gate();
         let (record, _) = runtime::watch(ScopeRecord {
             state: ScopeState::Unstarted,
             startup: None,
@@ -952,7 +946,6 @@ impl ScopeCell {
             dynamic_route: Mutex::new(None),
             current_children: Mutex::new(Vec::new()),
             parent: Mutex::new(None),
-            observation_gate: RwLock::new(observation_gate),
             lifecycle_seq: AtomicPoisonedCounter::new(),
             lifecycle: LifecycleHub::default(),
             snapshots: SnapshotHub::default(),
@@ -1067,10 +1060,7 @@ impl ScopeCell {
     }
 
     fn current_observation_gate(&self) -> ObservationGate {
-        self.observation_gate
-            .read()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone()
+        self.member.current_observation_gate()
     }
 
     fn adopt_observation_gate(
@@ -1104,19 +1094,12 @@ impl ScopeCell {
             // that merely captured this obsolete gate retries after acquiring
             // it and observing the replacement.
             let current_guard = current.lock();
-            let mut installed = self
-                .observation_gate
-                .write()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if current.same_gate(&installed) {
-                *installed = gate.clone();
+            if current.same_gate(&self.current_observation_gate()) {
                 self.member.install_observation_gate_locked(&current, gate);
-                drop(installed);
                 self.adopt_descendant_observation_gates_locked(&current, gate, txn);
                 drop(current_guard);
                 return;
             }
-            drop(installed);
             drop(current_guard);
         }
     }
@@ -1151,22 +1134,9 @@ impl ScopeCell {
             .collect::<Vec<_>>();
         for descendant in descendants {
             if let Some(scope) = descendant.scope {
-                let mut installed = scope
-                    .observation_gate
-                    .write()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                if installed.same_gate(previous) {
-                    *installed = gate.clone();
-                    descendant
-                        .member
-                        .install_observation_gate_locked(previous, gate);
-                } else {
-                    assert!(
-                        installed.same_gate(gate),
-                        "one resident tree must share one observation gate"
-                    );
-                }
-                drop(installed);
+                descendant
+                    .member
+                    .install_observation_gate_locked(previous, gate);
                 scope.adopt_descendant_observation_gates_locked(previous, gate, _txn);
             } else {
                 descendant
@@ -1413,7 +1383,7 @@ impl ScopeCell {
         self.with_observation_gate(|wakes| {
             let receiver = self.snapshots.subscribe(self.snapshot_locked(), wakes);
             if self.observation_closed.load(Ordering::Acquire) {
-                self.snapshots.close_deferred(wakes);
+                self.snapshots.close(wakes);
             }
             receiver
         })
@@ -1423,7 +1393,7 @@ impl ScopeCell {
         self.with_observation_gate(|wakes| {
             let events = self.lifecycle.subscribe();
             if self.observation_closed.load(Ordering::Acquire) {
-                self.lifecycle.close_deferred(wakes);
+                self.lifecycle.close(wakes);
             }
             events
         })
@@ -1505,12 +1475,11 @@ impl ScopeCell {
     }
 
     fn publish_snapshot_chain_locked(&self, wakes: &mut ObservationTxn<'_>) {
-        self.snapshots
-            .publish_deferred(wakes, || self.snapshot_locked());
+        self.snapshots.publish(wakes, || self.snapshot_locked());
         for ancestor in self.ancestors_locked() {
             ancestor
                 .snapshots
-                .publish_deferred(wakes, || ancestor.snapshot_locked());
+                .publish(wakes, || ancestor.snapshot_locked());
         }
     }
 
@@ -1525,9 +1494,9 @@ impl ScopeCell {
             .mint(Ordering::Release, Ordering::Relaxed);
         let Some(seq) = seq.map(LifecycleSeq::new) else {
             self.publish_snapshot_chain_locked(wakes);
-            self.lifecycle.publish_lagged_deferred(wakes, 1);
+            self.lifecycle.publish_lagged(wakes, 1);
             for ancestor in self.ancestors_locked() {
-                ancestor.lifecycle.publish_lagged_deferred(wakes, 1);
+                ancestor.lifecycle.publish_lagged(wakes, 1);
             }
             return;
         };
@@ -1540,12 +1509,12 @@ impl ScopeCell {
             seq,
             kind,
         };
-        self.lifecycle.publish_deferred(wakes, event.clone());
+        self.lifecycle.publish(wakes, event.clone());
         let mut child_id = self.member.id().clone();
         for ancestor in self.ancestors_locked() {
             event.scope_path.insert(0, child_id);
             child_id = ancestor.member.id().clone();
-            ancestor.lifecycle.publish_deferred(wakes, event.clone());
+            ancestor.lifecycle.publish(wakes, event.clone());
         }
     }
 
@@ -1555,13 +1524,14 @@ impl ScopeCell {
         }
         // Closure follows the final state/snapshot/event publication performed
         // by the caller while this same observation gate remains held.
-        self.snapshots.close_deferred(wakes);
-        self.lifecycle.close_deferred(wakes);
+        self.snapshots.close(wakes);
+        self.lifecycle.close(wakes);
     }
 
     #[cfg(test)]
     pub(crate) fn replace_observation_gate(&self, gate: ObservationGate) {
         *self
+            .member
             .observation_gate
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = gate;

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -100,7 +100,11 @@ pub(crate) enum MemberTransition {
 /// Whether a terminal child incarnation failed during aggregate startup.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum StartupDisposition {
+    /// Terminalization is outside the supervised startup decision.
+    Unchanged,
+    /// The supervised exit did not abort aggregate startup.
     NotAborted,
+    /// The supervised exit aborted aggregate startup.
     Aborted,
 }
 
@@ -470,7 +474,7 @@ impl MemberCell {
                 }
             };
             if let Some(terminal_exit) = terminal_exit {
-                self.publish_terminal_locked(terminal_exit, txn, None);
+                self.terminalize_locked(terminal_exit, StartupDisposition::Unchanged, txn);
             }
         });
     }
@@ -483,30 +487,17 @@ impl MemberCell {
         }
     }
 
-    pub(crate) fn terminalize(&self, exit: Exit) {
+    pub(crate) fn terminalize(&self, exit: Exit, startup: StartupDisposition) {
         self.with_observation_txn(|txn| {
-            self.terminalize_locked(exit, txn);
+            self.terminalize_locked(exit, startup, txn);
         });
     }
 
-    pub(crate) fn terminalize_locked(&self, exit: Exit, txn: &mut ObservationTxn<'_>) -> Exit {
-        self.terminalize_in(exit, txn, None)
-    }
-
-    fn terminalize_child_locked(
+    pub(crate) fn terminalize_locked(
         &self,
         exit: Exit,
         startup: StartupDisposition,
         txn: &mut ObservationTxn<'_>,
-    ) -> Exit {
-        self.terminalize_in(exit, txn, Some(startup == StartupDisposition::Aborted))
-    }
-
-    fn terminalize_in(
-        &self,
-        exit: Exit,
-        txn: &mut ObservationTxn<'_>,
-        startup_aborted: Option<bool>,
     ) -> Exit {
         let terminal_exit = {
             let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
@@ -535,30 +526,22 @@ impl MemberCell {
                 }
             }
         };
-        self.publish_terminal_locked(terminal_exit.clone(), txn, startup_aborted);
-        terminal_exit
-    }
-
-    fn publish_terminal_locked(
-        &self,
-        terminal_exit: Exit,
-        txn: &mut ObservationTxn<'_>,
-        startup_aborted: Option<bool>,
-    ) {
         let mut published = false;
         self.record.modify_silently(|record| {
-            if let Some(startup_aborted) = startup_aborted {
-                record.startup_aborted = startup_aborted;
+            match startup {
+                StartupDisposition::Unchanged => {}
+                StartupDisposition::NotAborted => record.startup_aborted = false,
+                StartupDisposition::Aborted => record.startup_aborted = true,
             }
             if !matches!(record.stage, MemberStage::Terminal(_)) {
                 record.incarnation = None;
                 record.restart_at = None;
                 record.last_exit = Some(terminal_exit.clone());
-                record.stage = MemberStage::Terminal(terminal_exit);
+                record.stage = MemberStage::Terminal(terminal_exit.clone());
                 published = true;
             }
         });
-        let record_changed = published || startup_aborted.is_some();
+        let record_changed = published || startup != StartupDisposition::Unchanged;
         // Store before discharge so reentrant mailbox wakers observe the
         // winning exit. Notification-driven readers still see
         // discharge-before-pulse; tree-scoped publication defers both until
@@ -582,6 +565,7 @@ impl MemberCell {
         if record_changed {
             txn.pulse(&self.record);
         }
+        terminal_exit
     }
 
     pub(crate) async fn wait_terminal(&self) -> Exit {
@@ -863,30 +847,29 @@ pub(crate) enum ScopeControlEvent {
 /// gate and takes an [`ObservationTxn`] capability. Identity allocation and
 /// lifecycle sequence minting remain independent driver-only counters. The
 /// member-record watch is intentionally also the driver's wake bus.
-pub(crate) struct ScopeCell {
-    pub(crate) member: Arc<MemberCell>,
-    pub(crate) flavor: ScopeFlavor,
-    pub(crate) child_identity: Mutex<ScopeIdentity>,
+struct ScopeObservation {
     config: Mutex<ObservationConfig>,
     record: runtime::WatchSender<ScopeRecord>,
-    control: Mutex<ScopeControl>,
-    dynamic_route: Mutex<Option<Arc<ErasedDynamicRoute>>>,
     // `ResidentChild::drop` emits `Removed` by taking the observation gate
     // itself, so dropping a resident anywhere the gate is already held
-    // self-deadlocks — not just inside a mutation callback. In-gate removal
-    // paths must instead consume the resident through
-    // `complete_removal(txn)`, which emits under the already-held gate.
-    // Letting the bare destructor run is reserved for the orphaned path,
-    // where the parent `Weak` is dead and the drop emits nothing. Adding a
-    // resident inside a mutation callback remains safe. Dropping a resident
-    // while holding this mutex would likewise self-deadlock: removal paths
-    // move removed residents into outer storage before the drop runs.
+    // self-deadlocks. In-gate removal paths must consume the resident through
+    // `complete_removal(txn)`. Dropping a resident while holding this mutex
+    // likewise self-deadlocks, so removal moves it into outer storage first.
     current_children: Mutex<Vec<ResidentChild>>,
     parent: Mutex<Option<Weak<ScopeCell>>>,
     lifecycle_seq: AtomicPoisonedCounter,
     lifecycle: LifecycleHub,
     snapshots: SnapshotHub,
-    observation_closed: AtomicBool,
+    closed: AtomicBool,
+}
+
+pub(crate) struct ScopeCell {
+    pub(crate) member: Arc<MemberCell>,
+    pub(crate) flavor: ScopeFlavor,
+    pub(crate) child_identity: Mutex<ScopeIdentity>,
+    control: Mutex<ScopeControl>,
+    dynamic_route: Mutex<Option<Arc<ErasedDynamicRoute>>>,
+    observation: ScopeObservation,
     #[cfg(test)]
     runtime_storage: Mutex<RuntimeStorage>,
     #[cfg(test)]
@@ -940,16 +923,18 @@ impl ScopeCell {
             member,
             flavor,
             child_identity: Mutex::new(child_identity),
-            config: Mutex::new(ObservationConfig::default()),
-            record,
             control: Mutex::new(ScopeControl::default()),
             dynamic_route: Mutex::new(None),
-            current_children: Mutex::new(Vec::new()),
-            parent: Mutex::new(None),
-            lifecycle_seq: AtomicPoisonedCounter::new(),
-            lifecycle: LifecycleHub::default(),
-            snapshots: SnapshotHub::default(),
-            observation_closed: AtomicBool::new(false),
+            observation: ScopeObservation {
+                config: Mutex::new(ObservationConfig::default()),
+                record,
+                current_children: Mutex::new(Vec::new()),
+                parent: Mutex::new(None),
+                lifecycle_seq: AtomicPoisonedCounter::new(),
+                lifecycle: LifecycleHub::default(),
+                snapshots: SnapshotHub::default(),
+                closed: AtomicBool::new(false),
+            },
             #[cfg(test)]
             runtime_storage: Mutex::new(RuntimeStorage::default()),
             #[cfg(test)]
@@ -958,12 +943,12 @@ impl ScopeCell {
     }
 
     pub(crate) fn record(&self) -> ScopeRecord {
-        self.record.read_cloned()
+        self.observation.record.read_cloned()
     }
 
     #[cfg(test)]
     pub(crate) fn record_watcher(&self) -> runtime::WatchReceiver<ScopeRecord> {
-        self.record.watcher()
+        self.observation.record.watcher()
     }
 
     pub(crate) fn resident_projections(&self) -> Vec<ResidentProjection> {
@@ -980,13 +965,15 @@ impl ScopeCell {
     }
 
     fn current_children(&self) -> MutexGuard<'_, Vec<ResidentChild>> {
-        self.current_children
+        self.observation
+            .current_children
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     fn parent(&self) -> Option<Arc<ScopeCell>> {
-        self.parent
+        self.observation
+            .parent
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .as_ref()
@@ -995,6 +982,7 @@ impl ScopeCell {
 
     fn set_parent(&self, parent: &Arc<ScopeCell>, txn: &mut ObservationTxn<'_>) {
         *self
+            .observation
             .parent
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::downgrade(parent));
@@ -1193,10 +1181,10 @@ impl ScopeCell {
         {
             route.close_admission(txn);
         }
-        self.record.modify_silently(|record| {
+        self.observation.record.modify_silently(|record| {
             record.state = state.clone();
         });
-        txn.pulse(&self.record);
+        txn.pulse(&self.observation.record);
         txn.pulse(&self.member.record);
         self.emit_locked(txn, LifecycleEventKind::ScopeState { state });
     }
@@ -1204,6 +1192,7 @@ impl ScopeCell {
     pub(crate) fn set_observation_config(&self, strategy: Strategy, intensity: Intensity) {
         self.with_observation_gate(|wakes| {
             *self
+                .observation
                 .config
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner) = ObservationConfig {
@@ -1274,10 +1263,10 @@ impl ScopeCell {
         scheduled: LifecycleEventKind,
     ) {
         self.with_observation_gate(|wakes| {
-            self.record.modify_silently(|scope| {
+            self.observation.record.modify_silently(|scope| {
                 scope.total_restarts = total_restarts;
             });
-            wakes.pulse(&self.record);
+            wakes.pulse(&self.observation.record);
             member.transition_locked(wakes, transition);
             self.emit_locked(wakes, exited);
             self.emit_locked(wakes, scheduled);
@@ -1305,13 +1294,17 @@ impl ScopeCell {
             // follows terminality. A child that has already left residency
             // owns its nested scope through `SlotCell::terminalize_never_started`
             // instead.
-            let nested = self
+            let resident = self
                 .current_children()
                 .iter()
                 .find(|resident| resident.projection.member.membership() == member.membership())
-                .and_then(|resident| resident.projection.scope.as_ref())
-                .cloned();
-            let terminal_exit = member.terminalize_child_locked(exit, startup, wakes);
+                .map(|resident| resident.projection.clone());
+            debug_assert!(
+                resident.is_some(),
+                "a supervised terminal child must remain in parent residency"
+            );
+            let nested = resident.and_then(|resident| resident.scope);
+            let terminal_exit = member.terminalize_locked(exit, startup, wakes);
             self.evict_child_identity(member);
             if record.last_incarnation.is_none()
                 && let Some(scope) = &nested
@@ -1381,20 +1374,27 @@ impl ScopeCell {
 
     pub(crate) fn subscribe_snapshots(&self) -> SnapshotReceiver {
         self.with_observation_gate(|wakes| {
-            let receiver = self.snapshots.subscribe(self.snapshot_locked(), wakes);
-            if self.observation_closed.load(Ordering::Acquire) {
-                self.snapshots.close(wakes);
-            }
+            let receiver = self
+                .observation
+                .snapshots
+                .subscribe(self.snapshot_locked(), wakes);
+            debug_assert!(
+                !self.observation.closed.load(Ordering::Acquire)
+                    || receiver.borrow_latest_and_closed().1,
+                "closed snapshot state is installed before later subscriptions"
+            );
             receiver
         })
     }
 
     pub(crate) fn subscribe_lifecycle(&self) -> LifecycleEvents {
-        self.with_observation_gate(|wakes| {
-            let events = self.lifecycle.subscribe();
-            if self.observation_closed.load(Ordering::Acquire) {
-                self.lifecycle.close(wakes);
-            }
+        self.with_observation_gate(|_txn| {
+            let events = self.observation.lifecycle.subscribe();
+            debug_assert!(
+                !self.observation.closed.load(Ordering::Acquire)
+                    || self.observation.lifecycle.is_closed(),
+                "closed lifecycle state is installed before later subscriptions"
+            );
             events
         })
     }
@@ -1402,6 +1402,7 @@ impl ScopeCell {
     fn snapshot_locked(&self) -> Arc<ScopeSnapshot> {
         let record = self.record();
         let config = *self
+            .observation
             .config
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -1423,7 +1424,9 @@ impl ScopeCell {
             strategy: (self.flavor == ScopeFlavor::Ordered).then_some(config.strategy),
             intensity: config.intensity,
             total_restarts: record.total_restarts,
-            lifecycle_seq: LifecycleSeq::new(self.lifecycle_seq.load(Ordering::Acquire)),
+            lifecycle_seq: LifecycleSeq::new(
+                self.observation.lifecycle_seq.load(Ordering::Acquire),
+            ),
             children: children.into(),
         })
     }
@@ -1457,10 +1460,9 @@ impl ScopeCell {
             retention: options.retention,
             restart_at: record.restart_at,
             nested,
-            scope_seq: child
-                .scope
-                .as_ref()
-                .map(|scope| LifecycleSeq::new(scope.lifecycle_seq.load(Ordering::Acquire))),
+            scope_seq: child.scope.as_ref().map(|scope| {
+                LifecycleSeq::new(scope.observation.lifecycle_seq.load(Ordering::Acquire))
+            }),
         }
     }
 
@@ -1475,9 +1477,12 @@ impl ScopeCell {
     }
 
     fn publish_snapshot_chain_locked(&self, wakes: &mut ObservationTxn<'_>) {
-        self.snapshots.publish(wakes, || self.snapshot_locked());
+        self.observation
+            .snapshots
+            .publish(wakes, || self.snapshot_locked());
         for ancestor in self.ancestors_locked() {
             ancestor
+                .observation
                 .snapshots
                 .publish(wakes, || ancestor.snapshot_locked());
         }
@@ -1490,13 +1495,14 @@ impl ScopeCell {
         // mint is still a compare-and-swap so an emit that ever escaped the
         // gate could reorder events but never duplicate a sequence value.
         let seq = self
+            .observation
             .lifecycle_seq
             .mint(Ordering::Release, Ordering::Relaxed);
         let Some(seq) = seq.map(LifecycleSeq::new) else {
             self.publish_snapshot_chain_locked(wakes);
-            self.lifecycle.publish_lagged(wakes, 1);
+            self.observation.lifecycle.publish_lagged(wakes, 1);
             for ancestor in self.ancestors_locked() {
-                ancestor.lifecycle.publish_lagged(wakes, 1);
+                ancestor.observation.lifecycle.publish_lagged(wakes, 1);
             }
             return;
         };
@@ -1509,23 +1515,25 @@ impl ScopeCell {
             seq,
             kind,
         };
-        self.lifecycle.publish(wakes, event.clone());
+        self.observation.lifecycle.publish(wakes, event.clone());
         let mut child_id = self.member.id().clone();
         for ancestor in self.ancestors_locked() {
             event.scope_path.insert(0, child_id);
             child_id = ancestor.member.id().clone();
-            ancestor.lifecycle.publish(wakes, event.clone());
+            ancestor.observation.lifecycle.publish(wakes, event.clone());
         }
     }
 
     fn close_observation_locked(&self, wakes: &mut ObservationTxn<'_>) {
-        if self.observation_closed.swap(true, Ordering::AcqRel) {
+        if self.observation.closed.swap(true, Ordering::AcqRel) {
             return;
         }
         // Closure follows the final state/snapshot/event publication performed
         // by the caller while this same observation gate remains held.
-        self.snapshots.close(wakes);
-        self.lifecycle.close(wakes);
+        self.observation
+            .snapshots
+            .close(wakes, || self.snapshot_locked());
+        self.observation.lifecycle.close(wakes);
     }
 
     #[cfg(test)]
@@ -1539,7 +1547,9 @@ impl ScopeCell {
 
     #[cfg(test)]
     pub(crate) fn set_lifecycle_sequence(&self, current: u64) {
-        self.lifecycle_seq.set(current, Ordering::Relaxed);
+        self.observation
+            .lifecycle_seq
+            .set(current, Ordering::Relaxed);
     }
 
     pub(crate) fn set_startup(&self, startup: Result<(), StartupError>) {
@@ -1548,7 +1558,7 @@ impl ScopeCell {
 
     fn set_startup_locked(&self, startup: Result<(), StartupError>, txn: &mut ObservationTxn<'_>) {
         let mut published = false;
-        self.record.modify_silently(|record| {
+        self.observation.record.modify_silently(|record| {
             if record.startup.is_none() {
                 record.startup = Some(startup);
                 published = true;
@@ -1556,7 +1566,7 @@ impl ScopeCell {
         });
         if published {
             txn.pulse(&self.member.record);
-            txn.pulse(&self.record);
+            txn.pulse(&self.observation.record);
         }
     }
 
@@ -1568,7 +1578,7 @@ impl ScopeCell {
         self.with_observation_gate(|wakes| {
             let mut control = self.control.lock().expect("scope control mutex poisoned");
             let epoch = control.epochs.begin()?;
-            self.record.modify_silently(|record| {
+            self.observation.record.modify_silently(|record| {
                 record.total_restarts = TotalRestarts::ZERO;
                 record.startup = None;
                 record.state = state.clone();
@@ -1577,7 +1587,7 @@ impl ScopeCell {
             // stale finish and a newer begin can no longer cross these two
             // state planes in opposite orders.
             drop(control);
-            wakes.pulse(&self.record);
+            wakes.pulse(&self.observation.record);
             wakes.pulse(&self.member.record);
             self.emit_locked(wakes, LifecycleEventKind::ScopeState { state });
             Some(epoch)
@@ -1608,9 +1618,10 @@ impl ScopeCell {
                 // the epoch can never strand `wait_terminal`.
                 drop(control);
                 if let Some(exit) = terminal_exit {
-                    self.member.terminalize_locked(exit, wakes);
+                    self.member
+                        .terminalize_locked(exit, StartupDisposition::Unchanged, wakes);
                     wakes.pulse(&self.member.record);
-                    wakes.pulse(&self.record);
+                    wakes.pulse(&self.observation.record);
                     self.close_observation_locked(wakes);
                 }
                 return;
@@ -1793,23 +1804,9 @@ impl ScopeCell {
 
     pub(crate) fn set_admitted_children(self: &Arc<Self>, children: Vec<ResidentProjection>) {
         self.with_observation_gate(|wakes| {
-            let gate = self.current_observation_gate();
             self.clear_residents_locked(wakes);
             for child in children {
-                if let Some(scope) = &child.scope {
-                    scope.adopt_observation_gate(self, &gate, wakes);
-                    scope.set_parent(self, wakes);
-                } else {
-                    child.member.adopt_observation_gate(&gate, wakes);
-                }
-                child
-                    .member
-                    .transition_locked(wakes, MemberTransition::Admitted);
-                let id = child.member.id().clone();
-                let membership = child.member.membership();
-                self.current_children()
-                    .push(ResidentChild::new(self, child));
-                self.emit_locked(wakes, LifecycleEventKind::Added { id, membership });
+                self.admit_child_locked(child, wakes);
             }
         });
     }
@@ -1905,7 +1902,7 @@ impl ScopeCell {
     }
 
     pub(crate) async fn wait_started(&self) -> Result<(), StartupError> {
-        let mut watcher = self.record.watcher();
+        let mut watcher = self.observation.record.watcher();
         loop {
             if let Some(result) = watcher.borrow_and_update_cloned().startup {
                 return result;
@@ -1920,7 +1917,7 @@ impl ScopeCell {
         // synchronously before the aborted nested driver runs its own scope
         // epilogue. Membership terminality is therefore the finality fence,
         // not proof that the scope record has already reached `Stopped`.
-        let mut watcher = self.record.watcher();
+        let mut watcher = self.observation.record.watcher();
         loop {
             match watcher.borrow_and_update_cloned().state {
                 ScopeState::Stopped { reason } => return reason,
@@ -1952,20 +1949,21 @@ impl ScopeCell {
         epoch_owner: Option<MutexGuard<'_, ScopeControl>>,
     ) {
         let state = ScopeState::Stopped { reason };
-        self.record.modify_silently(|record| {
+        self.observation.record.modify_silently(|record| {
             if record.startup.is_none() {
                 record.startup = Some(Err(StartupError::ShutdownRequested));
             }
             record.state = state.clone();
         });
         if let Some(exit) = terminal_exit {
-            self.member.terminalize_locked(exit, wakes);
+            self.member
+                .terminalize_locked(exit, StartupDisposition::Unchanged, wakes);
         }
         drop(epoch_owner);
         wakes.pulse(&self.member.record);
         // `wait_started` must not observe terminal startup until the member
         // and incarnation-control planes are mutually consistent.
-        wakes.pulse(&self.record);
+        wakes.pulse(&self.observation.record);
         self.emit_locked(wakes, LifecycleEventKind::ScopeState { state });
     }
 
@@ -1974,10 +1972,11 @@ impl ScopeCell {
     }
 
     pub(crate) fn terminalize_never_started_locked(&self, txn: &mut ObservationTxn<'_>) {
-        if self.observation_closed.load(Ordering::Acquire) {
+        if self.observation.closed.load(Ordering::Acquire) {
             return;
         }
-        self.member.terminalize_locked(Exit::never_started(), txn);
+        self.member
+            .terminalize_locked(Exit::never_started(), StartupDisposition::Unchanged, txn);
         self.publish_stopped_locked(txn, StopReason::NeverStarted, None, None);
         self.close_observation_locked(txn);
     }

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -202,7 +202,6 @@ pub(crate) struct MemberCell {
     terminal_disposal_pending: AtomicBool,
     mailbox: Mutex<MemberMailbox>,
     options: OnceLock<ResolvedCommonOptions>,
-    pub(crate) removal: Latch,
 }
 
 #[derive(Default)]
@@ -259,7 +258,6 @@ impl MemberCell {
             terminal_disposal_pending: AtomicBool::new(false),
             mailbox: Mutex::new(MemberMailbox::default()),
             options: OnceLock::new(),
-            removal: Latch::default(),
         })
     }
 

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -1224,6 +1224,9 @@ impl ScopeCell {
         member: &MemberCell,
         txn: &mut ObservationTxn<'_>,
     ) {
+        if member.record().membership_status == MembershipStatus::Removing {
+            return;
+        }
         member.update_locked(txn, |record| {
             record.membership_status = MembershipStatus::Removing;
         });

--- a/crates/shelterwood/src/definition.rs
+++ b/crates/shelterwood/src/definition.rs
@@ -87,18 +87,15 @@ macro_rules! common_options_setters {
     };
 
     (@emit raw_readiness) => {
-        /// Overrides the actor's declared readiness mode.
-        pub fn readiness(mut self, readiness: Readiness) -> Result<Self, PolicyError> {
-            if readiness == Readiness::AfterInit {
-                return Err(PolicyError::UnsupportedReadiness);
-            }
-            self.options.readiness = Some(readiness);
-            Ok(self)
-        }
+        common_options_setters!(@readiness "Overrides the actor's declared readiness mode.");
     };
 
     (@emit task_readiness) => {
-        /// Overrides task readiness (`Immediate` or `Manual`).
+        common_options_setters!(@readiness "Overrides task readiness (`Immediate` or `Manual`).");
+    };
+
+    (@readiness $doc:literal) => {
+        #[doc = $doc]
         pub fn readiness(mut self, readiness: Readiness) -> Result<Self, PolicyError> {
             if readiness == Readiness::AfterInit {
                 return Err(PolicyError::UnsupportedReadiness);
@@ -109,16 +106,15 @@ macro_rules! common_options_setters {
     };
 
     (@emit structural_readiness_deadline) => {
-        /// Overrides the structural readiness deadline.
-        #[must_use]
-        pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
-            self.options.readiness_deadline = deadline;
-            self
-        }
+        common_options_setters!(@readiness_deadline "Overrides the structural readiness deadline.");
     };
 
     (@emit task_readiness_deadline) => {
-        /// Overrides the readiness deadline.
+        common_options_setters!(@readiness_deadline "Overrides the readiness deadline.");
+    };
+
+    (@readiness_deadline $doc:literal) => {
+        #[doc = $doc]
         #[must_use]
         pub fn readiness_deadline(mut self, deadline: ReadinessDeadline) -> Self {
             self.options.readiness_deadline = deadline;

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -49,8 +49,7 @@ use crate::{
     identity::IncarnationCounter,
     observe::LifecycleEventKind,
     plan::{
-        BuilderCore, ChildConstruction, ChildPlan, LowerError, RuntimeScopePlan, ScopeFactory,
-        ScopePlan, SlotCell,
+        BuilderCore, ChildConstruction, ChildPlan, LowerError, ScopeFactory, ScopePlan, SlotCell,
     },
     policy::{DefaultsInheritance, ResolvedDefaults, ScopeFlavor},
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
@@ -591,7 +590,7 @@ async fn run_nested_tree_with_epoch(
             return Err(crate::ExitError::from_startup_failure(failure));
         }
     };
-    run_scope_incarnation(plan.take_for_runtime(), ScopeRole::Nested(latches), epoch)
+    run_scope_incarnation(plan, ScopeRole::Nested(latches), epoch)
         .await
         .into_nested_result()
 }
@@ -604,7 +603,7 @@ async fn run_scope(plan: ScopePlan, role: ScopeRole) -> StopReason {
         drop(plan);
         return StopReason::NeverStarted;
     };
-    run_scope_incarnation(plan.take_for_runtime(), role, epoch).await
+    run_scope_incarnation(plan, role, epoch).await
 }
 
 /// Derives the membership index and incompleteness count for a freshly
@@ -623,7 +622,7 @@ fn index_children(children: &ChildArena<ChildRuntime>) -> (HashMap<Membership, C
 }
 
 async fn run_scope_incarnation(
-    mut plan: RuntimeScopePlan,
+    mut plan: ScopePlan,
     role: ScopeRole,
     epoch: ScopeEpochGuard,
 ) -> StopReason {
@@ -659,7 +658,7 @@ async fn run_scope_incarnation(
         (None, None)
     };
     // Transfer children one at a time. The not-yet-converted suffix remains
-    // owned by RuntimeScopePlan, while ChildRuntime::from_plan arms the current
+    // owned by ScopePlan, while ChildRuntime::from_plan arms the current
     // child's obligation before fallible setup. Thus a panic at any point has
     // exactly one terminality owner for every child.
     let mut children = ChildArena::default();

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -98,24 +98,27 @@ impl SystemRun {
         let Some(driver) = self.driver.take() else {
             return;
         };
-        // Only a crashed or cancelled driver leaves a live root incarnation to
-        // classify; cancellation of the driver itself is the one join verdict
-        // that proves the root observed cancellation.
-        let (join, cancellation) = match runtime::join(driver).await {
-            runtime::JoinOutcome::Ok { .. } => return,
-            runtime::JoinOutcome::Panic { message } => (
-                runtime::JoinOutcome::Panic { message },
-                Cancellation::NotObserved,
-            ),
-            runtime::JoinOutcome::Cancelled => {
-                (runtime::JoinOutcome::Cancelled, Cancellation::Observed)
-            }
-        };
-        self.root.finish_live_root_incarnation(
-            StopReason::ShutdownRequested,
-            classify_exit(None, join, None, cancellation),
-        );
+        if let Err(exit) = classify_root_driver_join(runtime::join(driver).await) {
+            self.root
+                .finish_live_root_incarnation(StopReason::ShutdownRequested, exit);
+        }
     }
+}
+
+fn classify_root_driver_join(
+    outcome: runtime::JoinOutcome<StopReason>,
+) -> Result<StopReason, Exit> {
+    let (join, cancellation) = match outcome {
+        runtime::JoinOutcome::Ok { value } => return Ok(value),
+        runtime::JoinOutcome::Panic { message } => (
+            runtime::JoinOutcome::Panic { message },
+            Cancellation::NotObserved,
+        ),
+        runtime::JoinOutcome::Cancelled => {
+            (runtime::JoinOutcome::Cancelled, Cancellation::Observed)
+        }
+    };
+    Err(classify_exit(None, join, None, cancellation))
 }
 
 impl Drop for SystemRun {
@@ -137,21 +140,13 @@ pub(crate) fn spawn_system(plan: ScopePlan) -> SystemRun {
     let monitor_root = Arc::clone(&root);
     let driver = runtime::spawn(async move { run_scope(plan, ScopeRole::Root).await });
     let lifecycle = runtime::spawn(async move {
-        let (join, cancellation) = match runtime::join(driver).await {
-            runtime::JoinOutcome::Ok { value } => return value,
-            runtime::JoinOutcome::Panic { message } => (
-                runtime::JoinOutcome::Panic { message },
-                Cancellation::NotObserved,
-            ),
-            runtime::JoinOutcome::Cancelled => {
-                (runtime::JoinOutcome::Cancelled, Cancellation::Observed)
+        match classify_root_driver_join(runtime::join(driver).await) {
+            Ok(reason) => reason,
+            Err(exit) => {
+                monitor_root.finish_live_root_incarnation(StopReason::ShutdownRequested, exit);
+                StopReason::ShutdownRequested
             }
-        };
-        monitor_root.finish_live_root_incarnation(
-            StopReason::ShutdownRequested,
-            classify_exit(None, join, None, cancellation),
-        );
-        StopReason::ShutdownRequested
+        }
     });
     SystemRun {
         root,
@@ -694,7 +689,7 @@ async fn run_scope_incarnation(
         events,
         disposal_events,
         deadlines: DeadlineQueue::default(),
-        jitter: runtime::JitterRng::from_system_entropy(),
+        jitter: runtime::JitterRng::new(),
         lifecycle: epoch.lifecycle(),
         next_ordered_start,
         role,
@@ -800,7 +795,7 @@ async fn run_scope_incarnation(
         // one: disposal runs on the blocking pool, so its completion never had
         // a fixed position relative to concurrent exits.
         while let Some(event) = runtime::unbounded_mpsc_try_recv(&mut disposal_event_receiver) {
-            pending.push(Pending::Driver(event).classified());
+            pending.push(Pending::from(event).classified());
         }
         let now = runtime::now();
         while let Some(deadline) = scope.deadlines.pop_due(now) {
@@ -856,10 +851,10 @@ async fn run_scope_incarnation(
                     continue;
                 }
                 runtime::ScopeWake::Message(Some(event)) => {
-                    pending.push(Pending::Driver(event).classified());
+                    pending.push(Pending::from(event).classified());
                 }
                 runtime::ScopeWake::ControlMessage(Some(event)) => {
-                    pending.push(Pending::Driver(event).classified());
+                    pending.push(Pending::from(event).classified());
                 }
                 runtime::ScopeWake::Message(None) | runtime::ScopeWake::ControlMessage(None) => {
                     continue;
@@ -896,25 +891,24 @@ async fn run_scope_incarnation(
                 Pending::Force => {
                     scope.force_all();
                 }
-                Pending::Driver(DriverEvent::Removal(removal)) => scope.handle_removal(removal),
-                Pending::Driver(DriverEvent::Admission(request)) => {
+                Pending::Removal(removal) => scope.handle_removal(removal),
+                Pending::Admission(request) => {
                     scope.handle_admission(request);
                 }
-                Pending::Driver(DriverEvent::Child(ChildEvent::Ready { child, incarnation })) => {
+                Pending::Child(ChildEvent::Ready { child, incarnation }) => {
                     scope.handle_ready(child, incarnation);
                 }
-                Pending::Driver(DriverEvent::Child(ChildEvent::SelfStop {
-                    child,
-                    incarnation,
-                })) => scope.handle_self_stop(child, incarnation),
-                Pending::Driver(DriverEvent::Child(ChildEvent::Exited {
+                Pending::Child(ChildEvent::SelfStop { child, incarnation }) => {
+                    scope.handle_self_stop(child, incarnation)
+                }
+                Pending::Child(ChildEvent::Exited {
                     child,
                     incarnation,
                     recorded,
                     join,
                     cancellation,
                     readiness_signal_seen,
-                })) => scope.handle_exit(
+                }) => scope.handle_exit(
                     child,
                     incarnation,
                     recorded,
@@ -922,10 +916,9 @@ async fn run_scope_incarnation(
                     cancellation,
                     readiness_signal_seen,
                 ),
-                Pending::Driver(DriverEvent::Child(ChildEvent::ConstructionDisposed {
-                    child,
-                    panic,
-                })) => scope.handle_construction_disposed(child, panic),
+                Pending::Child(ChildEvent::ConstructionDisposed { child, panic }) => {
+                    scope.handle_construction_disposed(child, panic);
+                }
                 Pending::Deadline(deadline) => scope.handle_deadline(deadline),
             }
         }

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -528,12 +528,6 @@ fn remove_dynamic_impl(
     if removal.is_some() {
         scope.set_child_removing_locked(&member, txn);
     }
-    // The fire linearizes inside the transaction; the waker-visible wake is
-    // deferred past the gate release.
-    if member.removal.fire_silently() {
-        let removal = member.removal.clone();
-        txn.defer(move || removal.notify());
-    }
     if let Some(removal) = removal {
         defer_driver_event(txn, control, DriverEvent::Removal(removal));
     }

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -11,7 +11,6 @@ use crate::{
     cells::{
         DynamicRoute, ErasedDynamicRoute, ErasedDynamicSlot, MemberStage, ObservationTxn, ScopeCell,
     },
-    engine::MembershipStatus,
     plan::{
         ChildConstruction, SlotCell, checked_id, concrete_dynamic_slot, concrete_dynamic_slot_ref,
         erase_dynamic_slot, mint_reserved_slot,
@@ -149,7 +148,9 @@ impl DynamicEntry {
     }
 
     pub(super) fn mark_removing(&mut self, _txn: &mut ObservationTxn<'_>) -> Option<ChildKey> {
-        let key = self.key()?;
+        let DynamicMembershipState::Resident { key, .. } = self.state else {
+            return None;
+        };
         self.state = DynamicMembershipState::Removing { key };
         Some(key)
     }
@@ -455,12 +456,8 @@ fn signal_fused_cancel_impl(
     }
     let latch = latch.clone();
     txn.defer(move || latch.notify());
-    // A fused drop and an explicit `remove` dedup only within their own
-    // source (each behind a once-firing latch), not against each other:
-    // `mark_removing` also succeeds on an already-Removing entry, so the
-    // same membership can queue one `RemovalRequest` per source. The
-    // duplicate is benign by construction — the shared transaction retains
-    // one Removing phase/projection, and `begin_stop_child` is idempotent.
+    // The authoritative state transition owns request publication, so a
+    // racing explicit removal cannot queue the same membership again.
     let removal = {
         let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
         state
@@ -473,9 +470,7 @@ fn signal_fused_cancel_impl(
             })
     };
     if let Some(removal) = removal {
-        if slot.member.record().membership_status != MembershipStatus::Removing {
-            scope.set_child_removing_locked(&slot.member, txn);
-        }
+        scope.set_child_removing_locked(&slot.member, txn);
         defer_driver_event(txn, control, DriverEvent::Removal(removal));
     }
 }
@@ -526,11 +521,11 @@ fn remove_dynamic_impl(
     // registration is reclaimed before the removal response completes.
     let member = Arc::clone(&entry.slot.member);
     let membership = member.membership();
-    let key = entry
+    let removal = entry
         .mark_removing(txn)
-        .expect("a non-reservation has a resident child key");
+        .map(|key| RemovalRequest { membership, key });
     drop(state);
-    if member.record().membership_status != MembershipStatus::Removing {
+    if removal.is_some() {
         scope.set_child_removing_locked(&member, txn);
     }
     // The fire linearizes inside the transaction; the waker-visible wake is
@@ -538,15 +533,9 @@ fn remove_dynamic_impl(
     if member.removal.fire_silently() {
         let removal = member.removal.clone();
         txn.defer(move || removal.notify());
-        // This latch dedups repeated `remove` calls, but not a concurrent
-        // fused drop, which queues its own `RemovalRequest` for the same
-        // membership (see `signal_fused_cancel_impl`). The driver's stop
-        // path must therefore stay idempotent under a second delivery.
-        defer_driver_event(
-            txn,
-            control,
-            DriverEvent::Removal(RemovalRequest { membership, key }),
-        );
+    }
+    if let Some(removal) = removal {
+        defer_driver_event(txn, control, DriverEvent::Removal(removal));
     }
     response
 }

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -525,10 +525,10 @@ fn remove_dynamic_impl(
         .mark_removing(txn)
         .map(|key| RemovalRequest { membership, key });
     drop(state);
-    if removal.is_some() {
-        scope.set_child_removing_locked(&member, txn);
-    }
     if let Some(removal) = removal {
+        // Projection first, then the deferred request: the same order the
+        // fused source commits in.
+        scope.set_child_removing_locked(&member, txn);
         defer_driver_event(txn, control, DriverEvent::Removal(removal));
     }
     response

--- a/crates/shelterwood/src/driver/events.rs
+++ b/crates/shelterwood/src/driver/events.rs
@@ -49,7 +49,9 @@ pub(super) enum Pending {
     AncestorShutdown,
     AncestorAbort,
     Force,
-    Driver(DriverEvent),
+    Child(ChildEvent),
+    Admission(AdmissionRequest),
+    Removal(RemovalRequest),
     Deadline(DeadlineKind),
 }
 
@@ -60,7 +62,14 @@ impl Pending {
                 ArbitrationClass::ScopeShutdown
             }
             Self::RestartShutdown { .. } => ArbitrationClass::BackoffDue,
-            Self::Driver(event) => driver_event_class(event),
+            Self::Child(ChildEvent::SelfStop { .. }) | Self::Removal(_) => {
+                ArbitrationClass::MembershipRemoval
+            }
+            Self::Child(ChildEvent::Ready { .. }) => ArbitrationClass::ReadinessSignal,
+            Self::Child(ChildEvent::Exited { .. } | ChildEvent::ConstructionDisposed { .. }) => {
+                ArbitrationClass::ChildExit
+            }
+            Self::Admission(_) => ArbitrationClass::Admission,
             Self::Deadline(DeadlineKind::Readiness { .. }) => ArbitrationClass::ReadinessDeadline,
             Self::Deadline(DeadlineKind::Restart { .. }) => ArbitrationClass::BackoffDue,
             Self::Deadline(DeadlineKind::Stop { .. }) => ArbitrationClass::StopDeadline,
@@ -69,6 +78,16 @@ impl Pending {
 
     pub(super) fn classified(self) -> (ArbitrationClass, Self) {
         (self.class(), self)
+    }
+}
+
+impl From<DriverEvent> for Pending {
+    fn from(event: DriverEvent) -> Self {
+        match event {
+            DriverEvent::Child(event) => Self::Child(event),
+            DriverEvent::Admission(request) => Self::Admission(request),
+            DriverEvent::Removal(request) => Self::Removal(request),
+        }
     }
 }
 
@@ -81,7 +100,7 @@ pub(super) fn collect_driver_events(
         let Some(event) = runtime::unbounded_mpsc_try_recv(receiver) else {
             return false;
         };
-        pending.push(Pending::Driver(event).classified());
+        pending.push(Pending::from(event).classified());
     }
     // Collecting exactly `limit` events does not by itself show a capped
     // lane. Probe once more so a lane that drained right at the limit skips
@@ -90,7 +109,7 @@ pub(super) fn collect_driver_events(
     let Some(event) = runtime::unbounded_mpsc_try_recv(receiver) else {
         return false;
     };
-    pending.push(Pending::Driver(event).classified());
+    pending.push(Pending::from(event).classified());
     true
 }
 
@@ -100,18 +119,6 @@ pub(super) fn restart_shutdown_work(child: ChildKey, target: Epoch) -> (Arbitrat
     // first get the chance to trip intensity or fail startup; the
     // execution-time suppression check then observes that drain.
     Pending::RestartShutdown { child, target }.classified()
-}
-
-pub(super) fn driver_event_class(event: &DriverEvent) -> ArbitrationClass {
-    match event {
-        DriverEvent::Child(ChildEvent::SelfStop { .. }) => ArbitrationClass::MembershipRemoval,
-        DriverEvent::Removal(_) => ArbitrationClass::MembershipRemoval,
-        DriverEvent::Child(ChildEvent::Ready { .. }) => ArbitrationClass::ReadinessSignal,
-        DriverEvent::Child(ChildEvent::Exited { .. } | ChildEvent::ConstructionDisposed { .. }) => {
-            ArbitrationClass::ChildExit
-        }
-        DriverEvent::Admission(_) => ArbitrationClass::Admission,
-    }
 }
 
 impl ScopeRuntime {

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -35,31 +35,16 @@ impl ScopeRuntime {
         let Some(control) = &self.dynamic else {
             return;
         };
-        let root = Arc::clone(&self.root);
-        let tracked = root.with_observation_gate(|txn| {
-            let tracked = {
-                let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-                state
-                    .entry_mut(member.id())
-                    .filter(|entry| entry.slot.member.membership() == membership)
-                    .and_then(|entry| entry.mark_removing(txn))
-                    .is_some_and(|tracked| tracked == key)
-            };
-            // The Removing projection publishes outside the dynamic-state
-            // mutex, like the sibling writers in `admission_control`; the
-            // observation gate alone serializes the mutation.
-            if tracked && member.record().membership_status != MembershipStatus::Removing {
-                root.set_child_removing_locked(&member, txn);
-            }
-            tracked
-        });
+        let tracked = control
+            .state
+            .lock()
+            .expect("dynamic-state mutex poisoned")
+            .entry(member.id())
+            .filter(|entry| entry.slot.member.membership() == membership)
+            .is_some_and(|entry| entry.is_removing() && entry.matches_key(key));
         if !tracked {
             return;
         }
-        // A fused drop and an explicit `remove` can each queue one request for
-        // the same membership. The phase/projection transaction above,
-        // `begin_stop_child`'s ladder guards, and `finalize_removal`'s exact
-        // match keep that duplicate delivery idempotent.
         if self.children[key].is_terminal() {
             self.finalize_removal(key);
         } else {

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -78,7 +78,7 @@ async fn task_aborted_scope_driver_resolves_startup() {
     let scope = Arc::clone(&plan.root);
     let epoch = ScopeEpochGuard::begin(&scope).expect("test scope epoch is available");
     let driver = crate::runtime::spawn(run_scope_incarnation(
-        plan.take_for_runtime(),
+        plan,
         ScopeRole::Nested(NestedScopeLatches {
             parent_ready: CompletionGatedLatch::default(),
             ancestor: AncestorCommandLatches {
@@ -250,7 +250,7 @@ async fn scope_plan_conversion_panic_terminalizes_every_child() {
     );
 
     let mut driver = Box::pin(run_scope_incarnation(
-        plan.take_for_runtime(),
+        plan,
         ScopeRole::Nested(NestedScopeLatches {
             parent_ready: CompletionGatedLatch::default(),
             ancestor: AncestorCommandLatches {
@@ -334,7 +334,7 @@ async fn conversion_unwind_evicts_never_started_child_identities() {
         .is_err()
     );
     let mut driver = Box::pin(run_scope_incarnation(
-        plan.take_for_runtime(),
+        plan,
         ScopeRole::Nested(NestedScopeLatches {
             parent_ready: CompletionGatedLatch::default(),
             ancestor: AncestorCommandLatches {
@@ -451,11 +451,7 @@ async fn initial_added_wake_observes_the_keyed_dynamic_route() {
             .is_pending()
     );
 
-    let driver = crate::runtime::spawn(run_scope_incarnation(
-        plan.take_for_runtime(),
-        ScopeRole::Root,
-        epoch,
-    ));
+    let driver = crate::runtime::spawn(run_scope_incarnation(plan, ScopeRole::Root, epoch));
     let abort = driver.abort_handle();
     assert!(matches!(
         crate::runtime::timeout(Duration::from_secs(1), probe.observed.fired()).await,

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -50,7 +50,7 @@ async fn attaching_after_terminality_closes_the_mailbox() {
         std::future::poll_fn(|context| Poll::Ready(parked.as_mut().poll(context))).await;
     assert!(first_poll.is_pending());
 
-    member.terminalize(Exit::never_started());
+    member.terminalize(Exit::never_started(), StartupDisposition::Unchanged);
     member.attach_mailbox(mailbox);
 
     let parked = match crate::runtime::timeout(Duration::from_secs(1), parked).await {

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -1038,13 +1038,7 @@ async fn fused_cancellation_during_conversion_is_rejected_by_the_under_lock_rech
     assert!(matches!(member.record().stage, MemberStage::Terminal(_)));
 }
 
-#[derive(Clone, Copy)]
-enum DuplicateRemovalDelivery {
-    WhileActive,
-    DuringDisposal,
-}
-
-async fn exercise_double_removal(delivery: DuplicateRemovalDelivery) {
+async fn exercise_coalesced_removal() {
     let (
         mut scope,
         mut event_receiver,
@@ -1106,50 +1100,24 @@ async fn exercise_double_removal(delivery: DuplicateRemovalDelivery) {
     let mut removal_response =
         super::super::remove_dynamic(&root, member.id(), Some(member.membership()));
 
-    let mut removals = Vec::new();
-    while removals.len() < 2 {
-        let event =
-            match crate::runtime::timeout(Duration::from_secs(2), dynamic_event_receiver.recv())
-                .await
-            {
-                crate::runtime::Timeout::Completed(Some(event)) => event,
-                crate::runtime::Timeout::Completed(None) => {
-                    panic!("the dynamic-control lane remains open")
-                }
-                crate::runtime::Timeout::Elapsed => {
-                    panic!("both removal sources reach the driver")
-                }
-            };
-        let DriverEvent::Removal(removal) = event else {
-            panic!("only removal requests reach the dynamic-control lane here")
-        };
-        removals.push(removal);
-    }
+    let removal = match crate::runtime::timeout(
+        Duration::from_secs(2),
+        dynamic_event_receiver.recv(),
+    )
+    .await
+    {
+        crate::runtime::Timeout::Completed(Some(DriverEvent::Removal(removal))) => removal,
+        crate::runtime::Timeout::Completed(_) => panic!("one removal request reaches the driver"),
+        crate::runtime::Timeout::Elapsed => panic!("the removal request reaches the driver"),
+    };
+    assert_eq!(removal.membership, membership);
+    assert_eq!(removal.key, key);
     assert!(
-        removals
-            .iter()
-            .all(|removal| { removal.membership == membership && removal.key == key })
+        crate::runtime::unbounded_mpsc_try_recv(&mut dynamic_event_receiver).is_none(),
+        "the state transition coalesces fused and explicit removal sources"
     );
 
-    scope.handle_removal(removals.remove(0));
-    let active = scope.children[key]
-        .active
-        .as_ref()
-        .expect("the first removal begins the live stop ladder");
-    let ladder = active.ladder.expect("the stop ladder is armed");
-    let stop_deadline = active.stop_deadline;
-    let deadline_count = scope.deadlines.len();
-
-    if matches!(delivery, DuplicateRemovalDelivery::WhileActive) {
-        scope.handle_removal(removals.remove(0));
-        let active = scope.children[key]
-            .active
-            .as_ref()
-            .expect("the duplicate leaves the incarnation active");
-        assert_eq!(active.ladder, Some(ladder));
-        assert_eq!(active.stop_deadline, stop_deadline);
-        assert_eq!(scope.deadlines.len(), deadline_count);
-    }
+    scope.handle_removal(removal);
 
     let exit = match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
         crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {
@@ -1173,23 +1141,6 @@ async fn exercise_double_removal(delivery: DuplicateRemovalDelivery) {
     scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4, exit.5);
     assert!(scope.children[key].pending_terminal.is_some());
 
-    if matches!(delivery, DuplicateRemovalDelivery::DuringDisposal) {
-        // Defense-in-depth, pinned jointly rather than individually: the
-        // duplicate is dropped by `begin_stop_child`'s terminal/disposing
-        // guard, and even without that guard `begin_terminal_disposal`'s
-        // pending-terminal guard returns before disturbing disposal. Either
-        // check alone suffices to protect this observable, so this test
-        // fails only when both are removed together.
-        scope.handle_removal(removals.remove(0));
-        assert!(
-            scope
-                .children
-                .get(key)
-                .is_some_and(|child| child.pending_terminal.is_some()),
-            "the duplicate cannot bypass retained-construction disposal"
-        );
-    }
-    assert!(removals.is_empty());
     assert_eq!(
         removal_response.try_receive(),
         None,
@@ -1240,13 +1191,8 @@ async fn exercise_double_removal(delivery: DuplicateRemovalDelivery) {
 }
 
 #[crate::runtime::test]
-async fn double_removal_is_idempotent_while_the_child_is_active() {
-    exercise_double_removal(DuplicateRemovalDelivery::WhileActive).await;
-}
-
-#[crate::runtime::test]
-async fn double_removal_is_idempotent_during_construction_disposal() {
-    exercise_double_removal(DuplicateRemovalDelivery::DuringDisposal).await;
+async fn fused_and_explicit_removal_queue_once_at_transition() {
+    exercise_coalesced_removal().await;
 }
 
 #[crate::runtime::test]
@@ -1343,7 +1289,7 @@ async fn fused_only_removal_commits_phase_and_projection_together() {
     assert_eq!(
         member.record().membership_status,
         MembershipStatus::Removing,
-        "handle_removal publishes the Removing projection"
+        "driver handling preserves the already-published Removing projection"
     );
     assert!(matches!(
         root.snapshot()

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -114,7 +114,7 @@ fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
         response.try_receive().is_none(),
         "closing admission must not complete removal before teardown"
     );
-    member.terminalize(Exit::never_started());
+    member.terminalize(Exit::never_started(), StartupDisposition::Unchanged);
     assert!(root.prune_child(&member));
     assert!(
         response.try_receive().is_none(),

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -1285,6 +1285,7 @@ async fn fused_only_removal_commits_phase_and_projection_together() {
     assert_eq!(removal.membership, membership);
     assert_eq!(removal.key, key);
 
+    let duplicate = removal;
     scope.handle_removal(removal);
     assert_eq!(
         member.record().membership_status,
@@ -1297,6 +1298,30 @@ async fn fused_only_removal_commits_phase_and_projection_together() {
             .map(|child| child.membership_status),
         Some(MembershipStatus::Removing)
     ));
+
+    // Coalescing at the `Resident -> Removing` transition means no source can
+    // queue this request twice any more, so the driver-side idempotence guards
+    // lost their only coverage. They remain load-bearing for the pairings that
+    // *can* still deliver a removal to an actively-stopping child in one batch
+    // (`Pending::Shutdown` / `Force` / `SelfStop` alongside a removal, and
+    // `DeadlineKind::Restart` re-entry), so pin them with a synthetic
+    // duplicate: re-delivery must not rewind the armed ladder, push the stop
+    // deadline out, or arm a second timer.
+    let active = scope.children[key]
+        .active
+        .as_ref()
+        .expect("the removal begins the live stop ladder");
+    let ladder = active.ladder.expect("the stop ladder is armed");
+    let stop_deadline = active.stop_deadline;
+    let deadline_count = scope.deadlines.len();
+    scope.handle_removal(duplicate);
+    let active = scope.children[key]
+        .active
+        .as_ref()
+        .expect("the duplicate leaves the incarnation active");
+    assert_eq!(active.ladder, Some(ladder));
+    assert_eq!(active.stop_deadline, stop_deadline);
+    assert_eq!(scope.deadlines.len(), deadline_count);
 
     let exit = match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
         crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -121,7 +121,7 @@ async fn incarnation_exhaustion_uses_post_disposal_retention_routing() {
         .with_lifecycle(ScopeLifecycle::running())
         .with_next_ordered_start(Some(key))
         .build();
-    plan.take_for_runtime().finish_transfer();
+    plan.finish_transfer();
 
     scope.children[key].incarnations =
         IncarnationCounter::near_exhaustion(scope.children[key].slot.member.membership());
@@ -226,7 +226,7 @@ async fn first_spawn_exhaustion_stops_without_reporting_a_startup_abort() {
         .with_children(children)
         .with_next_ordered_start(Some(key))
         .build();
-    plan.take_for_runtime().finish_transfer();
+    plan.finish_transfer();
 
     // Burn the counter's last usable generation without touching the
     // member record: the child is still an unspawned initial member, so
@@ -324,7 +324,7 @@ async fn latched_shutdown_keeps_the_startup_verdict_for_its_follow_up_event() {
         .with_children(children)
         .with_next_ordered_start(Some(key))
         .build();
-    plan.take_for_runtime().finish_transfer();
+    plan.finish_transfer();
 
     assert!(scope.children[key].initial);
     scope.spawn_child(key);

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -360,11 +360,7 @@ async fn blocked_initial_scope_factory_owns_its_stop_epilogue() {
     let plan = tree.lower_for_test();
     let root = Arc::clone(&plan.root);
     let epoch = ScopeEpochGuard::begin(&root).expect("parent epoch is available");
-    let driver = crate::runtime::spawn(run_scope_incarnation(
-        plan.take_for_runtime(),
-        ScopeRole::Root,
-        epoch,
-    ));
+    let driver = crate::runtime::spawn(run_scope_incarnation(plan, ScopeRole::Root, epoch));
     let abort = driver.abort_handle();
 
     assert!(matches!(
@@ -423,11 +419,7 @@ async fn blocked_restart_scope_factory_supersedes_the_stale_stopped_projection()
     let plan = tree.lower_for_test();
     let root = Arc::clone(&plan.root);
     let epoch = ScopeEpochGuard::begin(&root).expect("parent epoch is available");
-    let driver = crate::runtime::spawn(run_scope_incarnation(
-        plan.take_for_runtime(),
-        ScopeRole::Root,
-        epoch,
-    ));
+    let driver = crate::runtime::spawn(run_scope_incarnation(plan, ScopeRole::Root, epoch));
     let abort = driver.abort_handle();
 
     assert!(matches!(

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -35,7 +35,7 @@ async fn latched_shutdown_upgrades_an_intensity_drain() {
         .with_children(children)
         .with_lifecycle(ScopeLifecycle::running())
         .build();
-    plan.take_for_runtime().finish_transfer();
+    plan.finish_transfer();
 
     scope.spawn_child(key);
     let active = scope.children[key]
@@ -108,7 +108,7 @@ async fn force_upgrades_an_intensity_drain_to_shutdown_requested() {
         .with_children(children)
         .with_lifecycle(ScopeLifecycle::running())
         .build();
-    plan.take_for_runtime().finish_transfer();
+    plan.finish_transfer();
 
     scope.spawn_child(key);
     let active = scope.children[key]
@@ -183,7 +183,7 @@ async fn force_uses_the_stop_funnel_for_every_ordered_child() {
         .with_children(children)
         .with_lifecycle(ScopeLifecycle::running())
         .build();
-    plan.take_for_runtime().finish_transfer();
+    plan.finish_transfer();
 
     for key in &keys {
         scope.spawn_child(*key);
@@ -299,7 +299,7 @@ fn forced_ordered_drain_advances_an_inactive_suffix_iteratively() {
         .with_lifecycle(ScopeLifecycle::running())
         .with_hard_forced(true)
         .build();
-    plan.take_for_runtime().finish_transfer();
+    plan.finish_transfer();
 
     scope.begin_drain(StopReason::ShutdownRequested);
 

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -451,7 +451,7 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
     });
     let mut pending = [
         restart_shutdown_work(nested, target),
-        Pending::Driver(exit).classified(),
+        Pending::from(exit).classified(),
     ];
     arbitrate(&mut pending);
     for (_, event) in pending {
@@ -459,14 +459,14 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
             Pending::RestartShutdown { child, target } => {
                 scope.expedite_restart_shutdown(child, target);
             }
-            Pending::Driver(DriverEvent::Child(ChildEvent::Exited {
+            Pending::Child(ChildEvent::Exited {
                 child,
                 incarnation,
                 recorded,
                 join,
                 cancellation,
                 readiness_signal_seen,
-            })) => scope.handle_exit(
+            }) => scope.handle_exit(
                 child,
                 incarnation,
                 recorded,
@@ -617,20 +617,20 @@ async fn same_batch_intensity_exit_suppresses_retained_expedite_retry() {
         readiness_signal_seen: false,
     });
     let mut pending = [
-        Pending::Driver(nested_exit).classified(),
-        Pending::Driver(trip_exit).classified(),
+        Pending::from(nested_exit).classified(),
+        Pending::from(trip_exit).classified(),
     ];
     arbitrate(&mut pending);
     for (_, event) in pending {
         match event {
-            Pending::Driver(DriverEvent::Child(ChildEvent::Exited {
+            Pending::Child(ChildEvent::Exited {
                 child,
                 incarnation,
                 recorded,
                 join,
                 cancellation,
                 readiness_signal_seen,
-            })) => scope.handle_exit(
+            }) => scope.handle_exit(
                 child,
                 incarnation,
                 recorded,
@@ -719,42 +719,39 @@ async fn same_batch_self_stop_preserves_fired_readiness_for_startup() {
     active.abort_handle.abort();
 
     let mut pending = [
-        Pending::Driver(DriverEvent::Child(ChildEvent::Exited {
+        Pending::Child(ChildEvent::Exited {
             child: key,
             incarnation,
             recorded: Some(RecordedOutcome::returned(Ok(()))),
             join: crate::runtime::JoinOutcome::Ok { value: () },
             cancellation: Cancellation::NotObserved,
             readiness_signal_seen: true,
-        }))
+        })
         .classified(),
-        Pending::Driver(DriverEvent::Child(ChildEvent::SelfStop {
+        Pending::Child(ChildEvent::SelfStop {
             child: key,
             incarnation,
-        }))
+        })
         .classified(),
     ];
     arbitrate(&mut pending);
     assert!(
-        matches!(
-            pending[0].1,
-            Pending::Driver(DriverEvent::Child(ChildEvent::SelfStop { .. }))
-        ),
+        matches!(pending[0].1, Pending::Child(ChildEvent::SelfStop { .. })),
         "the regression premise: arbitration orders the stop ahead of the exit"
     );
     for (_, event) in pending {
         match event {
-            Pending::Driver(DriverEvent::Child(ChildEvent::SelfStop { child, incarnation })) => {
+            Pending::Child(ChildEvent::SelfStop { child, incarnation }) => {
                 scope.handle_self_stop(child, incarnation)
             }
-            Pending::Driver(DriverEvent::Child(ChildEvent::Exited {
+            Pending::Child(ChildEvent::Exited {
                 child,
                 incarnation,
                 recorded,
                 join,
                 cancellation,
                 readiness_signal_seen,
-            })) => scope.handle_exit(
+            }) => scope.handle_exit(
                 child,
                 incarnation,
                 recorded,

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -78,7 +78,7 @@ async fn pre_admission_restart_shutdown_does_not_expedite_the_following_incarnat
         .with_lifecycle(ScopeLifecycle::running())
         .with_children(children)
         .build();
-    plan.take_for_runtime().finish_transfer();
+    plan.finish_transfer();
 
     scope.spawn_child(key);
     let first = scope.children[key]
@@ -204,7 +204,7 @@ async fn early_restart_shutdown_does_not_expedite_a_never_started_ordered_child(
         .with_children(children)
         .with_next_ordered_start(Some(first))
         .build();
-    plan.take_for_runtime().finish_transfer();
+    plan.finish_transfer();
 
     // Ordered startup spawns "a" and parks on its (never-fired) readiness.
     scope.progress_startup();
@@ -282,7 +282,7 @@ async fn restart_shutdown_arriving_before_exit_is_retried_after_the_child_become
         .with_lifecycle(ScopeLifecycle::running())
         .with_children(children)
         .build();
-    plan.take_for_runtime().finish_transfer();
+    plan.finish_transfer();
 
     let target = scope.children[key]
         .slot
@@ -393,7 +393,7 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
         .with_lifecycle(ScopeLifecycle::running())
         .with_next_ordered_start(next_ordered_start)
         .build();
-    plan.take_for_runtime().finish_transfer();
+    plan.finish_transfer();
 
     root.transition_child(
         &scope.children[nested].slot.member,
@@ -554,7 +554,7 @@ async fn same_batch_intensity_exit_suppresses_retained_expedite_retry() {
         .with_lifecycle(ScopeLifecycle::running())
         .with_next_ordered_start(next_ordered_start)
         .build();
-    plan.take_for_runtime().finish_transfer();
+    plan.finish_transfer();
 
     let target = scope.children[nested]
         .slot
@@ -705,7 +705,7 @@ async fn same_batch_self_stop_preserves_fired_readiness_for_startup() {
         .with_children(children)
         .with_next_ordered_start(Some(key))
         .build();
-    plan.take_for_runtime().finish_transfer();
+    plan.finish_transfer();
 
     scope.spawn_child(key);
     let active = scope.children[key]

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -121,7 +121,7 @@ impl ScopeRuntimeBuilder {
             events: self.events,
             disposal_events: self.disposal_events,
             deadlines: super::super::DeadlineQueue::default(),
-            jitter: crate::runtime::JitterRng::from_system_entropy(),
+            jitter: crate::runtime::JitterRng::new(),
             lifecycle: self.lifecycle,
             next_ordered_start: self.next_ordered_start,
             role: ScopeRole::Root,

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -34,7 +34,8 @@ struct ObserveMemberOnMailboxWake {
 impl ObserveMemberOnMailboxWake {
     fn observe(&self) {
         let before = self.member.record().stage;
-        self.member.terminalize(self.competing_exit.clone());
+        self.member
+            .terminalize(self.competing_exit.clone(), StartupDisposition::Unchanged);
         let after = self.member.record().stage;
         *self.observed.lock().expect("observation mutex poisoned") = Some((before, after));
     }
@@ -255,7 +256,7 @@ fn panicking_mailbox_waker_cannot_skip_the_terminal_pulse() {
     );
 
     catch_unwind(AssertUnwindSafe(|| {
-        member.terminalize(Exit::never_started());
+        member.terminalize(Exit::never_started(), StartupDisposition::Unchanged);
     }))
     .expect_err("the hostile mailbox waker still surfaces its panic");
     assert_eq!(
@@ -314,7 +315,7 @@ fn mailbox_teardown_panic_precedes_a_terminal_pulse_panic() {
     );
 
     let payload = catch_unwind(AssertUnwindSafe(|| {
-        member.terminalize(Exit::never_started());
+        member.terminalize(Exit::never_started(), StartupDisposition::Unchanged);
     }))
     .expect_err("the primary mailbox panic still surfaces");
     assert_eq!(
@@ -457,7 +458,7 @@ fn terminality_signal_follows_mailbox_termination() {
     let mut changed = Box::pin(watcher.changed());
     assert!(changed.as_mut().poll(&mut context).is_pending());
 
-    member.terminalize(Exit::never_started());
+    member.terminalize(Exit::never_started(), StartupDisposition::Unchanged);
 
     assert_eq!(
         *probe.observed.lock().expect("observation mutex poisoned"),
@@ -629,7 +630,7 @@ fn mailbox_wake_observes_terminal_record_and_reentrant_terminality_is_idempotent
             .is_pending()
     );
 
-    member.terminalize(first_exit.clone());
+    member.terminalize(first_exit.clone(), StartupDisposition::Unchanged);
 
     assert_eq!(
         *probe.observed.lock().expect("observation mutex poisoned"),
@@ -704,7 +705,7 @@ fn concurrent_terminalizers_return_after_one_consistent_record_is_visible() {
         let start = Arc::clone(&start);
         std::thread::spawn(move || {
             start.wait();
-            member.terminalize(exit);
+            member.terminalize(exit, StartupDisposition::Unchanged);
             assert!(matches!(member.record().stage, MemberStage::Terminal(_)));
         })
     })

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -332,7 +332,7 @@ impl RestartState {
         (self.attempt, self.cumulative)
     }
 
-    pub(crate) fn settled(&mut self) {
+    fn settled(&mut self) {
         self.attempt = RestartAttempt::ZERO;
     }
 
@@ -385,7 +385,6 @@ pub(crate) fn schedule_restart(
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ReadinessState {
     Unconfigured,
-    Immediate,
     Waiting { deadline: Option<Instant> },
     Ready,
     Disarmed,
@@ -453,7 +452,7 @@ impl ReadinessGate {
                     ..
                 },
             ) => {
-                self.state = ReadinessState::Immediate;
+                self.state = ReadinessState::Ready;
                 Some(ReadinessEffect::BecameReady)
             }
             (
@@ -510,7 +509,7 @@ impl ReadinessGate {
                     signal_seen: false, ..
                 },
             )
-            | (ReadinessState::Immediate | ReadinessState::Ready | ReadinessState::Disarmed, _)
+            | (ReadinessState::Ready | ReadinessState::Disarmed, _)
             | (
                 ReadinessState::Unconfigured,
                 ReadinessEvent::Signal | ReadinessEvent::Deadline { .. },

--- a/crates/shelterwood/src/identity.rs
+++ b/crates/shelterwood/src/identity.rs
@@ -27,15 +27,6 @@ thread_local! {
 pub struct ChildId(Arc<str>);
 
 impl ChildId {
-    pub(crate) fn validate(value: impl Into<String>) -> Result<Self, IdError> {
-        let value = value.into();
-        if value.is_empty() {
-            Err(IdError::Empty)
-        } else {
-            Ok(Self(Arc::from(value)))
-        }
-    }
-
     /// Returns the identifier as text.
     #[must_use]
     pub fn as_str(&self) -> &str {
@@ -59,11 +50,6 @@ impl From<String> for ChildId {
     fn from(value: String) -> Self {
         Self(Arc::from(value))
     }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum IdError {
-    Empty,
 }
 
 /// A child's identity within one supervising scope.

--- a/crates/shelterwood/src/mailbox/cell.rs
+++ b/crates/shelterwood/src/mailbox/cell.rs
@@ -232,7 +232,12 @@ impl<M> MailboxState<M> {
             | MailboxBinding::Bound(BoundState::Full { waiters, .. }) => std::mem::take(waiters),
             MailboxBinding::Bound(BoundState::Available(_)) => WaiterQueue::default(),
             MailboxBinding::Terminal(_) => {
-                unreachable!("a terminal mailbox has no live transition")
+                // Terminalization takes the waiters exactly once and no live
+                // transition follows it. This runs under the mailbox mutex
+                // with no way to release it first, so diagnose in debug rather
+                // than poisoning the lock for every sender in release.
+                debug_assert!(false, "a terminal mailbox has no live transition");
+                WaiterQueue::default()
             }
         }
     }
@@ -575,17 +580,23 @@ impl<M: Send + 'static> MailboxCell<M> {
                         drop(state);
                         Submission::Accepted(acceptance.finish(&self.changed))
                     }
-                    Err(Rejected {
-                        message,
-                        reason: RejectionReason::Full,
-                    }) => {
+                    Err(Rejected { message, reason }) => {
+                        if !matches!(reason, RejectionReason::Full) {
+                            // `Full` is the only rejection a bound, configured
+                            // mailbox can produce. Follow `bind`'s convention
+                            // and release the lock before panicking, so an
+                            // invariant break stays on this thread instead of
+                            // poisoning the mutex under every other sender --
+                            // and so the rejected payload's destructor does not
+                            // run under it either.
+                            drop(state);
+                            drop(message);
+                            unreachable!("a bound configured mailbox rejected as {reason:?}");
+                        }
                         let operation = SendOperation::new(message);
                         operation.observe(incarnation);
                         state.park(&operation);
                         Submission::Parked(operation)
-                    }
-                    Err(Rejected { reason, .. }) => {
-                        unreachable!("a bound configured mailbox rejected as {reason:?}")
                     }
                 }
             }

--- a/crates/shelterwood/src/mailbox/cell.rs
+++ b/crates/shelterwood/src/mailbox/cell.rs
@@ -221,6 +221,22 @@ impl<M> MailboxState<M> {
         }
     }
 
+    /// Detaches every waiter from a non-terminal binding before a transition.
+    ///
+    /// Taking directly from the owning variant avoids temporarily claiming
+    /// the mailbox is terminal merely to move its queue out.
+    fn take_waiters(&mut self) -> WaiterQueue<M> {
+        match &mut self.binding {
+            MailboxBinding::Unbound(waiters)
+            | MailboxBinding::Frozen { waiters, .. }
+            | MailboxBinding::Bound(BoundState::Full { waiters, .. }) => std::mem::take(waiters),
+            MailboxBinding::Bound(BoundState::Available(_)) => WaiterQueue::default(),
+            MailboxBinding::Terminal(_) => {
+                unreachable!("a terminal mailbox has no live transition")
+            }
+        }
+    }
+
     fn remove_waiter(&mut self, registration: WaiterId) -> Option<Arc<SendOperation<M>>> {
         let mut available = None;
         let removed = match &mut self.binding {
@@ -358,6 +374,18 @@ struct Acceptance<M> {
     displaced: Option<Envelope<M>>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RejectionReason {
+    NotAccepting,
+    Unconfigured,
+    Full,
+}
+
+struct Rejected<M> {
+    message: M,
+    reason: RejectionReason,
+}
+
 impl<M> Acceptance<M> {
     fn finish(self, changed: &Signal) -> Incarnation {
         changed.pulse();
@@ -383,7 +411,7 @@ impl<M: Send + 'static> Default for Promotion<M> {
 impl<M: Send + 'static> Promotion<M> {
     // Drop is the completion path on every ownership edge. `finish` only
     // names the intentional consume point; its Drop still wakes all accepted
-    // senders and isolates every displaced-message destructor.
+    // senders and panic-contains each displaced-message destructor inline.
     fn finish(self) {}
 
     fn finish_isolated(mut self) {
@@ -547,11 +575,17 @@ impl<M: Send + 'static> MailboxCell<M> {
                         drop(state);
                         Submission::Accepted(acceptance.finish(&self.changed))
                     }
-                    Err(message) => {
+                    Err(Rejected {
+                        message,
+                        reason: RejectionReason::Full,
+                    }) => {
                         let operation = SendOperation::new(message);
                         operation.observe(incarnation);
                         state.park(&operation);
                         Submission::Parked(operation)
+                    }
+                    Err(Rejected { reason, .. }) => {
+                        unreachable!("a bound configured mailbox rejected as {reason:?}")
                     }
                 }
             }
@@ -591,24 +625,26 @@ impl<M: Send + 'static> MailboxCell<M> {
                 kind: SendErrorKind::NotRunning,
             }),
             BindingStatus::Bound(incarnation) => {
-                if state.kind.is_none() {
-                    return Err(SendError {
-                        actor_id: self.actor_id.clone(),
-                        incarnation_observed: None,
-                        message,
-                        kind: SendErrorKind::NotRunning,
-                    });
-                }
                 match accept_locked(&mut state, message, &self.accepted) {
                     Ok(acceptance) => {
                         drop(state);
                         Ok(acceptance.finish(&self.changed))
                     }
-                    Err(message) => Err(SendError {
+                    Err(Rejected { message, reason }) => Err(SendError {
                         actor_id: self.actor_id.clone(),
-                        incarnation_observed: Some(incarnation),
+                        incarnation_observed: match reason {
+                            RejectionReason::Full | RejectionReason::NotAccepting => {
+                                Some(incarnation)
+                            }
+                            RejectionReason::Unconfigured => None,
+                        },
                         message,
-                        kind: SendErrorKind::Full,
+                        kind: match reason {
+                            RejectionReason::Full => SendErrorKind::Full,
+                            RejectionReason::Unconfigured | RejectionReason::NotAccepting => {
+                                SendErrorKind::NotRunning
+                            }
+                        },
                     }),
                 }
             }
@@ -780,13 +816,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             drop(state);
             panic!("mailbox must close the prior incarnation before rebinding");
         }
-        let binding = std::mem::replace(
-            &mut state.binding,
-            MailboxBinding::Bound(BoundState::Available(incarnation)),
-        );
-        let MailboxBinding::Unbound(mut waiters) = binding else {
-            unreachable!("the bind-order contract was checked above")
-        };
+        let mut waiters = state.take_waiters();
         state.last_bound = Some(incarnation);
         // Binding is an observation edge for every operation that remained
         // parked through it, including FIFO overflow that cannot be promoted
@@ -805,7 +835,9 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
                 &self.accepted,
             )
         };
-        if !waiters.is_empty() {
+        if waiters.is_empty() {
+            state.binding = MailboxBinding::Bound(BoundState::Available(incarnation));
+        } else {
             let MailboxKind::Queue(capacity) = kind else {
                 unreachable!("a latest mailbox finishes all waiting submissions")
             };
@@ -825,13 +857,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         if state.status() != BindingStatus::Bound(incarnation) {
             return;
         }
-        let last_bound = state.last_bound;
-        let binding = std::mem::replace(&mut state.binding, MailboxBinding::Terminal(last_bound));
-        let waiters = match binding {
-            MailboxBinding::Bound(BoundState::Available(_)) => WaiterQueue::default(),
-            MailboxBinding::Bound(BoundState::Full { waiters, .. }) => waiters,
-            _ => unreachable!("the status check selected a bound mailbox"),
-        };
+        let waiters = state.take_waiters();
         state.binding = MailboxBinding::Frozen {
             incarnation,
             waiters,
@@ -849,14 +875,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         ) {
             return None;
         }
-        let last_bound = state.last_bound;
-        let binding = std::mem::replace(&mut state.binding, MailboxBinding::Terminal(last_bound));
-        let waiters = match binding {
-            MailboxBinding::Bound(BoundState::Available(_)) => WaiterQueue::default(),
-            MailboxBinding::Bound(BoundState::Full { waiters, .. })
-            | MailboxBinding::Frozen { waiters, .. } => waiters,
-            _ => unreachable!("the status check selected a live mailbox"),
-        };
+        let waiters = state.take_waiters();
         state.binding = MailboxBinding::Unbound(waiters);
         let queue = std::mem::take(&mut state.queue);
         let latest = state.latest.take();
@@ -875,17 +894,8 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             return None;
         }
         let final_incarnation = state.last_bound;
-        let binding = std::mem::replace(
-            &mut state.binding,
-            MailboxBinding::Terminal(final_incarnation),
-        );
-        let waiters = match binding {
-            MailboxBinding::Unbound(waiters)
-            | MailboxBinding::Frozen { waiters, .. }
-            | MailboxBinding::Bound(BoundState::Full { waiters, .. }) => waiters,
-            MailboxBinding::Bound(BoundState::Available(_)) => WaiterQueue::default(),
-            MailboxBinding::Terminal(_) => unreachable!("terminality was checked above"),
-        };
+        let waiters = state.take_waiters();
+        state.binding = MailboxBinding::Terminal(final_incarnation);
         let queue = std::mem::take(&mut state.queue);
         let latest = state.latest.take();
         let termination = Termination {
@@ -927,20 +937,41 @@ fn accept_locked<M>(
     state: &mut MailboxState<M>,
     message: M,
     accepted: &AtomicPoisonedCounter,
-) -> Result<Acceptance<M>, M> {
+) -> Result<Acceptance<M>, Rejected<M>> {
     let incarnation = match &state.binding {
         MailboxBinding::Bound(BoundState::Available(incarnation)) => *incarnation,
+        MailboxBinding::Bound(BoundState::Full { .. }) => {
+            return Err(Rejected {
+                message,
+                reason: RejectionReason::Full,
+            });
+        }
         MailboxBinding::Unbound(_)
-        | MailboxBinding::Bound(BoundState::Full { .. })
         | MailboxBinding::Frozen { .. }
-        | MailboxBinding::Terminal(_) => return Err(message),
+        | MailboxBinding::Terminal(_) => {
+            return Err(Rejected {
+                message,
+                reason: RejectionReason::NotAccepting,
+            });
+        }
     };
     let kind = match state.kind {
         Some(MailboxKind::Queue(capacity)) if state.queue.len() < capacity.get() => {
             MailboxKind::Queue(capacity)
         }
         Some(MailboxKind::Latest) => MailboxKind::Latest,
-        Some(MailboxKind::Queue(_)) | None => return Err(message),
+        Some(MailboxKind::Queue(_)) => {
+            return Err(Rejected {
+                message,
+                reason: RejectionReason::Full,
+            });
+        }
+        None => {
+            return Err(Rejected {
+                message,
+                reason: RejectionReason::Unconfigured,
+            });
+        }
     };
     let accepted_sequence = mint_accepted_sequence(accepted);
     let displaced = match kind {

--- a/crates/shelterwood/src/mailbox/deadline.rs
+++ b/crates/shelterwood/src/mailbox/deadline.rs
@@ -8,8 +8,8 @@ use std::{
 /// Whether an operation is being polled before or after its deadline expires.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum DeadlinePhase {
-    BeforeExpiry,
-    Elapsed,
+    InitialAttempt,
+    TimeoutArbitration,
 }
 
 pub(super) trait DeadlineOperation {
@@ -55,7 +55,7 @@ impl<F> Deadlined<F> {
             budget: None,
             timer: None,
             started: false,
-            phase: DeadlinePhase::BeforeExpiry,
+            phase: DeadlinePhase::InitialAttempt,
         }
     }
 }
@@ -85,11 +85,11 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             .expect("a started deadline future retains its captured budget");
         if let Poll::Ready(result) =
             this.operation
-                .poll_deadlined(context, budget, DeadlinePhase::BeforeExpiry)
+                .poll_deadlined(context, budget, DeadlinePhase::InitialAttempt)
         {
             return Poll::Ready(result);
         }
-        if this.phase == DeadlinePhase::BeforeExpiry {
+        if this.phase == DeadlinePhase::InitialAttempt {
             if this
                 .timer
                 .as_mut()
@@ -103,11 +103,11 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             // The timer is a one-shot future: polling it again after it
             // resolves panics. Latch the transition and release it, so an
             // elapsed poll that stays pending re-polls only the operation.
-            this.phase = DeadlinePhase::Elapsed;
+            this.phase = DeadlinePhase::TimeoutArbitration;
             this.timer = None;
         }
         this.operation
-            .poll_deadlined(context, budget, DeadlinePhase::Elapsed)
+            .poll_deadlined(context, budget, DeadlinePhase::TimeoutArbitration)
     }
 }
 
@@ -134,7 +134,7 @@ mod tests {
             _budget: crate::deadline::Deadline,
             phase: super::DeadlinePhase,
         ) -> Poll<usize> {
-            if phase == super::DeadlinePhase::BeforeExpiry {
+            if phase == super::DeadlinePhase::InitialAttempt {
                 return Poll::Pending;
             }
             self.elapsed_polls += 1;

--- a/crates/shelterwood/src/mailbox/deadline.rs
+++ b/crates/shelterwood/src/mailbox/deadline.rs
@@ -5,10 +5,19 @@ use std::{
     time::Duration,
 };
 
-/// Whether an operation is being polled before or after its deadline expires.
+/// Which of the two passes an operation is being polled in.
+///
+/// A `Deadlined` future polls its operation twice per wakeup: once optimistic,
+/// and -- once the timer has fired -- again to let the operation arbitrate
+/// between a value that landed concurrently and the timeout it would otherwise
+/// report. The distinction is the pass, not merely whether the clock has
+/// passed the deadline.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum DeadlinePhase {
+    /// Optimistic pass: the operation may only complete on its own terms.
     InitialAttempt,
+    /// Post-expiry pass: the operation closes its channel and decides between
+    /// a concurrently delivered value and reporting the timeout.
     TimeoutArbitration,
 }
 

--- a/crates/shelterwood/src/mailbox/futures.rs
+++ b/crates/shelterwood/src/mailbox/futures.rs
@@ -11,14 +11,14 @@ use std::{
 use crate::{
     ChildId, Incarnation, Membership,
     cells::MemberCell,
-    runtime::{DisposingReceiver, OneShotClose, dispose_detached},
+    runtime::{DisposingReceiver, dispose_detached},
 };
 
 use super::{
     CallError, CallErrorKind, Replied, Reply, ReplyError, SendError, SendErrorKind,
     cell::{MailboxCell, OperationOutcome, SendOperation, Submission, Withdrawal},
     deadline::{DeadlineOperation, DeadlinePhase, Deadlined},
-    reply::ReplyOperation,
+    reply::{ReplyOperation, ReplyPoll, poll_reply},
 };
 
 /// Future returned by [`ReplyReceiver::recv`](crate::ReplyReceiver::recv).
@@ -386,7 +386,7 @@ impl<M: Send + 'static> DeadlineOperation for TimedSend<M> {
         if let Poll::Ready(result) = Pin::new(&mut self.send).poll(context) {
             return Poll::Ready(result);
         }
-        if phase == DeadlinePhase::BeforeExpiry {
+        if phase == DeadlinePhase::InitialAttempt {
             Poll::Pending
         } else {
             Poll::Ready(withdraw_send(&mut self.send))
@@ -462,29 +462,18 @@ impl<M, T> CallOperation<M, T> {
             .reply
             .as_mut()
             .expect("accepted call retains reply state");
-        match reply.inner.poll_receive(context) {
-            Poll::Ready(Some(value)) => Poll::Ready(Ok(Replied { value, incarnation })),
-            Poll::Ready(None) => Poll::Ready(Err(CallError {
+        match poll_reply(reply, context, phase) {
+            Poll::Ready(ReplyPoll::Value(value)) => Poll::Ready(Ok(Replied { value, incarnation })),
+            Poll::Ready(ReplyPoll::SenderClosed) => Poll::Ready(Err(CallError {
                 actor_id: self.actor.id().clone(),
                 incarnation_observed: Some(incarnation),
                 kind: CallErrorKind::ReplyDropped,
             })),
-            Poll::Pending if phase == DeadlinePhase::Elapsed => {
-                match reply.inner.close_and_poll_receive(context) {
-                    OneShotClose::Value(value) => Poll::Ready(Ok(Replied { value, incarnation })),
-                    OneShotClose::SenderClosed => Poll::Ready(Err(CallError {
-                        actor_id: self.actor.id().clone(),
-                        incarnation_observed: Some(incarnation),
-                        kind: CallErrorKind::ReplyDropped,
-                    })),
-                    OneShotClose::Empty => Poll::Ready(Err(CallError {
-                        actor_id: self.actor.id().clone(),
-                        incarnation_observed: Some(incarnation),
-                        kind: CallErrorKind::ResponseTimedOut,
-                    })),
-                    OneShotClose::Pending => Poll::Pending,
-                }
-            }
+            Poll::Ready(ReplyPoll::TimedOut) => Poll::Ready(Err(CallError {
+                actor_id: self.actor.id().clone(),
+                incarnation_observed: Some(incarnation),
+                kind: CallErrorKind::ResponseTimedOut,
+            })),
             Poll::Pending => Poll::Pending,
         }
     }
@@ -506,7 +495,7 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
         phase: DeadlinePhase,
     ) -> Poll<Self::Output> {
         if self.make_msg.is_some() {
-            if phase == DeadlinePhase::Elapsed {
+            if phase == DeadlinePhase::TimeoutArbitration {
                 return Poll::Ready(self.short_circuit());
             }
             // Capture the one overall budget before invoking user code. A
@@ -567,7 +556,7 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
             return self.poll_reply(context, accepted, phase);
         }
 
-        if phase == DeadlinePhase::BeforeExpiry {
+        if phase == DeadlinePhase::InitialAttempt {
             return Poll::Pending;
         }
 
@@ -580,7 +569,7 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
         match result {
             Ok(incarnation) => {
                 self.accepted = Some(incarnation);
-                self.poll_reply(context, incarnation, DeadlinePhase::Elapsed)
+                self.poll_reply(context, incarnation, DeadlinePhase::TimeoutArbitration)
             }
             Err(error) => {
                 self.close_reply();

--- a/crates/shelterwood/src/mailbox/futures.rs
+++ b/crates/shelterwood/src/mailbox/futures.rs
@@ -23,11 +23,11 @@ use super::{
 
 /// Future returned by [`ReplyReceiver::recv`](crate::ReplyReceiver::recv).
 #[must_use]
-pub struct ReplyReceive<T: Send + 'static> {
+pub struct ReplyReceive<T> {
     pub(super) deadlined: Deadlined<ReplyOperation<T>>,
 }
 
-impl<T: Send + 'static> fmt::Debug for ReplyReceive<T> {
+impl<T> fmt::Debug for ReplyReceive<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("ReplyReceive")
@@ -411,13 +411,13 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
 
 /// Cancellation-safe future returned by [`ActorRef::call`].
 #[must_use]
-pub struct CallFuture<M, T: Send + 'static> {
+pub struct CallFuture<M, T> {
     deadlined: Deadlined<CallOperation<M, T>>,
 }
 
 type MessageConstructor<M, T> = Box<dyn FnOnce(Reply<T>) -> M + Send + 'static>;
 
-struct CallOperation<M, T: Send + 'static> {
+struct CallOperation<M, T> {
     actor: ActorRef<M>,
     make_msg: Option<MessageConstructor<M, T>>,
     send: Option<SendFuture<M>>,
@@ -429,7 +429,7 @@ struct CallOperation<M, T: Send + 'static> {
     dispose_constructor: fn(MessageConstructor<M, T>),
 }
 
-impl<M, T: Send + 'static> Drop for CallOperation<M, T> {
+impl<M, T> Drop for CallOperation<M, T> {
     fn drop(&mut self) {
         if let Some(make_msg) = self.make_msg.take() {
             // An unstarted or short-circuited call discards its constructor
@@ -441,7 +441,7 @@ impl<M, T: Send + 'static> Drop for CallOperation<M, T> {
     }
 }
 
-impl<M, T: Send + 'static> fmt::Debug for CallFuture<M, T> {
+impl<M, T> fmt::Debug for CallFuture<M, T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("CallFuture")
@@ -451,7 +451,7 @@ impl<M, T: Send + 'static> fmt::Debug for CallFuture<M, T> {
     }
 }
 
-impl<M, T: Send + 'static> CallOperation<M, T> {
+impl<M, T> CallOperation<M, T> {
     fn poll_reply(
         &mut self,
         context: &mut Context<'_>,

--- a/crates/shelterwood/src/mailbox/futures.rs
+++ b/crates/shelterwood/src/mailbox/futures.rs
@@ -23,11 +23,11 @@ use super::{
 
 /// Future returned by [`ReplyReceiver::recv`](crate::ReplyReceiver::recv).
 #[must_use]
-pub struct ReplyReceive<T> {
+pub struct ReplyReceive<T: Send + 'static> {
     pub(super) deadlined: Deadlined<ReplyOperation<T>>,
 }
 
-impl<T> fmt::Debug for ReplyReceive<T> {
+impl<T: Send + 'static> fmt::Debug for ReplyReceive<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("ReplyReceive")
@@ -411,13 +411,13 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
 
 /// Cancellation-safe future returned by [`ActorRef::call`].
 #[must_use]
-pub struct CallFuture<M, T> {
+pub struct CallFuture<M, T: Send + 'static> {
     deadlined: Deadlined<CallOperation<M, T>>,
 }
 
 type MessageConstructor<M, T> = Box<dyn FnOnce(Reply<T>) -> M + Send + 'static>;
 
-struct CallOperation<M, T> {
+struct CallOperation<M, T: Send + 'static> {
     actor: ActorRef<M>,
     make_msg: Option<MessageConstructor<M, T>>,
     send: Option<SendFuture<M>>,
@@ -429,7 +429,7 @@ struct CallOperation<M, T> {
     dispose_constructor: fn(MessageConstructor<M, T>),
 }
 
-impl<M, T> Drop for CallOperation<M, T> {
+impl<M, T: Send + 'static> Drop for CallOperation<M, T> {
     fn drop(&mut self) {
         if let Some(make_msg) = self.make_msg.take() {
             // An unstarted or short-circuited call discards its constructor
@@ -441,7 +441,7 @@ impl<M, T> Drop for CallOperation<M, T> {
     }
 }
 
-impl<M, T> fmt::Debug for CallFuture<M, T> {
+impl<M, T: Send + 'static> fmt::Debug for CallFuture<M, T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("CallFuture")
@@ -451,7 +451,7 @@ impl<M, T> fmt::Debug for CallFuture<M, T> {
     }
 }
 
-impl<M, T> CallOperation<M, T> {
+impl<M, T: Send + 'static> CallOperation<M, T> {
     fn poll_reply(
         &mut self,
         context: &mut Context<'_>,
@@ -480,7 +480,7 @@ impl<M, T> CallOperation<M, T> {
 
     fn close_reply(&mut self) {
         if let Some(reply) = &mut self.reply {
-            reply.inner.close();
+            reply.close();
         }
     }
 }

--- a/crates/shelterwood/src/mailbox/reply.rs
+++ b/crates/shelterwood/src/mailbox/reply.rs
@@ -58,11 +58,11 @@ impl<T: Send + 'static> Reply<T> {
 }
 
 /// The owned, non-cloneable receive half of [`Reply::channel`].
-pub struct ReplyReceiver<T> {
+pub struct ReplyReceiver<T: Send + 'static> {
     pub(super) receiver: DisposingReceiver<T>,
 }
 
-impl<T> fmt::Debug for ReplyReceiver<T> {
+impl<T: Send + 'static> fmt::Debug for ReplyReceiver<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("ReplyReceiver")
@@ -84,7 +84,7 @@ impl<T: Send + 'static> ReplyReceiver<T> {
     }
 }
 
-pub(super) struct ReplyOperation<T> {
+pub(super) struct ReplyOperation<T: Send + 'static> {
     receiver: DisposingReceiver<T>,
 }
 
@@ -94,16 +94,16 @@ pub(super) enum ReplyPoll<T> {
     TimedOut,
 }
 
-pub(super) fn poll_reply<T>(
+pub(super) fn poll_reply<T: Send + 'static>(
     receiver: &mut DisposingReceiver<T>,
     context: &mut Context<'_>,
     phase: DeadlinePhase,
 ) -> Poll<ReplyPoll<T>> {
-    match receiver.inner.poll_receive(context) {
+    match receiver.poll_receive(context) {
         Poll::Ready(Some(value)) => Poll::Ready(ReplyPoll::Value(value)),
         Poll::Ready(None) => Poll::Ready(ReplyPoll::SenderClosed),
         Poll::Pending if phase == DeadlinePhase::TimeoutArbitration => {
-            match receiver.inner.close_and_poll_receive(context) {
+            match receiver.close_and_poll_receive(context) {
                 OneShotClose::Value(value) => Poll::Ready(ReplyPoll::Value(value)),
                 OneShotClose::SenderClosed => Poll::Ready(ReplyPoll::SenderClosed),
                 OneShotClose::Empty => Poll::Ready(ReplyPoll::TimedOut),
@@ -114,7 +114,7 @@ pub(super) fn poll_reply<T>(
     }
 }
 
-impl<T> DeadlineOperation for ReplyOperation<T> {
+impl<T: Send + 'static> DeadlineOperation for ReplyOperation<T> {
     type Output = Result<T, ReplyError>;
 
     fn poll_deadlined(
@@ -132,7 +132,7 @@ impl<T> DeadlineOperation for ReplyOperation<T> {
     }
 
     fn short_circuit(&mut self) -> Self::Output {
-        self.receiver.inner.close();
+        self.receiver.close();
         Err(ReplyError::Timeout)
     }
 }

--- a/crates/shelterwood/src/mailbox/reply.rs
+++ b/crates/shelterwood/src/mailbox/reply.rs
@@ -88,6 +88,32 @@ pub(super) struct ReplyOperation<T> {
     receiver: DisposingReceiver<T>,
 }
 
+pub(super) enum ReplyPoll<T> {
+    Value(T),
+    SenderClosed,
+    TimedOut,
+}
+
+pub(super) fn poll_reply<T>(
+    receiver: &mut DisposingReceiver<T>,
+    context: &mut Context<'_>,
+    phase: DeadlinePhase,
+) -> Poll<ReplyPoll<T>> {
+    match receiver.inner.poll_receive(context) {
+        Poll::Ready(Some(value)) => Poll::Ready(ReplyPoll::Value(value)),
+        Poll::Ready(None) => Poll::Ready(ReplyPoll::SenderClosed),
+        Poll::Pending if phase == DeadlinePhase::TimeoutArbitration => {
+            match receiver.inner.close_and_poll_receive(context) {
+                OneShotClose::Value(value) => Poll::Ready(ReplyPoll::Value(value)),
+                OneShotClose::SenderClosed => Poll::Ready(ReplyPoll::SenderClosed),
+                OneShotClose::Empty => Poll::Ready(ReplyPoll::TimedOut),
+                OneShotClose::Pending => Poll::Pending,
+            }
+        }
+        Poll::Pending => Poll::Pending,
+    }
+}
+
 impl<T> DeadlineOperation for ReplyOperation<T> {
     type Output = Result<T, ReplyError>;
 
@@ -97,17 +123,10 @@ impl<T> DeadlineOperation for ReplyOperation<T> {
         _budget: crate::deadline::Deadline,
         phase: DeadlinePhase,
     ) -> Poll<Self::Output> {
-        match self.receiver.inner.poll_receive(context) {
-            Poll::Ready(Some(value)) => Poll::Ready(Ok(value)),
-            Poll::Ready(None) => Poll::Ready(Err(ReplyError::Dropped)),
-            Poll::Pending if phase == DeadlinePhase::Elapsed => {
-                match self.receiver.inner.close_and_poll_receive(context) {
-                    OneShotClose::Value(value) => Poll::Ready(Ok(value)),
-                    OneShotClose::SenderClosed => Poll::Ready(Err(ReplyError::Dropped)),
-                    OneShotClose::Empty => Poll::Ready(Err(ReplyError::Timeout)),
-                    OneShotClose::Pending => Poll::Pending,
-                }
-            }
+        match poll_reply(&mut self.receiver, context, phase) {
+            Poll::Ready(ReplyPoll::Value(value)) => Poll::Ready(Ok(value)),
+            Poll::Ready(ReplyPoll::SenderClosed) => Poll::Ready(Err(ReplyError::Dropped)),
+            Poll::Ready(ReplyPoll::TimedOut) => Poll::Ready(Err(ReplyError::Timeout)),
             Poll::Pending => Poll::Pending,
         }
     }

--- a/crates/shelterwood/src/mailbox/reply.rs
+++ b/crates/shelterwood/src/mailbox/reply.rs
@@ -58,11 +58,11 @@ impl<T: Send + 'static> Reply<T> {
 }
 
 /// The owned, non-cloneable receive half of [`Reply::channel`].
-pub struct ReplyReceiver<T: Send + 'static> {
+pub struct ReplyReceiver<T> {
     pub(super) receiver: DisposingReceiver<T>,
 }
 
-impl<T: Send + 'static> fmt::Debug for ReplyReceiver<T> {
+impl<T> fmt::Debug for ReplyReceiver<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("ReplyReceiver")
@@ -84,7 +84,7 @@ impl<T: Send + 'static> ReplyReceiver<T> {
     }
 }
 
-pub(super) struct ReplyOperation<T: Send + 'static> {
+pub(super) struct ReplyOperation<T> {
     receiver: DisposingReceiver<T>,
 }
 
@@ -94,7 +94,7 @@ pub(super) enum ReplyPoll<T> {
     TimedOut,
 }
 
-pub(super) fn poll_reply<T: Send + 'static>(
+pub(super) fn poll_reply<T>(
     receiver: &mut DisposingReceiver<T>,
     context: &mut Context<'_>,
     phase: DeadlinePhase,
@@ -114,7 +114,7 @@ pub(super) fn poll_reply<T: Send + 'static>(
     }
 }
 
-impl<T: Send + 'static> DeadlineOperation for ReplyOperation<T> {
+impl<T> DeadlineOperation for ReplyOperation<T> {
     type Output = Result<T, ReplyError>;
 
     fn poll_deadlined(

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -359,6 +359,12 @@ impl SnapshotHub {
             .0
         });
         if sender.receiver_count() == 0 {
+            // Publication is skipped while receiverless, so the first
+            // subscriber after a quiet stretch installs current state itself.
+            // A closed hub already holds the authoritative terminal
+            // projection, installed by `close`; leave it, and skip the pulse
+            // that would then wake nobody about nothing.
+            let mut refreshed = false;
             sender.modify_silently(|state| {
                 if state.closed {
                     return;
@@ -368,8 +374,11 @@ impl SnapshotHub {
                     .generation
                     .mint()
                     .expect("snapshot generation space exhausted");
+                refreshed = true;
             });
-            txn.pulse(sender);
+            if refreshed {
+                txn.pulse(sender);
+            }
         }
         let inner = sender.watcher();
         let seen_generation = inner.borrow_cloned().generation.current();
@@ -471,7 +480,7 @@ impl SnapshotHub {
     pub(crate) fn is_closed(&self) -> bool {
         self.sender
             .get()
-            .is_some_and(|sender| sender.read_cloned().closed)
+            .is_some_and(|sender| sender.read_with(|state| state.closed))
     }
 }
 
@@ -611,7 +620,7 @@ impl LifecycleHub {
     }
 
     pub(crate) fn is_closed(&self) -> bool {
-        self.channels.signal.read_cloned().closed
+        self.channels.signal.read_with(|signal| signal.closed)
     }
 
     /// Publishes while the containing scope's observation gate is held.
@@ -675,7 +684,10 @@ impl fmt::Debug for LifecycleHub {
         formatter
             .debug_struct("LifecycleHub")
             .field("receivers", &self.channels.events.receiver_count())
-            .field("closed", &self.channels.signal.read_cloned().closed)
+            .field(
+                "closed",
+                &self.channels.signal.read_with(|signal| signal.closed),
+            )
             .finish()
     }
 }

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -412,6 +412,11 @@ impl SnapshotHub {
     }
 
     /// Closes while the containing scope's observation gate is held.
+    ///
+    /// The retained watch state is the hub's only record of closure, so an
+    /// unsubscribed hub is materialized here rather than left empty: a later
+    /// subscriber must be able to learn that the scope is terminal, and there
+    /// is no longer a separate closed flag for it to read.
     pub(crate) fn close(
         &self,
         txn: &mut crate::cells::ObservationTxn<'_>,
@@ -434,15 +439,26 @@ impl SnapshotHub {
             return;
         }
         let mut modified = false;
-        let receiverless = sender.receiver_count() == 0;
         sender.modify_silently(|state| {
             if !state.closed {
-                if receiverless {
-                    state.snapshot = final_snapshot
-                        .take()
-                        .expect("final snapshot is built exactly once")(
-                    );
-                }
+                // Install the caller's authoritative terminal projection
+                // unconditionally, whether or not receivers are attached.
+                // Publication is skipped entirely while receiverless, and one
+                // close site (`finish_incarnation_with_terminal`'s stale-epoch
+                // branch) deliberately closes without publishing a `Stopped`
+                // projection first, so the retained value is not otherwise
+                // reliably terminal -- and it is what every later subscriber
+                // reads, since a closed hub declines to install their
+                // recomputed snapshot.
+                //
+                // The install is silent: no generation mint, so live receivers
+                // see exactly the closure they saw before rather than an extra
+                // conflated event. A closed hub delivers no further changes,
+                // so this only corrects what `borrow_latest` reports.
+                state.snapshot = final_snapshot
+                    .take()
+                    .expect("final snapshot is built exactly once")(
+                );
                 state.closed = true;
                 modified = true;
             }
@@ -831,6 +847,40 @@ mod tests {
             }
         ));
         assert!(receiver.changed().await.is_err());
+    }
+
+    #[crate::runtime::test]
+    async fn snapshot_close_installs_the_terminal_state_even_with_live_receivers() {
+        // A close site may terminalize without publishing a `Stopped`
+        // projection first; the retained value is what every later subscriber
+        // reads, so closure must install the authoritative one regardless of
+        // who is currently attached.
+        let hub = SnapshotHub::default();
+        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut live = hub.subscribe(snapshot(ScopeState::Running), &mut txn);
+        drop(txn);
+
+        let mut txn = crate::cells::ObservationTxn::detached();
+        hub.close(&mut txn, || {
+            snapshot(ScopeState::Stopped {
+                reason: crate::StopReason::Finished,
+            })
+        });
+        drop(txn);
+
+        assert!(live.changed().await.is_err());
+        drop(live);
+
+        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut later = hub.subscribe(snapshot(ScopeState::Running), &mut txn);
+        drop(txn);
+        assert!(matches!(
+            later.borrow_latest().state,
+            ScopeState::Stopped {
+                reason: crate::StopReason::Finished
+            }
+        ));
+        assert!(later.changed().await.is_err());
     }
 
     #[crate::runtime::test]

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -417,11 +417,14 @@ impl SnapshotHub {
         txn: &mut crate::cells::ObservationTxn<'_>,
         final_snapshot: impl FnOnce() -> Arc<ScopeSnapshot>,
     ) {
+        let mut final_snapshot = Some(final_snapshot);
         let mut initialized = false;
         let sender = self.sender.get_or_init(|| {
             initialized = true;
             runtime::watch(SnapshotHubState {
-                snapshot: final_snapshot(),
+                snapshot: final_snapshot
+                    .take()
+                    .expect("final snapshot is built exactly once")(),
                 generation: crate::identity::PoisonedCounter::new(),
                 closed: true,
             })
@@ -431,8 +434,15 @@ impl SnapshotHub {
             return;
         }
         let mut modified = false;
+        let receiverless = sender.receiver_count() == 0;
         sender.modify_silently(|state| {
             if !state.closed {
+                if receiverless {
+                    state.snapshot = final_snapshot
+                        .take()
+                        .expect("final snapshot is built exactly once")(
+                    );
+                }
                 state.closed = true;
                 modified = true;
             }
@@ -790,6 +800,34 @@ mod tests {
             receiver.borrow_latest().state,
             ScopeState::Stopped {
                 reason: crate::StopReason::NeverStarted
+            }
+        ));
+        assert!(receiver.changed().await.is_err());
+    }
+
+    #[crate::runtime::test]
+    async fn initialized_receiverless_snapshot_close_refreshes_the_terminal_state() {
+        let hub = SnapshotHub::default();
+        let mut txn = crate::cells::ObservationTxn::detached();
+        let receiver = hub.subscribe(snapshot(ScopeState::Running), &mut txn);
+        drop(txn);
+        drop(receiver);
+
+        let mut txn = crate::cells::ObservationTxn::detached();
+        hub.close(&mut txn, || {
+            snapshot(ScopeState::Stopped {
+                reason: crate::StopReason::Finished,
+            })
+        });
+        drop(txn);
+
+        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut receiver = hub.subscribe(snapshot(ScopeState::Running), &mut txn);
+        drop(txn);
+        assert!(matches!(
+            receiver.borrow_latest().state,
+            ScopeState::Stopped {
+                reason: crate::StopReason::Finished
             }
         ));
         assert!(receiver.changed().await.is_err());

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -412,19 +412,40 @@ impl SnapshotHub {
     }
 
     /// Closes while the containing scope's observation gate is held.
-    pub(crate) fn close(&self, txn: &mut crate::cells::ObservationTxn<'_>) {
-        if let Some(sender) = self.sender.get() {
-            let mut modified = false;
-            sender.modify_silently(|state| {
-                if !state.closed {
-                    state.closed = true;
-                    modified = true;
-                }
-            });
-            if modified {
-                txn.pulse(sender);
-            }
+    pub(crate) fn close(
+        &self,
+        txn: &mut crate::cells::ObservationTxn<'_>,
+        final_snapshot: impl FnOnce() -> Arc<ScopeSnapshot>,
+    ) {
+        let mut initialized = false;
+        let sender = self.sender.get_or_init(|| {
+            initialized = true;
+            runtime::watch(SnapshotHubState {
+                snapshot: final_snapshot(),
+                generation: crate::identity::PoisonedCounter::new(),
+                closed: true,
+            })
+            .0
+        });
+        if initialized {
+            return;
         }
+        let mut modified = false;
+        sender.modify_silently(|state| {
+            if !state.closed {
+                state.closed = true;
+                modified = true;
+            }
+        });
+        if modified {
+            txn.pulse(sender);
+        }
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        self.sender
+            .get()
+            .is_some_and(|sender| sender.read_cloned().closed)
     }
 }
 
@@ -439,13 +460,7 @@ impl fmt::Debug for SnapshotHub {
                     .get()
                     .map_or(0, |sender| sender.receiver_count()),
             )
-            .field(
-                "closed",
-                &self
-                    .sender
-                    .get()
-                    .is_some_and(|sender| sender.read_cloned().closed),
-            )
+            .field("closed", &self.is_closed())
             .finish()
     }
 }
@@ -567,6 +582,10 @@ impl LifecycleHub {
             signal,
             seen_explicit_lag,
         }
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        self.channels.signal.read_cloned().closed
     }
 
     /// Publishes while the containing scope's observation gate is held.
@@ -712,7 +731,11 @@ mod tests {
                 reason: crate::StopReason::Finished,
             })
         });
-        hub.close(&mut txn);
+        hub.close(&mut txn, || {
+            snapshot(ScopeState::Stopped {
+                reason: crate::StopReason::Finished,
+            })
+        });
         drop(txn);
 
         assert!(matches!(
@@ -747,6 +770,29 @@ mod tests {
             }
         ));
         assert!(after_close.changed().await.is_err());
+    }
+
+    #[crate::runtime::test]
+    async fn receiverless_snapshot_close_installs_the_terminal_state() {
+        let hub = SnapshotHub::default();
+        let mut txn = crate::cells::ObservationTxn::detached();
+        hub.close(&mut txn, || {
+            snapshot(ScopeState::Stopped {
+                reason: crate::StopReason::NeverStarted,
+            })
+        });
+        drop(txn);
+
+        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut receiver = hub.subscribe(snapshot(ScopeState::Running), &mut txn);
+        drop(txn);
+        assert!(matches!(
+            receiver.borrow_latest().state,
+            ScopeState::Stopped {
+                reason: crate::StopReason::NeverStarted
+            }
+        ));
+        assert!(receiver.changed().await.is_err());
     }
 
     #[crate::runtime::test]

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -2,10 +2,7 @@
 
 use std::{
     fmt,
-    sync::{
-        Arc, OnceLock,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
 
@@ -338,7 +335,6 @@ impl fmt::Debug for SnapshotReceiver {
 #[derive(Default)]
 pub(crate) struct SnapshotHub {
     sender: OnceLock<runtime::WatchSender<SnapshotHubState>>,
-    closed: AtomicBool,
 }
 
 #[derive(Clone, Debug)]
@@ -354,18 +350,6 @@ impl SnapshotHub {
         initial: Arc<ScopeSnapshot>,
         txn: &mut crate::cells::ObservationTxn<'_>,
     ) -> SnapshotReceiver {
-        if self.closed.load(Ordering::Acquire) {
-            let (sender, inner) = runtime::watch(SnapshotHubState {
-                snapshot: initial,
-                generation: crate::identity::PoisonedCounter::new(),
-                closed: true,
-            });
-            drop(sender);
-            return SnapshotReceiver {
-                inner,
-                seen_generation: 0,
-            };
-        }
         let sender = self.sender.get_or_init(|| {
             runtime::watch(SnapshotHubState {
                 snapshot: Arc::clone(&initial),
@@ -374,15 +358,11 @@ impl SnapshotHub {
             })
             .0
         });
-        // `close` may win between the first atomic check and lazy sender
-        // initialization. Reconcile the channel state after initialization so
-        // that first subscriber still observes closure; once installed,
-        // `close` itself performs this publication and wakeup.
-        if self.closed.load(Ordering::Acquire) {
-            sender.modify_silently(|state| state.closed = true);
-            txn.pulse(sender);
-        } else if sender.receiver_count() == 0 {
+        if sender.receiver_count() == 0 {
             sender.modify_silently(|state| {
+                if state.closed {
+                    return;
+                }
                 state.snapshot = initial;
                 state
                     .generation
@@ -399,41 +379,15 @@ impl SnapshotHub {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn publish(&self, snapshot: impl FnOnce() -> Arc<ScopeSnapshot>) {
-        if self.closed.load(Ordering::Acquire) {
-            return;
-        }
-        let Some(sender) = self.sender.get() else {
-            return;
-        };
-        if sender.receiver_count() > 0 {
-            sender.send_if_modified(|state| {
-                // `close` and publication serialize on the retained watch
-                // state. The atomic is the fast path; this check prevents a
-                // publisher that passed it just before closure from mutating
-                // the terminal value afterward.
-                if state.closed {
-                    return false;
-                }
-                state.snapshot = snapshot();
-                state
-                    .generation
-                    .mint()
-                    .expect("snapshot generation space exhausted");
-                true
-            });
-        }
-    }
-
-    pub(crate) fn publish_deferred(
+    /// Publishes while the containing scope's observation gate is held.
+    ///
+    /// The gate serializes publication, subscription, and closure, so the
+    /// retained watch state is the only hub-local source of terminality.
+    pub(crate) fn publish(
         &self,
-        wakes: &mut crate::cells::ObservationTxn<'_>,
+        txn: &mut crate::cells::ObservationTxn<'_>,
         snapshot: impl FnOnce() -> Arc<ScopeSnapshot>,
     ) {
-        if self.closed.load(Ordering::Acquire) {
-            return;
-        }
         let Some(sender) = self.sender.get() else {
             return;
         };
@@ -453,27 +407,23 @@ impl SnapshotHub {
             modified = true;
         });
         if modified {
-            wakes.pulse(sender);
+            txn.pulse(sender);
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn close(&self) {
-        if self.closed.swap(true, Ordering::AcqRel) {
-            return;
-        }
+    /// Closes while the containing scope's observation gate is held.
+    pub(crate) fn close(&self, txn: &mut crate::cells::ObservationTxn<'_>) {
         if let Some(sender) = self.sender.get() {
-            sender.send_modify(|state| state.closed = true);
-        }
-    }
-
-    pub(crate) fn close_deferred(&self, wakes: &mut crate::cells::ObservationTxn<'_>) {
-        if self.closed.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        if let Some(sender) = self.sender.get() {
-            sender.modify_silently(|state| state.closed = true);
-            wakes.pulse(sender);
+            let mut modified = false;
+            sender.modify_silently(|state| {
+                if !state.closed {
+                    state.closed = true;
+                    modified = true;
+                }
+            });
+            if modified {
+                txn.pulse(sender);
+            }
         }
     }
 }
@@ -489,7 +439,13 @@ impl fmt::Debug for SnapshotHub {
                     .get()
                     .map_or(0, |sender| sender.receiver_count()),
             )
-            .field("closed", &self.closed.load(Ordering::Acquire))
+            .field(
+                "closed",
+                &self
+                    .sender
+                    .get()
+                    .is_some_and(|sender| sender.read_cloned().closed),
+            )
             .finish()
     }
 }
@@ -576,7 +532,6 @@ impl fmt::Debug for LifecycleEvents {
 
 pub(crate) struct LifecycleHub {
     channels: LifecycleChannels,
-    closed: AtomicBool,
 }
 
 struct LifecycleChannels {
@@ -599,7 +554,6 @@ impl Default for LifecycleHub {
         let (signal, _) = runtime::watch(LifecycleSignal::default());
         Self {
             channels: LifecycleChannels { events, signal },
-            closed: AtomicBool::new(false),
         }
     }
 }
@@ -615,24 +569,10 @@ impl LifecycleHub {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn publish(&self, event: LifecycleEvent) {
-        tracing::trace!(
-            scope = ?event.scope,
-            seq = event.seq.get(),
-            path = ?event.scope_path,
-            kind = ?event.kind,
-            "scope lifecycle event"
-        );
-        if self.closed.load(Ordering::Acquire) {
-            return;
-        }
-        self.publish_past_fast_path(event);
-    }
-
-    pub(crate) fn publish_deferred(
+    /// Publishes while the containing scope's observation gate is held.
+    pub(crate) fn publish(
         &self,
-        wakes: &mut crate::cells::ObservationTxn<'_>,
+        txn: &mut crate::cells::ObservationTxn<'_>,
         event: LifecycleEvent,
     ) {
         tracing::trace!(
@@ -642,9 +582,6 @@ impl LifecycleHub {
             kind = ?event.kind,
             "scope lifecycle event"
         );
-        if self.closed.load(Ordering::Acquire) {
-            return;
-        }
         let mut published = false;
         self.channels.signal.modify_silently(|signal| {
             if signal.closed {
@@ -654,52 +591,12 @@ impl LifecycleHub {
             published = true;
         });
         if published {
-            wakes.pulse(&self.channels.signal);
+            txn.pulse(&self.channels.signal);
         }
     }
 
-    /// The enqueue half of [`publish`](Self::publish), after the atomic
-    /// fast-path check. Split out so tests can pin the close race: calling
-    /// this on a closed hub is exactly a publisher that read `closed ==
-    /// false` and then lost the linearization race to `close`.
-    #[cfg(test)]
-    fn publish_past_fast_path(&self, event: LifecycleEvent) {
-        self.channels.signal.send_if_modified(|signal| {
-            // Enqueue and activity notification share the same linearization
-            // point as closure. A publisher that passed the atomic fast-path
-            // check cannot append after receivers have observed `closed`.
-            if signal.closed {
-                return false;
-            }
-            let _ = self.channels.events.send(event);
-            // The watch version is also the no-loss activity notification for
-            // async receivers. Its value changes only for explicit lag.
-            true
-        });
-    }
-
-    #[cfg(test)]
-    pub(crate) fn publish_lagged(&self, dropped: u64) {
-        if self.closed.load(Ordering::Acquire) {
-            return;
-        }
-        self.channels.signal.send_if_modified(|signal| {
-            if signal.closed {
-                return false;
-            }
-            signal.explicit_lag = signal.explicit_lag.saturating_add(dropped);
-            true
-        });
-    }
-
-    pub(crate) fn publish_lagged_deferred(
-        &self,
-        wakes: &mut crate::cells::ObservationTxn<'_>,
-        dropped: u64,
-    ) {
-        if self.closed.load(Ordering::Acquire) {
-            return;
-        }
+    /// Publishes an explicit lag marker under the observation gate.
+    pub(crate) fn publish_lagged(&self, txn: &mut crate::cells::ObservationTxn<'_>, dropped: u64) {
         let mut published = false;
         self.channels.signal.modify_silently(|signal| {
             if signal.closed {
@@ -709,27 +606,22 @@ impl LifecycleHub {
             published = true;
         });
         if published {
-            wakes.pulse(&self.channels.signal);
+            txn.pulse(&self.channels.signal);
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn close(&self) {
-        if !self.closed.swap(true, Ordering::AcqRel) {
-            self.channels
-                .signal
-                .send_modify(|signal| signal.closed = true);
+    /// Closes while the containing scope's observation gate is held.
+    pub(crate) fn close(&self, txn: &mut crate::cells::ObservationTxn<'_>) {
+        let mut modified = false;
+        self.channels.signal.modify_silently(|signal| {
+            if !signal.closed {
+                signal.closed = true;
+                modified = true;
+            }
+        });
+        if modified {
+            txn.pulse(&self.channels.signal);
         }
-    }
-
-    pub(crate) fn close_deferred(&self, wakes: &mut crate::cells::ObservationTxn<'_>) {
-        if self.closed.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        self.channels
-            .signal
-            .modify_silently(|signal| signal.closed = true);
-        wakes.pulse(&self.channels.signal);
     }
 }
 
@@ -738,7 +630,7 @@ impl fmt::Debug for LifecycleHub {
         formatter
             .debug_struct("LifecycleHub")
             .field("receivers", &self.channels.events.receiver_count())
-            .field("closed", &self.closed.load(Ordering::Acquire))
+            .field("closed", &self.channels.signal.read_cloned().closed)
             .finish()
     }
 }
@@ -760,10 +652,7 @@ pub enum WaitError {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        sync::{Arc, atomic::Ordering},
-        thread,
-    };
+    use std::sync::Arc;
 
     use crate::{
         Intensity, ScopeState,
@@ -791,41 +680,22 @@ mod tests {
     #[test]
     fn snapshot_projection_is_skipped_without_subscribers() {
         let hub = SnapshotHub::default();
-        hub.publish(|| panic!("projection must be lazy when no receiver exists"));
+        let mut txn = crate::cells::ObservationTxn::detached();
+        hub.publish(&mut txn, || {
+            panic!("projection must be lazy when no receiver exists")
+        });
     }
 
     #[crate::runtime::test]
-    async fn snapshot_publication_that_linearizes_before_close_is_drained() {
-        let hub = Arc::new(SnapshotHub::default());
+    async fn snapshot_publication_before_close_is_drained() {
+        let hub = SnapshotHub::default();
         let mut txn = crate::cells::ObservationTxn::detached();
         let mut snapshots = hub.subscribe(snapshot(ScopeState::Unstarted), &mut txn);
         drop(txn);
-        let (entered, wait_for_release) = std::sync::mpsc::channel();
-        let (release, released) = std::sync::mpsc::channel();
 
-        let publisher = {
-            let hub = Arc::clone(&hub);
-            thread::spawn(move || {
-                hub.publish(|| {
-                    entered.send(()).expect("test remains active");
-                    released.recv().expect("publisher is released");
-                    snapshot(ScopeState::Running)
-                });
-            })
-        };
-        wait_for_release
-            .recv()
-            .expect("publisher reaches the serialized channel update");
-        let closer = {
-            let hub = Arc::clone(&hub);
-            thread::spawn(move || hub.close())
-        };
-        while !hub.closed.load(Ordering::Acquire) {
-            thread::yield_now();
-        }
-        release.send(()).expect("publisher is still waiting");
-        publisher.join().expect("publisher does not panic");
-        closer.join().expect("closer does not panic");
+        let mut txn = crate::cells::ObservationTxn::detached();
+        hub.publish(&mut txn, || snapshot(ScopeState::Running));
+        drop(txn);
 
         assert_eq!(
             snapshots
@@ -835,8 +705,32 @@ mod tests {
                 .state,
             ScopeState::Running
         );
+
+        let mut txn = crate::cells::ObservationTxn::detached();
+        hub.publish(&mut txn, || {
+            snapshot(ScopeState::Stopped {
+                reason: crate::StopReason::Finished,
+            })
+        });
+        hub.close(&mut txn);
+        drop(txn);
+
+        assert!(matches!(
+            snapshots
+                .changed()
+                .await
+                .expect("final publication precedes close")
+                .state,
+            ScopeState::Stopped {
+                reason: crate::StopReason::Finished
+            }
+        ));
         assert!(snapshots.changed().await.is_err());
-        hub.publish(|| panic!("publication after close must remain lazy"));
+        let mut txn = crate::cells::ObservationTxn::detached();
+        hub.publish(&mut txn, || {
+            panic!("publication after close must remain lazy")
+        });
+        drop(txn);
 
         let mut txn = crate::cells::ObservationTxn::detached();
         let mut after_close = hub.subscribe(
@@ -862,13 +756,15 @@ mod tests {
         let waiter = crate::runtime::spawn(async move { events.recv().await });
         crate::runtime::yield_now().await;
 
-        hub.close();
+        let mut txn = crate::cells::ObservationTxn::detached();
+        hub.close(&mut txn);
+        drop(txn);
 
         assert_eq!(crate::runtime::join_resuming(waiter).await, None);
     }
 
     #[test]
-    fn lifecycle_publication_that_lost_the_close_race_appends_nothing() {
+    fn lifecycle_publication_after_close_appends_nothing() {
         let mut identity = ScopeIdentity::new();
         let membership = identity
             .mint_membership(&crate::ChildId::from("scope"))
@@ -876,18 +772,21 @@ mod tests {
             .membership();
         let hub = LifecycleHub::default();
         let mut events = hub.subscribe();
-        hub.close();
+        let mut txn = crate::cells::ObservationTxn::detached();
+        hub.close(&mut txn);
 
-        // A publisher that read `closed == false` and then lost the
-        // linearization race to `close` must append nothing.
-        hub.publish_past_fast_path(LifecycleEvent {
-            scope_path: Vec::new(),
-            scope: membership,
-            seq: LifecycleSeq::new(1),
-            kind: LifecycleEventKind::ScopeState {
-                state: ScopeState::Running,
+        hub.publish(
+            &mut txn,
+            LifecycleEvent {
+                scope_path: Vec::new(),
+                scope: membership,
+                seq: LifecycleSeq::new(1),
+                kind: LifecycleEventKind::ScopeState {
+                    state: ScopeState::Running,
+                },
             },
-        });
+        );
+        drop(txn);
 
         assert!(matches!(
             events.try_recv(),
@@ -913,13 +812,17 @@ mod tests {
         let hub = LifecycleHub::default();
         let mut events = hub.subscribe();
 
-        hub.publish_lagged(1);
-        hub.publish(event(1));
+        let mut txn = crate::cells::ObservationTxn::detached();
+        hub.publish_lagged(&mut txn, 1);
+        hub.publish(&mut txn, event(1));
+        drop(txn);
         assert_eq!(events.try_recv(), Ok(LifecycleItem::Lagged { dropped: 1 }));
 
+        let mut txn = crate::cells::ObservationTxn::detached();
         for seq in 2..=(LIFECYCLE_EVENT_CAPACITY as u64 + 2) {
-            hub.publish(event(seq));
+            hub.publish(&mut txn, event(seq));
         }
+        drop(txn);
         assert_eq!(
             events.try_recv(),
             Ok(LifecycleItem::Lagged { dropped: 2 }),
@@ -951,11 +854,13 @@ mod tests {
         let hub = LifecycleHub::default();
         let mut events = hub.subscribe();
 
-        hub.publish_lagged(2);
-        hub.publish(event(1));
-        hub.close();
-        hub.publish_lagged(3);
-        hub.publish(event(2));
+        let mut txn = crate::cells::ObservationTxn::detached();
+        hub.publish_lagged(&mut txn, 2);
+        hub.publish(&mut txn, event(1));
+        hub.close(&mut txn);
+        hub.publish_lagged(&mut txn, 3);
+        hub.publish(&mut txn, event(2));
+        drop(txn);
 
         assert_eq!(events.try_recv(), Ok(LifecycleItem::Lagged { dropped: 2 }));
         assert_eq!(events.try_recv(), Ok(LifecycleItem::Event(event(1))));

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -442,14 +442,6 @@ pub(crate) struct ScopePlan {
 
 struct ScopePlanTerminality;
 
-pub(crate) struct RuntimeScopePlan {
-    pub(crate) root: Arc<ScopeCell>,
-    pub(crate) config: ScopeConfig,
-    pub(crate) defaults: ResolvedDefaults,
-    pub(crate) children: Vec<ChildPlan>,
-    terminality: Option<ScopePlanTerminality>,
-}
-
 fn terminalize_plan(
     root: &ScopeCell,
     children: &[ChildPlan],
@@ -470,27 +462,6 @@ fn terminalize_plan(
 }
 
 impl ScopePlan {
-    /// Consumes declaration ownership and transfers its terminality obligation
-    /// to the runtime plan. There is no independently mutable disarm bit: a
-    /// caller either owns the declaration plan or has consumed it here.
-    pub(crate) fn take_for_runtime(mut self) -> RuntimeScopePlan {
-        RuntimeScopePlan {
-            root: Arc::clone(&self.root),
-            config: self.config.clone(),
-            defaults: self.defaults.clone(),
-            children: std::mem::take(&mut self.children),
-            terminality: self.terminality.take(),
-        }
-    }
-}
-
-impl Drop for ScopePlan {
-    fn drop(&mut self) {
-        terminalize_plan(&self.root, &self.children, &mut self.terminality);
-    }
-}
-
-impl RuntimeScopePlan {
     /// Finishes the transfer after every child has installed its own
     /// terminality obligation. Consuming `self` makes a partial handoff
     /// impossible to mistake for a completed one.
@@ -505,7 +476,7 @@ impl RuntimeScopePlan {
     }
 }
 
-impl Drop for RuntimeScopePlan {
+impl Drop for ScopePlan {
     fn drop(&mut self) {
         terminalize_plan(&self.root, &self.children, &mut self.terminality);
     }

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -1,7 +1,7 @@
 //! Declaration lowering and its owned construction plan.
 
 use std::{
-    collections::HashMap,
+    collections::HashSet,
     sync::{Arc, Mutex},
 };
 
@@ -10,7 +10,7 @@ use crate::{
     admission::ReserveError,
     cells::{ErasedDynamicSlot, MemberCell, ObservationTxn, ScopeCell},
     definition::DefinitionSource,
-    identity::{IdError, ScopeIdentity},
+    identity::ScopeIdentity,
     policy::{
         ChildMode, CommonOptions, InvalidPolicy, PolicyField, ResolvedCommonOptions,
         ResolvedDefaults, ScopeFlavor, resolve_common,
@@ -259,7 +259,7 @@ pub(crate) struct BuilderCore {
     pub(crate) root: Arc<ScopeCell>,
     pub(crate) config: ScopeConfig,
     pub(crate) slots: Vec<Arc<SlotCell>>,
-    ids: HashMap<ChildId, Arc<SlotCell>>,
+    ids: HashSet<ChildId>,
     /// The stable scope whose identity map `lower(root_override)` adopts the
     /// slots' lineages into. Eviction must target the map a lineage actually
     /// entered: before adoption begins the lineages live in `root`'s map,
@@ -292,7 +292,7 @@ impl BuilderCore {
             root,
             config: ScopeConfig::default(),
             slots: Vec::new(),
-            ids: HashMap::new(),
+            ids: HashSet::new(),
             adopting_root: None,
             armed: true,
         }
@@ -304,11 +304,11 @@ impl BuilderCore {
         scope: Option<ScopeFlavor>,
     ) -> Result<Arc<SlotCell>, ReserveError> {
         let id = checked_id(id)?;
-        if self.ids.contains_key(&id) {
+        if self.ids.contains(&id) {
             return Err(ReserveError::DuplicateId(id));
         }
         let slot = mint_reserved_slot(&self.root, &id, scope)?;
-        self.ids.insert(id, Arc::clone(&slot));
+        self.ids.insert(id);
         self.slots.push(Arc::clone(&slot));
         Ok(slot)
     }
@@ -576,9 +576,11 @@ impl ScopeConstruction {
 
 pub(crate) fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError> {
     let id = id.into();
-    ChildId::validate(id.as_str().to_owned()).map_err(|error| match error {
-        IdError::Empty => ReserveError::EmptyId,
-    })
+    if id.as_str().is_empty() {
+        Err(ReserveError::EmptyId)
+    } else {
+        Ok(id)
+    }
 }
 
 #[cfg(test)]

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -140,7 +140,10 @@ impl SlotCell {
         if let Some(scope) = &self.scope {
             scope.terminalize_never_started();
         } else {
-            self.member.terminalize(Exit::never_started());
+            self.member.terminalize(
+                Exit::never_started(),
+                crate::cells::StartupDisposition::Unchanged,
+            );
         }
         owner.evict_child_identity(&self.member);
     }
@@ -150,7 +153,11 @@ impl SlotCell {
         owner: &ScopeCell,
         txn: &mut ObservationTxn<'_>,
     ) {
-        self.member.terminalize_locked(Exit::never_started(), txn);
+        self.member.terminalize_locked(
+            Exit::never_started(),
+            crate::cells::StartupDisposition::Unchanged,
+            txn,
+        );
         if let Some(scope) = &self.scope {
             scope.terminalize_never_started_locked(txn);
         }

--- a/crates/shelterwood/src/policy.rs
+++ b/crates/shelterwood/src/policy.rs
@@ -91,11 +91,11 @@ pub(crate) enum ChildMode {
 }
 
 /// The default bounded FIFO mailbox capacity.
-pub const DEFAULT_MAILBOX_CAPACITY: usize = 64;
+pub(crate) const DEFAULT_MAILBOX_CAPACITY: usize = 64;
 /// The default child shutdown grace.
-pub const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+pub(crate) const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 /// The default gated-readiness deadline.
-pub const DEFAULT_READINESS_DEADLINE: Duration = Duration::from_secs(30);
+pub(crate) const DEFAULT_READINESS_DEADLINE: Duration = Duration::from_secs(30);
 
 /// The condition under which an exited child is restarted.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/crates/shelterwood/src/runtime/spawn.rs
+++ b/crates/shelterwood/src/runtime/spawn.rs
@@ -260,6 +260,10 @@ pub(crate) struct JitterRng(fastrand::Rng);
 
 impl JitterRng {
     pub(crate) fn new() -> Self {
+        // `fastrand::Rng::new` seeds from the thread-local generator, falling
+        // back to a fixed seed if that is unavailable (during TLS teardown).
+        // Restart jitter would then be deterministic and correlated across
+        // scopes -- degraded spread, never a correctness break.
         Self(fastrand::Rng::new())
     }
 

--- a/crates/shelterwood/src/runtime/spawn.rs
+++ b/crates/shelterwood/src/runtime/spawn.rs
@@ -259,8 +259,8 @@ where
 pub(crate) struct JitterRng(fastrand::Rng);
 
 impl JitterRng {
-    pub(crate) fn from_system_entropy() -> Self {
-        Self(fastrand::Rng::with_seed(fastrand::u64(..)))
+    pub(crate) fn new() -> Self {
+        Self(fastrand::Rng::new())
     }
 
     pub(crate) fn sample<R>(&mut self, range: R) -> u64

--- a/crates/shelterwood/src/runtime/sync.rs
+++ b/crates/shelterwood/src/runtime/sync.rs
@@ -391,17 +391,31 @@ impl<T> OneShotReceiver<T> {
 ///
 /// A value stored before the receive side is cancelled is user-owned:
 /// destroying it inline could block or panic whoever dropped the holder. The
-/// value type stays `Send + 'static`, so drop can route an unclaimed stored
-/// value through isolated disposal directly.
-pub(crate) struct DisposingReceiver<T: Send + 'static> {
+/// disposal function is captured at construction, where the value type's
+/// `Send + 'static` bounds hold, so unbounded holders can still route an
+/// unclaimed stored value through isolated disposal on drop.
+///
+/// The erasure is load-bearing API design, not incidental: `Drop` must repeat
+/// whatever bounds the struct declares, so bounding this type would push
+/// `T: Send + 'static` onto the *definitions* of the public wrappers that hold
+/// it (`ReplyReceiver`, `ReplyReceive`, `CallFuture`, `OneShotTaskRef`) and
+/// force downstream generic declarations to carry a bound they never asked
+/// for. Execution bounds belong on constructors and operational impls here.
+pub(crate) struct DisposingReceiver<T> {
     inner: OneShotReceiver<T>,
+    dispose: fn(T),
 }
 
 impl<T: Send + 'static> DisposingReceiver<T> {
     pub(crate) fn new(inner: OneShotReceiver<T>) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            dispose: dispose_detached::<T>,
+        }
     }
+}
 
+impl<T> DisposingReceiver<T> {
     pub(crate) fn poll_receive(
         &mut self,
         context: &mut std::task::Context<'_>,
@@ -421,10 +435,10 @@ impl<T: Send + 'static> DisposingReceiver<T> {
     }
 }
 
-impl<T: Send + 'static> Drop for DisposingReceiver<T> {
+impl<T> Drop for DisposingReceiver<T> {
     fn drop(&mut self) {
         if let Some(value) = self.inner.close_and_take() {
-            dispose_detached(value);
+            (self.dispose)(value);
         }
     }
 }

--- a/crates/shelterwood/src/runtime/sync.rs
+++ b/crates/shelterwood/src/runtime/sync.rs
@@ -38,7 +38,6 @@ impl Signal {
     pub(crate) fn watcher(&self) -> SignalWatcher {
         SignalWatcher {
             inner: self.inner.watcher(),
-            _signal: self.clone(),
         }
     }
 
@@ -50,9 +49,6 @@ impl Signal {
 
 pub(crate) struct SignalWatcher {
     inner: WatchReceiver<()>,
-    // Retain the source through every watcher so channel closure cannot turn
-    // into a spurious pulse.
-    _signal: Signal,
 }
 
 impl SignalWatcher {
@@ -395,27 +391,40 @@ impl<T> OneShotReceiver<T> {
 ///
 /// A value stored before the receive side is cancelled is user-owned:
 /// destroying it inline could block or panic whoever dropped the holder. The
-/// disposal function is captured at construction, where the value type's
-/// `Send + 'static` bounds hold, so unbounded holders can still route an
-/// unclaimed stored value through isolated disposal on drop.
-pub(crate) struct DisposingReceiver<T> {
-    pub(crate) inner: OneShotReceiver<T>,
-    dispose: fn(T),
+/// value type stays `Send + 'static`, so drop can route an unclaimed stored
+/// value through isolated disposal directly.
+pub(crate) struct DisposingReceiver<T: Send + 'static> {
+    inner: OneShotReceiver<T>,
 }
 
 impl<T: Send + 'static> DisposingReceiver<T> {
     pub(crate) fn new(inner: OneShotReceiver<T>) -> Self {
-        Self {
-            inner,
-            dispose: dispose_detached::<T>,
-        }
+        Self { inner }
+    }
+
+    pub(crate) fn poll_receive(
+        &mut self,
+        context: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<T>> {
+        self.inner.poll_receive(context)
+    }
+
+    pub(crate) fn close_and_poll_receive(
+        &mut self,
+        context: &mut std::task::Context<'_>,
+    ) -> OneShotClose<T> {
+        self.inner.close_and_poll_receive(context)
+    }
+
+    pub(crate) fn close(&mut self) {
+        self.inner.close();
     }
 }
 
-impl<T> Drop for DisposingReceiver<T> {
+impl<T: Send + 'static> Drop for DisposingReceiver<T> {
     fn drop(&mut self) {
         if let Some(value) = self.inner.close_and_take() {
-            (self.dispose)(value);
+            dispose_detached(value);
         }
     }
 }

--- a/crates/shelterwood/src/runtime/sync.rs
+++ b/crates/shelterwood/src/runtime/sync.rs
@@ -450,18 +450,6 @@ impl<T> WatchSender<T> {
         self.0.send_modify(|_| {});
     }
 
-    #[cfg(test)]
-    pub(crate) fn send_modify(&self, update: impl FnOnce(&mut T)) {
-        self.0.send_modify(update);
-    }
-
-    /// The remaining production writers pulse or replace whole values; only
-    /// test-side publication needs conditional notification.
-    #[cfg(test)]
-    pub(crate) fn send_if_modified(&self, update: impl FnOnce(&mut T) -> bool) -> bool {
-        self.0.send_if_modified(update)
-    }
-
     /// Mutates the retained value without advancing the watch version.
     ///
     /// This is only for compound publication that must finish another

--- a/crates/shelterwood/src/runtime/sync.rs
+++ b/crates/shelterwood/src/runtime/sync.rs
@@ -485,6 +485,14 @@ impl<T> WatchSender<T> {
         });
         debug_assert!(!notified);
     }
+
+    /// Reads a projection of the retained value without cloning it.
+    ///
+    /// `project` runs under the watch's read guard, so it must stay cheap and
+    /// must not touch the same channel.
+    pub(crate) fn read_with<R>(&self, project: impl FnOnce(&T) -> R) -> R {
+        project(&self.0.borrow())
+    }
 }
 
 impl<T: Clone> WatchSender<T> {

--- a/crates/shelterwood/src/scope.rs
+++ b/crates/shelterwood/src/scope.rs
@@ -181,8 +181,95 @@ impl DynamicScopeRef {
     }
 }
 
-/// The ordered-scope surface remains available without duplicating inherent
-/// forwarding methods on the capability-preserving dynamic handle.
+/// The shared observation/control surface, forwarded inherently.
+///
+/// The [`Deref`] impl below already makes every [`ScopeRef`] method resolve
+/// through ordinary method syntax, and it is what keeps a newly added method
+/// reachable here without touching this block. These forwards exist for the
+/// resolution form deref coercion cannot serve: associated-function paths.
+/// `DynamicScopeRef::id(&scope)` and `let f = DynamicScopeRef::request_shutdown`
+/// are pinned public API (`tests/api_trait_conformance.rs`), and
+/// associated-function lookup does not follow deref, so dropping these would
+/// silently retract that form. Appendix B.9 states `DynamicScopeRef` carries
+/// "everything on `ScopeRef`" -- keep both mechanisms.
+impl DynamicScopeRef {
+    /// Returns this scope's child id within its parent.
+    #[must_use]
+    pub fn id(&self) -> &ChildId {
+        self.0.id()
+    }
+
+    /// Returns the scope membership identity.
+    #[must_use]
+    pub fn membership(&self) -> Membership {
+        self.0.membership()
+    }
+
+    /// Computes an authoritative recursive snapshot on demand.
+    #[must_use]
+    pub fn snapshot(&self) -> Arc<ScopeSnapshot> {
+        self.0.snapshot()
+    }
+
+    /// Subscribes to conflated recursive snapshots.
+    #[must_use]
+    pub fn subscribe_snapshots(&self) -> SnapshotReceiver {
+        self.0.subscribe_snapshots()
+    }
+
+    /// Subscribes to this scope's lifecycle and all forwarded descendants.
+    #[must_use]
+    pub fn subscribe_lifecycle(&self) -> LifecycleEvents {
+        self.0.subscribe_lifecycle()
+    }
+
+    /// Looks up a direct child in an authoritative current snapshot.
+    #[must_use]
+    pub fn child(&self, id: impl AsRef<str>) -> Option<ChildSnapshot> {
+        self.0.child(id)
+    }
+
+    /// Traverses a child-id path in an authoritative current snapshot.
+    #[must_use]
+    pub fn descendant<I, S>(&self, path: I) -> Option<ChildSnapshot>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.0.descendant(path)
+    }
+
+    /// Requests shutdown without waiting.
+    pub fn request_shutdown(&self) {
+        self.0.request_shutdown();
+    }
+
+    /// Waits for a named child snapshot satisfying an at-or-past predicate.
+    ///
+    /// Snapshot watches conflate intermediate states, so `pred` should accept
+    /// every state at or beyond the desired edge and must remain cheap and
+    /// non-blocking.
+    pub async fn wait_for_child<P>(
+        &self,
+        id: impl Into<ChildId>,
+        pred: P,
+        timeout: Duration,
+    ) -> Result<ChildSnapshot, WaitError>
+    where
+        P: FnMut(&ChildSnapshot) -> bool + Send,
+    {
+        self.0.wait_for_child(id, pred, timeout).await
+    }
+
+    /// Waits for terminal membership state.
+    pub async fn wait_stopped(&self) -> StopReason {
+        self.0.wait_stopped().await
+    }
+}
+
+/// Backstop for methods declared outside the forwarding block above: any
+/// future `ScopeRef` method remains reachable on `DynamicScopeRef` through
+/// deref, even before an inherent forward is added.
 impl Deref for DynamicScopeRef {
     type Target = ScopeRef;
 

--- a/crates/shelterwood/src/scope.rs
+++ b/crates/shelterwood/src/scope.rs
@@ -22,160 +22,73 @@ pub struct ScopeRef {
     pub(crate) cell: Arc<ScopeCell>,
 }
 
-/// Declares the shared synchronous observation/control surface once for both
-/// handle types: `ScopeRef` gets the inherent method bodies and
-/// `DynamicScopeRef` gets an identical inherent forward, so a method added
-/// here can never silently miss the dynamic handle (UFCS and rustdoc
-/// included). The `Deref` impl below additionally backstops methods added
-/// outside this macro.
-macro_rules! impl_scope_ref_sync_surface {
-    (
-        $(
-            $(#[$attribute:meta])*
-            fn $method:ident $(<$($generic:ident),+>)? (
-                &$receiver:ident $(, $argument:ident: $argument_type:ty)* $(,)?
-            ) $(-> $output:ty)?
-            $(where [$($constraint:tt)*])?
-            $body:block
-        )*
-    ) => {
-        impl ScopeRef {
-            $(
-                $(#[$attribute])*
-                pub fn $method $(<$($generic),+>)? (
-                    &$receiver,
-                    $($argument: $argument_type),*
-                ) $(-> $output)?
-                $(where $($constraint)*)?
-                $body
-            )*
-        }
-
-        impl DynamicScopeRef {
-            $(
-                $(#[$attribute])*
-                pub fn $method $(<$($generic),+>)? (
-                    &$receiver,
-                    $($argument: $argument_type),*
-                ) $(-> $output)?
-                $(where $($constraint)*)?
-                {
-                    $receiver.0.$method($($argument),*)
-                }
-            )*
-        }
-    };
-}
-
-/// The asynchronous half of the shared surface; see
-/// [`impl_scope_ref_sync_surface`]. `shutdown_and_wait` is deliberately not
-/// declared here: it calls into the driver, which the scope layer must not
-/// reference, so both handles hand-forward it from `tree.rs` instead.
-macro_rules! impl_scope_ref_async_surface {
-    (
-        $(
-            $(#[$attribute:meta])*
-            fn $method:ident $(<$($generic:ident),+>)? (
-                &$receiver:ident $(, $argument:ident: $argument_type:ty)* $(,)?
-            ) $(-> $output:ty)?
-            $(where [$($constraint:tt)*])?
-            $body:block
-        )*
-    ) => {
-        impl ScopeRef {
-            $(
-                $(#[$attribute])*
-                pub async fn $method $(<$($generic),+>)? (
-                    &$receiver,
-                    $($argument: $argument_type),*
-                ) $(-> $output)?
-                $(where $($constraint)*)?
-                $body
-            )*
-        }
-
-        impl DynamicScopeRef {
-            $(
-                $(#[$attribute])*
-                pub async fn $method $(<$($generic),+>)? (
-                    &$receiver,
-                    $($argument: $argument_type),*
-                ) $(-> $output)?
-                $(where $($constraint)*)?
-                {
-                    $receiver.0.$method($($argument),*).await
-                }
-            )*
-        }
-    };
-}
-
-impl_scope_ref_sync_surface! {
+impl ScopeRef {
     /// Returns this scope's child id within its parent.
     #[must_use]
-    fn id(&self) -> &ChildId {
+    pub fn id(&self) -> &ChildId {
         self.cell.member.id()
     }
 
     /// Returns the scope membership identity.
     #[must_use]
-    fn membership(&self) -> Membership {
+    pub fn membership(&self) -> Membership {
         self.cell.member.membership()
     }
 
     /// Computes an authoritative recursive snapshot on demand.
     #[must_use]
-    fn snapshot(&self) -> Arc<ScopeSnapshot> {
+    pub fn snapshot(&self) -> Arc<ScopeSnapshot> {
         self.cell.snapshot()
     }
 
     /// Subscribes to conflated recursive snapshots.
     #[must_use]
-    fn subscribe_snapshots(&self) -> SnapshotReceiver {
+    pub fn subscribe_snapshots(&self) -> SnapshotReceiver {
         self.cell.subscribe_snapshots()
     }
 
     /// Subscribes to this scope's lifecycle and all forwarded descendants.
     #[must_use]
-    fn subscribe_lifecycle(&self) -> LifecycleEvents {
+    pub fn subscribe_lifecycle(&self) -> LifecycleEvents {
         self.cell.subscribe_lifecycle()
     }
 
     /// Looks up a direct child in an authoritative current snapshot.
     #[must_use]
-    fn child(&self, id: impl AsRef<str>) -> Option<ChildSnapshot> {
+    pub fn child(&self, id: impl AsRef<str>) -> Option<ChildSnapshot> {
         self.snapshot().child(id).cloned()
     }
 
     /// Traverses a child-id path in an authoritative current snapshot.
     #[must_use]
-    fn descendant<I, S>(&self, path: I) -> Option<ChildSnapshot>
-    where [
+    pub fn descendant<I, S>(&self, path: I) -> Option<ChildSnapshot>
+    where
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
-    ] {
+    {
         self.snapshot().descendant(path).cloned()
     }
 
     /// Requests shutdown without waiting.
-    fn request_shutdown(&self) {
+    pub fn request_shutdown(&self) {
         let _ = self.cell.request_shutdown();
     }
 }
 
-impl_scope_ref_async_surface! {
+impl ScopeRef {
     /// Waits for a named child snapshot satisfying an at-or-past predicate.
     ///
     /// Snapshot watches conflate intermediate states, so `pred` should accept
     /// every state at or beyond the desired edge and must remain cheap and
     /// non-blocking.
-    fn wait_for_child<P>(
+    pub async fn wait_for_child<P>(
         &self,
         id: impl Into<ChildId>,
         pred: P,
         timeout: Duration,
     ) -> Result<ChildSnapshot, WaitError>
-    where [P: FnMut(&ChildSnapshot) -> bool + Send]
+    where
+        P: FnMut(&ChildSnapshot) -> bool + Send,
     {
         let id = id.into();
         let mut pred = pred;
@@ -217,7 +130,7 @@ impl_scope_ref_async_surface! {
     }
 
     /// Waits for terminal membership state.
-    fn wait_stopped(&self) -> StopReason {
+    pub async fn wait_stopped(&self) -> StopReason {
         self.cell.wait_stopped().await
     }
 }
@@ -268,9 +181,8 @@ impl DynamicScopeRef {
     }
 }
 
-/// Backstop for methods declared outside the shared-surface macros: any
-/// future `ScopeRef` method remains reachable on `DynamicScopeRef` through
-/// deref, even before the shared declaration is updated.
+/// The ordered-scope surface remains available without duplicating inherent
+/// forwarding methods on the capability-preserving dynamic handle.
 impl Deref for DynamicScopeRef {
     type Target = ScopeRef;
 

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -258,12 +258,12 @@ impl Hash for TaskRef {
 
 /// The sole claim to a one-shot task's typed completion value.
 #[must_use]
-pub struct OneShotTaskRef<T> {
+pub struct OneShotTaskRef<T: Send + 'static> {
     completion: runtime::DisposingReceiver<T>,
     task: TaskRef,
 }
 
-impl<T> fmt::Debug for OneShotTaskRef<T> {
+impl<T: Send + 'static> fmt::Debug for OneShotTaskRef<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("OneShotTaskRef")
@@ -303,7 +303,7 @@ impl<T: Send + 'static> OneShotTaskRef<T> {
         // with a closed, empty channel is therefore a framework invariant
         // violation, not an application exit that can be reported as `Err`.
         Ok(
-            std::future::poll_fn(|context| self.completion.inner.poll_receive(context))
+            std::future::poll_fn(|context| self.completion.poll_receive(context))
                 .await
                 .expect("completed one-shot task must publish its typed value"),
         )

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -448,7 +448,10 @@ mod tests {
         let mut context = Context::from_waker(Waker::noop());
 
         assert!(matches!(waiting.as_mut().poll(&mut context), Poll::Pending));
-        member.terminalize(Exit::new(ExitKind::Completed, Cancellation::NotObserved));
+        member.terminalize(
+            Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+            crate::cells::StartupDisposition::Unchanged,
+        );
         assert_eq!(waiting.await, Ok(42));
     }
 
@@ -466,7 +469,7 @@ mod tests {
         );
 
         assert!(matches!(waiting.as_mut().poll(&mut context), Poll::Pending));
-        member.terminalize(exit.clone());
+        member.terminalize(exit.clone(), crate::cells::StartupDisposition::Unchanged);
         assert_eq!(waiting.await, Err(exit));
     }
 
@@ -475,7 +478,10 @@ mod tests {
     async fn completed_terminal_publication_requires_a_typed_value() {
         let (sender, claim, member) = one_shot_claim::<u8>();
         drop(sender);
-        member.terminalize(Exit::new(ExitKind::Completed, Cancellation::NotObserved));
+        member.terminalize(
+            Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+            crate::cells::StartupDisposition::Unchanged,
+        );
 
         let _ = claim.wait().await;
     }

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -258,12 +258,12 @@ impl Hash for TaskRef {
 
 /// The sole claim to a one-shot task's typed completion value.
 #[must_use]
-pub struct OneShotTaskRef<T: Send + 'static> {
+pub struct OneShotTaskRef<T> {
     completion: runtime::DisposingReceiver<T>,
     task: TaskRef,
 }
 
-impl<T: Send + 'static> fmt::Debug for OneShotTaskRef<T> {
+impl<T> fmt::Debug for OneShotTaskRef<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("OneShotTaskRef")

--- a/crates/shelterwood/src/tree/admission.rs
+++ b/crates/shelterwood/src/tree/admission.rs
@@ -66,6 +66,25 @@ impl<H> PendingAdmission<H> {
             &self.reservation.slot,
         );
     }
+
+    fn annul(&self) {
+        let signal_panic = self.fused_cancel.as_ref().and_then(|cancel| {
+            crate::runtime::catch_panic(|| {
+                crate::driver::signal_fused_cancel(
+                    &self.reservation.scope,
+                    self.reservation.control.as_ref(),
+                    &self.reservation.slot,
+                    cancel,
+                );
+            })
+            .err()
+        });
+        let cleanup_panic = crate::runtime::catch_panic(|| self.cancel_reservation()).err();
+        crate::runtime::resume_preferred_panic(crate::runtime::UnwindPanics {
+            primary: signal_panic,
+            cleanup: cleanup_panic,
+        });
+    }
 }
 
 enum AdmissionState<H> {
@@ -174,41 +193,11 @@ impl<H> Drop for Admission<H> {
                 // polled or not. Firing the latch before cancelling keeps the
                 // scope's control-plane wake and the cancellation evidence in
                 // the same order the in-flight path uses.
-                let signal_panic = pending.fused_cancel.as_ref().and_then(|cancel| {
-                    crate::runtime::catch_panic(|| {
-                        crate::driver::signal_fused_cancel(
-                            &pending.reservation.scope,
-                            pending.reservation.control.as_ref(),
-                            &pending.reservation.slot,
-                            cancel,
-                        );
-                    })
-                    .err()
-                });
-                let cleanup_panic =
-                    crate::runtime::catch_panic(|| pending.cancel_reservation()).err();
-                crate::runtime::resume_preferred_panic(crate::runtime::UnwindPanics {
-                    primary: signal_panic,
-                    cleanup: cleanup_panic,
-                });
+                pending.annul();
             }
             AdmissionState::InFlight { pending, .. } => {
-                if let Some(cancel) = &pending.fused_cancel {
-                    let signal_panic = crate::runtime::catch_panic(|| {
-                        crate::driver::signal_fused_cancel(
-                            &pending.reservation.scope,
-                            pending.reservation.control.as_ref(),
-                            &pending.reservation.slot,
-                            cancel,
-                        );
-                    })
-                    .err();
-                    let cleanup_panic =
-                        crate::runtime::catch_panic(|| pending.cancel_reservation()).err();
-                    crate::runtime::resume_preferred_panic(crate::runtime::UnwindPanics {
-                        primary: signal_panic,
-                        cleanup: cleanup_panic,
-                    });
+                if pending.fused_cancel.is_some() {
+                    pending.annul();
                 }
             }
             AdmissionState::Immediate(_) | AdmissionState::Done => {}
@@ -231,10 +220,6 @@ impl fmt::Debug for Removal {
     }
 }
 
-fn lost_removal_response_outcome() -> RemoveOutcome {
-    RemoveOutcome::Removed
-}
-
 impl Removal {
     pub(super) fn new(response: crate::driver::RemovalResponse) -> Self {
         Self {
@@ -246,7 +231,7 @@ impl Removal {
                     // preserve the removal goal, but flag the invariant break
                     // in debug builds just as admission does above.
                     debug_assert!(false, "removal response obligation must complete");
-                    lost_removal_response_outcome()
+                    RemoveOutcome::Removed
                 })
             }),
         }
@@ -305,14 +290,6 @@ mod tests {
             panic!("hostile observation waker");
         }
     }
-    #[test]
-    fn lost_removal_response_policy_fails_closed() {
-        assert_eq!(
-            super::lost_removal_response_outcome(),
-            crate::RemoveOutcome::Removed
-        );
-    }
-
     #[test]
     fn closed_removal_response_fails_closed_after_debug_diagnostic() {
         let (sender, response) = crate::runtime::oneshot();

--- a/crates/shelterwood/src/tree/admission.rs
+++ b/crates/shelterwood/src/tree/admission.rs
@@ -220,6 +220,13 @@ impl fmt::Debug for Removal {
     }
 }
 
+/// Fail-closed outcome when the removal response obligation never completes.
+///
+/// Named so the policy is assertable in every profile: the release fallback is
+/// only reachable once `debug_assert!` is compiled out, so a test that observes
+/// the returned value runs in exactly the builds CI does not exercise.
+const LOST_REMOVAL_RESPONSE_OUTCOME: RemoveOutcome = RemoveOutcome::Removed;
+
 impl Removal {
     pub(super) fn new(response: crate::driver::RemovalResponse) -> Self {
         Self {
@@ -231,7 +238,7 @@ impl Removal {
                     // preserve the removal goal, but flag the invariant break
                     // in debug builds just as admission does above.
                     debug_assert!(false, "removal response obligation must complete");
-                    RemoveOutcome::Removed
+                    LOST_REMOVAL_RESPONSE_OUTCOME
                 })
             }),
         }
@@ -291,6 +298,18 @@ mod tests {
         }
     }
     #[test]
+    fn lost_removal_response_policy_fails_closed() {
+        // Profile-independent: the release fallback below is unreachable in
+        // the debug builds CI runs, so the policy itself is pinned here rather
+        // than only through the value a release build happens to observe.
+        assert_eq!(
+            super::LOST_REMOVAL_RESPONSE_OUTCOME,
+            crate::RemoveOutcome::Removed,
+            "a lost removal response must preserve the removal goal"
+        );
+    }
+
+    #[test]
     fn closed_removal_response_fails_closed_after_debug_diagnostic() {
         let (sender, response) = crate::runtime::oneshot();
         drop(sender);
@@ -308,7 +327,7 @@ mod tests {
         #[cfg(not(debug_assertions))]
         assert_eq!(
             observed.expect("release fallback does not panic"),
-            std::task::Poll::Ready(crate::RemoveOutcome::Removed)
+            std::task::Poll::Ready(super::LOST_REMOVAL_RESPONSE_OUTCOME)
         );
     }
 

--- a/crates/shelterwood/src/tree/dynamic_api.rs
+++ b/crates/shelterwood/src/tree/dynamic_api.rs
@@ -27,6 +27,20 @@ impl ScopeRef {
 }
 
 impl DynamicScopeRef {
+    fn define_or_reject<D, S, H>(
+        definition: D,
+        slot: Result<S, ReserveError>,
+        define: impl FnOnce(S, D) -> Admission<H>,
+    ) -> Admission<H>
+    where
+        D: Send + 'static,
+    {
+        match slot {
+            Ok(slot) => define(slot, definition),
+            Err(error) => Admission::error(dispose_rejected(definition, error)),
+        }
+    }
+
     fn reserve_actor_with<M: Send + 'static>(
         &self,
         id: impl Into<ChildId>,
@@ -85,10 +99,11 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: ActorDef<A>,
     ) -> Admission<ActorRef<A::Msg>> {
-        match self.reserve_actor_with(id, AdmissionOwnership::Fused) {
-            Ok(slot) => slot.core.define_raw(definition.into_raw()),
-            Err(error) => Admission::error(dispose_rejected(definition, error)),
-        }
+        Self::define_or_reject(
+            definition,
+            self.reserve_actor_with(id, AdmissionOwnership::Fused),
+            |slot, definition| slot.core.define_raw(definition.into_raw()),
+        )
     }
 
     /// Adds a consuming one-shot callback-oriented actor, resolving at admission.
@@ -97,10 +112,11 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: ActorOnceDef<A>,
     ) -> Admission<ActorRef<A::Msg>> {
-        match self.reserve_actor_with(id, AdmissionOwnership::Fused) {
-            Ok(slot) => slot.core.define_once_raw(definition.into_raw()),
-            Err(error) => Admission::error(dispose_rejected(definition, error)),
-        }
+        Self::define_or_reject(
+            definition,
+            self.reserve_actor_with(id, AdmissionOwnership::Fused),
+            |slot, definition| slot.core.define_once_raw(definition.into_raw()),
+        )
     }
 
     /// Adds a restartable raw actor, resolving at admission.
@@ -109,10 +125,11 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: RawDef<R>,
     ) -> Admission<ActorRef<R::Msg>> {
-        match self.reserve_actor_with(id, AdmissionOwnership::Fused) {
-            Ok(slot) => slot.core.define_raw(definition),
-            Err(error) => Admission::error(dispose_rejected(definition, error)),
-        }
+        Self::define_or_reject(
+            definition,
+            self.reserve_actor_with(id, AdmissionOwnership::Fused),
+            |slot, definition| slot.core.define_raw(definition),
+        )
     }
 
     /// Adds a consuming one-shot raw actor, resolving at admission.
@@ -121,10 +138,11 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: RawOnceDef<R>,
     ) -> Admission<ActorRef<R::Msg>> {
-        match self.reserve_actor_with(id, AdmissionOwnership::Fused) {
-            Ok(slot) => slot.core.define_once_raw(definition),
-            Err(error) => Admission::error(dispose_rejected(definition, error)),
-        }
+        Self::define_or_reject(
+            definition,
+            self.reserve_actor_with(id, AdmissionOwnership::Fused),
+            |slot, definition| slot.core.define_once_raw(definition),
+        )
     }
 
     /// Reserves a task id synchronously and exposes its exact handle.
@@ -136,10 +154,11 @@ impl DynamicScopeRef {
 
     /// Adds a restartable task, resolving at admission rather than startup.
     pub fn add_task(&self, id: impl Into<ChildId>, definition: TaskDef) -> Admission<TaskRef> {
-        match self.reserve_task_with(id, AdmissionOwnership::Fused) {
-            Ok(slot) => slot.core.define(definition),
-            Err(error) => Admission::error(dispose_rejected(definition, error)),
-        }
+        Self::define_or_reject(
+            definition,
+            self.reserve_task_with(id, AdmissionOwnership::Fused),
+            |slot, definition| slot.core.define(definition),
+        )
     }
 
     /// Adds a consuming one-shot task, resolving at admission.
@@ -148,10 +167,11 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: TaskOnceDef<T>,
     ) -> Admission<(TaskRef, OneShotTaskRef<T>)> {
-        match self.reserve_task_with(id, AdmissionOwnership::Fused) {
-            Ok(slot) => slot.core.define_once(definition),
-            Err(error) => Admission::error(dispose_rejected(definition, error)),
-        }
+        Self::define_or_reject(
+            definition,
+            self.reserve_task_with(id, AdmissionOwnership::Fused),
+            |slot, definition| slot.core.define_once(definition),
+        )
     }
 
     /// Reserves a typed subtree id synchronously.
@@ -170,10 +190,11 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: SubtreeDef<T>,
     ) -> Admission<T::Ref> {
-        match self.reserve_subtree_with::<T>(id, AdmissionOwnership::Fused) {
-            Ok(slot) => slot.core.define(definition),
-            Err(error) => Admission::error(dispose_rejected(definition, error)),
-        }
+        Self::define_or_reject(
+            definition,
+            self.reserve_subtree_with::<T>(id, AdmissionOwnership::Fused),
+            |slot, definition| slot.core.define(definition),
+        )
     }
 
     /// Adds a consuming one-shot subtree, resolving at admission.
@@ -182,10 +203,11 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: SubtreeOnceDef<T>,
     ) -> Admission<T::Ref> {
-        match self.reserve_subtree_with::<T>(id, AdmissionOwnership::Fused) {
-            Ok(slot) => slot.core.define_once(definition),
-            Err(error) => Admission::error(dispose_rejected(definition, error)),
-        }
+        Self::define_or_reject(
+            definition,
+            self.reserve_subtree_with::<T>(id, AdmissionOwnership::Fused),
+            |slot, definition| slot.core.define_once(definition),
+        )
     }
 
     /// Latches id-based removal synchronously; the returned future only

--- a/crates/shelterwood/src/tree/system.rs
+++ b/crates/shelterwood/src/tree/system.rs
@@ -182,7 +182,9 @@ impl<R: Clone> System<R> {
     pub fn scope(&self) -> R {
         self.root.clone()
     }
+}
 
+impl<R> System<R> {
     /// Waits until the declared tree is ready or startup terminally fails.
     pub async fn wait_started(&self) -> Result<(), StartupError> {
         self.run.root.wait_started().await

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -46,7 +46,9 @@ fn documented_identity_handle_token_and_owned_value_bounds_compile() {
     // Dynamic scope handles inherit every observation/control method through
     // this relationship, so adding a ScopeRef method cannot omit it here.
     assert_deref::<DynamicScopeRef, ScopeRef>();
-    // Ordinary method syntax continues to resolve the inherited surface.
+    // Existing inherent methods remain addressable through UFCS as well as
+    // ordinary method syntax.
+    let _ = DynamicScopeRef::id;
     let _assert_dynamic_scope_method = |scope: &DynamicScopeRef| {
         let _ = scope.id();
     };

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -46,9 +46,10 @@ fn documented_identity_handle_token_and_owned_value_bounds_compile() {
     // Dynamic scope handles inherit every observation/control method through
     // this relationship, so adding a ScopeRef method cannot omit it here.
     assert_deref::<DynamicScopeRef, ScopeRef>();
-    // Existing inherent methods remain addressable through UFCS as well as
-    // ordinary method syntax.
-    let _ = DynamicScopeRef::id;
+    // Ordinary method syntax continues to resolve the inherited surface.
+    let _assert_dynamic_scope_method = |scope: &DynamicScopeRef| {
+        let _ = scope.id();
+    };
     assert_send_sync::<SnapshotReceiver>();
     assert_send_sync::<LifecycleEvents>();
     assert_send_sync::<CancellationToken>();

--- a/crates/shelterwood/tests/common/policy.rs
+++ b/crates/shelterwood/tests/common/policy.rs
@@ -1,5 +1,5 @@
 use shelterwood::{Backoff, RestartCondition, RestartPolicy};
 
-pub fn never() -> RestartPolicy {
+pub(crate) fn never() -> RestartPolicy {
     RestartPolicy::new(RestartCondition::Never, Backoff::Immediate)
 }

--- a/crates/shelterwood/tests/common/waiting.rs
+++ b/crates/shelterwood/tests/common/waiting.rs
@@ -1,13 +1,34 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
 use shelterwood::{TaskDef, Tree};
 
-pub fn task() -> TaskDef {
+pub(crate) fn task() -> TaskDef {
     TaskDef::new(|context| async move {
         context.shutdown_token().cancelled().await;
         Ok(())
     })
 }
 
-pub fn tree() -> Tree {
+pub(crate) fn signalled_waiting_task(
+    started: Arc<AtomicBool>,
+    cancelled: Arc<AtomicBool>,
+) -> TaskDef {
+    TaskDef::new(move |context| {
+        let started = Arc::clone(&started);
+        let cancelled = Arc::clone(&cancelled);
+        async move {
+            started.store(true, Ordering::SeqCst);
+            context.shutdown_token().cancelled().await;
+            cancelled.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    })
+}
+
+pub(crate) fn tree() -> Tree {
     let mut tree = Tree::new();
     tree.add_task("worker", task()).expect("valid task");
     tree

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -10,7 +10,7 @@ use crate::common::{
     POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet,
     policy::never,
     poll_once, poll_until,
-    waiting::{task as waiting_task, tree as waiting_tree},
+    waiting::{signalled_waiting_task, task as waiting_task, tree as waiting_tree},
 };
 use shelterwood::{
     Actor, ActorOnceDef, Backoff, ChildState, Context as ActorContext, DynamicScopeRef,
@@ -687,20 +687,10 @@ async fn select_and_timeout_preserve_fused_and_split_admission_ownership() {
         .reserve_task("split-timeout")
         .expect("split reservation");
     let task = slot.task_ref();
-    let mut split = Box::pin(slot.define(TaskDef::new({
-        let split_started = Arc::clone(&split_started);
-        let split_cancelled = Arc::clone(&split_cancelled);
-        move |context| {
-            let split_started = Arc::clone(&split_started);
-            let split_cancelled = Arc::clone(&split_cancelled);
-            async move {
-                split_started.store(true, Ordering::SeqCst);
-                context.shutdown_token().cancelled().await;
-                split_cancelled.store(true, Ordering::SeqCst);
-                Ok(())
-            }
-        }
-    })));
+    let mut split = Box::pin(slot.define(signalled_waiting_task(
+        Arc::clone(&split_started),
+        Arc::clone(&split_cancelled),
+    )));
     assert!(poll_once(split.as_mut()).is_pending());
     let timed_admission = async move {
         let _split = split;
@@ -752,20 +742,7 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
     let fused_cancelled = Arc::new(AtomicBool::new(false));
     let mut fused = Box::pin(scope.add_task(
         "fused-after-admission",
-        TaskDef::new({
-            let fused_started = Arc::clone(&fused_started);
-            let fused_cancelled = Arc::clone(&fused_cancelled);
-            move |context| {
-                let fused_started = Arc::clone(&fused_started);
-                let fused_cancelled = Arc::clone(&fused_cancelled);
-                async move {
-                    fused_started.store(true, Ordering::SeqCst);
-                    context.shutdown_token().cancelled().await;
-                    fused_cancelled.store(true, Ordering::SeqCst);
-                    Ok(())
-                }
-            }
-        }),
+        signalled_waiting_task(Arc::clone(&fused_started), Arc::clone(&fused_cancelled)),
     ));
     assert!(poll_once(fused.as_mut()).is_pending());
     assert!(
@@ -792,20 +769,10 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
     let split_cancelled = Arc::new(AtomicBool::new(false));
     let slot = scope.reserve_task("split").expect("split reservation");
     let split_task = slot.task_ref();
-    let mut split = Box::pin(slot.define(TaskDef::new({
-        let split_started = Arc::clone(&split_started);
-        let split_cancelled = Arc::clone(&split_cancelled);
-        move |context| {
-            let split_started = Arc::clone(&split_started);
-            let split_cancelled = Arc::clone(&split_cancelled);
-            async move {
-                split_started.store(true, Ordering::SeqCst);
-                context.shutdown_token().cancelled().await;
-                split_cancelled.store(true, Ordering::SeqCst);
-                Ok(())
-            }
-        }
-    })));
+    let mut split = Box::pin(slot.define(signalled_waiting_task(
+        Arc::clone(&split_started),
+        Arc::clone(&split_cancelled),
+    )));
     assert!(poll_once(split.as_mut()).is_pending());
     drop(split);
     assert!(
@@ -826,20 +793,10 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
         .reserve_task("split-after-admission")
         .expect("split reservation");
     let split_after_task = slot.task_ref();
-    let mut split_after = Box::pin(slot.define(TaskDef::new({
-        let split_after_started = Arc::clone(&split_after_started);
-        let split_after_cancelled = Arc::clone(&split_after_cancelled);
-        move |context| {
-            let split_after_started = Arc::clone(&split_after_started);
-            let split_after_cancelled = Arc::clone(&split_after_cancelled);
-            async move {
-                split_after_started.store(true, Ordering::SeqCst);
-                context.shutdown_token().cancelled().await;
-                split_after_cancelled.store(true, Ordering::SeqCst);
-                Ok(())
-            }
-        }
-    })));
+    let mut split_after = Box::pin(slot.define(signalled_waiting_task(
+        Arc::clone(&split_after_started),
+        Arc::clone(&split_after_cancelled),
+    )));
     assert!(poll_once(split_after.as_mut()).is_pending());
     assert!(
         poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -802,14 +802,18 @@ async fn wait_for_child_handles_later_ids_terminal_children_timeouts_and_scope_t
         .shutdown(Duration::from_secs(1))
         .await
         .expect("root shuts down");
-    assert!(matches!(
-        scope
-            .wait_for_child("missing", |_| false, Duration::ZERO)
-            .await,
-        Err(WaitError::ScopeTerminated {
-            state: ScopeState::Stopped { .. }
-        })
-    ));
+    let after_shutdown = scope
+        .wait_for_child("missing", |_| false, Duration::ZERO)
+        .await;
+    assert!(
+        matches!(
+            after_shutdown,
+            Err(WaitError::ScopeTerminated {
+                state: ScopeState::Stopped { .. }
+            })
+        ),
+        "terminal scope wait returned {after_shutdown:?}"
+    );
 
     let mut declaration = Tree::new();
     let never_spawned = declaration

--- a/flake.nix
+++ b/flake.nix
@@ -33,15 +33,6 @@
           ...
         }:
         {
-          cargo-clippy = craneLibNightly.cargoClippy (
-            commonArgs
-            // {
-              cargoArtifacts = cargoArtifactsNightly;
-              cargoExtraArgs = "--locked";
-              cargoClippyExtraArgs = "--workspace --all-targets --all-features -- -D warnings -W unreachable-pub";
-              doInstallCargoArtifacts = false;
-            }
-          );
           api-enforcement = craneLibNightly.mkCargoDerivation (
             commonArgs
             // {

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,15 @@
           ...
         }:
         {
+          cargo-clippy = craneLibNightly.cargoClippy (
+            commonArgs
+            // {
+              cargoArtifacts = cargoArtifactsNightly;
+              cargoExtraArgs = "--locked";
+              cargoClippyExtraArgs = "--workspace --all-targets --all-features -- -D warnings -W unreachable-pub";
+              doInstallCargoArtifacts = false;
+            }
+          );
           api-enforcement = craneLibNightly.mkCargoDerivation (
             commonArgs
             // {

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ fmt:
     cargo +nightly fmt --all --check
 
 lint:
-    cargo +nightly clippy --locked --workspace --all-targets --all-features -- -D warnings -W unreachable-pub
+    cargo +nightly clippy --locked --workspace --all-targets --all-features -- -D warnings
 
 check:
     cargo check --locked --workspace --all-targets --all-features

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ fmt:
     cargo +nightly fmt --all --check
 
 lint:
-    cargo +nightly clippy --locked --workspace --all-targets --all-features -- -D warnings
+    cargo +nightly clippy --locked --workspace --all-targets --all-features -- -D warnings -W unreachable-pub
 
 check:
     cargo check --locked --workspace --all-targets --all-features

--- a/tools/api-reachability/Cargo.toml
+++ b/tools/api-reachability/Cargo.toml
@@ -6,5 +6,8 @@ rust-version = "1.97.1"
 license = "MIT OR Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 serde_json.workspace = true


### PR DESCRIPTION
## Summary

- **#30 — observation hubs and gate storage:** routes snapshot/lifecycle hub mutation through the caller's observation transaction, removes test-only twin state, keeps one observation gate on `MemberCell`, and preserves terminal snapshots even when closure happens without live receivers.
- **#31 — tree remainders:** shares dynamic add/reject plumbing across child kinds, centralizes pending-admission annulment, removes the removal-response fallback wrapper, and narrows `System<R>`'s `Clone` bound to the method that needs it.
- **#32 — mailbox remainders:** shares reply/call receive-close arbitration, names deadline phases by behavior, extracts waiter ownership without placeholder terminal state, and carries explicit mailbox rejection reasons.
- **#33 — cell remainders:** unifies member terminalization and child admission helpers, groups scope observation state, removes redundant post-close subscribe actions, and makes receiverless close retain the authoritative terminal snapshot.
- **#34 — scope forwarding:** replaces forwarding macros with ordinary `ScopeRef` implementations plus `Deref` from `DynamicScopeRef`; the API conformance pin now exercises normal method resolution.
- **#35 — targeted small wins:** deduplicates option-setter macro arms; removes unnecessary child-id allocation and map values; collapses identical readiness state; tightens visibility; simplifies disposal, RNG, signal watcher, and actor factory storage; enables `unreachable_pub` in both local and Nix CI; flattens pending driver events; shares root-driver join classification; coalesces removal requests at the state transition; removes the now-unobserved member-removal latch; and factors the repeated signalled waiting-task fixture.
- **RuntimeScopePlan residual:** removes the duplicate runtime plan type entirely. `ScopePlan` now owns the staged child terminality handoff through completion.

## Behavior and impact

The public supervision behavior is unchanged, and the public API surface is source-compatible with `main` -- verified by compiling a downstream crate against both refs, including the two patterns an earlier revision of this branch broke (`DynamicScopeRef::id(&scope)` as an associated-function path, and `struct Stored<T> { receiver: Option<ReplyReceiver<T>> }` with an unconstrained `T`). The one deliberate delta is a widening: narrowing `impl<R: Clone> System<R>` to `scope()` moves `wait_started` / `start_or_shutdown` / `shutdown` / `wait` into an unbounded `impl<R>`, so they are now callable for non-`Clone` `R`. That is additive and backward-compatible.

Dynamic fused/explicit removal now emits one driver request at the authoritative `Resident -> Removing` transition. Observation closure installs the authoritative terminal `Stopped` snapshot unconditionally, so later subscribers read current truth whether or not receivers were attached. `unreachable_pub` is enforced through `[workspace.lints.rust]`, which covers every crate, target, and lane -- `cargo check` included -- without forking the template's clippy check.

## Adversarial review

A fresh review audited every issue item and residual bullet, receiverless closure, lock ordering, drop/panic containment, public API reachability, local/Nix CI parity, dead compatibility remnants, and commit mapping. It found one low-severity dead-state remnant: transition-level removal coalescing had left `MemberCell`'s removal latch with writers but no readers. Commit `4df173e` removes the obsolete latch and its notification path.

A second review round then confirmed both outstanding Codex findings and three of its own; all are fixed in `a8f4599..d1613a7`:

- **`a8f4599`** (Codex P2, confirmed): removing `DisposingReceiver`'s `dispose: fn(T)` field forced `T: Send + 'static` onto the *definitions* of `ReplyReceiver`, `ReplyReceive`, `CallFuture`, and `OneShotTaskRef`, and through them onto downstream generic declarations. The field was not dead -- `Drop` must repeat the struct's bounds, so it is the erasure that keeps those wrappers unbounded. Restored, with the private-`inner` cleanup kept.
- **`fa8ba49`** (Codex P2, confirmed): `Deref` does not serve associated-function paths, so replacing the inherent forwards retracted `DynamicScopeRef::id(&scope)` and friends -- a form this repo pinned deliberately in #135. Restored as an ordinary impl block; both forwarding macros stay deleted, which was item 34's actual ask.
- **`2b5d77c`**: closure refreshed the retained snapshot only when receiverless, but `finish_incarnation_with_terminal`'s stale-epoch branch closes without publishing a `Stopped` projection first -- so with a live receiver the retained value could stay non-terminal and be what every later subscriber reads. Now installed unconditionally and silently.
- **`83e68fd`**: replaced the vendored clippy override with `[workspace.lints.rust]`; re-verified by injecting an unreachable `pub` item and confirming both `just lint` and `nix build .#checks.x86_64-linux.cargo-clippy` fail.
- **`67a1cbe`**: restored the fail-closed removal policy assertion (it had become reachable only in release builds, which CI does not run) and the duplicate-removal idempotence coverage, via a synthetic second `RemovalRequest`.
- **`d1613a7`**: panic venue, doc, and redundant-read tidy-ups.

Cleared with reasoning: removal coalescing and the latch deletion (every prior enqueue path still yields exactly one request; the latch had zero readers on `main`), observation-gate serialization and pulse parity, the deleted `cfg(test)` hub twins, the `add_*` collapse, `Admission::drop` annulment, `Pending` flattening (stable sort preserves intra-class FIFO), the shared `poll_reply` lift, the `DeadlinePhase` renames, `SignalWatcher`'s `_signal` removal, `RuntimeScopePlan` deletion, and the `ReadinessState::Immediate` collapse.

## Validation

- `./tools/dev cargo test --locked -p shelterwood --lib driver::tests::dynamic::` — 18 passed
- `./tools/dev cargo test --locked -p shelterwood --lib` — 239 passed
- `./tools/dev cargo test --locked -p shelterwood --test integration dynamic::fused_drop_withdraws_or_removes_while_split_drop_detaches`
- `./tools/dev cargo test --locked -p shelterwood --test integration observation::wait_for_child_handles_later_ids_terminal_children_timeouts_and_scope_termination -- --exact`
- `./tools/dev just ci` — 540 nextest tests plus doctests, docs, API reachability, enforcement, packaged-crate, and formatting checks passed
- `./tools/dev just ci-nix` — all authoritative clean Nix checks passed

Closes #190
