### PR TITLE
Funnel driver wakes through one collection site

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1236,7 +1236,16 @@ enum Readiness { Immediate, AfterInit, Manual }   // mode only — the deadline 
   the membership *not yet* marked removing fails startup under the
   rule above, while once the mark is in place removal outranks it and
   the aggregate simply shrinks. Both orders are legal; which one a
-  given run takes is not specified. The aggregate fires at most once
+  given run takes is not specified. The mark suppresses the member's
+  own **readiness edge** on the same terms: a membership observed
+  removing where a readiness edge would be published emits no `Ready`
+  (B.4) and is credited to no aggregate, even when its readiness latch
+  fired before the mark — and this binds every membership, not only
+  initial ones, so a runtime-added member being removed publishes no
+  per-child `Ready` either. Which side of *that* race a run takes is
+  likewise unspecified; what is pinned is that the mark is consulted
+  where the edge would be published, never by arbitration position
+  (§14.2). The aggregate fires at most once
   per scope incarnation and is latched: an already-ready child that
   fails and restarts afterwards does not rewind it — readiness is a
   startup-phase edge, not a liveness signal (snapshots carry liveness,
@@ -1383,7 +1392,11 @@ One classification, produced at one point, used by every consumer.
   restarts (§10), and a membership whose removal is in progress
   (`membership_status: Removing`, B.6) has its restarts suppressed even
   while its containing scope keeps running — dynamic removal of one
-  child must not depend on the whole scope draining (§11).
+  child must not depend on the whole scope draining (§11). The same
+  mark suppresses that membership's readiness publication (§6): one
+  level-triggered removal source, consulted at execution time by every
+  site that would otherwise publish or schedule on the membership's
+  behalf.
 - There is exactly **one incarnation runner**, and it yields this one exit
   type — including `Panicked` — regardless of how it is hosted. The
   supervisor is a policy loop over the runner's output. (The public
@@ -2763,7 +2776,13 @@ Both questions are resolved:
    pins the complete table without runtime selection; each pending item
    derives its class through `Pending::class()` rather than accepting a class
    beside it at collection sites, and the driver drains all currently eligible
-   inputs into that table before applying effects.
+   inputs into that table before applying effects. Class position is not,
+   however, what protects a leaving membership from a spurious readiness edge:
+   a child's self-stop shares membership removal's class, so a queued removal
+   cannot be ordered ahead of the readiness that self-stop dispatch replays.
+   That rule is structural instead — the readiness publication site consults
+   the membership's removal mark at execution time (§6, §7), the same
+   discipline exit dispatch follows for restart suppression.
 
 (Resolved elsewhere: stage-generic `handle` is rejected — drain-stage
 rejection stays value-level, §5.4; the conflating-mailbox control lane is

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -944,6 +944,10 @@ async fn run_scope_incarnation(
             }
         }
 
+        // Settlement is level-triggered from authoritative state after every
+        // batch. Any transition that changes the startup aggregate therefore
+        // gets the same recomputation point as terminal completion.
+        scope.progress_startup();
         if let Some(reason) = scope.finish_if_ready() {
             let root_exit = scope.role.is_root().then(|| reason.root_exit());
             // ScopeRuntime's synchronous epilogue clears dynamic state,

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -866,27 +866,25 @@ async fn run_scope_incarnation(
             )
             .await
             {
-                runtime::ScopeWake::Signal | runtime::ScopeWake::ParentShutdown => continue,
+                runtime::ScopeWake::Signal
+                | runtime::ScopeWake::ParentShutdown
+                | runtime::ScopeWake::Message(None)
+                | runtime::ScopeWake::ControlMessage(None) => {}
                 runtime::ScopeWake::Deadline => {
                     // A producer becoming ready at the same instant owns the
                     // tie over its deadline. Give tasks woken by that clock
                     // edge one turn to publish their retained readiness
                     // latch before collecting due registrations.
                     runtime::yield_now().await;
-                    continue;
                 }
-                runtime::ScopeWake::Message(Some(event)) => {
+                runtime::ScopeWake::Message(Some(event))
+                | runtime::ScopeWake::ControlMessage(Some(event)) => {
                     retain_woken_event(event, &mut pending);
-                    continue;
-                }
-                runtime::ScopeWake::ControlMessage(Some(event)) => {
-                    retain_woken_event(event, &mut pending);
-                    continue;
-                }
-                runtime::ScopeWake::Message(None) | runtime::ScopeWake::ControlMessage(None) => {
-                    continue;
                 }
             }
+            // Every wake re-enters the collection site above. Nothing is
+            // dispatched from this arm.
+            continue;
         }
 
         arbitrate(&mut pending);

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -768,8 +768,8 @@ async fn run_scope_incarnation(
     }
 
     let mut signal = root.signal().watcher();
+    let mut pending = Vec::new();
     loop {
-        let mut pending = Vec::new();
         if root.take_shutdown_request(scope.epoch) {
             pending.push(Pending::Shutdown.classified());
         }
@@ -871,9 +871,11 @@ async fn run_scope_incarnation(
                 }
                 runtime::ScopeWake::Message(Some(event)) => {
                     pending.push(Pending::from(event).classified());
+                    continue;
                 }
                 runtime::ScopeWake::ControlMessage(Some(event)) => {
                     pending.push(Pending::from(event).classified());
+                    continue;
                 }
                 runtime::ScopeWake::Message(None) | runtime::ScopeWake::ControlMessage(None) => {
                     continue;
@@ -882,7 +884,7 @@ async fn run_scope_incarnation(
         }
 
         arbitrate(&mut pending);
-        for (_, event) in pending {
+        for (_, event) in pending.drain(..) {
             match event {
                 Pending::Shutdown => {
                     if let Some(latches) = scope.role.ancestor() {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -213,6 +213,11 @@ struct ScopeRuntime {
     next_ordered_start: Option<ChildKey>,
     role: ScopeRole,
     dynamic: Option<Arc<DynamicControl>>,
+    // Removing an initial member can complete startup. Hold its response
+    // obligation until the batch epilogue has recomputed that aggregate, so
+    // observing `Removed` implies the declared set already reflects the
+    // committed shrink.
+    pending_startup_removals: Vec<DynamicEntry>,
     epoch: Epoch,
     ancestor_shutdown_seen: bool,
     ancestor_abort_seen: bool,
@@ -722,6 +727,7 @@ async fn run_scope_incarnation(
         next_ordered_start,
         role,
         dynamic,
+        pending_startup_removals: Vec::new(),
         ancestor_shutdown_seen: false,
         ancestor_abort_seen: false,
         hard_forced: false,
@@ -948,6 +954,11 @@ async fn run_scope_incarnation(
         // batch. Any transition that changes the startup aggregate therefore
         // gets the same recomputation point as terminal completion.
         scope.progress_startup();
+        // A removal response is also an observation edge: SPEC §6 promises
+        // that a returned `Removed` has already been incorporated into the
+        // startup aggregate. Finalization retains starting-phase obligations
+        // until the recomputation above establishes that order.
+        scope.publish_startup_removals();
         if let Some(reason) = scope.finish_if_ready() {
             let root_exit = scope.role.is_root().then(|| reason.root_exit());
             // ScopeRuntime's synchronous epilogue clears dynamic state,

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -22,7 +22,7 @@ use child::ChildRuntime;
 use child::{ChildTerminality, discharge_child_terminality, report_slot};
 use events::{
     ChildEvent, DeadlineKind, DriverEvent, EventLanes, MIN_EVENT_BATCH_LIMIT, Pending,
-    collect_event_lanes, restart_shutdown_work,
+    collect_event_lanes, restart_shutdown_work, retain_woken_event,
 };
 use removal::RemovalRequest;
 pub(crate) use shutdown::shutdown_scope;
@@ -870,11 +870,11 @@ async fn run_scope_incarnation(
                     continue;
                 }
                 runtime::ScopeWake::Message(Some(event)) => {
-                    pending.push(Pending::from(event).classified());
+                    retain_woken_event(event, &mut pending);
                     continue;
                 }
                 runtime::ScopeWake::ControlMessage(Some(event)) => {
-                    pending.push(Pending::from(event).classified());
+                    retain_woken_event(event, &mut pending);
                     continue;
                 }
                 runtime::ScopeWake::Message(None) | runtime::ScopeWake::ControlMessage(None) => {

--- a/crates/shelterwood/src/driver/events.rs
+++ b/crates/shelterwood/src/driver/events.rs
@@ -91,6 +91,16 @@ impl From<DriverEvent> for Pending {
     }
 }
 
+/// Retains the item that ended a blocking wait. The driver then returns to
+/// its single collection site so this head is arbitrated with every other
+/// input that became eligible before the wake was observed.
+pub(super) fn retain_woken_event(
+    event: DriverEvent,
+    pending: &mut Vec<(ArbitrationClass, Pending)>,
+) {
+    pending.push(Pending::from(event).classified());
+}
+
 /// The three unbounded lanes one driver wake collects from, in collection
 /// order.
 pub(super) struct EventLanes<'a> {

--- a/crates/shelterwood/src/driver/events.rs
+++ b/crates/shelterwood/src/driver/events.rs
@@ -94,6 +94,14 @@ impl From<DriverEvent> for Pending {
 /// Retains the item that ended a blocking wait. The driver then returns to
 /// its single collection site so this head is arbitrated with every other
 /// input that became eligible before the wake was observed.
+///
+/// The retained head keeps its own lane's FIFO position — it was that
+/// channel's head — but it sits ahead of the whole re-entered collection, so
+/// a woken *control* head precedes the primary lane the collection order
+/// otherwise puts first. `MembershipRemoval` is the only class both lanes
+/// produce (`Removal` and `SelfStop`), and neither ordering of that pair
+/// changes a verdict: readiness publication consults the removal sources at
+/// execution time rather than relying on arbitration position.
 pub(super) fn retain_woken_event(
     event: DriverEvent,
     pending: &mut Vec<(ArbitrationClass, Pending)>,

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -84,11 +84,21 @@ impl ScopeRuntime {
         });
         if let Some(entry) = entry {
             self.reclaim_child(key);
-            if self.lifecycle.is_starting() {
-                self.pending_startup_removals.push(entry);
-            } else {
-                drop(entry);
-            }
+            self.release_removed_entry(entry);
+        }
+    }
+
+    /// Releases a committed removal's entry. The drop completes the in-flight
+    /// removal response, so during `Starting` — where the reclaim that
+    /// precedes it can shrink the declared initial set — the completion is
+    /// retained until the batch epilogue recomputes the aggregate. That
+    /// ordering is what makes a returned `RemoveOutcome::Removed` imply
+    /// startup already saw the shrunken set (SPEC §6).
+    fn release_removed_entry(&mut self, entry: DynamicEntry) {
+        if self.lifecycle.is_starting() {
+            self.pending_startup_removals.push(entry);
+        } else {
+            drop(entry);
         }
     }
 
@@ -123,10 +133,15 @@ impl ScopeRuntime {
         if self.root.flavor == ScopeFlavor::Dynamic {
             self.reclaim_child(key);
         }
-        // The entry's drop completes any in-flight removal response; it must
-        // follow the Removed edge so a woken remover never sees the child
-        // resident.
-        drop(removed);
+        // The entry's release completes any in-flight removal response; it
+        // must follow the Removed edge so a woken remover never sees the
+        // child resident. A removal that latches between this path's
+        // `dynamic_membership_is_removing` check and the gate above lands its
+        // response here rather than in `finalize_removal`, so it takes the
+        // same starting-phase retention.
+        if let Some(entry) = removed {
+            self.release_removed_entry(entry);
+        }
     }
 
     pub(super) fn reclaim_child(&mut self, key: ChildKey) {

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -84,8 +84,18 @@ impl ScopeRuntime {
         });
         if let Some(entry) = entry {
             self.reclaim_child(key);
-            drop(entry);
+            if self.lifecycle.is_starting() {
+                self.pending_startup_removals.push(entry);
+            } else {
+                drop(entry);
+            }
         }
+    }
+
+    /// Publishes removal completions whose committed membership shrink had to
+    /// be observed by startup settlement first.
+    pub(super) fn publish_startup_removals(&mut self) {
+        drop(std::mem::take(&mut self.pending_startup_removals));
     }
 
     pub(super) fn prune_terminal(&mut self, key: ChildKey) {

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -84,17 +84,6 @@ impl ScopeRuntime {
         });
         if let Some(entry) = entry {
             self.reclaim_child(key);
-            // Removal is an owner action, not a startup failure: the reclaim
-            // above shrank the declared initial set, so re-evaluate the
-            // aggregate (self-guarded on `is_starting`). This runs outside
-            // the observation gate closed above — `complete_startup` reopens
-            // that gate, and it is not reentrant.
-            //
-            // Ordered ahead of the entry's drop: that drop completes the
-            // in-flight removal response, so recomputing first is what makes
-            // a returned `RemoveOutcome::Removed` imply the aggregate already
-            // saw the shrunken set.
-            self.progress_startup();
             drop(entry);
         }
     }
@@ -123,13 +112,6 @@ impl ScopeRuntime {
         });
         if self.root.flavor == ScopeFlavor::Dynamic {
             self.reclaim_child(key);
-            // Symmetry with `finalize_removal`: a reclaim can shrink the
-            // declared initial set. Unreachable during `Starting` today —
-            // every terminal route for an unready initial member routes
-            // through `fail_startup` or the removal branch — but it closes
-            // the residual missed-recomputation class rather than relying on
-            // that reachability argument holding forever.
-            self.progress_startup();
         }
         // The entry's drop completes any in-flight removal response; it must
         // follow the Removed edge so a woken remover never sees the child

--- a/crates/shelterwood/src/driver/startup.rs
+++ b/crates/shelterwood/src/driver/startup.rs
@@ -29,6 +29,20 @@ impl ScopeRuntime {
                 false
             }
             ReadinessEffect::BecameReady => {
+                // Removal outranks readiness structurally, and arbitration
+                // alone does not deliver that: `SelfStop` shares removal's
+                // class, so a same-batch `Removal` cannot preempt the
+                // readiness `handle_self_stop` replays, and an exit's
+                // readiness step runs from the same collection. Consult the
+                // removal sources at execution time — the discipline exit
+                // dispatch already follows — so no readiness edge is
+                // published for, or credited to startup by, a membership the
+                // owner already observes as `Removing`. The internal latch
+                // still records that the edge happened: a removing member's
+                // terminal routes through `finalize_removal`, and its exit
+                // classification must not mistake a post-ready stop for a
+                // pre-ready failure.
+                let removing = self.dispatch_membership_status(key) == MembershipStatus::Removing;
                 let Some(child) = self.children.get_mut(key) else {
                     return false;
                 };
@@ -42,6 +56,9 @@ impl ScopeRuntime {
                     self.deadlines.cancel(deadline);
                 }
                 active.ready_signal.fire();
+                if removing {
+                    return false;
+                }
                 if !self.lifecycle.startup_complete() {
                     child.initial_ready = true;
                 }

--- a/crates/shelterwood/src/driver/tests/events.rs
+++ b/crates/shelterwood/src/driver/tests/events.rs
@@ -11,6 +11,73 @@ fn disposed_child(pending: &Pending) -> ChildKey {
     }
 }
 
+/// Pins the post-blocking-wake gap: removal is queued on the control lane
+/// before readiness reaches the primary lane, but the biased wait returns the
+/// primary head. Retaining that head and re-entering the common collection
+/// site must put both events in one arbitration batch, where removal wins.
+#[crate::runtime::test]
+async fn blocking_primary_wake_recollects_control_removal_before_arbitration() {
+    let identity = isolated_scope("identity", ScopeFlavor::Dynamic);
+    let membership = identity.member.membership();
+    let key = ChildKey(1);
+    let incarnation = IncarnationCounter::fixture(membership)
+        .mint()
+        .expect("fixture incarnation is available");
+    let (primary, mut primary_receiver) = crate::runtime::unbounded_mpsc();
+    let (control, mut control_receiver) = crate::runtime::unbounded_mpsc();
+    let (_disposal, mut disposal_receiver) = crate::runtime::unbounded_mpsc();
+
+    let wait = crate::runtime::wait_scope(
+        crate::runtime::ScopeWait {
+            signal: future::pending::<()>(),
+            parent_shutdown: future::pending::<()>(),
+        },
+        &mut primary_receiver,
+        Some(&mut control_receiver),
+        None,
+    );
+    let publisher = crate::runtime::spawn(async move {
+        crate::runtime::yield_now().await;
+        control
+            .send(DriverEvent::Removal(RemovalRequest { membership, key }))
+            .expect("the control lane remains open");
+        primary
+            .send(DriverEvent::Child(ChildEvent::Ready {
+                child: key,
+                incarnation,
+            }))
+            .expect("the primary lane remains open");
+    });
+    let wake = wait.await;
+    assert!(matches!(
+        crate::runtime::join(publisher).await,
+        crate::runtime::JoinOutcome::Ok { value: () }
+    ));
+    let crate::runtime::ScopeWake::Message(Some(event)) = wake else {
+        panic!("the biased blocking wait returns the later primary head");
+    };
+
+    let mut pending = Vec::new();
+    super::super::retain_woken_event(event, &mut pending);
+    assert!(!super::super::collect_event_lanes(
+        super::super::EventLanes {
+            primary: &mut primary_receiver,
+            control: Some(&mut control_receiver),
+            disposal: &mut disposal_receiver,
+        },
+        super::super::MIN_EVENT_BATCH_LIMIT,
+        &mut pending,
+    ));
+    arbitrate(&mut pending);
+
+    assert_eq!(pending.len(), 2);
+    assert!(matches!(pending[0].1, Pending::Removal(_)));
+    assert!(matches!(
+        pending[1].1,
+        Pending::Child(ChildEvent::Ready { .. })
+    ));
+}
+
 /// Pins the wiring the driver's per-wake collection depends on: the disposal
 /// lane is collected last, through the same cap as the other two, and its
 /// saturation reaches the caller so the loop yields a scheduler turn instead

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -947,3 +947,75 @@ async fn ordered_startup_advances_past_a_reclaimed_cursor() {
         "the live successor still gates the aggregate"
     );
 }
+
+/// A removal response is an observation boundary, not merely a wake. Keep it
+/// pending after membership commit until the batch epilogue has recomputed
+/// startup over the shrunken declared set.
+#[crate::runtime::test]
+async fn startup_removal_response_follows_aggregate_recomputation() {
+    let mut tree = DynamicTree::new();
+    tree.add_task(
+        "gate",
+        TaskDef::new(|_| future::pending::<crate::ExitResult>())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness is valid")
+            .readiness_deadline(ReadinessDeadline::Unbounded),
+    )
+    .expect("valid initial member");
+
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.member
+        .update(|record| record.stage = MemberStage::Running);
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
+    let (control_events, _control_event_receiver) = crate::runtime::unbounded_mpsc();
+    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+    let control = DynamicControl::new(control_events);
+    let mut children = ChildArena::default();
+    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+    let key = children
+        .insert(child)
+        .unwrap_or_else(|_| panic!("the fixture fits in the child-key domain"));
+    root.with_observation_gate(|txn| {
+        control.register_initial(children.iter().map(|(key, child)| (&child.slot, key)), txn);
+    });
+    root.set_dynamic_route(Some(control.clone()));
+    let member = Arc::clone(&children[key].slot.member);
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+        .with_defaults(plan.defaults.clone())
+        .with_children(children)
+        .with_dynamic(Some(control))
+        .build();
+    plan.finish_transfer();
+
+    assert!(scope.terminalize_child(
+        key,
+        Exit::never_started(),
+        None,
+        StartupDisposition::NotAborted,
+    ));
+    let mut removal = super::super::remove_dynamic(&root, member.id(), Some(member.membership()));
+    scope.finalize_removal(key);
+
+    assert_eq!(
+        removal.try_receive(),
+        None,
+        "membership commit alone cannot publish Removed before settlement"
+    );
+    assert!(!scope.lifecycle.startup_complete());
+
+    scope.progress_startup();
+    assert!(scope.lifecycle.startup_complete());
+    assert_eq!(root.record().startup, Some(Ok(())));
+    scope.publish_startup_removals();
+    assert_eq!(removal.try_receive(), Some(RemoveOutcome::Removed));
+}

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -1019,3 +1019,128 @@ async fn startup_removal_response_follows_aggregate_recomputation() {
     scope.publish_startup_removals();
     assert_eq!(removal.try_receive(), Some(RemoveOutcome::Removed));
 }
+
+/// A latched removal outranks readiness structurally, and arbitration alone
+/// cannot deliver that: `SelfStop` shares `MembershipRemoval` with `Removal`
+/// and the primary lane is collected first, so the queued removal can never
+/// preempt the readiness `handle_self_stop` replays. Publication consults the
+/// removal sources at execution time instead — without that, a `Ready` is
+/// published for a membership the owner already observes as `Removing`, and
+/// it completes scope startup on a member that is leaving.
+#[crate::runtime::test]
+async fn queued_removal_suppresses_replayed_self_stop_readiness() {
+    let mut tree = DynamicTree::new();
+    tree.add_task(
+        "gate",
+        TaskDef::new(|_| future::pending::<crate::ExitResult>())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness is valid")
+            .readiness_deadline(ReadinessDeadline::Unbounded),
+    )
+    .expect("valid initial member");
+
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.member
+        .update(|record| record.stage = MemberStage::Running);
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
+    let (control_events, mut control_event_receiver) = crate::runtime::unbounded_mpsc();
+    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+    let control = DynamicControl::new(control_events);
+    let mut children = ChildArena::default();
+    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+    let key = children
+        .insert(child)
+        .unwrap_or_else(|_| panic!("the fixture fits in the child-key domain"));
+    root.with_observation_gate(|txn| {
+        control.register_initial(children.iter().map(|(key, child)| (&child.slot, key)), txn);
+    });
+    root.set_dynamic_route(Some(control.clone()));
+    let member = Arc::clone(&children[key].slot.member);
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+        .with_defaults(plan.defaults.clone())
+        .with_children(children)
+        .with_dynamic(Some(control))
+        .build();
+    plan.finish_transfer();
+
+    scope.spawn_child(key);
+    let active = scope.children[key]
+        .active
+        .as_ref()
+        .expect("the spawned child is active");
+    let incarnation = active.incarnation;
+    // The application task fired readiness and then stopped; the driver has
+    // not drained the corresponding Ready event yet.
+    assert!(active.ready_signal.fire());
+
+    let mut lifecycle = root.subscribe_lifecycle();
+    let _removal = super::super::remove_dynamic(&root, member.id(), Some(member.membership()));
+    assert_eq!(
+        member.record().membership_status,
+        MembershipStatus::Removing,
+        "remove() latches Removing in the caller's observation gate"
+    );
+
+    // The premise: full-drain collection leads with the primary lane, so the
+    // self-stop sorts ahead of the removal it shares a class with.
+    let mut pending = vec![
+        Pending::Child(ChildEvent::SelfStop {
+            child: key,
+            incarnation,
+        })
+        .classified(),
+    ];
+    while let Some(event) = crate::runtime::unbounded_mpsc_try_recv(&mut control_event_receiver) {
+        pending.push(Pending::from(event).classified());
+    }
+    arbitrate(&mut pending);
+    assert_eq!(
+        pending.len(),
+        2,
+        "the removal request reached the control lane"
+    );
+    assert!(
+        matches!(pending[0].1, Pending::Child(ChildEvent::SelfStop { .. })),
+        "the premise: arbitration cannot order the removal ahead of the self-stop"
+    );
+    assert!(matches!(pending[1].1, Pending::Removal(_)));
+
+    scope.handle_self_stop(key, incarnation);
+
+    let mut published = Vec::new();
+    while let Ok(crate::observe::LifecycleItem::Event(event)) = lifecycle.try_recv() {
+        published.push(event.kind);
+    }
+    assert!(
+        !published
+            .iter()
+            .any(|kind| matches!(kind, LifecycleEventKind::Ready { .. })),
+        "no readiness edge is published for an already-Removing membership: {published:?}"
+    );
+    assert!(
+        !matches!(member.record().stage, MemberStage::Running),
+        "the suppressed edge does not project Running: {:?}",
+        member.record().stage
+    );
+    assert!(
+        !scope.children[key].initial_ready,
+        "a leaving membership is not credited to the startup aggregate"
+    );
+    assert!(!scope.lifecycle.startup_complete());
+    scope.progress_startup();
+    assert!(
+        !scope.lifecycle.startup_complete(),
+        "startup waits for the removal to shrink the declared set"
+    );
+    assert_eq!(root.record().state, ScopeState::Starting);
+}

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -126,6 +126,7 @@ impl ScopeRuntimeBuilder {
             next_ordered_start: self.next_ordered_start,
             role: ScopeRole::Root,
             dynamic: self.dynamic,
+            pending_startup_removals: Vec::new(),
             epoch: self.epoch,
             ancestor_shutdown_seen: false,
             ancestor_abort_seen: false,


### PR DESCRIPTION
## What changed

- hoist the pending driver batch across blocking waits and route message wakes back through shutdown/force checks, all event lanes, and due-deadline collection before arbitration
- run startup settlement beside terminal settlement in the per-batch epilogue, removing the removal-specific recomputation hooks
- pin the post-blocking-wake cross-lane case where a queued removal must arbitrate ahead of a later primary-lane readiness event
- retain starting-phase removal completions until that epilogue recomputes the shrunken initial set, preserving SPEC §6's `Removed` observation ordering
- suppress readiness publication and startup credit for an already-`Removing` membership, consulted at the publication site rather than by arbitration position

Each Stage 1 item from #214 is represented by its own commit. The removal-completion change and the readiness-suppression guard are separate adversarial-review fixes.

## Why

A blocking primary/control message wake previously fell directly into arbitration with only the one returned event. That bypassed the driver’s full collection table and could publish `Ready` for a membership whose removal was already queued on the other lane. Centralizing collection also gives startup and terminal settlement one level-triggered batch epilogue.

The review found that simply moving startup recomputation after batch dispatch let `finalize_removal` wake a remover before the epilogue ran on a multi-thread runtime. Retaining only starting-phase completion obligations through recomputation preserves the commit-time shrink rule without restoring removal-specific settlement calls.

**The loop restructure alone does not close #204's class.** It closes the blocking-wake instance, but arbitration position was never sufficient for the rest: `SelfStop` shares `ArbitrationClass::MembershipRemoval` with `Removal`, and the primary lane is collected first, so a queued removal can never be ordered ahead of the readiness that `handle_self_stop` replays through `handle_ready` — and `apply_readiness_effect::BecameReady` consulted nothing about membership. Ordinary full-drain collection therefore still published `Ready` for an already-`Removing` member and completed scope startup on it (pinned by `queued_removal_suppresses_replayed_self_stop_readiness`, which fails without the guard). What closes the class is the execution-time consult of the removal sources at the publication site — the discipline exit dispatch already follows. The internal readiness latch still records that the edge happened, so a removing member's exit classification does not mistake a post-ready stop for a pre-ready failure.

`prune_terminal` gets the same starting-phase retention as `finalize_removal`, through a shared `release_removed_entry`: a removal that latches between the terminal route's `dynamic_membership_is_removing` check and the prune's observation gate lands its response there, and would otherwise complete `Removed` ahead of the epilogue's recomputation.

## Impact

The driver now applies the same collection and arbitration rules whether work was already queued or arrived through a blocking wait, and §14.2's "drains all currently eligible inputs into that table before applying effects" holds literally. Removal wins over same-membership readiness **structurally rather than by arbitration position**, startup aggregate changes are reconsidered after every dispatched batch, and a returned `Removed` still implies that startup has already incorporated the shrunken declared set.

The suppression rule is user-observable (a lifecycle-event subscriber sees one fewer `Ready`) and is not yet stated in SPEC.md — §6's aggregate bullet says removal outranks a marked member's own pre-ready *failure*, and §7 says it suppresses *restarts*, but neither covers its readiness edge. A spec amendment follows separately.

## Validation

- `./tools/dev just ci`
- 605 nextest tests passed
- doctests, clippy, rustdoc/API reachability, runtime/exit/layering guards, enforcement fixtures, packaged-doc checks, package verification, and Nix formatting all passed

Closes #204.
Part of #214 (Stage 1).
