### PR TITLE
Pin product behavior edge cases

### DIFF
--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -2077,3 +2077,37 @@ impl ScopeCell {
         self.close_observation_locked(txn);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::Arc,
+    };
+
+    use crate::{ChildId, MemberCell, ScopeCell, identity::ScopeIdentity, policy::ScopeFlavor};
+
+    #[test]
+    fn destructor_shutdown_tolerates_a_poisoned_control_mutex() {
+        let id = ChildId::from("root");
+        let mut identity = ScopeIdentity::new();
+        let member = MemberCell::new(
+            id.clone(),
+            identity
+                .mint_membership(&id)
+                .expect("root membership is available"),
+        );
+        let scope = ScopeCell::new(member, ScopeFlavor::Dynamic, ScopeIdentity::new());
+
+        let poison = Arc::clone(&scope);
+        assert!(
+            catch_unwind(AssertUnwindSafe(move || {
+                let _control = poison.control.lock().expect("control starts healthy");
+                panic!("inject control poison");
+            }))
+            .is_err()
+        );
+
+        assert!(scope.request_shutdown_ignoring_poison().is_some());
+    }
+}

--- a/crates/shelterwood-core/src/engine.rs
+++ b/crates/shelterwood-core/src/engine.rs
@@ -1521,6 +1521,17 @@ mod tests {
             Some(ReadinessEffect::BecameReady)
         );
 
+        let mut unsignaled_exit = ReadinessGate::new();
+        unsignaled_exit.step(ReadinessEvent::Configure {
+            readiness: crate::Readiness::Manual,
+            deadline: None,
+        });
+        assert_eq!(
+            unsignaled_exit.step(ReadinessEvent::Exit { signal_seen: false }),
+            Some(ReadinessEffect::Disarmed)
+        );
+        assert!(!unsignaled_exit.needs_signal_watch());
+
         let mut timed_out = ReadinessGate::new();
         assert_eq!(
             timed_out.step(ReadinessEvent::Configure {

--- a/crates/shelterwood-core/src/identity.rs
+++ b/crates/shelterwood-core/src/identity.rs
@@ -664,6 +664,28 @@ mod tests {
     }
 
     #[test]
+    fn terminal_eviction_recovers_an_exhausted_id_with_a_fresh_lineage() {
+        const TEST_LINEAGE: u64 = u64::MAX;
+        let id = ChildId::from("worker");
+        // The global allocator cannot reach this fixture lineage in the test,
+        // so recovery must allocate a distinct comparison domain.
+        let mut scope = ScopeIdentity::near_exhaustion(id.clone(), TEST_LINEAGE);
+        let last = scope
+            .mint_membership(&id)
+            .expect("last usable membership is minted")
+            .membership();
+        assert!(scope.mint_membership(&id).is_none());
+
+        scope.evict(&id, last);
+        let recovered = scope
+            .mint_membership(&id)
+            .expect("terminal eviction releases the exhausted id")
+            .membership();
+        assert!(!last.supersedes(recovered));
+        assert!(!recovered.supersedes(last));
+    }
+
+    #[test]
     fn exhausted_stable_domain_rejects_a_rebuilt_declaration() {
         let id = ChildId::from("worker");
         let mut stable = ScopeIdentity::near_exhaustion(id.clone(), 7);

--- a/crates/shelterwood-core/src/policy.rs
+++ b/crates/shelterwood-core/src/policy.rs
@@ -1042,6 +1042,7 @@ mod tests {
         assert_eq!(JitterSample::new(f64::NAN).0, 0.0);
         assert_eq!(JitterSample::new(f64::INFINITY).0, 0.0);
         assert_eq!(JitterSample::new(1.0).0, 1.0 - f64::EPSILON);
+        assert_eq!(JitterSample::from_u64_ratio(1, 0).0, 0.0);
         assert_eq!(JitterSample::from_u64_ratio(0, u64::MAX).0, 0.0);
         assert_eq!(
             JitterSample::from_u64_ratio(u64::MAX, u64::MAX).0,

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -761,6 +761,12 @@ impl<M> MailboxCell<M> {
                     message,
                     newest_observed,
                 } => {
+                    // Mailbox terminality linearizes in the binding, while a
+                    // parked operation linearizes when its own outcome leaves
+                    // `Waiting`. A terminal teardown may therefore have
+                    // detached this waiter without discharging it yet; an
+                    // already-expired withdrawal legitimately wins that
+                    // operation-local race.
                     let message = message
                         .take()
                         .expect("a waiting operation must retain its message");
@@ -930,6 +936,10 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         }
         let final_incarnation = state.last_bound;
         let waiters = state.take_waiters();
+        // This binding transition linearizes mailbox terminality. Each
+        // detached waiter is decided separately by its `Waiting ->` outcome
+        // transition, so an already-expired withdrawal may beat the deferred
+        // discharge even after this mailbox-wide transition.
         state.binding = MailboxBinding::Terminal(final_incarnation);
         let queue = std::mem::take(&mut state.queue);
         let latest = state.latest.take();
@@ -1166,10 +1176,11 @@ pub(super) mod tests {
             atomic::{AtomicUsize, Ordering},
         },
         task::{Context, Poll, Wake, Waker},
+        time::Duration,
     };
 
     use crate::{
-        ActorIdentity, ActorRef, ChildId, MailboxControl, SendErrorKind,
+        ActorIdentity, ActorRef, ChildId, MailboxControl, MailboxReceiver, SendErrorKind,
         identity::ScopeIdentity,
         policy::{ResolvedDefaults, ResolvedMailbox},
     };
@@ -1353,6 +1364,54 @@ pub(super) mod tests {
             super::MailboxBinding::Bound(super::BoundState::Available(bound))
                 if bound == incarnation
         ));
+    }
+
+    #[test]
+    fn receive_promotes_multiple_parked_senders_in_fifo_order() {
+        let (mailbox, actor) = actor();
+        MailboxControl::configure(
+            &*mailbox,
+            ResolvedMailbox::Queue(
+                std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
+            ),
+        );
+        let mut identity = ScopeIdentity::new();
+        let (_, mut incarnations) = identity
+            .mint_membership(&ChildId::from("actor"))
+            .expect("membership available")
+            .into_pair();
+        let incarnation = incarnations.mint().expect("incarnation available");
+        MailboxControl::bind(&*mailbox, incarnation);
+        let receiver = MailboxReceiver::new(Arc::clone(&mailbox), incarnation);
+
+        assert!(matches!(actor.try_send(0), Ok(bound) if bound == incarnation));
+        let mut sends: Vec<_> = (1_u8..=3)
+            .map(|message| Box::pin(actor.send(message)))
+            .collect();
+        for send in &mut sends {
+            park_with(send, Waker::noop());
+        }
+
+        let send_count = sends.len();
+        for (delivered, send) in sends.iter_mut().enumerate() {
+            assert_eq!(receiver.try_recv(), Some(delivered as u8));
+            assert!(matches!(
+                send.as_mut().poll(&mut Context::from_waker(Waker::noop())),
+                Poll::Ready(Ok(bound)) if bound == incarnation
+            ));
+
+            let remaining = send_count - delivered - 1;
+            if remaining > 0 {
+                assert!(matches!(
+                    &mailbox.state.lock().expect("mailbox mutex poisoned").binding,
+                    super::MailboxBinding::Bound(super::BoundState::Full { waiters, .. })
+                        if waiters.len() == remaining
+                ));
+            }
+        }
+
+        assert_eq!(receiver.try_recv(), Some(3));
+        assert_eq!(receiver.try_recv(), None);
     }
 
     #[test]
@@ -1566,6 +1625,31 @@ pub(super) mod tests {
                 .waiters()
                 .is_none()
         );
+    }
+
+    #[crate::runtime::test(start_paused = true)]
+    async fn expired_timeout_can_race_detached_terminal_teardown() {
+        let (mailbox, actor) = actor();
+        let width = Duration::from_secs(1);
+        let mut send = Box::pin(actor.send_timeout(1, width));
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        crate::runtime::advance(width * 2).await;
+
+        let teardown = MailboxControl::prepare_termination(&*mailbox)
+            .expect("live mailbox prepares terminal teardown");
+        // Teardown remains retained: timeout sees terminal binding after the
+        // waiter queue was detached but before its waiter was discharged.
+        let Poll::Ready(Err(error)) = send.as_mut().poll(&mut Context::from_waker(Waker::noop()))
+        else {
+            panic!("the expired send withdraws before deferred discharge");
+        };
+        assert_eq!(error.kind, SendErrorKind::TimedOut);
+        assert_eq!(error.message, 1);
+        drop(teardown);
     }
 
     #[test]

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -1650,6 +1650,12 @@ pub(super) mod tests {
         assert_eq!(error.kind, SendErrorKind::TimedOut);
         assert_eq!(error.message, 1);
         drop(teardown);
+
+        let retry = actor
+            .try_send(2)
+            .expect_err("the terminal mailbox rejects a retry");
+        assert_eq!(retry.kind, SendErrorKind::Terminated);
+        assert_eq!(retry.incarnation_observed, None);
     }
 
     #[test]

--- a/crates/shelterwood-mailbox/src/errors.rs
+++ b/crates/shelterwood-mailbox/src/errors.rs
@@ -11,7 +11,10 @@ pub enum SendErrorKind {
     Full,
     /// The membership is terminal.
     Terminated,
-    /// A timed send was withdrawn before acceptance.
+    /// A timed send was withdrawn before acceptance. An already-expired
+    /// withdrawal can win before deferred waiter discharge even when mailbox
+    /// termination linearized first; a retry then reports `Terminated` with
+    /// the final incarnation.
     TimedOut,
 }
 
@@ -63,7 +66,10 @@ impl fmt::Display for SendErrorKind {
 pub enum CallErrorKind {
     /// The membership terminalized before acceptance.
     Terminated,
-    /// The request was withdrawn before acceptance.
+    /// The request was withdrawn before acceptance. An already-expired
+    /// withdrawal can win before deferred waiter discharge even when mailbox
+    /// termination linearized first; a retry then reports `Terminated` with
+    /// the final incarnation.
     AcceptanceTimedOut,
     /// The request was accepted but its response missed the deadline.
     ResponseTimedOut,

--- a/crates/shelterwood-mailbox/src/errors.rs
+++ b/crates/shelterwood-mailbox/src/errors.rs
@@ -13,8 +13,8 @@ pub enum SendErrorKind {
     Terminated,
     /// A timed send was withdrawn before acceptance. An already-expired
     /// withdrawal can win before deferred waiter discharge even when mailbox
-    /// termination linearized first; a retry then reports `Terminated` with
-    /// the final incarnation.
+    /// termination linearized first; a retry then reports `Terminated` and
+    /// includes the final incarnation when one existed.
     TimedOut,
 }
 
@@ -68,8 +68,8 @@ pub enum CallErrorKind {
     Terminated,
     /// The request was withdrawn before acceptance. An already-expired
     /// withdrawal can win before deferred waiter discharge even when mailbox
-    /// termination linearized first; a retry then reports `Terminated` with
-    /// the final incarnation.
+    /// termination linearized first; a retry then reports `Terminated` and
+    /// includes the final incarnation when one existed.
     AcceptanceTimedOut,
     /// The request was accepted but its response missed the deadline.
     ResponseTimedOut,

--- a/crates/shelterwood-runtime/Cargo.toml
+++ b/crates/shelterwood-runtime/Cargo.toml
@@ -9,7 +9,9 @@ homepage = "https://github.com/ralexstokes/shelterwood"
 repository = "https://github.com/ralexstokes/shelterwood"
 
 [features]
-test-util = ["tokio/test-util"]
+# `rt-multi-thread` is the dedicated-runtime fixture's, not the library's: the
+# adapter itself never builds a runtime.
+test-util = ["tokio/test-util", "tokio/rt-multi-thread"]
 
 [lints]
 workspace = true

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -19,6 +19,70 @@ pub fn is_available() -> bool {
     tokio::runtime::Handle::try_current().is_ok()
 }
 
+/// One task hosted on a runtime the test can destroy underneath it.
+///
+/// Runtime teardown is the only way to produce a genuinely cancelled spawned
+/// task, and it cannot be staged from inside the runtime being torn down:
+/// dropping a runtime blocks until its workers stop, and a test awaiting the
+/// consequences of that teardown is itself a task on some runtime. So the task
+/// under test gets its own runtime on its own thread, while the assertions stay
+/// on the caller's runtime, and the cancellation edge between them is real.
+///
+/// The teardown signal is the request channel closing, which covers explicit
+/// [`shutdown`](Self::shutdown) and dropping this handle alike — a test that
+/// panics before tearing down still releases the thread.
+#[cfg(any(test, feature = "test-util"))]
+pub struct DedicatedRuntime {
+    teardown: std::sync::mpsc::Sender<()>,
+    thread: std::thread::JoinHandle<()>,
+}
+
+#[cfg(any(test, feature = "test-util"))]
+impl DedicatedRuntime {
+    /// Two workers: one for the hosted task, one so a task it spawns or wakes
+    /// still makes progress while the first is parked.
+    const WORKER_THREADS: usize = 2;
+
+    /// Spawns `task` onto a fresh dedicated runtime.
+    pub fn spawn<F>(task: F) -> (Self, JoinHandle<F::Output>)
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(Self::WORKER_THREADS)
+            .enable_all()
+            .build()
+            .expect("a dedicated runtime builds");
+        let handle = JoinHandle {
+            inner: runtime.spawn(task),
+        };
+        let (teardown, request) = std::sync::mpsc::channel();
+        let thread = std::thread::spawn(move || {
+            // Both teardown edges arrive as this receive returning: a request
+            // to shut down, or the disconnect from a dropped handle.
+            let _ = request.recv();
+            drop(runtime);
+        });
+        (Self { teardown, thread }, handle)
+    }
+
+    /// Destroys the runtime, cancelling the hosted task, and waits for the
+    /// teardown to finish.
+    ///
+    /// The wait is offloaded because a dropping runtime blocks its thread until
+    /// every worker has stopped; awaiting that here keeps the caller's own
+    /// worker free.
+    pub async fn shutdown(self) {
+        let Self { teardown, thread } = self;
+        drop(teardown);
+        join_resuming(spawn_blocking(move || {
+            thread.join().expect("dedicated runtime teardown completes")
+        }))
+        .await;
+    }
+}
+
 pub struct ActorWork {
     handle: Option<JoinHandle<()>>,
     abort: AbortHandle,

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -328,7 +328,7 @@ impl<T> OneShotReceiver<T> {
     /// The shared transition word distinguishes sender-drop from receiver
     /// close, which Tokio's post-close `try_recv` result alone cannot do. A
     /// send that wins but is preempted before publishing returns `Pending`;
-    /// the preceding channel poll registered the wake for its completion.
+    /// the channel poll in that branch registers the wake for its completion.
     pub fn close_and_poll_receive(
         &mut self,
         context: &mut std::task::Context<'_>,
@@ -632,7 +632,7 @@ mod tests {
             Arc,
             atomic::{AtomicUsize, Ordering},
         },
-        task::{Context, Poll, Waker},
+        task::{Context, Poll, Wake, Waker},
         time::Duration,
     };
 
@@ -640,6 +640,14 @@ mod tests {
         CompletionGatedLatch, JoinOutcome, Latch, OneShotClose, Signal, Timeout, join, oneshot,
         spawn, timeout, yield_now,
     };
+
+    struct CountWake(Arc<AtomicUsize>);
+
+    impl Wake for CountWake {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
 
     #[test]
     fn closing_oneshot_distinguishes_value_sender_drop_and_receiver_win() {
@@ -732,6 +740,48 @@ mod tests {
         assert_eq!(transitions, 1);
         assert!(latch.is_fired());
         assert!(!latch.fire());
+    }
+
+    #[test]
+    fn silent_fire_defers_a_parked_waiters_wake_until_notify() {
+        let latch = Latch::default();
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let waker = Waker::from(Arc::new(CountWake(Arc::clone(&wakes))));
+        let mut fired = Box::pin(latch.fired());
+
+        assert!(
+            fired
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending()
+        );
+        assert!(latch.fire_silently());
+        assert!(latch.is_fired());
+        assert_eq!(wakes.load(Ordering::SeqCst), 0);
+
+        latch.notify();
+        assert_eq!(wakes.load(Ordering::SeqCst), 1);
+        assert!(
+            fired
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_ready()
+        );
+    }
+
+    #[test]
+    fn completion_waiters_cover_parked_and_already_completed_paths() {
+        let parked = CompletionGatedLatch::default();
+        let mut waiting = Box::pin(parked.completed());
+        let mut context = Context::from_waker(Waker::noop());
+        assert!(waiting.as_mut().poll(&mut context).is_pending());
+        assert!(!parked.complete());
+        assert!(waiting.as_mut().poll(&mut context).is_ready());
+
+        let completed = CompletionGatedLatch::default();
+        assert!(!completed.complete());
+        let mut immediate = Box::pin(completed.completed());
+        assert!(immediate.as_mut().poll(&mut context).is_ready());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -772,16 +772,24 @@ mod tests {
     #[test]
     fn completion_waiters_cover_parked_and_already_completed_paths() {
         let parked = CompletionGatedLatch::default();
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let waker = Waker::from(Arc::new(CountWake(Arc::clone(&wakes))));
         let mut waiting = Box::pin(parked.completed());
-        let mut context = Context::from_waker(Waker::noop());
+        let mut context = Context::from_waker(&waker);
         assert!(waiting.as_mut().poll(&mut context).is_pending());
         assert!(!parked.complete());
+        assert_eq!(wakes.load(Ordering::SeqCst), 1);
         assert!(waiting.as_mut().poll(&mut context).is_ready());
 
         let completed = CompletionGatedLatch::default();
         assert!(!completed.complete());
         let mut immediate = Box::pin(completed.completed());
-        assert!(immediate.as_mut().poll(&mut context).is_ready());
+        assert!(
+            immediate
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_ready()
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/shelterwood/doctests/docs/retry-and-ordering.md
+++ b/crates/shelterwood/doctests/docs/retry-and-ordering.md
@@ -17,7 +17,7 @@ Treat these tokens as part of the protocol, not merely diagnostic metadata.
 | `ReplyDropped` | The request was accepted, but its `Reply` was dropped unanswered. | Retry only an idempotent operation, only under one overall deadline, and only after a newer incarnation is running. |
 | `Terminated` | The target membership ended before acceptance. | That handle can never follow a same-id replacement. Obtain the replacement's new handle deliberately. |
 
-An already-expired acceptance timeout can win withdrawal before deferred waiter discharge even when mailbox termination linearized first; it still proves guaranteed-never-accepted, and a retry then reports `Terminated` with the final incarnation.
+An already-expired acceptance timeout can win withdrawal before deferred waiter discharge even when mailbox termination linearized first; it still proves guaranteed-never-accepted, and a retry then reports `Terminated`, including the final incarnation when one existed.
 
 For a safe `ReplyDropped` retry in the core API:
 

--- a/crates/shelterwood/doctests/docs/retry-and-ordering.md
+++ b/crates/shelterwood/doctests/docs/retry-and-ordering.md
@@ -17,6 +17,8 @@ Treat these tokens as part of the protocol, not merely diagnostic metadata.
 | `ReplyDropped` | The request was accepted, but its `Reply` was dropped unanswered. | Retry only an idempotent operation, only under one overall deadline, and only after a newer incarnation is running. |
 | `Terminated` | The target membership ended before acceptance. | That handle can never follow a same-id replacement. Obtain the replacement's new handle deliberately. |
 
+An already-expired acceptance timeout can win withdrawal before deferred waiter discharge even when mailbox termination linearized first; it still proves guaranteed-never-accepted, and a retry then reports `Terminated` with the final incarnation.
+
 For a safe `ReplyDropped` retry in the core API:
 
 1. Give the logical operation a durable id and make duplicate processing

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -143,9 +143,19 @@ impl Drop for SystemRun {
 
 pub(crate) fn spawn_system(plan: ScopePlan) -> SystemRun {
     let root = Arc::clone(&plan.root);
-    let monitor_root = Arc::clone(&root);
     let driver = runtime::spawn(async move { run_scope(plan, ScopeRole::Root).await });
-    let lifecycle = runtime::spawn(async move {
+    let lifecycle = monitor_root_driver(Arc::clone(&root), driver);
+    SystemRun {
+        root,
+        driver: Some(lifecycle),
+    }
+}
+
+fn monitor_root_driver(
+    monitor_root: Arc<ScopeCell>,
+    driver: runtime::JoinHandle<StopReason>,
+) -> runtime::JoinHandle<StopReason> {
+    runtime::spawn(async move {
         match classify_root_driver_join(runtime::join(driver).await) {
             Ok(reason) => reason,
             Err(exit) => {
@@ -153,11 +163,7 @@ pub(crate) fn spawn_system(plan: ScopePlan) -> SystemRun {
                 StopReason::ShutdownRequested
             }
         }
-    });
-    SystemRun {
-        root,
-        driver: Some(lifecycle),
-    }
+    })
 }
 
 struct AncestorCommandLatches {

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -4,29 +4,7 @@ use super::support::*;
 async fn runtime_teardown_finishes_the_cancelled_root_driver() {
     let plan = DynamicTree::new().lower_for_test();
     let root = Arc::clone(&plan.root);
-    let (driver_sender, driver_receiver) = std::sync::mpsc::sync_channel(1);
-    let (teardown_sender, teardown_receiver) = std::sync::mpsc::sync_channel(0);
-    let runtime_thread = std::thread::spawn(move || {
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
-            .enable_all()
-            .build()
-            .expect("dedicated driver runtime");
-        let guard = runtime.enter();
-        let driver = crate::runtime::spawn(async move { run_scope(plan, ScopeRole::Root).await });
-        drop(guard);
-        driver_sender
-            .send(driver)
-            .expect("the monitor receives the root driver");
-        teardown_receiver
-            .recv()
-            .expect("the test requests runtime teardown");
-        drop(runtime);
-    });
-
-    let driver = driver_receiver
-        .recv()
-        .expect("dedicated runtime publishes the driver handle");
+    let (hosted, driver) = DedicatedRuntime::spawn(run_scope(plan, ScopeRole::Root));
     let monitor = monitor_root_driver(Arc::clone(&root), driver);
     root.wait_started().await.expect("root starts");
     let wakes = Arc::new(AtomicUsize::new(0));
@@ -40,10 +18,7 @@ async fn runtime_teardown_finishes_the_cancelled_root_driver() {
         "the live root observer parks before runtime teardown"
     );
 
-    teardown_sender
-        .send(())
-        .expect("dedicated runtime remains live");
-    runtime_thread.join().expect("runtime teardown completes");
+    hosted.shutdown().await;
 
     assert!(matches!(
         crate::runtime::timeout(DRIVER_PROGRESS_WAIT, crate::runtime::join(monitor)).await,

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -1,5 +1,52 @@
 use super::support::*;
 
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+async fn runtime_teardown_finishes_the_cancelled_root_driver() {
+    let plan = DynamicTree::new().lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let (driver_sender, driver_receiver) = std::sync::mpsc::sync_channel(1);
+    let (teardown_sender, teardown_receiver) = std::sync::mpsc::sync_channel(0);
+    let runtime_thread = std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("dedicated driver runtime");
+        let guard = runtime.enter();
+        let driver = crate::runtime::spawn(async move { run_scope(plan, ScopeRole::Root).await });
+        drop(guard);
+        driver_sender
+            .send(driver)
+            .expect("the monitor receives the root driver");
+        teardown_receiver
+            .recv()
+            .expect("the test requests runtime teardown");
+        drop(runtime);
+    });
+
+    let driver = driver_receiver
+        .recv()
+        .expect("dedicated runtime publishes the driver handle");
+    let monitor = monitor_root_driver(Arc::clone(&root), driver);
+    root.wait_started().await.expect("root starts");
+
+    teardown_sender
+        .send(())
+        .expect("dedicated runtime remains live");
+    runtime_thread.join().expect("runtime teardown completes");
+
+    assert!(matches!(
+        crate::runtime::timeout(Duration::from_secs(1), root.wait_stopped()).await,
+        crate::runtime::Timeout::Completed(StopReason::ShutdownRequested)
+    ));
+    assert!(matches!(
+        crate::runtime::join(monitor).await,
+        crate::runtime::JoinOutcome::Ok {
+            value: StopReason::ShutdownRequested
+        }
+    ));
+}
+
 #[crate::runtime::test]
 async fn latched_shutdown_upgrades_an_intensity_drain() {
     let mut tree = Tree::new();

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -29,6 +29,16 @@ async fn runtime_teardown_finishes_the_cancelled_root_driver() {
         .expect("dedicated runtime publishes the driver handle");
     let monitor = monitor_root_driver(Arc::clone(&root), driver);
     root.wait_started().await.expect("root starts");
+    let wakes = Arc::new(AtomicUsize::new(0));
+    let stopped_waker = Waker::from(Arc::new(CountWake(Arc::clone(&wakes))));
+    let mut stopped = Box::pin(root.wait_stopped());
+    assert!(
+        stopped
+            .as_mut()
+            .poll(&mut Context::from_waker(&stopped_waker))
+            .is_pending(),
+        "the live root observer parks before runtime teardown"
+    );
 
     teardown_sender
         .send(())
@@ -36,14 +46,24 @@ async fn runtime_teardown_finishes_the_cancelled_root_driver() {
     runtime_thread.join().expect("runtime teardown completes");
 
     assert!(matches!(
-        crate::runtime::timeout(Duration::from_secs(1), root.wait_stopped()).await,
-        crate::runtime::Timeout::Completed(StopReason::ShutdownRequested)
+        crate::runtime::timeout(DRIVER_PROGRESS_WAIT, crate::runtime::join(monitor)).await,
+        crate::runtime::Timeout::Completed(crate::runtime::JoinOutcome::Ok {
+            value: StopReason::ShutdownRequested,
+        })
+    ));
+    assert!(
+        wakes.load(Ordering::SeqCst) > 0,
+        "the join monitor wakes an observer parked before cancellation"
+    );
+    assert!(matches!(
+        stopped
+            .as_mut()
+            .poll(&mut Context::from_waker(Waker::noop())),
+        Poll::Ready(StopReason::ShutdownRequested)
     ));
     assert!(matches!(
-        crate::runtime::join(monitor).await,
-        crate::runtime::JoinOutcome::Ok {
-            value: StopReason::ShutdownRequested
-        }
+        root.member.record().stage,
+        MemberStage::Terminal(ref exit) if exit.cancellation() == Cancellation::Observed
     ));
 }
 

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -36,9 +36,9 @@ pub(super) use super::super::{
     MemberTransition, NestedScopeLatches, Pending, RemovalRequest, RemovalResponses,
     ResidentProjection, RuntimeStorage, ScopeCell, ScopeControlEvent, ScopeEpochGuard, ScopeFlavor,
     ScopeRole, ScopeRuntime, StartupDisposition, cancel_dynamic_reservation,
-    discharge_child_terminality, report_slot, reserve_dynamic, resident_projection,
-    restart_shutdown_work, run_nested_factory, run_nested_tree, run_scope_incarnation,
-    storage::Obligation,
+    discharge_child_terminality, monitor_root_driver, report_slot, reserve_dynamic,
+    resident_projection, restart_shutdown_work, run_nested_factory, run_nested_tree, run_scope,
+    run_scope_incarnation, storage::Obligation,
 };
 
 pub(super) struct ChildArena<T> {

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -27,7 +27,7 @@ pub(super) use crate::{
     mailbox::{MailboxCell, actor_ref_from_parts},
     plan::{BuilderCore, ChildConstruction, SlotCell, resolve_fixture_options},
     policy::ResolvedDefaults,
-    runtime::{CompletionGatedLatch, Latch},
+    runtime::{CompletionGatedLatch, DedicatedRuntime, Latch},
 };
 
 pub(super) use super::super::{

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -1420,6 +1420,10 @@ impl<M: Send + 'static> RawContext<M> {
                 return None;
             }
             if self.shutdown.is_cancelled() {
+                // Every driver path freezes (or closes) this incarnation's
+                // mailbox before firing its shutdown token. That ordering is
+                // what makes the frozen accepted prefix a complete drain
+                // boundary once cancellation is observable here.
                 self.freeze_and_report();
                 return None;
             }

--- a/crates/shelterwood/src/tree/admission.rs
+++ b/crates/shelterwood/src/tree/admission.rs
@@ -155,6 +155,9 @@ impl<H: Unpin> Future for Admission<H> {
                     return Poll::Ready(Err(error));
                 }
                 AdmissionState::Unpolled(pending) => {
+                    // Keep the annul-owning `Unpolled` state installed until
+                    // this fallible operation returns. If it unwinds, Drop
+                    // must still find `pending` and cancel the reservation.
                     let wait = match pending.start() {
                         Ok(wait) => wait,
                         Err(error) => {

--- a/docs/retry-and-ordering.md
+++ b/docs/retry-and-ordering.md
@@ -17,7 +17,7 @@ Treat these tokens as part of the protocol, not merely diagnostic metadata.
 | `ReplyDropped` | The request was accepted, but its `Reply` was dropped unanswered. | Retry only an idempotent operation, only under one overall deadline, and only after a newer incarnation is running. |
 | `Terminated` | The target membership ended before acceptance. | That handle can never follow a same-id replacement. Obtain the replacement's new handle deliberately. |
 
-An already-expired acceptance timeout can win withdrawal before deferred waiter discharge even when mailbox termination linearized first; it still proves guaranteed-never-accepted, and a retry then reports `Terminated` with the final incarnation.
+An already-expired acceptance timeout can win withdrawal before deferred waiter discharge even when mailbox termination linearized first; it still proves guaranteed-never-accepted, and a retry then reports `Terminated`, including the final incarnation when one existed.
 
 For a safe `ReplyDropped` retry in the core API:
 

--- a/docs/retry-and-ordering.md
+++ b/docs/retry-and-ordering.md
@@ -17,6 +17,8 @@ Treat these tokens as part of the protocol, not merely diagnostic metadata.
 | `ReplyDropped` | The request was accepted, but its `Reply` was dropped unanswered. | Retry only an idempotent operation, only under one overall deadline, and only after a newer incarnation is running. |
 | `Terminated` | The target membership ended before acceptance. | That handle can never follow a same-id replacement. Obtain the replacement's new handle deliberately. |
 
+An already-expired acceptance timeout can win withdrawal before deferred waiter discharge even when mailbox termination linearized first; it still proves guaranteed-never-accepted, and a retry then reports `Terminated` with the final incarnation.
+
 For a safe `ReplyDropped` retry in the core API:
 
 1. Give the logical operation a durable id and make duplicate processing


### PR DESCRIPTION
## Summary

- add direct regression coverage for all nine product-behavior gaps from #213
- exercise the cancelled root-driver monitor with a dedicated-runtime teardown fixture
- clarify the accepted timeout-versus-terminality arbitration in public docs and code comments
- record the three load-bearing invariants called out in the issue

## Why

These paths were implemented but only indirectly covered, so regressions could surface as rare production anomalies. The timeout race was also easy to misread as a lost-result bug even though the existing arbitration is intentional and spec-consistent.

Closes #213.

## User and developer impact

Runtime behavior is unchanged. The new tests pin readiness disarming, exhausted-id recovery, poison-tolerant shutdown, driver cancellation, FIFO waiter promotion, timeout arbitration, deferred latch wakes, completion waits, and zero-denominator jitter normalization. Public retry guidance now explains why an expired timeout can win before deferred terminal waiter discharge and what a retry observes.

## Validation

- `./tools/dev just ci`
- `./tools/dev just ci-nix`
