### PR TITLE
Consolidate test polling and repeated fixtures

### DIFF
--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -191,6 +191,14 @@ impl CompletionGatedLatch {
         )
     }
 
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn is_completed(&self) -> bool {
+        matches!(
+            self.state.load(Ordering::Acquire),
+            COMPLETION_GATE_CLOSED | COMPLETION_GATE_CLOSED_FIRED
+        )
+    }
+
     pub async fn fired(&self) {
         self.fired.fired().await;
     }

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -657,15 +657,7 @@ async fn admission_conversion_panic_does_not_poison_dynamic_cleanup() {
     reservation
         .slot
         .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
-    let response = super::super::start_admission(
-        Arc::clone(&reservation.control),
-        Arc::clone(&reservation.slot),
-        None,
-    )
-    .expect("admission starts inside the runtime");
-    let Some(DriverEvent::Admission(request)) = event_receiver.recv().await else {
-        panic!("admission enqueueing submits the request")
-    };
+    let (response, request) = begin_admission(&reservation, &mut event_receiver, None).await;
 
     assert!(
         catch_unwind(AssertUnwindSafe(|| {
@@ -723,15 +715,8 @@ async fn annulment_before_admission_owns_never_started_terminality() {
     reservation
         .slot
         .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
-    let response = super::super::start_admission(
-        Arc::clone(&reservation.control),
-        Arc::clone(&reservation.slot),
-        None,
-    )
-    .expect("admission starts inside the runtime");
-    let Some(DriverEvent::Admission(request)) = dynamic_event_receiver.recv().await else {
-        panic!("admission enqueueing submits the request")
-    };
+    let (response, request) =
+        begin_admission(&reservation, &mut dynamic_event_receiver, None).await;
 
     cancel_dynamic_reservation(
         &reservation.scope,
@@ -809,15 +794,8 @@ async fn annulment_after_promotion_is_inert_and_supervision_owns_the_exit() {
                 }
             }
         })));
-    let mut response = super::super::start_admission(
-        Arc::clone(&reservation.control),
-        Arc::clone(&reservation.slot),
-        None,
-    )
-    .expect("admission starts inside the runtime");
-    let Some(DriverEvent::Admission(request)) = dynamic_event_receiver.recv().await else {
-        panic!("admission enqueueing submits the request")
-    };
+    let (mut response, request) =
+        begin_admission(&reservation, &mut dynamic_event_receiver, None).await;
     scope.handle_admission(request);
     assert!(matches!(response.try_receive(), Some(Ok(()))));
     assert!(matches!(
@@ -861,26 +839,13 @@ async fn annulment_after_promotion_is_inert_and_supervision_owns_the_exit() {
         crate::runtime::Timeout::Elapsed => panic!("the removal must reach the driver"),
     };
     scope.handle_removal(removal);
-    let exit = match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
-        crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {
-            child,
-            incarnation,
-            recorded,
-            join,
-            cancellation,
-            readiness_signal_seen,
-        }))) => (
-            child,
-            incarnation,
-            recorded,
-            join,
-            cancellation,
-            readiness_signal_seen,
-        ),
-        crate::runtime::Timeout::Completed(_) => panic!("the stopped child reports exit"),
-        crate::runtime::Timeout::Elapsed => panic!("the stopped child exit must arrive"),
-    };
-    scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4, exit.5);
+    recv_child_exit(
+        &mut event_receiver,
+        Duration::from_secs(2),
+        "the stopped child exit",
+    )
+    .await
+    .dispatch(&mut scope);
     let disposal =
         match crate::runtime::timeout(Duration::from_secs(2), disposal_event_receiver.recv()).await
         {
@@ -936,30 +901,47 @@ async fn annulment_racing_admission_resolves_to_one_terminalization_owner() {
         reservation
             .slot
             .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
-        let response = super::super::start_admission(
-            Arc::clone(&reservation.control),
-            Arc::clone(&reservation.slot),
-            None,
-        )
-        .expect("admission starts inside the runtime");
-        let Some(DriverEvent::Admission(request)) = dynamic_event_receiver.recv().await else {
-            panic!("admission enqueueing submits the request")
-        };
+        let (response, request) =
+            begin_admission(&reservation, &mut dynamic_event_receiver, None).await;
 
-        let barrier = Arc::new(Barrier::new(2));
-        let annul = {
-            let barrier = Arc::clone(&barrier);
+        let (contender_ready, contenders_ready) = std::sync::mpsc::sync_channel(2);
+        let state_control = Arc::clone(&control);
+        let state = state_control
+            .state
+            .lock()
+            .expect("dynamic-state mutex remains healthy");
+        let runtime = tokio::runtime::Handle::current();
+        let (scope, annul) = std::thread::scope(|threads| {
+            let annul_ready = contender_ready.clone();
             let annul_control = Arc::clone(&reservation.control);
             let annul_slot = Arc::clone(&reservation.slot);
             let annul_scope = Arc::clone(&reservation.scope);
-            std::thread::spawn(move || {
-                barrier.wait();
+            let annul = threads.spawn(move || {
+                annul_ready
+                    .send(())
+                    .expect("the race coordinator remains available");
                 cancel_dynamic_reservation(&annul_scope, annul_control.as_ref(), &annul_slot);
-            })
-        };
-        barrier.wait();
-        scope.handle_admission(request);
-        annul.join().expect("the annul thread completes");
+            });
+            let admission = threads.spawn(move || {
+                let _runtime = runtime.enter();
+                contender_ready
+                    .send(())
+                    .expect("the race coordinator remains available");
+                scope.handle_admission(request);
+                scope
+            });
+            contenders_ready
+                .recv()
+                .expect("the annulment contender reaches the mutex boundary");
+            contenders_ready
+                .recv()
+                .expect("the admission contender reaches the mutex boundary");
+            drop(state);
+            let annul = annul.join();
+            let scope = admission.join().expect("the admission contender completes");
+            (scope, annul)
+        });
+        annul.expect("the annul contender completes");
 
         // Whichever side won the dynamic-state mutex, exactly one owner
         // published terminality (or none, if the admission won): the record,
@@ -1014,15 +996,12 @@ async fn fused_cancellation_overtaking_admission_rejects_before_conversion() {
         .slot
         .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
     let fused_cancel = Latch::default();
-    let response = super::super::start_admission(
-        Arc::clone(&reservation.control),
-        Arc::clone(&reservation.slot),
+    let (response, request) = begin_admission(
+        &reservation,
+        &mut dynamic_event_receiver,
         Some(fused_cancel.clone()),
     )
-    .expect("admission starts inside the runtime");
-    let Some(DriverEvent::Admission(request)) = dynamic_event_receiver.recv().await else {
-        panic!("admission enqueueing submits the request")
-    };
+    .await;
 
     // Fused cancellation linearizes after Admission is queued but before
     // the driver handles it. A reserved entry has no arena key, so
@@ -1088,15 +1067,12 @@ async fn fused_cancellation_during_conversion_is_rejected_by_the_under_lock_rech
         .slot
         .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
     let fused_cancel = Latch::default();
-    let response = super::super::start_admission(
-        Arc::clone(&reservation.control),
-        Arc::clone(&reservation.slot),
+    let (response, request) = begin_admission(
+        &reservation,
+        &mut dynamic_event_receiver,
         Some(fused_cancel.clone()),
     )
-    .expect("admission starts inside the runtime");
-    let Some(DriverEvent::Admission(request)) = dynamic_event_receiver.recv().await else {
-        panic!("admission enqueueing submits the request")
-    };
+    .await;
 
     // Fused cancellation fires while the driver is already inside child
     // conversion: past the pre-conversion latch check, parked on the child
@@ -1166,7 +1142,13 @@ async fn fused_cancellation_during_conversion_is_rejected_by_the_under_lock_rech
     assert!(matches!(member.record().stage, MemberStage::Terminal(_)));
 }
 
-async fn exercise_coalesced_removal() {
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum RemovalSource {
+    FusedAndExplicit,
+    FusedOnly,
+}
+
+async fn exercise_coalesced_removal(source: RemovalSource) {
     let (
         mut scope,
         mut event_receiver,
@@ -1194,15 +1176,12 @@ async fn exercise_coalesced_removal() {
             }
         })));
     let fused_cancel = Latch::default();
-    let mut admission_response = super::super::start_admission(
-        Arc::clone(&reservation.control),
-        Arc::clone(&reservation.slot),
+    let (mut admission_response, request) = begin_admission(
+        &reservation,
+        &mut dynamic_event_receiver,
         Some(fused_cancel.clone()),
     )
-    .expect("admission starts inside the runtime");
-    let Some(DriverEvent::Admission(request)) = dynamic_event_receiver.recv().await else {
-        panic!("admission enqueueing submits the request")
-    };
+    .await;
     scope.handle_admission(request);
     assert!(matches!(admission_response.try_receive(), Some(Ok(()))));
     assert!(matches!(
@@ -1218,14 +1197,32 @@ async fn exercise_coalesced_removal() {
         .get(member.id())
         .and_then(DynamicEntry::key)
         .expect("the admission installs its child key");
+
+    if source == RemovalSource::FusedOnly {
+        assert_eq!(member.record().membership_status, MembershipStatus::Active);
+    }
     super::super::signal_fused_cancel(
         &reservation.scope,
         control.as_ref(),
         &reservation.slot,
         &fused_cancel,
     );
-    let mut removal_response =
-        super::super::remove_dynamic(&root, member.id(), Some(member.membership()));
+    let mut removal_response = (source == RemovalSource::FusedAndExplicit)
+        .then(|| super::super::remove_dynamic(&root, member.id(), Some(member.membership())));
+
+    if source == RemovalSource::FusedOnly {
+        assert_eq!(
+            member.record().membership_status,
+            MembershipStatus::Removing,
+            "the fused source commits the Removing projection with its phase"
+        );
+        assert!(matches!(
+            root.snapshot()
+                .child("worker")
+                .map(|child| child.membership_status),
+            Some(MembershipStatus::Removing)
+        ));
+    }
 
     let removal = match crate::runtime::timeout(
         Duration::from_secs(2),
@@ -1238,40 +1235,61 @@ async fn exercise_coalesced_removal() {
         crate::runtime::Timeout::Elapsed => panic!("the removal request reaches the driver"),
     };
     assert_eq!(removal.key, key);
-    assert!(
-        crate::runtime::unbounded_mpsc_try_recv(&mut dynamic_event_receiver).is_none(),
-        "the state transition coalesces fused and explicit removal sources"
-    );
+    if source == RemovalSource::FusedAndExplicit {
+        assert!(
+            crate::runtime::unbounded_mpsc_try_recv(&mut dynamic_event_receiver).is_none(),
+            "the state transition coalesces fused and explicit removal sources"
+        );
+    }
 
+    let duplicate = removal;
     scope.handle_removal(removal);
+    if source == RemovalSource::FusedOnly {
+        assert_eq!(
+            member.record().membership_status,
+            MembershipStatus::Removing,
+            "driver handling preserves the already-published Removing projection"
+        );
+        assert!(matches!(
+            root.snapshot()
+                .child("worker")
+                .map(|child| child.membership_status),
+            Some(MembershipStatus::Removing)
+        ));
 
-    let exit = match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
-        crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {
-            child,
-            incarnation,
-            recorded,
-            join,
-            cancellation,
-            readiness_signal_seen,
-        }))) => (
-            child,
-            incarnation,
-            recorded,
-            join,
-            cancellation,
-            readiness_signal_seen,
-        ),
-        crate::runtime::Timeout::Completed(_) => panic!("the stopped child reports exit"),
-        crate::runtime::Timeout::Elapsed => panic!("the stopped child exit must arrive"),
-    };
-    scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4, exit.5);
+        let active = scope.children[key]
+            .active
+            .as_ref()
+            .expect("the removal begins the live stop ladder");
+        let ladder = active.ladder.expect("the stop ladder is armed");
+        let stop_deadline = active.stop_deadline;
+        let deadline_count = scope.deadlines.len();
+        scope.handle_removal(duplicate);
+        let active = scope.children[key]
+            .active
+            .as_ref()
+            .expect("the duplicate leaves the incarnation active");
+        assert_eq!(active.ladder, Some(ladder));
+        assert_eq!(active.stop_deadline, stop_deadline);
+        assert_eq!(scope.deadlines.len(), deadline_count);
+    }
+
+    recv_child_exit(
+        &mut event_receiver,
+        Duration::from_secs(2),
+        "the stopped child exit",
+    )
+    .await
+    .dispatch(&mut scope);
     assert!(scope.children[key].pending_terminal.is_some());
 
-    assert_eq!(
-        removal_response.try_receive(),
-        None,
-        "removal completion waits for terminality, disposal, and pruning"
-    );
+    if let Some(response) = &mut removal_response {
+        assert_eq!(
+            response.try_receive(),
+            None,
+            "removal completion waits for terminality, disposal, and pruning"
+        );
+    }
 
     let disposal =
         match crate::runtime::timeout(Duration::from_secs(2), disposal_event_receiver.recv()).await
@@ -1300,10 +1318,9 @@ async fn exercise_coalesced_removal() {
             .entries
             .contains_key(member.id())
     );
-    assert_eq!(
-        removal_response.receive().await,
-        Some(RemoveOutcome::Removed)
-    );
+    if let Some(response) = removal_response {
+        assert_eq!(response.receive().await, Some(RemoveOutcome::Removed));
+    }
     let mut added = 0;
     let mut removed = 0;
     while let Ok(LifecycleItem::Event(event)) = lifecycle.try_recv() {
@@ -1318,194 +1335,12 @@ async fn exercise_coalesced_removal() {
 
 #[crate::runtime::test]
 async fn fused_and_explicit_removal_queue_once_at_transition() {
-    exercise_coalesced_removal().await;
+    exercise_coalesced_removal(RemovalSource::FusedAndExplicit).await;
 }
 
 #[crate::runtime::test]
 async fn fused_only_removal_commits_phase_and_projection_together() {
-    let (
-        mut scope,
-        mut event_receiver,
-        mut dynamic_event_receiver,
-        mut disposal_event_receiver,
-        control,
-    ) = running_dynamic_fixture();
-    let root = Arc::clone(&scope.root);
-    let mut lifecycle = root.subscribe_lifecycle();
-    let started = Latch::default();
-    let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
-        .expect("running dynamic scope reserves the child");
-    let member = Arc::clone(&reservation.slot.member);
-    reservation
-        .slot
-        .define(ChildConstruction::Task(TaskDef::new({
-            let started = started.clone();
-            move |context| {
-                let started = started.clone();
-                async move {
-                    started.fire();
-                    context.shutdown_token().cancelled().await;
-                    Ok(())
-                }
-            }
-        })));
-    let fused_cancel = Latch::default();
-    let mut admission_response = super::super::start_admission(
-        Arc::clone(&reservation.control),
-        Arc::clone(&reservation.slot),
-        Some(fused_cancel.clone()),
-    )
-    .expect("admission starts inside the runtime");
-    let Some(DriverEvent::Admission(request)) = dynamic_event_receiver.recv().await else {
-        panic!("admission enqueueing submits the request")
-    };
-    scope.handle_admission(request);
-    assert!(matches!(admission_response.try_receive(), Some(Ok(()))));
-    assert!(matches!(
-        crate::runtime::timeout(Duration::from_secs(2), started.fired()).await,
-        crate::runtime::Timeout::Completed(())
-    ));
-    let key = control
-        .state
-        .lock()
-        .expect("dynamic-state mutex poisoned")
-        .entries
-        .get(member.id())
-        .and_then(DynamicEntry::key)
-        .expect("the admission installs its child key");
-
-    // A fused drop is the only removal source in this variant. Its dynamic
-    // phase and public projection commit under one observation transaction,
-    // before the deferred driver request is delivered.
-    assert_eq!(member.record().membership_status, MembershipStatus::Active);
-    super::super::signal_fused_cancel(
-        &reservation.scope,
-        control.as_ref(),
-        &reservation.slot,
-        &fused_cancel,
-    );
-    assert_eq!(
-        member.record().membership_status,
-        MembershipStatus::Removing,
-        "the fused source commits the Removing projection with its phase"
-    );
-    assert!(matches!(
-        root.snapshot()
-            .child("worker")
-            .map(|child| child.membership_status),
-        Some(MembershipStatus::Removing)
-    ));
-    let removal = match crate::runtime::timeout(
-        Duration::from_secs(2),
-        dynamic_event_receiver.recv(),
-    )
-    .await
-    {
-        crate::runtime::Timeout::Completed(Some(DriverEvent::Removal(removal))) => removal,
-        crate::runtime::Timeout::Completed(_) => {
-            panic!("the fused source queues exactly one removal")
-        }
-        crate::runtime::Timeout::Elapsed => panic!("the fused removal reaches the driver"),
-    };
-    assert_eq!(removal.key, key);
-
-    let duplicate = removal;
-    scope.handle_removal(removal);
-    assert_eq!(
-        member.record().membership_status,
-        MembershipStatus::Removing,
-        "driver handling preserves the already-published Removing projection"
-    );
-    assert!(matches!(
-        root.snapshot()
-            .child("worker")
-            .map(|child| child.membership_status),
-        Some(MembershipStatus::Removing)
-    ));
-
-    // Coalescing at the `Resident -> Removing` transition means no source can
-    // queue this request twice any more, so the driver-side idempotence guards
-    // lost their only coverage. They remain load-bearing for the pairings that
-    // *can* still deliver a removal to an actively-stopping child in one batch
-    // (`Pending::Shutdown` / `Force` / `SelfStop` alongside a removal, and
-    // `DeadlineKind::Restart` re-entry), so pin them with a synthetic
-    // duplicate: re-delivery must not rewind the armed ladder, push the stop
-    // deadline out, or arm a second timer.
-    let active = scope.children[key]
-        .active
-        .as_ref()
-        .expect("the removal begins the live stop ladder");
-    let ladder = active.ladder.expect("the stop ladder is armed");
-    let stop_deadline = active.stop_deadline;
-    let deadline_count = scope.deadlines.len();
-    scope.handle_removal(duplicate);
-    let active = scope.children[key]
-        .active
-        .as_ref()
-        .expect("the duplicate leaves the incarnation active");
-    assert_eq!(active.ladder, Some(ladder));
-    assert_eq!(active.stop_deadline, stop_deadline);
-    assert_eq!(scope.deadlines.len(), deadline_count);
-
-    let exit = match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
-        crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {
-            child,
-            incarnation,
-            recorded,
-            join,
-            cancellation,
-            readiness_signal_seen,
-        }))) => (
-            child,
-            incarnation,
-            recorded,
-            join,
-            cancellation,
-            readiness_signal_seen,
-        ),
-        crate::runtime::Timeout::Completed(_) => panic!("the stopped child reports exit"),
-        crate::runtime::Timeout::Elapsed => panic!("the stopped child exit must arrive"),
-    };
-    scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4, exit.5);
-    assert!(scope.children[key].pending_terminal.is_some());
-
-    let disposal =
-        match crate::runtime::timeout(Duration::from_secs(2), disposal_event_receiver.recv()).await
-        {
-            crate::runtime::Timeout::Completed(Some(event)) => event,
-            crate::runtime::Timeout::Completed(None) => {
-                panic!("the disposal lane remains open")
-            }
-            crate::runtime::Timeout::Elapsed => {
-                panic!("retained construction disposal completes")
-            }
-        };
-    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = disposal else {
-        panic!("the stop path reports retained construction disposal")
-    };
-    assert_eq!(child, key);
-    scope.handle_construction_disposed(child, panic);
-
-    assert!(scope.children.get(key).is_none());
-    assert!(root.snapshot().child("worker").is_none());
-    assert!(
-        !control
-            .state
-            .lock()
-            .expect("dynamic-state mutex poisoned")
-            .entries
-            .contains_key(member.id())
-    );
-    let mut added = 0;
-    let mut removed = 0;
-    while let Ok(LifecycleItem::Event(event)) = lifecycle.try_recv() {
-        match event.kind {
-            LifecycleEventKind::Added { .. } => added += 1,
-            LifecycleEventKind::Removed { .. } => removed += 1,
-            _ => {}
-        }
-    }
-    assert_eq!((added, removed), (1, 1));
+    exercise_coalesced_removal(RemovalSource::FusedOnly).await;
 }
 
 pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
@@ -1577,26 +1412,13 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
     assert_eq!(starts.load(Ordering::SeqCst), 1);
 
     release_failure.fire();
-    let exit = match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
-        crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {
-            child,
-            incarnation,
-            recorded,
-            join,
-            cancellation,
-            readiness_signal_seen,
-        }))) => (
-            child,
-            incarnation,
-            recorded,
-            join,
-            cancellation,
-            readiness_signal_seen,
-        ),
-        crate::runtime::Timeout::Completed(_) => panic!("the first incarnation reports exit"),
-        crate::runtime::Timeout::Elapsed => panic!("the first incarnation exit must arrive"),
-    };
-    let key = exit.0;
+    let exit = recv_child_exit(
+        &mut event_receiver,
+        Duration::from_secs(2),
+        "the first incarnation exit",
+    )
+    .await;
+    let key = exit.child;
     assert!(
         crate::runtime::unbounded_mpsc_send(
             &scope.events,
@@ -1630,7 +1452,7 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
         "exit dispatch and the public projection share the fused-cancel commit"
     );
 
-    scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4, exit.5);
+    exit.dispatch(&mut scope);
     assert!(scope.children[key].restart_deadline.is_none());
     assert_eq!(
         root.snapshot().total_restarts,

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -930,12 +930,17 @@ async fn annulment_racing_admission_resolves_to_one_terminalization_owner() {
                 scope.handle_admission(request);
                 scope
             });
+            // Both contenders are running before the dynamic-state mutex is
+            // released, so neither can finish ahead of the other: the guard,
+            // not the rendezvous, is what forces them to overlap. The
+            // rendezvous only proves each thread reached its send — the
+            // channel is shared, so neither receive names a contender.
             contenders_ready
                 .recv()
-                .expect("the annulment contender reaches the mutex boundary");
+                .expect("a contender starts before the mutex is released");
             contenders_ready
                 .recv()
-                .expect("the admission contender reaches the mutex boundary");
+                .expect("both contenders start before the mutex is released");
             drop(state);
             let annul = annul.join();
             let scope = admission.join().expect("the admission contender completes");

--- a/crates/shelterwood/src/driver/tests/events.rs
+++ b/crates/shelterwood/src/driver/tests/events.rs
@@ -192,39 +192,23 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
             }
         })));
     let fused_cancel = Latch::default();
-    let mut response = super::super::start_admission(
-        Arc::clone(&reservation.control),
-        Arc::clone(&reservation.slot),
+    let (mut response, request) = begin_admission(
+        &reservation,
+        &mut event_receiver,
         Some(fused_cancel.clone()),
     )
-    .expect("the running scope accepts the admission");
-    let Some(DriverEvent::Admission(request)) = event_receiver.recv().await else {
-        panic!("admission enqueueing submits the request")
-    };
+    .await;
     scope.handle_admission(request);
     assert!(matches!(response.try_receive(), Some(Ok(()))));
 
-    let exit = match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, event_receiver.recv()).await {
-        crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {
-            child,
-            incarnation,
-            recorded,
-            join,
-            cancellation,
-            readiness_signal_seen,
-        }))) => (
-            child,
-            incarnation,
-            recorded,
-            join,
-            cancellation,
-            readiness_signal_seen,
-        ),
-        crate::runtime::Timeout::Completed(_) => panic!("the first incarnation reports exit"),
-        crate::runtime::Timeout::Elapsed => panic!("the first incarnation exit must arrive"),
-    };
-    let key = exit.0;
-    scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4, exit.5);
+    let exit = recv_child_exit(
+        &mut event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "the first incarnation exit",
+    )
+    .await;
+    let key = exit.child;
+    exit.dispatch(&mut scope);
     assert!(
         scope.children[key].restart_deadline.is_some(),
         "a live fused admission does not suppress the restart at exit dispatch"

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -329,25 +329,12 @@ async fn latched_shutdown_keeps_the_startup_verdict_for_its_follow_up_event() {
     assert!(scope.supervisor.is_initial(key));
     scope.spawn_child(key);
     assert!(!scope.supervisor.initial_ready(key));
-    let exit = match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
-        crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {
-            child,
-            incarnation,
-            recorded,
-            join,
-            cancellation,
-            readiness_signal_seen,
-        }))) => (
-            child,
-            incarnation,
-            recorded,
-            join,
-            cancellation,
-            readiness_signal_seen,
-        ),
-        crate::runtime::Timeout::Completed(_) => panic!("the pre-ready failure reports exit"),
-        crate::runtime::Timeout::Elapsed => panic!("the pre-ready failure exit must arrive"),
-    };
+    let exit = recv_child_exit(
+        &mut event_receiver,
+        Duration::from_secs(2),
+        "the pre-ready failure exit",
+    )
+    .await;
 
     // The stop request latches after this batch was collected: it is
     // visible to `has_stop_request`, but its `Pending::Shutdown` follow-up
@@ -355,7 +342,7 @@ async fn latched_shutdown_keeps_the_startup_verdict_for_its_follow_up_event() {
     assert!(root.request_shutdown().is_some());
     assert!(root.has_stop_request(scope.epoch));
 
-    scope.handle_exit(exit.0, exit.1, exit.2, exit.3, exit.4, exit.5);
+    exit.dispatch(&mut scope);
     assert!(
         scope.children[key].restart_deadline.is_some(),
         "a latched scope stop does not reclassify exit dispatch"

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -980,6 +980,8 @@ fn receiverless_config_state_is_atomic_under_concurrent_snapshots() {
     scope.set_observation_config(Default::default(), first);
 
     let start = Arc::new(Barrier::new(2));
+    let (first_update, first_update_seen) = std::sync::mpsc::sync_channel(0);
+    let (first_snapshot, first_snapshot_seen) = std::sync::mpsc::sync_channel(0);
     let writer_scope = Arc::clone(&scope);
     let writer_start = Arc::clone(&start);
     let writer = std::thread::spawn(move || {
@@ -987,16 +989,32 @@ fn receiverless_config_state_is_atomic_under_concurrent_snapshots() {
         for update in 0..UPDATES {
             let intensity = if update % 2 == 0 { second } else { first };
             writer_scope.set_observation_config(Default::default(), intensity);
+            if update == 0 {
+                first_update
+                    .send(())
+                    .expect("the snapshot reader remains available");
+                first_snapshot_seen
+                    .recv()
+                    .expect("the snapshot reader acknowledges its observation");
+            }
         }
     });
 
     start.wait();
-    for _ in 0..UPDATES {
+    first_update_seen
+        .recv()
+        .expect("the writer publishes its first update");
+    for snapshot in 0..UPDATES {
         let intensity = scope.snapshot().intensity;
         assert!(
             intensity == first || intensity == second,
             "a snapshot observes one complete configuration update"
         );
+        if snapshot == 0 {
+            first_snapshot
+                .send(())
+                .expect("the config writer remains available");
+        }
     }
     writer.join().expect("config writer completes");
 }

--- a/crates/shelterwood/src/driver/tests/reports.rs
+++ b/crates/shelterwood/src/driver/tests/reports.rs
@@ -100,6 +100,6 @@ fn owned_report_token_records_readiness_at_completion() {
     let (token, claim) = report_slot(Latch::default(), None, readiness.clone());
     readiness.fire();
     token.record(RecordedOutcome::returned(Ok(())));
-    assert!(!readiness.fire(), "completion closes retained capabilities");
+    assert!(readiness.is_completed());
     assert!(claim.receive().readiness_signal_seen);
 }

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -14,10 +14,11 @@ pub(super) use std::{
 
 pub(super) use crate::{
     ActorRef, Backoff, Cancellation, ChildId, ChildState, DynamicTree, Exit, ExitError, ExitKind,
-    GracePhase, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, Mailbox,
-    MembershipStatus, RawOnceDef, Readiness, ReadinessDeadline, RemoveOutcome, ReserveError,
-    RestartCondition, RestartCount, RestartPolicy, Retention, ScopeRef, ScopeState, SendErrorKind,
-    StartupError, StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
+    GracePhase, Incarnation, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError,
+    Mailbox, MembershipStatus, RawOnceDef, Readiness, ReadinessDeadline, RemoveOutcome,
+    ReserveError, RestartCondition, RestartCount, RestartPolicy, Retention, ScopeRef, ScopeState,
+    SendErrorKind, StartupError, StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef,
+    TaskDef, Tree,
     engine::{
         ChildKey, Effect as SupervisorEffect, Epoch, Event as SupervisorEvent, ScopeLifecycle,
         StopLadder, SupervisorState, arbitrate, step as supervisor_step,
@@ -30,16 +31,84 @@ pub(super) use crate::{
     runtime::{CompletionGatedLatch, Latch},
 };
 
+pub(super) struct ObservedExit {
+    pub(super) child: ChildKey,
+    incarnation: Incarnation,
+    recorded: Option<RecordedOutcome>,
+    join: crate::runtime::JoinOutcome<()>,
+    cancellation: Cancellation,
+    readiness_signal_seen: bool,
+}
+
+impl ObservedExit {
+    pub(super) fn dispatch(self, scope: &mut ScopeRuntime) {
+        scope.handle_exit(
+            self.child,
+            self.incarnation,
+            self.recorded,
+            self.join,
+            self.cancellation,
+            self.readiness_signal_seen,
+        );
+    }
+}
+
+pub(super) async fn recv_child_exit(
+    receiver: &mut crate::runtime::UnboundedMpscReceiver<DriverEvent>,
+    timeout: Duration,
+    expectation: &str,
+) -> ObservedExit {
+    match crate::runtime::timeout(timeout, receiver.recv()).await {
+        crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {
+            child,
+            incarnation,
+            recorded,
+            join,
+            cancellation,
+            readiness_signal_seen,
+        }))) => ObservedExit {
+            child,
+            incarnation,
+            recorded,
+            join,
+            cancellation,
+            readiness_signal_seen,
+        },
+        crate::runtime::Timeout::Completed(_) => panic!("expected {expectation}"),
+        crate::runtime::Timeout::Elapsed => panic!("timed out waiting for {expectation}"),
+    }
+}
+
 pub(super) use super::super::{
-    AncestorCommandLatches, ChildEvent, ChildResources, ChildRuntime, ChildTerminality,
-    DriverEvent, DynamicControl, DynamicEntry, GateCapture, MemberCell, MemberStage,
-    MemberTransition, NestedScopeLatches, Pending, RemovalRequest, RemovalResponses,
-    ResidentProjection, RuntimeStorage, ScopeCell, ScopeControlEvent, ScopeEpochGuard, ScopeFlavor,
-    ScopeRole, ScopeRuntime, StartupDisposition, cancel_dynamic_reservation,
-    discharge_child_terminality, report_slot, reserve_dynamic, resident_projection,
-    restart_shutdown_work, run_nested_factory, run_nested_tree, run_scope_incarnation,
-    storage::Obligation,
+    AdmissionRequest, AncestorCommandLatches, ChildEvent, ChildResources, ChildRuntime,
+    ChildTerminality, DriverEvent, DynamicControl, DynamicEntry, DynamicReservation, GateCapture,
+    MemberCell, MemberStage, MemberTransition, NestedScopeLatches, Pending, RemovalRequest,
+    RemovalResponses, ResidentProjection, RuntimeStorage, ScopeCell, ScopeControlEvent,
+    ScopeEpochGuard, ScopeFlavor, ScopeRole, ScopeRuntime, StartupDisposition,
+    cancel_dynamic_reservation, discharge_child_terminality, report_slot, reserve_dynamic,
+    resident_projection, restart_shutdown_work, run_nested_factory, run_nested_tree,
+    run_scope_incarnation, storage::Obligation,
 };
+
+pub(super) async fn begin_admission(
+    reservation: &DynamicReservation,
+    receiver: &mut crate::runtime::UnboundedMpscReceiver<DriverEvent>,
+    fused_cancel: Option<Latch>,
+) -> (
+    crate::runtime::OneShotReceiver<Result<(), ReserveError>>,
+    AdmissionRequest,
+) {
+    let response = super::super::start_admission(
+        Arc::clone(&reservation.control),
+        Arc::clone(&reservation.slot),
+        fused_cancel,
+    )
+    .expect("admission starts inside the runtime");
+    let Some(DriverEvent::Admission(request)) = receiver.recv().await else {
+        panic!("admission enqueueing submits the request")
+    };
+    (response, request)
+}
 
 pub(super) struct ChildArena<T> {
     children: BTreeMap<ChildKey, T>,

--- a/crates/shelterwood/tests/acceptance/assistant.rs
+++ b/crates/shelterwood/tests/acceptance/assistant.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, ChildState, Context, DeadlineElapsed, DynamicScopeRef,
     DynamicTree, ExitError, ExitResult, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
@@ -420,15 +420,12 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
     let root = system.scope();
     let mut lifecycle = root.subscribe_lifecycle();
 
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             gateway_scope
                 .snapshot()
                 .child("bridge")
                 .is_some_and(|child| matches!(child.state, ChildState::Starting))
-        })
-        .await
-    );
+        }).await;
     gateway.bridge_gate.release();
     system.wait_started().await.expect("control plane starts");
     gateway
@@ -452,15 +449,12 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .expect("session admitted");
     let session_membership = session.membership();
 
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             session
                 .snapshot()
                 .child("stream")
                 .is_some_and(|child| matches!(child.state, ChildState::Starting))
-        })
-        .await
-    );
+        }).await;
     stream.send(1).await.expect("first stream update accepted");
     stream.send(2).await.expect("second stream update accepted");
     stream.send(3).await.expect("third stream update accepted");
@@ -517,8 +511,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .send(SessionControlMessage::Crash)
         .await
         .expect("control panic request accepted");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             session.snapshot().child("control").is_some_and(|child| {
                 matches!(child.state, ChildState::Running)
                     && child.restart_count == RestartCount::ZERO.bump()
@@ -526,10 +519,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
                         incarnation.supersedes(first_control_incarnation)
                     })
             })
-        })
-        .await,
-        "session actor panic is isolated and restarted"
-    );
+        }, "session actor panic is isolated and restarted").await;
 
     let (completions, mut completed) = unbounded_channel();
     let tool = tools
@@ -552,8 +542,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .send(ToolMessage::Crash)
         .await
         .expect("tool panic request accepted");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             tools
                 .as_scope()
                 .snapshot()
@@ -565,10 +554,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
                             incarnation.supersedes(first_tool_incarnation)
                         })
                 })
-        })
-        .await,
-        "nested tool panic is isolated one scope level deeper"
-    );
+        }, "nested tool panic is isolated one scope level deeper").await;
     tool.send(ToolMessage::Work)
         .await
         .expect("offload request accepted");
@@ -839,6 +825,8 @@ async fn assistant_sessions_idle_evict_on_timers_and_streams_cancel_mid_flight()
         .await
         .expect("idle timer fires after the re-armed window")
         .expect("eviction signal arrives");
+    assert!(evicted.try_recv().is_err(), "exactly one eviction is emitted");
+    assert_quiet(Duration::from_secs(1), || evicted.try_recv().is_ok()).await;
 
     // Eviction is removal of the session scope; the stream is cut off
     // mid-flight: senders now fail terminally and no value ever leaks.

--- a/crates/shelterwood/tests/acceptance/assistant.rs
+++ b/crates/shelterwood/tests/acceptance/assistant.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, ChildState, Context, DeadlineElapsed, DynamicScopeRef,
     DynamicTree, ExitError, ExitResult, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
@@ -420,12 +420,13 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
     let root = system.scope();
     let mut lifecycle = root.subscribe_lifecycle();
 
-    crate::common::assert_eventually!(|| {
-            gateway_scope
-                .snapshot()
-                .child("bridge")
-                .is_some_and(|child| matches!(child.state, ChildState::Starting))
-        }).await;
+    assert_eventually!(|| {
+        gateway_scope
+            .snapshot()
+            .child("bridge")
+            .is_some_and(|child| matches!(child.state, ChildState::Starting))
+    })
+    .await;
     gateway.bridge_gate.release();
     system.wait_started().await.expect("control plane starts");
     gateway
@@ -449,12 +450,13 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .expect("session admitted");
     let session_membership = session.membership();
 
-    crate::common::assert_eventually!(|| {
-            session
-                .snapshot()
-                .child("stream")
-                .is_some_and(|child| matches!(child.state, ChildState::Starting))
-        }).await;
+    assert_eventually!(|| {
+        session
+            .snapshot()
+            .child("stream")
+            .is_some_and(|child| matches!(child.state, ChildState::Starting))
+    })
+    .await;
     stream.send(1).await.expect("first stream update accepted");
     stream.send(2).await.expect("second stream update accepted");
     stream.send(3).await.expect("third stream update accepted");
@@ -511,7 +513,8 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .send(SessionControlMessage::Crash)
         .await
         .expect("control panic request accepted");
-    crate::common::assert_eventually!(|| {
+    assert_eventually!(
+        || {
             session.snapshot().child("control").is_some_and(|child| {
                 matches!(child.state, ChildState::Running)
                     && child.restart_count == RestartCount::ZERO.bump()
@@ -519,7 +522,10 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
                         incarnation.supersedes(first_control_incarnation)
                     })
             })
-        }, "session actor panic is isolated and restarted").await;
+        },
+        "session actor panic is isolated and restarted"
+    )
+    .await;
 
     let (completions, mut completed) = unbounded_channel();
     let tool = tools
@@ -542,7 +548,8 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
         .send(ToolMessage::Crash)
         .await
         .expect("tool panic request accepted");
-    crate::common::assert_eventually!(|| {
+    assert_eventually!(
+        || {
             tools
                 .as_scope()
                 .snapshot()
@@ -554,7 +561,10 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
                             incarnation.supersedes(first_tool_incarnation)
                         })
                 })
-        }, "nested tool panic is isolated one scope level deeper").await;
+        },
+        "nested tool panic is isolated one scope level deeper"
+    )
+    .await;
     tool.send(ToolMessage::Work)
         .await
         .expect("offload request accepted");

--- a/crates/shelterwood/tests/acceptance/sidecar.rs
+++ b/crates/shelterwood/tests/acceptance/sidecar.rs
@@ -1,6 +1,6 @@
 use std::{future, time::Duration};
 
-use crate::common::{ReleaseGate, policy::never};
+use crate::common::{ReleaseGate, assert_eventually, policy::never};
 use shelterwood::{
     Actor, ActorOnceDef, ChildState, Context, ExitError, ExitKind, ExitResult, GracePhase,
     Readiness, ReadinessDeadline, Shutdown, StartOrShutdownError, StopContext, SubtreeOnceDef,
@@ -190,9 +190,7 @@ async fn sidecar_runs_two_host_owned_cycles_with_readiness_and_policy_exact_shut
         let fixture = sidecar(cycle, journal.clone());
         let system = fixture.tree.spawn().expect("runtime is available");
         let scope = system.scope();
-        crate::common::assert_eventually!(|| {
-                log.events(cycle, "config") == ["started"]
-            }).await;
+        assert_eventually!(|| log.events(cycle, "config") == ["started"]).await;
         let parked = scope.snapshot();
         assert!(matches!(
             parked.child("config").expect("config child").state,
@@ -302,9 +300,7 @@ async fn sidecar_startup_failure_leaves_prefix_supervised_until_host_rolls_it_ba
     let mut fixture = failing_sidecar();
     let system = fixture.tree.spawn().expect("runtime is available");
     let scope = system.scope();
-    crate::common::assert_eventually!(|| {
-            fixture.log.events(99, "config") == ["started"]
-        }).await;
+    assert_eventually!(|| fixture.log.events(99, "config") == ["started"]).await;
     fixture.gate.release();
     let startup = system
         .wait_started()

--- a/crates/shelterwood/tests/acceptance/sidecar.rs
+++ b/crates/shelterwood/tests/acceptance/sidecar.rs
@@ -1,6 +1,6 @@
 use std::{future, time::Duration};
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, policy::never, poll_until};
+use crate::common::{ReleaseGate, policy::never};
 use shelterwood::{
     Actor, ActorOnceDef, ChildState, Context, ExitError, ExitKind, ExitResult, GracePhase,
     Readiness, ReadinessDeadline, Shutdown, StartOrShutdownError, StopContext, SubtreeOnceDef,
@@ -190,12 +190,9 @@ async fn sidecar_runs_two_host_owned_cycles_with_readiness_and_policy_exact_shut
         let fixture = sidecar(cycle, journal.clone());
         let system = fixture.tree.spawn().expect("runtime is available");
         let scope = system.scope();
-        assert!(
-            poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+        crate::common::assert_eventually!(|| {
                 log.events(cycle, "config") == ["started"]
-            })
-            .await
-        );
+            }).await;
         let parked = scope.snapshot();
         assert!(matches!(
             parked.child("config").expect("config child").state,
@@ -305,12 +302,9 @@ async fn sidecar_startup_failure_leaves_prefix_supervised_until_host_rolls_it_ba
     let mut fixture = failing_sidecar();
     let system = fixture.tree.spawn().expect("runtime is available");
     let scope = system.scope();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             fixture.log.events(99, "config") == ["started"]
-        })
-        .await
-    );
+        }).await;
     fixture.gate.release();
     let startup = system
         .wait_started()

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::common::{
-    POLL_TIMEOUT, ReleaseGate, assert_quiet, waiting::task as waiting_task,
+    POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet, waiting::task as waiting_task,
 };
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, ChildState, Context, DynamicTree, ExitError, ExitKind,
@@ -344,12 +344,13 @@ async fn restartable_and_dynamic_actor_definition_surfaces_work() {
         )
         .await
         .expect("dynamic actor admitted");
-    crate::common::assert_eventually!(|| {
-            dynamic_events
-                .lock()
-                .expect("events mutex poisoned")
-                .contains(&"init")
-        }).await;
+    assert_eventually!(|| {
+        dynamic_events
+            .lock()
+            .expect("events mutex poisoned")
+            .contains(&"init")
+    })
+    .await;
     actor
         .send(BasicMessage::Stop)
         .await
@@ -476,9 +477,7 @@ async fn handler_error_joins_offloads_before_returning_to_a_raw_decorator() {
         .send(OffloadThenFailMessage::Start)
         .await
         .expect("actor live");
-    crate::common::assert_eventually!(|| {
-            log.lock().expect("teardown log mutex poisoned").len() == 2
-        }).await;
+    assert_eventually!(|| log.lock().expect("teardown log mutex poisoned").len() == 2).await;
     assert_eq!(
         *log.lock().expect("teardown log mutex poisoned"),
         ["offload-destroyed", "decorator-resumed"]

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -6,7 +6,9 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until};
+use crate::common::{
+    POLL_TIMEOUT, ReleaseGate, assert_quiet, waiting::task as waiting_task,
+};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, ChildState, Context, DynamicTree, ExitError, ExitKind,
     ExitResult, Handler, Mailbox, RawActor, RawContext, RawOnceDef, Readiness, Retention, ScopeRef,
@@ -342,15 +344,12 @@ async fn restartable_and_dynamic_actor_definition_surfaces_work() {
         )
         .await
         .expect("dynamic actor admitted");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             dynamic_events
                 .lock()
                 .expect("events mutex poisoned")
                 .contains(&"init")
-        })
-        .await
-    );
+        }).await;
     actor
         .send(BasicMessage::Stop)
         .await
@@ -477,12 +476,9 @@ async fn handler_error_joins_offloads_before_returning_to_a_raw_decorator() {
         .send(OffloadThenFailMessage::Start)
         .await
         .expect("actor live");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             log.lock().expect("teardown log mutex poisoned").len() == 2
-        })
-        .await
-    );
+        }).await;
     assert_eq!(
         *log.lock().expect("teardown log mutex poisoned"),
         ["offload-destroyed", "decorator-resumed"]
@@ -493,23 +489,6 @@ async fn handler_error_joins_offloads_before_returning_to_a_raw_decorator() {
         .expect("tree shuts down");
 }
 
-struct InertActor;
-
-impl Actor for InertActor {
-    type Msg = ();
-    type Args = ReleaseGate;
-
-    async fn init(entered: ReleaseGate, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
-        entered.release();
-        Ok(Self)
-    }
-
-    async fn handle(&mut self, (): Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
-        context.mark_ready();
-        Ok(())
-    }
-}
-
 #[tokio::test(start_paused = true)]
 async fn manual_readiness_override_on_a_wrapped_handler_stays_gated() {
     let init_entered = ReleaseGate::default();
@@ -517,7 +496,7 @@ async fn manual_readiness_override_on_a_wrapped_handler_stays_gated() {
     let actor = tree
         .add_raw_once(
             "gated",
-            RawOnceDef::new(Handler::<InertActor>::new(init_entered.clone()))
+            RawOnceDef::new(Handler::<ManualActor>::new(init_entered.clone()))
                 .readiness(Readiness::Manual)
                 .expect("manual readiness override"),
         )
@@ -686,10 +665,7 @@ async fn handler_context_scope_shutdown_request_stops_the_tree() {
         .expect("valid actor");
     tree.add_task(
         "parked",
-        TaskDef::new(|context| async move {
-            context.shutdown_token().cancelled().await;
-            Ok(())
-        }),
+        waiting_task(),
     )
     .expect("valid parked task");
     let system = tree.spawn().expect("runtime is available");
@@ -732,10 +708,7 @@ async fn stop_context_scope_shutdown_request_escalates_a_local_stop() {
         .expect("valid actor");
     tree.add_task(
         "parked",
-        TaskDef::new(|context| async move {
-            context.shutdown_token().cancelled().await;
-            Ok(())
-        }),
+        waiting_task(),
     )
     .expect("valid parked task");
     let system = tree.spawn().expect("runtime is available");

--- a/crates/shelterwood/tests/common/mod.rs
+++ b/crates/shelterwood/tests/common/mod.rs
@@ -15,13 +15,13 @@ pub(crate) use timing::{
 
 macro_rules! assert_eventually {
     ($predicate:expr $(,)?) => {
-        $crate::common::assert_eventually_predicate(stringify!($predicate), $predicate, None)
+        $crate::common::assert_eventually_predicate(stringify!($predicate), $predicate, || None)
     };
     ($predicate:expr, $($context:tt)+) => {
         $crate::common::assert_eventually_predicate(
             stringify!($predicate),
             $predicate,
-            Some(format!($($context)+)),
+            || Some(format!($($context)+)),
         )
     };
 }

--- a/crates/shelterwood/tests/common/mod.rs
+++ b/crates/shelterwood/tests/common/mod.rs
@@ -9,4 +9,21 @@ register_test_modules!(
 
 pub(crate) use gates::{DestructorBlocker, DestructorGate, ReleaseGate};
 pub(crate) use ownership::{ConsumeCount, ConsumeGuard, LiveFlag, PanicOnDrop};
-pub(crate) use timing::{POLL_TIMEOUT, advance_time, assert_quiet, poll_once, poll_until};
+pub(crate) use timing::{
+    POLL_TIMEOUT, advance_time, assert_eventually_predicate, assert_quiet, poll_once, poll_until,
+};
+
+macro_rules! assert_eventually {
+    ($predicate:expr $(,)?) => {
+        $crate::common::assert_eventually_predicate(stringify!($predicate), $predicate, None)
+    };
+    ($predicate:expr, $($context:tt)+) => {
+        $crate::common::assert_eventually_predicate(
+            stringify!($predicate),
+            $predicate,
+            Some(format!($($context)+)),
+        )
+    };
+}
+
+pub(crate) use assert_eventually;

--- a/crates/shelterwood/tests/common/timing.rs
+++ b/crates/shelterwood/tests/common/timing.rs
@@ -45,14 +45,14 @@ pub(crate) async fn poll_until(
 pub(crate) fn assert_eventually_predicate(
     expression: &'static str,
     predicate: impl FnMut() -> bool,
-    context: Option<String>,
+    context: impl FnOnce() -> Option<String>,
 ) -> impl Future<Output = ()> {
     let caller = Location::caller();
     async move {
         if poll_until(POLL_TIMEOUT, POLL_INTERVAL, predicate).await {
             return;
         }
-        match context {
+        match context() {
             Some(context) => panic!(
                 "predicate `{expression}` did not become true within {POLL_TIMEOUT:?} at {caller}: {context}"
             ),
@@ -79,7 +79,7 @@ pub(crate) async fn assert_quiet(duration: Duration, mut predicate: impl FnMut()
 
 #[cfg(test)]
 mod tests {
-    use std::{future, task::Poll, time::Duration};
+    use std::{cell::Cell, future, task::Poll, time::Duration};
 
     use super::{assert_quiet, poll_once};
 
@@ -97,5 +97,18 @@ mod tests {
         assert_quiet(duration, || false).await;
 
         assert_eq!(tokio::time::Instant::now() - started_at, duration);
+    }
+
+    #[tokio::test]
+    async fn eventual_assertion_context_is_evaluated_only_on_failure() {
+        let evaluated = Cell::new(false);
+
+        crate::common::assert_eventually!(|| true, "{}", {
+            evaluated.set(true);
+            "unexpected context evaluation"
+        })
+        .await;
+
+        assert!(!evaluated.get());
     }
 }

--- a/crates/shelterwood/tests/common/timing.rs
+++ b/crates/shelterwood/tests/common/timing.rs
@@ -1,5 +1,6 @@
 use std::{
     future::Future,
+    panic::Location,
     pin::Pin,
     task::{Context, Poll, Waker},
     time::Duration,
@@ -7,6 +8,8 @@ use std::{
 
 /// Shared wall-clock budget for eventually-consistent test observations.
 pub(crate) const POLL_TIMEOUT: Duration = Duration::from_secs(5);
+
+const POLL_INTERVAL: Duration = Duration::from_millis(1);
 
 /// Polls a pinned future once with a no-op waker.
 pub(crate) fn poll_once<F: Future>(future: Pin<&mut F>) -> Poll<F::Output> {
@@ -37,11 +40,32 @@ pub(crate) async fn poll_until(
     .is_ok()
 }
 
+/// Waits for an eventually-consistent predicate and reports its source text.
+#[track_caller]
+pub(crate) fn assert_eventually_predicate(
+    expression: &'static str,
+    predicate: impl FnMut() -> bool,
+    context: Option<String>,
+) -> impl Future<Output = ()> {
+    let caller = Location::caller();
+    async move {
+        if poll_until(POLL_TIMEOUT, POLL_INTERVAL, predicate).await {
+            return;
+        }
+        match context {
+            Some(context) => panic!(
+                "predicate `{expression}` did not become true within {POLL_TIMEOUT:?} at {caller}: {context}"
+            ),
+            None => panic!(
+                "predicate `{expression}` did not become true within {POLL_TIMEOUT:?} at {caller}"
+            ),
+        }
+    }
+}
+
 /// Asserts that a predicate is false at 1 ms samples across a bounded quiet
 /// window; it does not observe continuous truth between samples.
 pub(crate) async fn assert_quiet(duration: Duration, mut predicate: impl FnMut() -> bool) {
-    const POLL_INTERVAL: Duration = Duration::from_millis(1);
-
     let deadline = tokio::time::Instant::now() + duration;
     loop {
         assert!(!predicate(), "quiet-window predicate became true");

--- a/crates/shelterwood/tests/common/waiting.rs
+++ b/crates/shelterwood/tests/common/waiting.rs
@@ -3,7 +3,37 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
-use shelterwood::{TaskDef, Tree};
+use shelterwood::{CancellationToken, Readiness, TaskDef, Tree};
+
+pub(crate) async fn liveness_probe(
+    shutdown: CancellationToken,
+    gate: super::ReleaseGate,
+) -> bool {
+    tokio::select! {
+        biased;
+        () = shutdown.cancelled() => false,
+        () = gate.wait() => true,
+    }
+}
+
+pub(crate) fn gate_released_manual_ready_task(
+    gate: super::ReleaseGate,
+    on_start: impl Fn() + Clone + Send + Sync + 'static,
+) -> TaskDef {
+    TaskDef::new(move |context| {
+        let gate = gate.clone();
+        let on_start = on_start.clone();
+        async move {
+            on_start();
+            gate.wait().await;
+            context.mark_ready();
+            context.shutdown_token().cancelled().await;
+            Ok(())
+        }
+    })
+    .readiness(Readiness::Manual)
+    .expect("manual readiness is supported for tasks")
+}
 
 pub(crate) fn task() -> TaskDef {
     TaskDef::new(|context| async move {
@@ -48,17 +78,11 @@ pub(crate) fn liveness_probed_waiting_task(
         let liveness_seen = Arc::clone(&liveness_seen);
         async move {
             started.store(true, Ordering::SeqCst);
-            let shutdown = context.shutdown_token();
-            tokio::select! {
-                biased;
-                () = shutdown.cancelled() => {
-                    cancelled.store(true, Ordering::SeqCst);
-                    return Ok(());
-                }
-                () = liveness_gate.wait() => {
-                    liveness_seen.store(true, Ordering::SeqCst);
-                }
+            if !liveness_probe(context.shutdown_token(), liveness_gate).await {
+                cancelled.store(true, Ordering::SeqCst);
+                return Ok(());
             }
+            liveness_seen.store(true, Ordering::SeqCst);
             context.shutdown_token().cancelled().await;
             cancelled.store(true, Ordering::SeqCst);
             Ok(())

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::common::{
-    ReleaseGate, advance_time, assert_quiet, poll_once,
+    ReleaseGate, advance_time, assert_eventually, assert_quiet, poll_once,
     waiting::task as waiting_task,
 };
 use shelterwood::{
@@ -203,16 +203,12 @@ async fn acceptance_winning_the_deadline_withdrawal_race_succeeds() {
 
     advance_time(deadline).await;
     gate.release();
-    crate::common::assert_eventually!(|| {
-            values.lock().expect("values mutex poisoned").contains(&1)
-        }).await;
+    assert_eventually!(|| values.lock().expect("values mutex poisoned").contains(&1)).await;
     assert!(
         matches!(poll_once(timed.as_mut()), Poll::Ready(Ok(value)) if value == accepting),
         "acceptance is checked before successful withdrawal at the boundary"
     );
-    crate::common::assert_eventually!(|| {
-            values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
-        }).await;
+    assert_eventually!(|| values.lock().expect("values mutex poisoned").as_slice() == [1, 2]).await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -241,9 +237,7 @@ async fn call_promotion_winning_the_deadline_race_reports_response_timeout() {
 
     advance_time(deadline).await;
     gate.release();
-    crate::common::assert_eventually!(|| {
-            calls.load(Ordering::SeqCst) == 1
-        }).await;
+    assert_eventually!(|| calls.load(Ordering::SeqCst) == 1).await;
     let Poll::Ready(Err(error)) = poll_once(call.as_mut()) else {
         panic!("promotion must win before deadline withdrawal");
     };
@@ -299,9 +293,7 @@ async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction
     assert!(!constructed.load(Ordering::SeqCst));
 
     gate.release();
-    crate::common::assert_eventually!(|| {
-            values.lock().expect("values mutex poisoned").as_slice() == [1]
-        }).await;
+    assert_eventually!(|| values.lock().expect("values mutex poisoned").as_slice() == [1]).await;
     assert_quiet(Duration::from_millis(20), || {
         values.lock().expect("values mutex poisoned").contains(&2)
             || calls.load(Ordering::SeqCst) != 0
@@ -555,11 +547,12 @@ async fn overflowing_restart_delay_has_no_substitute_and_never_restarts() {
 
     // SPEC B.6: an exact deadline too distant for the runtime clock to
     // represent and arm has no substitute, and therefore never fires.
-    crate::common::assert_eventually!(|| {
-            system.scope().child("restart").is_some_and(|child| {
-                matches!(child.state, ChildState::Restarting) && child.restart_at.is_none()
-            })
-        }).await;
+    assert_eventually!(|| {
+        system.scope().child("restart").is_some_and(|child| {
+            matches!(child.state, ChildState::Restarting) && child.restart_at.is_none()
+        })
+    })
+    .await;
     assert_quiet(Duration::from_secs(1), || {
         starts.load(Ordering::SeqCst) != 1
     })

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -7,7 +7,10 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
+use crate::common::{
+    ReleaseGate, advance_time, assert_quiet, poll_once,
+    waiting::task as waiting_task,
+};
 use shelterwood::{
     Backoff, CallErrorKind, ChildState, ExitError, ExitResult, Jitter, Mailbox, RawActor,
     RawContext, RawOnceDef, Readiness, ReadinessDeadline, Reply, ReplyError, RestartCondition,
@@ -200,22 +203,16 @@ async fn acceptance_winning_the_deadline_withdrawal_race_succeeds() {
 
     advance_time(deadline).await;
     gate.release();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             values.lock().expect("values mutex poisoned").contains(&1)
-        })
-        .await
-    );
+        }).await;
     assert!(
         matches!(poll_once(timed.as_mut()), Poll::Ready(Ok(value)) if value == accepting),
         "acceptance is checked before successful withdrawal at the boundary"
     );
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
-        })
-        .await
-    );
+        }).await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -244,12 +241,9 @@ async fn call_promotion_winning_the_deadline_race_reports_response_timeout() {
 
     advance_time(deadline).await;
     gate.release();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             calls.load(Ordering::SeqCst) == 1
-        })
-        .await
-    );
+        }).await;
     let Poll::Ready(Err(error)) = poll_once(call.as_mut()) else {
         panic!("promotion must win before deadline withdrawal");
     };
@@ -305,12 +299,9 @@ async fn zero_deadlines_short_circuit_without_acceptance_or_message_construction
     assert!(!constructed.load(Ordering::SeqCst));
 
     gate.release();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             values.lock().expect("values mutex poisoned").as_slice() == [1]
-        })
-        .await
-    );
+        }).await;
     assert_quiet(Duration::from_millis(20), || {
         values.lock().expect("values mutex poisoned").contains(&2)
             || calls.load(Ordering::SeqCst) != 0
@@ -564,14 +555,11 @@ async fn overflowing_restart_delay_has_no_substitute_and_never_restarts() {
 
     // SPEC B.6: an exact deadline too distant for the runtime clock to
     // represent and arm has no substitute, and therefore never fires.
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             system.scope().child("restart").is_some_and(|child| {
                 matches!(child.state, ChildState::Restarting) && child.restart_at.is_none()
             })
-        })
-        .await
-    );
+        }).await;
     assert_quiet(Duration::from_secs(1), || {
         starts.load(Ordering::SeqCst) != 1
     })
@@ -588,10 +576,7 @@ async fn zero_duration_wait_observes_an_already_satisfied_child() {
     let mut tree = Tree::new();
     tree.add_task(
         "ready",
-        TaskDef::new(|context| async move {
-            context.shutdown_token().cancelled().await;
-            Ok(())
-        }),
+        waiting_task(),
     )
     .expect("valid task");
     let system = tree.spawn().expect("runtime is available");

--- a/crates/shelterwood/tests/defaults.rs
+++ b/crates/shelterwood/tests/defaults.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once};
 use shelterwood::{
     Actor, ActorDef, Backoff, Context, DynamicTree, ExitError, ExitKind, ExitResult, GracePhase,
     MailboxShutdown, RawActor, RawContext, RawOnceDef, Readiness, RestartCount, Retention,
@@ -119,13 +119,9 @@ async fn default_child_shutdown_grace_is_five_seconds() {
             .saturating_duration_since(tokio::time::Instant::now()),
     )
     .await;
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             poll_once(shutdown.as_mut()).is_ready()
-        })
-        .await,
-        "grace elapses at 5s and the abort ladder completes"
-    );
+        }, "grace elapses at 5s and the abort ladder completes").await;
     drop(shutdown);
 
     let exit = task.wait().await;
@@ -277,13 +273,9 @@ async fn default_restart_backoff_and_retention_follow_definition_ownership() {
         .expect("one-shot task is admitted");
     completion.wait().await.expect("one-shot task completes");
     one_shot.wait().await;
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             scope.as_scope().child("one-shot").is_none()
-        })
-        .await,
-        "the default one-shot retention removes the terminal membership"
-    );
+        }, "the default one-shot retention removes the terminal membership").await;
 
     system
         .shutdown(Duration::from_secs(1))

--- a/crates/shelterwood/tests/defaults.rs
+++ b/crates/shelterwood/tests/defaults.rs
@@ -10,7 +10,9 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once};
+use crate::common::{
+    POLL_TIMEOUT, ReleaseGate, advance_time, assert_eventually, assert_quiet, poll_once,
+};
 use shelterwood::{
     Actor, ActorDef, Backoff, Context, DynamicTree, ExitError, ExitKind, ExitResult, GracePhase,
     MailboxShutdown, RawActor, RawContext, RawOnceDef, Readiness, RestartCount, Retention,
@@ -119,9 +121,11 @@ async fn default_child_shutdown_grace_is_five_seconds() {
             .saturating_duration_since(tokio::time::Instant::now()),
     )
     .await;
-    crate::common::assert_eventually!(|| {
-            poll_once(shutdown.as_mut()).is_ready()
-        }, "grace elapses at 5s and the abort ladder completes").await;
+    assert_eventually!(
+        || poll_once(shutdown.as_mut()).is_ready(),
+        "grace elapses at 5s and the abort ladder completes"
+    )
+    .await;
     drop(shutdown);
 
     let exit = task.wait().await;
@@ -273,9 +277,11 @@ async fn default_restart_backoff_and_retention_follow_definition_ownership() {
         .expect("one-shot task is admitted");
     completion.wait().await.expect("one-shot task completes");
     one_shot.wait().await;
-    crate::common::assert_eventually!(|| {
-            scope.as_scope().child("one-shot").is_none()
-        }, "the default one-shot retention removes the terminal membership").await;
+    assert_eventually!(
+        || scope.as_scope().child("one-shot").is_none(),
+        "the default one-shot retention removes the terminal membership"
+    )
+    .await;
 
     system
         .shutdown(Duration::from_secs(1))

--- a/crates/shelterwood/tests/delivery.rs
+++ b/crates/shelterwood/tests/delivery.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, poll_once};
+use crate::common::{ReleaseGate, assert_eventually, poll_once};
 use shelterwood::{
     CallErrorKind, ExitError, ExitResult, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Reply,
     SendErrorKind, Shutdown, SubtreeOnceDef, Tree,
@@ -70,16 +70,15 @@ async fn accepted_but_undelivered_prefix_never_crosses_an_incarnation() {
     actor.try_send(2).expect("remainder accepts");
     actor.try_send(3).expect("remainder accepts");
     gate.release();
-    crate::common::assert_eventually!(|| {
-            generation.load(Ordering::SeqCst) == 2
-        }).await;
+    assert_eventually!(|| generation.load(Ordering::SeqCst) == 2).await;
     actor
         .send(4)
         .await
         .expect("fresh message reaches replacement");
-    crate::common::assert_eventually!(|| {
-            log.lock().expect("prefix log mutex poisoned").as_slice() == [(1, 1), (2, 4)]
-        }).await;
+    assert_eventually!(|| {
+        log.lock().expect("prefix log mutex poisoned").as_slice() == [(1, 1), (2, 4)]
+    })
+    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -237,9 +236,7 @@ async fn queue_preserves_per_sender_fifo_under_interleaved_senders() {
     sender_a.await.expect("sender a joins");
     sender_b.await.expect("sender b joins");
     gate.release();
-    crate::common::assert_eventually!(|| {
-            log.lock().expect("order log mutex poisoned").len() == 4
-        }).await;
+    assert_eventually!(|| log.lock().expect("order log mutex poisoned").len() == 4).await;
     let log = log.lock().expect("order log mutex poisoned").clone();
     let a: Vec<_> = log
         .iter()
@@ -351,15 +348,17 @@ async fn send_cancellation_withdraws_before_acceptance_but_not_after() {
     assert!(poll_once(before.as_mut()).is_pending());
     drop(before);
     gate.release();
-    crate::common::assert_eventually!(|| {
-            log.lock().expect("send log mutex poisoned").as_slice() == [(2, 1)]
-        }).await;
+    assert_eventually!(|| {
+        log.lock().expect("send log mutex poisoned").as_slice() == [(2, 1)]
+    })
+    .await;
     let mut after = Box::pin(actor.send(3));
     assert!(matches!(poll_once(after.as_mut()), Poll::Ready(Ok(_))));
     drop(after);
-    crate::common::assert_eventually!(|| {
-            log.lock().expect("send log mutex poisoned").as_slice() == [(2, 1), (2, 3)]
-        }).await;
+    assert_eventually!(|| {
+        log.lock().expect("send log mutex poisoned").as_slice() == [(2, 1), (2, 3)]
+    })
+    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -406,9 +405,7 @@ async fn call_cancellation_withdraws_before_acceptance_but_processes_after() {
         gate.release();
         let expected = usize::from(accepted_before_drop);
         if accepted_before_drop {
-            crate::common::assert_eventually!(|| {
-                    calls.load(Ordering::SeqCst) == expected
-                }).await;
+            assert_eventually!(|| calls.load(Ordering::SeqCst) == expected).await;
         }
         system
             .shutdown(Duration::from_secs(1))

--- a/crates/shelterwood/tests/delivery.rs
+++ b/crates/shelterwood/tests/delivery.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, poll_once, poll_until};
+use crate::common::{ReleaseGate, poll_once};
 use shelterwood::{
     CallErrorKind, ExitError, ExitResult, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Reply,
     SendErrorKind, Shutdown, SubtreeOnceDef, Tree,
@@ -70,22 +70,16 @@ async fn accepted_but_undelivered_prefix_never_crosses_an_incarnation() {
     actor.try_send(2).expect("remainder accepts");
     actor.try_send(3).expect("remainder accepts");
     gate.release();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             generation.load(Ordering::SeqCst) == 2
-        })
-        .await
-    );
+        }).await;
     actor
         .send(4)
         .await
         .expect("fresh message reaches replacement");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             log.lock().expect("prefix log mutex poisoned").as_slice() == [(1, 1), (2, 4)]
-        })
-        .await
-    );
+        }).await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -243,12 +237,9 @@ async fn queue_preserves_per_sender_fifo_under_interleaved_senders() {
     sender_a.await.expect("sender a joins");
     sender_b.await.expect("sender b joins");
     gate.release();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             log.lock().expect("order log mutex poisoned").len() == 4
-        })
-        .await
-    );
+        }).await;
     let log = log.lock().expect("order log mutex poisoned").clone();
     let a: Vec<_> = log
         .iter()
@@ -360,21 +351,15 @@ async fn send_cancellation_withdraws_before_acceptance_but_not_after() {
     assert!(poll_once(before.as_mut()).is_pending());
     drop(before);
     gate.release();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             log.lock().expect("send log mutex poisoned").as_slice() == [(2, 1)]
-        })
-        .await
-    );
+        }).await;
     let mut after = Box::pin(actor.send(3));
     assert!(matches!(poll_once(after.as_mut()), Poll::Ready(Ok(_))));
     drop(after);
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             log.lock().expect("send log mutex poisoned").as_slice() == [(2, 1), (2, 3)]
-        })
-        .await
-    );
+        }).await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -421,12 +406,9 @@ async fn call_cancellation_withdraws_before_acceptance_but_processes_after() {
         gate.release();
         let expected = usize::from(accepted_before_drop);
         if accepted_before_drop {
-            assert!(
-                poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+            crate::common::assert_eventually!(|| {
                     calls.load(Ordering::SeqCst) == expected
-                })
-                .await
-            );
+                }).await;
         }
         system
             .shutdown(Duration::from_secs(1))

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -11,7 +11,8 @@ use std::{
 };
 
 use crate::common::{
-    DestructorBlocker, DestructorGate, POLL_TIMEOUT, PanicOnDrop, ReleaseGate, policy::never,
+    DestructorBlocker, DestructorGate, POLL_TIMEOUT, PanicOnDrop, ReleaseGate, assert_eventually,
+    policy::never,
 };
 use shelterwood::{
     Backoff, CallErrorKind, Cancellation, ChildState, DynamicTree, ExitError, ExitKind, ExitResult,
@@ -258,9 +259,11 @@ async fn panicking_unread_messages_are_all_disposed_without_reclassifying_the_ac
         .shutdown(Duration::from_secs(1))
         .await
         .expect("payload panics do not unwind the scope driver");
-    crate::common::assert_eventually!(|| {
-            drops.load(Ordering::SeqCst) == 2
-        }, "one payload panic must not strand the remaining unread messages").await;
+    assert_eventually!(
+        || drops.load(Ordering::SeqCst) == 2,
+        "one payload panic must not strand the remaining unread messages"
+    )
+    .await;
     let exit = loop {
         let Some(item) = lifecycle.recv().await else {
             panic!("actor exit was not published")

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -173,7 +173,13 @@ async fn assert_disposed_off_current(
     drops: &mut tokio::sync::mpsc::UnboundedReceiver<ThreadId>,
     description: &str,
 ) {
-    assert_disposed_off(drops, thread::current().id(), description).await;
+    let actual = drops
+        .recv()
+        .await
+        .unwrap_or_else(|| panic!("{description}"));
+    // The test task may migrate while `recv` is pending, so sample its worker
+    // only after the disposal report wakes it.
+    assert_ne!(actual, thread::current().id(), "{description}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -12,7 +12,6 @@ use std::{
 
 use crate::common::{
     DestructorBlocker, DestructorGate, POLL_TIMEOUT, PanicOnDrop, ReleaseGate, policy::never,
-    poll_until,
 };
 use shelterwood::{
     Backoff, CallErrorKind, Cancellation, ChildState, DynamicTree, ExitError, ExitKind, ExitResult,
@@ -158,6 +157,25 @@ async fn poll_pending<F: Future>(future: &mut std::pin::Pin<Box<F>>) {
     .await;
 }
 
+async fn assert_disposed_off(
+    drops: &mut tokio::sync::mpsc::UnboundedReceiver<ThreadId>,
+    forbidden: ThreadId,
+    description: &str,
+) {
+    let actual = drops
+        .recv()
+        .await
+        .unwrap_or_else(|| panic!("{description}"));
+    assert_ne!(actual, forbidden, "{description}");
+}
+
+async fn assert_disposed_off_current(
+    drops: &mut tokio::sync::mpsc::UnboundedReceiver<ThreadId>,
+    description: &str,
+) {
+    assert_disposed_off(drops, thread::current().id(), description).await;
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn blocking_unread_message_does_not_hold_bounded_shutdown() {
     let gate = DestructorGate::default();
@@ -177,7 +195,7 @@ async fn blocking_unread_message_does_not_hold_bounded_shutdown() {
 
     let mut shutdown = tokio::spawn(system.shutdown(Duration::from_secs(1)));
     wait_for_destructor(&gate).await;
-    let bounded = tokio::time::timeout(Duration::from_secs(1), &mut shutdown).await;
+    let bounded = tokio::time::timeout(POLL_TIMEOUT, &mut shutdown).await;
     gate.release();
     let result = match bounded {
         Ok(joined) => joined.expect("shutdown task joins"),
@@ -234,13 +252,9 @@ async fn panicking_unread_messages_are_all_disposed_without_reclassifying_the_ac
         .shutdown(Duration::from_secs(1))
         .await
         .expect("payload panics do not unwind the scope driver");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             drops.load(Ordering::SeqCst) == 2
-        })
-        .await,
-        "one payload panic must not strand the remaining unread messages"
-    );
+        }, "one payload panic must not strand the remaining unread messages").await;
     let exit = loop {
         let Some(item) = lifecycle.recv().await else {
             panic!("actor exit was not published")
@@ -490,8 +504,7 @@ async fn non_runtime_reservation_cancellation_contains_destructor_panic() {
     let cancellation_thread = cancellation
         .join()
         .expect("cancellation outside a Tokio runtime must not panic");
-    let disposal_thread = drops.recv().await.expect("definition was disposed");
-    assert_ne!(disposal_thread, cancellation_thread);
+    assert_disposed_off(&mut drops, cancellation_thread, "definition was disposed").await;
     assert!(matches!(task.wait().await.kind(), ExitKind::NeverStarted));
     system
         .shutdown(Duration::from_secs(1))
@@ -599,11 +612,12 @@ async fn non_runtime_disposals_run_off_callers_and_contain_panics() {
         dropper_thread
     });
     let late_dropper_thread = late_dropper.join().expect("late cancellation never panics");
-    let late_disposal_thread = drops
-        .recv()
-        .await
-        .expect("disposal keeps running after a contained destructor panic");
-    assert_ne!(late_disposal_thread, late_dropper_thread);
+    assert_disposed_off(
+        &mut drops,
+        late_dropper_thread,
+        "disposal keeps running after a contained destructor panic",
+    )
+    .await;
 
     system
         .shutdown(Duration::from_secs(1))
@@ -630,13 +644,7 @@ async fn unadmitted_removal_completes_after_blocking_definition_disposal() {
     }));
     let mut removal = Box::pin(scope.remove_task(&task));
     wait_for_destructor(&gate).await;
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("definition disposal reports its thread"),
-        thread::current().id()
-    );
+    assert_disposed_off_current(&mut drops, "definition disposal reports its thread").await;
     assert!(matches!(task.wait().await.kind(), ExitKind::NeverStarted));
     poll_pending(&mut removal).await;
     gate.release();
@@ -688,13 +696,7 @@ async fn restart_window_removal_joins_factory_disposal_before_terminality() {
     let mut removal = Box::pin(scope.remove_task(&task));
     poll_pending(&mut removal).await;
     wait_for_destructor(&gate).await;
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("factory disposal reports its thread"),
-        thread::current().id()
-    );
+    assert_disposed_off_current(&mut drops, "factory disposal reports its thread").await;
     poll_pending(&mut removal).await;
     let mut terminal = Box::pin(task.wait());
     poll_pending(&mut terminal).await;
@@ -728,7 +730,7 @@ async fn unadmitted_removal_completes_when_the_panic_payload_destructor_panics()
     }));
 
     assert_eq!(
-        tokio::time::timeout(Duration::from_secs(1), scope.remove_task(&task))
+        tokio::time::timeout(POLL_TIMEOUT, scope.remove_task(&task))
             .await
             .expect("panic payload disposal publishes removal completion"),
         RemoveOutcome::Removed
@@ -835,14 +837,8 @@ async fn zero_shutdown_reports_the_live_child_but_detaches_blocking_factory_disp
 
     let mut shutdown = tokio::spawn(system.shutdown(Duration::ZERO));
     wait_for_destructor(&gate).await;
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("factory disposal reports its thread"),
-        thread::current().id()
-    );
-    let bounded = tokio::time::timeout(Duration::from_secs(1), &mut shutdown).await;
+    assert_disposed_off_current(&mut drops, "factory disposal reports its thread").await;
+    let bounded = tokio::time::timeout(POLL_TIMEOUT, &mut shutdown).await;
     gate.release();
     let result = bounded
         .expect("hard escalation is not held by factory disposal")
@@ -884,14 +880,8 @@ async fn startup_rollback_detaches_never_started_one_shot_state_after_escalation
     let system = tree.spawn().expect("runtime is available");
     let mut rollback = tokio::spawn(system.start_or_shutdown(Duration::ZERO));
     wait_for_destructor(&gate).await;
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("one-shot state reports its thread"),
-        thread::current().id()
-    );
-    let bounded = tokio::time::timeout(Duration::from_secs(1), &mut rollback).await;
+    assert_disposed_off_current(&mut drops, "one-shot state reports its thread").await;
+    let bounded = tokio::time::timeout(POLL_TIMEOUT, &mut rollback).await;
     gate.release();
     let result = bounded
         .expect("rollback escalation is not held by one-shot state")
@@ -937,13 +927,7 @@ async fn startup_rollback_joins_never_started_disposal_before_terminality() {
     let mut rollback = Box::pin(system.start_or_shutdown(Duration::from_secs(5)));
     poll_pending(&mut rollback).await;
     wait_for_destructor(&gate).await;
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("one-shot state reports its thread"),
-        thread::current().id()
-    );
+    assert_disposed_off_current(&mut drops, "one-shot state reports its thread").await;
     poll_pending(&mut rollback).await;
     let mut terminal = Box::pin(completion.wait());
     poll_pending(&mut terminal).await;
@@ -983,15 +967,9 @@ async fn hard_shutdown_detaches_failed_nested_lowering_disposal() {
 
     let system = tree.spawn().expect("runtime is available");
     wait_for_destructor(&gate).await;
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("failed definition disposal reports its thread"),
-        thread::current().id()
-    );
+    assert_disposed_off_current(&mut drops, "failed definition disposal reports its thread").await;
     let mut shutdown = tokio::spawn(system.shutdown(Duration::ZERO));
-    let bounded = tokio::time::timeout(Duration::from_secs(1), &mut shutdown).await;
+    let bounded = tokio::time::timeout(POLL_TIMEOUT, &mut shutdown).await;
     gate.release();
     let result = bounded
         .expect("hard shutdown is not held by failed lowering disposal")
@@ -1037,13 +1015,7 @@ async fn restart_window_cleanup_is_isolated_without_reclassifying_the_recorded_e
         .shutdown(Duration::ZERO)
         .await
         .expect("restart-window cleanup does not become a shutdown straggler");
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("restart-window factory was disposed"),
-        thread::current().id()
-    );
+    assert_disposed_off_current(&mut drops, "restart-window factory was disposed").await;
     assert!(matches!(
         task.wait().await.kind(),
         ExitKind::Failed(error) if error.to_string() == "restart me"
@@ -1066,17 +1038,11 @@ async fn abandoned_one_shot_completion_disposes_blocking_value_off_the_task() {
 
     let system = tree.spawn().expect("runtime is available");
     wait_for_destructor(&gate).await;
-    let bounded = tokio::time::timeout(Duration::from_secs(1), task.wait()).await;
+    let bounded = tokio::time::timeout(POLL_TIMEOUT, task.wait()).await;
     gate.release();
     let exit = bounded.expect("a blocked abandoned-claim disposal must not hang the task");
     assert!(matches!(exit.kind(), ExitKind::Completed));
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("abandoned result reports its disposal thread"),
-        thread::current().id()
-    );
+    assert_disposed_off_current(&mut drops, "abandoned result reports its disposal thread").await;
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
 }
 
@@ -1099,13 +1065,7 @@ async fn abandoned_one_shot_completion_keeps_completed_verdict_through_destructo
         matches!(exit.kind(), ExitKind::Completed),
         "an abandoned claim's destructor panic must not reclassify the task: {exit:?}"
     );
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("abandoned result reports its disposal thread"),
-        thread::current().id()
-    );
+    assert_disposed_off_current(&mut drops, "abandoned result reports its disposal thread").await;
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
 }
 
@@ -1131,12 +1091,12 @@ async fn duplicate_id_rejection_disposes_blocking_definition_off_the_caller() {
     assert!(matches!(error, ReserveError::DuplicateId(id) if id.as_str() == "dup"));
 
     wait_for_destructor(&gate).await;
-    let disposal_thread = drops
-        .recv()
-        .await
-        .expect("rejected definition reports its disposal thread");
+    assert_disposed_off_current(
+        &mut drops,
+        "rejected definition reports its disposal thread",
+    )
+    .await;
     gate.release();
-    assert_ne!(disposal_thread, thread::current().id());
 }
 
 struct HostileCapture {
@@ -1166,13 +1126,7 @@ async fn duplicate_id_rejection_contains_definition_destructor_panic() {
         )
         .expect_err("duplicate id is rejected without unwinding the caller");
     assert!(matches!(error, ReserveError::DuplicateId(id) if id.as_str() == "dup"));
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("rejected definition reports its disposal thread"),
-        thread::current().id()
-    );
+    assert_disposed_off_current(&mut drops, "rejected definition reports its disposal thread").await;
 }
 
 #[tokio::test]
@@ -1193,13 +1147,7 @@ async fn dynamic_duplicate_rejection_disposes_definition_before_admission() {
             }
         }),
     );
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("rejected definition reports its disposal thread"),
-        thread::current().id()
-    );
+    assert_disposed_off_current(&mut drops, "rejected definition reports its disposal thread").await;
     let error = admission.await.expect_err("duplicate id is rejected");
     assert!(matches!(error, ReserveError::DuplicateId(id) if id.as_str() == "dup"));
     system
@@ -1227,12 +1175,8 @@ async fn cancelled_send_disposes_blocking_message_off_the_caller() {
     };
 
     wait_for_destructor(&gate).await;
-    let disposal_thread = drops
-        .recv()
-        .await
-        .expect("withdrawn message reports its disposal thread");
+    assert_disposed_off_current(&mut drops, "withdrawn message reports its disposal thread").await;
     gate.release();
-    assert_ne!(disposal_thread, thread::current().id());
     drop(tree);
 }
 
@@ -1247,13 +1191,7 @@ async fn cancelled_send_contains_message_destructor_panic() {
         Box::pin(actor.send(DropProbe::panicking(dropped, "cancelled send destructor")));
     poll_pending(&mut pending).await;
     drop(pending);
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("withdrawn message reports its disposal thread"),
-        thread::current().id()
-    );
+    assert_disposed_off_current(&mut drops, "withdrawn message reports its disposal thread").await;
 }
 
 struct ReplyThenPark {
@@ -1307,12 +1245,8 @@ async fn cancelled_call_disposes_stored_reply_off_the_caller() {
     replied.wait().await;
     drop(call);
     wait_for_destructor(&gate).await;
-    let disposal_thread = drops
-        .recv()
-        .await
-        .expect("stored reply reports its disposal thread");
+    assert_disposed_off_current(&mut drops, "stored reply reports its disposal thread").await;
     gate.release();
-    assert_ne!(disposal_thread, thread::current().id());
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -1325,13 +1259,7 @@ async fn dropped_reply_receiver_disposes_stored_value_through_isolated_disposal(
     let (reply, receiver) = Reply::<DropProbe>::channel();
     reply.send(DropProbe::panicking(dropped, "unclaimed reply destructor"));
     drop(receiver);
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("stored reply reports its disposal thread"),
-        thread::current().id()
-    );
+    assert_disposed_off_current(&mut drops, "stored reply reports its disposal thread").await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1352,12 +1280,12 @@ async fn unclaimed_completion_value_disposes_blocking_destructor_off_the_claim_h
     assert!(matches!(exit.kind(), ExitKind::Completed));
     drop(completion);
     wait_for_destructor(&gate).await;
-    let disposal_thread = drops
-        .recv()
-        .await
-        .expect("unclaimed completion reports its disposal thread");
+    assert_disposed_off_current(
+        &mut drops,
+        "unclaimed completion reports its disposal thread",
+    )
+    .await;
     gate.release();
-    assert_ne!(disposal_thread, thread::current().id());
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
 }
 
@@ -1377,13 +1305,7 @@ async fn unclaimed_completion_value_contains_destructor_panic() {
     let exit = task.wait().await;
     assert!(matches!(exit.kind(), ExitKind::Completed));
     drop(completion);
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("unclaimed completion reports its disposal thread"),
-        thread::current().id()
-    );
+    assert_disposed_off_current(&mut drops, "unclaimed completion reports its disposal thread").await;
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
 }
 
@@ -1433,13 +1355,7 @@ async fn terminated_call_disposes_recovered_message_off_the_caller() {
         .await
         .expect_err("terminated actor rejects the call");
     assert!(matches!(error.kind, CallErrorKind::Terminated));
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("recovered message reports its disposal thread"),
-        thread::current().id()
-    );
+    assert_disposed_off_current(&mut drops, "recovered message reports its disposal thread").await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1467,12 +1383,8 @@ async fn acceptance_timed_out_call_disposes_recovered_message_off_the_caller() {
         .expect_err("unbound mailbox never accepts within the deadline");
     assert!(matches!(error.kind, CallErrorKind::AcceptanceTimedOut));
     wait_for_destructor(&gate).await;
-    let disposal_thread = drops
-        .recv()
-        .await
-        .expect("recovered message reports its disposal thread");
+    assert_disposed_off_current(&mut drops, "recovered message reports its disposal thread").await;
     gate.release();
-    assert_ne!(disposal_thread, thread::current().id());
     drop(tree);
 }
 
@@ -1514,11 +1426,12 @@ async fn overdue_call_construction_disposes_message_off_constructor_task_and_con
         .recv()
         .await
         .expect("constructor reports its thread");
-    let disposal_thread = drops
-        .recv()
-        .await
-        .expect("overdue message destructor runs despite its contained panic");
-    assert_ne!(disposal_thread, construction_thread);
+    assert_disposed_off(
+        &mut drops,
+        construction_thread,
+        "overdue message destructor runs despite its contained panic",
+    )
+    .await;
     drop(tree);
 }
 
@@ -1538,13 +1451,7 @@ async fn dropped_unstarted_call_disposes_constructor_off_the_caller() {
         Duration::from_secs(1),
     );
     drop(call);
-    assert_ne!(
-        drops
-            .recv()
-            .await
-            .expect("unstarted constructor reports its disposal thread"),
-        thread::current().id()
-    );
+    assert_disposed_off_current(&mut drops, "unstarted constructor reports its disposal thread").await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1555,12 +1462,8 @@ async fn late_reply_send_disposes_unclaimed_value_off_the_sender() {
     drop(receiver);
     reply.send(BlockingDropProbe::new(&gate, dropped));
     wait_for_destructor(&gate).await;
-    let disposal_thread = drops
-        .recv()
-        .await
-        .expect("late reply reports its disposal thread");
+    assert_disposed_off_current(&mut drops, "late reply reports its disposal thread").await;
     gate.release();
-    assert_ne!(disposal_thread, thread::current().id());
 }
 
 struct OffloadPanic {

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until};
+use crate::common::{ReleaseGate, assert_quiet, poll_until};
 use shelterwood::{
     Actor, ActorOnceDef, Cancellation, Context, Exit, ExitError, ExitKind, ExitResult, GracePhase,
     LifecycleEventKind, LifecycleEvents, LifecycleItem, Mailbox, MailboxShutdown, SendErrorKind,
@@ -142,12 +142,9 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
     system.wait_started().await.expect("actor starts");
 
     let accepting_incarnation = actor.send(Message::Stop).await.expect("stop accepted");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             stop_entered.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     actor
         .send(Message::Value(1))
         .await
@@ -158,12 +155,9 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
         .expect("prefix accepted");
     allow_stop.release();
 
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             drain_entered.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     let rejection = actor
         .try_send(Message::Value(3))
         .expect_err("frozen intake rejects fail-fast sends");

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, assert_quiet, poll_until};
+use crate::common::{ReleaseGate, assert_eventually, assert_quiet, poll_until};
 use shelterwood::{
     Actor, ActorOnceDef, Cancellation, Context, Exit, ExitError, ExitKind, ExitResult, GracePhase,
     LifecycleEventKind, LifecycleEvents, LifecycleItem, Mailbox, MailboxShutdown, SendErrorKind,
@@ -142,9 +142,7 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
     system.wait_started().await.expect("actor starts");
 
     let accepting_incarnation = actor.send(Message::Stop).await.expect("stop accepted");
-    crate::common::assert_eventually!(|| {
-            stop_entered.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| stop_entered.load(Ordering::SeqCst)).await;
     actor
         .send(Message::Value(1))
         .await
@@ -155,9 +153,7 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
         .expect("prefix accepted");
     allow_stop.release();
 
-    crate::common::assert_eventually!(|| {
-            drain_entered.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| drain_entered.load(Ordering::SeqCst)).await;
     let rejection = actor
         .try_send(Message::Value(3))
         .expect_err("frozen intake rejects fail-fast sends");

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -7,9 +7,8 @@ use std::{
 };
 
 use crate::common::{
-    POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet,
-    policy::never,
-    poll_once, poll_until,
+    POLL_TIMEOUT, ReleaseGate, advance_time, assert_eventually, assert_quiet, policy::never,
+    poll_once,
     waiting::{
         liveness_probe, liveness_probed_waiting_task, signalled_waiting_task, task as waiting_task,
         tree as waiting_tree,
@@ -38,9 +37,11 @@ use shelterwood::{
 /// transaction. An absent resident is therefore a sound signal that the id
 /// is free again.
 async fn wait_for_id_release(scope: &DynamicScopeRef, id: &str) {
-    crate::common::assert_eventually!(|| {
-            scope.as_scope().child(id).is_none()
-        }, "removal of {id} did not release its id").await;
+    assert_eventually!(
+        || scope.as_scope().child(id).is_none(),
+        "removal of {id} did not release its id"
+    )
+    .await;
 }
 
 struct DropProbe(Arc<AtomicBool>);
@@ -170,9 +171,11 @@ fn signalled_waiting_tree(
 
 async fn assert_positive_liveness(gate: &ReleaseGate, observed: &Arc<AtomicBool>) {
     gate.release();
-    crate::common::assert_eventually!(|| {
-            observed.load(Ordering::SeqCst)
-        }, "the detached child must execute work released after its admission future was dropped").await;
+    assert_eventually!(
+        || observed.load(Ordering::SeqCst),
+        "the detached child must execute work released after its admission future was dropped"
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -354,12 +357,16 @@ async fn task_raw_and_subtree_admissions_resolve_before_manual_startup() {
     .expect("subtree is admitted");
 
     for id in ["gated-task", "gated-raw", "gated-subtree"] {
-        crate::common::assert_eventually!(|| {
+        assert_eventually!(
+            || {
                 scope
                     .as_scope()
                     .child(id)
                     .is_some_and(|child| matches!(child.state, ChildState::Starting))
-            }, "{id} remains admitted but startup-gated").await;
+            },
+            "{id} remains admitted but startup-gated"
+        )
+        .await;
     }
     assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
     assert_eq!(scope.remove_actor(&raw).await, RemoveOutcome::Removed);
@@ -666,9 +673,7 @@ async fn removal_is_synchronous_detached_and_shared() {
         Err(ReserveError::RemovalInProgress(ref id)) if id.as_str() == "worker"
     ));
     drop(first);
-    crate::common::assert_eventually!(|| {
-            cancelled.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| cancelled.load(Ordering::SeqCst)).await;
     gate.release();
     assert_eq!(second.await, RemoveOutcome::Removed);
     let replacement = scope
@@ -839,9 +844,11 @@ async fn select_and_timeout_preserve_fused_and_split_admission_ownership() {
             .await
             .is_err()
     );
-    crate::common::assert_eventually!(|| {
-            split_started.load(Ordering::SeqCst)
-        }, "timing out a polled split admission detaches the running child").await;
+    assert_eventually!(
+        || split_started.load(Ordering::SeqCst),
+        "timing out a polled split admission detaches the running child"
+    )
+    .await;
     assert!(matches!(
         scope.reserve_task("split-timeout"),
         Err(ReserveError::DuplicateId(_))
@@ -880,13 +887,9 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
         signalled_waiting_task(Arc::clone(&fused_started), Arc::clone(&fused_cancelled)),
     ));
     assert!(poll_once(fused.as_mut()).is_pending());
-    crate::common::assert_eventually!(|| {
-            fused_started.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| fused_started.load(Ordering::SeqCst)).await;
     drop(fused);
-    crate::common::assert_eventually!(|| {
-            fused_cancelled.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| fused_cancelled.load(Ordering::SeqCst)).await;
     wait_for_id_release(&scope, "fused-after-admission").await;
     let reused = scope
         .add_task("fused-after-admission", waiting_task())
@@ -908,9 +911,7 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
     )));
     assert!(poll_once(split.as_mut()).is_pending());
     drop(split);
-    crate::common::assert_eventually!(|| {
-            split_started.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| split_started.load(Ordering::SeqCst)).await;
     assert_quiet(Duration::from_millis(20), || {
         split_cancelled.load(Ordering::SeqCst)
     })
@@ -933,9 +934,7 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
         Arc::clone(&split_after_liveness_seen),
     )));
     assert!(poll_once(split_after.as_mut()).is_pending());
-    crate::common::assert_eventually!(|| {
-            split_after_started.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| split_after_started.load(Ordering::SeqCst)).await;
     drop(split_after);
     assert_quiet(Duration::from_millis(20), || {
         split_after_cancelled.load(Ordering::SeqCst)
@@ -973,13 +972,9 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
         }),
     ));
     assert!(poll_once(fused_actor.as_mut()).is_pending());
-    crate::common::assert_eventually!(|| {
-            actor_started.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| actor_started.load(Ordering::SeqCst)).await;
     drop(fused_actor);
-    crate::common::assert_eventually!(|| {
-            actor_cancelled.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| actor_cancelled.load(Ordering::SeqCst)).await;
     wait_for_id_release(&scope, "fused-actor").await;
     let actor = scope
         .add_raw("fused-actor", RawDef::factory(|| WaitingRaw))
@@ -998,13 +993,9 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
         )),
     ));
     assert!(poll_once(fused_subtree.as_mut()).is_pending());
-    crate::common::assert_eventually!(|| {
-            subtree_started.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| subtree_started.load(Ordering::SeqCst)).await;
     drop(fused_subtree);
-    crate::common::assert_eventually!(|| {
-            subtree_cancelled.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| subtree_cancelled.load(Ordering::SeqCst)).await;
     wait_for_id_release(&scope, "fused-subtree").await;
     let subtree = scope
         .add_subtree_once("fused-subtree", SubtreeOnceDef::new(waiting_tree()))
@@ -1029,9 +1020,7 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
         )),
     })));
     assert!(poll_once(split_actor.as_mut()).is_pending());
-    crate::common::assert_eventually!(|| {
-            actor_started.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| actor_started.load(Ordering::SeqCst)).await;
     drop(split_actor);
     assert_quiet(Duration::from_millis(20), || {
         actor_cancelled.load(Ordering::SeqCst)
@@ -1059,9 +1048,7 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
             )),
         ))));
     assert!(poll_once(split_subtree.as_mut()).is_pending());
-    crate::common::assert_eventually!(|| {
-            subtree_started.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| subtree_started.load(Ordering::SeqCst)).await;
     drop(split_subtree);
     assert_quiet(Duration::from_millis(20), || {
         subtree_cancelled.load(Ordering::SeqCst)
@@ -1102,9 +1089,7 @@ async fn removing_a_member_releases_its_factory_before_scope_shutdown() {
         )
         .await
         .expect("task admitted");
-    crate::common::assert_eventually!(|| {
-            started.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| started.load(Ordering::SeqCst)).await;
 
     assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
     assert!(factory_dropped.load(Ordering::SeqCst));
@@ -1297,9 +1282,7 @@ async fn dynamic_scope_rejects_reservations_between_incarnations() {
     let scope = root.add_subtree("dynamic", subtree).expect("valid subtree");
     let system = root.spawn().expect("runtime is available");
 
-    crate::common::assert_eventually!(|| {
-            first_started.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| first_started.load(Ordering::SeqCst)).await;
     system
         .scope()
         .wait_for_child(
@@ -1386,9 +1369,7 @@ fn pending_restart_subtree(
 }
 
 async fn await_first_restart_window(root: &ScopeRef, starts: &Arc<AtomicUsize>) {
-    crate::common::assert_eventually!(|| {
-            starts.load(Ordering::SeqCst) == 1
-        }).await;
+    assert_eventually!(|| starts.load(Ordering::SeqCst) == 1).await;
     root.wait_for_child(
         "nested",
         |child| matches!(child.state, ChildState::Restarting),
@@ -1488,13 +1469,11 @@ async fn assert_pending_restart_shutdown_is_expedited<R: Clone>(
     // never reaches a *later* incarnation only re-measures the quiet interior
     // of the window it already observed.
     advance_time(width + Duration::from_secs(1)).await;
-    assert!(
-        poll_until(Duration::from_secs(5), Duration::from_millis(1), || {
-            starts.load(Ordering::SeqCst) >= 3
-        })
-        .await,
+    assert_eventually!(
+        || starts.load(Ordering::SeqCst) >= 3,
         "a consumed pending request must not suppress the ordinary backoff restart"
-    );
+    )
+    .await;
     assert_eq!(
         starts.load(Ordering::SeqCst),
         3,
@@ -1581,9 +1560,7 @@ async fn draining_scopes_reject_admission_and_treat_removal_as_absent() {
     system.wait_started().await.expect("root starts");
     let scope = system.scope();
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(2)));
-    crate::common::assert_eventually!(|| {
-            cancelled.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| cancelled.load(Ordering::SeqCst)).await;
     assert!(matches!(
         scope.add_task("late", waiting_task()).await,
         Err(ReserveError::NotAdmitting(NotAdmittingCause::Draining))
@@ -1811,9 +1788,11 @@ async fn startup_failed_roots_reject_reservation_and_admission_with_startup_fail
         .wait_started()
         .await
         .expect_err("pre-ready terminal exit aborts startup");
-    crate::common::assert_eventually!(|| {
-            matches!(scope.as_scope().snapshot().state, ScopeState::StartupFailed)
-        }, "the root publishes StartupFailed while the started prefix remains supervised").await;
+    assert_eventually!(
+        || matches!(scope.as_scope().snapshot().state, ScopeState::StartupFailed),
+        "the root publishes StartupFailed while the started prefix remains supervised"
+    )
+    .await;
 
     assert!(matches!(
         scope.reserve_task("late"),

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -11,7 +11,7 @@ use crate::common::{
     policy::never,
     poll_once, poll_until,
     waiting::{
-        liveness_probed_waiting_task, signalled_waiting_task, task as waiting_task,
+        liveness_probe, liveness_probed_waiting_task, signalled_waiting_task, task as waiting_task,
         tree as waiting_tree,
     },
 };
@@ -38,13 +38,9 @@ use shelterwood::{
 /// transaction. An absent resident is therefore a sound signal that the id
 /// is free again.
 async fn wait_for_id_release(scope: &DynamicScopeRef, id: &str) {
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             scope.as_scope().child(id).is_none()
-        })
-        .await,
-        "removal of {id} did not release its id"
-    );
+        }, "removal of {id} did not release its id").await;
 }
 
 struct DropProbe(Arc<AtomicBool>);
@@ -132,15 +128,11 @@ impl RawActor for SignalledWaitingRaw {
     async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
         self.started.store(true, Ordering::SeqCst);
         if let Some((gate, observed)) = &self.liveness {
-            let shutdown = context.shutdown_token();
-            tokio::select! {
-                biased;
-                () = shutdown.cancelled() => {
-                    self.cancelled.store(true, Ordering::SeqCst);
-                    return Ok(());
-                }
-                () = gate.wait() => observed.store(true, Ordering::SeqCst),
+            if !liveness_probe(context.shutdown_token(), gate.clone()).await {
+                self.cancelled.store(true, Ordering::SeqCst);
+                return Ok(());
             }
+            observed.store(true, Ordering::SeqCst);
         }
         context.shutdown_token().cancelled().await;
         self.cancelled.store(true, Ordering::SeqCst);
@@ -160,15 +152,11 @@ fn signalled_waiting_tree(
             TaskOnceDef::new(move |context| async move {
                 started.store(true, Ordering::SeqCst);
                 if let Some((gate, observed)) = liveness {
-                    let shutdown = context.shutdown_token();
-                    tokio::select! {
-                        biased;
-                        () = shutdown.cancelled() => {
-                            cancelled.store(true, Ordering::SeqCst);
-                            return Ok::<_, ExitError>(());
-                        }
-                        () = gate.wait() => observed.store(true, Ordering::SeqCst),
+                    if !liveness_probe(context.shutdown_token(), gate).await {
+                        cancelled.store(true, Ordering::SeqCst);
+                        return Ok::<_, ExitError>(());
                     }
+                    observed.store(true, Ordering::SeqCst);
                 }
                 context.shutdown_token().cancelled().await;
                 cancelled.store(true, Ordering::SeqCst);
@@ -182,13 +170,9 @@ fn signalled_waiting_tree(
 
 async fn assert_positive_liveness(gate: &ReleaseGate, observed: &Arc<AtomicBool>) {
     gate.release();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             observed.load(Ordering::SeqCst)
-        })
-        .await,
-        "the detached child must execute work released after its admission future was dropped"
-    );
+        }, "the detached child must execute work released after its admission future was dropped").await;
 }
 
 #[tokio::test]
@@ -370,16 +354,12 @@ async fn task_raw_and_subtree_admissions_resolve_before_manual_startup() {
     .expect("subtree is admitted");
 
     for id in ["gated-task", "gated-raw", "gated-subtree"] {
-        assert!(
-            poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+        crate::common::assert_eventually!(|| {
                 scope
                     .as_scope()
                     .child(id)
                     .is_some_and(|child| matches!(child.state, ChildState::Starting))
-            })
-            .await,
-            "{id} remains admitted but startup-gated"
-        );
+            }, "{id} remains admitted but startup-gated").await;
     }
     assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
     assert_eq!(scope.remove_actor(&raw).await, RemoveOutcome::Removed);
@@ -590,7 +570,7 @@ async fn exact_scope_removal_does_not_touch_a_same_id_successor() {
         .await
         .expect("first subtree admitted");
     assert_eq!(
-        tokio::time::timeout(Duration::from_secs(1), root.remove_scope(&first))
+        tokio::time::timeout(POLL_TIMEOUT, root.remove_scope(&first))
             .await
             .expect("first subtree removal completes"),
         RemoveOutcome::Removed
@@ -606,7 +586,7 @@ async fn exact_scope_removal_does_not_touch_a_same_id_successor() {
         RemoveOutcome::AlreadyAbsent
     );
     assert_eq!(
-        tokio::time::timeout(Duration::from_secs(1), root.remove_scope(&second))
+        tokio::time::timeout(POLL_TIMEOUT, root.remove_scope(&second))
             .await
             .expect("second subtree removal completes"),
         RemoveOutcome::Removed
@@ -686,12 +666,9 @@ async fn removal_is_synchronous_detached_and_shared() {
         Err(ReserveError::RemovalInProgress(ref id)) if id.as_str() == "worker"
     ));
     drop(first);
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             cancelled.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     gate.release();
     assert_eq!(second.await, RemoveOutcome::Removed);
     let replacement = scope
@@ -862,13 +839,9 @@ async fn select_and_timeout_preserve_fused_and_split_admission_ownership() {
             .await
             .is_err()
     );
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             split_started.load(Ordering::SeqCst)
-        })
-        .await,
-        "timing out a polled split admission detaches the running child"
-    );
+        }, "timing out a polled split admission detaches the running child").await;
     assert!(matches!(
         scope.reserve_task("split-timeout"),
         Err(ReserveError::DuplicateId(_))
@@ -907,19 +880,13 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
         signalled_waiting_task(Arc::clone(&fused_started), Arc::clone(&fused_cancelled)),
     ));
     assert!(poll_once(fused.as_mut()).is_pending());
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             fused_started.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     drop(fused);
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             fused_cancelled.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     wait_for_id_release(&scope, "fused-after-admission").await;
     let reused = scope
         .add_task("fused-after-admission", waiting_task())
@@ -941,12 +908,9 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
     )));
     assert!(poll_once(split.as_mut()).is_pending());
     drop(split);
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             split_started.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     assert_quiet(Duration::from_millis(20), || {
         split_cancelled.load(Ordering::SeqCst)
     })
@@ -969,12 +933,9 @@ async fn fused_drop_withdraws_or_removes_while_split_drop_detaches() {
         Arc::clone(&split_after_liveness_seen),
     )));
     assert!(poll_once(split_after.as_mut()).is_pending());
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             split_after_started.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     drop(split_after);
     assert_quiet(Duration::from_millis(20), || {
         split_after_cancelled.load(Ordering::SeqCst)
@@ -1012,19 +973,13 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
         }),
     ));
     assert!(poll_once(fused_actor.as_mut()).is_pending());
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             actor_started.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     drop(fused_actor);
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             actor_cancelled.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     wait_for_id_release(&scope, "fused-actor").await;
     let actor = scope
         .add_raw("fused-actor", RawDef::factory(|| WaitingRaw))
@@ -1043,19 +998,13 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
         )),
     ));
     assert!(poll_once(fused_subtree.as_mut()).is_pending());
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             subtree_started.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     drop(fused_subtree);
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             subtree_cancelled.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     wait_for_id_release(&scope, "fused-subtree").await;
     let subtree = scope
         .add_subtree_once("fused-subtree", SubtreeOnceDef::new(waiting_tree()))
@@ -1080,12 +1029,9 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
         )),
     })));
     assert!(poll_once(split_actor.as_mut()).is_pending());
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             actor_started.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     drop(split_actor);
     assert_quiet(Duration::from_millis(20), || {
         actor_cancelled.load(Ordering::SeqCst)
@@ -1113,12 +1059,9 @@ async fn actor_and_subtree_slots_preserve_fused_and_split_drop_ownership() {
             )),
         ))));
     assert!(poll_once(split_subtree.as_mut()).is_pending());
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             subtree_started.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     drop(split_subtree);
     assert_quiet(Duration::from_millis(20), || {
         subtree_cancelled.load(Ordering::SeqCst)
@@ -1159,12 +1102,9 @@ async fn removing_a_member_releases_its_factory_before_scope_shutdown() {
         )
         .await
         .expect("task admitted");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             started.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
 
     assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
     assert!(factory_dropped.load(Ordering::SeqCst));
@@ -1357,12 +1297,9 @@ async fn dynamic_scope_rejects_reservations_between_incarnations() {
     let scope = root.add_subtree("dynamic", subtree).expect("valid subtree");
     let system = root.spawn().expect("runtime is available");
 
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             first_started.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     system
         .scope()
         .wait_for_child(
@@ -1449,12 +1386,9 @@ fn pending_restart_subtree(
 }
 
 async fn await_first_restart_window(root: &ScopeRef, starts: &Arc<AtomicUsize>) {
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             starts.load(Ordering::SeqCst) == 1
-        })
-        .await
-    );
+        }).await;
     root.wait_for_child(
         "nested",
         |child| matches!(child.state, ChildState::Restarting),
@@ -1609,7 +1543,7 @@ async fn same_batch_removal_suppresses_pending_restart_shutdown() {
     let removal = system.scope().remove_scope(&nested);
     nested.request_shutdown();
     assert_eq!(
-        tokio::time::timeout(Duration::from_secs(1), removal)
+        tokio::time::timeout(POLL_TIMEOUT, removal)
             .await
             .expect("removal does not wait for restart backoff"),
         RemoveOutcome::Removed
@@ -1647,12 +1581,9 @@ async fn draining_scopes_reject_admission_and_treat_removal_as_absent() {
     system.wait_started().await.expect("root starts");
     let scope = system.scope();
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(2)));
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             cancelled.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     assert!(matches!(
         scope.add_task("late", waiting_task()).await,
         Err(ReserveError::NotAdmitting(NotAdmittingCause::Draining))
@@ -1880,13 +1811,9 @@ async fn startup_failed_roots_reject_reservation_and_admission_with_startup_fail
         .wait_started()
         .await
         .expect_err("pre-ready terminal exit aborts startup");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             matches!(scope.as_scope().snapshot().state, ScopeState::StartupFailed)
-        })
-        .await,
-        "the root publishes StartupFailed while the started prefix remains supervised"
-    );
+        }, "the root publishes StartupFailed while the started prefix remains supervised").await;
 
     assert!(matches!(
         scope.reserve_task("late"),

--- a/crates/shelterwood/tests/lifecycle.rs
+++ b/crates/shelterwood/tests/lifecycle.rs
@@ -10,7 +10,8 @@ use std::{
 };
 
 use crate::common::{
-    POLL_TIMEOUT, ReleaseGate, assert_quiet, policy::never, poll_once, poll_until,
+    POLL_TIMEOUT, ReleaseGate, assert_quiet, policy::never, poll_once,
+    waiting::task as waiting_task,
 };
 use shelterwood::{
     Actor, ActorOnceDef, Cancellation, Context, DynamicTree, ExitError, ExitKind, ExitResult,
@@ -74,14 +75,11 @@ async fn fire_and_forget_owner_drop_still_tears_down() {
     let task = tree
         .add_task(
             "worker",
-            TaskDef::new(|context| async move {
-                context.shutdown_token().cancelled().await;
-                Ok(())
-            }),
+            waiting_task(),
         )
         .expect("valid task");
     drop(tree.spawn().expect("runtime is available"));
-    let exit = tokio::time::timeout(Duration::from_secs(1), task.wait())
+    let exit = tokio::time::timeout(POLL_TIMEOUT, task.wait())
         .await
         .expect("owner drop completes teardown");
     assert!(matches!(exit.kind(), ExitKind::Completed));
@@ -287,12 +285,9 @@ async fn replacement_starts_only_after_the_old_future_is_destroyed() {
         .wait_started()
         .await
         .expect("initial incarnation starts");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             starts.load(Ordering::SeqCst) >= 2
-        })
-        .await
-    );
+        }).await;
     assert_eq!(
         *order.lock().expect("order mutex poisoned"),
         ["start-1", "drop-1", "start-2"]
@@ -333,30 +328,21 @@ async fn ordered_teardown_is_reverse_and_joins_before_advancing() {
     system.wait_started().await.expect("tree starts");
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(2)));
 
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             order.lock().expect("order mutex poisoned").as_slice() == [2]
-        })
-        .await
-    );
+        }).await;
     assert_quiet(Duration::from_millis(15), || {
         order.lock().expect("order mutex poisoned").len() > 1
     })
     .await;
     gates[2].release();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             order.lock().expect("order mutex poisoned").as_slice() == [2, 1]
-        })
-        .await
-    );
+        }).await;
     gates[1].release();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             order.lock().expect("order mutex poisoned").as_slice() == [2, 1, 0]
-        })
-        .await
-    );
+        }).await;
     gates[0].release();
     shutdown
         .await
@@ -567,12 +553,9 @@ async fn dynamic_teardown_cancels_children_concurrently() {
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("tree starts");
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(2)));
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             cancelled.iter().all(|flag| flag.load(Ordering::SeqCst))
-        })
-        .await
-    );
+        }).await;
     gate.release();
     gate.release();
     shutdown

--- a/crates/shelterwood/tests/lifecycle.rs
+++ b/crates/shelterwood/tests/lifecycle.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use crate::common::{
-    POLL_TIMEOUT, ReleaseGate, assert_quiet, policy::never, poll_once,
+    POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet, policy::never, poll_once,
     waiting::task as waiting_task,
 };
 use shelterwood::{
@@ -285,9 +285,7 @@ async fn replacement_starts_only_after_the_old_future_is_destroyed() {
         .wait_started()
         .await
         .expect("initial incarnation starts");
-    crate::common::assert_eventually!(|| {
-            starts.load(Ordering::SeqCst) >= 2
-        }).await;
+    assert_eventually!(|| starts.load(Ordering::SeqCst) >= 2).await;
     assert_eq!(
         *order.lock().expect("order mutex poisoned"),
         ["start-1", "drop-1", "start-2"]
@@ -328,21 +326,18 @@ async fn ordered_teardown_is_reverse_and_joins_before_advancing() {
     system.wait_started().await.expect("tree starts");
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(2)));
 
-    crate::common::assert_eventually!(|| {
-            order.lock().expect("order mutex poisoned").as_slice() == [2]
-        }).await;
+    assert_eventually!(|| order.lock().expect("order mutex poisoned").as_slice() == [2]).await;
     assert_quiet(Duration::from_millis(15), || {
         order.lock().expect("order mutex poisoned").len() > 1
     })
     .await;
     gates[2].release();
-    crate::common::assert_eventually!(|| {
-            order.lock().expect("order mutex poisoned").as_slice() == [2, 1]
-        }).await;
+    assert_eventually!(|| order.lock().expect("order mutex poisoned").as_slice() == [2, 1]).await;
     gates[1].release();
-    crate::common::assert_eventually!(|| {
-            order.lock().expect("order mutex poisoned").as_slice() == [2, 1, 0]
-        }).await;
+    assert_eventually!(|| {
+        order.lock().expect("order mutex poisoned").as_slice() == [2, 1, 0]
+    })
+    .await;
     gates[0].release();
     shutdown
         .await
@@ -553,9 +548,7 @@ async fn dynamic_teardown_cancels_children_concurrently() {
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("tree starts");
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(2)));
-    crate::common::assert_eventually!(|| {
-            cancelled.iter().all(|flag| flag.load(Ordering::SeqCst))
-        }).await;
+    assert_eventually!(|| cancelled.iter().all(|flag| flag.load(Ordering::SeqCst))).await;
     gate.release();
     gate.release();
     shutdown

--- a/crates/shelterwood/tests/mailbox.rs
+++ b/crates/shelterwood/tests/mailbox.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, advance_time, assert_quiet, poll_once};
+use crate::common::{ReleaseGate, advance_time, assert_eventually, assert_quiet, poll_once};
 use shelterwood::{
     CallErrorKind, ExitResult, Mailbox, MailboxShutdown, PolicyError, RawActor, RawContext, RawDef,
     Reply, ReplyError, SendErrorKind, Tree,
@@ -147,9 +147,7 @@ async fn queue_backpressure_and_send_error_identity_are_exact() {
             .expect("send accepts"),
         accepting
     );
-    crate::common::assert_eventually!(|| {
-            values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
-        }).await;
+    assert_eventually!(|| values.lock().expect("values mutex poisoned").as_slice() == [1, 2]).await;
 
     system
         .shutdown(Duration::from_secs(1))
@@ -188,9 +186,7 @@ async fn latest_mailbox_keeps_only_the_newest_accepted_value() {
     actor.try_send(Message::Value(2)).expect("replace one");
     actor.try_send(Message::Value(3)).expect("replace two");
     gate.release();
-    crate::common::assert_eventually!(|| {
-            values.lock().expect("values mutex poisoned").as_slice() == [3]
-        }).await;
+    assert_eventually!(|| values.lock().expect("values mutex poisoned").as_slice() == [3]).await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -238,16 +234,12 @@ async fn timed_send_withdraws_and_recovers_the_message() {
     assert!(poll_once(cancelled.as_mut()).is_pending());
     drop(cancelled);
     gate.release();
-    crate::common::assert_eventually!(|| {
-            values.lock().expect("values mutex poisoned").as_slice() == [1]
-        }).await;
+    assert_eventually!(|| values.lock().expect("values mutex poisoned").as_slice() == [1]).await;
     actor
         .send(error.message)
         .await
         .expect("recovered message is safe to resend");
-    crate::common::assert_eventually!(|| {
-            values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
-        }).await;
+    assert_eventually!(|| values.lock().expect("values mutex poisoned").as_slice() == [1, 2]).await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -288,9 +280,7 @@ async fn call_distinguishes_success_drop_and_response_timeout() {
             tokio::spawn(
                 async move { call_actor.call(|reply| Message::Ask(7, reply), width).await },
             );
-        crate::common::assert_eventually!(|| {
-                asks.load(Ordering::SeqCst) == 1
-            }).await;
+        assert_eventually!(|| asks.load(Ordering::SeqCst) == 1).await;
         if mode == ReplyMode::Hold {
             advance_time(width).await;
         }

--- a/crates/shelterwood/tests/mailbox.rs
+++ b/crates/shelterwood/tests/mailbox.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
+use crate::common::{ReleaseGate, advance_time, assert_quiet, poll_once};
 use shelterwood::{
     CallErrorKind, ExitResult, Mailbox, MailboxShutdown, PolicyError, RawActor, RawContext, RawDef,
     Reply, ReplyError, SendErrorKind, Tree,
@@ -147,12 +147,9 @@ async fn queue_backpressure_and_send_error_identity_are_exact() {
             .expect("send accepts"),
         accepting
     );
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
-        })
-        .await
-    );
+        }).await;
 
     system
         .shutdown(Duration::from_secs(1))
@@ -191,12 +188,9 @@ async fn latest_mailbox_keeps_only_the_newest_accepted_value() {
     actor.try_send(Message::Value(2)).expect("replace one");
     actor.try_send(Message::Value(3)).expect("replace two");
     gate.release();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             values.lock().expect("values mutex poisoned").as_slice() == [3]
-        })
-        .await
-    );
+        }).await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -244,22 +238,16 @@ async fn timed_send_withdraws_and_recovers_the_message() {
     assert!(poll_once(cancelled.as_mut()).is_pending());
     drop(cancelled);
     gate.release();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             values.lock().expect("values mutex poisoned").as_slice() == [1]
-        })
-        .await
-    );
+        }).await;
     actor
         .send(error.message)
         .await
         .expect("recovered message is safe to resend");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             values.lock().expect("values mutex poisoned").as_slice() == [1, 2]
-        })
-        .await
-    );
+        }).await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -300,12 +288,9 @@ async fn call_distinguishes_success_drop_and_response_timeout() {
             tokio::spawn(
                 async move { call_actor.call(|reply| Message::Ask(7, reply), width).await },
             );
-        assert!(
-            poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+        crate::common::assert_eventually!(|| {
                 asks.load(Ordering::SeqCst) == 1
-            })
-            .await
-        );
+            }).await;
         if mode == ReplyMode::Hold {
             advance_time(width).await;
         }

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -8,8 +8,10 @@ use std::{
 };
 
 use crate::common::{
-    POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_once, poll_until,
-    waiting::{task as waiting_task, tree as waiting_tree},
+    POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_once,
+    waiting::{
+        gate_released_manual_ready_task, task as waiting_task, tree as waiting_tree,
+    },
 };
 use shelterwood::{
     Backoff, ChildState, DynamicScopeRef, DynamicTree, Intensity, Jitter, LIFECYCLE_EVENT_CAPACITY,
@@ -196,15 +198,12 @@ async fn catch_up_watermarks_dedupe_initial_events_discard_stale_scopes_and_intr
         .add_subtree_once("nested", SubtreeOnceDef::new(waiting_tree()))
         .await
         .expect("subtree admitted");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             root.as_scope()
                 .snapshot()
                 .child("nested")
                 .is_some_and(|child| matches!(child.state, ChildState::Running))
-        })
-        .await
-    );
+        }).await;
 
     // Prescribed acquisition order: subscribe first, snapshot second. Every
     // item already queued is reflected by the recursive watermark.
@@ -292,15 +291,12 @@ async fn removed_is_the_pruning_edge_not_the_retained_terminal_edge() {
     drop(completion);
     let membership = task.membership();
     task.wait().await;
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             root.as_scope()
                 .snapshot()
                 .child("retained")
                 .is_some_and(|child| child.state.is_terminal())
-        })
-        .await
-    );
+        }).await;
 
     let mut saw_exit = false;
     let mut saw_restart = false;
@@ -363,15 +359,12 @@ async fn removed_is_the_pruning_edge_not_the_retained_terminal_edge() {
     drop(teardown_completion);
     let teardown_membership = teardown_task.membership();
     teardown_task.wait().await;
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             root.as_scope()
                 .snapshot()
                 .child("teardown-tombstone")
                 .is_some_and(|child| child.state.is_terminal())
-        })
-        .await
-    );
+        }).await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -584,14 +577,11 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
         }
     };
 
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             root.snapshot()
                 .child("nested")
                 .is_some_and(|child| matches!(child.state, ChildState::Restarting))
-        })
-        .await
-    );
+        }).await;
     let restart_window = root.snapshot();
     let child = restart_window
         .child("nested")
@@ -643,14 +633,11 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
     assert_eq!(nested.membership(), scope_membership);
     assert_eq!(nested.snapshot().total_restarts, TotalRestarts::ZERO);
     assert!(nested.snapshot().lifecycle_seq >= starting.seq);
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             root.snapshot().child("nested").is_some_and(|child| {
                 matches!(child.state, ChildState::Running) && child.restart_at.is_none()
             })
-        })
-        .await
-    );
+        }).await;
 
     system
         .shutdown(Duration::from_secs(1))
@@ -1004,7 +991,7 @@ async fn hard_aborted_scope_pairs_added_with_exited_and_removed() {
             "a stopped scope never shows a live incarnation: {child:?}"
         );
     }
-    let exit = tokio::time::timeout(Duration::from_secs(1), stuck.wait())
+    let exit = tokio::time::timeout(POLL_TIMEOUT, stuck.wait())
         .await
         .expect("hard-aborted descendants terminalize");
     assert!(matches!(exit.kind(), shelterwood::ExitKind::Aborted { .. }));
@@ -1121,20 +1108,7 @@ async fn wait_for_child_with_a_far_future_deadline_stays_pending() {
     let mut tree = Tree::new();
     tree.add_task(
         "gated",
-        TaskDef::new({
-            let gate = gate.clone();
-            move |context| {
-                let gate = gate.clone();
-                async move {
-                    gate.wait().await;
-                    context.mark_ready();
-                    context.shutdown_token().cancelled().await;
-                    Ok(())
-                }
-            }
-        })
-        .readiness(shelterwood::Readiness::Manual)
-        .expect("manual readiness"),
+        gate_released_manual_ready_task(gate.clone(), || {}),
     )
     .expect("valid task");
     let system = tree.spawn().expect("runtime is available");
@@ -1178,13 +1152,9 @@ async fn snapshot_subscriptions_conflate_unobserved_transitions_to_the_latest_va
         .await
         .expect("ephemeral task is admitted");
     task.wait().await;
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             scope.as_scope().child("ephemeral").is_none()
-        })
-        .await,
-        "terminal removal reaches the latest snapshot"
-    );
+        }, "terminal removal reaches the latest snapshot").await;
 
     let latest = snapshots
         .changed()

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -8,10 +8,8 @@ use std::{
 };
 
 use crate::common::{
-    POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_once,
-    waiting::{
-        gate_released_manual_ready_task, task as waiting_task, tree as waiting_tree,
-    },
+    POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet, poll_once,
+    waiting::{gate_released_manual_ready_task, task as waiting_task, tree as waiting_tree},
 };
 use shelterwood::{
     Backoff, ChildState, DynamicScopeRef, DynamicTree, Intensity, Jitter, LIFECYCLE_EVENT_CAPACITY,
@@ -198,12 +196,13 @@ async fn catch_up_watermarks_dedupe_initial_events_discard_stale_scopes_and_intr
         .add_subtree_once("nested", SubtreeOnceDef::new(waiting_tree()))
         .await
         .expect("subtree admitted");
-    crate::common::assert_eventually!(|| {
-            root.as_scope()
-                .snapshot()
-                .child("nested")
-                .is_some_and(|child| matches!(child.state, ChildState::Running))
-        }).await;
+    assert_eventually!(|| {
+        root.as_scope()
+            .snapshot()
+            .child("nested")
+            .is_some_and(|child| matches!(child.state, ChildState::Running))
+    })
+    .await;
 
     // Prescribed acquisition order: subscribe first, snapshot second. Every
     // item already queued is reflected by the recursive watermark.
@@ -291,12 +290,13 @@ async fn removed_is_the_pruning_edge_not_the_retained_terminal_edge() {
     drop(completion);
     let membership = task.membership();
     task.wait().await;
-    crate::common::assert_eventually!(|| {
-            root.as_scope()
-                .snapshot()
-                .child("retained")
-                .is_some_and(|child| child.state.is_terminal())
-        }).await;
+    assert_eventually!(|| {
+        root.as_scope()
+            .snapshot()
+            .child("retained")
+            .is_some_and(|child| child.state.is_terminal())
+    })
+    .await;
 
     let mut saw_exit = false;
     let mut saw_restart = false;
@@ -359,12 +359,13 @@ async fn removed_is_the_pruning_edge_not_the_retained_terminal_edge() {
     drop(teardown_completion);
     let teardown_membership = teardown_task.membership();
     teardown_task.wait().await;
-    crate::common::assert_eventually!(|| {
-            root.as_scope()
-                .snapshot()
-                .child("teardown-tombstone")
-                .is_some_and(|child| child.state.is_terminal())
-        }).await;
+    assert_eventually!(|| {
+        root.as_scope()
+            .snapshot()
+            .child("teardown-tombstone")
+            .is_some_and(|child| child.state.is_terminal())
+    })
+    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -577,11 +578,12 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
         }
     };
 
-    crate::common::assert_eventually!(|| {
-            root.snapshot()
-                .child("nested")
-                .is_some_and(|child| matches!(child.state, ChildState::Restarting))
-        }).await;
+    assert_eventually!(|| {
+        root.snapshot()
+            .child("nested")
+            .is_some_and(|child| matches!(child.state, ChildState::Restarting))
+    })
+    .await;
     let restart_window = root.snapshot();
     let child = restart_window
         .child("nested")
@@ -633,11 +635,12 @@ async fn subtree_restart_keeps_scope_stream_and_sequence_but_refreshes_descendan
     assert_eq!(nested.membership(), scope_membership);
     assert_eq!(nested.snapshot().total_restarts, TotalRestarts::ZERO);
     assert!(nested.snapshot().lifecycle_seq >= starting.seq);
-    crate::common::assert_eventually!(|| {
-            root.snapshot().child("nested").is_some_and(|child| {
-                matches!(child.state, ChildState::Running) && child.restart_at.is_none()
-            })
-        }).await;
+    assert_eventually!(|| {
+        root.snapshot().child("nested").is_some_and(|child| {
+            matches!(child.state, ChildState::Running) && child.restart_at.is_none()
+        })
+    })
+    .await;
 
     system
         .shutdown(Duration::from_secs(1))
@@ -1152,9 +1155,11 @@ async fn snapshot_subscriptions_conflate_unobserved_transitions_to_the_latest_va
         .await
         .expect("ephemeral task is admitted");
     task.wait().await;
-    crate::common::assert_eventually!(|| {
-            scope.as_scope().child("ephemeral").is_none()
-        }, "terminal removal reaches the latest snapshot").await;
+    assert_eventually!(
+        || scope.as_scope().child("ephemeral").is_none(),
+        "terminal removal reaches the latest snapshot"
+    )
+    .await;
 
     let latest = snapshots
         .changed()

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
     Guard, LifecycleEventKind, LifecycleItem, Mailbox, Readiness, Shutdown, StartupError,
@@ -224,12 +224,9 @@ async fn timers_and_offload_completions_never_cross_an_incarnation_boundary() {
         .send(RestartMessage::Poison)
         .await
         .expect("actor live");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             generations.load(Ordering::SeqCst) >= 2
-        })
-        .await
-    );
+        }).await;
     actor
         .send(RestartMessage::Fresh)
         .await
@@ -409,13 +406,9 @@ async fn detached_run_blocking_completion_stays_with_its_old_incarnation() {
         .send(DetachedBlockingMessage::Poison)
         .await
         .expect("actor accepts poison");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             generations.load(Ordering::SeqCst) >= 2
-        })
-        .await,
-        "replacement starts while the old blocking thread remains detached"
-    );
+        }, "replacement starts while the old blocking thread remains detached").await;
 
     thread_release.release();
     // The gate only witnesses that the result's destructor ran somewhere; the
@@ -527,13 +520,9 @@ async fn offload_completion_wins_at_the_exact_deadline() {
         .send(DeadlineMessage::Start)
         .await
         .expect("actor live");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             armed.load(Ordering::SeqCst) && offload_started.load(Ordering::SeqCst)
-        })
-        .await,
-        "the offload is polled and its deadline is registered before time moves"
-    );
+        }, "the offload is polled and its deadline is registered before time moves").await;
     tokio::time::advance(Duration::from_secs(10)).await;
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert_eq!(*result.lock().expect("result mutex poisoned"), Some(Ok(42)));
@@ -600,13 +589,9 @@ async fn dropping_scoped_guard_suppresses_the_continuation() {
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("actor starts");
     actor.send(GuardMessage::Start).await.expect("actor live");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             guard_dropped.load(Ordering::SeqCst)
-        })
-        .await,
-        "the actor drops the guard before the negative window begins"
-    );
+        }, "the actor drops the guard before the negative window begins").await;
     assert_quiet(Duration::from_secs(1), || {
         deliveries.load(Ordering::SeqCst) != 0
     })
@@ -766,11 +751,13 @@ impl Actor for BlockingActor {
         BlockingMessage::Run: Self::Msg,
         context: &mut Context<'_, Self>,
     ) -> ExitResult {
+        let actor_task = tokio::task::id();
         let value = context.run_blocking(|token| {
             assert!(!token.is_cancelled());
             73usize
         });
         self.observed.store(value.await, Ordering::SeqCst);
+        assert_eq!(tokio::task::id(), actor_task);
         context.stop();
         Ok(())
     }
@@ -844,12 +831,9 @@ async fn dropping_run_blocking_future_cancels_and_detaches_its_thread() {
         .await
         .expect("actor live");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             cancelled.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
 }
 
 #[derive(Clone, Copy)]
@@ -965,7 +949,7 @@ async fn cancellation_destructor_panic_wakes_an_otherwise_idle_actor() {
 
     guard.cancel();
 
-    let exit = tokio::time::timeout(Duration::from_secs(1), async {
+    let exit = tokio::time::timeout(POLL_TIMEOUT, async {
         loop {
             let item = events.recv().await.expect("lifecycle remains open");
             let LifecycleItem::Event(event) = item else {
@@ -1326,13 +1310,9 @@ async fn queued_offload_panic_survives_hard_abort() {
         .send(PanicMessage::Trigger)
         .await
         .expect("mailbox accepts before readiness");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             queued.load(Ordering::SeqCst)
-        })
-        .await,
-        "offload panic is queued before hard abort"
-    );
+        }, "offload panic is queued before hard abort").await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -1402,13 +1382,9 @@ async fn hard_abort_preserves_owned_offload_panic_over_handler_destructor() {
     let mut events = system.scope().subscribe_lifecycle();
     system.wait_started().await.expect("actor starts");
     actor.send(()).await.expect("actor accepts trigger");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             queued.load(Ordering::SeqCst)
-        })
-        .await,
-        "offload panic is owned before hard abort"
-    );
+        }, "offload panic is owned before hard abort").await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -1506,12 +1482,9 @@ async fn incarnation_offloads_are_destroyed_before_actor_state_on_panic() {
         .send(CrashTeardownMessage::Start)
         .await
         .expect("actor live");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             log.lock().expect("drop log mutex poisoned").len() == 2
-        })
-        .await
-    );
+        }).await;
     assert_eq!(
         *log.lock().expect("drop log mutex poisoned"),
         ["offload", "actor"]
@@ -1654,12 +1627,9 @@ async fn offload_completion_flood_is_absorbed_and_fully_delivered() {
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("actor starts");
     actor.send(FloodMessage::Start).await.expect("actor live");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             completed_work.load(Ordering::SeqCst) == FLOOD
-        })
-        .await
-    );
+        }).await;
     release.release();
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
 }
@@ -1838,12 +1808,9 @@ async fn incarnation_offloads_are_destroyed_before_actor_state_on_error() {
         .send(FailTeardownMessage::Start)
         .await
         .expect("actor live");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             log.lock().expect("drop log mutex poisoned").len() == 2
-        })
-        .await
-    );
+        }).await;
     assert_eq!(
         *log.lock().expect("drop log mutex poisoned"),
         ["offload", "actor"]

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_quiet};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
     Guard, LifecycleEventKind, LifecycleItem, Mailbox, Readiness, Shutdown, StartupError,
@@ -224,9 +224,7 @@ async fn timers_and_offload_completions_never_cross_an_incarnation_boundary() {
         .send(RestartMessage::Poison)
         .await
         .expect("actor live");
-    crate::common::assert_eventually!(|| {
-            generations.load(Ordering::SeqCst) >= 2
-        }).await;
+    assert_eventually!(|| generations.load(Ordering::SeqCst) >= 2).await;
     actor
         .send(RestartMessage::Fresh)
         .await
@@ -406,9 +404,11 @@ async fn detached_run_blocking_completion_stays_with_its_old_incarnation() {
         .send(DetachedBlockingMessage::Poison)
         .await
         .expect("actor accepts poison");
-    crate::common::assert_eventually!(|| {
-            generations.load(Ordering::SeqCst) >= 2
-        }, "replacement starts while the old blocking thread remains detached").await;
+    assert_eventually!(
+        || generations.load(Ordering::SeqCst) >= 2,
+        "replacement starts while the old blocking thread remains detached"
+    )
+    .await;
 
     thread_release.release();
     // The gate only witnesses that the result's destructor ran somewhere; the
@@ -520,9 +520,11 @@ async fn offload_completion_wins_at_the_exact_deadline() {
         .send(DeadlineMessage::Start)
         .await
         .expect("actor live");
-    crate::common::assert_eventually!(|| {
-            armed.load(Ordering::SeqCst) && offload_started.load(Ordering::SeqCst)
-        }, "the offload is polled and its deadline is registered before time moves").await;
+    assert_eventually!(
+        || armed.load(Ordering::SeqCst) && offload_started.load(Ordering::SeqCst),
+        "the offload is polled and its deadline is registered before time moves"
+    )
+    .await;
     tokio::time::advance(Duration::from_secs(10)).await;
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert_eq!(*result.lock().expect("result mutex poisoned"), Some(Ok(42)));
@@ -589,9 +591,11 @@ async fn dropping_scoped_guard_suppresses_the_continuation() {
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("actor starts");
     actor.send(GuardMessage::Start).await.expect("actor live");
-    crate::common::assert_eventually!(|| {
-            guard_dropped.load(Ordering::SeqCst)
-        }, "the actor drops the guard before the negative window begins").await;
+    assert_eventually!(
+        || guard_dropped.load(Ordering::SeqCst),
+        "the actor drops the guard before the negative window begins"
+    )
+    .await;
     assert_quiet(Duration::from_secs(1), || {
         deliveries.load(Ordering::SeqCst) != 0
     })
@@ -734,16 +738,33 @@ enum BlockingMessage {
     Run,
 }
 
+/// What the handler observed around its `run_blocking` call. A handler
+/// cannot judge this itself: supervision contains a handler panic, so an
+/// in-handler assertion never reaches the test. The evidence is published
+/// instead, and the test body is the only place that judges it.
+struct BlockingObservation {
+    entered_on: tokio::task::Id,
+    resumed_on: tokio::task::Id,
+    cancelled_while_blocking: bool,
+}
+
 struct BlockingActor {
     observed: Arc<AtomicUsize>,
+    observation: Arc<Mutex<Option<BlockingObservation>>>,
 }
 
 impl Actor for BlockingActor {
     type Msg = BlockingMessage;
-    type Args = Arc<AtomicUsize>;
+    type Args = (Arc<AtomicUsize>, Arc<Mutex<Option<BlockingObservation>>>);
 
-    async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
-        Ok(Self { observed: args })
+    async fn init(
+        (observed, observation): Self::Args,
+        _: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        Ok(Self {
+            observed,
+            observation,
+        })
     }
 
     async fn handle(
@@ -751,13 +772,18 @@ impl Actor for BlockingActor {
         BlockingMessage::Run: Self::Msg,
         context: &mut Context<'_, Self>,
     ) -> ExitResult {
-        let actor_task = tokio::task::id();
-        let value = context.run_blocking(|token| {
-            assert!(!token.is_cancelled());
-            73usize
+        let entered_on = tokio::task::id();
+        let value = context.run_blocking(|token| (73usize, token.is_cancelled()));
+        let (value, cancelled_while_blocking) = value.await;
+        self.observed.store(value, Ordering::SeqCst);
+        *self
+            .observation
+            .lock()
+            .expect("blocking observation mutex poisoned") = Some(BlockingObservation {
+            entered_on,
+            resumed_on: tokio::task::id(),
+            cancelled_while_blocking,
         });
-        self.observed.store(value.await, Ordering::SeqCst);
-        assert_eq!(tokio::task::id(), actor_task);
         context.stop();
         Ok(())
     }
@@ -766,11 +792,12 @@ impl Actor for BlockingActor {
 #[tokio::test]
 async fn run_blocking_returns_on_the_actor_task() {
     let observed = Arc::new(AtomicUsize::new(0));
+    let observation = Arc::new(Mutex::new(None));
     let mut tree = Tree::new();
     let actor = tree
         .add_actor_once(
             "blocking",
-            ActorOnceDef::<BlockingActor>::new(Arc::clone(&observed)),
+            ActorOnceDef::<BlockingActor>::new((Arc::clone(&observed), Arc::clone(&observation))),
         )
         .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
@@ -778,6 +805,16 @@ async fn run_blocking_returns_on_the_actor_task() {
     actor.send(BlockingMessage::Run).await.expect("actor live");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert_eq!(observed.load(Ordering::SeqCst), 73);
+    let observation = observation
+        .lock()
+        .expect("blocking observation mutex poisoned")
+        .take()
+        .expect("the handler ran to completion");
+    assert!(!observation.cancelled_while_blocking);
+    assert_eq!(
+        observation.resumed_on, observation.entered_on,
+        "run_blocking resumes its handler on the actor task, not the blocking thread"
+    );
 }
 
 enum CancelBlockingMessage {
@@ -831,9 +868,7 @@ async fn dropping_run_blocking_future_cancels_and_detaches_its_thread() {
         .await
         .expect("actor live");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
-    crate::common::assert_eventually!(|| {
-            cancelled.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| cancelled.load(Ordering::SeqCst)).await;
 }
 
 #[derive(Clone, Copy)]
@@ -1310,9 +1345,11 @@ async fn queued_offload_panic_survives_hard_abort() {
         .send(PanicMessage::Trigger)
         .await
         .expect("mailbox accepts before readiness");
-    crate::common::assert_eventually!(|| {
-            queued.load(Ordering::SeqCst)
-        }, "offload panic is queued before hard abort").await;
+    assert_eventually!(
+        || queued.load(Ordering::SeqCst),
+        "offload panic is queued before hard abort"
+    )
+    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -1382,9 +1419,11 @@ async fn hard_abort_preserves_owned_offload_panic_over_handler_destructor() {
     let mut events = system.scope().subscribe_lifecycle();
     system.wait_started().await.expect("actor starts");
     actor.send(()).await.expect("actor accepts trigger");
-    crate::common::assert_eventually!(|| {
-            queued.load(Ordering::SeqCst)
-        }, "offload panic is owned before hard abort").await;
+    assert_eventually!(
+        || queued.load(Ordering::SeqCst),
+        "offload panic is owned before hard abort"
+    )
+    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -1482,9 +1521,7 @@ async fn incarnation_offloads_are_destroyed_before_actor_state_on_panic() {
         .send(CrashTeardownMessage::Start)
         .await
         .expect("actor live");
-    crate::common::assert_eventually!(|| {
-            log.lock().expect("drop log mutex poisoned").len() == 2
-        }).await;
+    assert_eventually!(|| log.lock().expect("drop log mutex poisoned").len() == 2).await;
     assert_eq!(
         *log.lock().expect("drop log mutex poisoned"),
         ["offload", "actor"]
@@ -1627,9 +1664,7 @@ async fn offload_completion_flood_is_absorbed_and_fully_delivered() {
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("actor starts");
     actor.send(FloodMessage::Start).await.expect("actor live");
-    crate::common::assert_eventually!(|| {
-            completed_work.load(Ordering::SeqCst) == FLOOD
-        }).await;
+    assert_eventually!(|| completed_work.load(Ordering::SeqCst) == FLOOD).await;
     release.release();
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
 }
@@ -1808,9 +1843,7 @@ async fn incarnation_offloads_are_destroyed_before_actor_state_on_error() {
         .send(FailTeardownMessage::Start)
         .await
         .expect("actor live");
-    crate::common::assert_eventually!(|| {
-            log.lock().expect("drop log mutex poisoned").len() == 2
-        }).await;
+    assert_eventually!(|| log.lock().expect("drop log mutex poisoned").len() == 2).await;
     assert_eq!(
         *log.lock().expect("drop log mutex poisoned"),
         ["offload", "actor"]

--- a/crates/shelterwood/tests/one_shot_resource_ownership.rs
+++ b/crates/shelterwood/tests/one_shot_resource_ownership.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::common::{
-    ConsumeCount, ConsumeGuard, POLL_TIMEOUT, ReleaseGate, policy::never, poll_once, poll_until,
+    ConsumeCount, ConsumeGuard, ReleaseGate, policy::never, poll_once,
 };
 use shelterwood::{
     Actor, ActorOnceDef, Context, DynamicTree, ExitError, ExitResult, RawActor, RawContext,
@@ -545,10 +545,7 @@ async fn cancelling_inflight_one_shot_adds_drops_every_kind_resource_once() {
         ("raw actor", &raw_count, &raw_started),
         ("subtree", &subtree_count, &subtree_started),
     ] {
-        assert!(
-            poll_until(POLL_TIMEOUT, Duration::from_millis(1), || count.get() == 1).await,
-            "cancelled {kind} admission disposes its resource"
-        );
+        crate::common::assert_eventually!(|| count.get() == 1, "cancelled {kind} admission disposes its resource").await;
         count.assert_once();
         assert!(
             !started.load(Ordering::SeqCst),

--- a/crates/shelterwood/tests/one_shot_resource_ownership.rs
+++ b/crates/shelterwood/tests/one_shot_resource_ownership.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::common::{
-    ConsumeCount, ConsumeGuard, ReleaseGate, policy::never, poll_once,
+    ConsumeCount, ConsumeGuard, ReleaseGate, assert_eventually, policy::never, poll_once,
 };
 use shelterwood::{
     Actor, ActorOnceDef, Context, DynamicTree, ExitError, ExitResult, RawActor, RawContext,
@@ -545,7 +545,11 @@ async fn cancelling_inflight_one_shot_adds_drops_every_kind_resource_once() {
         ("raw actor", &raw_count, &raw_started),
         ("subtree", &subtree_count, &subtree_started),
     ] {
-        crate::common::assert_eventually!(|| count.get() == 1, "cancelled {kind} admission disposes its resource").await;
+        assert_eventually!(
+            || count.get() == 1,
+            "cancelled {kind} admission disposes its resource"
+        )
+        .await;
         count.assert_once();
         assert!(
             !started.load(Ordering::SeqCst),

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -6,9 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{
-    ReleaseGate, assert_quiet, waiting::task as waiting_task,
-};
+use crate::common::{ReleaseGate, assert_eventually, assert_quiet, waiting::task as waiting_task};
 use shelterwood::{
     DynamicTree, ExitError, ExitResult, Mailbox, MailboxShutdown, PolicyError, RawActor,
     RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline, RemoveOutcome, ScopeDefaults,
@@ -241,9 +239,7 @@ async fn raw_manual_readiness_gates_ordered_startup_but_not_mailbox_acceptance()
         )
         .expect("valid sibling");
     let system = tree.spawn().expect("runtime is available");
-    crate::common::assert_eventually!(|| {
-            entered.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| entered.load(Ordering::SeqCst)).await;
     assert_quiet(Duration::from_millis(20), || {
         sibling_started.load(Ordering::SeqCst)
     })
@@ -255,13 +251,14 @@ async fn raw_manual_readiness_gates_ordered_startup_but_not_mailbox_acceptance()
     release_ready.release();
     system.wait_started().await.expect("manual gate releases");
     assert!(sibling_started.load(Ordering::SeqCst));
-    crate::common::assert_eventually!(|| {
-            values
-                .lock()
-                .expect("manual values mutex poisoned")
-                .as_slice()
-                == [7]
-        }).await;
+    assert_eventually!(|| {
+        values
+            .lock()
+            .expect("manual values mutex poisoned")
+            .as_slice()
+            == [7]
+    })
+    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -321,14 +318,15 @@ async fn raw_recv_is_shutdown_biased_and_try_recv_controls_drain_vs_discard() {
         let accepting = actor.try_send(1).expect("one accepts");
         actor.try_send(2).expect("two accepts");
         let shutdown = tokio::spawn(async move { system.shutdown(Duration::from_secs(1)).await });
-        crate::common::assert_eventually!(|| {
-                matches!(
-                    actor.try_send(3),
-                    Err(ref error)
-                        if error.kind == SendErrorKind::NotRunning
-                            && error.incarnation_observed == Some(accepting)
-                )
-            }).await;
+        assert_eventually!(|| {
+            matches!(
+                actor.try_send(3),
+                Err(ref error)
+                    if error.kind == SendErrorKind::NotRunning
+                        && error.incarnation_observed == Some(accepting)
+            )
+        })
+        .await;
         enter_loop.release();
         shutdown
             .await
@@ -488,13 +486,14 @@ async fn dynamic_scope_admits_uses_and_exactly_removes_a_raw_actor() {
         .await
         .expect("raw actor is admitted");
     actor.send(9).await.expect("dynamic actor accepts");
-    crate::common::assert_eventually!(|| {
-            values
-                .lock()
-                .expect("dynamic values mutex poisoned")
-                .as_slice()
-                == [9]
-        }).await;
+    assert_eventually!(|| {
+        values
+            .lock()
+            .expect("dynamic values mutex poisoned")
+            .as_slice()
+            == [9]
+    })
+    .await;
     assert_eq!(scope.remove_actor(&actor).await, RemoveOutcome::Removed);
     let terminal = actor.send(10).await.expect_err("removed actor is terminal");
     assert_eq!(terminal.kind, SendErrorKind::Terminated);
@@ -530,13 +529,14 @@ async fn deferred_queue_capacity_ignores_a_latest_scope_default() {
         .try_send(2)
         .expect("second value proves queue capacity did not become latest");
     gate.release();
-    crate::common::assert_eventually!(|| {
-            values
-                .lock()
-                .expect("default values mutex poisoned")
-                .as_slice()
-                == [1, 2]
-        }).await;
+    assert_eventually!(|| {
+        values
+            .lock()
+            .expect("default values mutex poisoned")
+            .as_slice()
+            == [1, 2]
+    })
+    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -646,9 +646,11 @@ async fn hard_abort_offload_panic_with_panicking_raw_destructor_is_contained() {
     let system = tree.spawn().expect("runtime is available");
     let mut events = system.scope().subscribe_lifecycle();
     system.wait_started().await.expect("actor starts");
-    crate::common::assert_eventually!(|| {
-            queued.load(Ordering::SeqCst)
-        }, "offload panic is queued before hard abort").await;
+    assert_eventually!(
+        || queued.load(Ordering::SeqCst),
+        "offload panic is queued before hard abort"
+    )
+    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::common::{
-    POLL_TIMEOUT, ReleaseGate, assert_quiet, poll_until, waiting::task as waiting_task,
+    ReleaseGate, assert_quiet, waiting::task as waiting_task,
 };
 use shelterwood::{
     DynamicTree, ExitError, ExitResult, Mailbox, MailboxShutdown, PolicyError, RawActor,
@@ -241,12 +241,9 @@ async fn raw_manual_readiness_gates_ordered_startup_but_not_mailbox_acceptance()
         )
         .expect("valid sibling");
     let system = tree.spawn().expect("runtime is available");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             entered.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     assert_quiet(Duration::from_millis(20), || {
         sibling_started.load(Ordering::SeqCst)
     })
@@ -258,16 +255,13 @@ async fn raw_manual_readiness_gates_ordered_startup_but_not_mailbox_acceptance()
     release_ready.release();
     system.wait_started().await.expect("manual gate releases");
     assert!(sibling_started.load(Ordering::SeqCst));
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             values
                 .lock()
                 .expect("manual values mutex poisoned")
                 .as_slice()
                 == [7]
-        })
-        .await
-    );
+        }).await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -327,17 +321,14 @@ async fn raw_recv_is_shutdown_biased_and_try_recv_controls_drain_vs_discard() {
         let accepting = actor.try_send(1).expect("one accepts");
         actor.try_send(2).expect("two accepts");
         let shutdown = tokio::spawn(async move { system.shutdown(Duration::from_secs(1)).await });
-        assert!(
-            poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+        crate::common::assert_eventually!(|| {
                 matches!(
                     actor.try_send(3),
                     Err(ref error)
                         if error.kind == SendErrorKind::NotRunning
                             && error.incarnation_observed == Some(accepting)
                 )
-            })
-            .await
-        );
+            }).await;
         enter_loop.release();
         shutdown
             .await
@@ -497,16 +488,13 @@ async fn dynamic_scope_admits_uses_and_exactly_removes_a_raw_actor() {
         .await
         .expect("raw actor is admitted");
     actor.send(9).await.expect("dynamic actor accepts");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             values
                 .lock()
                 .expect("dynamic values mutex poisoned")
                 .as_slice()
                 == [9]
-        })
-        .await
-    );
+        }).await;
     assert_eq!(scope.remove_actor(&actor).await, RemoveOutcome::Removed);
     let terminal = actor.send(10).await.expect_err("removed actor is terminal");
     assert_eq!(terminal.kind, SendErrorKind::Terminated);
@@ -542,16 +530,13 @@ async fn deferred_queue_capacity_ignores_a_latest_scope_default() {
         .try_send(2)
         .expect("second value proves queue capacity did not become latest");
     gate.release();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             values
                 .lock()
                 .expect("default values mutex poisoned")
                 .as_slice()
                 == [1, 2]
-        })
-        .await
-    );
+        }).await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -661,13 +646,9 @@ async fn hard_abort_offload_panic_with_panicking_raw_destructor_is_contained() {
     let system = tree.spawn().expect("runtime is available");
     let mut events = system.scope().subscribe_lifecycle();
     system.wait_started().await.expect("actor starts");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             queued.load(Ordering::SeqCst)
-        })
-        .await,
-        "offload panic is queued before hard abort"
-    );
+        }, "offload panic is queued before hard abort").await;
     system
         .shutdown(Duration::from_secs(1))
         .await

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::common::{
-    POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, policy::never,
+    POLL_TIMEOUT, ReleaseGate, advance_time, assert_eventually, assert_quiet, policy::never,
     waiting::{gate_released_manual_ready_task, task as waiting_task},
 };
 use shelterwood::{
@@ -81,12 +81,13 @@ async fn readiness_fired_before_failure_makes_the_failure_post_ready() {
     .expect("valid task");
 
     let system = tree.spawn().expect("runtime is available");
-    crate::common::assert_eventually!(|| {
-            system
-                .scope()
-                .child("ready-then-fail")
-                .is_some_and(|child| matches!(child.state, ChildState::Restarting))
-        }).await;
+    assert_eventually!(|| {
+        system
+            .scope()
+            .child("ready-then-fail")
+            .is_some_and(|child| matches!(child.state, ChildState::Restarting))
+    })
+    .await;
     assert_eq!(
         system.scope().snapshot().state,
         ScopeState::Running,
@@ -205,20 +206,19 @@ async fn immediate_restart_deadline_rechecks_aggregate_startup() {
     .expect("valid manual sibling");
 
     let system = tree.spawn().expect("runtime is available");
-    crate::common::assert_eventually!(|| {
-            system
-                .scope()
-                .child("restarting-immediate")
-                .is_some_and(|child| matches!(child.state, ChildState::Restarting))
-        }).await;
+    assert_eventually!(|| {
+        system
+            .scope()
+            .child("restarting-immediate")
+            .is_some_and(|child| matches!(child.state, ChildState::Restarting))
+    })
+    .await;
     release_manual.release();
     manual_ready.wait().await;
     assert_eq!(system.scope().snapshot().state, ScopeState::Starting);
 
     advance_time(backoff).await;
-    crate::common::assert_eventually!(|| {
-            incarnations.load(Ordering::SeqCst) == 2
-        }).await;
+    assert_eventually!(|| incarnations.load(Ordering::SeqCst) == 2).await;
     system
         .wait_started()
         .await
@@ -260,9 +260,10 @@ async fn ordered_startup_waits_for_manual_readiness() {
     .expect("valid task");
 
     let system = tree.spawn().expect("runtime is available");
-    crate::common::assert_eventually!(|| {
-            order.lock().expect("order mutex poisoned").as_slice() == ["gated"]
-        }).await;
+    assert_eventually!(|| {
+        order.lock().expect("order mutex poisoned").as_slice() == ["gated"]
+    })
+    .await;
     assert_quiet(Duration::from_millis(20), || {
         order.lock().expect("order mutex poisoned").len() > 1
     })
@@ -398,9 +399,7 @@ async fn ready_at_deadline_wins_and_shutdown_disarms_the_gate() {
         )
         .expect("valid task");
     let ready_system = ready_tree.spawn().expect("runtime is available");
-    crate::common::assert_eventually!(|| {
-            ready_started.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| ready_started.load(Ordering::SeqCst)).await;
     advance_time(width).await;
     ready_marked.wait().await;
     ready_system
@@ -483,13 +482,9 @@ async fn restart_before_aggregate_readiness_rearms_the_gate() {
     )
     .expect("valid task");
     let system = tree.spawn().expect("runtime is available");
-    crate::common::assert_eventually!(|| {
-            later_started.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| later_started.load(Ordering::SeqCst)).await;
     fail_first.release();
-    crate::common::assert_eventually!(|| {
-            incarnation.load(Ordering::SeqCst) == 2
-        }).await;
+    assert_eventually!(|| incarnation.load(Ordering::SeqCst) == 2).await;
     release_second.release();
     assert!(
         tokio::time::timeout(Duration::from_millis(20), system.wait_started())
@@ -647,9 +642,7 @@ async fn dynamic_startup_completes_after_removing_sole_unready_initial_member() 
         .expect("valid initial member");
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
-    crate::common::assert_eventually!(|| {
-            scope.as_scope().child("gate").is_some()
-        }).await;
+    assert_eventually!(|| scope.as_scope().child("gate").is_some()).await;
 
     assert_eq!(
         scope.remove("gate").await,
@@ -674,13 +667,14 @@ async fn dynamic_startup_completes_after_removing_last_unready_initial_member() 
         .expect("valid unready member");
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
-    crate::common::assert_eventually!(|| {
-            scope
-                .as_scope()
-                .child("ready")
-                .is_some_and(|child| matches!(child.state, ChildState::Running))
-                && scope.as_scope().child("gate").is_some()
-        }).await;
+    assert_eventually!(|| {
+        scope
+            .as_scope()
+            .child("ready")
+            .is_some_and(|child| matches!(child.state, ChildState::Running))
+            && scope.as_scope().child("gate").is_some()
+    })
+    .await;
 
     assert_eq!(
         scope.remove("gate").await,
@@ -707,9 +701,10 @@ async fn dynamic_startup_completes_after_removing_every_initial_member() {
         .expect("valid unready member");
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
-    crate::common::assert_eventually!(|| {
-            scope.as_scope().child("first").is_some() && scope.as_scope().child("second").is_some()
-        }).await;
+    assert_eventually!(|| {
+        scope.as_scope().child("first").is_some() && scope.as_scope().child("second").is_some()
+    })
+    .await;
 
     let (first, second) = tokio::join!(scope.remove("first"), scope.remove("second"));
     assert_eq!(first, shelterwood::RemoveOutcome::Removed);
@@ -742,9 +737,7 @@ async fn removal_completed_nested_startup_releases_the_ordered_sibling() {
 
     let system = root.spawn().expect("runtime is available");
     let scope = system.scope();
-    crate::common::assert_eventually!(|| {
-            nested_scope.as_scope().child("gate").is_some()
-        }).await;
+    assert_eventually!(|| nested_scope.as_scope().child("gate").is_some()).await;
     assert_quiet(Duration::from_secs(5), || {
         scope
             .child("after")
@@ -784,13 +777,14 @@ async fn removing_a_ready_initial_member_leaves_startup_pending() {
         .expect("valid unready member");
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
-    crate::common::assert_eventually!(|| {
-            scope
-                .as_scope()
-                .child("ready")
-                .is_some_and(|child| matches!(child.state, ChildState::Running))
-                && scope.as_scope().child("gate").is_some()
-        }).await;
+    assert_eventually!(|| {
+        scope
+            .as_scope()
+            .child("ready")
+            .is_some_and(|child| matches!(child.state, ChildState::Running))
+            && scope.as_scope().child("gate").is_some()
+    })
+    .await;
 
     assert_eq!(
         scope.remove("ready").await,
@@ -823,9 +817,7 @@ async fn runtime_dynamic_additions_never_join_aggregate_readiness() {
     .expect("valid initial member");
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
-    crate::common::assert_eventually!(|| {
-            initial_started.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| initial_started.load(Ordering::SeqCst)).await;
     let runtime_task = scope
         .add_task(
             "runtime",
@@ -846,9 +838,7 @@ async fn runtime_dynamic_additions_never_join_aggregate_readiness() {
         )
         .await
         .expect("runtime member is admitted");
-    crate::common::assert_eventually!(|| {
-            runtime_started.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| runtime_started.load(Ordering::SeqCst)).await;
     initial_release.release();
     // The regression this test targets — a runtime addition joining the
     // aggregate — would park `wait_started` forever behind the unbounded
@@ -1372,7 +1362,8 @@ async fn immediate_raw_construction_panic_classifies_post_ready() {
         .await
         .expect("spawn-time readiness classifies the construction panic post-ready");
     assert!(sibling_started.load(Ordering::SeqCst));
-    crate::common::assert_eventually!(|| {
+    assert_eventually!(
+        || {
             system
                 .scope()
                 .child("constructs-never")
@@ -1380,7 +1371,10 @@ async fn immediate_raw_construction_panic_classifies_post_ready() {
                     &child.state,
                     ChildState::Stopped { exit } if matches!(exit.kind(), ExitKind::Panicked { .. })
                 ))
-        }, "the terminal panic is an ordinary post-ready stop, not a startup abort").await;
+        },
+        "the terminal panic is an ordinary post-ready stop, not a startup abort"
+    )
+    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -7,7 +7,8 @@ use std::{
 };
 
 use crate::common::{
-    POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, policy::never, poll_until,
+    POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, policy::never,
+    waiting::{gate_released_manual_ready_task, task as waiting_task},
 };
 use shelterwood::{
     Actor, ActorOnceDef, Backoff, Cancellation, ChildState, Context, DynamicTree, ExitError,
@@ -80,15 +81,12 @@ async fn readiness_fired_before_failure_makes_the_failure_post_ready() {
     .expect("valid task");
 
     let system = tree.spawn().expect("runtime is available");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             system
                 .scope()
                 .child("ready-then-fail")
                 .is_some_and(|child| matches!(child.state, ChildState::Restarting))
-        })
-        .await
-    );
+        }).await;
     assert_eq!(
         system.scope().snapshot().state,
         ScopeState::Running,
@@ -207,26 +205,20 @@ async fn immediate_restart_deadline_rechecks_aggregate_startup() {
     .expect("valid manual sibling");
 
     let system = tree.spawn().expect("runtime is available");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             system
                 .scope()
                 .child("restarting-immediate")
                 .is_some_and(|child| matches!(child.state, ChildState::Restarting))
-        })
-        .await
-    );
+        }).await;
     release_manual.release();
     manual_ready.wait().await;
     assert_eq!(system.scope().snapshot().state, ScopeState::Starting);
 
     advance_time(backoff).await;
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             incarnations.load(Ordering::SeqCst) == 2
-        })
-        .await
-    );
+        }).await;
     system
         .wait_started()
         .await
@@ -244,23 +236,10 @@ async fn ordered_startup_waits_for_manual_readiness() {
     let mut tree = Tree::new();
     tree.add_task(
         "gated",
-        TaskDef::new({
+        gate_released_manual_ready_task(release_ready.clone(), {
             let order = Arc::clone(&order);
-            let release_ready = release_ready.clone();
-            move |context| {
-                let order = Arc::clone(&order);
-                let release_ready = release_ready.clone();
-                async move {
-                    order.lock().expect("order mutex poisoned").push("gated");
-                    release_ready.wait().await;
-                    context.mark_ready();
-                    context.shutdown_token().cancelled().await;
-                    Ok(())
-                }
-            }
+            move || order.lock().expect("order mutex poisoned").push("gated")
         })
-        .readiness(Readiness::Manual)
-        .expect("manual readiness")
         .readiness_deadline(ReadinessDeadline::Unbounded),
     )
     .expect("valid task");
@@ -281,12 +260,9 @@ async fn ordered_startup_waits_for_manual_readiness() {
     .expect("valid task");
 
     let system = tree.spawn().expect("runtime is available");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             order.lock().expect("order mutex poisoned").as_slice() == ["gated"]
-        })
-        .await
-    );
+        }).await;
     assert_quiet(Duration::from_millis(20), || {
         order.lock().expect("order mutex poisoned").len() > 1
     })
@@ -422,12 +398,9 @@ async fn ready_at_deadline_wins_and_shutdown_disarms_the_gate() {
         )
         .expect("valid task");
     let ready_system = ready_tree.spawn().expect("runtime is available");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             ready_started.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     advance_time(width).await;
     ready_marked.wait().await;
     ready_system
@@ -447,10 +420,7 @@ async fn ready_at_deadline_wins_and_shutdown_disarms_the_gate() {
     let shutdown_task = shutdown_tree
         .add_task(
             "edge",
-            TaskDef::new(|context| async move {
-                context.shutdown_token().cancelled().await;
-                Ok(())
-            })
+            waiting_task()
             .readiness(Readiness::Manual)
             .expect("manual readiness")
             .readiness_deadline(ReadinessDeadline::bounded(width).expect("non-zero deadline")),
@@ -505,40 +475,21 @@ async fn restart_before_aggregate_readiness_rearms_the_gate() {
     .expect("valid task");
     tree.add_task(
         "later",
-        TaskDef::new({
+        gate_released_manual_ready_task(release_second.clone(), {
             let later_started = Arc::clone(&later_started);
-            let release_second = release_second.clone();
-            move |context| {
-                let later_started = Arc::clone(&later_started);
-                let release_second = release_second.clone();
-                async move {
-                    later_started.store(true, Ordering::SeqCst);
-                    release_second.wait().await;
-                    context.mark_ready();
-                    context.shutdown_token().cancelled().await;
-                    Ok(())
-                }
-            }
+            move || later_started.store(true, Ordering::SeqCst)
         })
-        .readiness(Readiness::Manual)
-        .expect("manual readiness")
         .readiness_deadline(ReadinessDeadline::Unbounded),
     )
     .expect("valid task");
     let system = tree.spawn().expect("runtime is available");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             later_started.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     fail_first.release();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             incarnation.load(Ordering::SeqCst) == 2
-        })
-        .await
-    );
+        }).await;
     release_second.release();
     assert!(
         tokio::time::timeout(Duration::from_millis(20), system.wait_started())
@@ -671,13 +622,10 @@ async fn dynamic_startup_failure_keeps_other_initial_members_supervised() {
 /// A `Manual` member that never marks ready, so it gates its scope's
 /// aggregate until it is removed.
 fn unbounded_manual_gate() -> TaskDef {
-    TaskDef::new(|context| async move {
-        context.shutdown_token().cancelled().await;
-        Ok(())
-    })
-    .readiness(Readiness::Manual)
-    .expect("manual readiness")
-    .readiness_deadline(ReadinessDeadline::Unbounded)
+    waiting_task()
+        .readiness(Readiness::Manual)
+        .expect("manual readiness")
+        .readiness_deadline(ReadinessDeadline::Unbounded)
 }
 
 /// A `Manual` member that marks ready immediately and then parks.
@@ -699,12 +647,9 @@ async fn dynamic_startup_completes_after_removing_sole_unready_initial_member() 
         .expect("valid initial member");
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             scope.as_scope().child("gate").is_some()
-        })
-        .await
-    );
+        }).await;
 
     assert_eq!(
         scope.remove("gate").await,
@@ -729,16 +674,13 @@ async fn dynamic_startup_completes_after_removing_last_unready_initial_member() 
         .expect("valid unready member");
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             scope
                 .as_scope()
                 .child("ready")
                 .is_some_and(|child| matches!(child.state, ChildState::Running))
                 && scope.as_scope().child("gate").is_some()
-        })
-        .await
-    );
+        }).await;
 
     assert_eq!(
         scope.remove("gate").await,
@@ -765,12 +707,9 @@ async fn dynamic_startup_completes_after_removing_every_initial_member() {
         .expect("valid unready member");
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             scope.as_scope().child("first").is_some() && scope.as_scope().child("second").is_some()
-        })
-        .await
-    );
+        }).await;
 
     let (first, second) = tokio::join!(scope.remove("first"), scope.remove("second"));
     assert_eq!(first, shelterwood::RemoveOutcome::Removed);
@@ -803,12 +742,9 @@ async fn removal_completed_nested_startup_releases_the_ordered_sibling() {
 
     let system = root.spawn().expect("runtime is available");
     let scope = system.scope();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             nested_scope.as_scope().child("gate").is_some()
-        })
-        .await
-    );
+        }).await;
     assert_quiet(Duration::from_secs(5), || {
         scope
             .child("after")
@@ -848,16 +784,13 @@ async fn removing_a_ready_initial_member_leaves_startup_pending() {
         .expect("valid unready member");
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             scope
                 .as_scope()
                 .child("ready")
                 .is_some_and(|child| matches!(child.state, ChildState::Running))
                 && scope.as_scope().child("gate").is_some()
-        })
-        .await
-    );
+        }).await;
 
     assert_eq!(
         scope.remove("ready").await,
@@ -881,34 +814,18 @@ async fn runtime_dynamic_additions_never_join_aggregate_readiness() {
     let mut tree = DynamicTree::new();
     tree.add_task(
         "initial",
-        TaskDef::new({
-            let initial_release = initial_release.clone();
+        gate_released_manual_ready_task(initial_release.clone(), {
             let initial_started = Arc::clone(&initial_started);
-            move |context| {
-                let initial_release = initial_release.clone();
-                let initial_started = Arc::clone(&initial_started);
-                async move {
-                    initial_started.store(true, Ordering::SeqCst);
-                    initial_release.wait().await;
-                    context.mark_ready();
-                    context.shutdown_token().cancelled().await;
-                    Ok(())
-                }
-            }
+            move || initial_started.store(true, Ordering::SeqCst)
         })
-        .readiness(Readiness::Manual)
-        .expect("manual readiness")
         .readiness_deadline(ReadinessDeadline::Unbounded),
     )
     .expect("valid initial member");
     let system = tree.spawn().expect("runtime is available");
     let scope = system.scope();
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             initial_started.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     let runtime_task = scope
         .add_task(
             "runtime",
@@ -929,12 +846,9 @@ async fn runtime_dynamic_additions_never_join_aggregate_readiness() {
         )
         .await
         .expect("runtime member is admitted");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             runtime_started.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     initial_release.release();
     // The regression this test targets — a runtime addition joining the
     // aggregate — would park `wait_started` forever behind the unbounded
@@ -1458,8 +1372,7 @@ async fn immediate_raw_construction_panic_classifies_post_ready() {
         .await
         .expect("spawn-time readiness classifies the construction panic post-ready");
     assert!(sibling_started.load(Ordering::SeqCst));
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             system
                 .scope()
                 .child("constructs-never")
@@ -1467,10 +1380,7 @@ async fn immediate_raw_construction_panic_classifies_post_ready() {
                     &child.state,
                     ChildState::Stopped { exit } if matches!(exit.kind(), ExitKind::Panicked { .. })
                 ))
-        })
-        .await,
-        "the terminal panic is an ordinary post-ready stop, not a startup abort"
-    );
+        }, "the terminal panic is an ordinary post-ready stop, not a startup abort").await;
     system
         .shutdown(Duration::from_secs(1))
         .await

--- a/crates/shelterwood/tests/rebind.rs
+++ b/crates/shelterwood/tests/rebind.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::common::{
-    DestructorBlocker, DestructorGate, ReleaseGate, policy::never, poll_once,
+    DestructorBlocker, DestructorGate, ReleaseGate, assert_eventually, policy::never, poll_once,
 };
 use shelterwood::{
     Backoff, CallErrorKind, ExitError, ExitResult, Jitter, Mailbox, RawActor, RawContext, RawDef,
@@ -150,14 +150,15 @@ async fn rebind_refreshes_all_overflow_waiter_incarnation_evidence() {
 
     fail_first.release();
     let mut replacement = None;
-    crate::common::assert_eventually!(|| {
-            if let std::task::Poll::Ready(result) = poll_once(promoted.as_mut()) {
-                replacement = Some(result.expect("first waiter enters replacement capacity"));
-                true
-            } else {
-                false
-            }
-        }).await;
+    assert_eventually!(|| {
+        if let std::task::Poll::Ready(result) = poll_once(promoted.as_mut()) {
+            replacement = Some(result.expect("first waiter enters replacement capacity"));
+            true
+        } else {
+            false
+        }
+    })
+    .await;
     let replacement = replacement.expect("replacement bind promotes the first waiter");
     assert!(replacement.supersedes(first));
     assert_eq!(factories.load(Ordering::SeqCst), 2);
@@ -221,13 +222,14 @@ async fn send_rides_the_frozen_destructor_and_rebind_window() {
     destructor.release();
     let accepting = parked.await.expect("send rides into replacement");
     assert!(accepting.supersedes(first));
-    crate::common::assert_eventually!(|| {
-            deliveries
-                .lock()
-                .expect("deliveries mutex poisoned")
-                .as_slice()
-                == [(2, 42)]
-        }).await;
+    assert_eventually!(|| {
+        deliveries
+            .lock()
+            .expect("deliveries mutex poisoned")
+            .as_slice()
+            == [(2, 42)]
+    })
+    .await;
     assert_eq!(
         factories.load(Ordering::SeqCst),
         2,
@@ -307,15 +309,16 @@ async fn timed_send_withdraws_while_replacement_is_in_backoff() {
     assert!(poll_once(timed.as_mut()).is_pending());
     fail_first.release();
     let mut observed_rebind = None;
-    crate::common::assert_eventually!(|| {
-            match actor.try_send(0) {
-                Err(error) if error.kind == SendErrorKind::NotRunning => {
-                    observed_rebind = Some(error.incarnation_observed);
-                    true
-                }
-                _ => false,
+    assert_eventually!(|| {
+        match actor.try_send(0) {
+            Err(error) if error.kind == SendErrorKind::NotRunning => {
+                observed_rebind = Some(error.incarnation_observed);
+                true
             }
-        }).await;
+            _ => false,
+        }
+    })
+    .await;
     assert_eq!(observed_rebind, Some(None));
     tokio::time::advance(timeout).await;
     let error = timed.await.expect_err("backoff outlives timeout");
@@ -365,14 +368,18 @@ async fn dropping_a_parked_send_in_the_rebind_window_withdraws_it() {
     destructor.release();
     parked.await.expect("the retained send rides the window");
     actor.send(44).await.expect("replacement accepts");
-    crate::common::assert_eventually!(|| {
+    assert_eventually!(
+        || {
             deliveries
                 .lock()
                 .expect("deliveries mutex poisoned")
                 .as_slice()
                 == [(2, 42), (2, 44)]
-        }, "the withdrawn send must never be promoted at bind: {:?}",
-        deliveries.lock().expect("deliveries mutex poisoned")).await;
+        },
+        "the withdrawn send must never be promoted at bind: {:?}",
+        deliveries.lock().expect("deliveries mutex poisoned")
+    )
+    .await;
     system
         .shutdown(Duration::from_secs(1))
         .await

--- a/crates/shelterwood/tests/rebind.rs
+++ b/crates/shelterwood/tests/rebind.rs
@@ -7,8 +7,7 @@ use std::{
 };
 
 use crate::common::{
-    DestructorBlocker, DestructorGate, POLL_TIMEOUT, ReleaseGate, policy::never, poll_once,
-    poll_until,
+    DestructorBlocker, DestructorGate, ReleaseGate, policy::never, poll_once,
 };
 use shelterwood::{
     Backoff, CallErrorKind, ExitError, ExitResult, Jitter, Mailbox, RawActor, RawContext, RawDef,
@@ -151,17 +150,14 @@ async fn rebind_refreshes_all_overflow_waiter_incarnation_evidence() {
 
     fail_first.release();
     let mut replacement = None;
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             if let std::task::Poll::Ready(result) = poll_once(promoted.as_mut()) {
                 replacement = Some(result.expect("first waiter enters replacement capacity"));
                 true
             } else {
                 false
             }
-        })
-        .await
-    );
+        }).await;
     let replacement = replacement.expect("replacement bind promotes the first waiter");
     assert!(replacement.supersedes(first));
     assert_eq!(factories.load(Ordering::SeqCst), 2);
@@ -225,16 +221,13 @@ async fn send_rides_the_frozen_destructor_and_rebind_window() {
     destructor.release();
     let accepting = parked.await.expect("send rides into replacement");
     assert!(accepting.supersedes(first));
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             deliveries
                 .lock()
                 .expect("deliveries mutex poisoned")
                 .as_slice()
                 == [(2, 42)]
-        })
-        .await
-    );
+        }).await;
     assert_eq!(
         factories.load(Ordering::SeqCst),
         2,
@@ -314,8 +307,7 @@ async fn timed_send_withdraws_while_replacement_is_in_backoff() {
     assert!(poll_once(timed.as_mut()).is_pending());
     fail_first.release();
     let mut observed_rebind = None;
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             match actor.try_send(0) {
                 Err(error) if error.kind == SendErrorKind::NotRunning => {
                     observed_rebind = Some(error.incarnation_observed);
@@ -323,9 +315,7 @@ async fn timed_send_withdraws_while_replacement_is_in_backoff() {
                 }
                 _ => false,
             }
-        })
-        .await
-    );
+        }).await;
     assert_eq!(observed_rebind, Some(None));
     tokio::time::advance(timeout).await;
     let error = timed.await.expect_err("backoff outlives timeout");
@@ -375,18 +365,14 @@ async fn dropping_a_parked_send_in_the_rebind_window_withdraws_it() {
     destructor.release();
     parked.await.expect("the retained send rides the window");
     actor.send(44).await.expect("replacement accepts");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             deliveries
                 .lock()
                 .expect("deliveries mutex poisoned")
                 .as_slice()
                 == [(2, 42), (2, 44)]
-        })
-        .await,
-        "the withdrawn send must never be promoted at bind: {:?}",
-        deliveries.lock().expect("deliveries mutex poisoned")
-    );
+        }, "the withdrawn send must never be promoted at bind: {:?}",
+        deliveries.lock().expect("deliveries mutex poisoned")).await;
     system
         .shutdown(Duration::from_secs(1))
         .await

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::common::{
-    POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until,
+    POLL_TIMEOUT, ReleaseGate, advance_time, assert_eventually, assert_quiet, poll_once, poll_until,
     waiting::task as waiting_task,
 };
 use shelterwood::{
@@ -374,13 +374,9 @@ async fn intensity_window_ages_out_between_restart_schedules() {
     let system = root.spawn().expect("runtime is available");
     system.wait_started().await.expect("root starts");
     advance_time(Duration::from_secs(11)).await;
-    crate::common::assert_eventually!(|| {
-            starts.load(Ordering::SeqCst) >= 2
-        }).await;
+    assert_eventually!(|| starts.load(Ordering::SeqCst) >= 2).await;
     advance_time(Duration::from_secs(11)).await;
-    crate::common::assert_eventually!(|| {
-            starts.load(Ordering::SeqCst) >= 3
-        }).await;
+    assert_eventually!(|| starts.load(Ordering::SeqCst) >= 3).await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -560,9 +556,7 @@ async fn dynamic_and_always_members_do_not_finish_naturally() {
         .expect("valid task");
     let ordered = ordered.spawn().expect("runtime is available");
     ordered.wait_started().await.expect("ordered starts");
-    crate::common::assert_eventually!(|| {
-            starts.load(Ordering::SeqCst) >= 2
-        }).await;
+    assert_eventually!(|| starts.load(Ordering::SeqCst) >= 2).await;
     let ordered_scope = ordered.scope();
     let mut ordered_stopped = Box::pin(ordered_scope.wait_stopped());
     assert_quiet(Duration::from_millis(20), || {
@@ -651,9 +645,7 @@ async fn owning_shutdown_joins_recursively_aborted_scope_drivers() {
 
     let system = root.spawn().expect("runtime is available");
     system.wait_started().await.expect("tree starts");
-    crate::common::assert_eventually!(|| {
-            started.load(Ordering::Acquire)
-        }, "leaf starts polling").await;
+    assert_eventually!(|| started.load(Ordering::Acquire), "leaf starts polling").await;
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(5)));
     let returned_before_leaf_released =
         poll_until(Duration::from_millis(50), Duration::from_millis(1), || {
@@ -784,9 +776,7 @@ async fn locally_requested_subtree_shutdown_reads_cancelled() {
         .add_subtree_once("nested", SubtreeOnceDef::new(nested))
         .expect("valid subtree");
     let system = root.spawn().expect("runtime is available");
-    crate::common::assert_eventually!(|| {
-            started.load(Ordering::SeqCst)
-        }).await;
+    assert_eventually!(|| started.load(Ordering::SeqCst)).await;
     // The stop request comes from the subtree's own handle, not an
     // ancestor's ladder.
     sub.request_shutdown();

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -7,13 +7,16 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until};
+use crate::common::{
+    POLL_TIMEOUT, ReleaseGate, advance_time, assert_quiet, poll_once, poll_until,
+    waiting::task as waiting_task,
+};
 use shelterwood::{
     Actor, ActorOnceDef, Backoff, Cancellation, ChildState, Context, DefaultsInheritance,
     DynamicTree, ExitError, ExitKind, ExitResult, GracePhase, Intensity, LifecycleEventKind,
     LifecycleItem, LifecycleTryRecvError, Mailbox, MailboxShutdown, Readiness, ReadinessDeadline,
-    RestartAttempt, RestartCondition, RestartPolicy, ScopeDefaults, SendErrorKind, Shutdown,
-    StartupError, StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef,
+    RestartAttempt, RestartCondition, RestartPolicy, ScopeDefaults, ScopeRef, SendErrorKind,
+    Shutdown, StartupError, StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef,
     TaskOnceDef, TaskRef, Tree,
 };
 
@@ -33,10 +36,7 @@ async fn a_restartable_subtree_can_heal_an_unfilled_lowering_failure() {
             } else {
                 tree.add_task(
                     "healthy",
-                    TaskDef::new(|context| async move {
-                        context.shutdown_token().cancelled().await;
-                        Ok(())
-                    }),
+                    waiting_task(),
                 )
                 .expect("valid task");
             }
@@ -374,19 +374,13 @@ async fn intensity_window_ages_out_between_restart_schedules() {
     let system = root.spawn().expect("runtime is available");
     system.wait_started().await.expect("root starts");
     advance_time(Duration::from_secs(11)).await;
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             starts.load(Ordering::SeqCst) >= 2
-        })
-        .await
-    );
+        }).await;
     advance_time(Duration::from_secs(11)).await;
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             starts.load(Ordering::SeqCst) >= 3
-        })
-        .await
-    );
+        }).await;
     system
         .shutdown(Duration::from_secs(1))
         .await
@@ -498,6 +492,7 @@ async fn ordered_graces_sum_while_dynamic_graces_overlap() {
         .expect("child policies bound shutdown");
     let ordered_elapsed = tokio::time::Instant::now() - started;
     assert!(ordered_elapsed >= Duration::from_secs(20));
+    assert!(ordered_elapsed < Duration::from_secs(25));
 
     let mut dynamic = DynamicTree::new();
     dynamic.add_task("one", stubborn()).expect("valid task");
@@ -565,12 +560,9 @@ async fn dynamic_and_always_members_do_not_finish_naturally() {
         .expect("valid task");
     let ordered = ordered.spawn().expect("runtime is available");
     ordered.wait_started().await.expect("ordered starts");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             starts.load(Ordering::SeqCst) >= 2
-        })
-        .await
-    );
+        }).await;
     let ordered_scope = ordered.scope();
     let mut ordered_stopped = Box::pin(ordered_scope.wait_stopped());
     assert_quiet(Duration::from_millis(20), || {
@@ -659,13 +651,9 @@ async fn owning_shutdown_joins_recursively_aborted_scope_drivers() {
 
     let system = root.spawn().expect("runtime is available");
     system.wait_started().await.expect("tree starts");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             started.load(Ordering::Acquire)
-        })
-        .await,
-        "leaf starts polling"
-    );
+        }, "leaf starts polling").await;
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(5)));
     let returned_before_leaf_released =
         poll_until(Duration::from_millis(50), Duration::from_millis(1), || {
@@ -796,12 +784,9 @@ async fn locally_requested_subtree_shutdown_reads_cancelled() {
         .add_subtree_once("nested", SubtreeOnceDef::new(nested))
         .expect("valid subtree");
     let system = root.spawn().expect("runtime is available");
-    assert!(
-        poll_until(POLL_TIMEOUT, Duration::from_millis(1), || {
+    crate::common::assert_eventually!(|| {
             started.load(Ordering::SeqCst)
-        })
-        .await
-    );
+        }).await;
     // The stop request comes from the subtree's own handle, not an
     // ancestor's ladder.
     sub.request_shutdown();
@@ -971,6 +956,26 @@ impl Actor for CapacityActor {
     }
 }
 
+fn add_inherit_reset_subtrees(
+    root: &mut Tree,
+    inherited: Tree,
+    reset: Tree,
+) -> (ScopeRef, ScopeRef) {
+    let inherited = root
+        .add_subtree_once(
+            "inherited",
+            SubtreeOnceDef::new(inherited).defaults(DefaultsInheritance::Inherit),
+        )
+        .expect("valid inherited subtree");
+    let reset = root
+        .add_subtree_once(
+            "reset",
+            SubtreeOnceDef::new(reset).defaults(DefaultsInheritance::Reset),
+        )
+        .expect("valid reset subtree");
+    (inherited, reset)
+}
+
 #[tokio::test]
 async fn subtree_defaults_inherit_or_reset_end_to_end() {
     let inherited_entered = ReleaseGate::default();
@@ -1001,16 +1006,7 @@ async fn subtree_defaults_inherit_or_reset_end_to_end() {
         mailbox: Some(Mailbox::queue(1).expect("valid inherited capacity")),
         ..ScopeDefaults::default()
     });
-    root.add_subtree_once(
-        "inherited",
-        SubtreeOnceDef::new(inherited_tree).defaults(DefaultsInheritance::Inherit),
-    )
-    .expect("valid inherited subtree");
-    root.add_subtree_once(
-        "reset",
-        SubtreeOnceDef::new(reset_tree).defaults(DefaultsInheritance::Reset),
-    )
-    .expect("valid reset subtree");
+    add_inherit_reset_subtrees(&mut root, inherited_tree, reset_tree);
     let system = root.spawn().expect("runtime is available");
     system.wait_started().await.expect("both subtrees start");
 
@@ -1080,18 +1076,7 @@ async fn three_level_mailbox_capacity_walk_honors_inherit_and_reset() {
         mailbox: Some(Mailbox::latest()),
         ..ScopeDefaults::default()
     });
-    middle
-        .add_subtree_once(
-            "inherited",
-            SubtreeOnceDef::new(inherited_leaf).defaults(DefaultsInheritance::Inherit),
-        )
-        .expect("valid inherited leaf");
-    middle
-        .add_subtree_once(
-            "reset",
-            SubtreeOnceDef::new(reset_leaf).defaults(DefaultsInheritance::Reset),
-        )
-        .expect("valid reset leaf");
+    add_inherit_reset_subtrees(&mut middle, inherited_leaf, reset_leaf);
 
     let mut root = Tree::new();
     root.defaults(ScopeDefaults {
@@ -1211,16 +1196,7 @@ async fn subtree_restart_defaults_inherit_or_reset_end_to_end() {
         )),
         ..ScopeDefaults::default()
     });
-    root.add_subtree_once(
-        "inherited",
-        SubtreeOnceDef::new(inherited_tree).defaults(DefaultsInheritance::Inherit),
-    )
-    .expect("valid inherited subtree");
-    root.add_subtree_once(
-        "reset",
-        SubtreeOnceDef::new(reset_tree).defaults(DefaultsInheritance::Reset),
-    )
-    .expect("valid reset subtree");
+    add_inherit_reset_subtrees(&mut root, inherited_tree, reset_tree);
     let system = root.spawn().expect("runtime is available");
     system
         .wait_started()
@@ -1275,18 +1251,8 @@ async fn subtree_shutdown_defaults_inherit_or_reset_end_to_end() {
         child_shutdown: Some(Shutdown::Abort),
         ..ScopeDefaults::default()
     });
-    let inherited_scope = root
-        .add_subtree_once(
-            "inherited",
-            SubtreeOnceDef::new(inherited_tree).defaults(DefaultsInheritance::Inherit),
-        )
-        .expect("valid inherited subtree");
-    let reset_scope = root
-        .add_subtree_once(
-            "reset",
-            SubtreeOnceDef::new(reset_tree).defaults(DefaultsInheritance::Reset),
-        )
-        .expect("valid reset subtree");
+    let (inherited_scope, reset_scope) =
+        add_inherit_reset_subtrees(&mut root, inherited_tree, reset_tree);
     let system = root.spawn().expect("runtime is available");
     system.wait_started().await.expect("both workers start");
     inherited_started.wait().await;
@@ -1398,18 +1364,8 @@ async fn subtree_mailbox_shutdown_defaults_inherit_or_reset_end_to_end() {
         mailbox_shutdown: Some(MailboxShutdown::Discard),
         ..ScopeDefaults::default()
     });
-    let inherited_scope = root
-        .add_subtree_once(
-            "inherited",
-            SubtreeOnceDef::new(inherited_tree).defaults(DefaultsInheritance::Inherit),
-        )
-        .expect("valid inherited subtree");
-    let reset_scope = root
-        .add_subtree_once(
-            "reset",
-            SubtreeOnceDef::new(reset_tree).defaults(DefaultsInheritance::Reset),
-        )
-        .expect("valid reset subtree");
+    let (inherited_scope, reset_scope) =
+        add_inherit_reset_subtrees(&mut root, inherited_tree, reset_tree);
     let system = root.spawn().expect("runtime is available");
     system.wait_started().await.expect("both actors start");
     inherited_actor


### PR DESCRIPTION
## Summary

- add a source-reporting `assert_eventually!` helper and migrate 101 repeated polling assertions
- consolidate driver exit/admission fixtures plus integration waiting, disposal, liveness, and inherit/reset setup
- strengthen timing, exact-once, task-locality, latch-state, and concurrency coverage while widening positive real-clock backstops to the suite-wide budget

The two original flake fixes and end-to-end driver-yield coverage had already landed on `main`; this completes the remaining #212 cleanup. The reviewed branch removes 555 net lines.

## Validation

- `./tools/dev cargo nextest run -p shelterwood --test integration` (321 passed)
- `./tools/dev just ci` (629 tests passed)
- `./tools/dev just ci-nix`

Closes #212