### PR TITLE
Consume the upstream devshell fingerprint fix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,17 @@
+# `use flake` watches flake.nix and flake.lock, but mkRustProject also reads the
+# toolchain file while evaluating the devshell.
+watch_file rust-toolchain.toml
 use flake
 
 # Marker consumed by ./tools/dev: the physical path of this checkout plus a
 # fingerprint of the flake inputs the devshell was built from. Lets the wrapper
 # tell a correctly loaded devshell apart from one inherited from a sibling
-# worktree — or from this same checkout before a branch switch changed the flake.
-export REPO_DEVSHELL="$(pwd -P):$(cat flake.nix flake.lock 2>/dev/null | sha256sum | cut -d' ' -f1)"
+# worktree — or from this same checkout before a branch switch changed an input.
+# Nix is the one hashing tool guaranteed to exist before the shell is loaded.
+devshell_fingerprint=
+for input in flake.nix flake.lock rust-toolchain.toml; do
+    [ -f "$input" ] || continue
+    input_hash=$(nix hash file --type sha256 "$input")
+    devshell_fingerprint="${devshell_fingerprint:+$devshell_fingerprint:}$input_hash"
+done
+export REPO_DEVSHELL="$(pwd -P):$devshell_fingerprint"

--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1786309496,
-        "narHash": "sha256-8qy0c/s32KzlNoV4xTe1lBGmth+vZGMkefegjh2NI5k=",
+        "lastModified": 1786473420,
+        "narHash": "sha256-9WIbT6F5Rgn4mXEURbKM3HBlxH20mWueLALrksNSTrc=",
         "owner": "ralexstokes",
         "repo": "rust-nix-template",
-        "rev": "844a6ee6506bd04d59224f2e23f804273dc8744f",
+        "rev": "b0c7bcc1dcad6126d3a055bcfd8d07058417e576",
         "type": "github"
       },
       "original": {

--- a/tools/dev
+++ b/tools/dev
@@ -28,10 +28,18 @@ here=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd -P)
 # IN_NIX_SHELL is not a sufficient test: it stays set when a shell rooted in
 # another checkout spawns us. Only skip re-entry when the active devshell
 # matches both this checkout and its current flake inputs — a branch switch
-# that changes flake.nix/flake.lock invalidates the marker. .envrc exports the
-# same path:fingerprint format. The marker embeds the checkout path, so one
-# variable name is safe to share across every project using this template.
-want="$here:$(cat "$here/flake.nix" "$here/flake.lock" 2>/dev/null | sha256sum | cut -d' ' -f1)"
+# that changes flake.nix, flake.lock, or rust-toolchain.toml invalidates the
+# marker. .envrc exports the same path:fingerprint format. The marker embeds the
+# checkout path, so one variable name is safe to share across every project.
+# Nix is the one hashing tool guaranteed to exist before the shell is loaded.
+devshell_fingerprint=
+for input in flake.nix flake.lock rust-toolchain.toml; do
+    input="$here/$input"
+    [ -f "$input" ] || continue
+    input_hash=$(nix hash file --type sha256 "$input")
+    devshell_fingerprint="${devshell_fingerprint:+$devshell_fingerprint:}$input_hash"
+done
+want="$here:$devshell_fingerprint"
 if [ "${REPO_DEVSHELL:-}" = "$want" ]; then
     exec "$@"
 fi


### PR DESCRIPTION
## What changed

- advance the `rust-env` flake input from `844a6ee` to upstream merge commit `b0c7bcc`
- sync `tools/dev` with the fixed consumer template so its fingerprint includes `rust-toolchain.toml`
- sync `.envrc` so direnv watches and fingerprints `rust-toolchain.toml`
- use the already-required `nix hash file` instead of GNU-specific `sha256sum`

## Why

Upstream [rust-nix-template#2](https://github.com/ralexstokes/rust-nix-template/pull/2) fixed the devshell invalidation defect tracked in #191 item 28. `mkRustProject` reads `rust-toolchain.toml` while evaluating the shell, but shelterwood's marker covered only `flake.nix` and `flake.lock`. A toolchain-only branch change could therefore accept a stale inherited shell.

The local `tools/dev` and `.envrc` blobs match the corresponding consumer template files at `b0c7bcc` byte for byte. The Nix installer action remains on `main`, matching the upstream decision and the intended scope of this update.

## Impact

Toolchain-only changes now invalidate both direct wrapper reuse and direnv state, including on platforms that do not provide GNU `sha256sum` by default.

## Validation

- `./tools/dev sh -n tools/dev`
- `./tools/dev sh -n .envrc`
- `./tools/dev just ci` (602 tests plus formatting, Clippy, doctests, docs, API enforcement, and package checks)
- `./tools/dev just ci-nix` (all clean Nix checks passed)
- Git blob comparison against `templates/default/tools/dev` and `templates/default/.envrc` at upstream `b0c7bcc`

Refs #191 (item 28).