### PR TITLE
Avoid dropping mailbox wakers under core locks

### DIFF
--- a/crates/shelterwood/src/mailbox/cell.rs
+++ b/crates/shelterwood/src/mailbox/cell.rs
@@ -1203,6 +1203,12 @@ pub(super) mod tests {
                 .mailbox
                 .upgrade()
                 .expect("the cancelling send retains its mailbox");
+            drop(
+                mailbox
+                    .state
+                    .try_lock()
+                    .expect("waker drop runs after the mailbox lock is released"),
+            );
             let error = mailbox
                 .try_send(2)
                 .expect_err("a reentrant try-send observes the unbound mailbox");

--- a/crates/shelterwood/src/mailbox/cell.rs
+++ b/crates/shelterwood/src/mailbox/cell.rs
@@ -732,7 +732,18 @@ impl<M: Send + 'static> MailboxCell<M> {
 }
 
 impl<M> MailboxCell<M> {
-    pub(super) fn withdraw(&self, operation: &Arc<SendOperation<M>>) -> Withdrawal<M> {
+    /// Withdraws a send operation and releases the waker it had registered.
+    ///
+    /// The waker is returned rather than destroyed here: a `RawWaker` vtable is
+    /// caller code, so only the caller knows whether its destructor may run
+    /// inline. Withdrawal guarantees only that neither core lock is held once
+    /// the waker is handed back, and that the recovered message is handed over
+    /// first, so a hostile waker destructor can neither poison a core mutex nor
+    /// divert the message from the caller's chosen disposal route.
+    pub(super) fn withdraw(
+        &self,
+        operation: &Arc<SendOperation<M>>,
+    ) -> (Withdrawal<M>, Option<Waker>) {
         let mut mailbox = self.state.lock().expect("mailbox mutex poisoned");
         let current_observation = match mailbox.status() {
             BindingStatus::Bound(incarnation) | BindingStatus::Frozen(incarnation) => {
@@ -766,24 +777,34 @@ impl<M> MailboxCell<M> {
                         state.waker.take(),
                     )
                 }
-                OperationOutcome::Accepted(incarnation) => (
-                    Withdrawal::Accepted(*incarnation),
-                    state.registration.take(),
-                    None,
-                ),
+                OperationOutcome::Accepted(incarnation) => {
+                    let incarnation = *incarnation;
+                    // Acceptance took the waker in the same critical section
+                    // that published this outcome, so no registration survives
+                    // it for withdrawal to release.
+                    debug_assert!(state.waker.is_none());
+                    (
+                        Withdrawal::Accepted(incarnation),
+                        state.registration.take(),
+                        None,
+                    )
+                }
                 OperationOutcome::Terminated {
                     message,
                     final_incarnation,
-                } => (
-                    Withdrawal::Terminated {
-                        message: message
-                            .take()
-                            .expect("a terminal operation must retain its message"),
-                        observed: *final_incarnation,
-                    },
-                    state.registration.take(),
-                    None,
-                ),
+                } => {
+                    let message = message
+                        .take()
+                        .expect("a terminal operation must retain its message");
+                    let observed = *final_incarnation;
+                    // Termination likewise took the waker before publishing.
+                    debug_assert!(state.waker.is_none());
+                    (
+                        Withdrawal::Terminated { message, observed },
+                        state.registration.take(),
+                        None,
+                    )
+                }
                 OperationOutcome::Withdrawn => {
                     panic!("a send operation was withdrawn more than once")
                 }
@@ -797,8 +818,7 @@ impl<M> MailboxCell<M> {
             }
         }
         drop(mailbox);
-        drop(waker);
-        result
+        (result, waker)
     }
 }
 
@@ -1302,7 +1322,7 @@ pub(super) mod tests {
 
         assert!(matches!(
             mailbox.withdraw(&operation),
-            super::Withdrawal::Withdrawn { message: 2, .. }
+            (super::Withdrawal::Withdrawn { message: 2, .. }, None)
         ));
         assert!(matches!(
             mailbox.state.lock().expect("mailbox mutex poisoned").binding,
@@ -1360,7 +1380,7 @@ pub(super) mod tests {
     }
 
     #[test]
-    fn cancelling_a_send_drops_its_waker_after_both_locks() {
+    fn withdrawal_releases_its_waker_instead_of_destroying_it_under_the_locks() {
         let (mailbox, _) = actor();
         let operation = match mailbox.submit(1) {
             super::Submission::Parked(operation) => operation,
@@ -1381,8 +1401,23 @@ pub(super) mod tests {
             .waker = Some(hostile.clone());
         drop(hostile);
 
-        let Err(panic) = catch_unwind(AssertUnwindSafe(|| mailbox.withdraw(&operation))) else {
-            panic!("the hostile waker drop panic remains caller-visible")
+        let (withdrawal, waker) = mailbox.withdraw(&operation);
+        assert!(matches!(
+            withdrawal,
+            super::Withdrawal::Withdrawn { message: 1, .. }
+        ));
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            0,
+            "withdrawal releases the waker rather than running its destructor"
+        );
+        let waker = waker.expect("withdrawal releases the waker the operation had registered");
+
+        // Whoever accepts the released waker runs its destructor with neither
+        // core lock held, so the reentrant probe inside it succeeds and its
+        // panic reaches only that owner.
+        let Err(panic) = catch_unwind(AssertUnwindSafe(move || drop(waker))) else {
+            panic!("the hostile waker drop panic reaches whoever destroys it")
         };
         assert_eq!(
             panic.downcast_ref::<&'static str>().copied(),

--- a/crates/shelterwood/src/mailbox/cell.rs
+++ b/crates/shelterwood/src/mailbox/cell.rs
@@ -740,7 +740,7 @@ impl<M> MailboxCell<M> {
             }
             BindingStatus::Unbound | BindingStatus::Terminal(_) => None,
         };
-        let (result, registration) = {
+        let (result, registration, waker) = {
             let mut state = operation
                 .state
                 .lock()
@@ -760,15 +760,16 @@ impl<M> MailboxCell<M> {
                     // (including zero-duration) deadline poll.
                     let observed = (*newest_observed).or(current_observation);
                     state.outcome = OperationOutcome::Withdrawn;
-                    state.waker = None;
                     (
                         Withdrawal::Withdrawn { message, observed },
                         state.registration.take(),
+                        state.waker.take(),
                     )
                 }
                 OperationOutcome::Accepted(incarnation) => (
                     Withdrawal::Accepted(*incarnation),
                     state.registration.take(),
+                    None,
                 ),
                 OperationOutcome::Terminated {
                     message,
@@ -781,6 +782,7 @@ impl<M> MailboxCell<M> {
                         observed: *final_incarnation,
                     },
                     state.registration.take(),
+                    None,
                 ),
                 OperationOutcome::Withdrawn => {
                     panic!("a send operation was withdrawn more than once")
@@ -794,6 +796,8 @@ impl<M> MailboxCell<M> {
                 debug_assert!(matches!(mailbox.status(), BindingStatus::Terminal(_)));
             }
         }
+        drop(mailbox);
+        drop(waker);
         result
     }
 }
@@ -1138,7 +1142,7 @@ pub(super) mod tests {
         future::Future,
         panic::{AssertUnwindSafe, catch_unwind},
         sync::{
-            Arc,
+            Arc, Weak,
             atomic::{AtomicUsize, Ordering},
         },
         task::{Context, Poll, Wake, Waker},
@@ -1167,6 +1171,46 @@ pub(super) mod tests {
     impl Wake for CountWake {
         fn wake(self: Arc<Self>) {
             self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct ReentrantPanicDrop {
+        mailbox: Weak<MailboxCell<u8>>,
+        operation: Weak<super::SendOperation<u8>>,
+        drops: Arc<AtomicUsize>,
+    }
+
+    impl Wake for ReentrantPanicDrop {
+        fn wake(self: Arc<Self>) {
+            panic!("the withdrawal regression only drops its waker")
+        }
+    }
+
+    impl Drop for ReentrantPanicDrop {
+        fn drop(&mut self) {
+            let operation = self
+                .operation
+                .upgrade()
+                .expect("the cancelling send retains its operation");
+            drop(
+                operation
+                    .state
+                    .try_lock()
+                    .expect("waker drop runs after the operation lock is released"),
+            );
+
+            let mailbox = self
+                .mailbox
+                .upgrade()
+                .expect("the cancelling send retains its mailbox");
+            let error = mailbox
+                .try_send(2)
+                .expect_err("a reentrant try-send observes the unbound mailbox");
+            assert_eq!(error.kind, SendErrorKind::NotRunning);
+            assert_eq!(error.message, 2);
+
+            self.drops.fetch_add(1, Ordering::SeqCst);
+            panic!("injected waker drop panic");
         }
     }
 
@@ -1306,6 +1350,54 @@ pub(super) mod tests {
         assert_eq!(
             waiters.direct_removals, SENDS,
             "mass cancellation must do one direct unlink per parked send"
+        );
+    }
+
+    #[test]
+    fn cancelling_a_send_drops_its_waker_after_both_locks() {
+        let (mailbox, _) = actor();
+        let operation = match mailbox.submit(1) {
+            super::Submission::Parked(operation) => operation,
+            super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+                panic!("an unbound mailbox parks its send")
+            }
+        };
+        let drops = Arc::new(AtomicUsize::new(0));
+        let hostile = Waker::from(Arc::new(ReentrantPanicDrop {
+            mailbox: Arc::downgrade(&mailbox),
+            operation: Arc::downgrade(&operation),
+            drops: Arc::clone(&drops),
+        }));
+        operation
+            .state
+            .lock()
+            .expect("send operation mutex poisoned")
+            .waker = Some(hostile.clone());
+        drop(hostile);
+
+        let Err(panic) = catch_unwind(AssertUnwindSafe(|| mailbox.withdraw(&operation))) else {
+            panic!("the hostile waker drop panic remains caller-visible")
+        };
+        assert_eq!(
+            panic.downcast_ref::<&'static str>().copied(),
+            Some("injected waker drop panic")
+        );
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        drop(
+            operation
+                .state
+                .lock()
+                .expect("hostile waker drop cannot poison the operation lock"),
+        );
+        let state = mailbox
+            .state
+            .lock()
+            .expect("hostile waker drop cannot poison the mailbox lock");
+        assert!(
+            state
+                .waiters()
+                .expect("an unbound mailbox retains its waiter queue")
+                .is_empty()
         );
     }
 

--- a/crates/shelterwood/src/mailbox/futures.rs
+++ b/crates/shelterwood/src/mailbox/futures.rs
@@ -4,7 +4,7 @@ use std::{
     hash::{Hash, Hasher},
     pin::Pin,
     sync::Arc,
-    task::{Context, Poll},
+    task::{Context, Poll, Waker},
     time::Duration,
 };
 
@@ -208,16 +208,23 @@ impl<M: Send + 'static> SendFuture<M> {
         }
     }
 
-    fn withdraw(&mut self) -> Withdrawal<M> {
+    /// Withdraws this send, also releasing any waker it had registered.
+    ///
+    /// The waker travels back to the caller unchanged: only the caller knows
+    /// whether a `RawWaker` destructor may run on its thread.
+    fn withdraw(&mut self) -> (Withdrawal<M>, Option<Waker>) {
         match std::mem::replace(&mut self.state, SendFutureState::Done) {
-            SendFutureState::Immediate(mut message) => Withdrawal::Withdrawn {
-                message: message
-                    .take()
-                    .expect("an unsubmitted send retains its message"),
-                observed: self.mailbox.current_observation(),
-            },
+            SendFutureState::Immediate(mut message) => (
+                Withdrawal::Withdrawn {
+                    message: message
+                        .take()
+                        .expect("an unsubmitted send retains its message"),
+                    observed: self.mailbox.current_observation(),
+                },
+                None,
+            ),
             SendFutureState::Parked(operation) => self.mailbox.withdraw(&operation),
-            SendFutureState::Sent(incarnation) => Withdrawal::Accepted(incarnation),
+            SendFutureState::Sent(incarnation) => (Withdrawal::Accepted(incarnation), None),
             SendFutureState::Done => panic!("a completed send was withdrawn"),
         }
     }
@@ -277,44 +284,68 @@ impl<M: Send + 'static> Future for SendFuture<M> {
         let SendFutureState::Parked(operation) = &this.state else {
             panic!("a completed send future was polled")
         };
-        // A RawWaker vtable is caller code: clone before taking the operation
-        // lock, and release the lock before destroying either this clone or a
-        // previously registered waker.
-        let next_waker = context.waker().clone();
-        let mut operation_state = operation
-            .state
-            .lock()
-            .expect("send operation mutex poisoned");
-        match &mut operation_state.outcome {
-            OperationOutcome::Accepted(incarnation) => {
-                let incarnation = *incarnation;
-                drop(operation_state);
-                this.state = SendFutureState::Sent(incarnation);
-                Poll::Ready(Ok(incarnation))
+        // A `RawWaker` vtable is caller code, so no branch here may run one
+        // under the operation lock, and a completing outcome must never depend
+        // on one at all. The loop inspects the outcome locked, then -- only
+        // when parking actually needs a different waker -- releases the lock to
+        // clone and comes back to install it. `will_wake` is a pointer
+        // comparison rather than a vtable call, so the repeat-poll fast path
+        // touches no caller code whatsoever.
+        //
+        // Reacquiring re-reads the outcome, so an acceptance or termination
+        // that lands in the unlocked window is reported instead of parked. The
+        // outcome transition and the waker take stay atomic under the operation
+        // lock in `SendOperation::accept`/`terminate`, so installing after that
+        // re-read cannot lose a wakeup: any completion ordered after it takes
+        // the waker this poll registered.
+        let mut cloned_waker: Option<Waker> = None;
+        loop {
+            let mut operation_state = operation
+                .state
+                .lock()
+                .expect("send operation mutex poisoned");
+            match &mut operation_state.outcome {
+                OperationOutcome::Accepted(incarnation) => {
+                    let incarnation = *incarnation;
+                    drop(operation_state);
+                    this.state = SendFutureState::Sent(incarnation);
+                    return Poll::Ready(Ok(incarnation));
+                }
+                OperationOutcome::Terminated {
+                    message,
+                    final_incarnation,
+                } => {
+                    let error = SendError {
+                        actor_id: this.mailbox.actor_id.clone(),
+                        incarnation_observed: *final_incarnation,
+                        message: message
+                            .take()
+                            .expect("a terminal operation retains its message until observed"),
+                        kind: SendErrorKind::Terminated,
+                    };
+                    drop(operation_state);
+                    this.state = SendFutureState::Done;
+                    return Poll::Ready(Err(error));
+                }
+                OperationOutcome::Waiting { .. } => {
+                    if let Some(next_waker) = cloned_waker.take() {
+                        let stale_waker = operation_state.waker.replace(next_waker);
+                        drop(operation_state);
+                        drop(stale_waker);
+                        return Poll::Pending;
+                    }
+                    if operation_state
+                        .waker
+                        .as_ref()
+                        .is_some_and(|registered| registered.will_wake(context.waker()))
+                    {
+                        return Poll::Pending;
+                    }
+                    drop(operation_state);
+                    cloned_waker = Some(context.waker().clone());
+                }
+                OperationOutcome::Withdrawn => panic!("a withdrawn send future was polled"),
             }
-            OperationOutcome::Terminated {
-                message,
-                final_incarnation,
-            } => {
-                let error = SendError {
-                    actor_id: this.mailbox.actor_id.clone(),
-                    incarnation_observed: *final_incarnation,
-                    message: message
-                        .take()
-                        .expect("a terminal operation retains its message until observed"),
-                    kind: SendErrorKind::Terminated,
-                };
-                drop(operation_state);
-                this.state = SendFutureState::Done;
-                Poll::Ready(Err(error))
-            }
-            OperationOutcome::Waiting { .. } => {
-                let stale_waker = operation_state.waker.replace(next_waker);
-                drop(operation_state);
-                drop(stale_waker);
-                Poll::Pending
-            }
-            OperationOutcome::Withdrawn => panic!("a withdrawn send future was polled"),
         }
     }
 }
@@ -331,12 +362,26 @@ impl<M> Drop for SendFuture<M> {
                     (self.dispose)(message);
                 }
             }
-            SendFutureState::Parked(operation) => match self.mailbox.withdraw(&operation) {
-                Withdrawal::Withdrawn { message, .. } | Withdrawal::Terminated { message, .. } => {
-                    (self.dispose)(message);
+            SendFutureState::Parked(operation) => {
+                let (withdrawal, waker) = self.mailbox.withdraw(&operation);
+                match withdrawal {
+                    Withdrawal::Withdrawn { message, .. }
+                    | Withdrawal::Terminated { message, .. } => {
+                        (self.dispose)(message);
+                    }
+                    Withdrawal::Accepted(_) => {}
                 }
-                Withdrawal::Accepted(_) => {}
-            },
+                // A RawWaker vtable is caller code and there is no caller left
+                // to surface a panic to. Destroying it inline would run a
+                // possibly blocking or panicking user destructor in this drop
+                // glue -- during an unwind that is a double panic and an abort
+                // -- so route it through isolated disposal like the message.
+                // Sequencing it after the message also keeps a hostile waker
+                // destructor from diverting the message from that route.
+                if let Some(waker) = waker {
+                    dispose_detached(waker);
+                }
+            }
             SendFutureState::Sent(_) | SendFutureState::Done => {}
         }
     }
@@ -363,7 +408,8 @@ impl<M> fmt::Debug for SendTimeout<M> {
 
 fn withdraw_send<M: Send + 'static>(send: &mut SendFuture<M>) -> Result<Incarnation, SendError<M>> {
     let actor_id = send.mailbox.actor_id.clone();
-    match send.withdraw() {
+    let (withdrawal, waker) = send.withdraw();
+    let result = match withdrawal {
         Withdrawal::Withdrawn { message, observed } => Err(SendError {
             actor_id,
             incarnation_observed: observed,
@@ -377,7 +423,13 @@ fn withdraw_send<M: Send + 'static>(send: &mut SendFuture<M>) -> Result<Incarnat
             message,
             kind: SendErrorKind::Terminated,
         }),
-    }
+    };
+    // Unlike the cancellation path this is a normal return on the caller's own
+    // task, so the caller's waker destructor stays inline and its panic stays
+    // visible; no core lock is held and the recovered message already belongs
+    // to `result`.
+    drop(waker);
+    result
 }
 
 impl<M: Send + 'static> DeadlineOperation for TimedSend<M> {
@@ -623,10 +675,12 @@ mod tests {
         future::Future,
         mem::ManuallyDrop,
         sync::{
-            Arc, Weak,
+            Arc, Mutex, Weak,
             atomic::{AtomicUsize, Ordering},
         },
-        task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+        task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker},
+        thread::ThreadId,
+        time::Duration,
     };
 
     use crate::{
@@ -635,7 +689,10 @@ mod tests {
         identity::ScopeIdentity,
     };
 
-    use super::{super::cell::tests::actor, ActorRef, MailboxCell, SendFutureState, SendOperation};
+    use super::{
+        super::cell::tests::actor, ActorRef, MailboxCell, SendFuture, SendFutureState,
+        SendOperation,
+    };
 
     #[derive(Default)]
     struct WakerVtableCalls {
@@ -810,5 +867,198 @@ mod tests {
         let state = mailbox.state.lock().expect("mailbox mutex poisoned");
         assert!(state.queue.is_empty());
         assert!(state.waiters().is_some_and(|waiters| waiters.is_empty()));
+    }
+
+    /// Records the thread a destructor ran on, so a test can tell an inline
+    /// destructor apart from one that reached isolated disposal.
+    type DisposalThread = Arc<Mutex<Option<ThreadId>>>;
+
+    fn disposal_thread() -> DisposalThread {
+        Arc::new(Mutex::new(None))
+    }
+
+    fn await_disposal(recorder: &DisposalThread) -> ThreadId {
+        for _ in 0..1_000 {
+            if let Some(thread) = *recorder.lock().expect("disposal recorder mutex") {
+                return thread;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        panic!("isolated disposal never destroyed the value")
+    }
+
+    /// A caller waker whose destructor records itself and then panics.
+    struct HostileWakerDrop(DisposalThread);
+
+    impl Wake for HostileWakerDrop {
+        fn wake(self: Arc<Self>) {
+            panic!("the cancellation regressions only destroy their waker")
+        }
+    }
+
+    impl Drop for HostileWakerDrop {
+        fn drop(&mut self) {
+            *self.0.lock().expect("disposal recorder mutex") = Some(std::thread::current().id());
+            panic!("injected waker drop panic");
+        }
+    }
+
+    struct ThreadRecordingDrop(DisposalThread);
+
+    impl Drop for ThreadRecordingDrop {
+        fn drop(&mut self) {
+            *self.0.lock().expect("disposal recorder mutex") = Some(std::thread::current().id());
+        }
+    }
+
+    /// Parks `send` behind a hostile waker and releases the caller's own
+    /// reference, leaving the registered clone as the last owner.
+    fn park_behind_hostile_waker<M: Send + 'static>(
+        send: &mut std::pin::Pin<Box<SendFuture<M>>>,
+        recorder: &DisposalThread,
+    ) {
+        let hostile = Waker::from(Arc::new(HostileWakerDrop(Arc::clone(recorder))));
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(&hostile))
+                .is_pending()
+        );
+        drop(hostile);
+    }
+
+    #[test]
+    fn cancelling_a_send_contains_a_hostile_waker_destructor() {
+        let (_, actor) = actor();
+        let mut send = Box::pin(actor.send(1u8));
+        let waker_thread = disposal_thread();
+        park_behind_hostile_waker(&mut send, &waker_thread);
+
+        // Cancellation is drop glue with no caller left to receive a panic, so
+        // the destructor must reach isolated disposal rather than run here.
+        drop(send);
+
+        assert_ne!(
+            await_disposal(&waker_thread),
+            std::thread::current().id(),
+            "a cancelled send disposes its waker off the cancelling thread"
+        );
+    }
+
+    #[test]
+    fn a_hostile_waker_destructor_cannot_double_panic_through_cancellation() {
+        let (_, actor) = actor();
+        let mut send = Box::pin(actor.send(1u8));
+        let waker_thread = disposal_thread();
+        park_behind_hostile_waker(&mut send, &waker_thread);
+
+        // Before containment this aborted the process: a panicking waker
+        // destructor reached from drop glue during an unwind is a double panic.
+        let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let _send = send;
+            panic!("primary unwind");
+        }))
+        .expect_err("the primary panic survives cancellation");
+        assert_eq!(
+            payload.downcast_ref::<&'static str>().copied(),
+            Some("primary unwind")
+        );
+        assert_ne!(await_disposal(&waker_thread), std::thread::current().id());
+    }
+
+    #[test]
+    fn a_hostile_waker_destructor_cannot_divert_a_cancelled_message() {
+        let mut identity = ScopeIdentity::new();
+        let id = ChildId::from("actor");
+        let member = MemberCell::new(
+            id.clone(),
+            identity.mint_membership(&id).expect("membership available"),
+        );
+        let mailbox: Arc<MailboxCell<ThreadRecordingDrop>> = MailboxCell::new(member.id().clone());
+        member.attach_mailbox(mailbox.clone());
+        let actor = ActorRef::new(member, Arc::clone(&mailbox));
+
+        let message_thread = disposal_thread();
+        let waker_thread = disposal_thread();
+        let mut send = Box::pin(actor.send(ThreadRecordingDrop(Arc::clone(&message_thread))));
+        park_behind_hostile_waker(&mut send, &waker_thread);
+
+        drop(send);
+
+        let here = std::thread::current().id();
+        assert_ne!(
+            await_disposal(&message_thread),
+            here,
+            "a hostile waker destructor cannot divert the message from isolated disposal"
+        );
+        assert_ne!(await_disposal(&waker_thread), here);
+    }
+
+    #[test]
+    fn a_completed_send_reports_its_outcome_without_touching_the_caller_vtable() {
+        let (mailbox, actor) = actor();
+        let mut send = Box::pin(actor.send(1));
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        let operation = match &send.as_ref().get_ref().state {
+            SendFutureState::Parked(operation) => Arc::clone(operation),
+            SendFutureState::Immediate(_) | SendFutureState::Sent(_) | SendFutureState::Done => {
+                panic!("an unbound mailbox parks its send")
+            }
+        };
+        let teardown =
+            MailboxControl::prepare_termination(&*mailbox).expect("the mailbox terminates once");
+        let _ = teardown.finish();
+
+        let calls = Arc::new(WakerVtableCalls::default());
+        let hostile = operation_lock_probe_waker(&operation, Arc::clone(&calls));
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(&hostile))
+                .is_ready()
+        );
+        assert_eq!(
+            calls.clones.load(Ordering::SeqCst),
+            0,
+            "a completing poll never speculatively clones the caller waker"
+        );
+        drop(hostile);
+        assert_eq!(calls.drops.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn repolling_a_parked_send_with_the_same_waker_touches_no_vtable() {
+        let (_, actor) = actor();
+        let mut send = Box::pin(actor.send(1));
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        let operation = match &send.as_ref().get_ref().state {
+            SendFutureState::Parked(operation) => Arc::clone(operation),
+            SendFutureState::Immediate(_) | SendFutureState::Sent(_) | SendFutureState::Done => {
+                panic!("an unbound mailbox parks its send")
+            }
+        };
+        let calls = Arc::new(WakerVtableCalls::default());
+        let hostile = operation_lock_probe_waker(&operation, Arc::clone(&calls));
+
+        for _ in 0..4 {
+            assert!(
+                send.as_mut()
+                    .poll(&mut Context::from_waker(&hostile))
+                    .is_pending()
+            );
+        }
+
+        assert_eq!(
+            calls.clones.load(Ordering::SeqCst),
+            1,
+            "will_wake registers once and skips the vtable on every repoll"
+        );
+        assert_eq!(calls.drops.load(Ordering::SeqCst), 0);
     }
 }

--- a/crates/shelterwood/src/mailbox/futures.rs
+++ b/crates/shelterwood/src/mailbox/futures.rs
@@ -277,6 +277,10 @@ impl<M: Send + 'static> Future for SendFuture<M> {
         let SendFutureState::Parked(operation) = &this.state else {
             panic!("a completed send future was polled")
         };
+        // A RawWaker vtable is caller code: clone before taking the operation
+        // lock, and release the lock before destroying either this clone or a
+        // previously registered waker.
+        let next_waker = context.waker().clone();
         let mut operation_state = operation
             .state
             .lock()
@@ -305,7 +309,9 @@ impl<M: Send + 'static> Future for SendFuture<M> {
                 Poll::Ready(Err(error))
             }
             OperationOutcome::Waiting { .. } => {
-                operation_state.waker = Some(context.waker().clone());
+                let stale_waker = operation_state.waker.replace(next_waker);
+                drop(operation_state);
+                drop(stale_waker);
                 Poll::Pending
             }
             OperationOutcome::Withdrawn => panic!("a withdrawn send future was polled"),
@@ -615,11 +621,12 @@ impl<M: Send + 'static, T: Send + 'static> Future for CallFuture<M, T> {
 mod tests {
     use std::{
         future::Future,
+        mem::ManuallyDrop,
         sync::{
-            Arc,
+            Arc, Weak,
             atomic::{AtomicUsize, Ordering},
         },
-        task::{Context, Poll, Waker},
+        task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
     };
 
     use crate::{
@@ -628,7 +635,78 @@ mod tests {
         identity::ScopeIdentity,
     };
 
-    use super::{super::cell::tests::actor, ActorRef, MailboxCell};
+    use super::{super::cell::tests::actor, ActorRef, MailboxCell, SendFutureState, SendOperation};
+
+    #[derive(Default)]
+    struct WakerVtableCalls {
+        clones: AtomicUsize,
+        drops: AtomicUsize,
+    }
+
+    struct OperationLockProbe {
+        operation: Weak<SendOperation<u8>>,
+        calls: Arc<WakerVtableCalls>,
+    }
+
+    impl OperationLockProbe {
+        fn assert_operation_unlocked(&self, callback: &str) {
+            let operation = self
+                .operation
+                .upgrade()
+                .expect("the parked send retains its operation");
+            let _guard = operation
+                .state
+                .try_lock()
+                .unwrap_or_else(|_| panic!("waker {callback} ran under the operation lock"));
+        }
+    }
+
+    unsafe fn clone_operation_lock_probe(data: *const ()) -> RawWaker {
+        // SAFETY: every pointer using this vtable was produced by
+        // `Arc::into_raw` for an `OperationLockProbe`. `ManuallyDrop` preserves
+        // the reference represented by `data`; the returned raw waker owns the
+        // newly cloned reference.
+        let probe = ManuallyDrop::new(unsafe { Arc::<OperationLockProbe>::from_raw(data.cast()) });
+        probe.assert_operation_unlocked("clone");
+        probe.calls.clones.fetch_add(1, Ordering::SeqCst);
+        let cloned = Arc::clone(&probe);
+        RawWaker::new(Arc::into_raw(cloned).cast(), &OPERATION_LOCK_PROBE_VTABLE)
+    }
+
+    unsafe fn wake_operation_lock_probe(data: *const ()) {
+        // SAFETY: `wake` consumes the raw-waker reference represented by data.
+        drop(unsafe { Arc::<OperationLockProbe>::from_raw(data.cast()) });
+    }
+
+    unsafe fn wake_operation_lock_probe_by_ref(_data: *const ()) {}
+
+    unsafe fn drop_operation_lock_probe(data: *const ()) {
+        // SAFETY: `drop` consumes the raw-waker reference represented by data.
+        let probe = unsafe { Arc::<OperationLockProbe>::from_raw(data.cast()) };
+        probe.assert_operation_unlocked("drop");
+        probe.calls.drops.fetch_add(1, Ordering::SeqCst);
+    }
+
+    static OPERATION_LOCK_PROBE_VTABLE: RawWakerVTable = RawWakerVTable::new(
+        clone_operation_lock_probe,
+        wake_operation_lock_probe,
+        wake_operation_lock_probe_by_ref,
+        drop_operation_lock_probe,
+    );
+
+    fn operation_lock_probe_waker(
+        operation: &Arc<SendOperation<u8>>,
+        calls: Arc<WakerVtableCalls>,
+    ) -> Waker {
+        let probe = Arc::new(OperationLockProbe {
+            operation: Arc::downgrade(operation),
+            calls,
+        });
+        let raw = RawWaker::new(Arc::into_raw(probe).cast(), &OPERATION_LOCK_PROBE_VTABLE);
+        // SAFETY: `raw` owns one `OperationLockProbe` reference and its vtable
+        // maintains that reference count for every clone, wake, and drop.
+        unsafe { Waker::from_raw(raw) }
+    }
 
     #[test]
     fn an_accepted_send_reports_acceptance_on_every_poll() {
@@ -655,6 +733,46 @@ mod tests {
         };
         assert_eq!(first, second);
         assert_eq!(first, incarnation);
+    }
+
+    #[test]
+    fn replacing_a_send_waker_runs_its_vtable_outside_the_operation_lock() {
+        let (_, actor) = actor();
+        let mut send = Box::pin(actor.send(1));
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        let operation = match &send.as_ref().get_ref().state {
+            SendFutureState::Parked(operation) => Arc::clone(operation),
+            SendFutureState::Immediate(_) | SendFutureState::Sent(_) | SendFutureState::Done => {
+                panic!("an unbound mailbox parks its send")
+            }
+        };
+        let calls = Arc::new(WakerVtableCalls::default());
+        let hostile = operation_lock_probe_waker(&operation, Arc::clone(&calls));
+
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(&hostile))
+                .is_pending()
+        );
+        drop(hostile);
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+
+        assert_eq!(calls.clones.load(Ordering::SeqCst), 1);
+        assert_eq!(calls.drops.load(Ordering::SeqCst), 2);
+        drop(
+            operation
+                .state
+                .lock()
+                .expect("hostile waker callbacks cannot poison the operation lock"),
+        );
     }
 
     struct CountedDrop(Arc<AtomicUsize>);


### PR DESCRIPTION
## Summary

Keep every caller-supplied waker vtable call out of the mailbox's core mutexes, and keep a hostile waker destructor from escaping cancellation drop glue.

## Issue items and commits

1. **`SendFuture::poll` waker clone/replacement/drop** — `62d9541`
   - Clone the incoming context waker before acquiring the send-operation mutex.
   - Replace the registered waker while locked, then release the mutex before dropping the stale waker.
   - Add a hostile raw-waker regression whose clone and drop callbacks attempt to reacquire the operation mutex.

2. **Mailbox withdrawal waker removal/drop** — `a61e49d`
   - Take the registered waker while holding the operation mutex.
   - Finish direct waiter unlinking, release both the operation and mailbox mutexes, then drop the waker.
   - Add a hostile waker-drop regression that reacquires the operation mutex, re-enters `try_send`, panics, and verifies neither core mutex is poisoned.

3. **Cancellation containment and clone elision** — `15c354d`
   - `MailboxCell::withdraw` returns the released waker instead of destroying it, handing the recovered message over first, so the caller chooses where a `RawWaker` destructor runs.
   - `SendFuture::drop` routes that waker through isolated disposal beside the message. A panicking destructor can no longer escape drop glue, so cancellation reached during an unwind is no longer a double panic and a process abort, and it can no longer divert the message from its own isolated disposal.
   - `SendFuture::poll` stops cloning the context waker speculatively: it inspects the outcome locked, takes a `will_wake` fast path, and only otherwise unlocks to clone and reacquires to install. Reacquiring re-reads the outcome, and the outcome transition and waker take stay atomic under the operation lock, so the unlocked window cannot lose a wakeup.
   - `withdraw`'s accepted and terminated arms `debug_assert` that acceptance and termination already took the waker.
   - Regression coverage moves onto the public `SendFuture::drop` -> `withdraw` path, including the unwind case that aborted before.

## Semantics

No caller vtable call happens under a core mutex, and none happens at all on a completing poll or on a repoll with an equivalent waker. Waker destruction is exactly-once on every path.

Where a waker destructor runs is now explicit per path:

- **Cancellation (`SendFuture::drop`)** — isolated disposal. There is no caller left to receive a panic and this is drop glue, so nothing user-controlled runs inline.
- **Timeout arbitration (`send_timeout`/`call`)** — inline on the caller's own task, as before. This is a normal return, not drop glue, so a hostile destructor's panic stays visible to the caller who supplied the waker. No lock is held and the recovered message already belongs to the returned result.

## Validation

- `./tools/dev cargo nextest run -p shelterwood --lib mailbox::` — 24 passed
- `./tools/dev just ci` — passed (582 nextest tests plus lint, docs, API/layering, and package checks)
- `./tools/dev just ci-nix` — passed

Each new regression was also run against the pre-fix code and fails there: the unwind case reproduces the `SIGABRT`, the containment case surfaces `injected waker drop panic` out of `SendFuture::drop`, the completing poll records 1 speculative clone instead of 0, and four repolls record 4 clones instead of 1.

Fixes #202
