### PR TITLE
Isolate disposal during blocking-pool shutdown

### DIFF
--- a/crates/shelterwood/doctests/docs/shutdown-and-resources.md
+++ b/crates/shelterwood/doctests/docs/shutdown-and-resources.md
@@ -113,7 +113,10 @@ runtime's lifetime. On a healthy runtime it uses Tokio's blocking pool, so a
 permanently blocked destructor can make the default `Runtime::drop` wait
 indefinitely. Embedding hosts that cannot accept that wait must choose Tokio's
 `Runtime::shutdown_timeout` or `Runtime::shutdown_background` as a host-level
-mitigation, accepting that blocking work may then outlive the runtime.
+mitigation, accepting that blocking work may then outlive the runtime. Once
+either returns, disposals submitted during teardown may still be in flight on
+a Shelterwood-owned thread that nothing joins, so a host that exits the process
+immediately afterwards loses those destructors.
 
 A shutdown request through a pre-spawn scope handle is retained as a pending
 stop. The first incarnation starts and immediately enters teardown; the timeout

--- a/crates/shelterwood/doctests/docs/shutdown-and-resources.md
+++ b/crates/shelterwood/doctests/docs/shutdown-and-resources.md
@@ -108,6 +108,13 @@ requires `panic = "unwind"`. The standard double-panic exclusion remains: a
 destructor that panics while its user future is already unwinding aborts the
 process before the supervisor can publish an exit.
 
+Shelterwood's detached disposal is detached from the caller, not from the
+runtime's lifetime. On a healthy runtime it uses Tokio's blocking pool, so a
+permanently blocked destructor can make the default `Runtime::drop` wait
+indefinitely. Embedding hosts that cannot accept that wait must choose Tokio's
+`Runtime::shutdown_timeout` or `Runtime::shutdown_background` as a host-level
+mitigation, accepting that blocking work may then outlive the runtime.
+
 A shutdown request through a pre-spawn scope handle is retained as a pending
 stop. The first incarnation starts and immediately enters teardown; the timeout
 for `shutdown_and_wait` begins when that incarnation starts, because there is

--- a/crates/shelterwood/src/runtime/disposal.rs
+++ b/crates/shelterwood/src/runtime/disposal.rs
@@ -200,6 +200,12 @@ fn run_fallback_disposals() {
 /// The pending check distinguishes rejection from a task that ran to
 /// completion before the submitter observed its reference count; requeueing
 /// the latter would leave empty jobs behind a blocked fallback disposal.
+///
+/// This pins Tokio's `spawn_task` shutdown path: a rejected closure is
+/// destroyed synchronously, before `spawn_blocking` returns. A future Tokio
+/// that deferred that drop would leave the count at two and degrade
+/// fail-safe to the old inline behavior rather than misroute a live closure.
+/// The end-to-end regression below pins the behavior we rely on.
 fn blocking_spawn_needs_fallback<T, C>(job: &Arc<DisposalJob<T, C>>) -> bool
 where
     T: Send + 'static,
@@ -303,10 +309,30 @@ mod tests {
             mpsc,
         },
         thread::{self, ThreadId},
-        time::Duration,
+        time::{Duration, Instant},
     };
 
-    use super::{DisposalJob, DisposalPanic, blocking_spawn_needs_fallback, dispose_detached};
+    use super::{
+        DisposalJob, DisposalPanic, Isolated, blocking_spawn_needs_fallback, dispose_detached,
+    };
+
+    /// Name of the shared non-runtime disposal thread, asserted on to pin
+    /// *where* isolated destruction lands rather than merely where it does not.
+    const FALLBACK_THREAD: &str = "shelterwood-disposal";
+
+    /// Deadlock escape hatch for the hostile destructors below. A correct run
+    /// releases them in microseconds and never reaches this bound; a
+    /// regression that runs them inline reaches it and then fails the thread
+    /// assertions, so the suite reports a diagnosis instead of a hang.
+    const DESTRUCTOR_ESCAPE: Duration = Duration::from_secs(5);
+
+    /// The thread a user destructor ran on.
+    type DestructorThread = (ThreadId, Option<String>);
+
+    fn describe_current_thread() -> DestructorThread {
+        let current = thread::current();
+        (current.id(), current.name().map(str::to_owned))
+    }
 
     struct PanickingDrop(Arc<AtomicUsize>);
 
@@ -369,21 +395,34 @@ mod tests {
     }
 
     struct BlockingDrop {
-        entered: mpsc::Sender<ThreadId>,
+        entered: mpsc::Sender<DestructorThread>,
         release: Arc<(Mutex<bool>, Condvar)>,
         finished: mpsc::Sender<()>,
     }
 
     impl Drop for BlockingDrop {
         fn drop(&mut self) {
-            let _ = self.entered.send(thread::current().id());
+            let _ = self.entered.send(describe_current_thread());
             let (released, wake) = &*self.release;
             let mut released = released.lock().expect("release mutex available");
+            let deadline = Instant::now() + DESTRUCTOR_ESCAPE;
             while !*released {
-                released = wake.wait(released).expect("release mutex available");
+                let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                    break;
+                };
+                released = wake
+                    .wait_timeout(released, remaining)
+                    .expect("release mutex available")
+                    .0;
             }
             let _ = self.finished.send(());
         }
+    }
+
+    fn release(gate: &Arc<(Mutex<bool>, Condvar)>) {
+        let (released, wake) = &**gate;
+        *released.lock().expect("release mutex available") = true;
+        wake.notify_all();
     }
 
     struct DisposeOnDrop {
@@ -410,7 +449,6 @@ mod tests {
             .max_blocking_threads(1)
             .build()
             .expect("test runtime");
-        let shutdown_thread = thread::current().id();
         let (worker_started, worker_started_rx) = mpsc::channel();
         let (release_worker, release_worker_rx) = mpsc::channel();
         drop(runtime.spawn_blocking(move || {
@@ -429,11 +467,11 @@ mod tests {
         let (returned, returned_rx) = mpsc::channel();
         let (entered, entered_rx) = mpsc::channel();
         let (finished, finished_rx) = mpsc::channel();
-        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
         let trigger = DisposeOnDrop {
             value: Some(BlockingDrop {
                 entered,
-                release: Arc::clone(&release),
+                release: Arc::clone(&gate),
                 finished,
             }),
             submitted,
@@ -455,17 +493,72 @@ mod tests {
         // the blocking-pool teardown cannot return from submission.
         let submission_returned = returned_rx.recv_timeout(Duration::from_secs(1));
 
-        let (released, wake) = &*release;
-        *released.lock().expect("release mutex available") = true;
-        wake.notify_all();
+        release(&gate);
         finished_rx
             .recv_timeout(Duration::from_secs(1))
             .expect("the fallback destructor finishes after release");
 
         let teardown_thread = teardown_thread.expect("runtime teardown submits disposal");
-        let destructor_thread = destructor_thread.expect("the hostile destructor starts");
-        assert_ne!(destructor_thread, shutdown_thread);
+        let (destructor_thread, destructor_name) =
+            destructor_thread.expect("the hostile destructor starts");
         assert_ne!(destructor_thread, teardown_thread);
+        assert_eq!(
+            destructor_name.as_deref(),
+            Some(FALLBACK_THREAD),
+            "a rejected blocking submission must land on the shared fallback thread"
+        );
         submission_returned.expect("a hostile destructor must not block runtime teardown");
+    }
+
+    /// The embedding-host shape of #205: a live task owns an [`Isolated`]
+    /// value and the host tears its runtime down from its own thread.
+    ///
+    /// `shutdown_background` shuts the blocking pool down *before* Tokio drops
+    /// the task, so the drop glue submits into an already shut-down pool. The
+    /// regression runs the user destructor inline, parking the host inside
+    /// `shutdown_background` — which is precisely the mitigation the shutdown
+    /// docs direct hosts to, so it must not be the thing that hangs.
+    #[test]
+    fn embedder_runtime_teardown_isolates_a_task_held_value() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime");
+        let embedder_thread = thread::current().id();
+        let (entered, entered_rx) = mpsc::channel();
+        let (finished, finished_rx) = mpsc::channel();
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let held = Isolated::new(BlockingDrop {
+            entered,
+            release: Arc::clone(&gate),
+            finished,
+        });
+        runtime.spawn(async move {
+            let _held = held;
+            std::future::pending::<()>().await;
+        });
+        // Poll the task once so the runtime, not this thread, owns the value.
+        runtime.block_on(async { tokio::task::yield_now().await });
+
+        runtime.shutdown_background();
+        // Returning here at all is half the regression: on the inline path
+        // this thread is still inside `shutdown_background` running the
+        // hostile destructor, and only the escape hatch frees it.
+        let (destructor_thread, destructor_name) = entered_rx
+            .recv_timeout(DESTRUCTOR_ESCAPE + Duration::from_secs(1))
+            .expect("the hostile destructor starts");
+        release(&gate);
+        finished_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the isolated destructor finishes after release");
+
+        assert_ne!(
+            destructor_thread, embedder_thread,
+            "runtime teardown must not run a user destructor on the host thread"
+        );
+        assert_eq!(
+            destructor_name.as_deref(),
+            Some(FALLBACK_THREAD),
+            "a shut-down blocking pool must hand disposal to the fallback thread"
+        );
     }
 }

--- a/crates/shelterwood/src/runtime/disposal.rs
+++ b/crates/shelterwood/src/runtime/disposal.rs
@@ -94,6 +94,13 @@ where
         // worker or double-panic while the job is being dropped.
         discard_panic(catch_panic(|| completion(panic)).err());
     }
+
+    fn is_pending(&self) -> bool {
+        self.state
+            .lock()
+            .expect("disposal job mutex poisoned")
+            .is_some()
+    }
 }
 
 impl<T, C> Drop for DisposalJob<T, C>
@@ -187,6 +194,20 @@ fn run_fallback_disposals() {
     }
 }
 
+/// Returns whether Tokio synchronously rejected the blocking task.
+///
+/// Sole ownership proves that Tokio no longer holds the submitted closure.
+/// The pending check distinguishes rejection from a task that ran to
+/// completion before the submitter observed its reference count; requeueing
+/// the latter would leave empty jobs behind a blocked fallback disposal.
+fn blocking_spawn_needs_fallback<T, C>(job: &Arc<DisposalJob<T, C>>) -> bool
+where
+    T: Send + 'static,
+    C: FnOnce(Option<DisposalPanic>) + Send + 'static,
+{
+    Arc::strong_count(job) == 1 && job.is_pending()
+}
+
 fn dispatch_disposal<T, C>(job: Arc<DisposalJob<T, C>>)
 where
     T: Send + 'static,
@@ -202,7 +223,7 @@ where
                 // destroys the closure, leaving `job` as the only reference.
                 // Fall through so the fallback thread, rather than this
                 // runtime-teardown thread, owns user destruction.
-                if Arc::strong_count(&job) != 1 {
+                if !blocking_spawn_needs_fallback(&job) {
                     return;
                 }
             }
@@ -285,7 +306,7 @@ mod tests {
         time::Duration,
     };
 
-    use super::{DisposalJob, DisposalPanic, dispose_detached};
+    use super::{DisposalJob, DisposalPanic, blocking_spawn_needs_fallback, dispose_detached};
 
     struct PanickingDrop(Arc<AtomicUsize>);
 
@@ -317,6 +338,34 @@ mod tests {
                 message: Some(message)
             })) if message == "cancelled disposal job payload"
         ));
+    }
+
+    #[test]
+    fn fallback_detection_distinguishes_blocking_spawn_outcomes() {
+        let accepted = DisposalJob::new((), |_| {});
+        let accepted_worker = Arc::clone(&accepted);
+        assert!(
+            !blocking_spawn_needs_fallback(&accepted),
+            "an accepted closure still owned by Tokio must stay on its blocking pool"
+        );
+        drop(accepted_worker);
+
+        let rejected = DisposalJob::new((), |_| {});
+        let rejected_worker = Arc::clone(&rejected);
+        drop(rejected_worker);
+        assert!(
+            blocking_spawn_needs_fallback(&rejected),
+            "a synchronously dropped closure must move to the fallback queue"
+        );
+
+        let completed = DisposalJob::new((), |_| {});
+        let completed_worker = Arc::clone(&completed);
+        completed_worker.finish();
+        drop(completed_worker);
+        assert!(
+            !blocking_spawn_needs_fallback(&completed),
+            "an already-completed closure must not enqueue an empty job"
+        );
     }
 
     struct BlockingDrop {
@@ -390,8 +439,9 @@ mod tests {
             submitted,
             returned,
         };
-        // With the only worker occupied, this task stays queued until runtime
-        // shutdown rejects it and drops `trigger` on that worker.
+        // With the only worker occupied, this outer task stays queued. After
+        // shutdown begins, Tokio runs it while draining the worker queue; its
+        // nested disposal submission is then synchronously rejected.
         drop(runtime.spawn_blocking(move || drop(trigger)));
         runtime.shutdown_background();
         release_worker

--- a/crates/shelterwood/src/runtime/disposal.rs
+++ b/crates/shelterwood/src/runtime/disposal.rs
@@ -197,7 +197,14 @@ where
         match catch_panic(|| task::spawn_blocking(move || worker.finish())) {
             Ok(handle) => {
                 drop(handle);
-                return;
+                // Tokio returns a handle even when the blocking pool is
+                // already shutting down. In that case it synchronously
+                // destroys the closure, leaving `job` as the only reference.
+                // Fall through so the fallback thread, rather than this
+                // runtime-teardown thread, owns user destruction.
+                if Arc::strong_count(&job) != 1 {
+                    return;
+                }
             }
             Err(payload) => discard_panic(Some(payload)),
         }
@@ -268,12 +275,17 @@ pub(crate) fn dispose_all<T: Send + 'static>(values: Vec<T>) -> Latch {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        Arc, Mutex,
-        atomic::{AtomicUsize, Ordering},
+    use std::{
+        sync::{
+            Arc, Condvar, Mutex,
+            atomic::{AtomicUsize, Ordering},
+            mpsc,
+        },
+        thread::{self, ThreadId},
+        time::Duration,
     };
 
-    use super::{DisposalJob, DisposalPanic};
+    use super::{DisposalJob, DisposalPanic, dispose_detached};
 
     struct PanickingDrop(Arc<AtomicUsize>);
 
@@ -305,5 +317,105 @@ mod tests {
                 message: Some(message)
             })) if message == "cancelled disposal job payload"
         ));
+    }
+
+    struct BlockingDrop {
+        entered: mpsc::Sender<ThreadId>,
+        release: Arc<(Mutex<bool>, Condvar)>,
+        finished: mpsc::Sender<()>,
+    }
+
+    impl Drop for BlockingDrop {
+        fn drop(&mut self) {
+            let _ = self.entered.send(thread::current().id());
+            let (released, wake) = &*self.release;
+            let mut released = released.lock().expect("release mutex available");
+            while !*released {
+                released = wake.wait(released).expect("release mutex available");
+            }
+            let _ = self.finished.send(());
+        }
+    }
+
+    struct DisposeOnDrop {
+        value: Option<BlockingDrop>,
+        submitted: mpsc::Sender<ThreadId>,
+        returned: mpsc::Sender<()>,
+    }
+
+    impl Drop for DisposeOnDrop {
+        fn drop(&mut self) {
+            let _ = self.submitted.send(thread::current().id());
+            dispose_detached(
+                self.value
+                    .take()
+                    .expect("teardown submits the disposal exactly once"),
+            );
+            let _ = self.returned.send(());
+        }
+    }
+
+    #[test]
+    fn shut_down_blocking_pool_falls_back_off_the_teardown_thread() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .max_blocking_threads(1)
+            .build()
+            .expect("test runtime");
+        let shutdown_thread = thread::current().id();
+        let (worker_started, worker_started_rx) = mpsc::channel();
+        let (release_worker, release_worker_rx) = mpsc::channel();
+        drop(runtime.spawn_blocking(move || {
+            worker_started
+                .send(())
+                .expect("test observes the occupied blocking worker");
+            release_worker_rx
+                .recv()
+                .expect("test releases the occupied blocking worker");
+        }));
+        worker_started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the sole blocking worker starts");
+
+        let (submitted, submitted_rx) = mpsc::channel();
+        let (returned, returned_rx) = mpsc::channel();
+        let (entered, entered_rx) = mpsc::channel();
+        let (finished, finished_rx) = mpsc::channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let trigger = DisposeOnDrop {
+            value: Some(BlockingDrop {
+                entered,
+                release: Arc::clone(&release),
+                finished,
+            }),
+            submitted,
+            returned,
+        };
+        // With the only worker occupied, this task stays queued until runtime
+        // shutdown rejects it and drops `trigger` on that worker.
+        drop(runtime.spawn_blocking(move || drop(trigger)));
+        runtime.shutdown_background();
+        release_worker
+            .send(())
+            .expect("the blocking-pool teardown may proceed");
+
+        let teardown_thread = submitted_rx.recv_timeout(Duration::from_secs(1));
+        let destructor_thread = entered_rx.recv_timeout(Duration::from_secs(1));
+        // This must arrive while the hostile destructor is still blocked. On
+        // the regression path dispose_detached runs the destructor inline, so
+        // the blocking-pool teardown cannot return from submission.
+        let submission_returned = returned_rx.recv_timeout(Duration::from_secs(1));
+
+        let (released, wake) = &*release;
+        *released.lock().expect("release mutex available") = true;
+        wake.notify_all();
+        finished_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the fallback destructor finishes after release");
+
+        let teardown_thread = teardown_thread.expect("runtime teardown submits disposal");
+        let destructor_thread = destructor_thread.expect("the hostile destructor starts");
+        assert_ne!(destructor_thread, shutdown_thread);
+        assert_ne!(destructor_thread, teardown_thread);
+        submission_returned.expect("a hostile destructor must not block runtime teardown");
     }
 }

--- a/docs/shutdown-and-resources.md
+++ b/docs/shutdown-and-resources.md
@@ -113,7 +113,10 @@ runtime's lifetime. On a healthy runtime it uses Tokio's blocking pool, so a
 permanently blocked destructor can make the default `Runtime::drop` wait
 indefinitely. Embedding hosts that cannot accept that wait must choose Tokio's
 `Runtime::shutdown_timeout` or `Runtime::shutdown_background` as a host-level
-mitigation, accepting that blocking work may then outlive the runtime.
+mitigation, accepting that blocking work may then outlive the runtime. Once
+either returns, disposals submitted during teardown may still be in flight on
+a Shelterwood-owned thread that nothing joins, so a host that exits the process
+immediately afterwards loses those destructors.
 
 A shutdown request through a pre-spawn scope handle is retained as a pending
 stop. The first incarnation starts and immediately enters teardown; the timeout

--- a/docs/shutdown-and-resources.md
+++ b/docs/shutdown-and-resources.md
@@ -108,6 +108,13 @@ requires `panic = "unwind"`. The standard double-panic exclusion remains: a
 destructor that panics while its user future is already unwinding aborts the
 process before the supervisor can publish an exit.
 
+Shelterwood's detached disposal is detached from the caller, not from the
+runtime's lifetime. On a healthy runtime it uses Tokio's blocking pool, so a
+permanently blocked destructor can make the default `Runtime::drop` wait
+indefinitely. Embedding hosts that cannot accept that wait must choose Tokio's
+`Runtime::shutdown_timeout` or `Runtime::shutdown_background` as a host-level
+mitigation, accepting that blocking work may then outlive the runtime.
+
 A shutdown request through a pre-spawn scope handle is retained as a pending
 stop. The first incarnation starts and immediately enters teardown; the timeout
 for `shutdown_and_wait` begins when that incarnation starts, because there is


### PR DESCRIPTION
## Summary

- Detect Tokio's accepted-but-synchronously-dropped `spawn_blocking` closure during blocking-pool shutdown and fall through to the shared fallback disposal thread.
- Distinguish a synchronously rejected closure from a healthy blocking task that already completed, avoiding empty fallback jobs behind a blocked destructor.
- Add two deterministic regressions: one occupies the sole blocking worker and proves a hostile blocking destructor neither runs on nor blocks the *submitting* thread, and one tears a runtime down from the embedding host's own thread and proves the same for the host.
- Document that detached disposal is detached from the caller, not from a healthy runtime's blocking-pool lifetime, plus the embedding-host `Runtime::shutdown_timeout` / `Runtime::shutdown_background` mitigation and what that mitigation costs.

## Root cause and impact

Tokio preserves compatibility by returning a `JoinHandle` when `spawn_blocking` is called after its blocking pool starts shutting down, while synchronously destroying the submitted closure. The previous unconditional return then dropped the disposal job's last `Arc` on the submitting thread, so a blocking user destructor could stall runtime teardown despite Shelterwood's isolation guarantee.

The fix detects that the caller's job is the sole remaining strong reference and still contains pending work, then routes it through the existing non-runtime fallback queue. The pending-work check prevents a fast, successfully completed blocking task from spuriously enqueueing an empty job.

## Scope of the guarantee

The isolation guarantee this restores is about the **submitting** thread. Two adjacent behaviors are unchanged and intentional:

- **Plain `drop(runtime)` still blocks indefinitely on a hostile destructor.** `Runtime::drop` shuts the scheduler down *before* the blocking pool, so a disposal submitted from task drop glue is accepted and queued rather than rejected. A blocking-pool worker later drains and destroys it, and `BlockingPool::shutdown(None)` joins that worker. Verified by repro. This is the case the new doc paragraph describes, and the fix is what makes its stated mitigation actually work: before this change `shutdown_timeout` / `shutdown_background` hit the *rejected* path and deadlocked the host thread too, so the documented escape hatch was not one.
- **Disposal is deferred past the return of `shutdown_timeout` / `shutdown_background`.** Where the old inline path destroyed the value before returning, it now runs on a Shelterwood-owned thread that nothing joins, so a host that exits the process immediately afterwards loses those destructors. Now stated in `docs/shutdown-and-resources.md`.

## Item / commit mapping

1. **Shut-down blocking-pool fallback and regression** — `8c710c4 fix disposal during blocking-pool shutdown`
2. **Runtime-lifetime documentation from #192** — `28e6d85 document disposal runtime lifetime`
3. **Adversarial review hardening of closure-outcome detection** — `e08e8a7 distinguish completed disposal submissions`
4. **Second adversarial review round: embedder-thread regression, non-vacuous assertions, doc and comment gaps** — `3dee73d Pin embedder-thread disposal isolation`

## Review notes addressed in commit 4

- The original regression's "teardown thread" is a `tokio-rt-worker` draining its queue, not the embedding host's thread. The host-thread shape — the one #205 actually names — was untested, and it is strictly worse pre-fix: `shutdown_background()` never returns. `embedder_runtime_teardown_isolates_a_task_held_value` covers it.
- `assert_ne!(destructor_thread, shutdown_thread)` was vacuous; that variable held the test's own thread, which never submits the disposal on either path. Replaced with an assertion that the destructor lands on the named shared fallback thread, which pins where isolated destruction goes rather than only where it does not.
- Both hostile destructors get a bounded escape hatch, unreachable on a correct run, so a regression reports a thread-identity assertion instead of hanging until nextest's `terminate-after`.
- The classifier's dependence on Tokio destroying a rejected closure before `spawn_blocking` returns is now recorded, along with the fact that a future Tokio deferring that drop degrades fail-safe to the old inline behavior rather than misrouting a live closure.

## Not in scope

- The driver-task cancellation test gap noted in the second half of #205 (`classify_root_driver_join` / the `spawn_system` lifecycle monitor, `driver.rs:107-154`). **#205 stays open after this merges.**
- `spawn_blocking_work` reaches the same Tokio rejection path with no handling, and `join_resuming` turns the resulting cancellation into an invariant panic. Filed separately as #222.

## Validation

- `./tools/dev cargo nextest run -p shelterwood --lib runtime::disposal` — 4 passed; both regressions confirmed to fail with clean thread-identity assertions when the fall-through is disabled.
- Flake checks on the disposal tests: 200/200 serial, 384/384 at 48-way process concurrency.
- Race stress (not committed): 40 rounds × 64 concurrent `dispose_then` submissions staggered against `shutdown_background`, plus `dispose_all` across the same edge — every value destroyed exactly once and every completion fired exactly once.
- `./tools/dev just ci` — passed, including clippy, 578 nextest tests, doctests, rustdoc, path/API checks, packaged docs/crate, and Nix formatting.
- `./tools/dev just ci-nix` — all authoritative clean Nix checks passed (run on commit 3).

Refs #205
Related to #192, #222
