### PR TITLE
Fence scope shutdown on epilogue completion

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2227,26 +2227,36 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
   the funnel, but the draining parent schedules nothing — §10's mode
   dispatch.)
 - The owner has two further consuming awaits. `shutdown(timeout)` requests
-  the §10 ladder and waits until every descendant is stopped *and joined*.
+  the §10 ladder and waits for the root driver's terminal epilogue. While a
+  framework driver remains scheduled, it joins each child before completing.
   The timeout bounds the **cooperative** phase, not the return: at expiry
-  the stragglers are hard-aborted recursively and joined, and the call
-  returns the structured shutdown-timeout error (§7) naming them. That
-  final join is the one unbounded remainder — a hard-aborted future can
-  block arbitrarily in `Drop`, and returning before the join would leave
-  teardown running concurrently with the caller, the worse contract;
-  `run_blocking` threads detach past abort (§5.5) and are never joined.
+  the stragglers owned by scheduled drivers are hard-aborted and joined, and
+  the call returns the structured shutdown-timeout error (§7) naming them.
+  There is one recursive-join exception: if a framework driver misses its
+  abort acknowledgement and its ancestor hard-aborts it at the tidy-beat
+  backstop, the driver's synchronous `Drop` epilogue requests abort for its
+  active children but cannot await their join handles. Those deeper tasks
+  may finish cancellation and destroy their user futures after the owner's
+  call returns. The return still joins the root driver and completes the
+  target scope epilogue; that epilogue has requested stop or abort for each
+  directly owned child. It does not claim either a recursive join or completed
+  abort propagation through deeper fallback boundaries.
+  `run_blocking` threads are a separate, unconditional detach-past-abort
+  exception (§5.5) and are never joined.
   Expiry does not bypass the single ladder: the stragglers are driven
   through its abort tail — abort token, one tidy-abort beat, hard abort
-  (§10) — concurrently, then joined. A
+  (§10) — concurrently, then joined while their scope driver remains
+  scheduled. A
   zero timeout skips only the cooperative *wait*: every descendant is
   escalated immediately through that same abort tail (tokens still fire
   in order, the tidy beat still runs — `shutdown(0)` means "every child
   under `Abort` policy", §10, not a second mechanism), then the same
-  joins. The zero form is exempt from Appendix B's
+  driver-owned joins. The zero form is exempt from Appendix B's
   zero-budget-fails-immediately rule (stated there): this timeout is an
-  escalation bound, not a failure deadline. Nothing continues tearing
-  down after it returns, and consuming the owner is what makes the wait
-  explicit. `wait()` awaits natural termination without requesting
+  escalation bound, not a failure deadline. Except for the documented
+  hard-abort fallback and `run_blocking` detach boundaries, no teardown
+  remains after return; consuming the owner makes that wait explicit.
+  `wait()` awaits natural termination without requesting
   shutdown, and resolves with the root's terminal reason (B.6:
   `Finished`, `IntensityTripped`, or `ShutdownRequested` when teardown
   was requested concurrently elsewhere);
@@ -3617,7 +3627,10 @@ implied on all; error/outcome types are B.3 and B.8):
   landing in a restart window is held by §10's pending-incarnation
   stop latch and armed onto the next incarnation, which
   starts and immediately begins teardown), and the call resolves once
-  *that incarnation* is stopped and joined. Under a parent `Always`
+  *that incarnation* has finished its scope epilogue. On the ordinary
+  teardown path that includes joining its children; §11 defines the
+  recursive-join exception when an ancestor hard-aborts a framework driver.
+  Under a parent `Always`
   policy (§11's nested-shutdown rule) a fresh incarnation may already
   be running at resolution — the contract is about the incarnation the
   latch stopped, deliberately not about the membership. A **pre-spawn**
@@ -3688,15 +3701,16 @@ enums are non-exhaustive.
 - `shutdown(self, timeout) -> Result<(), ShutdownTimeout>` — `Ok` iff
   every descendant stopped within the cooperative phase;
   `ShutdownTimeout` is §7's structured straggler report (child-id
-  paths with membership tokens). Fully joined on return either way
-  (§11).
+  paths with membership tokens). The root driver is joined on return either
+  way; recursive joining is subject to §11's hard-abort fallback boundary.
 - `wait(self) -> StopReason` — infallible; `StopReason` is B.6's
   `Stopped { reason }` payload (`IntensityTripped` and `StartupFailed`
   carrying their structured data).
 - `shutdown_and_wait(&self, timeout) -> Result<(), ShutdownTimeout>` —
   the owner's `shutdown` shapes on the non-owning handle (semantics
   above); an already-terminal scope resolves `Ok` immediately only after any
-  live incarnation has finished its scope epilogue.
+  live incarnation has finished its scope epilogue. Descendant joining is
+  subject to §11's hard-abort fallback boundary.
 - `wait_stopped(&self) -> StopReason` — the membership's terminal
   reason, `NeverStarted` included (§3.2).
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -3638,19 +3638,44 @@ implied on all; error/outcome types are B.3 and B.8):
   incarnation has ever existed, so the request arms §10's pending
   latch and waits for the first incarnation, which starts and
   immediately begins teardown. The timeout is an escalation bound on a
-  live teardown and **arms only when the latch begins acting** — at
-  that incarnation's start — never at the call: pre-spawn there is
+  live teardown and **arms only when the latch begins acting** — at that
+  incarnation's *drain entry*, never at the call: pre-spawn there is
   nothing to escalate, and the call waits exactly as a parked send
   does, bounded by §3.2's no-hang rule — a membership terminalized
   with no incarnation ever spawned (tree dropped unspawned, rejected
   or withdrawn insertion) resolves the call immediately as
-  already-stopped. Concurrent
+  already-stopped. Drain entry is the precise arming edge because the
+  budget bounds the **cooperative** phase: the incarnation must first get
+  the wake in which it consumes the latch, enters `Draining`, and starts
+  each child's stop ladder, or a zero budget would report every child that
+  cooperates on that wake — and every child sitting in a restart backoff
+  window — as a straggler, which §7's report explicitly is not for. One
+  consequence is normative: when an ancestor hard-aborts the incarnation
+  **before** it reaches drain entry, the latch never acts and the budget
+  never arms, so there is no cooperative phase to bound and no straggler
+  report to make. The call then waits on that incarnation's drop epilogue
+  — synchronous, awaiting nothing (§11's fallback boundary) — and resolves
+  `Ok`. A caller therefore cannot use this timeout to bound its own
+  return; the return is bounded by the epilogue, as it is on the ordinary
+  path once the budget expires (§11's unbounded join remainder).
+  Concurrent
   callers ride one latch and observe one teardown. A scope whose
   membership is already terminal resolves immediately only when its scope
   projection is `Unstarted` or `Stopped`; if parent teardown published
   terminal membership before a live incarnation's epilogue, the call still
   waits for that incarnation to finish (`Ok` — the terminal state is
   `wait_stopped()`'s and the snapshot's to report, not this call's).
+  That settlement test reads membership and scope projection as two
+  planes, not one atomic fact: a nested driver already inside its first
+  poll when its ancestor publishes terminal membership still reaches
+  `begin_incarnation`, so a wait can settle a hair before that epoch
+  becomes visible. The window is sanctioned rather than closed — the
+  incarnation publishes `Starting` from `begin_incarnation`, superseding
+  the stale `Unstarted`/`Stopped` projection under the same observation
+  gate *before* any of that incarnation's user code runs, and its epoch
+  owner still publishes the final `Stopped` projection — so the settled
+  call reports the state that held at its own resolution and the later
+  incarnation remains `wait_stopped()`'s and the snapshot's to report.
   `wait_stopped()` is the membership-level await — the scope
   analogue of `TaskRef::wait()`: it rides restarts and resolves at
   membership terminality with the scope's terminal state

--- a/SPEC.md
+++ b/SPEC.md
@@ -3632,10 +3632,13 @@ implied on all; error/outcome types are B.3 and B.8):
   with no incarnation ever spawned (tree dropped unspawned, rejected
   or withdrawn insertion) resolves the call immediately as
   already-stopped. Concurrent
-  callers ride one latch and observe one teardown; a scope whose
-  membership is already terminal resolves immediately (`Ok` — its
-  terminal state is `wait_stopped()`'s and the snapshot's to report,
-  not this call's). `wait_stopped()` is the membership-level await — the scope
+  callers ride one latch and observe one teardown. A scope whose
+  membership is already terminal resolves immediately only when its scope
+  projection is `Unstarted` or `Stopped`; if parent teardown published
+  terminal membership before a live incarnation's epilogue, the call still
+  waits for that incarnation to finish (`Ok` — the terminal state is
+  `wait_stopped()`'s and the snapshot's to report, not this call's).
+  `wait_stopped()` is the membership-level await — the scope
   analogue of `TaskRef::wait()`: it rides restarts and resolves at
   membership terminality with the scope's terminal state
   (`Stopped { reason: NeverStarted }` for a scope membership that
@@ -3692,7 +3695,8 @@ enums are non-exhaustive.
   carrying their structured data).
 - `shutdown_and_wait(&self, timeout) -> Result<(), ShutdownTimeout>` —
   the owner's `shutdown` shapes on the non-owning handle (semantics
-  above); an already-terminal scope resolves `Ok` immediately.
+  above); an already-terminal scope resolves `Ok` immediately only after any
+  live incarnation has finished its scope epilogue.
 - `wait_stopped(&self) -> StopReason` — the membership's terminal
   reason, `NeverStarted` included (§3.2).
 

--- a/crates/shelterwood/doctests/docs/embedding.md
+++ b/crates/shelterwood/doctests/docs/embedding.md
@@ -60,11 +60,14 @@ each fresh tree or actor incarnation.
 5. Call `system.shutdown(timeout).await` before closing host resources or
    destroying the runtime.
 6. Inspect a structured timeout report if cooperative teardown exceeded its
-   budget; all actor futures are nevertheless joined when the call returns.
+   budget. The root driver is joined on return; a nested framework driver that
+   hits the hard-abort fallback can leave deeper task cancellation finishing
+   asynchronously, as detailed in the shutdown guide.
 7. Build a new tree for another cycle. Builders and `System` are single-use by
    design; durable host state is what crosses cycles.
 
 Dropping `System` also requests graceful shutdown, but awaiting explicit
-shutdown is the only way for the host to know teardown has joined and to receive
+shutdown is the only way for the host to join the root driver and receive
 straggler evidence. See [shutdown and resource ownership](shutdown-and-resources.md)
-for grace, blocking-work, and teardown-notification rules.
+for the recursive hard-abort boundary, grace, blocking-work, and
+teardown-notification rules.

--- a/crates/shelterwood/doctests/docs/shutdown-and-resources.md
+++ b/crates/shelterwood/doctests/docs/shutdown-and-resources.md
@@ -102,6 +102,14 @@ after it expires Shelterwood escalates stragglers, so destruction of user
 futures can make the final return take longer. A zero timeout skips the
 cooperative wait but still follows token ordering and the tidy beat.
 
+The budget arms when the targeted incarnation enters its drain, not when the
+call is made: a child that cooperates on that first teardown wake, or that is
+sitting in a restart backoff window, is not a straggler. An incarnation its
+ancestor hard-aborts before it ever reaches drain entry therefore has no
+cooperative phase to bound — `shutdown_and_wait` waits on its drop epilogue
+and resolves `Ok` rather than reporting a timeout. Neither form of the call
+uses this timeout to bound its own return.
+
 Normally each scheduled scope driver joins its children before completing. A
 framework driver that misses its abort acknowledgement may instead be
 hard-aborted by its ancestor at the tidy-beat backstop. Its synchronous drop

--- a/crates/shelterwood/doctests/docs/shutdown-and-resources.md
+++ b/crates/shelterwood/doctests/docs/shutdown-and-resources.md
@@ -40,10 +40,11 @@ depend on such a notification arriving; scope order and cancellation tokens
 are the reliable control plane.
 
 Ordered scopes stop children in reverse declaration order, one fully joined
-child at a time. Put a slow resource owner earlier in declaration order so its
-dependents stop first and its close runs quiescent. Per-child graces therefore
-sum in an ordered scope. Dynamic scopes start all stop ladders together and
-drain concurrently.
+child at a time while the scope driver remains scheduled. Put a slow resource
+owner earlier in declaration order so its dependents stop first and its close
+runs quiescent. Per-child graces therefore sum in an ordered scope. Dynamic
+scopes start all stop ladders together and drain concurrently. The hard-abort
+fallback exception is described below.
 
 ## Raw actors must implement the drain policy
 
@@ -96,10 +97,22 @@ from `StopContext`.
 ## Owner and runtime lifetime
 
 `System::shutdown(timeout)` consumes the owner, requests teardown, and joins
-every descendant before returning. The timeout bounds the cooperative phase;
-after it expires Shelterwood escalates and joins stragglers, so destruction of
-user futures can make the final return take longer. A zero timeout skips the
+the root driver before returning. The timeout bounds the cooperative phase;
+after it expires Shelterwood escalates stragglers, so destruction of user
+futures can make the final return take longer. A zero timeout skips the
 cooperative wait but still follows token ordering and the tidy beat.
+
+Normally each scheduled scope driver joins its children before completing. A
+framework driver that misses its abort acknowledgement may instead be
+hard-aborted by its ancestor at the tidy-beat backstop. Its synchronous drop
+epilogue requests abort for active children but cannot await their join
+handles, so deeper task cancellation and user-future destruction may complete
+after `System::shutdown` or `shutdown_and_wait` returns. Return guarantees that
+the root driver is joined and the target scope epilogue is complete; that
+epilogue has requested stop or abort for each directly owned child. It does not
+guarantee either a recursive join or completed abort propagation through deeper
+fallback boundaries. `run_blocking` threads have the separate detach behavior
+described above.
 
 Dropping `System` requests graceful shutdown, but an embedding host should
 normally await `shutdown` before tearing down the Tokio runtime. The ambient

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -1865,6 +1865,21 @@ impl ScopeCell {
         control.epochs.finished(epoch)
     }
 
+    /// Whether a shutdown wait has crossed the finality fence for its target.
+    ///
+    /// Membership terminality alone is insufficient: parent-driver
+    /// destruction publishes it before the aborted nested driver runs the
+    /// scope epilogue that finishes the incarnation and publishes `Stopped`.
+    /// `None` is used only by the entry check, before a target epoch exists.
+    pub(crate) fn scope_settled(&self, epoch: Option<Epoch>) -> bool {
+        epoch.is_some_and(|epoch| self.incarnation_finished(epoch))
+            || (matches!(self.member.record().stage, MemberStage::Terminal(_))
+                && matches!(
+                    self.record().state,
+                    ScopeState::Stopped { .. } | ScopeState::Unstarted
+                ))
+    }
+
     pub(crate) fn set_admitted_children(self: &Arc<Self>, children: Vec<ResidentProjection>) {
         self.with_observation_gate(|wakes| {
             self.clear_residents_locked(wakes);

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -1614,6 +1614,18 @@ impl ScopeCell {
         self.with_observation_gate(|wakes| {
             let mut control = self.control.lock().expect("scope control mutex poisoned");
             let epoch = control.epochs.begin()?;
+            // The idle epoch plane pairs only with a settled projection:
+            // `Unstarted` before any mint, `Stopped` after every finish. That
+            // pairing is what lets `scope_settled` treat terminal membership
+            // plus a settled projection as final without stranding a scope
+            // that still owns a live incarnation.
+            debug_assert!(
+                matches!(
+                    self.record().state,
+                    ScopeState::Unstarted | ScopeState::Stopped { .. }
+                ),
+                "an idle scope projection is Unstarted or Stopped before a fresh incarnation mints"
+            );
             self.observation.record.modify_silently(|record| {
                 record.total_restarts = TotalRestarts::ZERO;
                 record.startup = None;
@@ -1871,6 +1883,20 @@ impl ScopeCell {
     /// destruction publishes it before the aborted nested driver runs the
     /// scope epilogue that finishes the incarnation and publishes `Stopped`.
     /// `None` is used only by the entry check, before a target epoch exists.
+    ///
+    /// This predicate is strictly weaker than membership terminality, so
+    /// shutdown liveness now rests on two structural invariants. First, every
+    /// live epoch has exactly one owner — the pre-driver epoch guard before a
+    /// scope runtime exists, the scope runtime itself afterwards — and both
+    /// finish it from `Drop`, so an unsettled target always has a pending
+    /// finisher. Second, an idle epoch plane implies a settled projection:
+    /// `begin_incarnation` is the only mint and it publishes `Starting`
+    /// under the control guard,
+    /// while [`Self::finish_incarnation`] always publishes `Stopped` under
+    /// that same guard, so `ScopeEpochs::Idle`/`Exhausted` can only pair with
+    /// `Unstarted` (never begun) or `Stopped`. Together they mean the
+    /// terminal-membership arm can never be the *only* reachable settlement
+    /// for a scope that still owns work.
     pub(crate) fn scope_settled(&self, epoch: Option<Epoch>) -> bool {
         epoch.is_some_and(|epoch| self.incarnation_finished(epoch))
             || (matches!(self.member.record().stage, MemberStage::Terminal(_))

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -26,9 +26,7 @@ fn collect_stragglers(scope: &ScopeCell, prefix: &[ChildId], out: &mut Vec<Shutd
 async fn wait_for_incarnation(scope: &ScopeCell, epoch: Epoch) {
     let mut watcher = scope.signal().watcher();
     loop {
-        if scope.incarnation_finished(epoch)
-            || matches!(scope.member.record().stage, MemberStage::Terminal(_))
-        {
+        if scope.scope_settled(Some(epoch)) {
             return;
         }
         watcher.changed().await;
@@ -39,7 +37,7 @@ pub(crate) async fn shutdown_scope(
     scope: Arc<ScopeCell>,
     timeout: Duration,
 ) -> Result<(), ShutdownTimeout> {
-    if matches!(scope.member.record().stage, MemberStage::Terminal(_)) {
+    if scope.scope_settled(None) {
         return Ok(());
     }
     let Some(epoch) = scope.request_shutdown() else {
@@ -48,9 +46,7 @@ pub(crate) async fn shutdown_scope(
     };
     let mut watcher = scope.signal().watcher();
     loop {
-        if scope.incarnation_finished(epoch)
-            || matches!(scope.member.record().stage, MemberStage::Terminal(_))
-        {
+        if scope.scope_settled(Some(epoch)) {
             return Ok(());
         }
         if matches!(scope.record().state, ScopeState::Draining) {

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -342,6 +342,140 @@ async fn terminal_scope_in_drain_waits_for_its_live_incarnation_to_stop() {
     shutdown.await.expect("the target incarnation settled");
 }
 
+/// The `#201` published state with a *real* driver behind it: a nested
+/// `ScopeRuntime` whose task the ancestor hard-aborted, so the settlement the
+/// fence waits on is the one the production epilogue actually performs.
+struct AbortedNestedDriverFixture {
+    parent: Arc<ScopeCell>,
+    nested: Arc<ScopeCell>,
+    incarnation: crate::identity::Incarnation,
+    driver: ScopeRuntime,
+    _events: crate::runtime::UnboundedMpscReceiver<DriverEvent>,
+    _disposal_events: crate::runtime::UnboundedMpscReceiver<DriverEvent>,
+}
+
+impl AbortedNestedDriverFixture {
+    fn new() -> Self {
+        let parent = isolated_scope("parent", ScopeFlavor::Ordered);
+        let nested = isolated_scope("nested", ScopeFlavor::Ordered);
+        let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
+        parent.set_admitted_children(vec![resident_projection(&slot)]);
+
+        let epoch = nested
+            .begin_incarnation(ScopeState::Starting)
+            .expect("nested scope epoch is available");
+        let mut incarnations = IncarnationCounter::fixture(nested.member.membership());
+        let incarnation = incarnations.mint().expect("child incarnation is available");
+        nested.member.update(|record| {
+            record.stage = MemberStage::Running;
+            record.incarnation = Some(incarnation);
+            record.last_incarnation = Some(incarnation);
+        });
+        nested.set_state(ScopeState::Running);
+        nested.set_admitted_children(Vec::new());
+
+        let (events, events_receiver) = crate::runtime::unbounded_mpsc();
+        let (disposal_events, disposal_receiver) = crate::runtime::unbounded_mpsc();
+        let driver = ScopeRuntimeBuilder::new(Arc::clone(&nested), epoch, events, disposal_events)
+            .with_lifecycle(ScopeLifecycle::running())
+            .build();
+        Self {
+            parent,
+            nested,
+            incarnation,
+            driver,
+            _events: events_receiver,
+            _disposal_events: disposal_receiver,
+        }
+    }
+
+    /// The ancestor's destruction edge: membership terminality is published
+    /// while the nested driver still owns its unfinished incarnation.
+    fn terminalize_from_parent(&self) {
+        assert!(self.parent.terminalize_child(
+            &self.nested.member,
+            Exit::new(
+                ExitKind::Aborted {
+                    phase: GracePhase::WithinGrace,
+                },
+                Cancellation::Observed,
+            ),
+            Some(self.incarnation),
+            StartupDisposition::NotAborted,
+        ));
+    }
+
+    fn scope_ref(&self) -> ScopeRef {
+        ScopeRef {
+            cell: Arc::clone(&self.nested),
+        }
+    }
+}
+
+#[crate::runtime::test]
+async fn aborted_nested_driver_epilogue_settles_a_shutdown_wait() {
+    let fixture = AbortedNestedDriverFixture::new();
+    let scope = fixture.scope_ref();
+    let mut shutdown = Box::pin(scope.shutdown_and_wait(Duration::from_secs(10)));
+    assert!(
+        std::future::poll_fn(|context| Poll::Ready(shutdown.as_mut().poll(context)))
+            .await
+            .is_pending(),
+        "the live incarnation accepts its shutdown request"
+    );
+
+    fixture.terminalize_from_parent();
+    assert!(
+        std::future::poll_fn(|context| Poll::Ready(shutdown.as_mut().poll(context)))
+            .await
+            .is_pending(),
+        "published membership terminality is not the nested epilogue"
+    );
+
+    // Tokio finally drops the hard-aborted driver's frame. Its synchronous
+    // epilogue is the whole settlement: nothing else can finish this epoch.
+    drop(fixture.driver);
+    assert!(
+        matches!(
+            std::future::poll_fn(|context| Poll::Ready(shutdown.as_mut().poll(context))).await,
+            Poll::Ready(Ok(()))
+        ),
+        "the aborted driver's epilogue settles the fence"
+    );
+    assert!(matches!(
+        fixture.nested.record().state,
+        ScopeState::Stopped { .. }
+    ));
+}
+
+#[crate::runtime::test]
+async fn aborted_nested_driver_epilogue_wakes_a_parked_shutdown_task() {
+    // Manual polling would hide a missing pulse, so this waiter is a real
+    // task: it can only resolve if the epilogue actually wakes it.
+    let fixture = AbortedNestedDriverFixture::new();
+    let scope = fixture.scope_ref();
+    let waiter =
+        crate::runtime::spawn(
+            async move { scope.shutdown_and_wait(Duration::from_secs(30)).await },
+        );
+    crate::runtime::yield_now().await;
+    fixture.terminalize_from_parent();
+    crate::runtime::yield_now().await;
+    drop(fixture.driver);
+
+    match crate::runtime::timeout(Duration::from_secs(5), crate::runtime::join(waiter)).await {
+        crate::runtime::Timeout::Completed(crate::runtime::JoinOutcome::Ok { value }) => {
+            value.expect("the target incarnation settled");
+        }
+        crate::runtime::Timeout::Completed(_) => {
+            panic!("the shutdown waiter task did not run to completion")
+        }
+        crate::runtime::Timeout::Elapsed => {
+            panic!("the scope epilogue never woke the parked shutdown waiter")
+        }
+    }
+}
+
 #[crate::runtime::test]
 async fn terminal_unstarted_scope_is_already_settled() {
     let scope = isolated_scope("scope", ScopeFlavor::Ordered);
@@ -548,6 +682,63 @@ async fn blocked_initial_scope_factory_owns_its_stop_epilogue() {
     assert!(matches!(
         crate::runtime::timeout(Duration::from_secs(2), waiter).await,
         crate::runtime::Timeout::Completed(StopReason::ShutdownRequested)
+    ));
+}
+
+/// The public-surface form of the `#201` window, plus B.9's arming edge: the
+/// ancestor's hard abort publishes terminal membership while the nested
+/// incarnation is still pre-drain, so `shutdown_and_wait` has no cooperative
+/// phase to bound and waits on the epilogue instead of expiring.
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 4)]
+async fn hard_aborted_incarnation_fences_shutdown_and_wait_without_arming_its_budget() {
+    let gate = Arc::new(FactoryGate::default());
+    let mut tree = Tree::new();
+    let nested = tree
+        .add_subtree(
+            "nested",
+            SubtreeDef::factory({
+                let gate = Arc::clone(&gate);
+                move || {
+                    gate.block();
+                    pending_tree()
+                }
+            }),
+        )
+        .expect("nested scope is valid");
+    let plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let epoch = ScopeEpochGuard::begin(&root).expect("parent epoch is available");
+    let driver = crate::runtime::spawn(run_scope_incarnation(plan, ScopeRole::Root, epoch));
+    let abort = driver.abort_handle();
+    assert!(matches!(
+        crate::runtime::timeout(Duration::from_secs(2), gate.wait_entered()).await,
+        crate::runtime::Timeout::Completed(())
+    ));
+
+    abort.abort();
+    assert!(matches!(
+        crate::runtime::join(driver).await,
+        crate::runtime::JoinOutcome::Cancelled
+    ));
+
+    // A budget far shorter than the blocked epilogue. It never arms: the
+    // incarnation was hard-aborted before drain entry, so there is no
+    // cooperative phase to escalate and no straggler report to make.
+    let mut shutdown = Box::pin(nested.shutdown_and_wait(Duration::from_millis(10)));
+    let inside_window =
+        crate::runtime::timeout(Duration::from_millis(250), shutdown.as_mut()).await;
+    gate.release();
+    assert!(
+        matches!(inside_window, crate::runtime::Timeout::Elapsed),
+        "shutdown_and_wait resolved inside the terminal-before-epilogue window"
+    );
+    assert!(matches!(
+        crate::runtime::timeout(Duration::from_secs(5), shutdown).await,
+        crate::runtime::Timeout::Completed(Ok(()))
+    ));
+    assert!(matches!(
+        nested.snapshot().state,
+        ScopeState::Stopped { .. }
     ));
 }
 

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -213,6 +213,17 @@ async fn terminal_scope_waits_for_its_live_incarnation_to_stop() {
     });
     nested.set_state(ScopeState::Running);
 
+    let nested_ref = ScopeRef {
+        cell: Arc::clone(&nested),
+    };
+    let mut parked_shutdown = Box::pin(nested_ref.shutdown_and_wait(Duration::from_secs(10)));
+    let first_shutdown_poll =
+        std::future::poll_fn(|context| Poll::Ready(parked_shutdown.as_mut().poll(context))).await;
+    assert!(
+        first_shutdown_poll.is_pending(),
+        "the live incarnation accepts its shutdown request before terminality"
+    );
+
     assert!(parent.terminalize_child(
         &nested.member,
         Exit::new(
@@ -225,9 +236,20 @@ async fn terminal_scope_waits_for_its_live_incarnation_to_stop() {
         StartupDisposition::NotAborted,
     ));
 
-    let nested_ref = ScopeRef {
-        cell: Arc::clone(&nested),
-    };
+    let before_epilogue =
+        std::future::poll_fn(|context| Poll::Ready(parked_shutdown.as_mut().poll(context))).await;
+    assert!(
+        before_epilogue.is_pending(),
+        "a parked shutdown wait must not treat published membership terminality as scope settlement"
+    );
+    let mut fresh_shutdown = Box::pin(nested_ref.shutdown_and_wait(Duration::from_secs(10)));
+    let fresh_before_epilogue =
+        std::future::poll_fn(|context| Poll::Ready(fresh_shutdown.as_mut().poll(context))).await;
+    assert!(
+        fresh_before_epilogue.is_pending(),
+        "a fresh shutdown wait must not short-circuit during the terminal-before-epilogue window"
+    );
+
     let mut snapshot_waiter =
         Box::pin(nested_ref.wait_for_child("missing", |_| false, Duration::from_secs(10)));
     let first_snapshot_poll =
@@ -246,6 +268,12 @@ async fn terminal_scope_waits_for_its_live_incarnation_to_stop() {
     );
 
     nested.finish_incarnation(epoch, StopReason::ShutdownRequested);
+    parked_shutdown
+        .await
+        .expect("the target incarnation settled");
+    fresh_shutdown
+        .await
+        .expect("the target incarnation settled");
     assert_eq!(waiter.await, StopReason::ShutdownRequested);
     assert!(matches!(
         snapshot_waiter.await,
@@ -255,6 +283,63 @@ async fn terminal_scope_waits_for_its_live_incarnation_to_stop() {
             }
         })
     ));
+}
+
+#[crate::runtime::test]
+async fn terminal_scope_in_drain_waits_for_its_live_incarnation_to_stop() {
+    let parent = isolated_scope("parent", ScopeFlavor::Ordered);
+    let nested = isolated_scope("nested", ScopeFlavor::Ordered);
+    let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
+    parent.set_admitted_children(vec![resident_projection(&slot)]);
+
+    let epoch = nested
+        .begin_incarnation(ScopeState::Starting)
+        .expect("nested scope epoch is available");
+    let mut incarnations = IncarnationCounter::fixture(nested.member.membership());
+    let incarnation = incarnations.mint().expect("child incarnation is available");
+    nested.member.update(|record| {
+        record.stage = MemberStage::Running;
+        record.incarnation = Some(incarnation);
+        record.last_incarnation = Some(incarnation);
+    });
+    nested.set_state(ScopeState::Running);
+
+    let nested_ref = ScopeRef {
+        cell: Arc::clone(&nested),
+    };
+    let mut shutdown = Box::pin(nested_ref.shutdown_and_wait(Duration::from_secs(10)));
+    let accepted =
+        std::future::poll_fn(|context| Poll::Ready(shutdown.as_mut().poll(context))).await;
+    assert!(accepted.is_pending(), "the live shutdown request parks");
+
+    nested.set_state(ScopeState::Draining);
+    let draining =
+        std::future::poll_fn(|context| Poll::Ready(shutdown.as_mut().poll(context))).await;
+    assert!(
+        draining.is_pending(),
+        "the shutdown wait enters its incarnation-completion phase"
+    );
+
+    assert!(parent.terminalize_child(
+        &nested.member,
+        Exit::new(
+            ExitKind::Aborted {
+                phase: GracePhase::WithinGrace,
+            },
+            Cancellation::Observed,
+        ),
+        Some(incarnation),
+        StartupDisposition::NotAborted,
+    ));
+    let before_epilogue =
+        std::future::poll_fn(|context| Poll::Ready(shutdown.as_mut().poll(context))).await;
+    assert!(
+        before_epilogue.is_pending(),
+        "the completion wait must not treat published membership terminality as scope settlement"
+    );
+
+    nested.finish_incarnation(epoch, StopReason::ShutdownRequested);
+    shutdown.await.expect("the target incarnation settled");
 }
 
 #[crate::runtime::test]

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -343,6 +343,63 @@ async fn terminal_scope_in_drain_waits_for_its_live_incarnation_to_stop() {
 }
 
 #[crate::runtime::test]
+async fn terminal_unstarted_scope_is_already_settled() {
+    let scope = isolated_scope("scope", ScopeFlavor::Ordered);
+    scope
+        .member
+        .terminalize(Exit::never_started(), StartupDisposition::Unchanged);
+    assert_eq!(scope.record().state, ScopeState::Unstarted);
+
+    let scope_ref = ScopeRef { cell: scope };
+    let mut shutdown = Box::pin(scope_ref.shutdown_and_wait(Duration::from_secs(10)));
+    let first_poll =
+        std::future::poll_fn(|context| Poll::Ready(shutdown.as_mut().poll(context))).await;
+    assert!(
+        matches!(first_poll, Poll::Ready(Ok(()))),
+        "terminal membership with no spawned incarnation settles at entry"
+    );
+}
+
+#[crate::runtime::test]
+async fn shutdown_wait_settles_its_epoch_after_a_newer_incarnation_starts() {
+    let scope = isolated_scope("scope", ScopeFlavor::Ordered);
+    let first = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("first scope epoch is available");
+    scope.set_state(ScopeState::Running);
+    let scope_ref = ScopeRef {
+        cell: Arc::clone(&scope),
+    };
+    let mut shutdown = Box::pin(scope_ref.shutdown_and_wait(Duration::from_secs(10)));
+    let accepted =
+        std::future::poll_fn(|context| Poll::Ready(shutdown.as_mut().poll(context))).await;
+    assert!(
+        accepted.is_pending(),
+        "the first live epoch accepts shutdown"
+    );
+
+    scope.set_state(ScopeState::Draining);
+    let draining =
+        std::future::poll_fn(|context| Poll::Ready(shutdown.as_mut().poll(context))).await;
+    assert!(draining.is_pending(), "the waiter targets the first epoch");
+
+    scope.finish_incarnation(first, StopReason::ShutdownRequested);
+    let second = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("second scope epoch is available");
+    scope.set_state(ScopeState::Running);
+    let superseded =
+        std::future::poll_fn(|context| Poll::Ready(shutdown.as_mut().poll(context))).await;
+    assert!(
+        matches!(superseded, Poll::Ready(Ok(()))),
+        "a newer live incarnation must not extend the captured epoch's wait"
+    );
+    assert!(!scope.incarnation_finished(second));
+
+    scope.finish_incarnation(second, StopReason::Finished);
+}
+
+#[crate::runtime::test]
 async fn wait_for_child_reloads_after_its_predicate_closes_the_snapshot_stream() {
     let scope = isolated_scope("scope", ScopeFlavor::Ordered);
     let epoch = scope

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -602,6 +602,13 @@ impl ScopeEpochs {
             current,
             last_stopped,
         };
+        // A shutdown wait settles on `finished(target)`, so a freshly minted
+        // epoch must not already read as finished — that would settle a wait
+        // against the incarnation it just started.
+        debug_assert!(
+            !self.finished(current),
+            "a freshly minted epoch is not already finished"
+        );
         Some(current)
     }
 
@@ -635,6 +642,14 @@ impl ScopeEpochs {
                 *self = Self::Idle {
                     last_stopped: last_stopped.max(Some(epoch)),
                 };
+                // Settlement is monotone: once an owner finishes its epoch,
+                // every later `finished(epoch)` — including one asked across a
+                // subsequent incarnation — keeps reporting it. A waiter that
+                // missed the pulse can therefore never park forever.
+                debug_assert!(
+                    self.finished(epoch),
+                    "a finished epoch stays observably finished"
+                );
                 true
             }
             Self::Idle { .. } | Self::Live { .. } | Self::Exhausted { .. } => false,

--- a/crates/shelterwood/src/tree/dynamic_api.rs
+++ b/crates/shelterwood/src/tree/dynamic_api.rs
@@ -20,7 +20,21 @@ use super::{
 };
 
 impl ScopeRef {
-    /// Requests shutdown and waits for this scope to stop.
+    /// Requests shutdown and waits for this scope's incarnation to finish its
+    /// scope epilogue.
+    ///
+    /// `timeout` bounds cooperative teardown, not this call's return: it arms
+    /// when the targeted incarnation enters its drain and, once expired,
+    /// escalates and reports stragglers while the wait continues to
+    /// completion. Membership terminality published by an ancestor's teardown
+    /// does not resolve the call while that incarnation is still running its
+    /// epilogue.
+    ///
+    /// A scheduled scope driver joins its children before completing. If an
+    /// ancestor hard-aborts a framework driver at the tidy-abort backstop, its
+    /// synchronous drop epilogue can only *request* abort for active children,
+    /// so cancellation and user-future destruction below that boundary may
+    /// finish after this call returns.
     pub async fn shutdown_and_wait(&self, timeout: Duration) -> Result<(), ShutdownTimeout> {
         crate::driver::shutdown_scope(Arc::clone(&self.cell), timeout).await
     }
@@ -78,7 +92,11 @@ impl DynamicScopeRef {
             })
     }
 
-    /// Requests shutdown and waits for this scope to stop.
+    /// Requests shutdown and waits for this scope's incarnation to finish its
+    /// scope epilogue.
+    ///
+    /// See [`ScopeRef::shutdown_and_wait`] for the timeout's arming edge and
+    /// the hard-abort join boundary.
     pub async fn shutdown_and_wait(&self, timeout: Duration) -> Result<(), ShutdownTimeout> {
         self.0.shutdown_and_wait(timeout).await
     }

--- a/crates/shelterwood/src/tree/system.rs
+++ b/crates/shelterwood/src/tree/system.rs
@@ -211,11 +211,15 @@ impl<R> System<R> {
         }
     }
 
-    /// Requests shutdown, escalates at `timeout`, joins, and consumes owner.
+    /// Requests shutdown, escalates at `timeout`, joins the root driver, and
+    /// consumes the owner.
     ///
     /// `timeout` bounds cooperative teardown, not necessarily this method's
-    /// wall-clock return: after escalation every actor future is still joined.
-    /// Blocking threads created by `run_blocking` detach past hard abort.
+    /// wall-clock return. A nested framework driver normally joins its
+    /// children, but its hard-abort fallback can only request their abort from
+    /// its synchronous drop epilogue; deeper task destruction may therefore
+    /// finish after return. Blocking threads created by `run_blocking` detach
+    /// past hard abort independently of that fallback.
     pub async fn shutdown(mut self, timeout: Duration) -> Result<(), ShutdownTimeout> {
         self.run.shutdown(timeout).await
     }

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -60,11 +60,14 @@ each fresh tree or actor incarnation.
 5. Call `system.shutdown(timeout).await` before closing host resources or
    destroying the runtime.
 6. Inspect a structured timeout report if cooperative teardown exceeded its
-   budget; all actor futures are nevertheless joined when the call returns.
+   budget. The root driver is joined on return; a nested framework driver that
+   hits the hard-abort fallback can leave deeper task cancellation finishing
+   asynchronously, as detailed in the shutdown guide.
 7. Build a new tree for another cycle. Builders and `System` are single-use by
    design; durable host state is what crosses cycles.
 
 Dropping `System` also requests graceful shutdown, but awaiting explicit
-shutdown is the only way for the host to know teardown has joined and to receive
+shutdown is the only way for the host to join the root driver and receive
 straggler evidence. See [shutdown and resource ownership](shutdown-and-resources.md)
-for grace, blocking-work, and teardown-notification rules.
+for the recursive hard-abort boundary, grace, blocking-work, and
+teardown-notification rules.

--- a/docs/shutdown-and-resources.md
+++ b/docs/shutdown-and-resources.md
@@ -102,6 +102,14 @@ after it expires Shelterwood escalates stragglers, so destruction of user
 futures can make the final return take longer. A zero timeout skips the
 cooperative wait but still follows token ordering and the tidy beat.
 
+The budget arms when the targeted incarnation enters its drain, not when the
+call is made: a child that cooperates on that first teardown wake, or that is
+sitting in a restart backoff window, is not a straggler. An incarnation its
+ancestor hard-aborts before it ever reaches drain entry therefore has no
+cooperative phase to bound — `shutdown_and_wait` waits on its drop epilogue
+and resolves `Ok` rather than reporting a timeout. Neither form of the call
+uses this timeout to bound its own return.
+
 Normally each scheduled scope driver joins its children before completing. A
 framework driver that misses its abort acknowledgement may instead be
 hard-aborted by its ancestor at the tidy-beat backstop. Its synchronous drop

--- a/docs/shutdown-and-resources.md
+++ b/docs/shutdown-and-resources.md
@@ -40,10 +40,11 @@ depend on such a notification arriving; scope order and cancellation tokens
 are the reliable control plane.
 
 Ordered scopes stop children in reverse declaration order, one fully joined
-child at a time. Put a slow resource owner earlier in declaration order so its
-dependents stop first and its close runs quiescent. Per-child graces therefore
-sum in an ordered scope. Dynamic scopes start all stop ladders together and
-drain concurrently.
+child at a time while the scope driver remains scheduled. Put a slow resource
+owner earlier in declaration order so its dependents stop first and its close
+runs quiescent. Per-child graces therefore sum in an ordered scope. Dynamic
+scopes start all stop ladders together and drain concurrently. The hard-abort
+fallback exception is described below.
 
 ## Raw actors must implement the drain policy
 
@@ -96,10 +97,22 @@ from `StopContext`.
 ## Owner and runtime lifetime
 
 `System::shutdown(timeout)` consumes the owner, requests teardown, and joins
-every descendant before returning. The timeout bounds the cooperative phase;
-after it expires Shelterwood escalates and joins stragglers, so destruction of
-user futures can make the final return take longer. A zero timeout skips the
+the root driver before returning. The timeout bounds the cooperative phase;
+after it expires Shelterwood escalates stragglers, so destruction of user
+futures can make the final return take longer. A zero timeout skips the
 cooperative wait but still follows token ordering and the tidy beat.
+
+Normally each scheduled scope driver joins its children before completing. A
+framework driver that misses its abort acknowledgement may instead be
+hard-aborted by its ancestor at the tidy-beat backstop. Its synchronous drop
+epilogue requests abort for active children but cannot await their join
+handles, so deeper task cancellation and user-future destruction may complete
+after `System::shutdown` or `shutdown_and_wait` returns. Return guarantees that
+the root driver is joined and the target scope epilogue is complete; that
+epilogue has requested stop or abort for each directly owned child. It does not
+guarantee either a recursive join or completed abort propagation through deeper
+fallback boundaries. `run_blocking` threads have the separate detach behavior
+described above.
 
 Dropping `System` requests graceful shutdown, but an embedding host should
 normally await `shutdown` before tearing down the Tokio runtime. The ambient


### PR DESCRIPTION
## Summary

`shutdown_and_wait` previously treated published member terminality as proof that a scope incarnation had finished. On the hard-abort backstop, a parent can terminalize a nested member before Tokio drops the nested driver and runs its scope epilogue, so parked and fresh callers could return during that window.

This change introduces one `ScopeCell::scope_settled` finality predicate and uses it at all three shutdown checks. Terminal membership now settles a wait only with an `Unstarted`/`Stopped` scope projection; otherwise the targeted epoch must be finished.

## Item and commit mapping

- `03edc72` — **fence fix and regression coverage**
  - routes the entry check, pre-drain loop, and post-drain `wait_for_incarnation` loop through `scope_settled`
  - covers a caller parked before terminal publication, a fresh caller inside the published terminal-before-epilogue window, and a caller already in the post-drain completion phase
- `b44a862` — **follow-up 1: already-terminal semantics**
  - clarifies SPEC B.9: immediate `Ok` requires `Unstarted`/`Stopped`; a terminalized live incarnation still owns an epilogue fence
- `629a4a9` — **follow-up 2: recursive hard-abort join boundary**
  - corrects SPEC §11, public guides, packaged docs, and `System::shutdown` rustdoc so the current contract does not claim a recursive join across a fallback boundary
  - deliberately defers survivor-style join-obligation transfer: `ScopeRuntime::drop` is synchronous, and safely retaining/awaiting active child join handles requires an independently owned survivor plus lifecycle integration, which is a broader architecture change than this stage-0 point fix
- `7ba68ad` — **adversarial-review hardening**
  - pins the `Terminal + Unstarted` never-spawned settlement case and captured-epoch supersession

Both decisions are also recorded on issue #201.

## Impact

`shutdown_and_wait` no longer resolves while its target incarnation is still running its scope epilogue. The documented shutdown guarantee now matches the hard-abort implementation: the root driver is joined and the target scope epilogue completes, while deeper cancellation/destruction or abort propagation can remain in flight only across the explicitly documented fallback boundary.

## Validation

- `./tools/dev cargo test -p shelterwood driver::tests::observation::terminal_scope -- --nocapture`
- `./tools/dev just ci`
  - nightly rustfmt and clippy with warnings denied
  - 578/578 nextest tests
  - doctests and rustdoc
  - API reachability and enforcement checks
  - packaged-crate verification
  - Nix formatting check

Refs #201