### PR TITLE
Consolidate supervision in the core reducer

### DIFF
--- a/crates/shelterwood-core/src/lib.rs
+++ b/crates/shelterwood-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod exit;
 pub mod identity;
 pub mod panic;
 pub mod policy;
+pub mod supervisor;
 
 pub use deadline::*;
 pub use engine::{MembershipStatus, ScopeState};

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -356,13 +356,21 @@ impl SupervisorState {
             .map(|(key, _)| *key)
     }
 
-    fn transition_incarnation(&mut self, child: ChildKey, next: IncarnationState) {
+    fn transition_incarnation(
+        &mut self,
+        child: ChildKey,
+        expected: &[IncarnationState],
+        next: IncarnationState,
+    ) -> bool {
         if let Some(record) = self.children.get_mut(&child) {
-            if record.state.membership_terminal() {
-                return;
+            if record.state.membership_terminal() || !expected.contains(&record.state.incarnation())
+            {
+                return false;
             }
             record.state = record.state.with_incarnation(next);
+            return true;
         }
+        false
     }
 
     fn mark_removing(&mut self, child: ChildKey) -> Option<IncarnationState> {
@@ -425,6 +433,13 @@ impl SupervisorState {
                         self.next_ordered_start = next;
                         continue;
                     };
+                    if record.state.membership_status() == MembershipStatus::Removing {
+                        // The queued removal transition owns stop and commit.
+                        // Until that commit shrinks the initial set, this
+                        // membership still gates ordered startup but can no
+                        // longer schedule construction.
+                        return;
+                    }
                     if !record.spawned_once {
                         effects.push(Effect::StartChild { child });
                         return;
@@ -440,6 +455,7 @@ impl SupervisorState {
                 for (&child, record) in &self.children {
                     if matches!(record.startup, StartupMembership::Initial { .. })
                         && !record.spawned_once
+                        && record.state.membership_status() == MembershipStatus::Active
                     {
                         effects.push(Effect::StartChild { child });
                     }
@@ -529,7 +545,11 @@ impl SupervisorState {
             } => self.admit(membership, initial, start_immediately, effects),
             Event::Spawned { child } => {
                 if let Some(record) = self.children.get_mut(&child)
-                    && !record.state.membership_terminal()
+                    && matches!(record.state, ChildState::Resident(_))
+                    && matches!(
+                        record.state.incarnation(),
+                        IncarnationState::Unstarted | IncarnationState::RestartPending
+                    )
                 {
                     record.spawned_once = true;
                     record.state = record.state.with_incarnation(IncarnationState::Active);
@@ -559,32 +579,49 @@ impl SupervisorState {
                 }
             }
             Event::IncarnationComplete { child } => {
-                self.transition_incarnation(child, IncarnationState::Complete);
+                self.transition_incarnation(
+                    child,
+                    &[IncarnationState::Active, IncarnationState::Stopping],
+                    IncarnationState::Complete,
+                );
             }
             Event::RestartPending { child } => {
-                if let Some(record) = self.children.get_mut(&child) {
-                    if record.state.membership_terminal() {
-                        return;
-                    }
-                    record.state = record
-                        .state
-                        .with_incarnation(IncarnationState::RestartPending);
-                    if self.lifecycle.is_starting()
-                        && let StartupMembership::Initial { ready } = &mut record.startup
-                    {
-                        *ready = false;
-                    }
+                if self.transition_incarnation(
+                    child,
+                    &[IncarnationState::Complete],
+                    IncarnationState::RestartPending,
+                ) && let Some(record) = self.children.get_mut(&child)
+                    && self.lifecycle.is_starting()
+                    && let StartupMembership::Initial { ready } = &mut record.startup
+                {
+                    *ready = false;
                 }
             }
             Event::StopStarted { child } => {
-                self.transition_incarnation(child, IncarnationState::Stopping);
+                self.transition_incarnation(
+                    child,
+                    &[IncarnationState::Active],
+                    IncarnationState::Stopping,
+                );
             }
             Event::DisposalStarted { child } => {
-                self.transition_incarnation(child, IncarnationState::Disposing);
+                self.transition_incarnation(
+                    child,
+                    &[
+                        IncarnationState::Unstarted,
+                        IncarnationState::Complete,
+                        IncarnationState::RestartPending,
+                    ],
+                    IncarnationState::Disposing,
+                );
             }
             Event::Terminalized { child } => {
-                self.transition_incarnation(child, IncarnationState::Joined);
-                if self.membership_status(child) == MembershipStatus::Removing {
+                if self.transition_incarnation(
+                    child,
+                    &[IncarnationState::Disposing],
+                    IncarnationState::Joined,
+                ) && self.membership_status(child) == MembershipStatus::Removing
+                {
                     effects.push(Effect::FinalizeRemoval { child });
                 }
             }
@@ -799,6 +836,11 @@ mod tests {
                 if mask & (1 << index) != 0 {
                     step(
                         &mut state,
+                        Event::DisposalStarted { child: *child },
+                        &mut Vec::new(),
+                    );
+                    step(
+                        &mut state,
                         Event::Terminalized { child: *child },
                         &mut Vec::new(),
                     );
@@ -814,10 +856,95 @@ mod tests {
     }
 
     #[test]
+    fn sampled_removal_suppresses_start_effects_until_commit() {
+        for flavor in [ScopeFlavor::Ordered, ScopeFlavor::Dynamic] {
+            let membership = memberships(1)[0];
+            let mut state = SupervisorState::new(flavor, ScopeLifecycle::starting());
+            let child = admit(&mut state, membership, true);
+            step(&mut state, Event::RemovalSampled { child }, &mut Vec::new());
+            let mut effects = Vec::new();
+            step(&mut state, Event::Settle, &mut effects);
+            assert!(
+                effects.is_empty(),
+                "{flavor:?} startup cannot schedule an already-latched membership"
+            );
+            assert!(state.lifecycle().is_starting());
+
+            step(&mut state, Event::RemovalLatched { child }, &mut effects);
+            assert_eq!(effects, [Effect::StopChild { child }]);
+            state.check_invariants();
+        }
+    }
+
+    #[test]
+    fn ordered_stop_releases_one_child_per_join_in_reverse_order() {
+        let members = memberships(3);
+        let mut state = SupervisorState::new(ScopeFlavor::Ordered, ScopeLifecycle::running());
+        let keys: Vec<_> = members
+            .iter()
+            .map(|membership| admit(&mut state, *membership, true))
+            .collect();
+        for &child in &keys {
+            step(&mut state, Event::Spawned { child }, &mut Vec::new());
+        }
+
+        let mut effects = Vec::new();
+        step(
+            &mut state,
+            Event::BeginDrain {
+                reason: StopReason::ShutdownRequested,
+            },
+            &mut effects,
+        );
+        assert!(matches!(effects.as_slice(), [Effect::DrainStarted { .. }]));
+        effects.clear();
+
+        for &expected in keys.iter().rev() {
+            step(&mut state, Event::Settle, &mut effects);
+            assert_eq!(effects, [Effect::StopChild { child: expected }]);
+            effects.clear();
+            assert_eq!(state.ordered_stop_waiting(), Some(expected));
+
+            step(
+                &mut state,
+                Event::IncarnationComplete { child: expected },
+                &mut effects,
+            );
+            step(
+                &mut state,
+                Event::DisposalStarted { child: expected },
+                &mut effects,
+            );
+            step(
+                &mut state,
+                Event::Terminalized { child: expected },
+                &mut effects,
+            );
+            assert!(effects.is_empty());
+        }
+
+        step(&mut state, Event::Settle, &mut effects);
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Finished {
+                reason: StopReason::ShutdownRequested
+            }]
+        ));
+        assert_eq!(state.ordered_stop_waiting(), None);
+        assert!(state.all_children_joined());
+        state.check_invariants();
+    }
+
+    #[test]
     fn registration_keys_are_monotonic_and_exhaustion_is_fail_closed() {
         let members = memberships(4);
         let mut state = SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::running());
         let first = admit(&mut state, members[0], false);
+        step(
+            &mut state,
+            Event::DisposalStarted { child: first },
+            &mut Vec::new(),
+        );
         step(
             &mut state,
             Event::Terminalized { child: first },
@@ -876,6 +1003,7 @@ mod tests {
         assert!(effects.is_empty());
         assert_eq!(state.len(), 1);
 
+        step(&mut state, Event::DisposalStarted { child }, &mut effects);
         step(&mut state, Event::Terminalized { child }, &mut effects);
         let terminal = state.child_state(child);
         for event in [
@@ -900,6 +1028,81 @@ mod tests {
             &mut effects,
         );
         assert_eq!(state.child_state(child), terminal);
+        state.check_invariants();
+    }
+
+    #[test]
+    fn stale_events_cannot_skip_or_regress_incarnation_phases() {
+        let membership = memberships(1)[0];
+        let mut state = SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::running());
+        let child = admit(&mut state, membership, false);
+
+        for event in [
+            Event::Ready {
+                child,
+                removal_latched: false,
+            },
+            Event::IncarnationComplete { child },
+            Event::RestartPending { child },
+            Event::StopStarted { child },
+            Event::Terminalized { child },
+        ] {
+            step(&mut state, event, &mut Vec::new());
+            assert_eq!(
+                state.child_state(child),
+                Some(ChildState::Resident(IncarnationState::Unstarted)),
+                "an event without its predecessor is a total no-op"
+            );
+        }
+
+        step(&mut state, Event::Spawned { child }, &mut Vec::new());
+        assert_eq!(
+            state.child_state(child),
+            Some(ChildState::Resident(IncarnationState::Active))
+        );
+        for event in [
+            Event::Spawned { child },
+            Event::RestartPending { child },
+            Event::DisposalStarted { child },
+            Event::Terminalized { child },
+        ] {
+            step(&mut state, event, &mut Vec::new());
+            assert_eq!(
+                state.child_state(child),
+                Some(ChildState::Resident(IncarnationState::Active)),
+                "duplicate/future events cannot skip an executing incarnation"
+            );
+        }
+
+        step(&mut state, Event::StopStarted { child }, &mut Vec::new());
+        step(&mut state, Event::Spawned { child }, &mut Vec::new());
+        assert_eq!(
+            state.child_state(child),
+            Some(ChildState::Resident(IncarnationState::Stopping)),
+            "a stale spawn cannot rewind a stop"
+        );
+        step(
+            &mut state,
+            Event::IncarnationComplete { child },
+            &mut Vec::new(),
+        );
+        step(&mut state, Event::StopStarted { child }, &mut Vec::new());
+        assert_eq!(
+            state.child_state(child),
+            Some(ChildState::Resident(IncarnationState::Complete)),
+            "a stale stop cannot rewind completed work"
+        );
+        step(&mut state, Event::RestartPending { child }, &mut Vec::new());
+        step(
+            &mut state,
+            Event::IncarnationComplete { child },
+            &mut Vec::new(),
+        );
+        assert_eq!(
+            state.child_state(child),
+            Some(ChildState::Resident(IncarnationState::RestartPending)),
+            "a duplicate completion cannot cancel pending restart state"
+        );
         state.check_invariants();
     }
 
@@ -943,98 +1146,111 @@ mod tests {
                     SmallEvent::Terminal(index),
                 ]);
             }
-            let mut unique_final = HashSet::new();
-            permutations(&mut schedule, 0, &mut |ordering| {
-                let mut state =
-                    SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::starting());
-                let keys: Vec<_> = members
-                    .iter()
-                    .map(|membership| admit(&mut state, *membership, true))
-                    .collect();
-                let mut published_ready = HashSet::new();
-                let mut removal_seen = HashSet::new();
-                let mut joined_seen = HashSet::new();
-                for event in ordering {
-                    let mut effects = Vec::new();
-                    match *event {
-                        SmallEvent::Spawn(index) => step(
-                            &mut state,
-                            Event::Spawned { child: keys[index] },
-                            &mut effects,
-                        ),
-                        SmallEvent::Ready(index) => {
-                            let removing =
-                                state.membership_status(keys[index]) == MembershipStatus::Removing;
-                            step(
+            for flavor in [ScopeFlavor::Ordered, ScopeFlavor::Dynamic] {
+                let mut unique_final = HashSet::new();
+                permutations(&mut schedule, 0, &mut |ordering| {
+                    let mut state = SupervisorState::new(flavor, ScopeLifecycle::starting());
+                    let keys: Vec<_> = members
+                        .iter()
+                        .map(|membership| admit(&mut state, *membership, true))
+                        .collect();
+                    let mut published_ready = HashSet::new();
+                    let mut removal_seen = HashSet::new();
+                    let mut joined_seen = HashSet::new();
+                    for event in ordering {
+                        let mut effects = Vec::new();
+                        match *event {
+                            SmallEvent::Spawn(index) => step(
                                 &mut state,
-                                Event::Ready {
-                                    child: keys[index],
-                                    removal_latched: removing,
-                                },
+                                Event::Spawned { child: keys[index] },
                                 &mut effects,
-                            );
-                            if !removing && state.initial_ready(keys[index]) {
-                                published_ready.insert(keys[index]);
+                            ),
+                            SmallEvent::Ready(index) => {
+                                let removing = state.membership_status(keys[index])
+                                    == MembershipStatus::Removing;
+                                step(
+                                    &mut state,
+                                    Event::Ready {
+                                        child: keys[index],
+                                        removal_latched: removing,
+                                    },
+                                    &mut effects,
+                                );
+                                if !removing && state.initial_ready(keys[index]) {
+                                    published_ready.insert(keys[index]);
+                                }
+                            }
+                            SmallEvent::Remove(index) => step(
+                                &mut state,
+                                Event::RemovalLatched { child: keys[index] },
+                                &mut effects,
+                            ),
+                            SmallEvent::Terminal(index) => {
+                                // Runtime terminal completion joins retained
+                                // definition disposal before publishing the
+                                // membership edge. Keep that ordered pair atomic
+                                // while permuting it against the other children'
+                                // inputs.
+                                step(
+                                    &mut state,
+                                    Event::DisposalStarted { child: keys[index] },
+                                    &mut effects,
+                                );
+                                step(
+                                    &mut state,
+                                    Event::Terminalized { child: keys[index] },
+                                    &mut effects,
+                                );
                             }
                         }
-                        SmallEvent::Remove(index) => step(
-                            &mut state,
-                            Event::RemovalLatched { child: keys[index] },
-                            &mut effects,
-                        ),
-                        SmallEvent::Terminal(index) => step(
-                            &mut state,
-                            Event::Terminalized { child: keys[index] },
-                            &mut effects,
-                        ),
+                        step(&mut state, Event::Settle, &mut effects);
+                        state.check_invariants();
+                        for child in &keys {
+                            if removal_seen.contains(child) {
+                                assert_eq!(
+                                    state.membership_status(*child),
+                                    MembershipStatus::Removing,
+                                    "removal is a monotone state transition"
+                                );
+                            }
+                            if joined_seen.contains(child) {
+                                assert!(state.joined(*child), "joined state cannot regress");
+                            }
+                            if state.membership_status(*child) == MembershipStatus::Removing {
+                                removal_seen.insert(*child);
+                                assert!(
+                                    !state.initial_ready(*child) || published_ready.contains(child),
+                                    "removal never manufactures a readiness edge"
+                                );
+                            }
+                            if state.joined(*child) {
+                                joined_seen.insert(*child);
+                            }
+                        }
+                        assert_eq!(
+                            state.all_children_joined(),
+                            keys.iter().all(|child| state.joined(*child))
+                        );
+                        for effect in &effects {
+                            match effect {
+                                Effect::StartChild { child }
+                                | Effect::StopChild { child }
+                                | Effect::ForceChild { child }
+                                | Effect::FinalizeRemoval { child } => {
+                                    assert!(state.contains(*child), "effects name a live key");
+                                }
+                                _ => {}
+                            }
+                        }
                     }
-                    step(&mut state, Event::Settle, &mut effects);
-                    state.check_invariants();
-                    for child in &keys {
-                        if removal_seen.contains(child) {
-                            assert_eq!(
-                                state.membership_status(*child),
-                                MembershipStatus::Removing,
-                                "removal is a monotone state transition"
-                            );
-                        }
-                        if joined_seen.contains(child) {
-                            assert!(state.joined(*child), "joined state cannot regress");
-                        }
-                        if state.membership_status(*child) == MembershipStatus::Removing {
-                            removal_seen.insert(*child);
-                            assert!(
-                                !state.initial_ready(*child) || published_ready.contains(child),
-                                "removal never manufactures a readiness edge"
-                            );
-                        }
-                        if state.joined(*child) {
-                            joined_seen.insert(*child);
-                        }
-                    }
-                    assert_eq!(
-                        state.all_children_joined(),
-                        keys.iter().all(|child| state.joined(*child))
+                    unique_final.insert(
+                        keys.iter()
+                            .map(|child| state.child_state(*child).expect("resident"))
+                            .collect::<Vec<_>>(),
                     );
-                    for effect in &effects {
-                        match effect {
-                            Effect::StartChild { child }
-                            | Effect::StopChild { child }
-                            | Effect::ForceChild { child }
-                            | Effect::FinalizeRemoval { child } => {
-                                assert!(state.contains(*child), "effects name a live key");
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-                unique_final.insert(
-                    keys.iter()
-                        .map(|child| state.child_state(*child).expect("resident"))
-                        .collect::<Vec<_>>(),
-                );
-            });
-            assert!(!unique_final.is_empty());
+                });
+                assert!(!unique_final.is_empty());
+            }
         }
     }
 }

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -122,6 +122,23 @@ struct ChildRecord {
     spawned_once: bool,
 }
 
+impl ChildRecord {
+    /// Whether a [`Effect::StartChild`] can still produce a [`Event::Spawned`]
+    /// edge, deliberately spelled as this event's own acceptance set.
+    ///
+    /// Settlement is level-triggered and its driver re-enters [`Event::Settle`]
+    /// until a pass emits nothing, so an effect the shell would decline is not
+    /// merely wasted — it is re-derived from unchanged state forever. Every
+    /// start emission is therefore gated on this predicate, and the reducer
+    /// never asks for construction it could not observe the result of.
+    fn startable(self) -> bool {
+        matches!(
+            self.state,
+            ChildState::Resident(IncarnationState::Unstarted | IncarnationState::RestartPending)
+        )
+    }
+}
+
 /// One input to the structural reducer.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Event {
@@ -441,7 +458,14 @@ impl SupervisorState {
                         return;
                     }
                     if !record.spawned_once {
-                        effects.push(Effect::StartChild { child });
+                        // A never-spawned membership can still be terminalized
+                        // in place — incarnation exhaustion is the reachable
+                        // case. It gates ordered startup exactly as an
+                        // unstarted one does, but asking for construction that
+                        // `Event::Spawned` would reject would spin settlement.
+                        if record.startable() {
+                            effects.push(Effect::StartChild { child });
+                        }
                         return;
                     }
                     if matches!(record.startup, StartupMembership::Initial { ready: false }) {
@@ -453,9 +477,11 @@ impl SupervisorState {
             }
             ScopeFlavor::Dynamic => {
                 for (&child, record) in &self.children {
+                    // `startable` subsumes the membership check: a `Removing`
+                    // record is never `Resident`.
                     if matches!(record.startup, StartupMembership::Initial { .. })
                         && !record.spawned_once
-                        && record.state.membership_status() == MembershipStatus::Active
+                        && record.startable()
                     {
                         effects.push(Effect::StartChild { child });
                     }
@@ -1106,6 +1132,66 @@ mod tests {
         state.check_invariants();
     }
 
+    /// Settlement is level-triggered and its driver re-enters [`Event::Settle`]
+    /// until a pass emits nothing, so a start effect the shell declines is
+    /// re-derived from unchanged state forever rather than merely wasted. Pin
+    /// the emission set to [`Event::Spawned`]'s acceptance set across every
+    /// child state, in both flavors and both membership statuses.
+    #[test]
+    fn start_effects_are_confined_to_the_spawn_transition() {
+        let phases = [
+            IncarnationState::Unstarted,
+            IncarnationState::Active,
+            IncarnationState::Stopping,
+            IncarnationState::Complete,
+            IncarnationState::RestartPending,
+            IncarnationState::Disposing,
+            IncarnationState::Joined,
+        ];
+        for flavor in [ScopeFlavor::Ordered, ScopeFlavor::Dynamic] {
+            for removing in [false, true] {
+                for phase in phases {
+                    let membership = memberships(1)[0];
+                    let mut state = SupervisorState::new(flavor, ScopeLifecycle::starting());
+                    let child = admit(&mut state, membership, true);
+                    state.children.get_mut(&child).expect("child").state = if removing {
+                        ChildState::Removing(phase)
+                    } else {
+                        ChildState::Resident(phase)
+                    };
+
+                    let mut effects = Vec::new();
+                    step(&mut state, Event::Settle, &mut effects);
+                    let started = effects.contains(&Effect::StartChild { child });
+
+                    // `spawned_once` is still false in every arm, so the flag
+                    // reports exactly whether the transition was accepted —
+                    // unlike the resulting state, which already reads `Active`
+                    // in the arm a stale spawn must not rewind.
+                    let mut spawned = state.clone();
+                    step(&mut spawned, Event::Spawned { child }, &mut Vec::new());
+                    assert_eq!(
+                        started,
+                        spawned.spawned_once(child),
+                        "{flavor:?} removing={removing} {phase:?}: a start effect must be one \
+                         accepted `Spawned` away from executing"
+                    );
+
+                    if !started {
+                        let mut again = Vec::new();
+                        step(&mut state, Event::Settle, &mut again);
+                        assert!(
+                            again.is_empty(),
+                            "{flavor:?} removing={removing} {phase:?}: settlement with no start \
+                             effect to honour must already be at its fixed point, got {again:?}"
+                        );
+                    }
+                    state.check_invariants();
+                }
+            }
+        }
+    }
+
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     enum SmallEvent {
         Spawn(usize),
@@ -1240,6 +1326,13 @@ mod tests {
                                     assert!(state.contains(*child), "effects name a live key");
                                 }
                                 _ => {}
+                            }
+                            if let Effect::StartChild { child } = effect {
+                                assert!(
+                                    state.children[child].startable(),
+                                    "a start effect the shell would decline re-derives from \
+                                     unchanged state and never lets settlement terminate"
+                                );
                             }
                         }
                     }

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -79,6 +79,16 @@ impl ChildState {
     }
 
     /// Whether the membership-terminal edge has been published.
+    ///
+    /// Identical to [`Self::joined`] *by construction*, not by accident: this
+    /// model routes every terminal through `Disposing`, and the shell
+    /// publishes the terminal stage only once retained-definition disposal has
+    /// joined. The state that separated them before the consolidation — a
+    /// published terminal with disposal still outstanding — is unrepresentable
+    /// here, so the old `!is_terminal() || is_disposing()` incompleteness test
+    /// collapses to `!joined()`. Both names are kept because the completion
+    /// trichotomy is the vocabulary the shutdown surface is stated in; see
+    /// `ScopeCell::settled` for the scope-level counterparts.
     pub fn membership_terminal(self) -> bool {
         self.incarnation() == IncarnationState::Joined
     }
@@ -735,7 +745,18 @@ impl SupervisorState {
         assert_eq!(self.children.len(), self.child_keys.len());
         for (&key, child) in &self.children {
             assert_eq!(self.child_keys.get(&child.membership), Some(&key));
-            assert_eq!(child.state.membership_terminal(), child.state.joined());
+            // A start effect is only ever derived from `startable`, so a
+            // spawnable record must be one `Event::Spawned` away from
+            // executing. This is the emission/acceptance agreement that keeps
+            // level-triggered settlement terminating.
+            assert!(!child.startable() || !child.state.membership_terminal());
+        }
+        // The ordered cursors are flavor-owned state; a dynamic scope that
+        // grew one would silently acquire a second stop sequencer.
+        if self.flavor != ScopeFlavor::Ordered {
+            assert!(self.next_ordered_start.is_none());
+            assert!(self.ordered_stop_cursor.is_none());
+            assert!(self.ordered_stop_waiting.is_none());
         }
         if let Some(waiting) = self.ordered_stop_waiting {
             assert!(self.lifecycle.is_draining());

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -1,0 +1,1040 @@
+//! Pure structural supervision reducer.
+//!
+//! Runtime adapters sample latches and clocks before constructing an
+//! [`Event`]. The reducer owns membership, startup, and ordered-stop state and
+//! emits commands through an [`EffectSink`]; it never runs user code, reads a
+//! clock, samples randomness, or performs I/O.
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    ops::Bound,
+};
+
+use crate::{
+    Membership, MembershipStatus, PoisonedCounter, ScopeFlavor, ScopeState, StopReason,
+    engine::{ChildCompletionState, ScopeLifecycle},
+};
+
+/// A never-reused child registration.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ChildKey(u64);
+
+impl ChildKey {
+    #[cfg(any(test, feature = "test-util"))]
+    pub const fn fixture(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// The incarnation-level portion of one authoritative child state.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum IncarnationState {
+    /// No incarnation has been started yet.
+    Unstarted,
+    /// The current incarnation is executing.
+    Active,
+    /// Cooperative or forced shutdown is in progress.
+    Stopping,
+    /// The incarnation has completed and no restart/terminal route has won.
+    Complete,
+    /// A restart deadline is pending.
+    RestartPending,
+    /// Terminal definition disposal is pending.
+    Disposing,
+    /// Membership terminality and joined disposal have both completed.
+    Joined,
+}
+
+/// Membership state and transition reason in one enum.
+///
+/// Removal is deliberately not a boolean parallel to incarnation state. The
+/// synchronous control-plane latch is sampled into [`Event::RemovalLatched`];
+/// after that transition, this enum is the reducer's sole authority.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ChildState {
+    /// Ordinary resident membership.
+    Resident(IncarnationState),
+    /// Planned removal won while the child was in the enclosed state.
+    Removing(IncarnationState),
+}
+
+impl ChildState {
+    fn incarnation(self) -> IncarnationState {
+        match self {
+            Self::Resident(state) | Self::Removing(state) => state,
+        }
+    }
+
+    fn with_incarnation(self, state: IncarnationState) -> Self {
+        match self {
+            Self::Resident(_) => Self::Resident(state),
+            Self::Removing(_) => Self::Removing(state),
+        }
+    }
+
+    fn removing(self) -> Self {
+        match self {
+            Self::Resident(state) | Self::Removing(state) => Self::Removing(state),
+        }
+    }
+
+    /// Whether the membership-terminal edge has been published.
+    pub fn membership_terminal(self) -> bool {
+        self.incarnation() == IncarnationState::Joined
+    }
+
+    /// Whether the current incarnation has stopped executing.
+    pub fn incarnation_complete(self) -> bool {
+        matches!(
+            self.incarnation(),
+            IncarnationState::Unstarted
+                | IncarnationState::Complete
+                | IncarnationState::RestartPending
+                | IncarnationState::Disposing
+                | IncarnationState::Joined
+        )
+    }
+
+    /// Whether terminal disposal has joined and no child work remains.
+    pub fn joined(self) -> bool {
+        self.incarnation() == IncarnationState::Joined
+    }
+
+    pub fn membership_status(self) -> MembershipStatus {
+        match self {
+            Self::Resident(_) => MembershipStatus::Active,
+            Self::Removing(_) => MembershipStatus::Removing,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StartupMembership {
+    Initial { ready: bool },
+    Runtime,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ChildRecord {
+    membership: Membership,
+    state: ChildState,
+    startup: StartupMembership,
+    spawned_once: bool,
+}
+
+/// One input to the structural reducer.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Event {
+    Admit {
+        membership: Membership,
+        initial: bool,
+        start_immediately: bool,
+    },
+    Spawned {
+        child: ChildKey,
+    },
+    Ready {
+        child: ChildKey,
+        /// Sample of the synchronous removal latch at step entry.
+        removal_latched: bool,
+    },
+    IncarnationComplete {
+        child: ChildKey,
+    },
+    RestartPending {
+        child: ChildKey,
+    },
+    StopStarted {
+        child: ChildKey,
+    },
+    DisposalStarted {
+        child: ChildKey,
+    },
+    Terminalized {
+        child: ChildKey,
+    },
+    /// Samples a fired removal latch into authoritative state without
+    /// replaying the separately queued removal command.
+    RemovalSampled {
+        child: ChildKey,
+    },
+    RemovalLatched {
+        child: ChildKey,
+    },
+    Reclaim {
+        child: ChildKey,
+    },
+    FailStartup,
+    BeginDrain {
+        reason: StopReason,
+    },
+    Force,
+    /// Level-triggered startup, ordered-stop, and finish recomputation.
+    Settle,
+}
+
+/// A command for the runtime shell or observation projection.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Effect {
+    Admitted {
+        child: ChildKey,
+    },
+    StartChild {
+        child: ChildKey,
+    },
+    StopChild {
+        child: ChildKey,
+    },
+    ForceChild {
+        child: ChildKey,
+    },
+    FinalizeRemoval {
+        child: ChildKey,
+    },
+    StartupCompleted {
+        state: ScopeState,
+    },
+    StartupFailed {
+        state: ScopeState,
+    },
+    DrainStarted {
+        state: ScopeState,
+        startup_pending: bool,
+    },
+    Finished {
+        reason: StopReason,
+    },
+}
+
+/// Destination for effects emitted synchronously by [`step`].
+pub trait EffectSink {
+    fn push(&mut self, effect: Effect);
+}
+
+impl EffectSink for Vec<Effect> {
+    fn push(&mut self, effect: Effect) {
+        Vec::push(self, effect);
+    }
+}
+
+/// Authoritative structural state for one scope incarnation.
+#[derive(Clone, Debug)]
+pub struct SupervisorState {
+    flavor: ScopeFlavor,
+    lifecycle: ScopeLifecycle,
+    children: BTreeMap<ChildKey, ChildRecord>,
+    child_keys: HashMap<Membership, ChildKey>,
+    keys: PoisonedCounter,
+    next_ordered_start: Option<ChildKey>,
+    ordered_stop_cursor: Option<ChildKey>,
+    ordered_stop_waiting: Option<ChildKey>,
+    hard_forced: bool,
+    finish_emitted: bool,
+    #[cfg(any(test, feature = "test-util"))]
+    ordered_stop_inspections: usize,
+}
+
+impl SupervisorState {
+    pub fn new(flavor: ScopeFlavor, lifecycle: ScopeLifecycle) -> Self {
+        Self {
+            flavor,
+            lifecycle,
+            children: BTreeMap::new(),
+            child_keys: HashMap::new(),
+            keys: PoisonedCounter::new(),
+            next_ordered_start: None,
+            ordered_stop_cursor: None,
+            ordered_stop_waiting: None,
+            hard_forced: false,
+            finish_emitted: false,
+            #[cfg(any(test, feature = "test-util"))]
+            ordered_stop_inspections: 0,
+        }
+    }
+
+    pub fn lifecycle(&self) -> &ScopeLifecycle {
+        &self.lifecycle
+    }
+
+    pub fn flavor(&self) -> ScopeFlavor {
+        self.flavor
+    }
+
+    pub fn hard_forced(&self) -> bool {
+        self.hard_forced
+    }
+
+    pub fn key_for(&self, membership: Membership) -> Option<ChildKey> {
+        self.child_keys.get(&membership).copied()
+    }
+
+    pub fn contains(&self, child: ChildKey) -> bool {
+        self.children.contains_key(&child)
+    }
+
+    pub fn membership(&self, child: ChildKey) -> Option<Membership> {
+        self.children.get(&child).map(|record| record.membership)
+    }
+
+    pub fn child_state(&self, child: ChildKey) -> Option<ChildState> {
+        self.children.get(&child).map(|record| record.state)
+    }
+
+    pub fn membership_status(&self, child: ChildKey) -> MembershipStatus {
+        self.child_state(child)
+            .map_or(MembershipStatus::Removing, ChildState::membership_status)
+    }
+
+    pub fn is_initial(&self, child: ChildKey) -> bool {
+        self.children
+            .get(&child)
+            .is_some_and(|record| matches!(record.startup, StartupMembership::Initial { .. }))
+    }
+
+    pub fn initial_ready(&self, child: ChildKey) -> bool {
+        self.children.get(&child).is_some_and(|record| {
+            matches!(record.startup, StartupMembership::Initial { ready: true })
+        })
+    }
+
+    pub fn spawned_once(&self, child: ChildKey) -> bool {
+        self.children
+            .get(&child)
+            .is_some_and(|record| record.spawned_once)
+    }
+
+    pub fn is_disposing(&self, child: ChildKey) -> bool {
+        self.child_state(child)
+            .is_some_and(|state| state.incarnation() == IncarnationState::Disposing)
+    }
+
+    pub fn membership_terminal(&self, child: ChildKey) -> bool {
+        self.child_state(child)
+            .is_some_and(ChildState::membership_terminal)
+    }
+
+    pub fn incarnation_complete(&self, child: ChildKey) -> bool {
+        self.child_state(child)
+            .is_some_and(ChildState::incarnation_complete)
+    }
+
+    pub fn joined(&self, child: ChildKey) -> bool {
+        self.child_state(child).is_some_and(ChildState::joined)
+    }
+
+    pub fn is_incomplete(&self, child: ChildKey) -> bool {
+        self.contains(child) && !self.joined(child)
+    }
+
+    /// Derived completion query; no counter can drift from child state.
+    pub fn all_children_joined(&self) -> bool {
+        self.children.values().all(|record| record.state.joined())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.children.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.children.len()
+    }
+
+    pub fn keys(&self) -> impl DoubleEndedIterator<Item = ChildKey> + '_ {
+        self.children.keys().copied()
+    }
+
+    pub fn keys_after(&self, child: ChildKey) -> impl DoubleEndedIterator<Item = ChildKey> + '_ {
+        self.children
+            .range((Bound::Excluded(child), Bound::Unbounded))
+            .map(|(key, _)| *key)
+    }
+
+    fn previous_key(&self, child: ChildKey) -> Option<ChildKey> {
+        self.children
+            .range(..child)
+            .next_back()
+            .map(|(key, _)| *key)
+    }
+
+    fn transition_incarnation(&mut self, child: ChildKey, next: IncarnationState) {
+        if let Some(record) = self.children.get_mut(&child) {
+            if record.state.membership_terminal() {
+                return;
+            }
+            record.state = record.state.with_incarnation(next);
+        }
+    }
+
+    fn mark_removing(&mut self, child: ChildKey) -> Option<IncarnationState> {
+        let record = self.children.get_mut(&child)?;
+        record.state = record.state.removing();
+        Some(record.state.incarnation())
+    }
+
+    fn admit(
+        &mut self,
+        membership: Membership,
+        initial: bool,
+        start_immediately: bool,
+        effects: &mut impl EffectSink,
+    ) {
+        if self.child_keys.contains_key(&membership) {
+            return;
+        }
+        let Some(raw) = self.keys.mint() else {
+            return;
+        };
+        let child = ChildKey(raw);
+        let replaced = self.children.insert(
+            child,
+            ChildRecord {
+                membership,
+                state: ChildState::Resident(IncarnationState::Unstarted),
+                startup: if initial {
+                    StartupMembership::Initial { ready: false }
+                } else {
+                    StartupMembership::Runtime
+                },
+                spawned_once: false,
+            },
+        );
+        debug_assert!(replaced.is_none(), "monotonic child keys are never reused");
+        let replaced = self.child_keys.insert(membership, child);
+        assert!(
+            replaced.is_none(),
+            "one live membership maps to exactly one child key"
+        );
+        if initial && self.flavor == ScopeFlavor::Ordered && self.next_ordered_start.is_none() {
+            self.next_ordered_start = Some(child);
+        }
+        effects.push(Effect::Admitted { child });
+        if start_immediately && !self.lifecycle.is_draining() && !self.lifecycle.startup_failed() {
+            effects.push(Effect::StartChild { child });
+        }
+    }
+
+    fn settle_startup(&mut self, effects: &mut impl EffectSink) {
+        if !self.lifecycle.is_starting() {
+            return;
+        }
+        match self.flavor {
+            ScopeFlavor::Ordered => {
+                while let Some(child) = self.next_ordered_start {
+                    let Some(record) = self.children.get(&child) else {
+                        let next = self.keys_after(child).next();
+                        self.next_ordered_start = next;
+                        continue;
+                    };
+                    if !record.spawned_once {
+                        effects.push(Effect::StartChild { child });
+                        return;
+                    }
+                    if matches!(record.startup, StartupMembership::Initial { ready: false }) {
+                        return;
+                    }
+                    let next = self.keys_after(child).next();
+                    self.next_ordered_start = next;
+                }
+            }
+            ScopeFlavor::Dynamic => {
+                for (&child, record) in &self.children {
+                    if matches!(record.startup, StartupMembership::Initial { .. })
+                        && !record.spawned_once
+                    {
+                        effects.push(Effect::StartChild { child });
+                    }
+                }
+            }
+        }
+        if self
+            .children
+            .values()
+            .all(|record| !matches!(record.startup, StartupMembership::Initial { ready: false }))
+            && let Some(state) = self.lifecycle.complete_startup()
+        {
+            effects.push(Effect::StartupCompleted { state });
+        }
+    }
+
+    fn begin_drain(&mut self, reason: StopReason, effects: &mut impl EffectSink) {
+        let Some(effect) = self.lifecycle.begin_drain(reason) else {
+            return;
+        };
+        effects.push(Effect::DrainStarted {
+            state: effect.state(),
+            startup_pending: effect.startup_pending(),
+        });
+        match self.flavor {
+            ScopeFlavor::Ordered => {
+                self.ordered_stop_cursor = self.children.keys().next_back().copied();
+            }
+            ScopeFlavor::Dynamic => {
+                for child in self.children.keys().copied() {
+                    if !self.children[&child].state.joined() {
+                        effects.push(Effect::StopChild { child });
+                    }
+                }
+            }
+        }
+    }
+
+    fn settle_ordered_stop(&mut self, effects: &mut impl EffectSink) {
+        if self.flavor != ScopeFlavor::Ordered || !self.lifecycle.is_draining() {
+            return;
+        }
+        if let Some(waiting) = self.ordered_stop_waiting {
+            if self.is_incomplete(waiting) {
+                return;
+            }
+            self.ordered_stop_waiting = None;
+        }
+        while let Some(child) = self.ordered_stop_cursor {
+            self.ordered_stop_cursor = self.previous_key(child);
+            #[cfg(any(test, feature = "test-util"))]
+            {
+                self.ordered_stop_inspections += 1;
+            }
+            if !self.is_incomplete(child) {
+                continue;
+            }
+            self.ordered_stop_waiting = Some(child);
+            effects.push(Effect::StopChild { child });
+            return;
+        }
+    }
+
+    fn settle_finish(&mut self, effects: &mut impl EffectSink) {
+        if self.finish_emitted {
+            return;
+        }
+        let reason = self.lifecycle.finish_if_ready(
+            self.flavor,
+            ChildCompletionState {
+                has_children: !self.children.is_empty(),
+                all_terminal: self.all_children_joined(),
+            },
+        );
+        if let Some(reason) = reason {
+            self.finish_emitted = true;
+            effects.push(Effect::Finished { reason });
+        }
+    }
+
+    fn apply(&mut self, event: Event, effects: &mut impl EffectSink) {
+        match event {
+            Event::Admit {
+                membership,
+                initial,
+                start_immediately,
+            } => self.admit(membership, initial, start_immediately, effects),
+            Event::Spawned { child } => {
+                if let Some(record) = self.children.get_mut(&child)
+                    && !record.state.membership_terminal()
+                {
+                    record.spawned_once = true;
+                    record.state = record.state.with_incarnation(IncarnationState::Active);
+                }
+            }
+            Event::Ready {
+                child,
+                removal_latched,
+            } => {
+                if removal_latched {
+                    self.mark_removing(child);
+                }
+                let Some(record) = self.children.get_mut(&child) else {
+                    return;
+                };
+                if record.state.membership_status() == MembershipStatus::Removing
+                    || record.state.membership_terminal()
+                    || !matches!(
+                        record.state.incarnation(),
+                        IncarnationState::Active | IncarnationState::Stopping
+                    )
+                {
+                    return;
+                }
+                if let StartupMembership::Initial { ready } = &mut record.startup {
+                    *ready = true;
+                }
+            }
+            Event::IncarnationComplete { child } => {
+                self.transition_incarnation(child, IncarnationState::Complete);
+            }
+            Event::RestartPending { child } => {
+                if let Some(record) = self.children.get_mut(&child) {
+                    if record.state.membership_terminal() {
+                        return;
+                    }
+                    record.state = record
+                        .state
+                        .with_incarnation(IncarnationState::RestartPending);
+                    if self.lifecycle.is_starting()
+                        && let StartupMembership::Initial { ready } = &mut record.startup
+                    {
+                        *ready = false;
+                    }
+                }
+            }
+            Event::StopStarted { child } => {
+                self.transition_incarnation(child, IncarnationState::Stopping);
+            }
+            Event::DisposalStarted { child } => {
+                self.transition_incarnation(child, IncarnationState::Disposing);
+            }
+            Event::Terminalized { child } => {
+                self.transition_incarnation(child, IncarnationState::Joined);
+                if self.membership_status(child) == MembershipStatus::Removing {
+                    effects.push(Effect::FinalizeRemoval { child });
+                }
+            }
+            Event::RemovalSampled { child } => {
+                self.mark_removing(child);
+            }
+            Event::RemovalLatched { child } => {
+                let Some(state) = self.mark_removing(child) else {
+                    return;
+                };
+                if state == IncarnationState::Joined {
+                    effects.push(Effect::FinalizeRemoval { child });
+                } else {
+                    effects.push(Effect::StopChild { child });
+                }
+            }
+            Event::Reclaim { child } => {
+                let Some(record) = self.children.get(&child) else {
+                    return;
+                };
+                if !record.state.joined() {
+                    return;
+                }
+                let membership = record.membership;
+                self.children.remove(&child);
+                let removed = self.child_keys.remove(&membership);
+                debug_assert_eq!(removed, Some(child));
+            }
+            Event::FailStartup => {
+                if let Some(state) = self.lifecycle.fail_startup() {
+                    effects.push(Effect::StartupFailed { state });
+                }
+            }
+            Event::BeginDrain { reason } => self.begin_drain(reason, effects),
+            Event::Force => {
+                self.hard_forced = true;
+                self.begin_drain(StopReason::ShutdownRequested, effects);
+                for child in self.children.keys().copied() {
+                    if !self.children[&child].state.joined() {
+                        effects.push(Effect::ForceChild { child });
+                    }
+                }
+            }
+            Event::Settle => {
+                self.settle_startup(effects);
+                self.settle_ordered_stop(effects);
+                self.settle_finish(effects);
+            }
+        }
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn ordered_stop_inspections(&self) -> usize {
+        self.ordered_stop_inspections
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn next_ordered_start(&self) -> Option<ChildKey> {
+        self.next_ordered_start
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn ordered_stop_waiting(&self) -> Option<ChildKey> {
+        self.ordered_stop_waiting
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn set_next_ordered_start_for_test(&mut self, next: Option<ChildKey>) {
+        self.next_ordered_start = next;
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn set_hard_forced_for_test(&mut self, forced: bool) {
+        self.hard_forced = forced;
+    }
+
+    #[cfg(test)]
+    fn check_invariants(&self) {
+        assert_eq!(self.children.len(), self.child_keys.len());
+        for (&key, child) in &self.children {
+            assert_eq!(self.child_keys.get(&child.membership), Some(&key));
+            assert_eq!(child.state.membership_terminal(), child.state.joined());
+        }
+        if let Some(waiting) = self.ordered_stop_waiting {
+            assert!(self.lifecycle.is_draining());
+            assert!(self.contains(waiting) || self.ordered_stop_cursor < Some(waiting));
+        }
+    }
+}
+
+/// Applies one total transition to [`SupervisorState`].
+pub fn step(state: &mut SupervisorState, event: Event, effects: &mut impl EffectSink) {
+    state.apply(event, effects);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use crate::{ChildId, ScopeIdentity};
+
+    use super::*;
+
+    fn memberships(count: usize) -> Vec<Membership> {
+        let mut identity = ScopeIdentity::new();
+        (0..count)
+            .map(|index| {
+                identity
+                    .mint_membership(&ChildId::from(format!("child-{index}")))
+                    .expect("membership mints")
+                    .into_pair()
+                    .0
+            })
+            .collect()
+    }
+
+    fn admit(state: &mut SupervisorState, membership: Membership, initial: bool) -> ChildKey {
+        let mut effects = Vec::new();
+        step(
+            state,
+            Event::Admit {
+                membership,
+                initial,
+                start_immediately: false,
+            },
+            &mut effects,
+        );
+        let [Effect::Admitted { child }] = effects.as_slice() else {
+            panic!("admission emits exactly one key")
+        };
+        *child
+    }
+
+    #[test]
+    fn transition_table_keeps_removal_in_the_authoritative_state() {
+        struct Case {
+            before: IncarnationState,
+            event: EventKind,
+            after: ChildState,
+            effect: EffectKind,
+        }
+        #[derive(Clone, Copy)]
+        enum EventKind {
+            Remove,
+            Terminal,
+        }
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        enum EffectKind {
+            Stop,
+            Finalize,
+            None,
+        }
+
+        let cases = [
+            Case {
+                before: IncarnationState::Active,
+                event: EventKind::Remove,
+                after: ChildState::Removing(IncarnationState::Active),
+                effect: EffectKind::Stop,
+            },
+            Case {
+                before: IncarnationState::Joined,
+                event: EventKind::Remove,
+                after: ChildState::Removing(IncarnationState::Joined),
+                effect: EffectKind::Finalize,
+            },
+            Case {
+                before: IncarnationState::Disposing,
+                event: EventKind::Terminal,
+                after: ChildState::Resident(IncarnationState::Joined),
+                effect: EffectKind::None,
+            },
+        ];
+
+        for case in cases {
+            let membership = memberships(1)[0];
+            let mut state = SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::starting());
+            let child = admit(&mut state, membership, true);
+            state.children.get_mut(&child).expect("child").state =
+                ChildState::Resident(case.before);
+            let mut effects = Vec::new();
+            step(
+                &mut state,
+                match case.event {
+                    EventKind::Remove => Event::RemovalLatched { child },
+                    EventKind::Terminal => Event::Terminalized { child },
+                },
+                &mut effects,
+            );
+            let effect = match effects.as_slice() {
+                [Effect::StopChild { .. }] => EffectKind::Stop,
+                [Effect::FinalizeRemoval { .. }] => EffectKind::Finalize,
+                [] => EffectKind::None,
+                other => panic!("unexpected effects: {other:?}"),
+            };
+            assert_eq!(state.child_state(child), Some(case.after));
+            assert_eq!(effect, case.effect);
+            state.check_invariants();
+        }
+    }
+
+    #[test]
+    fn derived_completion_property_matches_the_child_states() {
+        let members = memberships(3);
+        for mask in 0_u8..8 {
+            let mut state = SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::starting());
+            let keys: Vec<_> = members
+                .iter()
+                .map(|membership| admit(&mut state, *membership, true))
+                .collect();
+            for (index, child) in keys.iter().enumerate() {
+                if mask & (1 << index) != 0 {
+                    step(
+                        &mut state,
+                        Event::Terminalized { child: *child },
+                        &mut Vec::new(),
+                    );
+                }
+            }
+            assert_eq!(state.all_children_joined(), mask == 0b111);
+            assert_eq!(
+                state.all_children_joined(),
+                keys.iter().all(|child| state.joined(*child))
+            );
+            state.check_invariants();
+        }
+    }
+
+    #[test]
+    fn registration_keys_are_monotonic_and_exhaustion_is_fail_closed() {
+        let members = memberships(4);
+        let mut state = SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::running());
+        let first = admit(&mut state, members[0], false);
+        step(
+            &mut state,
+            Event::Terminalized { child: first },
+            &mut Vec::new(),
+        );
+        step(&mut state, Event::Reclaim { child: first }, &mut Vec::new());
+        let successor = admit(&mut state, members[1], false);
+        assert!(successor > first, "reclaim never makes a key reusable");
+
+        state.keys = PoisonedCounter::near_exhaustion();
+        let last = admit(&mut state, members[2], false);
+        assert_eq!(last, ChildKey(u64::MAX - 1));
+        let mut effects = Vec::new();
+        step(
+            &mut state,
+            Event::Admit {
+                membership: members[3],
+                initial: false,
+                start_immediately: false,
+            },
+            &mut effects,
+        );
+        assert!(effects.is_empty());
+        assert_eq!(state.key_for(members[3]), None);
+        step(
+            &mut state,
+            Event::Admit {
+                membership: members[3],
+                initial: false,
+                start_immediately: false,
+            },
+            &mut effects,
+        );
+        assert!(
+            effects.is_empty(),
+            "poisoned exhaustion remains fail closed"
+        );
+        state.check_invariants();
+    }
+
+    #[test]
+    fn duplicate_admission_and_stale_events_are_total_noops() {
+        let membership = memberships(1)[0];
+        let mut state = SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::running());
+        let child = admit(&mut state, membership, false);
+        let mut effects = Vec::new();
+        step(
+            &mut state,
+            Event::Admit {
+                membership,
+                initial: false,
+                start_immediately: true,
+            },
+            &mut effects,
+        );
+        assert!(effects.is_empty());
+        assert_eq!(state.len(), 1);
+
+        step(&mut state, Event::Terminalized { child }, &mut effects);
+        let terminal = state.child_state(child);
+        for event in [
+            Event::Spawned { child },
+            Event::Ready {
+                child,
+                removal_latched: false,
+            },
+            Event::IncarnationComplete { child },
+            Event::RestartPending { child },
+            Event::StopStarted { child },
+            Event::DisposalStarted { child },
+        ] {
+            step(&mut state, event, &mut effects);
+            assert_eq!(state.child_state(child), terminal);
+        }
+        step(
+            &mut state,
+            Event::Reclaim {
+                child: ChildKey::fixture(999),
+            },
+            &mut effects,
+        );
+        assert_eq!(state.child_state(child), terminal);
+        state.check_invariants();
+    }
+
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+    enum SmallEvent {
+        Spawn(usize),
+        Ready(usize),
+        Remove(usize),
+        Terminal(usize),
+    }
+
+    fn permutations<T: Copy>(values: &mut [T], at: usize, visit: &mut impl FnMut(&[T])) {
+        if at == values.len() {
+            visit(values);
+            return;
+        }
+        for index in at..values.len() {
+            values.swap(at, index);
+            permutations(values, at + 1, visit);
+            values.swap(at, index);
+        }
+    }
+
+    /// Exhausts every ordering of spawn/readiness/removal/terminal inputs for
+    /// two children (8! schedules), then every three-child ordering of the
+    /// adjudication-sensitive readiness/removal/terminal inputs (9!
+    /// schedules). Invalid/stale events are intentionally part of the state
+    /// space: totality requires them to be harmless.
+    #[test]
+    fn exhaustive_small_scope_interleavings_preserve_reducer_invariants() {
+        for width in [2, 3] {
+            let members = memberships(width);
+            let mut schedule = Vec::new();
+            for index in 0..width {
+                if width == 2 {
+                    schedule.push(SmallEvent::Spawn(index));
+                }
+                schedule.extend([
+                    SmallEvent::Ready(index),
+                    SmallEvent::Remove(index),
+                    SmallEvent::Terminal(index),
+                ]);
+            }
+            let mut unique_final = HashSet::new();
+            permutations(&mut schedule, 0, &mut |ordering| {
+                let mut state =
+                    SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::starting());
+                let keys: Vec<_> = members
+                    .iter()
+                    .map(|membership| admit(&mut state, *membership, true))
+                    .collect();
+                let mut published_ready = HashSet::new();
+                let mut removal_seen = HashSet::new();
+                let mut joined_seen = HashSet::new();
+                for event in ordering {
+                    let mut effects = Vec::new();
+                    match *event {
+                        SmallEvent::Spawn(index) => step(
+                            &mut state,
+                            Event::Spawned { child: keys[index] },
+                            &mut effects,
+                        ),
+                        SmallEvent::Ready(index) => {
+                            let removing =
+                                state.membership_status(keys[index]) == MembershipStatus::Removing;
+                            step(
+                                &mut state,
+                                Event::Ready {
+                                    child: keys[index],
+                                    removal_latched: removing,
+                                },
+                                &mut effects,
+                            );
+                            if !removing && state.initial_ready(keys[index]) {
+                                published_ready.insert(keys[index]);
+                            }
+                        }
+                        SmallEvent::Remove(index) => step(
+                            &mut state,
+                            Event::RemovalLatched { child: keys[index] },
+                            &mut effects,
+                        ),
+                        SmallEvent::Terminal(index) => step(
+                            &mut state,
+                            Event::Terminalized { child: keys[index] },
+                            &mut effects,
+                        ),
+                    }
+                    step(&mut state, Event::Settle, &mut effects);
+                    state.check_invariants();
+                    for child in &keys {
+                        if removal_seen.contains(child) {
+                            assert_eq!(
+                                state.membership_status(*child),
+                                MembershipStatus::Removing,
+                                "removal is a monotone state transition"
+                            );
+                        }
+                        if joined_seen.contains(child) {
+                            assert!(state.joined(*child), "joined state cannot regress");
+                        }
+                        if state.membership_status(*child) == MembershipStatus::Removing {
+                            removal_seen.insert(*child);
+                            assert!(
+                                !state.initial_ready(*child) || published_ready.contains(child),
+                                "removal never manufactures a readiness edge"
+                            );
+                        }
+                        if state.joined(*child) {
+                            joined_seen.insert(*child);
+                        }
+                    }
+                    assert_eq!(
+                        state.all_children_joined(),
+                        keys.iter().all(|child| state.joined(*child))
+                    );
+                    for effect in &effects {
+                        match effect {
+                            Effect::StartChild { child }
+                            | Effect::StopChild { child }
+                            | Effect::ForceChild { child }
+                            | Effect::FinalizeRemoval { child } => {
+                                assert!(state.contains(*child), "effects name a live key");
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                unique_final.insert(
+                    keys.iter()
+                        .map(|child| state.child_state(*child).expect("resident"))
+                        .collect::<Vec<_>>(),
+                );
+            });
+            assert!(!unique_final.is_empty());
+        }
+    }
+}

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -617,7 +617,13 @@ impl SupervisorState {
                     &[IncarnationState::Complete],
                     IncarnationState::RestartPending,
                 ) && let Some(record) = self.children.get_mut(&child)
-                    && self.lifecycle.is_starting()
+                    // Deliberately the *consumers'* predicate, not
+                    // `is_starting`: a startup-failed or draining scope has
+                    // not completed startup either, and every reader of this
+                    // flag gates on `startup_complete`. Narrowing it here
+                    // would let a pre-ready exit publish `NotAborted` where a
+                    // scope that already failed startup published `Aborted`.
+                    && !self.lifecycle.startup_complete()
                     && let StartupMembership::Initial { ready } = &mut record.startup
                 {
                     *ready = false;

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -1588,7 +1588,7 @@ impl ScopeCell {
             let epoch = control.epochs.begin()?;
             // The idle epoch plane pairs only with a settled projection:
             // `Unstarted` before any mint, `Stopped` after every finish. That
-            // pairing is what lets `scope_settled` treat terminal membership
+            // pairing is what lets `settled` treat terminal membership
             // plus a settled projection as final without stranding a scope
             // that still owns a live incarnation.
             debug_assert!(
@@ -1844,9 +1844,20 @@ impl ScopeCell {
         })
     }
 
-    pub(crate) fn incarnation_finished(&self, epoch: Epoch) -> bool {
+    fn incarnation_complete(&self, epoch: Epoch) -> bool {
         let control = self.control.lock().expect("scope control mutex poisoned");
         control.epochs.finished(epoch)
+    }
+
+    fn membership_terminal(&self) -> bool {
+        matches!(self.member.record().stage, MemberStage::Terminal(_))
+    }
+
+    fn joined(&self) -> bool {
+        matches!(
+            self.record().state,
+            ScopeState::Stopped { .. } | ScopeState::Unstarted
+        )
     }
 
     /// Whether a shutdown wait has crossed the finality fence for its target.
@@ -1869,13 +1880,9 @@ impl ScopeCell {
     /// `Unstarted` (never begun) or `Stopped`. Together they mean the
     /// terminal-membership arm can never be the *only* reachable settlement
     /// for a scope that still owns work.
-    pub(crate) fn scope_settled(&self, epoch: Option<Epoch>) -> bool {
-        epoch.is_some_and(|epoch| self.incarnation_finished(epoch))
-            || (matches!(self.member.record().stage, MemberStage::Terminal(_))
-                && matches!(
-                    self.record().state,
-                    ScopeState::Stopped { .. } | ScopeState::Unstarted
-                ))
+    pub(crate) fn settled(&self, epoch: Option<Epoch>) -> bool {
+        epoch.is_some_and(|epoch| self.incarnation_complete(epoch))
+            || (self.membership_terminal() && self.joined())
     }
 
     pub(crate) fn set_admitted_children(self: &Arc<Self>, children: Vec<ResidentProjection>) {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -8,14 +8,15 @@ mod shutdown;
 mod startup;
 
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
+    ops::{Index, IndexMut},
     sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
 
 mod storage;
 
-use storage::{ChildArena, ChildKey, Obligation};
+use storage::Obligation;
 
 use child::ChildRuntime;
 #[cfg(test)]
@@ -28,8 +29,8 @@ use removal::RemovalRequest;
 pub(crate) use shutdown::shutdown_scope;
 
 use crate::{
-    Cancellation, ChildId, Exit, GracePhase, Incarnation, JitterSample, Membership, Readiness,
-    ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure, StartupFailureCause,
+    Cancellation, ChildId, Exit, GracePhase, Incarnation, JitterSample, Readiness, ScopeState,
+    ShutdownStraggler, ShutdownTimeout, StartupFailure, StartupFailureCause,
     admission::{NotAdmittingCause, ReserveError},
     cells::{
         MemberStage, MemberTransition, ResidentProjection, ScopeCell, ScopeControlEvent,
@@ -37,10 +38,11 @@ use crate::{
     },
     deadline::Deadline,
     engine::{
-        ArbitrationClass, ChildCompletionState, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch,
-        IncarnationRun, IntensityState, MembershipStatus, ReadinessEffect, ReadinessEvent,
-        ReadinessGate, RestartState, ScopeLifecycle, ScopeMode, StopAction, StopLadder, arbitrate,
-        dispatch_exit, schedule_restart,
+        ArbitrationClass, ChildKey, DeadlineHandle, DeadlineQueue, Effect as SupervisorEffect,
+        Epoch, Event as SupervisorEvent, ExitDispatch, IncarnationRun, IntensityState,
+        MembershipStatus, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState,
+        ScopeLifecycle, ScopeMode, StopAction, StopLadder, SupervisorState, arbitrate,
+        dispatch_exit, schedule_restart, step as supervisor_step,
     },
     exit::{
         RecordedOutcome, StartupError, StopReason, classify_disposal_panic, classify_exit,
@@ -196,11 +198,11 @@ struct ScopeRuntime {
     defaults: ResolvedDefaults,
     intensity_policy: crate::Intensity,
     intensity: IntensityState,
-    children: ChildArena<ChildRuntime>,
-    // The index and count are maintained only at child installation/completion.
-    // Driver wakes resolve a subject directly and test completion in O(1).
-    child_keys: HashMap<Membership, ChildKey>,
-    incomplete_children: usize,
+    // Runtime resources are keyed by the arena owned by `supervisor`; this
+    // map carries no lifecycle or membership decisions.
+    children: ChildResources<ChildRuntime>,
+    supervisor: SupervisorState,
+    supervisor_effects: Vec<SupervisorEffect>,
     // Retained restart-shutdown facts whose subjects became inactive mid-batch.
     // `handle_exit` queues them here instead of expediting synchronously so the
     // retry re-enters arbitration on the next wake: an exit collected in the
@@ -211,8 +213,6 @@ struct ScopeRuntime {
     disposal_events: runtime::UnboundedMpscSender<DriverEvent>,
     deadlines: DeadlineQueue<DeadlineKind>,
     jitter: runtime::JitterRng,
-    lifecycle: ScopeLifecycle,
-    next_ordered_start: Option<ChildKey>,
     role: ScopeRole,
     dynamic: Option<Arc<DynamicControl>>,
     // Removing an initial member can complete startup. Hold its response
@@ -223,13 +223,104 @@ struct ScopeRuntime {
     epoch: Epoch,
     ancestor_shutdown_seen: bool,
     ancestor_abort_seen: bool,
-    hard_forced: bool,
-    ordered_stop_progressing: bool,
-    ordered_stop_cursor: Option<ChildKey>,
-    ordered_stop_waiting: Option<ChildKey>,
-    #[cfg(test)]
-    ordered_stop_inspections: usize,
     completion: Option<ScopeCompletion>,
+    finished: Option<StopReason>,
+}
+
+struct ChildResources<T>(BTreeMap<ChildKey, T>);
+
+impl<T> Default for ChildResources<T> {
+    fn default() -> Self {
+        Self(BTreeMap::new())
+    }
+}
+
+trait ChildKeyArg {
+    fn child_key(self) -> ChildKey;
+}
+
+impl ChildKeyArg for ChildKey {
+    fn child_key(self) -> ChildKey {
+        self
+    }
+}
+
+impl ChildKeyArg for &ChildKey {
+    fn child_key(self) -> ChildKey {
+        *self
+    }
+}
+
+impl<T> ChildResources<T> {
+    fn insert(&mut self, key: ChildKey, child: T) -> Option<T> {
+        self.0.insert(key, child)
+    }
+
+    fn get(&self, key: impl ChildKeyArg) -> Option<&T> {
+        self.0.get(&key.child_key())
+    }
+
+    fn get_mut(&mut self, key: impl ChildKeyArg) -> Option<&mut T> {
+        self.0.get_mut(&key.child_key())
+    }
+
+    fn remove(&mut self, key: impl ChildKeyArg) -> Option<T> {
+        self.0.remove(&key.child_key())
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (ChildKey, &T)> {
+        self.0.iter().map(|(key, child)| (*key, child))
+    }
+
+    fn values(&self) -> impl Iterator<Item = &T> {
+        self.0.values()
+    }
+
+    fn values_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.0.values_mut()
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[cfg(test)]
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn clear(&mut self) {
+        self.0.clear();
+    }
+}
+
+impl<T> Index<ChildKey> for ChildResources<T> {
+    type Output = T;
+
+    fn index(&self, key: ChildKey) -> &Self::Output {
+        self.get(key).expect("live child resource key")
+    }
+}
+
+impl<T> Index<&ChildKey> for ChildResources<T> {
+    type Output = T;
+
+    fn index(&self, key: &ChildKey) -> &Self::Output {
+        self.get(key).expect("live child resource key")
+    }
+}
+
+impl<T> IndexMut<ChildKey> for ChildResources<T> {
+    fn index_mut(&mut self, key: ChildKey) -> &mut Self::Output {
+        self.get_mut(key).expect("live child resource key")
+    }
+}
+
+impl<T> IndexMut<&ChildKey> for ChildResources<T> {
+    fn index_mut(&mut self, key: &ChildKey) -> &mut Self::Output {
+        self.get_mut(key).expect("live child resource key")
+    }
 }
 
 struct ScopeCompletion {
@@ -281,7 +372,7 @@ impl Drop for ScopeRuntime {
         let reason = completion
             .as_ref()
             .map(|completion| completion.reason.clone())
-            .or_else(|| self.lifecycle.draining_reason().cloned())
+            .or_else(|| self.supervisor.lifecycle().draining_reason().cloned())
             .unwrap_or(StopReason::ShutdownRequested);
         if let Some(exit) = completion.and_then(|completion| completion.root_exit) {
             self.root.finish_root_incarnation(self.epoch, reason, exit);
@@ -292,24 +383,73 @@ impl Drop for ScopeRuntime {
 }
 
 impl ScopeRuntime {
+    fn reduce(&mut self, event: SupervisorEvent) {
+        supervisor_step(&mut self.supervisor, event, &mut self.supervisor_effects);
+    }
+
+    fn flush_supervisor_effects(&mut self) {
+        while !self.supervisor_effects.is_empty() {
+            let effects = std::mem::take(&mut self.supervisor_effects);
+            for effect in effects {
+                match effect {
+                    SupervisorEffect::Admitted { .. } => {
+                        unreachable!("admission consumes its key synchronously")
+                    }
+                    SupervisorEffect::StartChild { child } => self.spawn_child(child),
+                    SupervisorEffect::StopChild { child } => self.begin_stop_child(child, None),
+                    SupervisorEffect::ForceChild { child } => self.force_child(child),
+                    SupervisorEffect::FinalizeRemoval { child } => self.finalize_removal(child),
+                    SupervisorEffect::StartupCompleted { state } => {
+                        self.publish_startup_complete(state);
+                    }
+                    SupervisorEffect::Finished { reason } => {
+                        self.finished.get_or_insert(reason);
+                    }
+                    SupervisorEffect::StartupFailed { .. }
+                    | SupervisorEffect::DrainStarted { .. } => {
+                        unreachable!("the transition owner publishes its contextual result")
+                    }
+                }
+            }
+        }
+    }
+
+    fn settle_supervisor(&mut self) {
+        loop {
+            self.reduce(SupervisorEvent::Settle);
+            if self.supervisor_effects.is_empty() {
+                break;
+            }
+            self.flush_supervisor_effects();
+            if self.finished.is_some() {
+                break;
+            }
+        }
+    }
+
     pub(super) fn insert_child(
         &mut self,
         child: ChildRuntime,
+        initial: bool,
     ) -> Result<ChildKey, Box<ChildRuntime>> {
         let membership = child.slot.member.membership();
-        let incomplete = child.is_incomplete();
-        let key = self.children.insert(child)?;
-        let replaced = self.child_keys.insert(membership, key);
-        assert!(
+        let before = self.supervisor_effects.len();
+        self.reduce(SupervisorEvent::Admit {
+            membership,
+            initial,
+            start_immediately: false,
+        });
+        let key = match self.supervisor_effects.get(before) {
+            Some(SupervisorEffect::Admitted { child }) => *child,
+            None => return Err(Box::new(child)),
+            Some(effect) => unreachable!("admission emitted {effect:?} before its key"),
+        };
+        self.supervisor_effects.remove(before);
+        let replaced = self.children.insert(key, child);
+        debug_assert!(
             replaced.is_none(),
-            "one live membership maps to exactly one child key"
+            "the reducer's monotonic child key is new to runtime resources"
         );
-        if incomplete {
-            self.incomplete_children = self
-                .incomplete_children
-                .checked_add(1)
-                .expect("an in-memory child count fits in usize");
-        }
         Ok(key)
     }
 
@@ -317,7 +457,7 @@ impl ScopeRuntime {
     fn record_storage(&self) {
         self.root.record_runtime_storage(RuntimeStorage {
             children: self.children.len(),
-            child_slots: self.children.storage_len(),
+            child_slots: self.children.len(),
             deadlines: self.deadlines.len(),
             deadline_slots: self.deadlines.storage_len(),
         });
@@ -332,12 +472,12 @@ impl ScopeRuntime {
             .dynamic
             .as_ref()
             .is_none_or(|current| !Arc::ptr_eq(current, &control))
-            || self.lifecycle.is_draining()
-            || self.lifecycle.startup_failed()
+            || self.supervisor.lifecycle().is_draining()
+            || self.supervisor.lifecycle().startup_failed()
         {
-            let cause = if self.lifecycle.is_draining() {
+            let cause = if self.supervisor.lifecycle().is_draining() {
                 NotAdmittingCause::Draining
-            } else if self.lifecycle.startup_failed() {
+            } else if self.supervisor.lifecycle().startup_failed() {
                 NotAdmittingCause::StartupFailed
             } else {
                 NotAdmittingCause::NoLiveIncarnation
@@ -385,8 +525,7 @@ impl ScopeRuntime {
         // Conversion can unwind while acquiring child identity or configuring
         // the mailbox. Keep that fallible work outside the control-plane lock
         // so driver teardown can still close reservations and removals.
-        let mut child = ChildRuntime::from_plan(plan, &self.root);
-        child.initial = false;
+        let child = ChildRuntime::from_plan(plan, &self.root);
         enum AdmissionInstall {
             Admitted(ChildKey),
             Rejected {
@@ -417,7 +556,7 @@ impl ScopeRuntime {
             // state transition: an exact remover sees either the reservation
             // or a resident carrying its live arena key, never an unindexed
             // admitted intermediate.
-            let key = match self.insert_child(child) {
+            let key = match self.insert_child(child, false) {
                 Ok(key) => key,
                 Err(child) => {
                     let removed = state.remove(id, txn);
@@ -642,21 +781,6 @@ async fn run_scope(plan: ScopePlan, role: ScopeRole) -> StopReason {
     run_scope_incarnation(plan, role, epoch).await
 }
 
-/// Derives the membership index and incompleteness count for a freshly
-/// assembled child arena. Production construction and the test builder both
-/// call this, so the derived state cannot drift between them.
-fn index_children(children: &ChildArena<ChildRuntime>) -> (HashMap<Membership, ChildKey>, usize) {
-    let child_keys = children
-        .iter()
-        .map(|(key, child)| (child.slot.member.membership(), key))
-        .collect();
-    let incomplete_children = children
-        .values()
-        .filter(|child| child.is_incomplete())
-        .count();
-    (child_keys, incomplete_children)
-}
-
 async fn run_scope_incarnation(
     mut plan: ScopePlan,
     role: ScopeRole,
@@ -697,48 +821,53 @@ async fn run_scope_incarnation(
     // owned by ScopePlan, while ChildRuntime::from_plan arms the current
     // child's obligation before fallible setup. Thus a panic at any point has
     // exactly one terminality owner for every child.
-    let mut children = ChildArena::default();
+    let mut supervisor = SupervisorState::new(root.flavor, epoch.lifecycle());
+    let mut supervisor_effects = Vec::new();
+    let mut children = ChildResources::default();
     plan.children.reverse();
     while let Some(child) = plan.children.pop() {
         let child = ChildRuntime::from_plan(child, &root);
-        if children.insert(child).is_err() {
-            unreachable!("a fresh child-key domain accommodates an in-memory child collection");
-        }
+        let membership = child.slot.member.membership();
+        supervisor_step(
+            &mut supervisor,
+            SupervisorEvent::Admit {
+                membership,
+                initial: true,
+                start_immediately: false,
+            },
+            &mut supervisor_effects,
+        );
+        let Some(SupervisorEffect::Admitted { child: key }) = supervisor_effects.pop() else {
+            unreachable!("a fresh child-key domain accommodates an in-memory child collection")
+        };
+        let replaced = children.insert(key, child);
+        debug_assert!(replaced.is_none());
     }
     if let Some(control) = &dynamic {
         root.with_observation_gate(|txn| {
             control.register_initial(children.iter().map(|(key, child)| (&child.slot, key)), txn);
         });
     }
-    let next_ordered_start = children.keys().next();
-    let (child_keys, incomplete_children) = index_children(&children);
     let mut scope = ScopeRuntime {
         root: Arc::clone(&root),
         defaults: plan.defaults.clone(),
         intensity_policy: plan.intensity_policy(),
         intensity: IntensityState::default(),
         children,
-        child_keys,
-        incomplete_children,
+        supervisor,
+        supervisor_effects,
         restart_shutdown_retries: Vec::new(),
         events,
         disposal_events,
         deadlines: DeadlineQueue::default(),
         jitter: runtime::JitterRng::new(),
-        lifecycle: epoch.lifecycle(),
-        next_ordered_start,
         role,
         dynamic,
         pending_startup_removals: Vec::new(),
         ancestor_shutdown_seen: false,
         ancestor_abort_seen: false,
-        hard_forced: false,
-        ordered_stop_progressing: false,
-        ordered_stop_cursor: None,
-        ordered_stop_waiting: None,
-        #[cfg(test)]
-        ordered_stop_inspections: 0,
         completion: None,
+        finished: None,
         // Transfer last: every fallible setup expression above remains
         // covered by the pre-driver guard, and completed construction moves
         // the raw epoch directly into ScopeRuntime's synchronous epilogue.
@@ -764,16 +893,7 @@ async fn run_scope_incarnation(
     #[cfg(test)]
     scope.record_storage();
 
-    match scope.root.flavor {
-        ScopeFlavor::Ordered => scope.progress_startup(),
-        ScopeFlavor::Dynamic => {
-            let children: Vec<_> = scope.children.keys().collect();
-            for child in children {
-                scope.spawn_child(child);
-            }
-            scope.progress_startup();
-        }
-    }
+    scope.settle_supervisor();
 
     let mut signal = root.signal().watcher();
     let mut pending = Vec::new();
@@ -953,13 +1073,13 @@ async fn run_scope_incarnation(
         // Settlement is level-triggered from authoritative state after every
         // batch. Any transition that changes the startup aggregate therefore
         // gets the same recomputation point as terminal completion.
-        scope.progress_startup();
+        scope.settle_supervisor();
         // A removal response is also an observation edge: SPEC §6 promises
         // that a returned `Removed` has already been incorporated into the
         // startup aggregate. Finalization retains starting-phase obligations
         // until the recomputation above establishes that order.
         scope.publish_startup_removals();
-        if let Some(reason) = scope.finish_if_ready() {
+        if let Some(reason) = scope.finished.take() {
             let root_exit = scope.role.is_root().then(|| stop_reason_root_exit(&reason));
             // ScopeRuntime's synchronous epilogue clears dynamic state,
             // discharges child obligations and residency, and only then

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -62,10 +62,11 @@ pub(super) struct DynamicEntry {
     pub(super) removal: Obligation<RemovalResponses>,
 }
 
-// The authoritative dynamic control-plane phase. `MemberRecord::membership_status`
-// is only its public observation projection; driver decisions use this enum.
-// A resident owns its arena key, so removal and restart paths never have to
-// rediscover the corresponding `ChildRuntime` with a linear scan.
+// Synchronous reservation transport and removal-latch state. Once admitted,
+// `SupervisorState` is the driver's authority; this phase is sampled at step
+// entry so callers can latch removal under the observation gate without
+// mutating reducer state behind its back. A resident retains its reducer key
+// so the sample never needs a linear runtime-resource scan.
 enum DynamicMembershipState {
     Reserved,
     Resident {
@@ -155,14 +156,13 @@ impl DynamicEntry {
         Some(key)
     }
 
-    pub(super) fn restart_is_suppressed(&self, key: ChildKey) -> bool {
+    pub(super) fn removal_latched(&self) -> bool {
         match &self.state {
             DynamicMembershipState::Reserved => false,
-            DynamicMembershipState::Resident {
-                key: resident,
-                fused_cancel,
-            } => *resident == key && fused_cancel.as_ref().is_some_and(Latch::is_fired),
-            DynamicMembershipState::Removing { key: removing } => *removing == key,
+            DynamicMembershipState::Resident { fused_cancel, .. } => {
+                fused_cancel.as_ref().is_some_and(Latch::is_fired)
+            }
+            DynamicMembershipState::Removing { .. } => true,
         }
     }
 }
@@ -464,10 +464,7 @@ fn signal_fused_cancel_impl(
             .entry_mut(slot.member.id())
             .filter(|entry| entry.slot.member.membership() == slot.member.membership())
             .and_then(|entry| entry.mark_removing(txn))
-            .map(|key| RemovalRequest {
-                membership: slot.member.membership(),
-                key,
-            })
+            .map(|key| RemovalRequest { key })
     };
     if let Some(removal) = removal {
         scope.set_child_removing_locked(&slot.member, txn);
@@ -520,10 +517,7 @@ fn remove_dynamic_impl(
     // through the normal removal path, like live residents, so that
     // registration is reclaimed before the removal response completes.
     let member = Arc::clone(&entry.slot.member);
-    let membership = member.membership();
-    let removal = entry
-        .mark_removing(txn)
-        .map(|key| RemovalRequest { membership, key });
+    let removal = entry.mark_removing(txn).map(|key| RemovalRequest { key });
     drop(state);
     if let Some(removal) = removal {
         // Projection first, then the deferred request: the same order the

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -544,6 +544,14 @@ impl ScopeRuntime {
         exited_incarnation: Option<Incarnation>,
         startup: StartupDisposition,
     ) -> bool {
+        // Production terminal publication follows joined construction
+        // disposal.  A few structural test/fallback paths synthesize that
+        // already-joined boundary directly, so normalize them through the
+        // same reducer predecessor instead of allowing `Terminalized` to
+        // skip arbitrary incarnation states.
+        if !self.supervisor.is_disposing(key) && !self.supervisor.membership_terminal(key) {
+            self.reduce(SupervisorEvent::DisposalStarted { child: key });
+        }
         let changed = self
             .children
             .get_mut(key)
@@ -554,6 +562,16 @@ impl ScopeRuntime {
     }
 
     pub(super) fn spawn_child(&mut self, key: ChildKey) {
+        // A queued start effect can outlive the synchronous removal latch
+        // that it was computed against. Re-sample that source at the single
+        // construction funnel so initial and freshly admitted children obey
+        // the same execution-time suppression rule as restart deadlines.
+        // Scope-stop sources remain owned by their ordered control event; this
+        // gate is the membership-local rule from SPEC §7.
+        if self.removal_latched(key) {
+            self.reduce(SupervisorEvent::RemovalSampled { child: key });
+            return;
+        }
         let Some(child) = self.children.get(key) else {
             return;
         };

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -558,6 +558,15 @@ impl ScopeRuntime {
             .expect("terminalized child remains registered")
             .terminalize(&self.root, exit, exited_incarnation, startup);
         self.reduce(SupervisorEvent::Terminalized { child: key });
+        // The reducer drops an event whose predecessor never ran, which keeps
+        // `step` total but leaves the shell no return channel. A child that
+        // published terminality without reaching `Joined` would never count
+        // toward completion, so the scope would simply never finish. Assert
+        // the transition landed rather than discovering it as a stall.
+        debug_assert!(
+            self.supervisor.joined(key),
+            "terminal publication must leave the reducer's membership joined"
+        );
         changed
     }
 
@@ -1041,6 +1050,13 @@ impl ScopeRuntime {
             return;
         }
         self.reduce(SupervisorEvent::DisposalStarted { child: key });
+        // Same reasoning as `terminalize_child`: a dropped `DisposalStarted`
+        // would make the later `Terminalized` unreachable too, stranding the
+        // membership short of `Joined` with no loud failure.
+        debug_assert!(
+            self.supervisor.is_disposing(key),
+            "terminal disposal must leave the reducer's incarnation disposing"
+        );
         let construction = {
             let Some(child) = self.children.get_mut(key) else {
                 return;

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -165,9 +165,6 @@ pub(super) struct ChildRuntime {
     pub(super) restart_deadline: Option<DeadlineHandle>,
     pub(super) restart_shutdown_pending: Option<Epoch>,
     pub(super) active: Option<ActiveChild>,
-    pub(super) initial_ready: bool,
-    pub(super) initial: bool,
-    pub(super) spawned_once: bool,
 }
 
 pub(super) struct PendingTerminal {
@@ -210,26 +207,17 @@ impl ChildRuntime {
             restart_deadline: None,
             restart_shutdown_pending: None,
             active: None,
-            initial_ready: false,
-            initial: true,
-            spawned_once: false,
         }
     }
 
+    #[cfg(test)]
     pub(super) fn is_disposing(&self) -> bool {
         self.pending_terminal.is_some()
     }
 
+    #[cfg(test)]
     pub(super) fn is_terminal(&self) -> bool {
         matches!(self.slot.member.record().stage, MemberStage::Terminal(_))
-    }
-
-    /// Reports whether this child still counts against scope completeness:
-    /// it has not published a terminal stage, or its terminal disposal is
-    /// still outstanding. Every `incomplete_children` adjustment and the
-    /// `child_keys` index derivation consult exactly this predicate.
-    pub(super) fn is_incomplete(&self) -> bool {
-        !self.is_terminal() || self.is_disposing()
     }
 
     pub(super) fn terminalize(
@@ -286,9 +274,7 @@ enum SpawnBody {
 
 struct SpawnDispatch {
     body: SpawnBody,
-    declared_readiness: Readiness,
     construction_spent: bool,
-    scope_child: bool,
 }
 
 /// Latches have deliberately separate ownership:
@@ -303,11 +289,22 @@ struct SpawnLatches {
     abort: Latch,
     ready: CompletionGatedLatch,
     local_stop: Latch,
-    framework_abort: Latch,
-    framework_abort_ack: Latch,
+    framework_abort: Option<Latch>,
+    framework_abort_ack: Option<Latch>,
 }
 
 impl SpawnLatches {
+    fn new(scope_child: bool) -> Self {
+        Self {
+            shutdown: Latch::default(),
+            abort: Latch::default(),
+            ready: CompletionGatedLatch::default(),
+            local_stop: Latch::default(),
+            framework_abort: scope_child.then(Latch::default),
+            framework_abort_ack: scope_child.then(Latch::default),
+        }
+    }
+
     fn task_context(&self) -> TaskContextLatches {
         TaskContextLatches {
             shutdown: self.shutdown.clone(),
@@ -321,8 +318,14 @@ impl SpawnLatches {
             parent_ready: self.ready.clone(),
             ancestor: AncestorCommandLatches {
                 shutdown: self.shutdown.clone(),
-                abort: self.framework_abort.clone(),
-                abort_ack: self.framework_abort_ack.clone(),
+                abort: self
+                    .framework_abort
+                    .clone()
+                    .expect("scope incarnations own a framework-abort latch"),
+                abort_ack: self
+                    .framework_abort_ack
+                    .clone()
+                    .expect("scope incarnations own a framework-abort acknowledgement"),
             },
         }
     }
@@ -369,9 +372,7 @@ fn dispatch_child_construction(
                     },
                     readiness: child.options.readiness,
                 },
-                declared_readiness: child.options.readiness,
                 construction_spent,
-                scope_child: false,
             }
         }
         ChildConstruction::Task(definition) => SpawnDispatch {
@@ -379,18 +380,14 @@ fn dispatch_child_construction(
                 factory: Arc::clone(&definition.factory),
                 context: TaskContext::new(id, incarnation, latches.task_context()),
             },
-            declared_readiness: child.options.readiness,
             construction_spent: false,
-            scope_child: false,
         },
         ChildConstruction::TaskOnce(definition) => SpawnDispatch {
             body: SpawnBody::TaskOnce {
                 body: definition.take_body(),
                 context: TaskContext::new(id, incarnation, latches.task_context()),
             },
-            declared_readiness: child.options.readiness,
             construction_spent: true,
-            scope_child: false,
         },
         ChildConstruction::Scope(definition) => {
             let inherited = match definition.defaults {
@@ -429,9 +426,7 @@ fn dispatch_child_construction(
             };
             SpawnDispatch {
                 body,
-                declared_readiness: child.options.readiness,
                 construction_spent,
-                scope_child: true,
             }
         }
     }
@@ -549,15 +544,12 @@ impl ScopeRuntime {
         exited_incarnation: Option<Incarnation>,
         startup: StartupDisposition,
     ) -> bool {
-        let changed = self.children[key].terminalize(&self.root, exit, exited_incarnation, startup);
-        debug_assert!(
-            !self.children[key].is_incomplete(),
-            "terminal completion leaves no disposal outstanding"
-        );
-        self.incomplete_children = self
-            .incomplete_children
-            .checked_sub(1)
-            .expect("a child completes terminality exactly once");
+        let changed = self
+            .children
+            .get_mut(key)
+            .expect("terminalized child remains registered")
+            .terminalize(&self.root, exit, exited_incarnation, startup);
+        self.reduce(SupervisorEvent::Terminalized { child: key });
         changed
     }
 
@@ -565,14 +557,17 @@ impl ScopeRuntime {
         let Some(child) = self.children.get(key) else {
             return;
         };
-        if self.lifecycle.is_draining()
+        if self.supervisor.lifecycle().is_draining()
             || child.active.is_some()
-            || child.is_terminal()
-            || child.is_disposing()
+            || self.supervisor.membership_terminal(key)
+            || self.supervisor.is_disposing(key)
         {
             return;
         }
-        let child = &mut self.children[key];
+        let child = self
+            .children
+            .get_mut(key)
+            .expect("the spawnable child remains registered");
         if let Some(deadline) = child.restart_deadline.take() {
             self.deadlines.cancel(deadline);
         }
@@ -583,12 +578,14 @@ impl ScopeRuntime {
                 .record()
                 .last_exit
                 .unwrap_or_else(Exit::never_started);
-            let startup =
-                if child.initial && !self.lifecycle.startup_complete() && !child.initial_ready {
-                    StartupDisposition::Aborted
-                } else {
-                    StartupDisposition::NotAborted
-                };
+            let startup = if self.supervisor.is_initial(key)
+                && !self.supervisor.lifecycle().startup_complete()
+                && !self.supervisor.initial_ready(key)
+            {
+                StartupDisposition::Aborted
+            } else {
+                StartupDisposition::NotAborted
+            };
             // Exhaustion is a terminal outcome, not an exceptional cleanup
             // path. Join retained-definition disposal before terminality,
             // retention, removal completion, or ordered-scope progression.
@@ -603,22 +600,13 @@ impl ScopeRuntime {
         //   exits first and orders late retained readiness capabilities;
         // - framework_abort/ack join nested-scope escalation before exit.
         // Each edge is level-triggered, so helper startup cannot lose a pulse.
-        let latches = SpawnLatches {
-            shutdown: Latch::default(),
-            abort: Latch::default(),
-            ready: CompletionGatedLatch::default(),
-            local_stop: Latch::default(),
-            framework_abort: Latch::default(),
-            framework_abort_ack: Latch::default(),
-        };
+        let scope_child = matches!(child.construction.get_mut(), ChildConstruction::Scope(_));
+        let latches = SpawnLatches::new(scope_child);
         let SpawnDispatch {
             body,
-            declared_readiness,
             construction_spent,
-            scope_child,
         } = dispatch_child_construction(child, &self.root, &self.defaults, incarnation, &latches);
         let now = runtime::now();
-        child.spawned_once = true;
         if let Some(mailbox) = &child.mailbox {
             #[cfg(debug_assertions)]
             debug_assert!(
@@ -643,7 +631,7 @@ impl ScopeRuntime {
             .readiness_deadline()
             .and_then(|duration| Deadline::after(now, duration).instant());
         let readiness_effect = readiness.step(ReadinessEvent::Configure {
-            readiness: declared_readiness,
+            readiness: child.options.readiness,
             deadline,
         });
         let gated = readiness.needs_signal_watch();
@@ -678,10 +666,11 @@ impl ScopeRuntime {
             readiness,
             readiness_deadline: None,
             ready_signal: latches.ready,
-            framework_abort: scope_child.then_some(latches.framework_abort),
-            framework_abort_ack: scope_child.then_some(latches.framework_abort_ack),
+            framework_abort: latches.framework_abort,
+            framework_abort_ack: latches.framework_abort_ack,
             stop_deadline: None,
         });
+        self.reduce(SupervisorEvent::Spawned { child: key });
         if let Some(effect) = readiness_effect {
             // `progress_startup` already owns this ordered-startup loop. Do
             // not re-enter it synchronously for an immediate child.
@@ -692,19 +681,37 @@ impl ScopeRuntime {
     }
 
     pub(super) fn begin_stop_child(&mut self, key: ChildKey, forced: Option<RecordedOutcome>) {
-        let Some(child) = self.children.get_mut(key) else {
+        let Some(child) = self.children.get(key) else {
             return;
         };
-        if child.is_terminal() || child.is_disposing() {
+        if self.supervisor.membership_terminal(key) || self.supervisor.is_disposing(key) {
             return;
         }
-        if let Some(active) = &mut child.active {
-            if active.ladder.is_some() {
-                if forced.is_some() {
-                    active.forced_outcome = forced;
-                }
-                return;
+        if child
+            .active
+            .as_ref()
+            .is_some_and(|active| active.ladder.is_some())
+        {
+            if let Some(active) = self
+                .children
+                .get_mut(key)
+                .and_then(|child| child.active.as_mut())
+                && forced.is_some()
+            {
+                active.forced_outcome = forced;
             }
+            return;
+        }
+        if child.active.is_some() {
+            self.reduce(SupervisorEvent::StopStarted { child: key });
+            let child = self
+                .children
+                .get_mut(key)
+                .expect("the stopped child remains registered");
+            let active = child
+                .active
+                .as_mut()
+                .expect("the stopped child remains active");
             self.root
                 .transition_child_stage(&child.slot.member, MemberTransition::Stopping, None);
             if let Some(mailbox) = &child.mailbox {
@@ -724,6 +731,10 @@ impl ScopeRuntime {
             });
             self.advance_ladder(key, runtime::now());
         } else {
+            let child = self
+                .children
+                .get_mut(key)
+                .expect("the inactive child remains registered");
             if let Some(deadline) = child.restart_deadline.take() {
                 self.deadlines.cancel(deadline);
             }
@@ -880,6 +891,7 @@ impl ScopeRuntime {
             },
             self.intensity_policy.within(),
         );
+        self.reduce(SupervisorEvent::IncarnationComplete { child: key });
 
         // Fused cancellation is a level-triggered source. It can linearize
         // before the forwarded Removal event or its public status projection
@@ -890,7 +902,7 @@ impl ScopeRuntime {
         // not turn this exit Terminal, or a restartable initial child
         // failing pre-ready would publish `StartupFailed` where the stop's
         // own follow-up event owns the verdict. The broader
-        // `restart_is_suppressed` still gates the restart deadline arm,
+        // `construction_is_suppressed` still gates the restart deadline arm,
         // where every suppression source has a guaranteed follow-up event.
         let membership_status = self.dispatch_membership_status(key);
         let child = self
@@ -898,7 +910,7 @@ impl ScopeRuntime {
             .get_mut(key)
             .expect("the exiting child remains registered");
 
-        let mode = if self.lifecycle.is_draining() {
+        let mode = if self.supervisor.lifecycle().is_draining() {
             ScopeMode::Draining
         } else {
             ScopeMode::Running
@@ -909,9 +921,9 @@ impl ScopeRuntime {
                 // membership failed before its *initial* readiness edge. A
                 // later incarnation stopped pre-ready (e.g. during drain)
                 // does not rewind it.
-                let startup = if child.initial
-                    && !self.lifecycle.startup_complete()
-                    && !child.initial_ready
+                let startup = if self.supervisor.is_initial(key)
+                    && !self.supervisor.lifecycle().startup_complete()
+                    && !self.supervisor.initial_ready(key)
                 {
                     StartupDisposition::Aborted
                 } else {
@@ -920,9 +932,6 @@ impl ScopeRuntime {
                 self.begin_terminal_disposal(key, exit, Some(incarnation), startup);
             }
             ExitDispatch::ScheduleRestart => {
-                if !self.lifecycle.startup_complete() {
-                    child.initial_ready = false;
-                }
                 let sample =
                     JitterSample::from_u64_ratio(self.jitter.sample(0..u64::MAX), u64::MAX);
                 let now = runtime::now();
@@ -958,21 +967,25 @@ impl ScopeRuntime {
                         delay: decision.delay(),
                     },
                 );
-                if let Some(trip) = decision.intensity_trip(self.intensity_policy) {
-                    if self.lifecycle.is_starting() {
+                let trip = decision.intensity_trip(self.intensity_policy);
+                if trip.is_none()
+                    && let Some(restart_at) = decision.restart_at()
+                {
+                    child.restart_deadline = Some(
+                        self.deadlines
+                            .push(restart_at, DeadlineKind::Restart { child: key }),
+                    );
+                }
+                let startup_pending = self.supervisor.lifecycle().is_starting();
+                self.reduce(SupervisorEvent::RestartPending { child: key });
+                if let Some(trip) = trip {
+                    if startup_pending {
                         self.begin_drain_with_startup(
                             StopReason::IntensityTripped(trip.clone()),
                             Err(StartupError::IntensityTripped(trip)),
                         );
                     } else {
                         self.begin_drain(StopReason::IntensityTripped(trip));
-                    }
-                } else {
-                    if let Some(restart_at) = decision.restart_at() {
-                        child.restart_deadline = Some(
-                            self.deadlines
-                                .push(restart_at, DeadlineKind::Restart { child: key }),
-                        );
                     }
                 }
             }
@@ -1003,6 +1016,13 @@ impl ScopeRuntime {
         exited_incarnation: Option<Incarnation>,
         startup: StartupDisposition,
     ) {
+        if !self.supervisor.contains(key)
+            || self.supervisor.is_disposing(key)
+            || self.supervisor.membership_terminal(key)
+        {
+            return;
+        }
+        self.reduce(SupervisorEvent::DisposalStarted { child: key });
         let construction = {
             let Some(child) = self.children.get_mut(key) else {
                 return;
@@ -1023,7 +1043,7 @@ impl ScopeRuntime {
             return;
         };
 
-        if self.hard_forced {
+        if self.supervisor.hard_forced() {
             runtime::dispose_detached(construction);
             self.handle_construction_disposed(key, None);
             return;
@@ -1082,19 +1102,18 @@ impl ScopeRuntime {
             StartupDisposition::NotAborted
         };
         self.terminalize_child(key, exit.clone(), terminal.exited_incarnation, startup);
-        if self.dynamic_membership_is_removing(key) {
-            self.finalize_removal(key);
-        } else if terminal.startup == StartupDisposition::Aborted && !self.lifecycle.is_draining() {
+        if self.supervisor.membership_status(key) == MembershipStatus::Removing {
+            self.flush_supervisor_effects();
+        } else if terminal.startup == StartupDisposition::Aborted
+            && !self.supervisor.lifecycle().is_draining()
+        {
             self.fail_startup(key, exit);
-            if self.children[key].options.retention == crate::Retention::Remove {
+            if self.children[&key].options.retention == crate::Retention::Remove {
                 self.prune_terminal(key);
             }
         } else {
-            if self.children[key].options.retention == crate::Retention::Remove {
+            if self.children[&key].options.retention == crate::Retention::Remove {
                 self.prune_terminal(key);
-            }
-            if self.lifecycle.is_draining() {
-                self.stop_next_ordered();
             }
         }
     }

--- a/crates/shelterwood/src/driver/events.rs
+++ b/crates/shelterwood/src/driver/events.rs
@@ -194,30 +194,17 @@ pub(super) fn restart_shutdown_work(child: ChildKey, target: Epoch) -> (Arbitrat
 impl ScopeRuntime {
     /// Projects the membership status from the *removal* sources alone:
     /// `Removing` when one has latched for this membership — the dynamic
-    /// entry's authoritative `Removing` control-plane state or a fired
+    /// entry's latched `Removing` control-plane state or a fired
     /// fused-cancel latch on its `Resident` state. Scope-level stop
     /// sources (drain, force, latched shutdown requests, ancestor latches)
     /// are deliberately excluded: each of those has a guaranteed follow-up
     /// event that owns the scope verdict, so exit dispatch must not
     /// reclassify the membership as `Removing` on their behalf.
-    pub(super) fn dispatch_membership_status(&self, key: ChildKey) -> MembershipStatus {
-        let Some(child) = self.children.get(key) else {
-            return MembershipStatus::Removing;
-        };
-        let removing = self.dynamic.as_ref().is_some_and(|control| {
-            control
-                .state
-                .lock()
-                .expect("dynamic-state mutex poisoned")
-                .entry(child.slot.member.id())
-                .filter(|entry| entry.slot.member.membership() == child.slot.member.membership())
-                .is_some_and(|entry| entry.restart_is_suppressed(key))
-        });
-        if removing {
-            MembershipStatus::Removing
-        } else {
-            MembershipStatus::Active
+    pub(super) fn dispatch_membership_status(&mut self, key: ChildKey) -> MembershipStatus {
+        if self.removal_latched(key) {
+            self.reduce(SupervisorEvent::RemovalSampled { child: key });
         }
+        self.supervisor.membership_status(key)
     }
 
     /// Reports whether any level-triggered stop source forbids constructing
@@ -227,15 +214,15 @@ impl ScopeRuntime {
     /// event, so this broad consult belongs only at sites that would
     /// otherwise invoke user construction — not at exit dispatch, where it
     /// would misclassify the membership and reroute the scope verdict.
-    pub(super) fn restart_is_suppressed(&self, key: ChildKey) -> bool {
-        self.lifecycle.is_draining()
-            || self.hard_forced
+    pub(super) fn construction_is_suppressed(&self, key: ChildKey) -> bool {
+        self.supervisor.lifecycle().is_draining()
+            || self.supervisor.hard_forced()
             || self.root.has_stop_request(self.epoch)
             || self
                 .role
                 .ancestor()
                 .is_some_and(|latches| latches.shutdown.is_fired() || latches.abort.is_fired())
-            || self.dispatch_membership_status(key) == MembershipStatus::Removing
+            || self.removal_latched(key)
     }
 
     pub(super) fn control_event_work(
@@ -244,9 +231,8 @@ impl ScopeRuntime {
     ) -> Option<(ArbitrationClass, Pending)> {
         match event {
             ScopeControlEvent::RestartShutdown { membership, target } => self
-                .child_keys
-                .get(&membership)
-                .copied()
+                .supervisor
+                .key_for(membership)
                 .map(|child| restart_shutdown_work(child, target)),
         }
     }
@@ -255,7 +241,7 @@ impl ScopeRuntime {
         // Collection and execution are separated by arbitration. Recheck
         // every level-triggered stop source so teardown/removal latched in the
         // same batch suppresses user construction immediately.
-        if self.restart_is_suppressed(key) {
+        if self.construction_is_suppressed(key) {
             if let Some(child) = self.children.get_mut(key) {
                 child.restart_shutdown_pending = None;
             }
@@ -269,7 +255,10 @@ impl ScopeRuntime {
         let Some(child) = self.children.get_mut(key) else {
             return;
         };
-        if !target_is_pending || child.is_terminal() || child.is_disposing() {
+        if !target_is_pending
+            || self.supervisor.membership_terminal(key)
+            || self.supervisor.is_disposing(key)
+        {
             child.restart_shutdown_pending = None;
             return;
         }
@@ -277,7 +266,7 @@ impl ScopeRuntime {
             child.restart_shutdown_pending = Some(target);
             return;
         }
-        if !child.spawned_once {
+        if !self.supervisor.spawned_once(key) {
             // Only a member in the restart gap may be expedited. The wake-start
             // scan this path replaced required `MemberStage::Restarting`; with
             // no active incarnation and the terminal/disposing cases excluded
@@ -332,7 +321,7 @@ impl ScopeRuntime {
                 // this deadline but before the deadline's batch runs. Recheck
                 // the level-triggered sources at execution time so a stale
                 // backoff edge never invokes user construction.
-                if self.restart_is_suppressed(child) {
+                if self.construction_is_suppressed(child) {
                     if let Some(child) = self.children.get_mut(child) {
                         child.restart_deadline.take();
                     }

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -2,68 +2,46 @@ use super::*;
 
 #[derive(Clone, Copy)]
 pub(super) struct RemovalRequest {
-    pub(super) membership: Membership,
     pub(super) key: ChildKey,
 }
 
 impl ScopeRuntime {
-    pub(super) fn dynamic_membership_is_removing(&self, key: ChildKey) -> bool {
-        let Some(child) = self.children.get(key) else {
-            return false;
-        };
-        self.dynamic.as_ref().is_some_and(|control| {
-            control
-                .state
-                .lock()
-                .expect("dynamic-state mutex poisoned")
-                .entry(child.slot.member.id())
-                .filter(|entry| entry.slot.member.membership() == child.slot.member.membership())
-                .is_some_and(|entry| entry.is_removing() && entry.matches_key(key))
-        })
+    pub(super) fn with_dynamic_entry<R>(
+        &self,
+        key: ChildKey,
+        inspect: impl FnOnce(&DynamicEntry) -> R,
+    ) -> Option<R> {
+        let child = self.children.get(key)?;
+        let control = self.dynamic.as_ref()?;
+        let state = control.state.lock().expect("dynamic-state mutex poisoned");
+        state
+            .entry(child.slot.member.id())
+            .filter(|entry| entry.slot.member.membership() == child.slot.member.membership())
+            .filter(|entry| entry.matches_key(key))
+            .map(inspect)
+    }
+
+    pub(super) fn removal_latched(&self, key: ChildKey) -> bool {
+        self.supervisor.membership_status(key) == MembershipStatus::Removing
+            || self
+                .with_dynamic_entry(key, DynamicEntry::removal_latched)
+                .unwrap_or(false)
     }
 
     pub(super) fn handle_removal(&mut self, removal: RemovalRequest) {
-        let RemovalRequest { membership, key } = removal;
-        let Some(member) = self
-            .children
-            .get(key)
-            .map(|child| Arc::clone(&child.slot.member))
-            .filter(|member| member.membership() == membership)
-        else {
-            return;
-        };
-        let Some(control) = &self.dynamic else {
-            return;
-        };
-        let tracked = control
-            .state
-            .lock()
-            .expect("dynamic-state mutex poisoned")
-            .entry(member.id())
-            .filter(|entry| entry.slot.member.membership() == membership)
-            .is_some_and(|entry| entry.is_removing() && entry.matches_key(key));
-        if !tracked {
+        let key = removal.key;
+        if !self.removal_latched(key) {
             return;
         }
-        if self.children[key].is_terminal() {
-            self.finalize_removal(key);
-        } else {
-            self.begin_stop_child(key, None);
-            if self
-                .children
-                .get(key)
-                .is_some_and(ChildRuntime::is_terminal)
-            {
-                self.finalize_removal(key);
-            }
-        }
+        self.reduce(SupervisorEvent::RemovalLatched { child: key });
+        self.flush_supervisor_effects();
     }
 
     pub(super) fn finalize_removal(&mut self, key: ChildKey) {
         let Some(control) = &self.dynamic else {
             return;
         };
-        let member = Arc::clone(&self.children[key].slot.member);
+        let member = Arc::clone(&self.children[&key].slot.member);
         let id = member.id().clone();
         let root = Arc::clone(&self.root);
         let entry = root.with_observation_gate(|txn| {
@@ -95,7 +73,7 @@ impl ScopeRuntime {
     /// ordering is what makes a returned `RemoveOutcome::Removed` imply
     /// startup already saw the shrunken set (SPEC §6).
     fn release_removed_entry(&mut self, entry: DynamicEntry) {
-        if self.lifecycle.is_starting() {
+        if self.supervisor.lifecycle().is_starting() {
             self.pending_startup_removals.push(entry);
         } else {
             drop(entry);
@@ -109,7 +87,7 @@ impl ScopeRuntime {
     }
 
     pub(super) fn prune_terminal(&mut self, key: ChildKey) {
-        let member = Arc::clone(&self.children[key].slot.member);
+        let member = Arc::clone(&self.children[&key].slot.member);
         let root = Arc::clone(&self.root);
         let removed = root.with_observation_gate(|txn| {
             let mut state = self
@@ -148,19 +126,9 @@ impl ScopeRuntime {
         let Some(mut child) = self.children.remove(key) else {
             return;
         };
-        // Reclaim never adjusts `incomplete_children`: every reclaim path runs
-        // after terminal completion, which already decremented the count. An
-        // early reclaim would leak the count and stall scope completion, so
-        // fail loudly instead.
         debug_assert!(
-            !child.is_incomplete(),
-            "reclaim runs only after terminal completion"
-        );
-        let removed = self.child_keys.remove(&child.slot.member.membership());
-        debug_assert_eq!(
-            removed,
-            Some(key),
-            "reclaimed memberships leave the key index"
+            self.supervisor.joined(key),
+            "reclaim runs only after joined terminal completion"
         );
         if let Some(deadline) = child.restart_deadline.take() {
             self.deadlines.cancel(deadline);
@@ -173,6 +141,7 @@ impl ScopeRuntime {
                 self.deadlines.cancel(deadline);
             }
         }
+        self.reduce(SupervisorEvent::Reclaim { child: key });
         #[cfg(test)]
         self.record_storage();
     }

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -26,7 +26,7 @@ fn collect_stragglers(scope: &ScopeCell, prefix: &[ChildId], out: &mut Vec<Shutd
 async fn wait_for_incarnation(scope: &ScopeCell, epoch: Epoch) {
     let mut watcher = scope.signal().watcher();
     loop {
-        if scope.scope_settled(Some(epoch)) {
+        if scope.settled(Some(epoch)) {
             return;
         }
         watcher.changed().await;
@@ -37,7 +37,7 @@ pub(crate) async fn shutdown_scope(
     scope: Arc<ScopeCell>,
     timeout: Duration,
 ) -> Result<(), ShutdownTimeout> {
-    if scope.scope_settled(None) {
+    if scope.settled(None) {
         return Ok(());
     }
     let Some(epoch) = scope.request_shutdown() else {
@@ -46,7 +46,7 @@ pub(crate) async fn shutdown_scope(
     };
     let mut watcher = scope.signal().watcher();
     loop {
-        if scope.scope_settled(Some(epoch)) {
+        if scope.settled(Some(epoch)) {
             return Ok(());
         }
         if matches!(scope.record().state, ScopeState::Draining) {
@@ -74,7 +74,8 @@ pub(crate) async fn shutdown_scope(
 impl ScopeRuntime {
     pub(super) fn begin_drain(&mut self, reason: StopReason) {
         let startup = self
-            .lifecycle
+            .supervisor
+            .lifecycle()
             .is_starting()
             .then_some(Err(StartupError::ShutdownRequested));
         self.begin_drain_transition(reason, startup);
@@ -93,104 +94,73 @@ impl ScopeRuntime {
         reason: StopReason,
         startup: Option<Result<(), StartupError>>,
     ) {
-        let Some(effect) = self.lifecycle.begin_drain(reason) else {
+        let before = self.supervisor_effects.len();
+        self.reduce(SupervisorEvent::BeginDrain { reason });
+        let Some(position) = self.supervisor_effects[before..]
+            .iter()
+            .position(|effect| matches!(effect, SupervisorEffect::DrainStarted { .. }))
+            .map(|position| before + position)
+        else {
             return;
         };
+        let SupervisorEffect::DrainStarted {
+            state,
+            startup_pending,
+        } = self.supervisor_effects.remove(position)
+        else {
+            unreachable!()
+        };
         if let Some(startup) = startup {
-            self.root.set_state_and_startup(effect.state(), startup);
+            self.root.set_state_and_startup(state, startup);
         } else {
-            debug_assert!(!effect.startup_pending());
-            self.root.set_state(effect.state());
+            debug_assert!(!startup_pending);
+            self.root.set_state(state);
         }
-        match self.root.flavor {
-            ScopeFlavor::Ordered => {
-                self.ordered_stop_cursor = self.children.keys().next_back();
-                self.stop_next_ordered();
-            }
-            ScopeFlavor::Dynamic => {
-                let children: Vec<_> = self.children.keys().collect();
-                for child in children {
-                    self.begin_stop_child(child, None);
-                }
-            }
-        }
-    }
-
-    pub(super) fn stop_next_ordered(&mut self) {
-        if self.root.flavor != ScopeFlavor::Ordered
-            || !self.lifecycle.is_draining()
-            || self.ordered_stop_progressing
-        {
-            return;
-        }
-        self.ordered_stop_progressing = true;
-        if let Some(key) = self.ordered_stop_waiting {
-            let waiting = self
-                .children
-                .get(key)
-                .is_some_and(ChildRuntime::is_incomplete);
-            if waiting {
-                self.ordered_stop_progressing = false;
-                return;
-            }
-            self.ordered_stop_waiting = None;
-        }
-        while let Some(key) = self.ordered_stop_cursor {
-            self.ordered_stop_cursor = self.children.previous_key(key);
-            #[cfg(test)]
-            {
-                self.ordered_stop_inspections += 1;
-            }
-            // The cursor key is held across await boundaries, so never index
-            // the arena with it: a reclaimed slot is treated as already gone.
-            let Some(child) = self.children.get(key) else {
-                continue;
-            };
-            if !child.is_incomplete() {
-                continue;
-            }
-            self.begin_stop_child(key, None);
-            let Some(child) = self.children.get(key) else {
-                continue;
-            };
-            if child.active.is_some() || child.is_disposing() {
-                self.ordered_stop_waiting = Some(key);
-                break;
-            }
-        }
-        self.ordered_stop_progressing = false;
+        self.flush_supervisor_effects();
+        self.settle_supervisor();
     }
 
     pub(super) fn force_all(&mut self) {
-        self.hard_forced = true;
-        // Unconditional: on an already-draining scope this is a pure monotone
-        // reason upgrade (no drain-entry side effects are replayed), and a
-        // hard-forced scope must terminalize as ShutdownRequested even if it
-        // was mid-drain for a lower-precedence reason.
-        self.begin_drain(StopReason::ShutdownRequested);
-        let now = runtime::now();
-        let children: Vec<_> = self.children.keys().collect();
-        for key in children {
-            // Every live membership enters the same stop funnel first. That
-            // owns mailbox freeze, readiness disarm, ordered-child handling,
-            // and the initial cooperative action.
-            self.begin_stop_child(key, None);
-            if let Some(ladder) = self
-                .children
-                .get_mut(key)
-                .and_then(|child| child.active.as_mut())
-                .and_then(|active| active.ladder.as_mut())
-            {
-                ladder.force(now);
+        let before = self.supervisor_effects.len();
+        self.reduce(SupervisorEvent::Force);
+        if let Some(position) = self.supervisor_effects[before..]
+            .iter()
+            .position(|effect| matches!(effect, SupervisorEffect::DrainStarted { .. }))
+            .map(|position| before + position)
+        {
+            let SupervisorEffect::DrainStarted {
+                state,
+                startup_pending,
+            } = self.supervisor_effects.remove(position)
+            else {
+                unreachable!()
+            };
+            if startup_pending {
+                self.root
+                    .set_state_and_startup(state, Err(StartupError::ShutdownRequested));
+            } else {
+                self.root.set_state(state);
             }
-            self.advance_ladder(key, now);
         }
-        let disposing = self
+        self.flush_supervisor_effects();
+        self.settle_supervisor();
+    }
+
+    pub(super) fn force_child(&mut self, key: ChildKey) {
+        let now = runtime::now();
+        // Every live membership enters the same stop funnel first. That owns
+        // mailbox freeze, readiness disarm, and the initial cooperative action.
+        self.begin_stop_child(key, None);
+        if let Some(ladder) = self
             .children
-            .keys()
-            .filter(|key| self.children[*key].pending_terminal.is_some())
-            .collect::<Vec<_>>();
-        for key in disposing {
+            .get_mut(key)
+            .and_then(|child| child.active.as_mut())
+            .and_then(|active| active.ladder.as_mut())
+        {
+            ladder.force(now);
+        }
+        self.advance_ladder(key, now);
+        if self.supervisor.is_disposing(key) {
             // The incarnation has already exited; only its retained factory
             // remains. Hard escalation detaches that cleanup, but must not
             // rewrite the actor's recorded verdict.
@@ -198,13 +168,9 @@ impl ScopeRuntime {
         }
     }
 
+    #[cfg(test)]
     pub(super) fn finish_if_ready(&mut self) -> Option<StopReason> {
-        self.lifecycle.finish_if_ready(
-            self.root.flavor,
-            ChildCompletionState {
-                has_children: !self.children.is_empty(),
-                all_terminal: self.incomplete_children == 0,
-            },
-        )
+        self.settle_supervisor();
+        self.finished.take()
     }
 }

--- a/crates/shelterwood/src/driver/startup.rs
+++ b/crates/shelterwood/src/driver/startup.rs
@@ -42,7 +42,12 @@ impl ScopeRuntime {
                 // terminal routes through `finalize_removal`, and its exit
                 // classification must not mistake a post-ready stop for a
                 // pre-ready failure.
-                let removing = self.dispatch_membership_status(key) == MembershipStatus::Removing;
+                let removal_latched = self.removal_latched(key);
+                self.reduce(SupervisorEvent::Ready {
+                    child: key,
+                    removal_latched,
+                });
+                let removing = self.supervisor.membership_status(key) == MembershipStatus::Removing;
                 let Some(child) = self.children.get_mut(key) else {
                     return false;
                 };
@@ -58,9 +63,6 @@ impl ScopeRuntime {
                 active.ready_signal.fire();
                 if removing {
                     return false;
-                }
-                if !self.lifecycle.startup_complete() {
-                    child.initial_ready = true;
                 }
                 self.root.transition_child_stage(
                     &child.slot.member,
@@ -82,61 +84,10 @@ impl ScopeRuntime {
     }
 
     pub(super) fn progress_startup(&mut self) {
-        if !self.lifecycle.is_starting() {
-            return;
-        }
-        match self.root.flavor {
-            ScopeFlavor::Ordered => {
-                while let Some(key) = self.next_ordered_start {
-                    // The cursor is held across `spawn_child`, and every
-                    // reclaim path (`finalize_removal`, `prune_terminal`) can
-                    // vacate a slot, so never index the arena with it: a
-                    // reclaimed slot is treated as already gone, the same
-                    // discipline `stop_next_ordered` follows for its own
-                    // cursor. `keys_after` ranges over the arena's ordered
-                    // key domain, so it still advances past a vacated key.
-                    if self
-                        .children
-                        .get(key)
-                        .is_some_and(|child| !child.spawned_once)
-                    {
-                        self.spawn_child(key);
-                    }
-                    if self
-                        .children
-                        .get(key)
-                        .is_some_and(|child| !child.initial_ready)
-                    {
-                        return;
-                    }
-                    self.next_ordered_start = self.children.keys_after(key).next();
-                }
-                if self
-                    .children
-                    .values()
-                    .filter(|child| child.initial)
-                    .all(|child| child.initial_ready)
-                {
-                    self.complete_startup();
-                }
-            }
-            ScopeFlavor::Dynamic => {
-                if self
-                    .children
-                    .values()
-                    .filter(|child| child.initial)
-                    .all(|child| child.initial_ready)
-                {
-                    self.complete_startup();
-                }
-            }
-        }
+        self.settle_supervisor();
     }
 
-    pub(super) fn complete_startup(&mut self) {
-        let Some(state) = self.lifecycle.complete_startup() else {
-            return;
-        };
+    pub(super) fn publish_startup_complete(&mut self, state: ScopeState) {
         self.root.set_state_and_startup(state, Ok(()));
         if let Some(parent_ready) = self.role.parent_ready() {
             parent_ready.fire();
@@ -173,15 +124,20 @@ impl ScopeRuntime {
                 exit,
             },
         };
-        let Some(state) = self.lifecycle.fail_startup() else {
+        let before = self.supervisor_effects.len();
+        self.reduce(SupervisorEvent::FailStartup);
+        let Some(SupervisorEffect::StartupFailed { state }) =
+            self.supervisor_effects.get(before).cloned()
+        else {
             return;
         };
+        self.supervisor_effects.remove(before);
         if self.root.flavor == ScopeFlavor::Ordered {
-            let later_children: Vec<_> = self.children.keys_after(key).collect();
+            let later_children: Vec<_> = self.supervisor.keys_after(key).collect();
             for later in later_children {
-                if !self.children[later].spawned_once
-                    && !self.children[later].is_disposing()
-                    && !self.children[later].is_terminal()
+                if !self.supervisor.spawned_once(later)
+                    && !self.supervisor.is_disposing(later)
+                    && !self.supervisor.membership_terminal(later)
                 {
                     self.begin_terminal_disposal(
                         later,

--- a/crates/shelterwood/src/driver/storage.rs
+++ b/crates/shelterwood/src/driver/storage.rs
@@ -1,11 +1,4 @@
-//! Non-driver storage primitives used by the mutable runtime shell.
-
-use std::{
-    collections::BTreeMap,
-    ops::{Bound, Index, IndexMut},
-};
-
-use crate::identity::PoisonedCounter;
+//! Fail-closed completion storage used by the runtime shell.
 
 /// An exactly-once synchronous completion.
 ///
@@ -51,116 +44,9 @@ impl<T> Drop for Obligation<T> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub(super) struct ChildKey(pub(super) u64);
-
-pub(super) struct ChildArena<T> {
-    // Keys are insertion-order ids and are never reused. A late event can
-    // therefore miss; it can never address a subsequently inserted child.
-    children: BTreeMap<ChildKey, T>,
-    // `u64::MAX` is poison and is never minted. Once exhausted, every later
-    // insertion fails closed instead of wrapping into the live key domain.
-    keys: PoisonedCounter,
-}
-
-impl<T> Default for ChildArena<T> {
-    fn default() -> Self {
-        Self {
-            children: BTreeMap::new(),
-            keys: PoisonedCounter::new(),
-        }
-    }
-}
-
-impl<T> ChildArena<T> {
-    pub(super) fn insert(&mut self, child: T) -> Result<ChildKey, Box<T>> {
-        let Some(next) = self.keys.mint() else {
-            return Err(Box::new(child));
-        };
-        let key = ChildKey(next);
-        let replaced = self.children.insert(key, child);
-        debug_assert!(replaced.is_none(), "monotonic child keys are never reused");
-        Ok(key)
-    }
-
-    pub(super) fn get(&self, key: ChildKey) -> Option<&T> {
-        self.children.get(&key)
-    }
-
-    pub(super) fn get_mut(&mut self, key: ChildKey) -> Option<&mut T> {
-        self.children.get_mut(&key)
-    }
-
-    pub(super) fn remove(&mut self, key: ChildKey) -> Option<T> {
-        self.children.remove(&key)
-    }
-
-    pub(super) fn keys(&self) -> impl DoubleEndedIterator<Item = ChildKey> + '_ {
-        self.children.keys().copied()
-    }
-
-    pub(super) fn keys_after(
-        &self,
-        key: ChildKey,
-    ) -> impl DoubleEndedIterator<Item = ChildKey> + '_ {
-        self.children
-            .range((Bound::Excluded(key), Bound::Unbounded))
-            .map(|(key, _)| *key)
-    }
-
-    pub(super) fn previous_key(&self, key: ChildKey) -> Option<ChildKey> {
-        self.children.range(..key).next_back().map(|(key, _)| *key)
-    }
-
-    pub(super) fn iter(&self) -> impl Iterator<Item = (ChildKey, &T)> {
-        self.children.iter().map(|(key, child)| (*key, child))
-    }
-
-    pub(super) fn values(&self) -> impl Iterator<Item = &T> {
-        self.children.values()
-    }
-
-    pub(super) fn values_mut(&mut self) -> impl Iterator<Item = &mut T> {
-        self.children.values_mut()
-    }
-
-    #[cfg(test)]
-    pub(super) fn len(&self) -> usize {
-        self.children.len()
-    }
-
-    pub(super) fn is_empty(&self) -> bool {
-        self.children.is_empty()
-    }
-
-    pub(super) fn clear(&mut self) {
-        self.children.clear();
-    }
-
-    #[cfg(test)]
-    pub(super) fn storage_len(&self) -> usize {
-        self.children.len()
-    }
-}
-
-impl<T> Index<ChildKey> for ChildArena<T> {
-    type Output = T;
-
-    fn index(&self, key: ChildKey) -> &Self::Output {
-        self.get(key).expect("live child key")
-    }
-}
-
-impl<T> IndexMut<ChildKey> for ChildArena<T> {
-    fn index_mut(&mut self, key: ChildKey) -> &mut Self::Output {
-        self.get_mut(key).expect("live child key")
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::BTreeMap,
         panic::{AssertUnwindSafe, catch_unwind},
         sync::{
             Arc,
@@ -168,9 +54,7 @@ mod tests {
         },
     };
 
-    use crate::identity::PoisonedCounter;
-
-    use super::{ChildArena, ChildKey, Obligation};
+    use super::Obligation;
 
     fn count_fallback(fallbacks: Arc<AtomicUsize>) {
         fallbacks.fetch_add(1, Ordering::SeqCst);
@@ -208,40 +92,6 @@ mod tests {
             fallbacks.load(Ordering::SeqCst),
             1,
             "drop cannot repeat a fallback that panicked"
-        );
-    }
-
-    #[test]
-    fn removed_child_keys_are_never_reused() {
-        let mut arena = ChildArena::default();
-        let stale = arena.insert("worker").expect("key mints");
-        let child = arena.remove(stale).expect("live key removes its child");
-        let current = arena.insert(child).expect("key mints");
-
-        assert!(current > stale, "keys advance monotonically across removal");
-        assert!(arena.get(stale).is_none());
-        assert!(arena.remove(stale).is_none());
-        assert!(arena.get(current).is_some());
-    }
-
-    #[test]
-    fn child_key_exhaustion_poison_is_never_minted() {
-        let mut arena = ChildArena {
-            children: BTreeMap::new(),
-            keys: PoisonedCounter::near_exhaustion(),
-        };
-        let last = arena.insert("worker").expect("the last usable key mints");
-        assert_eq!(last, ChildKey(u64::MAX - 1));
-        let child = arena.remove(last).expect("the last usable key is live");
-
-        let child = *arena
-            .insert(child)
-            .expect_err("the poison key is never minted");
-        assert!(arena.keys.is_poisoned());
-        assert!(arena.get(ChildKey(u64::MAX)).is_none());
-        assert!(
-            arena.insert(child).is_err(),
-            "the exhausted domain stays poisoned"
         );
     }
 }

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -106,7 +106,7 @@ fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
         .entries
         .insert(
             ChildId::from("worker"),
-            DynamicEntry::removing(slot, ChildKey(1), responses),
+            DynamicEntry::removing(slot, ChildKey::fixture(1), responses),
         );
 
     let entries = root.with_observation_gate(|txn| control.close(&root, txn));
@@ -242,7 +242,7 @@ fn dynamic_removal_waits_for_the_observation_gate_before_mutating_state() {
     root.set_admitted_children(vec![resident_projection(&slot)]);
     let (events, _receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events);
-    let key = ChildKey(1);
+    let key = ChildKey::fixture(1);
     control
         .state
         .lock()
@@ -310,10 +310,9 @@ async fn final_removal_holds_the_id_until_removed_publication_commits() {
         .expect("the slot is defined");
     let plan =
         crate::plan::ChildPlan::with_options(Arc::clone(&reservation.slot), definition, resolved);
-    let mut child = ChildRuntime::from_plan(plan, &root);
-    child.initial = false;
+    let child = ChildRuntime::from_plan(plan, &root);
     let key = root.with_observation_gate(|txn| {
-        let key = match scope.insert_child(child) {
+        let key = match scope.insert_child(child, false) {
             Ok(key) => key,
             Err(_) => panic!("the empty arena accepts its first child"),
         };
@@ -400,14 +399,13 @@ async fn removal_tolerates_synchronous_reclaim_from_the_stop_funnel() {
     let plan =
         crate::plan::ChildPlan::with_options(Arc::clone(&reservation.slot), definition, resolved);
     let mut child = ChildRuntime::from_plan(plan, &root);
-    child.initial = false;
     // Model the latent restart-gap shape: there is no active incarnation and
     // no retained construction, so a hard-force stop can terminalize and
     // reclaim this Removing member synchronously from `begin_stop_child`.
     drop(child.construction.take());
     let key = root.with_observation_gate(|txn| {
         let key = scope
-            .insert_child(child)
+            .insert_child(child, false)
             .unwrap_or_else(|_| panic!("the empty arena accepts its first child"));
         {
             let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
@@ -427,12 +425,9 @@ async fn removal_tolerates_synchronous_reclaim_from_the_stop_funnel() {
         root.admit_child_locked(resident_projection(&reservation.slot), txn);
         key
     });
-    scope.hard_forced = true;
+    scope.supervisor.set_hard_forced_for_test(true);
 
-    scope.handle_removal(RemovalRequest {
-        membership: member.membership(),
-        key,
-    });
+    scope.handle_removal(RemovalRequest { key });
 
     assert!(
         scope.children.get(key).is_none(),
@@ -515,9 +510,8 @@ async fn removal_from_a_foreign_thread_reaches_the_driver() {
         .mint_membership(&child_id)
         .expect("membership available");
     let member = MemberCell::new(child_id.clone(), membership);
-    let membership = member.membership();
     let slot = SlotCell::new(Arc::clone(&member), None);
-    let key = ChildKey(1);
+    let key = ChildKey::fixture(1);
     let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events);
     control
@@ -556,7 +550,6 @@ async fn removal_from_a_foreign_thread_reaches_the_driver() {
     let DriverEvent::Removal(observed) = event else {
         panic!("the queued event is the requested removal");
     };
-    assert_eq!(observed.membership, membership);
     assert_eq!(observed.key, key);
 }
 
@@ -1110,7 +1103,6 @@ async fn exercise_coalesced_removal() {
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
     let member = Arc::clone(&reservation.slot.member);
-    let membership = member.membership();
     reservation
         .slot
         .define(ChildConstruction::Task(TaskDef::new({
@@ -1168,7 +1160,6 @@ async fn exercise_coalesced_removal() {
         crate::runtime::Timeout::Completed(_) => panic!("one removal request reaches the driver"),
         crate::runtime::Timeout::Elapsed => panic!("the removal request reaches the driver"),
     };
-    assert_eq!(removal.membership, membership);
     assert_eq!(removal.key, key);
     assert!(
         crate::runtime::unbounded_mpsc_try_recv(&mut dynamic_event_receiver).is_none(),
@@ -1268,7 +1259,6 @@ async fn fused_only_removal_commits_phase_and_projection_together() {
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
     let member = Arc::clone(&reservation.slot.member);
-    let membership = member.membership();
     reservation
         .slot
         .define(ChildConstruction::Task(TaskDef::new({
@@ -1340,7 +1330,6 @@ async fn fused_only_removal_commits_phase_and_projection_together() {
         }
         crate::runtime::Timeout::Elapsed => panic!("the fused removal reaches the driver"),
     };
-    assert_eq!(removal.membership, membership);
     assert_eq!(removal.key, key);
 
     let duplicate = removal;
@@ -1489,7 +1478,6 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
                 }
             }
         })));
-    let membership = member.membership();
     let mut admission = Box::pin(make_admission(reservation));
     assert!(
         admission
@@ -1536,8 +1524,7 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
         crate::runtime::unbounded_mpsc_send(
             &scope.events,
             DriverEvent::Removal(RemovalRequest {
-                membership: root.member.membership(),
-                key: ChildKey(u64::MAX - 1),
+                key: ChildKey::fixture(u64::MAX - 1),
             }),
         )
         .is_ok(),
@@ -1585,7 +1572,7 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
     assert!(matches!(
         event_receiver.recv().await,
         Some(DriverEvent::Removal(queued))
-            if queued.membership == root.member.membership()
+            if queued.key == ChildKey::fixture(u64::MAX - 1)
     ));
     let forwarded =
         match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
@@ -1596,7 +1583,6 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
     let DriverEvent::Removal(removal) = forwarded else {
         panic!("the queued event is the fused removal")
     };
-    assert_eq!(removal.membership, membership);
     assert_eq!(removal.key, key);
     scope.handle_removal(removal);
     let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -72,6 +72,83 @@ async fn dynamic_high_cycle_add_remove_keeps_only_live_runtime_storage() {
         .await
         .expect("empty dynamic scope shuts down");
 }
+
+/// The reducer can emit an initial/admission `StartChild` before a concurrent
+/// caller commits removal.  Construction must re-sample the synchronous latch
+/// when that effect is executed: the forwarded `Removal` event is deliberately
+/// left queued here, so arbitration cannot be what suppresses the start.
+#[crate::runtime::test]
+async fn latched_removal_suppresses_a_queued_start_effect() {
+    let (mut scope, _events, mut dynamic_events, _disposal_events, control) =
+        running_dynamic_fixture();
+    let root = Arc::clone(&scope.root);
+    let starts = Arc::new(AtomicUsize::new(0));
+    let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
+        .expect("running dynamic scope reserves the child");
+    reservation
+        .slot
+        .define(ChildConstruction::Task(TaskDef::new({
+            let starts = Arc::clone(&starts);
+            move |_| {
+                starts.fetch_add(1, Ordering::SeqCst);
+                future::pending()
+            }
+        })));
+    let (definition, resolved) = reservation
+        .slot
+        .resolve_and_take_defined(&scope.defaults)
+        .expect("the slot is defined");
+    let plan =
+        crate::plan::ChildPlan::with_options(Arc::clone(&reservation.slot), definition, resolved);
+    let child = ChildRuntime::from_plan(plan, &root);
+    let key = root.with_observation_gate(|txn| {
+        let key = scope
+            .insert_child(child, false)
+            .unwrap_or_else(|_| panic!("the empty arena accepts its first child"));
+        control
+            .state
+            .lock()
+            .expect("dynamic-state mutex poisoned")
+            .entries
+            .get_mut(reservation.slot.member.id())
+            .expect("the reservation remains registered")
+            .promote(key, None, txn);
+        root.admit_child_locked(resident_projection(&reservation.slot), txn);
+        key
+    });
+
+    let _removal = super::super::remove_dynamic(
+        &root,
+        reservation.slot.member.id(),
+        Some(reservation.slot.member.membership()),
+    );
+    assert_eq!(
+        reservation.slot.member.record().membership_status,
+        MembershipStatus::Removing
+    );
+
+    // Model execution of a reducer effect that was emitted before removal
+    // won.  The removal event is still in the control lane at this point.
+    scope.spawn_child(key);
+    for _ in 0..8 {
+        crate::runtime::yield_now().await;
+    }
+    assert!(scope.children[key].active.is_none());
+    assert_eq!(
+        scope.supervisor.membership_status(key),
+        MembershipStatus::Removing
+    );
+    assert_eq!(
+        starts.load(Ordering::SeqCst),
+        0,
+        "a latch that wins before effect execution suppresses user construction"
+    );
+    assert!(matches!(
+        crate::runtime::unbounded_mpsc_try_recv(&mut dynamic_events),
+        Some(DriverEvent::Removal(RemovalRequest { key: queued })) if queued == key
+    ));
+}
+
 #[test]
 fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
     let mut identity = ScopeIdentity::new();

--- a/crates/shelterwood/src/driver/tests/events.rs
+++ b/crates/shelterwood/src/driver/tests/events.rs
@@ -19,7 +19,7 @@ fn disposed_child(pending: &Pending) -> ChildKey {
 async fn blocking_primary_wake_recollects_control_removal_before_arbitration() {
     let identity = isolated_scope("identity", ScopeFlavor::Dynamic);
     let membership = identity.member.membership();
-    let key = ChildKey(1);
+    let key = ChildKey::fixture(1);
     let incarnation = IncarnationCounter::fixture(membership)
         .mint()
         .expect("fixture incarnation is available");
@@ -39,7 +39,7 @@ async fn blocking_primary_wake_recollects_control_removal_before_arbitration() {
     let publisher = crate::runtime::spawn(async move {
         crate::runtime::yield_now().await;
         control
-            .send(DriverEvent::Removal(RemovalRequest { membership, key }))
+            .send(DriverEvent::Removal(RemovalRequest { key }))
             .expect("the control lane remains open");
         primary
             .send(DriverEvent::Child(ChildEvent::Ready {
@@ -87,9 +87,9 @@ async fn blocking_primary_wake_recollects_control_removal_before_arbitration() {
 #[test]
 fn every_event_lane_is_capped_and_a_saturated_lane_forces_a_yield() {
     let limit = super::super::MIN_EVENT_BATCH_LIMIT;
-    let primary_key = ChildKey(1);
-    let control_key = ChildKey(2);
-    let disposal_key = ChildKey(3);
+    let primary_key = ChildKey::fixture(1);
+    let control_key = ChildKey::fixture(2);
+    let disposal_key = ChildKey::fixture(3);
     let (primary, mut primary_receiver) = crate::runtime::unbounded_mpsc();
     let (control, mut control_receiver) = crate::runtime::unbounded_mpsc();
     let (disposal, mut disposal_receiver) = crate::runtime::unbounded_mpsc();
@@ -176,7 +176,6 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
     let starts = Arc::new(AtomicUsize::new(0));
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
-    let member = Arc::clone(&reservation.slot.member);
     reservation
         .slot
         .define(ChildConstruction::Task(TaskDef::new({
@@ -192,7 +191,6 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
                 }
             }
         })));
-    let membership = member.membership();
     let fused_cancel = Latch::default();
     let mut response = super::super::start_admission(
         Arc::clone(&reservation.control),
@@ -280,7 +278,6 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
     let DriverEvent::Removal(removal) = forwarded else {
         panic!("the queued event is the fused removal");
     };
-    assert_eq!(removal.membership, membership);
     assert_eq!(removal.key, key);
     scope.handle_removal(removal);
     let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -689,3 +689,78 @@ fn lifecycle_sequence_exhaustion_poison_is_never_minted_and_becomes_lag() {
         crate::LifecycleSeq::EXHAUSTED
     );
 }
+
+/// Level-triggered settlement re-enters the reducer until a pass emits
+/// nothing, so a start effect the construction funnel declines is re-derived
+/// from unchanged state rather than merely wasted. Incarnation exhaustion is
+/// the reachable shape: it terminalizes a membership that never spawned while
+/// the scope is still `Starting`, so `spawned_once` stays false with no
+/// `Spawned` edge ever coming. A regression here does not fail — it spins the
+/// driver task, which is why this pins the loop that `run_scope_incarnation`
+/// runs before its event loop even starts.
+#[crate::runtime::test]
+async fn settlement_terminates_when_the_first_spawn_exhausts_incarnations() {
+    let mut tree = Tree::new();
+    tree.add_task(
+        "worker",
+        TaskDef::new(|_| future::pending::<crate::ExitResult>()),
+    )
+    .expect("valid task");
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
+    let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
+    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+    let mut children = ChildArena::default();
+    let key = children
+        .insert(child)
+        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+        .with_defaults(plan.defaults.clone())
+        .with_intensity_policy(plan.intensity_policy())
+        .with_children(children)
+        .with_next_ordered_start(Some(key))
+        .build();
+    plan.finish_transfer();
+
+    scope.children[key].incarnations =
+        IncarnationCounter::near_exhaustion(scope.children[key].slot.member.membership());
+    assert!(scope.children[key].incarnations.mint().is_some());
+
+    // The pre-loop settlement in `run_scope_incarnation`: the reducer asks for
+    // construction, the funnel exhausts, and the child terminalizes in place.
+    scope.settle_supervisor();
+    assert!(scope.children[key].is_disposing());
+    assert!(
+        scope.supervisor.lifecycle().is_starting(),
+        "disposal is still in flight, so startup has not yet failed"
+    );
+
+    // Settling again over that state must still reach a fixed point: the
+    // membership gates ordered startup, but can no longer be constructed.
+    scope.settle_supervisor();
+
+    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) =
+        disposal_event_receiver
+            .recv()
+            .await
+            .expect("disposal reports completion")
+    else {
+        panic!("only construction disposal was armed")
+    };
+    scope.handle_construction_disposed(child, panic);
+    scope.settle_supervisor();
+    assert!(
+        scope.supervisor.lifecycle().startup_failed(),
+        "the pre-readiness position routes the scope's startup failure"
+    );
+}

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -234,8 +234,8 @@ async fn first_spawn_exhaustion_stops_without_reporting_a_startup_abort() {
     scope.children[key].incarnations =
         IncarnationCounter::near_exhaustion(scope.children[key].slot.member.membership());
     assert!(scope.children[key].incarnations.mint().is_some());
-    assert!(scope.children[key].initial);
-    assert!(!scope.children[key].initial_ready);
+    assert!(scope.supervisor.is_initial(key));
+    assert!(!scope.supervisor.initial_ready(key));
     assert_eq!(
         scope.children[key].slot.member.record().last_incarnation,
         None
@@ -326,9 +326,9 @@ async fn latched_shutdown_keeps_the_startup_verdict_for_its_follow_up_event() {
         .build();
     plan.finish_transfer();
 
-    assert!(scope.children[key].initial);
+    assert!(scope.supervisor.is_initial(key));
     scope.spawn_child(key);
-    assert!(!scope.children[key].initial_ready);
+    assert!(!scope.supervisor.initial_ready(key));
     let exit = match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
         crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {
             child,

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -157,7 +157,7 @@ fn stale_scope_driver_cannot_stop_a_newer_live_incarnation_projection() {
 
     scope.finish_incarnation(first, StopReason::Finished);
     assert_eq!(scope.record().state, ScopeState::Running);
-    assert!(!scope.incarnation_finished(second));
+    assert!(!scope.settled(Some(second)));
 
     scope.finish_incarnation(second, StopReason::Finished);
     assert_eq!(
@@ -166,7 +166,7 @@ fn stale_scope_driver_cannot_stop_a_newer_live_incarnation_projection() {
             reason: StopReason::Finished,
         }
     );
-    assert!(scope.incarnation_finished(second));
+    assert!(scope.settled(Some(second)));
 }
 
 #[test]
@@ -528,7 +528,7 @@ async fn shutdown_wait_settles_its_epoch_after_a_newer_incarnation_starts() {
         matches!(superseded, Poll::Ready(Ok(()))),
         "a newer live incarnation must not extend the captured epoch's wait"
     );
-    assert!(!scope.incarnation_finished(second));
+    assert!(!scope.settled(Some(second)));
 
     scope.finish_incarnation(second, StopReason::Finished);
 }

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -59,7 +59,7 @@ async fn latched_shutdown_upgrades_an_intensity_drain() {
         false,
     );
     assert!(matches!(
-        scope.lifecycle.draining_reason(),
+        scope.supervisor.lifecycle().draining_reason(),
         Some(StopReason::IntensityTripped(_))
     ));
 
@@ -68,7 +68,7 @@ async fn latched_shutdown_upgrades_an_intensity_drain() {
     assert!(root.take_shutdown_request(scope.epoch));
     scope.begin_drain(StopReason::ShutdownRequested);
     assert_eq!(
-        scope.lifecycle.draining_reason(),
+        scope.supervisor.lifecycle().draining_reason(),
         Some(&StopReason::ShutdownRequested)
     );
 }
@@ -128,7 +128,7 @@ async fn force_upgrades_an_intensity_drain_to_shutdown_requested() {
         false,
     );
     assert!(matches!(
-        scope.lifecycle.draining_reason(),
+        scope.supervisor.lifecycle().draining_reason(),
         Some(StopReason::IntensityTripped(_))
     ));
 
@@ -137,7 +137,7 @@ async fn force_upgrades_an_intensity_drain_to_shutdown_requested() {
     // shutdown request having upgraded the reason first.
     scope.force_all();
     assert_eq!(
-        scope.lifecycle.draining_reason(),
+        scope.supervisor.lifecycle().draining_reason(),
         Some(&StopReason::ShutdownRequested)
     );
     assert_eq!(
@@ -304,15 +304,15 @@ fn forced_ordered_drain_advances_an_inactive_suffix_iteratively() {
     scope.begin_drain(StopReason::ShutdownRequested);
 
     assert!(scope.children.values().all(ChildRuntime::is_terminal));
-    assert!(!scope.ordered_stop_progressing);
-    assert_eq!(scope.ordered_stop_waiting, None);
+    assert_eq!(scope.supervisor.ordered_stop_waiting(), None);
     assert_eq!(
-        scope.ordered_stop_inspections, CHILDREN,
+        scope.supervisor.ordered_stop_inspections(),
+        CHILDREN,
         "the reverse cursor inspects each ordered child exactly once"
     );
-    assert_eq!(
-        scope.incomplete_children, 0,
-        "terminal completion decrements the incremental count exactly once"
+    assert!(
+        scope.supervisor.all_children_joined(),
+        "completion is derived from authoritative child states"
     );
     assert_eq!(
         scope.finish_if_ready(),

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -186,7 +186,6 @@ async fn expedited_restart_progresses_synchronous_readiness() {
     // restart must still release ordered startup when configuration produces
     // an immediate readiness effect.
     child.options.readiness = Readiness::Immediate;
-    child.spawned_once = true;
     let mut children = ChildArena::default();
     let key = children
         .insert(child)
@@ -196,6 +195,7 @@ async fn expedited_restart_progresses_synchronous_readiness() {
         .with_children(children)
         .with_next_ordered_start(Some(key))
         .build();
+    scope.reduce(SupervisorEvent::Spawned { child: key });
     plan.finish_transfer();
     let target = nested_cell
         .request_shutdown()
@@ -203,9 +203,9 @@ async fn expedited_restart_progresses_synchronous_readiness() {
 
     scope.expedite_restart_shutdown(key, target);
 
-    assert!(scope.children[key].initial_ready);
+    assert!(scope.supervisor.initial_ready(key));
     assert!(
-        scope.lifecycle.startup_complete(),
+        scope.supervisor.lifecycle().startup_complete(),
         "synchronous readiness from an expedited spawn advances aggregate startup"
     );
     assert_eq!(root.record().startup, Some(Ok(())));
@@ -285,7 +285,7 @@ async fn early_restart_shutdown_does_not_expedite_a_never_started_ordered_child(
     // Ordered startup spawns "a" and parks on its (never-fired) readiness.
     scope.progress_startup();
     assert!(scope.children[first].active.is_some());
-    assert!(!scope.children[first].initial_ready);
+    assert!(!scope.supervisor.initial_ready(first));
 
     let event = root
         .take_control_events()
@@ -314,7 +314,7 @@ async fn early_restart_shutdown_does_not_expedite_a_never_started_ordered_child(
         "a never-started ordered child must not be expedite-spawned before its turn"
     );
     assert!(scope.children[nested].active.is_none());
-    assert!(!scope.children[nested].spawned_once);
+    assert!(!scope.supervisor.spawned_once(nested));
     assert!(scope.children[nested].restart_shutdown_pending.is_none());
     assert_eq!(
         nested_cell.begin_incarnation(ScopeState::Starting),
@@ -557,7 +557,7 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
     crate::runtime::yield_now().await;
     crate::runtime::yield_now().await;
 
-    assert!(scope.lifecycle.is_draining());
+    assert!(scope.supervisor.lifecycle().is_draining());
     assert_eq!(
         factories.load(std::sync::atomic::Ordering::SeqCst),
         0,
@@ -720,7 +720,7 @@ async fn same_batch_intensity_exit_suppresses_retained_expedite_retry() {
 
     // The nested exit deferred its retry through arbitration, so the trip
     // exit from the same batch drained the scope first.
-    assert!(scope.lifecycle.is_draining());
+    assert!(scope.supervisor.lifecycle().is_draining());
     let retries = std::mem::take(&mut scope.restart_shutdown_retries);
     assert_eq!(retries, vec![(nested, target)]);
     for (child, target) in retries {
@@ -850,7 +850,7 @@ async fn same_batch_self_stop_preserves_fired_readiness_for_startup() {
     scope.handle_construction_disposed(child, panic);
 
     assert!(
-        scope.lifecycle.startup_complete(),
+        scope.supervisor.lifecycle().startup_complete(),
         "the ready-before-stop child completes startup"
     );
     assert!(
@@ -870,7 +870,7 @@ async fn same_batch_self_stop_preserves_fired_readiness_for_startup() {
 }
 
 /// `next_ordered_start` is held across `spawn_child` and is never cleared by
-/// `reclaim_child`, so `progress_startup` must treat a vacated slot the way
+/// `reclaim_child`, so `progress_startup` must treat a reclaimed key the way
 /// `stop_next_ordered` treats its own cursor: already gone, advance past it.
 /// Ordered scopes carry no dynamic control today and so never reclaim, which
 /// is exactly why this is pinned here — the arena is a monotonic key domain,
@@ -924,17 +924,19 @@ async fn ordered_startup_advances_past_a_reclaimed_cursor() {
         .build();
     plan.finish_transfer();
 
-    // Vacate the slot the cursor points at, exactly as a reclaim would leave
-    // it, without disturbing the child that follows.
+    // Retire the authoritative record and runtime resource together, exactly
+    // as production reclaim does, without disturbing the child that follows.
+    scope.reduce(SupervisorEvent::Terminalized { child: gone });
     scope
         .children
         .remove(gone)
         .expect("the cursor's child is live before the reclaim");
+    scope.reduce(SupervisorEvent::Reclaim { child: gone });
 
     scope.progress_startup();
 
     assert_eq!(
-        scope.next_ordered_start,
+        scope.supervisor.next_ordered_start(),
         Some(next),
         "a vacated cursor advances to the next live child instead of panicking"
     );
@@ -943,7 +945,7 @@ async fn ordered_startup_advances_past_a_reclaimed_cursor() {
         "the following child starts at its ordered turn"
     );
     assert!(
-        !scope.lifecycle.startup_complete(),
+        !scope.supervisor.lifecycle().startup_complete(),
         "the live successor still gates the aggregate"
     );
 }
@@ -1011,10 +1013,10 @@ async fn startup_removal_response_follows_aggregate_recomputation() {
         None,
         "membership commit alone cannot publish Removed before settlement"
     );
-    assert!(!scope.lifecycle.startup_complete());
+    assert!(!scope.supervisor.lifecycle().startup_complete());
 
     scope.progress_startup();
-    assert!(scope.lifecycle.startup_complete());
+    assert!(scope.supervisor.lifecycle().startup_complete());
     assert_eq!(root.record().startup, Some(Ok(())));
     scope.publish_startup_removals();
     assert_eq!(removal.try_receive(), Some(RemoveOutcome::Removed));
@@ -1133,13 +1135,13 @@ async fn queued_removal_suppresses_replayed_self_stop_readiness() {
         member.record().stage
     );
     assert!(
-        !scope.children[key].initial_ready,
+        !scope.supervisor.initial_ready(key),
         "a leaving membership is not credited to the startup aggregate"
     );
-    assert!(!scope.lifecycle.startup_complete());
+    assert!(!scope.supervisor.lifecycle().startup_complete());
     scope.progress_startup();
     assert!(
-        !scope.lifecycle.startup_complete(),
+        !scope.supervisor.lifecycle().startup_complete(),
         "startup waits for the removal to shrink the declared set"
     );
     assert_eq!(root.record().state, ScopeState::Starting);

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -926,6 +926,7 @@ async fn ordered_startup_advances_past_a_reclaimed_cursor() {
 
     // Retire the authoritative record and runtime resource together, exactly
     // as production reclaim does, without disturbing the child that follows.
+    scope.reduce(SupervisorEvent::DisposalStarted { child: gone });
     scope.reduce(SupervisorEvent::Terminalized { child: gone });
     scope
         .children

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -1,5 +1,7 @@
 pub(super) use std::{
+    collections::BTreeMap,
     future::{self, Future},
+    ops::{Index, IndexMut},
     panic::{AssertUnwindSafe, catch_unwind},
     pin::Pin,
     sync::{
@@ -16,7 +18,10 @@ pub(super) use crate::{
     MembershipStatus, RawOnceDef, Readiness, ReadinessDeadline, RemoveOutcome, ReserveError,
     RestartCondition, RestartCount, RestartPolicy, Retention, ScopeRef, ScopeState, SendErrorKind,
     StartupError, StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
-    engine::{Epoch, ScopeLifecycle, StopLadder, arbitrate},
+    engine::{
+        ChildKey, Effect as SupervisorEffect, Epoch, Event as SupervisorEvent, ScopeLifecycle,
+        StopLadder, SupervisorState, arbitrate, step as supervisor_step,
+    },
     exit::RecordedOutcome,
     identity::{IncarnationCounter, ScopeIdentity},
     mailbox::{MailboxCell, actor_ref_from_parts},
@@ -26,15 +31,68 @@ pub(super) use crate::{
 };
 
 pub(super) use super::super::{
-    AncestorCommandLatches, ChildArena, ChildEvent, ChildKey, ChildRuntime, ChildTerminality,
+    AncestorCommandLatches, ChildEvent, ChildResources, ChildRuntime, ChildTerminality,
     DriverEvent, DynamicControl, DynamicEntry, GateCapture, MemberCell, MemberStage,
     MemberTransition, NestedScopeLatches, Pending, RemovalRequest, RemovalResponses,
     ResidentProjection, RuntimeStorage, ScopeCell, ScopeControlEvent, ScopeEpochGuard, ScopeFlavor,
     ScopeRole, ScopeRuntime, StartupDisposition, cancel_dynamic_reservation,
-    discharge_child_terminality, index_children, report_slot, reserve_dynamic, resident_projection,
+    discharge_child_terminality, report_slot, reserve_dynamic, resident_projection,
     restart_shutdown_work, run_nested_factory, run_nested_tree, run_scope_incarnation,
     storage::Obligation,
 };
+
+pub(super) struct ChildArena<T> {
+    children: BTreeMap<ChildKey, T>,
+    next: u64,
+}
+
+impl<T> Default for ChildArena<T> {
+    fn default() -> Self {
+        Self {
+            children: BTreeMap::new(),
+            next: 0,
+        }
+    }
+}
+
+impl<T> ChildArena<T> {
+    pub(super) fn insert(&mut self, child: T) -> Result<ChildKey, Box<T>> {
+        self.next += 1;
+        let key = ChildKey::fixture(self.next);
+        self.children.insert(key, child);
+        Ok(key)
+    }
+
+    pub(super) fn keys(&self) -> impl DoubleEndedIterator<Item = ChildKey> + '_ {
+        self.children.keys().copied()
+    }
+
+    pub(super) fn values_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.children.values_mut()
+    }
+
+    pub(super) fn iter(&self) -> impl Iterator<Item = (ChildKey, &T)> {
+        self.children.iter().map(|(key, child)| (*key, child))
+    }
+
+    fn into_iter(self) -> impl Iterator<Item = (ChildKey, T)> {
+        self.children.into_iter()
+    }
+}
+
+impl<T> Index<ChildKey> for ChildArena<T> {
+    type Output = T;
+
+    fn index(&self, key: ChildKey) -> &Self::Output {
+        &self.children[&key]
+    }
+}
+
+impl<T> IndexMut<ChildKey> for ChildArena<T> {
+    fn index_mut(&mut self, key: ChildKey) -> &mut Self::Output {
+        self.children.get_mut(&key).expect("fixture child key")
+    }
+}
 
 pub(super) struct ScopeRuntimeBuilder {
     root: Arc<ScopeCell>,
@@ -45,7 +103,7 @@ pub(super) struct ScopeRuntimeBuilder {
     intensity_policy: Intensity,
     children: ChildArena<ChildRuntime>,
     lifecycle: ScopeLifecycle,
-    next_ordered_start: Option<ChildKey>,
+    next_ordered_start: Option<Option<ChildKey>>,
     dynamic: Option<Arc<DynamicControl>>,
     hard_forced: bool,
 }
@@ -93,7 +151,7 @@ impl ScopeRuntimeBuilder {
     }
 
     pub(super) fn with_next_ordered_start(mut self, next: Option<ChildKey>) -> Self {
-        self.next_ordered_start = next;
+        self.next_ordered_start = Some(next);
         self
     }
 
@@ -108,34 +166,51 @@ impl ScopeRuntimeBuilder {
     }
 
     pub(super) fn build(self) -> ScopeRuntime {
-        let (child_keys, incomplete_children) = index_children(&self.children);
+        let mut supervisor = SupervisorState::new(self.root.flavor, self.lifecycle);
+        let mut supervisor_effects = Vec::new();
+        let mut children = ChildResources::default();
+        for (expected, child) in self.children.into_iter() {
+            supervisor_step(
+                &mut supervisor,
+                SupervisorEvent::Admit {
+                    membership: child.slot.member.membership(),
+                    initial: true,
+                    start_immediately: false,
+                },
+                &mut supervisor_effects,
+            );
+            let Some(SupervisorEffect::Admitted { child: actual }) = supervisor_effects.pop()
+            else {
+                panic!("fixture admission produces one key")
+            };
+            assert_eq!(actual, expected);
+            children.insert(actual, child);
+        }
+        if let Some(next) = self.next_ordered_start {
+            supervisor.set_next_ordered_start_for_test(next);
+        }
+        supervisor.set_hard_forced_for_test(self.hard_forced);
         ScopeRuntime {
             root: self.root,
             defaults: self.defaults,
             intensity_policy: self.intensity_policy,
             intensity: super::super::IntensityState::default(),
-            child_keys,
-            incomplete_children,
             restart_shutdown_retries: Vec::new(),
-            children: self.children,
+            children,
+            supervisor,
+            supervisor_effects,
             events: self.events,
             disposal_events: self.disposal_events,
             deadlines: super::super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::new(),
-            lifecycle: self.lifecycle,
-            next_ordered_start: self.next_ordered_start,
             role: ScopeRole::Root,
             dynamic: self.dynamic,
             pending_startup_removals: Vec::new(),
             epoch: self.epoch,
             ancestor_shutdown_seen: false,
             ancestor_abort_seen: false,
-            hard_forced: self.hard_forced,
-            ordered_stop_progressing: false,
-            ordered_stop_cursor: None,
-            ordered_stop_waiting: None,
-            ordered_stop_inspections: 0,
             completion: None,
+            finished: None,
         }
     }
 }

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -60,11 +60,8 @@ struct ObserveScopeOnStartupWake {
 impl ObserveScopeOnStartupWake {
     fn observe(&self) {
         let member = self.scope.member.record().stage;
-        let incarnation_finished = self
-            .epoch
-            .map(|epoch| self.scope.incarnation_finished(epoch));
-        *self.observed.lock().expect("observation mutex poisoned") =
-            Some((member, incarnation_finished));
+        let settled = self.epoch.map(|epoch| self.scope.settled(Some(epoch)));
+        *self.observed.lock().expect("observation mutex poisoned") = Some((member, settled));
     }
 }
 
@@ -115,7 +112,7 @@ async fn terminal_stop_paths_share_one_complete_observation_transition() {
         ));
         assert_eq!(scope.record().state, expected_state);
         assert_eq!(
-            epoch.map(|epoch| scope.incarnation_finished(epoch)),
+            epoch.map(|epoch| scope.settled(Some(epoch))),
             epoch.map(|_| true)
         );
         assert_eq!(snapshots.borrow_latest().state, expected_state);
@@ -192,7 +189,7 @@ async fn root_driver_panic_mid_drain_upgrades_to_the_join_monitor_verdict() {
         "the unwind epilogue leaves root terminality to the join monitor"
     );
     assert!(
-        scope.incarnation_finished(epoch),
+        scope.settled(Some(epoch)),
         "the unwind epilogue retires its epoch, so the join monitor must take \
          the no-live-epoch fallback this test is named for"
     );
@@ -430,7 +427,7 @@ fn stopped_publication_keeps_mailbox_panic_primary_and_finishes_observation() {
             reason: StopReason::ShutdownRequested
         }
     ));
-    assert!(scope.incarnation_finished(epoch));
+    assert!(scope.settled(Some(epoch)));
     assert!(matches!(
         events.try_recv(),
         Ok(LifecycleItem::Event(crate::LifecycleEvent {

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -1,1 +1,2 @@
 pub use shelterwood_core::engine::*;
+pub(crate) use shelterwood_core::supervisor::*;

--- a/tools/check-packaged-crate.sh
+++ b/tools/check-packaged-crate.sh
@@ -19,7 +19,12 @@ cd "$repo_root"
 # dependencies, then add each exact archive to it in dependency order. This
 # keeps package normalization honest even in Nix, where crates.io is already
 # replaced by a read-only vendored source.
-cargo vendor --locked --offline --respect-source-config "$vendor_root" >/dev/null
+# `cargo vendor` is the acquisition boundary for the isolated source. The
+# ordinary PR lane can start without crate archives in Cargo's user cache, so
+# allow this locked step to fetch a missing archive. Nix builds continue to use
+# their configured read-only source, and every operation against the generated
+# vendor below remains offline.
+cargo vendor --locked --respect-source-config "$vendor_root" >/dev/null
 mkdir -p "$package_home"
 cat > "$package_home/config.toml" <<EOF
 [source.crates-io]


### PR DESCRIPTION
## Summary

- add a tokio-free `SupervisorState` and total synchronous `step(&mut SupervisorState, Event, &mut EffectSink)` reducer in `shelterwood-core`
- move child-key/index ownership, authoritative child/removal state, startup aggregation, ordered start/stop cursors, drain/finish state, and derived completion into the reducer
- leave the façade driver as the runtime-resource/effect shell, sampling synchronous removal latches before reducer transitions and again at the single construction funnel
- expose the membership-terminal / incarnation-complete / joined predicates behind the single `settled(epoch)` shutdown surface
- absorb #210: distinct suppression naming, one dynamic-entry lookup helper, collapsed removal dispatch, no duplicate arena telemetry, no false readiness field, and scope-only framework latches
- add table-driven transitions, derived-state properties, key exhaustion/totality checks, legal-phase guards, ordered-stop coverage, and exhaustive 2–3 child event-order enumeration in both scope flavors

## Why

Stage 3 of #214 requires one structural authority that can be tested without Tokio, clocks, randomness, user code, or I/O. Previously the driver maintained arena indexes, lifecycle flags, startup bookkeeping, ordered cursors, removal state, and an incremental incomplete-child counter across separate structures and update sites.

The reducer now owns those decisions. Runtime latches remain synchronously writable, but are sampled into reducer events; removal is represented by `ChildState::Removing(...)` rather than a parallel driver flag.

A fresh adversarial pass after the draft was opened found and directly fixed a queued-`StartChild` removal race, illegal stale phase transitions, sampled-removal startup scheduling, and missing ordered-flavor/ordered-stop coverage.

## Validation

- `./tools/dev just ci`
  - formatting and `-D warnings` clippy
  - 614 tests, doctests, rustdoc/API reachability, and packaged-crate validation
- `./tools/dev just ci-nix`
- reducer suite enumerates all 8! two-child and all 9! three-child schedules for both ordered and dynamic scopes

Stacked on #226 (`agent/issue-214-stage-2`).

Part of #214.
Closes #210.