### PR TITLE
State the lock rule and audit the lock sites against it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,13 @@ rests on:
   `SnapshotHub`'s deferred retirement all encode that.
 - **`Arc` traffic that cannot reach zero.** Cloning an `Arc` under a lock is
   refcount work; dropping one is only refcount work while another owner is
-  provable. Prefer restructuring over the proof — three confirmed violations
-  (see #235) were each a drop that *looked* like refcount traffic.
+  provable. Prefer restructuring over the proof — every violation the #235
+  audit confirmed was a drop that *looked* like refcount traffic. One
+  exemption still rests on such a proof: `ScopeCell::clear_residents_locked`
+  and `prune_child_locked` drop `Arc<MemberCell>`s under the gate, and a
+  member record owns an `Exit`. They are safe only because the driver's own
+  child map outlives residency (`ScopeRuntime`'s `Drop` clears residents
+  before `self.children`), which is an ordering nothing enforces.
 - **Framework `dyn` seams.** `MailboxControl`, `MailboxTermination` and
   `DynamicRoute` are cross-crate implementation seams with framework-only
   impls, not user traits; calling them under a lock runs no caller code.
@@ -50,13 +55,25 @@ rests on:
   gate is outermost: everything else is taken under it or standalone, never
   around it. Inside, the documented orders are cells' member mailbox →
   `MailboxCell::state`, and `MailboxCell::state` → `SendOperation::state`.
+  Gate-to-gate is the one exception to "outermost": `adopt_observation_gate`
+  takes the adoptee's *current* gate while the adopting parent's is held, in
+  the parent-to-child direction only, and re-reads the installed pointer
+  under the acquired guard so a concurrent handoff retries rather than
+  deadlocks.
 
 Two conventions that are not the rule itself but travel with it: panicking
 while holding a mutex the codebase `.expect()`s poisons it for every later
 caller, so compute the verdict, release, *then* panic (`MailboxCell::bind` is
 the pattern; where releasing is impossible, `debug_assert!` instead, as
 `MailboxState::take_waiters` does). And a value that may block on destruction
-goes to `runtime::dispose_detached`, not merely past the unlock.
+goes to `runtime::dispose_detached`, not merely past the unlock. That second
+convention is currently met for mailbox payloads, construction closures and
+offloads, and *not* met for an `Exit`'s application error: no site in the
+workspace routes an `Exit` through isolated disposal, while the driver
+destroys exits inline on its own thread on several paths that hold no lock at
+all. Treat that as a known gap to close as a class, not by detaching whichever
+site a review happens to land on — a half-detached class reads as if the
+whole class were handled.
 
 Reviewing a new `.lock()` is one pass: name every value the critical section
 can destroy, every callback it can invoke, and every panic it can raise. If

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,68 @@
 # Project instructions
 
+## The lock rule
+
+**Code holding a framework mutex may only manipulate plain framework-owned
+data.** Wakes, drops of user values, formatting, user callbacks, and panic
+resumption happen after unlock.
+
+The framework runs arbitrary user code at moments it does not choose: waker
+`wake`/`clone`/`drop` vtable functions, destructors of user messages, actor
+state, construction closures and the type-erased error inside an `Exit`,
+`Debug`/`Display` on user errors, `Hash`/`Eq` on user timer keys. All of it is
+safe Rust that may panic, block, or re-enter. Under a framework mutex each of
+those becomes poisoning, an ABBA deadlock, or — during an unwind — a double
+panic and a process abort.
+
+Two types implement the rule and are the shapes to reach for:
+
+- **`ObservationTxn`** (`shelterwood-cells/src/cells.rs`) holds the
+  observation-gate guard plus a deferred-effect list. `defer`/`pulse` queue
+  work; `commit` drops the guard *then* runs the queue through a
+  `PanicAccumulator`. Its `Drop` runs the same path during an unwind, so a
+  poisoned transaction cannot strand already-committed wakes. Every retained
+  control-plane writer takes the token, which makes an out-of-transaction
+  mutation unavailable by construction.
+- **`Promotion`** (`shelterwood-mailbox/src/cell.rs`) is the same idea for the
+  mailbox promotion path: wakers and displaced messages accumulate inside the
+  critical section and `Drop` flushes them after it, panic-contained.
+  `Acceptance`, `Termination` and `MailboxPayload` are its single-purpose
+  siblings.
+
+What the rule does *not* forbid — the exemptions every remaining lock site
+rests on:
+
+- **Framework-owned data.** Counters, epochs, arena keys, binding state,
+  registration ids, request flags, identity maps. Locks held only over these
+  need no ceremony.
+- **Moving a user value out.** `take`/`mem::replace`/returning by value is not
+  a drop. What must be outside the critical section is the *destination*:
+  `Acceptance`'s `#[must_use]`, `withdraw`'s `(result, waker)` tuple, and
+  `SnapshotHub`'s deferred retirement all encode that.
+- **`Arc` traffic that cannot reach zero.** Cloning an `Arc` under a lock is
+  refcount work; dropping one is only refcount work while another owner is
+  provable. Prefer restructuring over the proof — three confirmed violations
+  (see #235) were each a drop that *looked* like refcount traffic.
+- **Framework `dyn` seams.** `MailboxControl`, `MailboxTermination` and
+  `DynamicRoute` are cross-crate implementation seams with framework-only
+  impls, not user traits; calling them under a lock runs no caller code.
+- **Nested framework locks in one direction.** The resident-tree observation
+  gate is outermost: everything else is taken under it or standalone, never
+  around it. Inside, the documented orders are cells' member mailbox →
+  `MailboxCell::state`, and `MailboxCell::state` → `SendOperation::state`.
+
+Two conventions that are not the rule itself but travel with it: panicking
+while holding a mutex the codebase `.expect()`s poisons it for every later
+caller, so compute the verdict, release, *then* panic (`MailboxCell::bind` is
+the pattern; where releasing is impossible, `debug_assert!` instead, as
+`MailboxState::take_waiters` does). And a value that may block on destruction
+goes to `runtime::dispose_detached`, not merely past the unlock.
+
+Reviewing a new `.lock()` is one pass: name every value the critical section
+can destroy, every callback it can invoke, and every panic it can raise. If
+any of those is user code, hand it to a transaction (`txn.defer`), an effects
+struct, or the caller.
+
 ## Running anything
 
 All tooling (`cargo`, `just`, `nextest`, `nixfmt`) comes from the Nix

--- a/SPEC.md
+++ b/SPEC.md
@@ -174,6 +174,22 @@ any single design rule:
   and timer retraction): decide the next action as a function of observed
   loop state, then await it. User code — actor bodies — is of course
   effectful; the constraint binds the engine.
+- **Locks hold framework data only.** A critical section over a framework
+  mutex manipulates plain framework-owned state and nothing else: wakes,
+  destruction of user-owned values, formatting of user types, user
+  callbacks, and panic resumption all happen after the guard is released.
+  The framework runs user code it did not schedule — waker vtable
+  functions, destructors of messages, actor state and the type-erased
+  error inside an `Exit`, `Hash` on a timer key — and every one of those
+  may panic, block, or re-enter, which under a lock is a poisoned mutex, a
+  deadlock, or an abort during unwind. The mechanism is an effects value
+  that accumulates the user-visible work inside the critical section and
+  discharges it, panic-contained, from `Drop` — the observation
+  transaction and the mailbox promotion are the two reference
+  implementations, and moving a value out (rather than dropping it in
+  place) is the degenerate case. What the rule buys is that a hostile
+  waker or destructor is an ordinary, testable outcome instead of a
+  liveness failure (§13.18).
 - **Promises are owned completions.** Every cross-task promise — an
   admission or removal awaiting resolution, an exit report awaiting
   publication, a resident child awaiting its `Removed` edge, a member
@@ -3022,6 +3038,22 @@ integration toolkit for the driver shell and the end-to-end invariants.
     rule). Where a fault-injection harness can destroy the driver at
     arbitrary await points, run the same assertions there; the fixed
     provocations above are the floor, not the ceiling.
+18. **User code never runs inside a framework critical section (§1's lock
+    rule).** The provocation is a hostile implementation of each seam the
+    framework invokes without scheduling it, driven through the path that
+    would run it under a lock. A waker whose `wake`/`clone`/`drop` panics
+    or re-enters the framework: park a send and complete it, cancel a
+    parked send during an unwind, and wake a snapshot or lifecycle
+    subscription from a publication — each must observe a released lock
+    (re-entering `snapshot()` from the waker succeeds; the mutex is
+    unpoisoned afterwards). A message, actor-state, or exit payload whose
+    destructor blocks or panics: displace it by conflation, recover it by
+    withdrawal, retire it by terminalization, and supersede it by
+    publication — every one must be destroyed after the guard, and the
+    blocking kind must reach isolated disposal rather than any framework
+    thread. The gate-held probe is the direct oracle: a payload
+    destructor that asks whether the observation gate is held must answer
+    no, on every path that retires one.
 
 ## 14. Core-spike decisions
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -3048,12 +3048,18 @@ integration toolkit for the driver shell and the end-to-end invariants.
     (re-entering `snapshot()` from the waker succeeds; the mutex is
     unpoisoned afterwards). A message, actor-state, or exit payload whose
     destructor blocks or panics: displace it by conflation, recover it by
-    withdrawal, retire it by terminalization, and supersede it by
-    publication — every one must be destroyed after the guard, and the
-    blocking kind must reach isolated disposal rather than any framework
-    thread. The gate-held probe is the direct oracle: a payload
-    destructor that asks whether the observation gate is held must answer
-    no, on every path that retires one.
+    withdrawal, retire it by terminalization, supersede it by a restart
+    schedule, and retire the projection that carried it — every one must
+    be destroyed after the guard. The gate-held probe is the direct
+    oracle: a payload destructor that asks whether the observation gate is
+    held must answer no, on every path that retires one. What this item
+    does *not* assert is where the destructor then runs: a mailbox
+    payload reaches isolated disposal, an `Exit`'s application error is
+    destroyed on the framework thread that released the guard. Moving the
+    second to isolated disposal is a separate rule about blocking
+    destructors on framework threads, tracked outside this item, because
+    the same thread already destroys exits on paths that hold no lock at
+    all.
 
 ## 14. Core-spike decisions
 

--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -420,6 +420,7 @@ impl MemberCell {
 
     pub fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
         self.with_observation_txn(|txn| {
+            let mut rejected = None;
             let terminal_exit = {
                 let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
                 match &mut *state {
@@ -430,7 +431,10 @@ impl MemberCell {
                     MemberMailbox::Attached(_)
                     | MemberMailbox::Terminal {
                         control: Some(_), ..
-                    } => panic!("a member can own only one mailbox"),
+                    } => {
+                        rejected = Some(mailbox);
+                        None
+                    }
                     MemberMailbox::Terminal {
                         control,
                         exit,
@@ -443,6 +447,17 @@ impl MemberCell {
                     }
                 }
             };
+            // Follow the mailbox layer's convention and release the lock before
+            // panicking, so a driver-contract violation stays on this thread
+            // instead of poisoning the mutex under every later mailbox lookup.
+            // The rejected mailbox still owns unread user messages, so the
+            // transaction destroys it after the gate is released -- during this
+            // panic's unwind, which is exactly when an inline destructor would
+            // be a double panic.
+            if let Some(rejected) = rejected {
+                txn.defer(move || drop(rejected));
+                panic!("a member can own only one mailbox");
+            }
             if let Some(terminal_exit) = terminal_exit {
                 self.terminalize_locked(terminal_exit, StartupDisposition::Unchanged, txn);
             }
@@ -469,13 +484,22 @@ impl MemberCell {
         startup: StartupDisposition,
         txn: &mut ObservationTxn<'_>,
     ) -> Exit {
+        // A losing terminalizer's exit is destroyed here, and an
+        // `ExitKind::Failed` payload owns a type-erased user error whose
+        // destructor may block, panic, or re-enter observation. Hand it to the
+        // transaction rather than dropping it under the gate.
+        let mut losing_exit = None;
         let terminal_exit = {
             let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
             match &*state {
                 MemberMailbox::Terminal {
                     exit: terminal_exit,
                     ..
-                } => terminal_exit.clone(),
+                } => {
+                    let terminal_exit = terminal_exit.clone();
+                    losing_exit = Some(exit);
+                    terminal_exit
+                }
                 MemberMailbox::Unattached => {
                     *state = MemberMailbox::Terminal {
                         control: None,
@@ -496,6 +520,9 @@ impl MemberCell {
                 }
             }
         };
+        if let Some(losing_exit) = losing_exit {
+            txn.defer(move || drop(losing_exit));
+        }
         let mut published = false;
         self.record.modify_silently(|record| {
             match startup {
@@ -634,6 +661,19 @@ impl ObservationGate {
         self.0
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Whether some thread — possibly this one — is inside the gate.
+    ///
+    /// The probe a lock-rule test needs: a value's destructor asks whether it
+    /// is running inside the critical section, which a same-thread `try_lock`
+    /// answers without the reentrant acquisition that would deadlock. A
+    /// poisoned but unheld gate reports `false`, matching [`Self::lock`]'s
+    /// deliberate poison tolerance.
+    #[cfg(any(test, feature = "test-util"))]
+    #[must_use]
+    pub fn is_held(&self) -> bool {
+        matches!(self.0.try_lock(), Err(std::sync::TryLockError::WouldBlock))
     }
 }
 

--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -90,7 +90,14 @@ impl MemberRecord {
     /// Every watch-channel writer routes stage changes through here (see
     /// [`MemberCell::transition`] for the wake-bus contract), so each arm
     /// asserts the source stages its driver call sites can actually present.
-    fn apply_transition(&mut self, transition: MemberTransition) {
+    ///
+    /// Returns the exit this transition displaced from `last_exit`, if any.
+    /// The record is mutated under the observation gate and the watch
+    /// channel's own lock, and an `ExitKind::Failed` payload owns a
+    /// type-erased user error, so the displaced value is surrendered to the
+    /// caller rather than destroyed here (§1's lock rule).
+    #[must_use]
+    fn apply_transition(&mut self, transition: MemberTransition) -> Option<Exit> {
         match transition {
             MemberTransition::Admitted => {
                 debug_assert!(
@@ -99,6 +106,7 @@ impl MemberRecord {
                     self.stage
                 );
                 self.stage = MemberStage::Admitted;
+                None
             }
             MemberTransition::Starting { incarnation } => {
                 debug_assert!(
@@ -110,6 +118,7 @@ impl MemberRecord {
                 self.incarnation = Some(incarnation);
                 self.last_incarnation = Some(incarnation);
                 self.restart_at = None;
+                None
             }
             MemberTransition::Running => {
                 debug_assert!(
@@ -119,6 +128,7 @@ impl MemberRecord {
                     self.stage
                 );
                 self.stage = MemberStage::Running;
+                None
             }
             MemberTransition::Stopping => {
                 debug_assert!(
@@ -127,6 +137,7 @@ impl MemberRecord {
                     self.stage
                 );
                 self.stage = MemberStage::Stopping;
+                None
             }
             MemberTransition::RestartScheduled {
                 exit,
@@ -143,9 +154,10 @@ impl MemberRecord {
                 );
                 self.stage = MemberStage::Restarting;
                 self.incarnation = None;
-                self.last_exit = Some(exit);
+                let displaced = self.last_exit.replace(exit);
                 self.restart_count = restart_count;
                 self.restart_at = restart_at;
+                displaced
             }
         }
     }
@@ -402,7 +414,18 @@ impl MemberCell {
     }
 
     pub fn transition_locked(&self, txn: &mut ObservationTxn<'_>, transition: MemberTransition) {
-        self.update_locked(txn, |record| record.apply_transition(transition));
+        // A restart schedule overwrites `last_exit`. The record is mutated
+        // under the gate and the watch channel's own lock, so the exit it
+        // displaces -- whose `ExitKind::Failed` payload owns a type-erased
+        // user error -- leaves the critical section and is destroyed by the
+        // transaction instead.
+        let mut displaced_exit = None;
+        self.update_locked(txn, |record| {
+            displaced_exit = record.apply_transition(transition);
+        });
+        if let Some(displaced_exit) = displaced_exit {
+            txn.defer(move || drop(displaced_exit));
+        }
     }
 
     pub fn set_options(&self, options: ResolvedCommonOptions) {
@@ -524,6 +547,9 @@ impl MemberCell {
             txn.defer(move || drop(losing_exit));
         }
         let mut published = false;
+        // Terminalization also overwrites `last_exit`, which a prior restart
+        // schedule may already have filled with a different user payload.
+        let mut displaced_exit = None;
         self.record.modify_silently(|record| {
             match startup {
                 StartupDisposition::Unchanged => {}
@@ -533,11 +559,14 @@ impl MemberCell {
             if !matches!(record.stage, MemberStage::Terminal(_)) {
                 record.incarnation = None;
                 record.restart_at = None;
-                record.last_exit = Some(terminal_exit.clone());
+                displaced_exit = record.last_exit.replace(terminal_exit.clone());
                 record.stage = MemberStage::Terminal(terminal_exit.clone());
                 published = true;
             }
         });
+        if let Some(displaced_exit) = displaced_exit {
+            txn.defer(move || drop(displaced_exit));
+        }
         let record_changed = published || startup != StartupDisposition::Unchanged;
         // Store before discharge so reentrant mailbox wakers observe the
         // winning exit. Notification-driven readers still see
@@ -1273,7 +1302,17 @@ impl ScopeCell {
         transition: MemberTransition,
         event: Option<LifecycleEventKind>,
     ) {
-        self.update_child_record(member, |record| record.apply_transition(transition), event);
+        // Routed through `transition_locked` rather than `update_child_record`
+        // so a restart schedule's displaced exit leaves the gate on this path
+        // too.
+        self.with_observation_gate(|wakes| {
+            member.transition_locked(wakes, transition);
+            if let Some(event) = event {
+                self.emit_locked(wakes, event);
+            } else {
+                self.publish_snapshot_chain_locked(wakes);
+            }
+        });
     }
 
     #[cfg(any(test, feature = "test-util"))]

--- a/crates/shelterwood-cells/src/observe.rs
+++ b/crates/shelterwood-cells/src/observe.rs
@@ -338,6 +338,17 @@ pub(crate) struct SnapshotHub {
     sender: OnceLock<runtime::WatchSender<SnapshotHubState>>,
 }
 
+/// Destroys a superseded snapshot after the observation gate is released.
+///
+/// A published projection carries every resident child's `Exit`, and an
+/// `ExitKind::Failed` payload owns a type-erased user error. The retained
+/// state is the payload's last owner whenever the member cell it was cloned
+/// from has already been reclaimed, so replacing it in place would run a user
+/// destructor under the gate *and* under the watch channel's own lock.
+fn retire_snapshot(txn: &mut crate::cells::ObservationTxn<'_>, retired: Arc<ScopeSnapshot>) {
+    txn.defer(move || drop(retired));
+}
+
 #[derive(Clone, Debug)]
 struct SnapshotHubState {
     snapshot: Arc<ScopeSnapshot>,
@@ -365,19 +376,19 @@ impl SnapshotHub {
             // A closed hub already holds the authoritative terminal
             // projection, installed by `close`; leave it, and skip the pulse
             // that would then wake nobody about nothing.
-            let mut refreshed = false;
+            let mut retired = None;
             sender.modify_silently(|state| {
                 if state.closed {
                     return;
                 }
-                state.snapshot = initial;
+                retired = Some(std::mem::replace(&mut state.snapshot, initial));
                 state
                     .generation
                     .mint()
                     .expect("snapshot generation space exhausted");
-                refreshed = true;
             });
-            if refreshed {
+            if let Some(retired) = retired {
+                retire_snapshot(txn, retired);
                 txn.pulse(sender);
             }
         }
@@ -404,19 +415,19 @@ impl SnapshotHub {
         if sender.receiver_count() == 0 {
             return;
         }
-        let mut modified = false;
+        let mut retired = None;
         sender.modify_silently(|state| {
             if state.closed {
                 return;
             }
-            state.snapshot = snapshot();
+            retired = Some(std::mem::replace(&mut state.snapshot, snapshot()));
             state
                 .generation
                 .mint()
                 .expect("snapshot generation space exhausted");
-            modified = true;
         });
-        if modified {
+        if let Some(retired) = retired {
+            retire_snapshot(txn, retired);
             txn.pulse(sender);
         }
     }
@@ -448,7 +459,7 @@ impl SnapshotHub {
         if initialized {
             return;
         }
-        let mut modified = false;
+        let mut retired = None;
         sender.modify_silently(|state| {
             if !state.closed {
                 // Install the caller's authoritative terminal projection
@@ -465,15 +476,17 @@ impl SnapshotHub {
                 // see exactly the closure they saw before rather than an extra
                 // conflated event. A closed hub delivers no further changes,
                 // so this only corrects what `borrow_latest` reports.
-                state.snapshot = final_snapshot
-                    .take()
-                    .expect("final snapshot is built exactly once")(
-                );
+                retired = Some(std::mem::replace(
+                    &mut state.snapshot,
+                    final_snapshot
+                        .take()
+                        .expect("final snapshot is built exactly once")(),
+                ));
                 state.closed = true;
-                modified = true;
             }
         });
-        if modified {
+        if let Some(retired) = retired {
+            retire_snapshot(txn, retired);
             txn.pulse(sender);
         }
     }
@@ -628,13 +641,27 @@ impl LifecycleHub {
         event: LifecycleEvent,
     ) {
         let mut published = false;
+        // An event carrying an `Exit` owns a type-erased user error, so the
+        // two paths that decline to retain one -- a closed hub, and a
+        // broadcast with no live receiver -- hand the undelivered value out of
+        // the critical section rather than destroying it under the observation
+        // gate. Neither is the payload's last owner today (the emitting
+        // member's record retains the same exit), so this holds the rule by
+        // construction rather than by that refcount argument. The bounded
+        // ring's *eviction* is the one retirement this hub cannot intercept,
+        // and it is reachable: see #244.
+        let mut undelivered = None;
         self.channels.signal.modify_silently(|signal| {
             if signal.closed {
+                undelivered = Some(event);
                 return;
             }
-            let _ = self.channels.events.send(event);
+            undelivered = self.channels.events.send(event).err();
             published = true;
         });
+        if let Some(undelivered) = undelivered {
+            txn.defer(move || drop(undelivered));
+        }
         if published {
             txn.pulse(&self.channels.signal);
         }

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -1222,3 +1222,66 @@ fn gate_handoff_rejects_a_scope_with_an_unadmitted_dynamic_reservation() {
     // started driver, while a scope is parented before its driver starts.
     root.set_admitted_children(vec![resident_projection(&slot)]);
 }
+
+/// SPEC §1's lock rule: nothing user-owned is destroyed inside a framework
+/// critical section. `Exit`'s type-erased application error is the cell
+/// layer's only user-owned value, and these are the three paths that retire
+/// one under the resident-tree observation gate.
+#[test]
+fn a_losing_terminal_exit_payload_is_destroyed_outside_the_gate() {
+    let scope = isolated_scope("scope", ScopeFlavor::Ordered);
+    scope.member.terminalize(
+        Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+        StartupDisposition::Unchanged,
+    );
+
+    let (losing, held_at_drop) = gate_probe_exit(&scope);
+    scope
+        .member
+        .terminalize(losing, StartupDisposition::Unchanged);
+
+    assert_eq!(
+        gate_probe_verdict(&held_at_drop),
+        Some(false),
+        "a competing terminalizer's exit payload must outlive the gate"
+    );
+}
+
+#[test]
+fn a_retired_snapshot_payload_is_destroyed_outside_the_gate() {
+    let root = isolated_scope("root", ScopeFlavor::Dynamic);
+    let child_id = ChildId::from("worker");
+    let member = MemberCell::new(
+        child_id.clone(),
+        root.child_identity
+            .lock()
+            .expect("scope identity mutex poisoned")
+            .mint_membership(&child_id)
+            .expect("child membership available"),
+    );
+    resolve_fixture_options(&member);
+    root.admit_child(ResidentProjection::new(Arc::clone(&member), None));
+    let subscription = root.subscribe_snapshots();
+
+    let (exit, held_at_drop) = gate_probe_exit(&root);
+    root.terminalize_child(&member, exit, None, StartupDisposition::Unchanged);
+    // Publication is skipped while receiverless, so the retained projection
+    // goes stale and outlives both residency and the member cell whose record
+    // holds the other clone. It is then the payload's last owner, and the next
+    // subscription's refresh is what destroys it.
+    drop(subscription);
+    root.prune_child(&member);
+    drop(member);
+    assert_eq!(
+        gate_probe_verdict(&held_at_drop),
+        None,
+        "the stale retained snapshot still owns the payload"
+    );
+
+    let _resubscribed = root.subscribe_snapshots();
+    assert_eq!(
+        gate_probe_verdict(&held_at_drop),
+        Some(false),
+        "a superseded snapshot's payload must outlive the gate"
+    );
+}

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -1225,8 +1225,12 @@ fn gate_handoff_rejects_a_scope_with_an_unadmitted_dynamic_reservation() {
 
 /// SPEC §1's lock rule: nothing user-owned is destroyed inside a framework
 /// critical section. `Exit`'s type-erased application error is the cell
-/// layer's only user-owned value, and these are the three paths that retire
-/// one under the resident-tree observation gate.
+/// layer's only user-owned value, and the tests below cover the paths that
+/// retire one under the resident-tree observation gate: a losing
+/// terminalization, a superseded snapshot (on subscription and on closure),
+/// and the member record's `last_exit` slot (on a restart schedule and on
+/// terminalization). The one remaining retirement is the lifecycle ring's
+/// eviction, which the hub cannot intercept — see #244.
 #[test]
 fn a_losing_terminal_exit_payload_is_destroyed_outside_the_gate() {
     let scope = isolated_scope("scope", ScopeFlavor::Ordered);
@@ -1283,5 +1287,106 @@ fn a_retired_snapshot_payload_is_destroyed_outside_the_gate() {
         gate_probe_verdict(&held_at_drop),
         Some(false),
         "a superseded snapshot's payload must outlive the gate"
+    );
+}
+
+/// The same rule on the member record's `last_exit` slot: a restart schedule
+/// overwrites the previous incarnation's exit while the record's watch lock
+/// and the observation gate are both held.
+#[test]
+fn a_superseded_restart_exit_payload_is_destroyed_outside_the_gate() {
+    let (root, member, mut incarnations) = restarting_member_fixture();
+
+    let (probe, held_at_drop) = gate_probe_exit(&root);
+    member.transition(MemberTransition::RestartScheduled {
+        exit: probe,
+        restart_count: RestartCount::ZERO.bump(),
+        restart_at: None,
+    });
+    assert_eq!(
+        gate_probe_verdict(&held_at_drop),
+        None,
+        "the record still owns the scheduled restart's exit"
+    );
+
+    let second = incarnations.mint().expect("restart incarnation available");
+    member.transition(MemberTransition::Starting {
+        incarnation: second,
+    });
+    member.transition(MemberTransition::RestartScheduled {
+        exit: Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+        restart_count: RestartCount::ZERO.bump().bump(),
+        restart_at: None,
+    });
+    assert_eq!(
+        gate_probe_verdict(&held_at_drop),
+        Some(false),
+        "a superseded restart exit payload must outlive the gate"
+    );
+}
+
+/// Terminalization writes the same slot, so it retires a prior restart's
+/// payload on a path distinct from the losing-terminalizer one above.
+#[test]
+fn a_restart_exit_payload_superseded_by_terminalization_outlives_the_gate() {
+    let (root, member, _incarnations) = restarting_member_fixture();
+
+    let (probe, held_at_drop) = gate_probe_exit(&root);
+    member.transition(MemberTransition::RestartScheduled {
+        exit: probe,
+        restart_count: RestartCount::ZERO.bump(),
+        restart_at: None,
+    });
+    assert_eq!(
+        gate_probe_verdict(&held_at_drop),
+        None,
+        "the record still owns the scheduled restart's exit"
+    );
+
+    member.terminalize(
+        Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+        StartupDisposition::Unchanged,
+    );
+    assert_eq!(
+        gate_probe_verdict(&held_at_drop),
+        Some(false),
+        "a terminalized member's superseded exit payload must outlive the gate"
+    );
+}
+
+/// `SnapshotHub::close` retires the same slot as `subscribe`, on the path a
+/// scope takes when it terminalizes after its last observer left.
+#[test]
+fn a_snapshot_retired_by_observation_closure_is_destroyed_outside_the_gate() {
+    let root = isolated_scope("root", ScopeFlavor::Dynamic);
+    let child_id = ChildId::from("worker");
+    let member = MemberCell::new(
+        child_id.clone(),
+        root.child_identity
+            .lock()
+            .expect("scope identity mutex poisoned")
+            .mint_membership(&child_id)
+            .expect("child membership available"),
+    );
+    resolve_fixture_options(&member);
+    root.admit_child(ResidentProjection::new(Arc::clone(&member), None));
+    let subscription = root.subscribe_snapshots();
+
+    let (exit, held_at_drop) = gate_probe_exit(&root);
+    root.terminalize_child(&member, exit, None, StartupDisposition::Unchanged);
+    drop(subscription);
+    root.prune_child(&member);
+    drop(member);
+    assert_eq!(
+        gate_probe_verdict(&held_at_drop),
+        None,
+        "the stale retained snapshot still owns the payload"
+    );
+
+    root.terminalize_never_started();
+    assert_eq!(
+        gate_probe_verdict(&held_at_drop),
+        Some(false),
+        "the projection a closing hub supersedes must outlive the gate"
     );
 }

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -331,6 +331,55 @@ pub(super) fn finished_tree() -> Tree {
     tree
 }
 
+/// A user error payload that records whether the observation gate was held
+/// when its destructor ran.
+///
+/// The lock rule's probe for `Exit`: an `ExitKind::Failed` carries a
+/// type-erased application error, so wherever the cell layer destroys an exit
+/// it is running caller code. `ObservationGate::is_held` answers from inside
+/// that destructor without the reentrant acquisition that would deadlock.
+pub(super) struct GateProbeError {
+    gate: crate::cells::ObservationGate,
+    held_at_drop: Arc<Mutex<Option<bool>>>,
+}
+
+/// Builds a failed exit whose payload reports where it was destroyed.
+pub(super) fn gate_probe_exit(scope: &Arc<ScopeCell>) -> (Exit, Arc<Mutex<Option<bool>>>) {
+    let held_at_drop = Arc::new(Mutex::new(None));
+    let exit = Exit::new(
+        ExitKind::Failed(ExitError::from(GateProbeError {
+            gate: scope.observation_gate(),
+            held_at_drop: Arc::clone(&held_at_drop),
+        })),
+        Cancellation::NotObserved,
+    );
+    (exit, held_at_drop)
+}
+
+pub(super) fn gate_probe_verdict(held_at_drop: &Arc<Mutex<Option<bool>>>) -> Option<bool> {
+    *held_at_drop.lock().expect("gate probe mutex poisoned")
+}
+
+impl std::fmt::Debug for GateProbeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("GateProbeError")
+    }
+}
+
+impl std::fmt::Display for GateProbeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("gate probe")
+    }
+}
+
+impl std::error::Error for GateProbeError {}
+
+impl Drop for GateProbeError {
+    fn drop(&mut self) {
+        *self.held_at_drop.lock().expect("gate probe mutex poisoned") = Some(self.gate.is_held());
+    }
+}
+
 pub(super) struct SnapshotReentryWake {
     scope: ScopeRef,
     observed: std::sync::mpsc::Sender<ScopeState>,

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -356,6 +356,27 @@ pub(super) fn gate_probe_exit(scope: &Arc<ScopeCell>) -> (Exit, Arc<Mutex<Option
     (exit, held_at_drop)
 }
 
+/// A dynamic root with one admitted, started child, plus the child's
+/// incarnation counter — the shape a restart schedule needs.
+pub(super) fn restarting_member_fixture() -> (Arc<ScopeCell>, Arc<MemberCell>, IncarnationCounter) {
+    let root = isolated_scope("root", ScopeFlavor::Dynamic);
+    let child_id = ChildId::from("worker");
+    let member = MemberCell::new(
+        child_id.clone(),
+        root.child_identity
+            .lock()
+            .expect("scope identity mutex poisoned")
+            .mint_membership(&child_id)
+            .expect("child membership available"),
+    );
+    resolve_fixture_options(&member);
+    let mut incarnations = member.take_incarnation_counter();
+    root.admit_child(ResidentProjection::new(Arc::clone(&member), None));
+    let first = incarnations.mint().expect("incarnation available");
+    member.transition(MemberTransition::Starting { incarnation: first });
+    (root, member, incarnations)
+}
+
 pub(super) fn gate_probe_verdict(held_at_drop: &Arc<Mutex<Option<bool>>>) -> Option<bool> {
     *held_at_drop.lock().expect("gate probe mutex poisoned")
 }

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -111,15 +111,28 @@ impl SlotCell {
     }
 
     pub(crate) fn define(&self, definition: ChildConstruction) {
-        let mut state = self.definition.lock().expect("definition mutex poisoned");
-        match *state {
-            DefinitionState::Undefined => {
-                *state = DefinitionState::Defined(Isolated::new(definition));
+        // A rejected definition owns user construction closures, and the
+        // panic below is a caller-contract violation rather than a broken
+        // slot. Release the lock before either destroys anything, so a hostile
+        // closure destructor cannot poison the definition mutex for every
+        // later lowering step. `Isolated` keeps the destruction itself off
+        // this thread.
+        let rejected = {
+            let mut state = self.definition.lock().expect("definition mutex poisoned");
+            match *state {
+                DefinitionState::Undefined => {
+                    *state = DefinitionState::Defined(Isolated::new(definition));
+                    None
+                }
+                DefinitionState::Defined(_) | DefinitionState::Lowered => {
+                    Some(Isolated::new(definition))
+                }
             }
-            DefinitionState::Defined(_) | DefinitionState::Lowered => {
-                panic!("a child slot was defined more than once")
-            }
-        }
+        };
+        assert!(
+            rejected.is_none(),
+            "a child slot was defined more than once"
+        );
     }
 
     pub(crate) fn is_undefined(&self) -> bool {


### PR DESCRIPTION
Closes #235.

## The rule, stated

`AGENTS.md` gains a "The lock rule" section — the mechanical statement, the user code the framework runs without scheduling it, `ObservationTxn` and `Promotion` as the two reference implementations, the exemption categories, and the one-pass check for a new `.lock()`. `SPEC.md` §1 gains it as a fourth implementation-shape constraint (alongside plain-data policies, pure core/mutable shell, and owned completions), with §13.18 as its test anchor. #214's destination named "a hard no-user-behavior-under-locks boundary in the concurrent substrate"; this is that boundary written down.

The exemptions are the part that makes the rule checkable rather than aspirational, so they are stated as categories every one of the 117 current production-module sites falls into: framework-owned data; *moving* a user value out (not a drop) as long as the destination is outside; `Arc` traffic that cannot reach zero; framework-only `dyn` seams; and nested framework locks in one direction. Two of those carry a named caveat rather than a clean claim — see "Doctrine corrections" below.

## The audit

All 117 `.lock()` spellings in the current base's production modules, by file: `shelterwood-cells/src/cells.rs` 43, `shelterwood-mailbox/src/cell.rs` 26, `shelterwood/src/raw.rs` 14, `shelterwood-runtime/src/disposal.rs` 8, `shelterwood/src/plan.rs` 7, `driver/admission_control.rs` 7, `shelterwood-mailbox/src/futures.rs` 6, `driver/removal.rs` 3, `tree/admission.rs` 2, `driver.rs` 1. (Of these, 5 in `futures.rs`, 2 in `tree/admission.rs`, 3 in `raw.rs` and 4 in `disposal.rs` are inside `mod tests`.) The issue's original 115-site snapshot grew by two while this PR was in flight: `2ff05cb` added one read-only mailbox-state assertion and one test that deliberately poisons a framework-only control mutex to verify recovery. Both are test-only and exempt; they are the +1 entries in `cells.rs` and mailbox `cell.rs` above.

The mailbox and the raw actor are clean: every waker leaves through `Promotion`/`Acceptance`/`withdraw`'s tuple, every message and offload future leaves through `MailboxPayload`/`RawDisposal`, and the two lock orders are documented at the type. The driver's control-plane sites are clean: every entry drop and every driver-event wake is deferred onto the transaction. `disposal.rs` is clean, resting on one non-obvious fact — `DisposalJob::finish`'s guard is a `let ... else` temporary, released by the end of that statement and therefore before `drop(value)`.

What the audit found is **one family**: `Exit`'s type-erased application error (`ExitError` → `Box<dyn Error + Send + Sync>`) is the only user-owned value the cell layer treats as plain data, and it is retired under the resident-tree observation gate on five paths. A blocking error destructor there holds the entire tree's observation; a panicking one unwinds out of a watch-channel closure; one running during an unwind is a double panic and an abort.

| Site | Status |
| --- | --- |
| `MemberCell::terminalize_locked` — the losing exit when a competing terminalizer already published | fixed, pinned |
| `MemberRecord::apply_transition` — `last_exit` overwritten by `RestartScheduled`, on every restart after the first | fixed, pinned |
| `MemberCell::terminalize_locked` — `last_exit` overwritten again by the record update, when terminalization follows a restart | fixed, pinned |
| `SnapshotHub::subscribe` / `close` — the superseded projection, replaced inside the watch channel's own lock | fixed, pinned |
| `SnapshotHub::publish` — same slot, same fix | fixed, **deliberately unpinned** (returns early while receiverless, so its projection cannot go stale; no discriminating case exists) |
| `LifecycleHub::publish` — the bounded broadcast ring evicts its oldest retained event | **#244**, with repro |

The fixed sites hand the value to `ObservationTxn::defer`, which is the mechanism the rule already names: the guard is released first and the queue runs through a `PanicAccumulator`, on the unwind path too. `apply_transition` is now `#[must_use] -> Option<Exit>` so the displaced payload cannot be silently dropped in place again. For the ring the hub owns neither the eviction nor the slot, so the fix is to own the ring — filed rather than merged.

The two `last_exit` writers were found by an adversarial review *after* the first pass had already edited `terminalize_locked` — the first pass audited the mailbox block and missed the record block twenty lines below. Auditing a call site is not auditing the function.

## Verification

`ObservationGate::is_held` is the probe this class needed: a payload destructor asks whether it is running inside the gate, which a same-thread `try_lock` answers without the reentrant acquisition that would deadlock. It is `cfg(test, test-util)`, in the same spirit as the existing `gate_capture_probe`.

Every shipped test was mutation-checked — the fix reverted, the test observed to fail, the fix restored. That check earned its keep twice:

- `SnapshotHub::close`'s retirement was fixed but pinned nothing. Reverting `publish` **and** `close` to the inline assignment left the whole suite green; only `subscribe` was actually held by a test. `close` is reachable and now has its own.
- A candidate test for the no-receiver lifecycle path passed with its fix reverted (the emitting member's record still holds a clone at emit time). Dropped rather than shipped as a test that pins nothing; the code change is kept, with a comment saying it holds the rule by construction rather than by that refcount argument.

`just ci` green on the merged tree: 633 tests.

## Doctrine corrections

Two claims in the first draft did not survive checking against the code, and are now stated with their caveats:

- **"The gate is outermost" has an exception.** `adopt_observation_gate` takes the adoptee's *current* gate while the adopting parent's is held — parent-to-child only, re-reading the installed pointer under the acquired guard so a concurrent handoff retries rather than deadlocks.
- **The `dispose_detached` convention is unmet for exits.** It holds for mailbox payloads, construction closures and offloads; no site in the workspace routes an `Exit` through isolated disposal, while the driver destroys exits inline on its own thread on paths holding no lock at all. AGENTS.md now says so plainly and marks it as a class to close, not a site to patch. SPEC §13.18 was rescoped for the same reason — as first written it asserted isolated disposal that this branch does not do, which is exactly #238's failure mode in a new clause.

## Also fixed

`MemberCell::attach_mailbox` and `SlotCell::define` panicked while holding a mutex every later caller `.expect()`s, poisoning it for everyone instead of keeping a caller-contract violation on the offending thread — the opposite of what `MailboxCell::bind` and `submit` do a layer down. Both now compute the verdict, release, then panic, with the rejected mailbox and definition (which own unread user messages and construction closures) destroyed outside the lock.

## Filed, not fixed

- **#244** — the lifecycle ring's eviction, with a repro. Needs the hub to own its ring.
- **#246** — isolate `Exit` application-error destruction as a class. Two candidate policies; the point is that detaching whichever site a review lands on would half-handle the class and read as if the whole class were handled.
- **#247** — `clear_residents_locked`/`prune_child_locked` drop `Arc<MemberCell>`s under the gate. Live at the cell layer; safe in production only because `ScopeRuntime::drop` clears residents before `self.children`, an ordering nothing enforces.

## Not done

The rule is stated and the sites audited, but nothing *enforces* it — a new `.lock()` that drops a user value still compiles. #236 is the structural answer for the densest region (make the class unwritable rather than detectable). An enforcement lane was considered and not proposed: "user-owned" is a semantic property of a type, not a syntactic one, and #191 item 27's AST-checker precedent is on hold for exactly that reason.
