### PR TITLE
Simplify remaining identity and runtime plumbing

### DIFF
--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -762,16 +762,7 @@ impl Drop for ResidentChild {
         let Some(parent) = completion.parent.upgrade() else {
             return;
         };
-        parent.with_observation_gate(|wakes| {
-            parent.emit_locked(
-                wakes,
-                LifecycleEventKind::Removed {
-                    id: completion.projection.member.id().clone(),
-                    membership: completion.projection.member.membership(),
-                    last_incarnation: completion.projection.member.record().last_incarnation,
-                },
-            );
-        });
+        parent.with_observation_gate(|txn| Self::publish_removal(completion, txn));
     }
 }
 
@@ -840,7 +831,7 @@ struct ScopeObservation {
 pub struct ScopeCell {
     pub member: Arc<MemberCell>,
     pub flavor: ScopeFlavor,
-    pub child_identity: Mutex<ScopeIdentity>,
+    child_identity: Mutex<ScopeIdentity>,
     control: Mutex<ScopeControl>,
     dynamic_route: Mutex<Option<Arc<ErasedDynamicRoute>>>,
     observation: ScopeObservation,
@@ -878,6 +869,24 @@ pub struct RuntimeStorage {
 }
 
 impl ScopeCell {
+    pub fn mint_membership(&self, id: &ChildId) -> Option<MintedMembership> {
+        self.child_identity
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .mint_membership(id)
+    }
+
+    pub fn adopt_or_mint_membership(
+        &self,
+        id: &ChildId,
+        provisional: Membership,
+    ) -> Option<Option<MintedMembership>> {
+        self.child_identity
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .adopt_or_mint_membership(id, provisional)
+    }
+
     pub fn evict_child_identity(&self, member: &MemberCell) {
         self.child_identity
             .lock()
@@ -1113,15 +1122,11 @@ impl ScopeCell {
             .map(|resident| resident.projection.clone())
             .collect::<Vec<_>>();
         for descendant in descendants {
+            descendant
+                .member
+                .install_observation_gate_locked(previous, gate);
             if let Some(scope) = descendant.scope {
-                descendant
-                    .member
-                    .install_observation_gate_locked(previous, gate);
                 scope.adopt_descendant_observation_gates_locked(previous, gate, _txn);
-            } else {
-                descendant
-                    .member
-                    .install_observation_gate_locked(previous, gate);
             }
         }
     }
@@ -1389,14 +1394,10 @@ impl ScopeCell {
             .config
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let children = self
-            .current_children()
-            .iter()
-            .map(|resident| resident.projection.clone())
-            .collect::<Vec<_>>();
+        let children = self.current_children();
         let children = children
             .iter()
-            .map(|child| self.child_snapshot_locked(child))
+            .map(|resident| self.child_snapshot_locked(&resident.projection))
             .collect::<Vec<_>>();
         Arc::new(ScopeSnapshot {
             state: record.state,

--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -836,8 +836,6 @@ pub struct ScopeCell {
     dynamic_route: Mutex<Option<Arc<ErasedDynamicRoute>>>,
     observation: ScopeObservation,
     #[cfg(any(test, feature = "test-util"))]
-    child_identity_reconciliations: AtomicUsize,
-    #[cfg(any(test, feature = "test-util"))]
     ancestor_parent_reads: AtomicUsize,
     #[cfg(any(test, feature = "test-util"))]
     runtime_storage: Mutex<RuntimeStorage>,
@@ -883,18 +881,10 @@ impl ScopeCell {
         id: &ChildId,
         provisional: Membership,
     ) -> Option<Option<MintedMembership>> {
-        #[cfg(any(test, feature = "test-util"))]
-        self.child_identity_reconciliations
-            .fetch_add(1, Ordering::Relaxed);
         self.child_identity
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .adopt_or_mint_membership(id, provisional)
-    }
-
-    #[cfg(any(test, feature = "test-util"))]
-    pub fn child_identity_reconciliations(&self) -> usize {
-        self.child_identity_reconciliations.load(Ordering::Relaxed)
     }
 
     pub fn evict_child_identity(&self, member: &MemberCell) {
@@ -930,8 +920,6 @@ impl ScopeCell {
                 snapshots: SnapshotHub::default(),
                 closed: AtomicBool::new(false),
             },
-            #[cfg(any(test, feature = "test-util"))]
-            child_identity_reconciliations: AtomicUsize::new(0),
             #[cfg(any(test, feature = "test-util"))]
             ancestor_parent_reads: AtomicUsize::new(0),
             #[cfg(any(test, feature = "test-util"))]

--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -836,6 +836,8 @@ pub struct ScopeCell {
     dynamic_route: Mutex<Option<Arc<ErasedDynamicRoute>>>,
     observation: ScopeObservation,
     #[cfg(any(test, feature = "test-util"))]
+    child_identity_reconciliations: AtomicUsize,
+    #[cfg(any(test, feature = "test-util"))]
     ancestor_parent_reads: AtomicUsize,
     #[cfg(any(test, feature = "test-util"))]
     runtime_storage: Mutex<RuntimeStorage>,
@@ -881,10 +883,18 @@ impl ScopeCell {
         id: &ChildId,
         provisional: Membership,
     ) -> Option<Option<MintedMembership>> {
+        #[cfg(any(test, feature = "test-util"))]
+        self.child_identity_reconciliations
+            .fetch_add(1, Ordering::Relaxed);
         self.child_identity
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .adopt_or_mint_membership(id, provisional)
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn child_identity_reconciliations(&self) -> usize {
+        self.child_identity_reconciliations.load(Ordering::Relaxed)
     }
 
     pub fn evict_child_identity(&self, member: &MemberCell) {
@@ -920,6 +930,8 @@ impl ScopeCell {
                 snapshots: SnapshotHub::default(),
                 closed: AtomicBool::new(false),
             },
+            #[cfg(any(test, feature = "test-util"))]
+            child_identity_reconciliations: AtomicUsize::new(0),
             #[cfg(any(test, feature = "test-util"))]
             ancestor_parent_reads: AtomicUsize::new(0),
             #[cfg(any(test, feature = "test-util"))]

--- a/crates/shelterwood-cells/src/observe.rs
+++ b/crates/shelterwood-cells/src/observe.rs
@@ -346,6 +346,12 @@ struct SnapshotHubState {
 }
 
 impl SnapshotHub {
+    /// Subscribes while the containing scope's observation gate is held.
+    ///
+    /// The transaction is taken but unused: the gate is what makes the
+    /// receiverless refresh below safe, and no wake can be owed, because the
+    /// only receiver that could observe the refresh is the one minted here —
+    /// and it captures the refreshed generation as already seen.
     pub(crate) fn subscribe(
         &self,
         initial: Arc<ScopeSnapshot>,

--- a/crates/shelterwood-cells/src/observe.rs
+++ b/crates/shelterwood-cells/src/observe.rs
@@ -349,7 +349,7 @@ impl SnapshotHub {
     pub(crate) fn subscribe(
         &self,
         initial: Arc<ScopeSnapshot>,
-        txn: &mut crate::cells::ObservationTxn<'_>,
+        _txn: &mut crate::cells::ObservationTxn<'_>,
     ) -> SnapshotReceiver {
         let sender = self.sender.get_or_init(|| {
             runtime::watch(SnapshotHubState {
@@ -363,9 +363,7 @@ impl SnapshotHub {
             // Publication is skipped while receiverless, so the first
             // subscriber after a quiet stretch installs current state itself.
             // A closed hub already holds the authoritative terminal
-            // projection, installed by `close`; leave it, and skip the pulse
-            // that would then wake nobody about nothing.
-            let mut refreshed = false;
+            // projection installed by `close`; leave it unchanged.
             sender.modify_silently(|state| {
                 if state.closed {
                     return;
@@ -375,11 +373,7 @@ impl SnapshotHub {
                     .generation
                     .mint()
                     .expect("snapshot generation space exhausted");
-                refreshed = true;
             });
-            if refreshed {
-                txn.pulse(sender);
-            }
         }
         let inner = sender.watcher();
         let seen_generation = inner.borrow_cloned().generation.current();

--- a/crates/shelterwood-core/src/identity.rs
+++ b/crates/shelterwood-core/src/identity.rs
@@ -261,10 +261,6 @@ impl FenceCounter {
         }
     }
 
-    fn sequence() -> Self {
-        Self::new(Lineage(0))
-    }
-
     #[cfg(any(test, feature = "test-util"))]
     fn near_exhaustion(lineage: u64) -> Self {
         Self {
@@ -299,7 +295,7 @@ impl FenceCounter {
 #[derive(Debug)]
 pub struct IncarnationCounter {
     membership: Membership,
-    counter: FenceCounter,
+    generations: PoisonedCounter,
 }
 
 /// An inseparable identity grant: the counter for an incarnation lineage is
@@ -311,6 +307,16 @@ pub struct MintedMembership {
 }
 
 impl MintedMembership {
+    fn new(membership: Membership) -> Self {
+        Self {
+            membership,
+            incarnation_counter: IncarnationCounter {
+                membership,
+                generations: PoisonedCounter::new(),
+            },
+        }
+    }
+
     #[cfg(any(test, feature = "test-util"))]
     pub fn membership(&self) -> Membership {
         self.membership
@@ -323,9 +329,10 @@ impl MintedMembership {
 
 impl IncarnationCounter {
     pub fn mint(&mut self) -> Option<Incarnation> {
-        self.counter.mint().map(|fence| Incarnation {
+        let generation = Generation::new(self.generations.mint()?)?;
+        Some(Incarnation {
             membership: self.membership,
-            generation: fence.generation,
+            generation,
         })
     }
 
@@ -333,7 +340,7 @@ impl IncarnationCounter {
     pub fn fixture(membership: Membership) -> Self {
         Self {
             membership,
-            counter: FenceCounter::sequence(),
+            generations: PoisonedCounter::new(),
         }
     }
 
@@ -341,7 +348,7 @@ impl IncarnationCounter {
     pub fn near_exhaustion(membership: Membership) -> Self {
         Self {
             membership,
-            counter: FenceCounter::near_exhaustion(0),
+            generations: PoisonedCounter::near_exhaustion(),
         }
     }
 }
@@ -390,13 +397,7 @@ impl ScopeIdentity {
                 Some(membership)
             }
         }?;
-        Some(MintedMembership {
-            membership,
-            incarnation_counter: IncarnationCounter {
-                membership,
-                counter: FenceCounter::sequence(),
-            },
-        })
+        Some(MintedMembership::new(membership))
     }
 
     /// Reconciles a declaration-time membership with this stable scope.
@@ -415,13 +416,7 @@ impl ScopeIdentity {
         match self.memberships.entry(id.clone()) {
             Entry::Occupied(mut entry) => {
                 let membership = entry.get_mut().mint().map(Membership)?;
-                Some(Some(MintedMembership {
-                    membership,
-                    incarnation_counter: IncarnationCounter {
-                        membership,
-                        counter: FenceCounter::sequence(),
-                    },
-                }))
+                Some(Some(MintedMembership::new(membership)))
             }
             Entry::Vacant(entry) => {
                 debug_assert_ne!(provisional.0.generation, Generation::POISON);
@@ -454,8 +449,7 @@ mod tests {
     use crate::ChildId;
 
     use super::{
-        AtomicPoisonedCounter, FenceCounter, Generation, IncarnationCounter, PoisonedCounter,
-        ScopeIdentity,
+        AtomicPoisonedCounter, Generation, IncarnationCounter, PoisonedCounter, ScopeIdentity,
     };
 
     #[test]
@@ -710,8 +704,9 @@ mod tests {
         assert!(!Generation::POISON.supersedes(second));
         assert!(!second.supersedes(Generation::POISON));
 
-        let mut sequence = FenceCounter::sequence();
-        assert_eq!(sequence.mint().map(|fence| fence.generation.get()), Some(1));
+        let membership = MembershipFixture::at(1, 1);
+        let mut sequence = IncarnationCounter::fixture(membership);
+        assert_eq!(sequence.mint().map(|value| value.generation.get()), Some(1));
     }
 
     struct MembershipFixture;

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -163,10 +163,7 @@ fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
     let child_id = ChildId::from("worker");
     let member = MemberCell::new(
         child_id.clone(),
-        root.child_identity
-            .lock()
-            .expect("scope identity mutex poisoned")
-            .mint_membership(&child_id)
+        root.mint_membership(&child_id)
             .expect("child membership available"),
     );
     let slot = SlotCell::new(Arc::clone(&member), None);
@@ -309,10 +306,7 @@ fn dynamic_removal_waits_for_the_observation_gate_before_mutating_state() {
     let child_id = ChildId::from("worker");
     let member = MemberCell::new(
         child_id.clone(),
-        root.child_identity
-            .lock()
-            .expect("scope identity mutex poisoned")
-            .mint_membership(&child_id)
+        root.mint_membership(&child_id)
             .expect("child membership available"),
     );
     let slot = SlotCell::new(Arc::clone(&member), None);
@@ -581,9 +575,6 @@ async fn removal_from_a_foreign_thread_reaches_the_driver() {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
     let child_id = ChildId::from("worker");
     let membership = root
-        .child_identity
-        .lock()
-        .expect("scope identity mutex poisoned")
         .mint_membership(&child_id)
         .expect("membership available");
     let member = MemberCell::new(child_id.clone(), membership);
@@ -1041,19 +1032,8 @@ async fn fused_cancellation_overtaking_admission_rejects_before_conversion() {
         "a reserved membership cannot emit a key-addressed Removal"
     );
 
-    // If handle_admission loses its first latch re-check, conversion now
-    // reaches this poisoned identity mutex and unwinds before the later
-    // under-lock check. The real guard rejects without touching it.
-    assert!(
-        catch_unwind(AssertUnwindSafe(|| {
-            let _identity = root
-                .child_identity
-                .lock()
-                .expect("scope identity mutex starts healthy");
-            panic!("poison conversion after the overtaking fused cancellation");
-        }))
-        .is_err()
-    );
+    // The first latch re-check rejects the reservation before child
+    // conversion, leaving no resident or dynamic-state entry behind.
     assert!(
         catch_unwind(AssertUnwindSafe(|| scope.handle_admission(request))).is_ok(),
         "overtaking fused cancellation rejects before fallible child conversion"

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -1033,10 +1033,17 @@ async fn fused_cancellation_overtaking_admission_rejects_before_conversion() {
     );
 
     // The first latch re-check rejects the reservation before child
-    // conversion, leaving no resident or dynamic-state entry behind.
+    // conversion. The reconciliation count replaces the old raw-mutex poison
+    // probe, preserving that proof while keeping identity storage private.
+    let reconciliations = root.child_identity_reconciliations();
     assert!(
         catch_unwind(AssertUnwindSafe(|| scope.handle_admission(request))).is_ok(),
         "overtaking fused cancellation rejects before fallible child conversion"
+    );
+    assert_eq!(
+        root.child_identity_reconciliations(),
+        reconciliations,
+        "the pre-conversion latch check rejects before identity reconciliation"
     );
     assert!(matches!(
         response.receive().await,

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -1032,18 +1032,18 @@ async fn fused_cancellation_overtaking_admission_rejects_before_conversion() {
         "a reserved membership cannot emit a key-addressed Removal"
     );
 
-    // The first latch re-check rejects the reservation before child
-    // conversion. The reconciliation count replaces the old raw-mutex poison
-    // probe, preserving that proof while keeping identity storage private.
-    let reconciliations = root.child_identity_reconciliations();
+    // Conversion issues the membership's incarnation counter to the child
+    // runtime and never returns it, so an unclaimed counter afterwards is
+    // evidence that the first latch re-check rejected before conversion ran.
+    // That is what the sibling under-lock test parks on to reach the later
+    // disjunct.
     assert!(
         catch_unwind(AssertUnwindSafe(|| scope.handle_admission(request))).is_ok(),
         "overtaking fused cancellation rejects before fallible child conversion"
     );
-    assert_eq!(
-        root.child_identity_reconciliations(),
-        reconciliations,
-        "the pre-conversion latch check rejects before identity reconciliation"
+    assert!(
+        member.lock_incarnation_counter().is_some(),
+        "the pre-conversion latch check rejects before the counter is issued"
     );
     assert!(matches!(
         response.receive().await,
@@ -1086,8 +1086,8 @@ async fn fused_cancellation_during_conversion_is_rejected_by_the_under_lock_rech
     };
 
     // Fused cancellation fires while the driver is already inside child
-    // conversion: past the pre-conversion latch check, parked on the child
-    // identity mutex held below. Only the re-check under the control-plane
+    // conversion: past the pre-conversion latch check, parked on the
+    // incarnation-counter mutex held below. Only the re-check under the control-plane
     // lock can observe this firing, so this interleaving pins that disjunct
     // specifically. The entry stays Reserved throughout — a fired latch
     // cannot mark a keyless reservation Removing — which keeps the

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -7,10 +7,7 @@ fn snapshot_rejects_a_resident_whose_options_were_never_resolved() {
     let child_id = ChildId::from("worker");
     let member = MemberCell::new(
         child_id.clone(),
-        root.child_identity
-            .lock()
-            .expect("scope identity mutex poisoned")
-            .mint_membership(&child_id)
+        root.mint_membership(&child_id)
             .expect("child membership available"),
     );
 
@@ -542,9 +539,6 @@ async fn wait_for_child_reloads_after_its_predicate_closes_the_snapshot_stream()
     scope.set_state(ScopeState::Running);
     let child_id = ChildId::from("child");
     let membership = scope
-        .child_identity
-        .lock()
-        .expect("scope identity mutex is healthy")
         .mint_membership(&child_id)
         .expect("child membership is available");
     let child = MemberCell::new(child_id, membership);
@@ -938,9 +932,6 @@ fn admitted_subtree_rehomes_existing_descendants_to_one_gate() {
     let raw_leaf = MemberCell::new(
         raw_leaf_id.clone(),
         nested
-            .child_identity
-            .lock()
-            .expect("scope identity mutex poisoned")
             .mint_membership(&raw_leaf_id)
             .expect("raw leaf membership is available"),
     );

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -40,9 +40,6 @@ pub(crate) fn mint_reserved_slot(
     child_scope: Option<ScopeFlavor>,
 ) -> Result<Arc<SlotCell>, ReserveError> {
     let membership = parent
-        .child_identity
-        .lock()
-        .expect("scope identity mutex poisoned")
         .mint_membership(id)
         .ok_or(ReserveError::IdentityExhausted)?;
     let member = MemberCell::new(id.clone(), membership);
@@ -166,13 +163,14 @@ impl SlotCell {
         owner: &ScopeCell,
         txn: &mut ObservationTxn<'_>,
     ) {
-        self.member.terminalize_locked(
-            Exit::never_started(),
-            crate::cells::StartupDisposition::Unchanged,
-            txn,
-        );
         if let Some(scope) = &self.scope {
             scope.terminalize_never_started_locked(txn);
+        } else {
+            self.member.terminalize_locked(
+                Exit::never_started(),
+                crate::cells::StartupDisposition::Unchanged,
+                txn,
+            );
         }
         owner.evict_child_identity(&self.member);
     }
@@ -360,16 +358,11 @@ impl BuilderCore {
             // evict the terminalized slots from the override's identity map,
             // not this builder's throwaway root.
             self.adopting_root = Some(Arc::clone(&root));
-            let mut identity = root
-                .child_identity
-                .lock()
-                .expect("scope identity mutex poisoned");
             for slot in &self.slots {
                 let Some(rebased) =
-                    identity.adopt_or_mint_membership(slot.member.id(), slot.member.membership())
+                    root.adopt_or_mint_membership(slot.member.id(), slot.member.membership())
                 else {
                     let id = slot.member.id().clone();
-                    drop(identity);
                     let disposal = self.begin_failed_disposal();
                     return Err(LowerError::IdentityExhausted { id, disposal });
                 };

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -352,7 +352,6 @@ struct EventQueue<M> {
     // sequence and there is no integer counter whose saturation could blur a
     // boundary.
     queue: Mutex<VecDeque<QueuedEvent<M>>>,
-    signal: Signal,
     disposal: RawDisposal,
 }
 
@@ -367,7 +366,6 @@ impl<M> EventQueue<M> {
     fn new(disposal: RawDisposal) -> Self {
         Self {
             queue: Mutex::new(VecDeque::new()),
-            signal: disposal.signal.clone(),
             disposal,
         }
     }
@@ -377,7 +375,7 @@ impl<M> EventQueue<M> {
             .lock()
             .expect("actor event queue mutex poisoned")
             .push_back(event);
-        self.signal.pulse();
+        self.disposal.signal.pulse();
     }
 
     #[cfg(test)]
@@ -396,7 +394,7 @@ impl<M> EventQueue<M> {
     ) {
         self.insert_with(event, before_insert);
         after_insert();
-        self.signal.pulse();
+        self.disposal.signal.pulse();
     }
 
     fn watermark(&self) -> usize {
@@ -597,8 +595,8 @@ impl<M> TimerStore<M> {
         // cannot unwind through a hostile key or message destructor.
         let key = Contained::new(key, self.disposal.clone());
         let message = Contained::new(message, self.disposal.clone());
-        self.remove(key.get());
         let hash = self.hash_key(key.get());
+        self.remove_hashed(hash, key.get());
         self.keyed.entry(hash).or_default().push(TimerEntry {
             key: Box::new(key.into_inner()),
             deadline,
@@ -618,6 +616,13 @@ impl<M> TimerStore<M> {
         K: Hash + Eq + 'static,
     {
         let hash = self.hash_key(key);
+        self.take_hashed(hash, key)
+    }
+
+    fn take_hashed<K>(&mut self, hash: KeyHash, key: &K) -> Option<TimerEntry<M>>
+    where
+        K: Eq + 'static,
+    {
         let (entry, empty) = {
             let bucket = self.keyed.get_mut(&hash)?;
             #[cfg(test)]
@@ -651,6 +656,17 @@ impl<M> TimerStore<M> {
         K: Hash + Eq + 'static,
     {
         let Some(entry) = self.take(key) else {
+            return false;
+        };
+        self.dispose_entry(entry);
+        true
+    }
+
+    fn remove_hashed<K>(&mut self, hash: KeyHash, key: &K) -> bool
+    where
+        K: Eq + 'static,
+    {
+        let Some(entry) = self.take_hashed(hash, key) else {
             return false;
         };
         self.dispose_entry(entry);
@@ -829,12 +845,6 @@ enum OffloadPoll {
     Finished,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum OffloadScope {
-    Unscoped,
-    Scoped,
-}
-
 struct SharedOffloadState {
     // Polling takes the future out of this mutex. Cancellation either takes
     // an idle future or marks an in-progress poll so that the poller disposes
@@ -845,19 +855,14 @@ struct SharedOffloadState {
 }
 
 impl SharedOffloadState {
-    fn new(
-        future: OffloadFuture,
-        panic: Arc<PanicSlot>,
-        signal: Signal,
-        finished: Latch,
-    ) -> SharedWork {
+    fn new(future: OffloadFuture, disposal: RawDisposal, finished: Latch) -> SharedWork {
         Arc::new(Self {
             state: Mutex::new(OffloadFutureState {
                 future: Some(future),
                 polling: false,
                 cancelled: false,
             }),
-            disposal: RawDisposal { panic, signal },
+            disposal,
             finished,
         })
     }
@@ -987,7 +992,6 @@ struct RawResources<M> {
     timer_orders: PoisonedCounter,
     ready_batch: Option<ReadyBatch>,
     events: Arc<EventQueue<M>>,
-    panic: Arc<PanicSlot>,
     disposal: RawDisposal,
     event_watcher: SignalWatcher,
     offloads: Vec<OffloadResource>,
@@ -997,12 +1001,9 @@ impl<M> Default for RawResources<M> {
     fn default() -> Self {
         let signal = Signal::default();
         let panic = Arc::new(PanicSlot::default());
-        let disposal = RawDisposal {
-            panic: Arc::clone(&panic),
-            signal,
-        };
+        let disposal = RawDisposal { panic, signal };
+        let event_watcher = disposal.signal.watcher();
         let events = Arc::new(EventQueue::new(disposal.clone()));
-        let event_watcher = events.signal.watcher();
         Self {
             accepting: true,
             continuations: ContinuationQueue::new(disposal.clone()),
@@ -1011,7 +1012,6 @@ impl<M> Default for RawResources<M> {
             timer_orders: PoisonedCounter::new(),
             ready_batch: None,
             events,
-            panic,
             disposal,
             event_watcher,
             offloads: Vec::new(),
@@ -1057,7 +1057,7 @@ impl<M> RawResources<M> {
         // take is destructive, so containment here would drop the retained
         // offload diagnostic and let the loop keep running.
         resume_preferred_panic_outside_unwind(UnwindPanics {
-            primary: self.panic.take(),
+            primary: self.disposal.panic.take(),
             cleanup: None,
         });
     }
@@ -1073,7 +1073,7 @@ impl<M> RawResources<M> {
                                 .to_owned()
                         });
                         tracing::error!(%message, "library-owned offload task panicked");
-                        self.panic.record(Box::new(message));
+                        self.disposal.panic.record(Box::new(message));
                     }
                 }
             }
@@ -1093,7 +1093,7 @@ impl<M> Drop for RawResources<M> {
         // `freeze` can transfer a destructor panic into the shared slot. Take
         // that retained application diagnostic after cleanup and preserve it
         // ahead of a direct framework-cleanup panic.
-        panics.record(self.panic.take());
+        panics.record(self.disposal.panic.take());
         panics.record(freeze_panic);
     }
 }
@@ -1352,8 +1352,8 @@ impl<M: Send + 'static> RawContext<M> {
         T: Send + 'static,
         C: FnOnce(Result<T, DeadlineElapsed>) -> M + Send + 'static,
     {
-        self.start_offload(work, continuation, deadline.into(), OffloadScope::Unscoped)
-            .map(|_| ())
+        self.start_offload(work, continuation, deadline.into())
+            .map(Guard::detach)
     }
 
     /// Starts guarded incarnation-owned async work with one deadline budget.
@@ -1374,8 +1374,7 @@ impl<M: Send + 'static> RawContext<M> {
         T: Send + 'static,
         C: FnOnce(Result<T, DeadlineElapsed>) -> M + Send + 'static,
     {
-        self.start_offload(work, continuation, deadline.into(), OffloadScope::Scoped)
-            .map(|guard| guard.expect("scoped offload must produce a guard"))
+        self.start_offload(work, continuation, deadline.into())
     }
 
     /// Starts blocking work with cancellation tied to shutdown and future drop.
@@ -1474,8 +1473,7 @@ impl<M: Send + 'static> RawContext<M> {
         work: F,
         continuation: C,
         deadline: DeadlineBudget,
-        scope: OffloadScope,
-    ) -> Result<Option<Guard>, Rejected<(F, C)>>
+    ) -> Result<Guard, Rejected<(F, C)>>
     where
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
@@ -1491,11 +1489,11 @@ impl<M: Send + 'static> RawContext<M> {
 
         let cancellation = Latch::default();
         let finished = Latch::default();
-        let guard = (scope == OffloadScope::Scoped).then(|| Guard {
+        let guard = Guard {
             cancellation: cancellation.clone(),
             finished: finished.clone(),
             armed: true,
-        });
+        };
         let events = Arc::clone(&self.resources.events);
         let disposal = self.resources.disposal.clone();
         // Zero selects no attempt (SPEC Appendix B): the work future is never
@@ -1548,8 +1546,7 @@ impl<M: Send + 'static> RawContext<M> {
         };
         let state = SharedOffloadState::new(
             Box::pin(operation),
-            Arc::clone(&self.resources.panic),
-            self.resources.events.signal.clone(),
+            self.resources.disposal.clone(),
             finished.clone(),
         );
         let task = runtime::spawn_actor_work(SharedOffloadFuture(Arc::clone(&state)));
@@ -1815,7 +1812,7 @@ impl<M: Send + 'static> RawContext<M> {
     }
 
     fn take_resource_panic(&self) -> Option<PanicPayload> {
-        self.resources.panic.take()
+        self.resources.disposal.panic.take()
     }
 }
 
@@ -2137,7 +2134,8 @@ mod tests {
 
     use super::{
         ArmingOrder, EventQueue, OffloadPoll, OffloadResource, PanicSlot, QueuedEvent, RawContext,
-        RawResources, RawRunContext, SharedOffloadFuture, SharedOffloadState, TimerMessage,
+        RawDisposal, RawResources, RawRunContext, SharedOffloadFuture, SharedOffloadState,
+        TimerMessage,
     };
     use crate::{
         ChildId, MailboxShutdown, Readiness,
@@ -2402,7 +2400,7 @@ mod tests {
     #[crate::runtime::test]
     async fn event_visibility_precedes_signal_without_losing_the_wakeup() {
         let queue = Arc::new(EventQueue::default());
-        let mut watcher = queue.signal.watcher();
+        let mut watcher = queue.disposal.signal.watcher();
         let inserted = Arc::new(Barrier::new(2));
         let release_signal = Arc::new(Barrier::new(2));
         let producer = {
@@ -2454,8 +2452,10 @@ mod tests {
                 drops: Arc::clone(&drops),
                 panic_on_drop: true,
             }),
-            Arc::clone(&panic),
-            Signal::default(),
+            RawDisposal {
+                panic: Arc::clone(&panic),
+                signal: Signal::default(),
+            },
             finished.clone(),
         );
         let poller = {
@@ -2491,8 +2491,7 @@ mod tests {
     fn absent_offload_future_does_not_claim_a_poller() {
         let state = SharedOffloadState::new(
             Box::pin(std::future::pending()),
-            Arc::new(PanicSlot::default()),
-            Signal::default(),
+            RawDisposal::default(),
             Latch::default(),
         );
         let future = state.take_for_poll().expect("fixture future is present");
@@ -2546,7 +2545,7 @@ mod tests {
     fn a_skipped_freeze_still_contains_queued_continuation_destructors() {
         let drops = Arc::new(AtomicUsize::new(0));
         let mut resources = RawResources::<CountedDrop>::default();
-        let panic = Arc::clone(&resources.panic);
+        let panic = Arc::clone(&resources.disposal.panic);
         resources.accepting = false;
         for panic_on_drop in [true, false] {
             resources.continuations.push_back(CountedDrop {
@@ -2614,7 +2613,7 @@ mod tests {
     #[test]
     fn resident_raw_collections_do_not_clone_disposal_per_element() {
         let mut resources = RawResources::<()>::default();
-        let baseline = Arc::strong_count(&resources.panic);
+        let baseline = Arc::strong_count(&resources.disposal.panic);
 
         resources.continuations.push_back(());
         resources.events.push(QueuedEvent {
@@ -2626,7 +2625,7 @@ mod tests {
             .replace(7_u8, None, ArmingOrder(1), TimerMessage::Once(()), None);
 
         assert_eq!(
-            Arc::strong_count(&resources.panic),
+            Arc::strong_count(&resources.disposal.panic),
             baseline,
             "continuations, events, and timers store raw elements without disposal clones"
         );
@@ -2647,6 +2646,7 @@ mod tests {
         resources.join_offloads().await;
 
         let payload = resources
+            .disposal
             .panic
             .take()
             .expect("the framework panic is retained for incarnation teardown");
@@ -2671,8 +2671,7 @@ mod tests {
                     drops: Arc::clone(&drops),
                     panic_on_drop,
                 }),
-                Arc::clone(&resources.panic),
-                resources.events.signal.clone(),
+                resources.disposal.clone(),
                 completion.clone(),
             );
             resources.offloads.push(OffloadResource {
@@ -2736,6 +2735,7 @@ mod tests {
             "one hostile destructor cannot skip later collection elements or drains"
         );
         let payload = resources
+            .disposal
             .panic
             .take()
             .expect("the first cleanup panic is retained");
@@ -2770,6 +2770,26 @@ mod timer_store_tests {
     impl std::hash::Hash for CollidingKey {
         fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
             0_u8.hash(state);
+        }
+    }
+
+    struct CountingHashKey {
+        value: u8,
+        hashes: Arc<AtomicUsize>,
+    }
+
+    impl PartialEq for CountingHashKey {
+        fn eq(&self, other: &Self) -> bool {
+            self.value == other.value
+        }
+    }
+
+    impl Eq for CountingHashKey {}
+
+    impl std::hash::Hash for CountingHashKey {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            self.hashes.fetch_add(1, Ordering::SeqCst);
+            std::hash::Hash::hash(&self.value, state);
         }
     }
 
@@ -2810,6 +2830,27 @@ mod timer_store_tests {
             panic!("expected a live one-shot timer")
         };
         message
+    }
+
+    #[test]
+    fn timer_replacement_hashes_each_incoming_key_once() {
+        let hashes = Arc::new(AtomicUsize::new(0));
+        let mut timers = TimerStore::default();
+
+        for (order, message) in [(1, "first"), (2, "second")] {
+            timers.replace(
+                CountingHashKey {
+                    value: 7,
+                    hashes: Arc::clone(&hashes),
+                },
+                None,
+                super::ArmingOrder(order),
+                TimerMessage::Once(message),
+                None,
+            );
+        }
+
+        assert_eq!(hashes.load(Ordering::SeqCst), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- collapse incarnation generation onto the shared poison-aware counter and centralize membership grants
- make `ScopeCell` identity operations explicit while simplifying removal, gate handoff, and snapshot assembly
- share raw disposal/signal state, use one RAII offload path, and avoid hashing replacement timer keys twice

## Why

This completes the remaining low-risk simplifications from #211 while preserving identity exhaustion, observation, panic-containment, and disposal behavior.

## Validation

- `./tools/dev just ci`
- `./tools/dev just ci-nix`

Closes #211