### PR TITLE
Make wait_for_child futures Send for non-Send IDs

### DIFF
--- a/crates/shelterwood/src/scope.rs
+++ b/crates/shelterwood/src/scope.rs
@@ -81,6 +81,11 @@ impl ScopeRef {
     /// Snapshot watches conflate intermediate states, so `pred` should accept
     /// every state at or beyond the desired edge and must remain cheap and
     /// non-blocking.
+    ///
+    /// `id` is converted through `Into<ChildId>` eagerly, on the calling
+    /// thread, before the future exists — so the conversion runs even when the
+    /// returned future is never polled. That is what keeps the future `Send`
+    /// for a non-`Send` `id`; the wait itself still begins at first poll.
     pub fn wait_for_child<P>(
         &self,
         id: impl Into<ChildId>,
@@ -260,6 +265,11 @@ impl DynamicScopeRef {
     /// Snapshot watches conflate intermediate states, so `pred` should accept
     /// every state at or beyond the desired edge and must remain cheap and
     /// non-blocking.
+    ///
+    /// `id` is converted through `Into<ChildId>` eagerly, on the calling
+    /// thread, before the future exists — so the conversion runs even when the
+    /// returned future is never polled. That is what keeps the future `Send`
+    /// for a non-`Send` `id`; the wait itself still begins at first poll.
     pub fn wait_for_child<P>(
         &self,
         id: impl Into<ChildId>,

--- a/crates/shelterwood/src/scope.rs
+++ b/crates/shelterwood/src/scope.rs
@@ -260,16 +260,16 @@ impl DynamicScopeRef {
     /// Snapshot watches conflate intermediate states, so `pred` should accept
     /// every state at or beyond the desired edge and must remain cheap and
     /// non-blocking.
-    pub async fn wait_for_child<P>(
+    pub fn wait_for_child<P>(
         &self,
         id: impl Into<ChildId>,
         pred: P,
         timeout: Duration,
-    ) -> Result<ChildSnapshot, WaitError>
+    ) -> impl std::future::Future<Output = Result<ChildSnapshot, WaitError>> + Send
     where
         P: FnMut(&ChildSnapshot) -> bool + Send,
     {
-        self.0.wait_for_child(id, pred, timeout).await
+        self.0.wait_for_child(id, pred, timeout)
     }
 
     /// Waits for terminal membership state.

--- a/crates/shelterwood/src/scope.rs
+++ b/crates/shelterwood/src/scope.rs
@@ -81,17 +81,28 @@ impl ScopeRef {
     /// Snapshot watches conflate intermediate states, so `pred` should accept
     /// every state at or beyond the desired edge and must remain cheap and
     /// non-blocking.
-    pub async fn wait_for_child<P>(
+    pub fn wait_for_child<P>(
         &self,
         id: impl Into<ChildId>,
         pred: P,
+        timeout: Duration,
+    ) -> impl std::future::Future<Output = Result<ChildSnapshot, WaitError>> + Send
+    where
+        P: FnMut(&ChildSnapshot) -> bool + Send,
+    {
+        let id = id.into();
+        self.wait_for_child_inner(id, pred, timeout)
+    }
+
+    async fn wait_for_child_inner<P>(
+        &self,
+        id: ChildId,
+        mut pred: P,
         timeout: Duration,
     ) -> Result<ChildSnapshot, WaitError>
     where
         P: FnMut(&ChildSnapshot) -> bool + Send,
     {
-        let id = id.into();
-        let mut pred = pred;
         let expires = crate::deadline::Deadline::after(crate::runtime::now(), timeout);
         let mut snapshots = self.subscribe_snapshots();
 

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -140,7 +140,11 @@ fn documented_identity_handle_token_and_owned_value_bounds_compile() {
     let _assert_dynamic_scope_futures = |scope: &DynamicScopeRef| {
         assert_send(scope.wait_stopped());
         assert_send(scope.shutdown_and_wait(Duration::ZERO));
-        assert_send(scope.wait_for_child("child", |_| true, Duration::ZERO));
+        assert_send(scope.wait_for_child(
+            RcId(Rc::new(()), "child".into()),
+            |_| true,
+            Duration::ZERO,
+        ));
     };
     let _assert_start_future = |system: System<ScopeRef>| {
         assert_send(system.start_or_shutdown(Duration::ZERO));

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -1,15 +1,15 @@
-use std::{cell::Cell, error::Error, hash::Hash, ops::Deref, time::Duration};
+use std::{cell::Cell, error::Error, hash::Hash, ops::Deref, rc::Rc, time::Duration};
 
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, ActorSlot, Admission, Blocking, BuildError, CallError,
-    CallFuture, Cancellation, CancellationToken, Context, DeadlineElapsed, DefaultsInheritance,
-    DynamicActorSlot, DynamicScopeRef, DynamicSubtreeSlot, DynamicTaskSlot, DynamicTree, ExitError,
-    ExitResult, GracePhase, Guard, Handler, Incarnation, Intensity, LifecycleEvents,
-    LifecycleTryRecvError, Mailbox, MailboxShutdown, Membership, MembershipStatus, OneShotTaskRef,
-    RawActor, RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline, Removal, Reply,
-    ReplyReceive, ReplyReceiver, ReserveError, RestartAttempt, RestartCount, RestartPolicy,
-    Retention, ScopeDefaults, ScopeRef, SendError, SendFuture, SendTimeout, Shutdown,
-    SnapshotClosed, SnapshotReceiver, StopContext, Strategy, SubtreeDef, SubtreeOnceDef,
+    CallFuture, Cancellation, CancellationToken, ChildId, Context, DeadlineElapsed,
+    DefaultsInheritance, DynamicActorSlot, DynamicScopeRef, DynamicSubtreeSlot, DynamicTaskSlot,
+    DynamicTree, ExitError, ExitResult, GracePhase, Guard, Handler, Incarnation, Intensity,
+    LifecycleEvents, LifecycleTryRecvError, Mailbox, MailboxShutdown, Membership, MembershipStatus,
+    OneShotTaskRef, RawActor, RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline,
+    Removal, Reply, ReplyReceive, ReplyReceiver, ReserveError, RestartAttempt, RestartCount,
+    RestartPolicy, Retention, ScopeDefaults, ScopeRef, SendError, SendFuture, SendTimeout,
+    Shutdown, SnapshotClosed, SnapshotReceiver, StopContext, Strategy, SubtreeDef, SubtreeOnceDef,
     SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, TotalRestarts, Tree, WaitError,
 };
 
@@ -59,6 +59,16 @@ assert_not_impl!(Incarnation: Ord);
 
 #[test]
 fn documented_identity_handle_token_and_owned_value_bounds_compile() {
+    struct RcId(Rc<()>, String);
+
+    impl From<RcId> for ChildId {
+        fn from(value: RcId) -> Self {
+            let RcId(not_send, id) = value;
+            drop(not_send);
+            id.into()
+        }
+    }
+
     assert_copy_eq_hash_send_sync::<Membership>();
     assert_copy_eq_hash_send_sync::<Incarnation>();
     assert_copy_eq_hash_send_sync::<Cancellation>();
@@ -121,7 +131,11 @@ fn documented_identity_handle_token_and_owned_value_bounds_compile() {
     let _assert_scope_futures = |scope: &ScopeRef| {
         assert_send(scope.wait_stopped());
         assert_send(scope.shutdown_and_wait(Duration::ZERO));
-        assert_send(scope.wait_for_child("child", |_| true, Duration::ZERO));
+        assert_send(scope.wait_for_child(
+            RcId(Rc::new(()), "child".into()),
+            |_| true,
+            Duration::ZERO,
+        ));
     };
     let _assert_dynamic_scope_futures = |scope: &DynamicScopeRef| {
         assert_send(scope.wait_stopped());

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -131,6 +131,9 @@ fn documented_identity_handle_token_and_owned_value_bounds_compile() {
     let _assert_scope_futures = |scope: &ScopeRef| {
         assert_send(scope.wait_stopped());
         assert_send(scope.shutdown_and_wait(Duration::ZERO));
+        // The ordinary `&str` id, then a deliberately non-`Send` one: the
+        // conversion happens before the future exists, so both are `Send`.
+        assert_send(scope.wait_for_child("child", |_| true, Duration::ZERO));
         assert_send(scope.wait_for_child(
             RcId(Rc::new(()), "child".into()),
             |_| true,
@@ -140,6 +143,7 @@ fn documented_identity_handle_token_and_owned_value_bounds_compile() {
     let _assert_dynamic_scope_futures = |scope: &DynamicScopeRef| {
         assert_send(scope.wait_stopped());
         assert_send(scope.shutdown_and_wait(Duration::ZERO));
+        assert_send(scope.wait_for_child("child", |_| true, Duration::ZERO));
         assert_send(scope.wait_for_child(
             RcId(Rc::new(()), "child".into()),
             |_| true,


### PR DESCRIPTION
## Summary

- eagerly convert `ScopeRef::wait_for_child` identifiers before constructing its private async future
- make the `DynamicScopeRef::wait_for_child` inherent forwarder non-async so it does not retain the original identifier
- pin the public `+ Send` future guarantee with a deliberately non-`Send` `RcId` conversion probe for both handles

## Why

The previous public `async fn` entry points retained their `impl Into<ChildId>` argument in the future's unpolled state. A non-`Send` input therefore made the returned future non-`Send`, contrary to SPEC B.9/B.10.

The conversion is now synchronous at the public call boundary, while the actual wait remains in a private async inner function that owns only `ChildId` and the `Send` predicate.

## Item / commit mapping

- `189cb1d` — fix `ScopeRef::wait_for_child` and add the core `RcId` conformance probe
- `7ff91c8` — fix the `DynamicScopeRef::wait_for_child` forwarder and extend the probe to that public entry point

## Validation

- `./tools/dev cargo test -p shelterwood --test integration api_trait_conformance`
- `./tools/dev cargo test -p shelterwood wait_for_child`
- `./tools/dev cargo test -p shelterwood --test integration zero_duration_wait_observes_an_already_satisfied_child`
- `./tools/dev just ci` (575 tests plus doctests, clippy, formatting, docs, reachability, enforcement, packaging)
- `./tools/dev just ci-nix`

Refs #203