### PR TITLE
Make stopped publication idempotent

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3301,7 +3301,11 @@ Ordering and delivery contract:
   descendant memberships). `Stopped` is an incarnation edge, not a
   closure signal: only membership terminality ends the stream (closure
   rule below), so every non-final `Stopped` is followed on the same
-  sequence by the next incarnation's `Starting`, and the positive
+  sequence either by the next incarnation's `Starting` or by a
+  strictly-higher-precedence `Stopped` for the *same* incarnation
+  (B.6's stop-reason lattice — a bounded, monotone correction, never a
+  repeat of an equal verdict), and the final `Stopped` is the one
+  followed by neither. The positive
   terminality signals are the membership edges — the parent's `Removed`
   for this scope child, or this stream's own closure, always preceded
   by the final event. Snapshot receivers hold the last published snapshot through the
@@ -3350,7 +3354,8 @@ Ordering and delivery contract:
   scope's final event — closure is always preceded by one (under
   sequence exhaustion, by the final `Lagged`), and per the restart
   rule above a `Stopped` alone is not closure: the final `Stopped` is
-  the one no restart follows. For a scope membership that never spawns
+  the one no restart and no precedence upgrade follows. For a scope
+  membership that never spawns
   (a declaring tree dropped unspawned, a withdrawn or rejected
   insertion, §3.2), that terminal event is
   `ScopeState { Stopped { reason: NeverStarted } }` (B.6), published at
@@ -3480,7 +3485,9 @@ ScopeSnapshot   { state: Unstarted                              // membership ex
                                                                 //   tree, rejected/withdrawn insertion,
                                                                 //   removal before first spawn, startup-
                                                                 //   aborted ordered sibling (§6) — the
-                                                                //   scope-state twin of §7's exit
+                                                                //   scope-state twin of §7's exit, an
+                                                                //   invariant the stop-reason lattice
+                                                                //   below preserves in either order
                   kind: Ordered | Dynamic, strategy (ordered only), intensity,
                   total_restarts: TotalRestarts,         // charges per §9.2 — group respawns count
                   lifecycle_seq: LifecycleSeq,           // aligns events with snapshots (§12)
@@ -3489,6 +3496,28 @@ ScopeSnapshot   { state: Unstarted                              // membership ex
                                                          //   pre-admission reserved cells are
                                                          //   absent (§3.2)
                 + child(id), descendant(path) traversal helpers
+
+**Stop-reason lattice.** Several owners can independently reach a stop verdict
+for one incarnation — a driver's drain epilogue, a join monitor's fallback
+after that driver panicked or was cancelled, a never-started terminalization —
+so a scope's published `Stopped { reason }` resolves competing verdicts by
+**precedence, never by arrival order**. The total order is
+`Finished < IntensityTripped < StartupFailed < ShutdownRequested <
+NeverStarted`. A later verdict replaces the published reason — and emits a
+corrected `ScopeState` edge, per B.4's non-final-`Stopped` rule — iff it
+strictly outranks the recorded one; equal or weaker verdicts are idempotent
+repeats that publish nothing. The order is severity-ascending: `Finished` is
+the weakest claim, since a drain that began on natural completion says nothing
+about how the teardown itself ended; `ShutdownRequested` supersedes the
+structured failures, matching §11's drain-upgrade rule, which joins through
+this same lattice; and `NeverStarted` is the top element because it is not a
+live incarnation's verdict but the membership-terminal twin of §7's
+`NeverStarted` exit, so the scope-state projection and the membership exit
+agree whichever publication lands first. The consequences are that
+`wait_stopped()`, the final snapshot, and the stream's last `ScopeState` event
+always report the same, highest-precedence verdict, and that a root driver
+that dies mid-drain reports the join monitor's `ShutdownRequested` rather than
+the abandoned drain's `Finished`.
 
 ActorStats (II §20)
                 { messages_received, messages_accepted, messages_conflated,

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -1993,19 +1993,35 @@ impl ScopeCell {
         }
     }
 
-    /// Commits at most one stopped-scope projection and applies its optional
-    /// member terminal edge under the resident-tree observation gate.
+    /// Commits a stopped-scope projection monotonically and applies its
+    /// optional member terminal edge under the resident-tree observation gate.
+    ///
+    /// Several owners can reach a stop verdict for one incarnation — a
+    /// driver's drain epilogue, a join monitor's fallback, a never-started
+    /// terminalization — so competing reasons resolve through
+    /// `StopPrecedence`, never through arrival order. A publication commits
+    /// only when it strictly outranks the recorded reason; equal or weaker
+    /// verdicts are idempotent repeats that mutate nothing. An upgrade
+    /// republishes the record, the snapshot and a corrected `ScopeState` edge,
+    /// so the stream never ends on an event that disagrees with the final
+    /// record (SPEC B.4's non-final-`Stopped` rule admits exactly this step).
     ///
     /// Member terminalization prepares mailbox teardown first; its deferred
     /// discharge is therefore queued before either member or scope pulses.
     /// `epoch_owner` carries a live incarnation's control ownership through
     /// both retained record mutations and is released before snapshot and
     /// lifecycle publication, preserving the stop transition's ownership
-    /// boundary. A later terminal fallback still terminalizes the member but
-    /// cannot replace the first authoritative stop reason or emit another
-    /// lifecycle edge. Observation closure remains a caller decision because
-    /// a nested scope's final event must precede its parent's terminal event
-    /// and only then close the nested streams.
+    /// boundary. A suppressed repeat still terminalizes the member and still
+    /// releases the epoch: only the scope-record mutation, snapshot pulse and
+    /// lifecycle edge are skipped. Because the ancestor snapshot chain is
+    /// republished by `emit_locked`, a suppressed repeat publishes no ancestor
+    /// snapshot either — a caller whose member terminal edge must reach an
+    /// ancestor projection has to publish that itself. Observation closure
+    /// remains a caller decision because a nested scope's final event must
+    /// precede its parent's terminal event and only then close the nested
+    /// streams; a subscriber attaching after the final event and before that
+    /// closure therefore resolves by closure alone, as it already does on the
+    /// stale-epoch path above.
     fn publish_stopped_locked(
         &self,
         wakes: &mut ObservationTxn<'_>,
@@ -2013,10 +2029,13 @@ impl ScopeCell {
         terminal_exit: Option<Exit>,
         epoch_owner: Option<MutexGuard<'_, ScopeControl>>,
     ) {
+        let incoming = reason.precedence();
         let state = ScopeState::Stopped { reason };
         let mut published = false;
         self.observation.record.modify_silently(|record| {
-            if matches!(&record.state, ScopeState::Stopped { .. }) {
+            if let ScopeState::Stopped { reason: recorded } = &record.state
+                && incoming <= recorded.precedence()
+            {
                 return;
             }
             if record.startup.is_none() {

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -1993,17 +1993,19 @@ impl ScopeCell {
         }
     }
 
-    /// Commits one stopped-scope projection and its optional member terminal
-    /// edge under the resident-tree observation gate.
+    /// Commits at most one stopped-scope projection and applies its optional
+    /// member terminal edge under the resident-tree observation gate.
     ///
     /// Member terminalization prepares mailbox teardown first; its deferred
     /// discharge is therefore queued before either member or scope pulses.
     /// `epoch_owner` carries a live incarnation's control ownership through
     /// both retained record mutations and is released before snapshot and
     /// lifecycle publication, preserving the stop transition's ownership
-    /// boundary. Observation closure remains a caller decision because a
-    /// nested scope's final event must precede its parent's terminal event and
-    /// only then close the nested streams.
+    /// boundary. A later terminal fallback still terminalizes the member but
+    /// cannot replace the first authoritative stop reason or emit another
+    /// lifecycle edge. Observation closure remains a caller decision because
+    /// a nested scope's final event must precede its parent's terminal event
+    /// and only then close the nested streams.
     fn publish_stopped_locked(
         &self,
         wakes: &mut ObservationTxn<'_>,
@@ -2012,11 +2014,16 @@ impl ScopeCell {
         epoch_owner: Option<MutexGuard<'_, ScopeControl>>,
     ) {
         let state = ScopeState::Stopped { reason };
+        let mut published = false;
         self.observation.record.modify_silently(|record| {
+            if matches!(&record.state, ScopeState::Stopped { .. }) {
+                return;
+            }
             if record.startup.is_none() {
                 record.startup = Some(Err(StartupError::ShutdownRequested));
             }
             record.state = state.clone();
+            published = true;
         });
         if let Some(exit) = terminal_exit {
             self.member
@@ -2026,8 +2033,10 @@ impl ScopeCell {
         wakes.pulse(&self.member.record);
         // `wait_started` must not observe terminal startup until the member
         // and incarnation-control planes are mutually consistent.
-        wakes.pulse(&self.observation.record);
-        self.emit_locked(wakes, LifecycleEventKind::ScopeState { state });
+        if published {
+            wakes.pulse(&self.observation.record);
+            self.emit_locked(wakes, LifecycleEventKind::ScopeState { state });
+        }
     }
 
     pub(crate) fn terminalize_never_started(&self) {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -266,18 +266,20 @@ impl Drop for ScopeRuntime {
         // corresponding members are terminal and no longer resident.
         drop(dynamic_entries);
         self.children.clear();
-        if !matches!(self.root.record().state, ScopeState::Stopped { .. }) {
-            let completion = self.completion.take();
-            let reason = completion
-                .as_ref()
-                .map(|completion| completion.reason.clone())
-                .or_else(|| self.lifecycle.draining_reason().cloned())
-                .unwrap_or(StopReason::ShutdownRequested);
-            if let Some(exit) = completion.and_then(|completion| completion.root_exit) {
-                self.root.finish_root_incarnation(self.epoch, reason, exit);
-            } else {
-                self.root.finish_incarnation(self.epoch, reason);
-            }
+        // Unconditional: the publisher is the idempotence point, joining this
+        // verdict into the stopped-reason lattice, but epoch retirement is not
+        // idempotent and has no other owner. Skipping the call on an
+        // already-`Stopped` record would strand this incarnation's epoch.
+        let completion = self.completion.take();
+        let reason = completion
+            .as_ref()
+            .map(|completion| completion.reason.clone())
+            .or_else(|| self.lifecycle.draining_reason().cloned())
+            .unwrap_or(StopReason::ShutdownRequested);
+        if let Some(exit) = completion.and_then(|completion| completion.root_exit) {
+            self.root.finish_root_incarnation(self.epoch, reason, exit);
+        } else {
+            self.root.finish_incarnation(self.epoch, reason);
         }
     }
 }

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -293,7 +293,11 @@ async fn scope_plan_conversion_panic_terminalizes_every_child() {
         root.wait_started().await,
         Err(crate::StartupError::ShutdownRequested)
     );
-    assert_eq!(root.wait_stopped().await, StopReason::NeverStarted);
+    assert_eq!(
+        root.wait_stopped().await,
+        StopReason::ShutdownRequested,
+        "the epoch guard's first stopped publication survives the plan fallback"
+    );
     assert!(
         root.snapshot().children.is_empty(),
         "the fallback must release every admitted residency"

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -295,8 +295,8 @@ async fn scope_plan_conversion_panic_terminalizes_every_child() {
     );
     assert_eq!(
         root.wait_stopped().await,
-        StopReason::ShutdownRequested,
-        "the epoch guard's first stopped publication survives the plan fallback"
+        StopReason::NeverStarted,
+        "the plan fallback's never-started verdict outranks the epoch guard's"
     );
     assert!(
         root.snapshot().children.is_empty(),

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -137,7 +137,7 @@ async fn terminal_stop_paths_share_one_complete_observation_transition() {
 }
 
 #[crate::runtime::test]
-async fn root_driver_panic_mid_drain_preserves_the_first_stopped_publication() {
+async fn root_driver_panic_mid_drain_upgrades_to_the_join_monitor_verdict() {
     let scope = isolated_scope("root", ScopeFlavor::Ordered);
     let epoch = scope
         .begin_incarnation(ScopeState::Starting)
@@ -176,22 +176,34 @@ async fn root_driver_panic_mid_drain_preserves_the_first_stopped_publication() {
     let panic_exit = super::super::classify_root_driver_join(crate::runtime::join(driver).await)
         .expect_err("the injected root-driver panic reaches its join monitor");
 
-    let stopped = ScopeState::Stopped {
+    let drained = ScopeState::Stopped {
         reason: StopReason::Finished,
+    };
+    let upgraded = ScopeState::Stopped {
+        reason: StopReason::ShutdownRequested,
     };
     assert_eq!(
         scope.record().state,
-        stopped,
+        drained,
         "ScopeRuntime's unwind epilogue publishes its established drain reason"
     );
     assert!(
         !matches!(scope.member.record().stage, MemberStage::Terminal(_)),
         "the unwind epilogue leaves root terminality to the join monitor"
     );
+    assert!(
+        scope.incarnation_finished(epoch),
+        "the unwind epilogue retires its epoch, so the join monitor must take \
+         the no-live-epoch fallback this test is named for"
+    );
 
     scope.finish_live_root_incarnation(StopReason::ShutdownRequested, panic_exit.clone());
 
-    assert_eq!(scope.record().state, stopped);
+    assert_eq!(
+        scope.record().state,
+        upgraded,
+        "ShutdownRequested strictly outranks the abandoned drain's Finished"
+    );
     assert!(matches!(
         scope.member.record().stage,
         MemberStage::Terminal(ref exit) if exit == &panic_exit
@@ -201,16 +213,154 @@ async fn root_driver_panic_mid_drain_preserves_the_first_stopped_publication() {
         Ok(LifecycleItem::Event(crate::LifecycleEvent {
             kind: LifecycleEventKind::ScopeState { state },
             ..
-        })) if state == stopped
+        })) if state == drained
     ));
+    assert!(
+        matches!(
+            events.try_recv(),
+            Ok(LifecycleItem::Event(crate::LifecycleEvent {
+                kind: LifecycleEventKind::ScopeState { state },
+                ..
+            })) if state == upgraded
+        ),
+        "the corrected verdict reaches the stream before it closes"
+    );
     assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Closed));
 
-    assert_eq!(snapshots.borrow_latest().state, stopped);
+    assert_eq!(snapshots.borrow_latest().state, upgraded);
     snapshots
         .changed()
         .await
-        .expect("the first stopped snapshot precedes fallback closure");
+        .expect("the upgraded stopped snapshot precedes fallback closure");
     assert!(snapshots.changed().await.is_err());
+}
+
+/// Drives one pair of competing stopped publications through the shared
+/// publisher and reports the settled record plus every `ScopeState` edge the
+/// lifecycle stream carried.
+async fn resolve_competing_stops(
+    first: StopReason,
+    second: StopReason,
+) -> (ScopeState, Vec<ScopeState>) {
+    let scope = isolated_scope("root", ScopeFlavor::Ordered);
+    let epoch = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    let handle = ScopeRef {
+        cell: Arc::clone(&scope),
+    };
+    let mut events = handle.subscribe_lifecycle();
+
+    scope.finish_incarnation(epoch, first);
+    scope.finish_live_root_incarnation(second, Exit::never_started());
+
+    let mut states = Vec::new();
+    while let Ok(LifecycleItem::Event(event)) = events.try_recv() {
+        if let LifecycleEventKind::ScopeState { state } = event.kind {
+            states.push(state);
+        }
+    }
+    assert_eq!(
+        events.try_recv(),
+        Err(LifecycleTryRecvError::Closed),
+        "the fallback closes observation once its verdict is published"
+    );
+    let settled = scope.record().state;
+    assert_eq!(
+        settled,
+        ScopeState::Stopped {
+            reason: scope.wait_stopped().await
+        },
+        "wait_stopped reports exactly the settled record"
+    );
+    (settled, states)
+}
+
+#[crate::runtime::test]
+async fn a_weaker_first_stop_is_upgraded_by_a_stronger_second() {
+    let (settled, states) =
+        resolve_competing_stops(StopReason::Finished, StopReason::ShutdownRequested).await;
+    assert_eq!(
+        settled,
+        ScopeState::Stopped {
+            reason: StopReason::ShutdownRequested
+        }
+    );
+    assert_eq!(
+        states,
+        vec![
+            ScopeState::Stopped {
+                reason: StopReason::Finished
+            },
+            ScopeState::Stopped {
+                reason: StopReason::ShutdownRequested
+            },
+        ],
+        "an upgrade corrects the stream instead of ending it on a stale verdict"
+    );
+}
+
+#[crate::runtime::test]
+async fn never_started_outranks_an_earlier_shutdown_requested() {
+    let (settled, states) =
+        resolve_competing_stops(StopReason::ShutdownRequested, StopReason::NeverStarted).await;
+    assert_eq!(
+        settled,
+        ScopeState::Stopped {
+            reason: StopReason::NeverStarted
+        },
+        "the scope state must agree with a never-started membership exit"
+    );
+    assert_eq!(
+        states,
+        vec![
+            ScopeState::Stopped {
+                reason: StopReason::ShutdownRequested
+            },
+            ScopeState::Stopped {
+                reason: StopReason::NeverStarted
+            },
+        ]
+    );
+}
+
+#[crate::runtime::test]
+async fn never_started_is_retained_against_a_later_shutdown_requested() {
+    let (settled, states) =
+        resolve_competing_stops(StopReason::NeverStarted, StopReason::ShutdownRequested).await;
+    assert_eq!(
+        settled,
+        ScopeState::Stopped {
+            reason: StopReason::NeverStarted
+        },
+        "the lattice resolves this pair the same way in either arrival order"
+    );
+    assert_eq!(
+        states,
+        vec![ScopeState::Stopped {
+            reason: StopReason::NeverStarted
+        }],
+        "a weaker repeat emits nothing"
+    );
+}
+
+#[crate::runtime::test]
+async fn an_exact_duplicate_stop_publishes_once() {
+    let (settled, states) =
+        resolve_competing_stops(StopReason::ShutdownRequested, StopReason::ShutdownRequested).await;
+    assert_eq!(
+        settled,
+        ScopeState::Stopped {
+            reason: StopReason::ShutdownRequested
+        }
+    );
+    assert_eq!(
+        states,
+        vec![ScopeState::Stopped {
+            reason: StopReason::ShutdownRequested
+        }],
+        "equal verdicts are idempotent repeats, not upgrades"
+    );
 }
 
 impl Wake for ObserveScopeOnStartupWake {

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -137,34 +137,60 @@ async fn terminal_stop_paths_share_one_complete_observation_transition() {
 }
 
 #[crate::runtime::test]
-async fn no_live_root_fallback_preserves_the_first_stopped_publication() {
+async fn root_driver_panic_mid_drain_preserves_the_first_stopped_publication() {
     let scope = isolated_scope("root", ScopeFlavor::Ordered);
     let epoch = scope
         .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
+    scope
+        .member
+        .update(|record| record.stage = MemberStage::Running);
+    scope.set_state_and_startup(ScopeState::Running, Ok(()));
+
+    let mut lifecycle = ScopeLifecycle::running();
+    assert!(
+        lifecycle.begin_drain(StopReason::Finished).is_some(),
+        "the driver enters its orderly drain before panicking"
+    );
+    scope.set_state(ScopeState::Draining);
+
     let handle = ScopeRef {
         cell: Arc::clone(&scope),
     };
     let mut snapshots = handle.subscribe_snapshots();
     let mut events = handle.subscribe_lifecycle();
 
-    scope.finish_incarnation(epoch, StopReason::Finished);
-    assert!(
-        !matches!(scope.member.record().stage, MemberStage::Terminal(_)),
-        "the driver-drop publication leaves root terminality to the join monitor"
-    );
-
-    let panic_exit = Exit::new(
-        ExitKind::Panicked {
-            message: Some("root driver panicked mid-drain".to_owned()),
-        },
-        Cancellation::NotObserved,
-    );
-    scope.finish_live_root_incarnation(StopReason::ShutdownRequested, panic_exit.clone());
+    let (events_tx, _events_rx) = crate::runtime::unbounded_mpsc();
+    let (disposal_events_tx, _disposal_events_rx) = crate::runtime::unbounded_mpsc();
+    let driver = crate::runtime::spawn({
+        let scope = Arc::clone(&scope);
+        async move {
+            let _runtime = ScopeRuntimeBuilder::new(scope, epoch, events_tx, disposal_events_tx)
+                .with_lifecycle(lifecycle)
+                .build();
+            panic!("root driver panicked mid-drain");
+            #[allow(unreachable_code)]
+            StopReason::Finished
+        }
+    });
+    let panic_exit = super::super::classify_root_driver_join(crate::runtime::join(driver).await)
+        .expect_err("the injected root-driver panic reaches its join monitor");
 
     let stopped = ScopeState::Stopped {
         reason: StopReason::Finished,
     };
+    assert_eq!(
+        scope.record().state,
+        stopped,
+        "ScopeRuntime's unwind epilogue publishes its established drain reason"
+    );
+    assert!(
+        !matches!(scope.member.record().stage, MemberStage::Terminal(_)),
+        "the unwind epilogue leaves root terminality to the join monitor"
+    );
+
+    scope.finish_live_root_incarnation(StopReason::ShutdownRequested, panic_exit.clone());
+
     assert_eq!(scope.record().state, stopped);
     assert!(matches!(
         scope.member.record().stage,

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -136,6 +136,57 @@ async fn terminal_stop_paths_share_one_complete_observation_transition() {
     }
 }
 
+#[crate::runtime::test]
+async fn no_live_root_fallback_preserves_the_first_stopped_publication() {
+    let scope = isolated_scope("root", ScopeFlavor::Ordered);
+    let epoch = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    let handle = ScopeRef {
+        cell: Arc::clone(&scope),
+    };
+    let mut snapshots = handle.subscribe_snapshots();
+    let mut events = handle.subscribe_lifecycle();
+
+    scope.finish_incarnation(epoch, StopReason::Finished);
+    assert!(
+        !matches!(scope.member.record().stage, MemberStage::Terminal(_)),
+        "the driver-drop publication leaves root terminality to the join monitor"
+    );
+
+    let panic_exit = Exit::new(
+        ExitKind::Panicked {
+            message: Some("root driver panicked mid-drain".to_owned()),
+        },
+        Cancellation::NotObserved,
+    );
+    scope.finish_live_root_incarnation(StopReason::ShutdownRequested, panic_exit.clone());
+
+    let stopped = ScopeState::Stopped {
+        reason: StopReason::Finished,
+    };
+    assert_eq!(scope.record().state, stopped);
+    assert!(matches!(
+        scope.member.record().stage,
+        MemberStage::Terminal(ref exit) if exit == &panic_exit
+    ));
+    assert!(matches!(
+        events.try_recv(),
+        Ok(LifecycleItem::Event(crate::LifecycleEvent {
+            kind: LifecycleEventKind::ScopeState { state },
+            ..
+        })) if state == stopped
+    ));
+    assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Closed));
+
+    assert_eq!(snapshots.borrow_latest().state, stopped);
+    snapshots
+        .changed()
+        .await
+        .expect("the first stopped snapshot precedes fallback closure");
+    assert!(snapshots.changed().await.is_err());
+}
+
 impl Wake for ObserveScopeOnStartupWake {
     fn wake(self: Arc<Self>) {
         self.observe();

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -667,28 +667,6 @@ enum StartupPhase {
     Failed,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-enum DrainReasonPrecedence {
-    Finished,
-    IntensityTripped,
-    StartupFailed,
-    ShutdownRequested,
-}
-
-impl DrainReasonPrecedence {
-    fn of(reason: &StopReason) -> Self {
-        match reason {
-            StopReason::Finished => Self::Finished,
-            StopReason::IntensityTripped(_) => Self::IntensityTripped,
-            StopReason::StartupFailed(_) => Self::StartupFailed,
-            StopReason::ShutdownRequested => Self::ShutdownRequested,
-            StopReason::NeverStarted => {
-                unreachable!("NeverStarted is not a live-incarnation drain reason")
-            }
-        }
-    }
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ScopeDrain {
     reason: StopReason,
@@ -809,16 +787,23 @@ impl ScopeLifecycle {
 
     /// Begins draining or monotonically upgrades an in-progress drain.
     ///
-    /// The returned effect exists only for the initial transition: upgrades
-    /// change the eventual verdict without repeating teardown side effects.
+    /// Upgrades join through `StopPrecedence`, the same lattice the stopped
+    /// publisher uses, so a drain verdict and a published verdict can never
+    /// resolve competing reasons in opposite directions. The returned effect
+    /// exists only for the initial transition: upgrades change the eventual
+    /// verdict without repeating teardown side effects.
     pub(crate) fn begin_drain(&mut self, reason: StopReason) -> Option<DrainEffect> {
-        let incoming_precedence = DrainReasonPrecedence::of(&reason);
+        debug_assert!(
+            !matches!(reason, StopReason::NeverStarted),
+            "NeverStarted is not a live-incarnation drain reason"
+        );
+        let incoming_precedence = reason.precedence();
         let startup = match &mut self.state {
             ScopeLifecycleState::Starting => StartupPhase::Pending,
             ScopeLifecycleState::Running => StartupPhase::Complete,
             ScopeLifecycleState::StartupFailed => StartupPhase::Failed,
             ScopeLifecycleState::Draining(drain) => {
-                if incoming_precedence > DrainReasonPrecedence::of(&drain.reason) {
+                if incoming_precedence > drain.reason.precedence() {
                     drain.reason = reason;
                 }
                 return None;

--- a/crates/shelterwood/src/exit.rs
+++ b/crates/shelterwood/src/exit.rs
@@ -53,6 +53,45 @@ impl StopReason {
             Self::NeverStarted => Exit::never_started(),
         }
     }
+
+    pub(crate) fn precedence(&self) -> StopPrecedence {
+        match self {
+            Self::Finished => StopPrecedence::Finished,
+            Self::IntensityTripped(_) => StopPrecedence::IntensityTripped,
+            Self::StartupFailed(_) => StopPrecedence::StartupFailed,
+            Self::ShutdownRequested => StopPrecedence::ShutdownRequested,
+            Self::NeverStarted => StopPrecedence::NeverStarted,
+        }
+    }
+}
+
+/// Total precedence order over stop reasons: the single lattice that resolves
+/// every competing stop verdict for one incarnation.
+///
+/// Two owners can each reach a stop verdict for the same incarnation — a
+/// driver's drain and a later teardown fallback, say — so the resolution rule
+/// must be a property of the reasons themselves rather than of arrival order.
+/// Both consumers join through this order: `ScopeLifecycle::begin_drain`
+/// upgrades an in-progress drain, and `ScopeCell`'s stopped publisher upgrades
+/// an already-published `Stopped` projection. Strictly-greater wins in both,
+/// so equal verdicts are idempotent repeats.
+///
+/// The order is severity-ascending. `Finished` is the weakest claim: a drain
+/// that began on natural completion says nothing about how the teardown
+/// itself ended. `ShutdownRequested` outranks the structured failures because
+/// a requested stop supersedes whatever the incarnation would otherwise have
+/// reported. `NeverStarted` is the top element because it is not a live
+/// incarnation's verdict at all but the membership-terminal twin of §7's
+/// `Exit::never_started()` (SPEC B.6): whenever a membership terminalizes
+/// without ever spawning, the scope-state projection must agree with the
+/// membership exit, in either arrival order.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum StopPrecedence {
+    Finished,
+    IntensityTripped,
+    StartupFailed,
+    ShutdownRequested,
+    NeverStarted,
 }
 
 /// Failure of the root startup barrier.


### PR DESCRIPTION
## Summary

- resolve competing stopped publications through a single precedence lattice instead of arrival order: `Finished < IntensityTripped < StartupFailed < ShutdownRequested < NeverStarted` (`StopPrecedence` in `exit.rs`, the one source of truth)
- `publish_stopped_locked` commits only when the incoming reason strictly outranks the recorded one; an upgrade republishes the record, snapshot, and a corrected `ScopeState` edge, while equal or weaker verdicts are idempotent repeats that mutate nothing
- `ScopeLifecycle::begin_drain` joins through the shared lattice (its private `DrainReasonPrecedence` copy is deleted), so a drain verdict and a published verdict can never resolve the same pair in opposite directions
- drop `ScopeRuntime::drop`'s already-`Stopped` guard: the publisher is the idempotence point, but epoch retirement is not idempotent and has no other owner
- regression tests pin the no-live-epoch branch and all four collision shapes (upgrade in both directions, suppression, exact duplicate)

## Root cause

Two owners can each reach a stop verdict for one incarnation — a driver's drain epilogue, the join monitor's fallback after that driver panicked or was cancelled, a never-started terminalization — and the publisher resolved them by arrival order, picking a winner for reasons unrelated to which verdict is authoritative.

An earlier revision of this PR replaced that with "first publication wins". Adversarial review showed first-wins gets two cases backwards: a root driver that dies mid-drain reported the abandoned drain's `Finished` instead of the join monitor's `ShutdownRequested` (the verdict #206 identified as intended, and the opposite of `begin_drain`'s own monotone upgrade rule), and a never-started terminalization only won when it arrived first, breaking B.6's twin invariant in the other arrival order.

## Adjudication (recorded per the spec-adjustment protocol)

- Stopped publication is **monotone in the precedence lattice**, not first-wins and not last-wins. `NeverStarted` ranks top because B.6 makes it the mandated scope-state twin of a never-started membership terminalization — it must win in both arrival orders. Below it, the order is exactly the pre-existing drain lattice.
- **SPEC B.6**: records the lattice; the never-started twin is restated as an invariant the lattice preserves.
- **SPEC B.4**: amended — a non-final `Stopped` is followed either by the next incarnation's `Starting` or by a strictly-higher-precedence `Stopped` for the same incarnation; the final `Stopped` is the one no restart and no precedence upgrade follows. Rationale: a lifecycle stream must not end on an event that disagrees with the final record; a corrected final event beats a single-but-wrong one.
- Residual (documented in the publisher's doc comment): a subscriber attaching between a publication and a later suppressed no-op repeat can still see closure without an event — the same pre-existing class as the stale-epoch branch; its initial snapshot is already terminal.

Instrumented whole-suite sweep after the change: exactly five collision sites exist repo-wide, and each resolves to the lattice verdict (`NeverStarted` in both arrival orders for the twin cases, `ShutdownRequested` over `Finished` for the mid-drain panic, pure suppression for the exact duplicate). Removing the `ScopeRuntime::drop` guard introduced no new collision sites.

## Validation

- `./tools/dev cargo nextest run -p shelterwood terminalization`
- `./tools/dev cargo test -p shelterwood root_driver_panic_mid_drain_upgrades_to_the_join_monitor_verdict`
- `./tools/dev just ci` (580 tests plus formatting, clippy, docs, layering/API enforcement, and packaging) — exit 0

Refs #206
