### PR TITLE
Complete dynamic startup after initial-member removal

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1218,8 +1218,11 @@ enum Readiness { Immediate, AfterInit, Manual }   // mode only — the deadline 
   lowered with — its declared initial set; runtime additions to a
   dynamic scope never join the aggregate, whether they are admitted
   before or after it fires (their per-child `Ready` events, B.4, are
-  the observation surface). The aggregate fires at most once per scope
-  incarnation and is latched: an already-ready child that fails and
+  the observation surface). Removing an initial member while the scope
+  is `Starting` shrinks that declared set, and the aggregate may complete
+  when the remaining initial members are ready. The aggregate fires at
+  most once per scope incarnation and is latched: an already-ready child
+  that fails and
   restarts afterwards does not rewind it — readiness is a
   startup-phase edge, not a liveness signal (snapshots carry liveness,
   B.6). The same latch decides the pre-fire race: a gated child that

--- a/SPEC.md
+++ b/SPEC.md
@@ -1194,7 +1194,10 @@ enum Readiness { Immediate, AfterInit, Manual }   // mode only — the deadline 
   per policy and holds the aggregate open (the latch rule below),
   exactly as an ordered gate does. A **terminal** pre-ready exit of an
   initial member before the aggregate fires is the scope's terminal
-  startup failure — and because every initial member was spawned at
+  startup failure — *unless* that exit is the commit of an
+  owner-initiated removal, in which case the member simply leaves
+  the declared set under the aggregate rule below and startup
+  continues — and because every initial member was spawned at
   lowering, there is no not-yet-started suffix: **no sibling
   terminalizes `NeverStarted`**. The transition is pinned: the scope
   leaves `Starting` the moment the exit funnel dispatches that terminal
@@ -1219,11 +1222,23 @@ enum Readiness { Immediate, AfterInit, Manual }   // mode only — the deadline 
   dynamic scope never join the aggregate, whether they are admitted
   before or after it fires (their per-child `Ready` events, B.4, are
   the observation surface). Removing an initial member while the scope
-  is `Starting` shrinks that declared set, and the aggregate may complete
-  when the remaining initial members are ready. The aggregate fires at
-  most once per scope incarnation and is latched: an already-ready child
-  that fails and
-  restarts afterwards does not rewind it — readiness is a
+  is `Starting` shrinks that declared set, and the aggregate may
+  complete when the remaining initial members are ready — including
+  the empty case, where removing every initial member completes
+  startup. The shrink is **commit-time, not request-time**: the member
+  leaves the declared set when its removal commits (residency
+  withdrawn, `Removed` published), so a slow-stopping member holds the
+  aggregate open for its whole stop ladder, and the recomputation is
+  ordered ahead of the removal response — a returned `Removed` implies
+  the aggregate has already seen the shrunken set. That commit point
+  pins the race against the member's own pre-ready failure: a terminal
+  pre-ready exit or readiness timeout whose terminal routing observes
+  the membership *not yet* marked removing fails startup under the
+  rule above, while once the mark is in place removal outranks it and
+  the aggregate simply shrinks. Both orders are legal; which one a
+  given run takes is not specified. The aggregate fires at most once
+  per scope incarnation and is latched: an already-ready child that
+  fails and restarts afterwards does not rewind it — readiness is a
   startup-phase edge, not a liveness signal (snapshots carry liveness,
   B.6). The same latch decides the pre-fire race: a gated child that
   restarts *before* the aggregate has fired holds it open until the
@@ -2537,6 +2552,16 @@ integration toolkit for the driver shell and the end-to-end invariants.
    while a gated runtime member sits unready); an already-ready child
    restarting before the aggregate fires holds it open, and one
    restarting after it fires does not rewind it.
+   Removal shrinks the declared set (§6), pinned by public-API repros
+   that hang the unfixed driver for a full virtual timeout: removing
+   the sole unready initial member completes startup; so does removing
+   the last unready one beside a ready sibling, removing every initial
+   member concurrently (the empty declared set), and removing the sole
+   unready member of a *nested* dynamic scope — which must publish the
+   aggregate up to an ordered parent and release its gated sibling.
+   The negative pins the guard: removing an *already-ready* initial
+   member while an unready one remains leaves the scope quietly
+   `Starting`.
 7. **Exactly one published exit report per incarnation, on every path
    including panic and abort; publication is post-join (§7's two-phase
    rule); one runner, one exit type.** The two hard provocations: an

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -85,6 +85,7 @@ impl ScopeRuntime {
         if let Some(entry) = entry {
             self.reclaim_child(key);
             drop(entry);
+            self.progress_startup();
         }
     }
 

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -84,8 +84,18 @@ impl ScopeRuntime {
         });
         if let Some(entry) = entry {
             self.reclaim_child(key);
-            drop(entry);
+            // Removal is an owner action, not a startup failure: the reclaim
+            // above shrank the declared initial set, so re-evaluate the
+            // aggregate (self-guarded on `is_starting`). This runs outside
+            // the observation gate closed above — `complete_startup` reopens
+            // that gate, and it is not reentrant.
+            //
+            // Ordered ahead of the entry's drop: that drop completes the
+            // in-flight removal response, so recomputing first is what makes
+            // a returned `RemoveOutcome::Removed` imply the aggregate already
+            // saw the shrunken set.
             self.progress_startup();
+            drop(entry);
         }
     }
 
@@ -113,6 +123,13 @@ impl ScopeRuntime {
         });
         if self.root.flavor == ScopeFlavor::Dynamic {
             self.reclaim_child(key);
+            // Symmetry with `finalize_removal`: a reclaim can shrink the
+            // declared initial set. Unreachable during `Starting` today —
+            // every terminal route for an unready initial member routes
+            // through `fail_startup` or the removal branch — but it closes
+            // the residual missed-recomputation class rather than relying on
+            // that reachability argument holding forever.
+            self.progress_startup();
         }
         // The entry's drop completes any in-flight removal response; it must
         // follow the Removed edge so a woken remover never sees the child

--- a/crates/shelterwood/src/driver/startup.rs
+++ b/crates/shelterwood/src/driver/startup.rs
@@ -71,14 +71,28 @@ impl ScopeRuntime {
         match self.root.flavor {
             ScopeFlavor::Ordered => {
                 while let Some(key) = self.next_ordered_start {
-                    if !self.children[key].spawned_once {
+                    // The cursor is held across `spawn_child`, and every
+                    // reclaim path (`finalize_removal`, `prune_terminal`) can
+                    // vacate a slot, so never index the arena with it: a
+                    // reclaimed slot is treated as already gone, the same
+                    // discipline `stop_next_ordered` follows for its own
+                    // cursor. `keys_after` ranges over the arena's ordered
+                    // key domain, so it still advances past a vacated key.
+                    if self
+                        .children
+                        .get(key)
+                        .is_some_and(|child| !child.spawned_once)
+                    {
                         self.spawn_child(key);
                     }
-                    if self.children[key].initial_ready {
-                        self.next_ordered_start = self.children.keys_after(key).next();
-                    } else {
+                    if self
+                        .children
+                        .get(key)
+                        .is_some_and(|child| !child.initial_ready)
+                    {
                         return;
                     }
+                    self.next_ordered_start = self.children.keys_after(key).next();
                 }
                 if self
                     .children

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -868,3 +868,82 @@ async fn same_batch_self_stop_preserves_fired_readiness_for_startup() {
         "a post-ready clean self-stop is not a startup abort"
     );
 }
+
+/// `next_ordered_start` is held across `spawn_child` and is never cleared by
+/// `reclaim_child`, so `progress_startup` must treat a vacated slot the way
+/// `stop_next_ordered` treats its own cursor: already gone, advance past it.
+/// Ordered scopes carry no dynamic control today and so never reclaim, which
+/// is exactly why this is pinned here — the arena is a monotonic key domain,
+/// so `keys_after` still ranges correctly over a removed key.
+#[crate::runtime::test]
+async fn ordered_startup_advances_past_a_reclaimed_cursor() {
+    let mut tree = Tree::new();
+    tree.add_task(
+        "gone",
+        TaskDef::new(|_| future::pending::<crate::ExitResult>())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness is valid")
+            .readiness_deadline(ReadinessDeadline::Unbounded),
+    )
+    .expect("valid task");
+    tree.add_task(
+        "next",
+        TaskDef::new(|_| future::pending::<crate::ExitResult>())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness is valid")
+            .readiness_deadline(ReadinessDeadline::Unbounded),
+    )
+    .expect("valid task");
+
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
+    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+    let mut children = ChildArena::default();
+    plan.children.reverse();
+    while let Some(child) = plan.children.pop() {
+        children
+            .insert(ChildRuntime::from_plan(child, &root))
+            .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+    }
+    let gone = children.keys().next().expect("first ordered child");
+    let next = children.keys().nth(1).expect("second ordered child");
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+        .with_defaults(plan.defaults.clone())
+        .with_children(children)
+        .with_next_ordered_start(Some(gone))
+        .build();
+    plan.finish_transfer();
+
+    // Vacate the slot the cursor points at, exactly as a reclaim would leave
+    // it, without disturbing the child that follows.
+    scope
+        .children
+        .remove(gone)
+        .expect("the cursor's child is live before the reclaim");
+
+    scope.progress_startup();
+
+    assert_eq!(
+        scope.next_ordered_start,
+        Some(next),
+        "a vacated cursor advances to the next live child instead of panicking"
+    );
+    assert!(
+        scope.children[next].active.is_some(),
+        "the following child starts at its ordered turn"
+    );
+    assert!(
+        !scope.lifecycle.startup_complete(),
+        "the live successor still gates the aggregate"
+    );
+}

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -668,20 +668,35 @@ async fn dynamic_startup_failure_keeps_other_initial_members_supervised() {
         .expect("owner rolls back sibling");
 }
 
+/// A `Manual` member that never marks ready, so it gates its scope's
+/// aggregate until it is removed.
+fn unbounded_manual_gate() -> TaskDef {
+    TaskDef::new(|context| async move {
+        context.shutdown_token().cancelled().await;
+        Ok(())
+    })
+    .readiness(Readiness::Manual)
+    .expect("manual readiness")
+    .readiness_deadline(ReadinessDeadline::Unbounded)
+}
+
+/// A `Manual` member that marks ready immediately and then parks.
+fn unbounded_manual_ready() -> TaskDef {
+    TaskDef::new(|context| async move {
+        context.mark_ready();
+        context.shutdown_token().cancelled().await;
+        Ok(())
+    })
+    .readiness(Readiness::Manual)
+    .expect("manual readiness")
+    .readiness_deadline(ReadinessDeadline::Unbounded)
+}
+
 #[tokio::test(start_paused = true)]
 async fn dynamic_startup_completes_after_removing_sole_unready_initial_member() {
     let mut tree = DynamicTree::new();
-    tree.add_task(
-        "gate",
-        TaskDef::new(|context| async move {
-            context.shutdown_token().cancelled().await;
-            Ok(())
-        })
-        .readiness(Readiness::Manual)
-        .expect("manual readiness")
-        .readiness_deadline(ReadinessDeadline::Unbounded),
-    )
-    .expect("valid initial member");
+    tree.add_task("gate", unbounded_manual_gate())
+        .expect("valid initial member");
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
     assert!(
@@ -708,29 +723,10 @@ async fn dynamic_startup_completes_after_removing_sole_unready_initial_member() 
 #[tokio::test(start_paused = true)]
 async fn dynamic_startup_completes_after_removing_last_unready_initial_member() {
     let mut tree = DynamicTree::new();
-    tree.add_task(
-        "ready",
-        TaskDef::new(|context| async move {
-            context.mark_ready();
-            context.shutdown_token().cancelled().await;
-            Ok(())
-        })
-        .readiness(Readiness::Manual)
-        .expect("manual readiness")
-        .readiness_deadline(ReadinessDeadline::Unbounded),
-    )
-    .expect("valid ready sibling");
-    tree.add_task(
-        "gate",
-        TaskDef::new(|context| async move {
-            context.shutdown_token().cancelled().await;
-            Ok(())
-        })
-        .readiness(Readiness::Manual)
-        .expect("manual readiness")
-        .readiness_deadline(ReadinessDeadline::Unbounded),
-    )
-    .expect("valid unready member");
+    tree.add_task("ready", unbounded_manual_ready())
+        .expect("valid ready sibling");
+    tree.add_task("gate", unbounded_manual_gate())
+        .expect("valid unready member");
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
     assert!(
@@ -755,6 +751,124 @@ async fn dynamic_startup_completes_after_removing_last_unready_initial_member() 
         .shutdown(Duration::from_secs(1))
         .await
         .expect("ready sibling stops");
+}
+
+/// The declared set can empty out: two removals in flight at once leave no
+/// initial member at all, and the aggregate completes on the vacuous set.
+#[tokio::test(start_paused = true)]
+async fn dynamic_startup_completes_after_removing_every_initial_member() {
+    let mut tree = DynamicTree::new();
+    tree.add_task("first", unbounded_manual_gate())
+        .expect("valid unready member");
+    tree.add_task("second", unbounded_manual_gate())
+        .expect("valid unready member");
+    let system = tree.spawn().expect("runtime is available");
+    let scope = system.scope();
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            scope.child("first").is_some() && scope.child("second").is_some()
+        })
+        .await
+    );
+
+    let (first, second) = tokio::join!(scope.remove("first"), scope.remove("second"));
+    assert_eq!(first, shelterwood::RemoveOutcome::Removed);
+    assert_eq!(second, shelterwood::RemoveOutcome::Removed);
+    tokio::time::timeout(Duration::from_secs(60), system.wait_started())
+        .await
+        .expect("an emptied declared set completes startup")
+        .expect("removal is not a startup failure");
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("empty root stops");
+}
+
+/// Completion has to publish upwards, not just locally: the nested dynamic
+/// scope's aggregate is the ordered parent's gate, so removal must release
+/// the sibling declared after it.
+#[tokio::test(start_paused = true)]
+async fn removal_completed_nested_startup_releases_the_ordered_sibling() {
+    let mut nested = DynamicTree::new();
+    nested
+        .add_task("gate", unbounded_manual_gate())
+        .expect("valid unready member");
+    let mut root = Tree::new();
+    let nested_scope = root
+        .add_subtree_once("nested", SubtreeOnceDef::new(nested))
+        .expect("valid nested dynamic scope");
+    root.add_task("after", unbounded_manual_ready())
+        .expect("valid gated sibling");
+
+    let system = root.spawn().expect("runtime is available");
+    let scope = system.scope();
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            nested_scope.child("gate").is_some()
+        })
+        .await
+    );
+    assert_quiet(Duration::from_secs(5), || {
+        scope
+            .child("after")
+            .is_some_and(|child| matches!(child.state, ChildState::Running))
+    })
+    .await;
+
+    assert_eq!(
+        nested_scope.remove("gate").await,
+        shelterwood::RemoveOutcome::Removed
+    );
+    tokio::time::timeout(Duration::from_secs(60), system.wait_started())
+        .await
+        .expect("nested completion releases the ordered gate")
+        .expect("removal is not a startup failure");
+    assert!(
+        scope
+            .child("after")
+            .is_some_and(|child| matches!(child.state, ChildState::Running)),
+        "the gated sibling starts once removal completes the nested aggregate"
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+}
+
+/// The negative that pins the recomputation's guard: removal recomputes the
+/// aggregate, it does not assert it. Dropping an already-ready member cannot
+/// complete startup while an unready one is still declared.
+#[tokio::test(start_paused = true)]
+async fn removing_a_ready_initial_member_leaves_startup_pending() {
+    let mut tree = DynamicTree::new();
+    tree.add_task("ready", unbounded_manual_ready())
+        .expect("valid ready member");
+    tree.add_task("gate", unbounded_manual_gate())
+        .expect("valid unready member");
+    let system = tree.spawn().expect("runtime is available");
+    let scope = system.scope();
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            scope
+                .child("ready")
+                .is_some_and(|child| matches!(child.state, ChildState::Running))
+                && scope.child("gate").is_some()
+        })
+        .await
+    );
+
+    assert_eq!(
+        scope.remove("ready").await,
+        shelterwood::RemoveOutcome::Removed
+    );
+    assert_quiet(Duration::from_secs(30), || {
+        !matches!(scope.snapshot().state, ScopeState::Starting)
+    })
+    .await;
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("the still-gated root stops");
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -668,6 +668,95 @@ async fn dynamic_startup_failure_keeps_other_initial_members_supervised() {
         .expect("owner rolls back sibling");
 }
 
+#[tokio::test(start_paused = true)]
+async fn dynamic_startup_completes_after_removing_sole_unready_initial_member() {
+    let mut tree = DynamicTree::new();
+    tree.add_task(
+        "gate",
+        TaskDef::new(|context| async move {
+            context.shutdown_token().cancelled().await;
+            Ok(())
+        })
+        .readiness(Readiness::Manual)
+        .expect("manual readiness")
+        .readiness_deadline(ReadinessDeadline::Unbounded),
+    )
+    .expect("valid initial member");
+    let system = tree.spawn().expect("runtime is available");
+    let scope = system.scope();
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            scope.child("gate").is_some()
+        })
+        .await
+    );
+
+    assert_eq!(
+        scope.remove("gate").await,
+        shelterwood::RemoveOutcome::Removed
+    );
+    tokio::time::timeout(Duration::from_secs(60), system.wait_started())
+        .await
+        .expect("removing the sole initial gate completes startup")
+        .expect("removal is not a startup failure");
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("empty root stops");
+}
+
+#[tokio::test(start_paused = true)]
+async fn dynamic_startup_completes_after_removing_last_unready_initial_member() {
+    let mut tree = DynamicTree::new();
+    tree.add_task(
+        "ready",
+        TaskDef::new(|context| async move {
+            context.mark_ready();
+            context.shutdown_token().cancelled().await;
+            Ok(())
+        })
+        .readiness(Readiness::Manual)
+        .expect("manual readiness")
+        .readiness_deadline(ReadinessDeadline::Unbounded),
+    )
+    .expect("valid ready sibling");
+    tree.add_task(
+        "gate",
+        TaskDef::new(|context| async move {
+            context.shutdown_token().cancelled().await;
+            Ok(())
+        })
+        .readiness(Readiness::Manual)
+        .expect("manual readiness")
+        .readiness_deadline(ReadinessDeadline::Unbounded),
+    )
+    .expect("valid unready member");
+    let system = tree.spawn().expect("runtime is available");
+    let scope = system.scope();
+    assert!(
+        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            scope
+                .child("ready")
+                .is_some_and(|child| matches!(child.state, ChildState::Running))
+                && scope.child("gate").is_some()
+        })
+        .await
+    );
+
+    assert_eq!(
+        scope.remove("gate").await,
+        shelterwood::RemoveOutcome::Removed
+    );
+    tokio::time::timeout(Duration::from_secs(60), system.wait_started())
+        .await
+        .expect("removing the final initial gate completes startup")
+        .expect("removal is not a startup failure");
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("ready sibling stops");
+}
+
 #[tokio::test]
 async fn runtime_dynamic_additions_never_join_aggregate_readiness() {
     let initial_release = ReleaseGate::default();


### PR DESCRIPTION
## Summary

- recompute aggregate startup after an initial dynamic member is fully removed and reclaimed
- add public-API regressions for removing the sole unready initial child and the last unready initial child beside a ready sibling
- specify that removal during `Starting` shrinks the declared initial set and may complete aggregate readiness

## Semantics

Removal is an owner action, not a startup failure. Once removal commits, `finalize_removal` asks the existing self-guarded startup computation to re-evaluate the remaining initial members. If all remaining members are ready (including the empty-set case), the scope completes startup normally.

This is the stage-0 point fix only; it does not restructure the driver loop epilogue.

## Validation

- Confirmed both new paused-time repros fail against the unmodified driver with elapsed 60-second virtual timeouts.
- `./tools/dev cargo test -p shelterwood --test integration dynamic_startup_completes_after_removing -- --nocapture` (2 passed)
- `./tools/dev just ci` (format, clippy, 577/577 tests, doctests, rustdoc, and remaining CI-mirror checks passed)

Refs #200