### PR TITLE
Remove lifecycle tracing under the observation gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,6 @@ dependencies = [
  "shelterwood-runtime",
  "thiserror",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/crates/shelterwood-cells/Cargo.toml
+++ b/crates/shelterwood-cells/Cargo.toml
@@ -19,7 +19,6 @@ shelterwood-core.workspace = true
 shelterwood-mailbox.workspace = true
 shelterwood-runtime.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
 shelterwood-core = { workspace = true, features = ["test-util"] }

--- a/crates/shelterwood-cells/src/observe.rs
+++ b/crates/shelterwood-cells/src/observe.rs
@@ -627,13 +627,6 @@ impl LifecycleHub {
         txn: &mut crate::cells::ObservationTxn<'_>,
         event: LifecycleEvent,
     ) {
-        tracing::trace!(
-            scope = ?event.scope,
-            seq = event.seq.get(),
-            path = ?event.scope_path,
-            kind = ?event.kind,
-            "scope lifecycle event"
-        );
         let mut published = false;
         self.channels.signal.modify_silently(|signal| {
             if signal.closed {


### PR DESCRIPTION
## Summary

- remove the lifecycle `trace!` call from `LifecycleHub::publish`
- remove `tracing` from `shelterwood-cells` and update the lockfile
- leave the two format-neutral `shelterwood/src/raw.rs` diagnostics unchanged

## Why

Formatting `LifecycleEventKind` can reach a user error's `Display` implementation while the observation gate mutex is held. With a TRACE subscriber installed, that violates the lock rule described in #235. The trace also duplicates the structured, ordered lifecycle stream already exposed through `subscribe_lifecycle()`.

## Impact

TRACE subscribers can no longer cause user formatting to run inside the observation gate. `shelterwood-cells` also sheds an otherwise-unused direct dependency, with no public API change.

This implements Part 1 of #237. It intentionally does not close the issue because the Part 2 choke-point design remains.

## Validation

- `./tools/dev just ci`