### PR TITLE
Narrow Tokio features and guard test registration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,5 +37,5 @@ shelterwood-core = { path = "crates/shelterwood-core", version = "0.1.0" }
 shelterwood-mailbox = { path = "crates/shelterwood-mailbox", version = "0.1.0" }
 shelterwood-runtime = { path = "crates/shelterwood-runtime", version = "0.1.0" }
 thiserror = "2.0.19"
-tokio = { version = "1.53.1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.53.1", features = ["macros", "rt", "sync", "time"] }
 tracing = "0.1.44"

--- a/crates/shelterwood-cells/Cargo.toml
+++ b/crates/shelterwood-cells/Cargo.toml
@@ -23,4 +23,4 @@ thiserror.workspace = true
 [dev-dependencies]
 shelterwood-core = { workspace = true, features = ["test-util"] }
 shelterwood-runtime = { workspace = true, features = ["test-util"] }
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }

--- a/crates/shelterwood-runtime/Cargo.toml
+++ b/crates/shelterwood-runtime/Cargo.toml
@@ -20,4 +20,4 @@ shelterwood-core.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }

--- a/crates/shelterwood/Cargo.toml
+++ b/crates/shelterwood/Cargo.toml
@@ -25,7 +25,7 @@ tracing.workspace = true
 shelterwood-cells = { workspace = true, features = ["test-util"] }
 shelterwood-core = { workspace = true, features = ["test-util"] }
 shelterwood-runtime = { workspace = true, features = ["test-util"] }
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }
 
 [[test]]
 name = "integration"

--- a/crates/shelterwood/tests/acceptance/mod.rs
+++ b/crates/shelterwood/tests/acceptance/mod.rs
@@ -1,5 +1,8 @@
 //! Application-scale acceptance scenarios from `SPEC.md` Appendix C.
 
-mod assistant;
-mod shard_store;
-mod sidecar;
+register_test_modules!(
+    "tests/acceptance";
+    mod assistant;
+    mod shard_store;
+    mod sidecar;
+);

--- a/crates/shelterwood/tests/common/mod.rs
+++ b/crates/shelterwood/tests/common/mod.rs
@@ -1,8 +1,11 @@
-mod gates;
-mod ownership;
-pub(crate) mod policy;
-mod timing;
-pub(crate) mod waiting;
+register_test_modules!(
+    "tests/common";
+    mod gates;
+    mod ownership;
+    pub(crate) mod policy;
+    mod timing;
+    pub(crate) mod waiting;
+);
 
 pub(crate) use gates::{DestructorBlocker, DestructorGate, ReleaseGate};
 pub(crate) use ownership::{ConsumeCount, ConsumeGuard, LiveFlag, PanicOnDrop};

--- a/crates/shelterwood/tests/mod.rs
+++ b/crates/shelterwood/tests/mod.rs
@@ -1,24 +1,86 @@
 //! Integration tests for Shelterwood's public behavior.
 
-mod acceptance;
-mod actor;
-mod api_trait_conformance;
-mod common;
-mod deadlines;
-mod defaults;
-mod delivery;
-mod disposal;
-mod drain;
-mod dynamic;
-mod events;
-mod lifecycle;
-mod mailbox;
-mod observation;
-mod offloads;
-mod one_shot_resource_ownership;
-mod policy_validation;
-mod raw;
-mod readiness;
-mod rebind;
-mod subtrees;
-mod tasks;
+use std::{collections::BTreeSet, fs, path::Path};
+
+macro_rules! register_test_modules {
+    ($directory:literal; $($visibility:vis mod $module:ident;)+) => {
+        $($visibility mod $module;)+
+
+        #[test]
+        fn every_test_module_is_registered() {
+            crate::assert_registered_test_modules(
+                $directory,
+                &[$(stringify!($module)),+],
+            );
+        }
+    };
+}
+
+fn assert_registered_test_modules(directory: &str, registered: &[&str]) {
+    let directory = Path::new(env!("CARGO_MANIFEST_DIR")).join(directory);
+    let registered = registered
+        .iter()
+        .map(|module| (*module).to_owned())
+        .collect::<BTreeSet<_>>();
+    let discovered = fs::read_dir(&directory)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", directory.display()))
+        .filter_map(|entry| {
+            let path = entry
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "failed to read an entry in {}: {error}",
+                        directory.display()
+                    )
+                })
+                .path();
+
+            if path.is_file()
+                && path.extension().is_some_and(|extension| extension == "rs")
+                && path.file_name().is_some_and(|name| name != "mod.rs")
+            {
+                path.file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .map(str::to_owned)
+            } else if path.is_dir() && path.join("mod.rs").is_file() {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .map(str::to_owned)
+            } else {
+                None
+            }
+        })
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        discovered,
+        registered,
+        "test module registration does not match {}",
+        directory.display()
+    );
+}
+
+register_test_modules!(
+    "tests";
+    mod acceptance;
+    mod actor;
+    mod api_trait_conformance;
+    mod common;
+    mod deadlines;
+    mod defaults;
+    mod delivery;
+    mod disposal;
+    mod drain;
+    mod dynamic;
+    mod events;
+    mod lifecycle;
+    mod mailbox;
+    mod observation;
+    mod offloads;
+    mod one_shot_resource_ownership;
+    mod policy_validation;
+    mod raw;
+    mod readiness;
+    mod rebind;
+    mod subtrees;
+    mod tasks;
+);


### PR DESCRIPTION
## Summary

- keep Tokio's production `macros`, `rt`, `sync`, and `time` features while moving `rt-multi-thread` to the dev-dependencies that exercise multi-thread runtimes
- add a `macro_rules!` registration helper that declares integration-test modules and records the same names for completeness checks
- check the root integration-test directory and both nested module directories so newly added but unregistered Rust test files fail visibly

## Why

This addresses item 29 of #191. The runtime adapter needs Tokio's macro support in production for `select!` and `pin!`, but it does not require the multi-thread scheduler in its normal dependency graph. Separately, `autotests = false` means Cargo cannot warn when a test file is added without being linked into the single integration harness.

Normal users now avoid enabling Tokio's multi-thread scheduler through Shelterwood, while test builds that need it retain it explicitly. The registration macro keeps declarations and the guard's expected module names in one source of truth.

## Validation

- `./tools/dev just ci`
- fault-injection check with a temporary unregistered `tests/*.rs` file; the new guard failed with the missing module in its diagnostic, and the probe was removed before committing