### PR TITLE
Handle blocking work rejection during runtime shutdown

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1098,10 +1098,14 @@ handlers non-blocking. Contracts:
   discards a later panic along with the detached thread (documented). A
   submission synchronously rejected by Tokio during blocking-pool shutdown
   moves to a detached Shelterwood-owned thread; the operation and destruction
-  of its captured state never run on the submitting runtime thread. If native
-  thread creation also fails, the captured state still reaches isolated
-  disposal and awaiting the future panics with a runtime-teardown cancellation
-  diagnostic rather than an internal task-invariant claim.
+  of its captured state stay off the submitting runtime thread while an
+  isolation worker can be created. If the dedicated fallback thread cannot
+  start, the captured state transfers to detached disposal and awaiting the
+  future panics with a runtime-teardown cancellation diagnostic rather than an
+  internal task-invariant claim. If the system cannot create the disposal
+  worker either, disposal's final no-loss fallback destroys the state
+  synchronously; thread exhaustion is the sole exception to the isolation
+  guarantee.
 - On orderly return, error, or caught-panic teardown, offloads, lifetime
   tasks, and monitor leases are frozen, cancelled, and joined before actor
   state is dropped. Hard abort necessarily drops the handler future (and

--- a/SPEC.md
+++ b/SPEC.md
@@ -1095,14 +1095,18 @@ handlers non-blocking. Contracts:
   closure's return value; a panic in the closure is captured and resumes
   where the future is awaited — on the actor task, the ordinary
   actor-panic path (§7) — while a future dropped before completion
-  discards a later panic along with the detached thread (documented). A
+  discards a later panic along with the detached thread (documented); a
+  return value or panic payload that already arrived is discarded through
+  detached disposal rather than in the awaiting task's drop glue. A
   submission synchronously rejected by Tokio during blocking-pool shutdown
   moves to a detached Shelterwood-owned thread; the operation and destruction
   of its captured state stay off the submitting runtime thread while an
-  isolation worker can be created. If the dedicated fallback thread cannot
-  start, the captured state transfers to detached disposal and awaiting the
-  future panics with a runtime-teardown cancellation diagnostic rather than an
-  internal task-invariant claim. If the system cannot create the disposal
+  isolation worker can be created. An operation that never runs at all —
+  Tokio discarded an already-accepted submission during runtime teardown, or
+  the dedicated fallback thread could not start — transfers its captured
+  state to detached disposal, and awaiting the future panics with a
+  runtime-teardown cancellation diagnostic rather than an internal
+  task-invariant claim. If the system cannot create the disposal
   worker either, disposal's final no-loss fallback destroys the state
   synchronously; thread exhaustion is the sole exception to the isolation
   guarantee.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1095,7 +1095,13 @@ handlers non-blocking. Contracts:
   closure's return value; a panic in the closure is captured and resumes
   where the future is awaited — on the actor task, the ordinary
   actor-panic path (§7) — while a future dropped before completion
-  discards a later panic along with the detached thread (documented).
+  discards a later panic along with the detached thread (documented). A
+  submission synchronously rejected by Tokio during blocking-pool shutdown
+  moves to a detached Shelterwood-owned thread; the operation and destruction
+  of its captured state never run on the submitting runtime thread. If native
+  thread creation also fails, the captured state still reaches isolated
+  disposal and awaiting the future panics with a runtime-teardown cancellation
+  diagnostic rather than an internal task-invariant claim.
 - On orderly return, error, or caught-panic teardown, offloads, lifetime
   tasks, and monitor leases are frozen, cancelled, and joined before actor
   state is dropped. Hard abort necessarily drops the handler future (and

--- a/crates/shelterwood-runtime/src/disposal.rs
+++ b/crates/shelterwood-runtime/src/disposal.rs
@@ -6,9 +6,8 @@ use std::{
     },
 };
 
-use tokio::task;
-
-use super::{Latch, catch_panic, contain_panic_payload, discard_panic, is_available};
+use super::{Latch, catch_panic, contain_panic_payload, discard_panic};
+use crate::spawn::{BlockingPoolJob, submit_blocking_job};
 
 /// Ownership wrapper for user values retained by framework state.
 ///
@@ -94,13 +93,6 @@ where
         // worker or double-panic while the job is being dropped.
         discard_panic(catch_panic(|| completion(panic)).err());
     }
-
-    fn is_pending(&self) -> bool {
-        self.state
-            .lock()
-            .expect("disposal job mutex poisoned")
-            .is_some()
-    }
 }
 
 impl<T, C> Drop for DisposalJob<T, C>
@@ -113,18 +105,20 @@ where
     }
 }
 
-/// Erased view of a queued disposal job for the shared fallback thread.
-trait QueuedDisposal: Send + Sync {
-    fn run(&self);
-}
-
-impl<T, C> QueuedDisposal for DisposalJob<T, C>
+impl<T, C> BlockingPoolJob for DisposalJob<T, C>
 where
     T: Send + 'static,
     C: FnOnce(Option<DisposalPanic>) + Send + 'static,
 {
     fn run(&self) {
         self.finish();
+    }
+
+    fn is_pending(&self) -> bool {
+        self.state
+            .lock()
+            .expect("disposal job mutex poisoned")
+            .is_some()
     }
 }
 
@@ -134,7 +128,7 @@ where
 /// under this lock, and submitters push and consult it under the same lock, so
 /// a queued job always has a live worker destined to drain it.
 struct FallbackDisposals {
-    queue: VecDeque<Arc<dyn QueuedDisposal>>,
+    queue: VecDeque<Arc<dyn BlockingPoolJob>>,
     worker_live: bool,
 }
 
@@ -146,7 +140,7 @@ static FALLBACK_DISPOSALS: Mutex<FallbackDisposals> = Mutex::new(FallbackDisposa
 /// Queues a disposal job for the shared fallback thread, lazily starting it.
 /// Returns `false` when no worker exists and none could be started; the
 /// caller must then finish the job itself.
-fn enqueue_fallback_disposal(job: Arc<dyn QueuedDisposal>) -> bool {
+fn enqueue_fallback_disposal(job: Arc<dyn BlockingPoolJob>) -> bool {
     let mut state = FALLBACK_DISPOSALS
         .lock()
         .expect("fallback disposal queue mutex poisoned");
@@ -194,47 +188,15 @@ fn run_fallback_disposals() {
     }
 }
 
-/// Returns whether Tokio synchronously rejected the blocking task.
-///
-/// Sole ownership proves that Tokio no longer holds the submitted closure.
-/// The pending check distinguishes rejection from a task that ran to
-/// completion before the submitter observed its reference count; requeueing
-/// the latter would leave empty jobs behind a blocked fallback disposal.
-///
-/// This pins Tokio's `spawn_task` shutdown path: a rejected closure is
-/// destroyed synchronously, before `spawn_blocking` returns. A future Tokio
-/// that deferred that drop would leave the count at two and degrade
-/// fail-safe to the old inline behavior rather than misroute a live closure.
-/// The end-to-end regression below pins the behavior we rely on.
-fn blocking_spawn_needs_fallback<T, C>(job: &Arc<DisposalJob<T, C>>) -> bool
-where
-    T: Send + 'static,
-    C: FnOnce(Option<DisposalPanic>) + Send + 'static,
-{
-    Arc::strong_count(job) == 1 && job.is_pending()
-}
-
 fn dispatch_disposal<T, C>(job: Arc<DisposalJob<T, C>>)
 where
     T: Send + 'static,
     C: FnOnce(Option<DisposalPanic>) + Send + 'static,
 {
-    if is_available() {
-        let worker = Arc::clone(&job);
-        match catch_panic(|| task::spawn_blocking(move || worker.finish())) {
-            Ok(handle) => {
-                drop(handle);
-                // Tokio returns a handle even when the blocking pool is
-                // already shutting down. In that case it synchronously
-                // destroys the closure, leaving `job` as the only reference.
-                // Fall through so the fallback thread, rather than this
-                // runtime-teardown thread, owns user destruction.
-                if !blocking_spawn_needs_fallback(&job) {
-                    return;
-                }
-            }
-            Err(payload) => discard_panic(Some(payload)),
-        }
+    // A rejected submission falls through so the fallback thread, rather than
+    // this runtime-teardown thread, owns user destruction.
+    if submit_blocking_job(&job) {
+        return;
     }
 
     // Outside a runtime, one shared lazily started thread drains a queue of
@@ -245,7 +207,7 @@ where
     // user destructors, exactly what isolation must prevent. Serialization is
     // the accepted trade: one blocking destructor delays later fallback
     // disposals instead of consuming another native thread.
-    if enqueue_fallback_disposal(Arc::clone(&job) as Arc<dyn QueuedDisposal>) {
+    if enqueue_fallback_disposal(Arc::clone(&job) as Arc<dyn BlockingPoolJob>) {
         return;
     }
 
@@ -312,9 +274,8 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use super::{
-        DisposalJob, DisposalPanic, Isolated, blocking_spawn_needs_fallback, dispose_detached,
-    };
+    use super::{DisposalJob, DisposalPanic, Isolated, dispose_detached};
+    use crate::spawn::{BlockingPoolJob, blocking_pool_accepted};
 
     /// Name of the shared non-runtime disposal thread, asserted on to pin
     /// *where* isolated destruction lands rather than merely where it does not.
@@ -371,7 +332,7 @@ mod tests {
         let accepted = DisposalJob::new((), |_| {});
         let accepted_worker = Arc::clone(&accepted);
         assert!(
-            !blocking_spawn_needs_fallback(&accepted),
+            blocking_pool_accepted(&accepted),
             "an accepted closure still owned by Tokio must stay on its blocking pool"
         );
         drop(accepted_worker);
@@ -380,16 +341,16 @@ mod tests {
         let rejected_worker = Arc::clone(&rejected);
         drop(rejected_worker);
         assert!(
-            blocking_spawn_needs_fallback(&rejected),
+            !blocking_pool_accepted(&rejected),
             "a synchronously dropped closure must move to the fallback queue"
         );
 
         let completed = DisposalJob::new((), |_| {});
         let completed_worker = Arc::clone(&completed);
-        completed_worker.finish();
+        completed_worker.run();
         drop(completed_worker);
         assert!(
-            !blocking_spawn_needs_fallback(&completed),
+            blocking_pool_accepted(&completed),
             "an already-completed closure must not enqueue an empty job"
         );
     }

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -1,10 +1,24 @@
-use std::{any::Any, future::Future, ops::RangeBounds, panic::resume_unwind};
+use std::{
+    any::Any,
+    future::{Future, poll_fn},
+    ops::RangeBounds,
+    panic::resume_unwind,
+    sync::{Arc, Mutex},
+};
 
 use tokio::{sync::mpsc, task};
 
 use shelterwood_core::exit::JoinVerdict as JoinOutcome;
 
-use super::{PanicPayload, catch_panic, discard_panic, sleep_until_std};
+use super::{
+    DisposingReceiver, OneShotSender, PanicPayload, catch_panic, discard_panic, dispose_detached,
+    oneshot, sleep_until_std,
+};
+
+const BLOCKING_FALLBACK_THREAD: &str = "shelterwood-blocking";
+
+type BlockingOutcome<T> = Result<T, PanicPayload>;
+type BlockingCompletion<T> = OneShotSender<BlockingOutcome<T>>;
 
 /// Counts the runtime's currently alive spawned tasks, keeping runtime
 /// metrics access in this module.
@@ -119,8 +133,133 @@ pub fn spawn_actor_work(future: impl Future<Output = ()> + Send + 'static) -> Ac
 pub fn spawn_blocking_work<T: Send + 'static>(
     operation: impl FnOnce() -> T + Send + 'static,
 ) -> impl Future<Output = T> + Send {
-    let handle = spawn_blocking(operation);
-    async move { join_resuming(handle).await }
+    let (completion, receiver) = oneshot();
+    let mut receiver = DisposingReceiver::new(receiver);
+    let job = BlockingJob::new(operation, completion);
+    let worker = Arc::clone(&job);
+
+    let mut needs_fallback = true;
+    match catch_panic(|| task::spawn_blocking(move || worker.run())) {
+        Ok(handle) => {
+            drop(handle);
+            // Tokio returns a handle even when the blocking pool is already
+            // shutting down. In that case it synchronously destroys the
+            // closure, leaving `job` as the only reference with pending work.
+            needs_fallback = blocking_spawn_needs_fallback(&job);
+        }
+        Err(payload) => discard_panic(Some(payload)),
+    }
+
+    if needs_fallback {
+        let worker = Arc::clone(&job);
+        // A blocking operation cannot share disposal's single fallback queue:
+        // one legitimately long operation would strand every later job. This
+        // path exists only for runtime teardown, so one detached thread per
+        // rejected operation is the appropriate degradation.
+        let fallback = std::thread::Builder::new()
+            .name(BLOCKING_FALLBACK_THREAD.to_owned())
+            .spawn(move || worker.run());
+        if let Err(error) = fallback {
+            // `job` still owns the operation. Its Drop implementation routes
+            // the captured closure through isolated disposal, so even native
+            // thread exhaustion cannot destroy user state on this submitter.
+            drop(error);
+        }
+    }
+    drop(job);
+
+    async move {
+        match poll_fn(|context| receiver.poll_receive(context)).await {
+            Some(Ok(value)) => value,
+            Some(Err(payload)) => resume_unwind(payload),
+            None => panic!("blocking operation was cancelled during runtime teardown"),
+        }
+    }
+}
+
+/// A blocking closure plus the completion lane that outlives its Tokio task.
+///
+/// Tokio can synchronously destroy a rejected `spawn_blocking` closure while
+/// still returning a join handle. Keeping the user closure behind an `Arc`
+/// lets the submitter detect that outcome and move the same job to a fallback
+/// thread without ever reclaiming the captured state inline.
+struct BlockingJob<F, T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    pending: Mutex<Option<(F, BlockingCompletion<T>)>>,
+}
+
+impl<F, T> BlockingJob<F, T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    fn new(operation: F, completion: BlockingCompletion<T>) -> Arc<Self> {
+        Arc::new(Self {
+            pending: Mutex::new(Some((operation, completion))),
+        })
+    }
+
+    fn run(&self) {
+        let Some((operation, completion)) = self
+            .pending
+            .lock()
+            .expect("blocking job mutex poisoned")
+            .take()
+        else {
+            return;
+        };
+        let outcome = catch_panic(operation);
+        if let Err(unclaimed) = completion.send(outcome) {
+            // The returned future was dropped. We are already on a blocking
+            // worker, but still contain a hostile result/panic-payload
+            // destructor so it cannot unwind through the worker entry point.
+            discard_panic(catch_panic(|| drop(unclaimed)).err());
+        }
+    }
+
+    fn is_pending(&self) -> bool {
+        self.pending
+            .lock()
+            .expect("blocking job mutex poisoned")
+            .is_some()
+    }
+}
+
+impl<F, T> Drop for BlockingJob<F, T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    fn drop(&mut self) {
+        let Some((operation, completion)) = self
+            .pending
+            .lock()
+            .expect("blocking job mutex poisoned")
+            .take()
+        else {
+            return;
+        };
+        // A cancelled or unstartable job must wake its waiter, but a hostile
+        // waiter waker must not interrupt isolation of the captured closure.
+        discard_panic(catch_panic(|| drop(completion)).err());
+        dispose_detached(operation);
+    }
+}
+
+/// Returns whether Tokio synchronously rejected a blocking work submission.
+///
+/// Sole ownership proves that Tokio no longer holds the submitted closure;
+/// the pending check distinguishes rejection from a fast task that completed
+/// before the submitter sampled the reference count.
+fn blocking_spawn_needs_fallback<F, T>(job: &Arc<BlockingJob<F, T>>) -> bool
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    Arc::strong_count(job) == 1 && job.is_pending()
 }
 
 /// A spawned operation owned by the library.
@@ -332,6 +471,50 @@ impl Default for JitterRng {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        sync::{Arc, Condvar, Mutex, mpsc},
+        thread::{self, ThreadId},
+        time::{Duration, Instant},
+    };
+
+    const WAIT: Duration = Duration::from_secs(5);
+
+    type ThreadDescription = (ThreadId, Option<String>);
+
+    fn describe_current_thread() -> ThreadDescription {
+        let current = thread::current();
+        (current.id(), current.name().map(str::to_owned))
+    }
+
+    struct BlockingDrop {
+        entered: mpsc::Sender<ThreadDescription>,
+        release: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl Drop for BlockingDrop {
+        fn drop(&mut self) {
+            let _ = self.entered.send(describe_current_thread());
+            let (released, wake) = &*self.release;
+            let mut released = released.lock().expect("release mutex available");
+            let deadline = Instant::now() + WAIT;
+            while !*released {
+                let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                    break;
+                };
+                released = wake
+                    .wait_timeout(released, remaining)
+                    .expect("release mutex available")
+                    .0;
+            }
+        }
+    }
+
+    fn release(gate: &Arc<(Mutex<bool>, Condvar)>) {
+        let (released, wake) = &**gate;
+        *released.lock().expect("release mutex available") = true;
+        wake.notify_all();
+    }
+
     #[tokio::test]
     async fn scope_wait_prefers_signal_when_both_control_futures_are_ready() {
         let (_sender, mut receiver) = super::unbounded_mpsc::<()>();
@@ -372,5 +555,100 @@ mod tests {
 
         assert!(matches!(wake, super::ScopeWake::Message(Some(999))));
         assert_eq!(control_receiver.try_recv(), Ok(0));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn blocking_work_preserves_values_and_panics() {
+        assert_eq!(super::spawn_blocking_work(|| 42_u8).await, 42);
+
+        let panicking = super::spawn(async {
+            super::spawn_blocking_work(|| panic!("blocking work panic")).await
+        });
+        assert!(matches!(
+            super::join(panicking).await,
+            super::JoinOutcome::Panic {
+                message: Some(message)
+            } if message == "blocking work panic"
+        ));
+    }
+
+    #[test]
+    fn shut_down_blocking_pool_runs_rejected_work_off_the_submitting_thread() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .max_blocking_threads(1)
+            .build()
+            .expect("test runtime");
+        let (worker_started, worker_started_rx) = mpsc::channel();
+        let (release_worker, release_worker_rx) = mpsc::channel();
+        drop(runtime.spawn_blocking(move || {
+            worker_started
+                .send(())
+                .expect("test observes the occupied blocking worker");
+            release_worker_rx
+                .recv()
+                .expect("test releases the occupied blocking worker");
+        }));
+        worker_started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the sole blocking worker starts");
+
+        let (future_tx, future_rx) = mpsc::channel();
+        let (submitted, submitted_rx) = mpsc::channel();
+        let (returned, returned_rx) = mpsc::channel();
+        let (entered, entered_rx) = mpsc::channel();
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let captured = BlockingDrop {
+            entered,
+            release: Arc::clone(&gate),
+        };
+        // This outer task stays queued behind the occupied worker. Tokio runs
+        // it while draining shutdown, so its nested blocking submission is
+        // synchronously rejected even though `spawn_blocking` returns a handle.
+        drop(runtime.spawn_blocking(move || {
+            let submitting_thread = thread::current().id();
+            let future = super::spawn_blocking_work(move || {
+                drop(captured);
+                42_u8
+            });
+            submitted
+                .send(submitting_thread)
+                .expect("test observes the submitting thread");
+            future_tx
+                .send(future)
+                .expect("test receives the blocking-work future");
+            returned.send(()).expect("test observes submission return");
+        }));
+        runtime.shutdown_background();
+        release_worker
+            .send(())
+            .expect("the blocking-pool teardown may proceed");
+
+        let submitting_thread = submitted_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("runtime teardown submits blocking work");
+        let future = future_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("a rejected submission still returns its future");
+        let (operation_thread, operation_name) = entered_rx
+            .recv_timeout(WAIT + Duration::from_secs(1))
+            .expect("the rejected operation starts");
+        // This arrives while the captured destructor is still blocked. On the
+        // regression path Tokio destroys the closure inline and submission
+        // cannot return until the escape hatch fires.
+        let submission_returned = returned_rx.recv_timeout(Duration::from_secs(1));
+
+        release(&gate);
+        submission_returned.expect("captured destruction must not block submission");
+
+        let consumer = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("consumer runtime");
+        assert_eq!(consumer.block_on(future), 42);
+        assert_ne!(operation_thread, submitting_thread);
+        assert_eq!(
+            operation_name.as_deref(),
+            Some(super::BLOCKING_FALLBACK_THREAD),
+            "a rejected operation must land on Shelterwood's fallback thread"
+        );
     }
 }

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -11,8 +11,8 @@ use tokio::{sync::mpsc, task};
 use shelterwood_core::exit::JoinVerdict as JoinOutcome;
 
 use super::{
-    DisposingReceiver, OneShotSender, PanicPayload, catch_panic, discard_panic, dispose_detached,
-    oneshot, sleep_until_std,
+    DisposingReceiver, OneShotReceiver, OneShotSender, PanicPayload, catch_panic, discard_panic,
+    dispose_detached, oneshot, sleep_until_std,
 };
 
 const BLOCKING_FALLBACK_THREAD: &str = "shelterwood-blocking";
@@ -134,7 +134,6 @@ pub fn spawn_blocking_work<T: Send + 'static>(
     operation: impl FnOnce() -> T + Send + 'static,
 ) -> impl Future<Output = T> + Send {
     let (completion, receiver) = oneshot();
-    let mut receiver = DisposingReceiver::new(receiver);
     let job = BlockingJob::new(operation, completion);
     let worker = Arc::clone(&job);
 
@@ -151,28 +150,52 @@ pub fn spawn_blocking_work<T: Send + 'static>(
     }
 
     if needs_fallback {
-        let worker = Arc::clone(&job);
         // A blocking operation cannot share disposal's single fallback queue:
         // one legitimately long operation would strand every later job. This
         // path exists only for runtime teardown, so one detached thread per
         // rejected operation is the appropriate degradation.
-        let fallback = std::thread::Builder::new()
-            .name(BLOCKING_FALLBACK_THREAD.to_owned())
-            .spawn(move || worker.run());
-        if let Err(error) = fallback {
-            // `job` still owns the operation. Its Drop implementation routes
-            // the captured closure through isolated disposal, so even native
-            // thread exhaustion cannot destroy user state on this submitter.
-            drop(error);
-        }
+        spawn_blocking_fallback_with(&job, |worker| {
+            std::thread::Builder::new()
+                .name(BLOCKING_FALLBACK_THREAD.to_owned())
+                .spawn(move || worker.run())
+        });
     }
     drop(job);
 
-    async move {
-        match poll_fn(|context| receiver.poll_receive(context)).await {
-            Some(Ok(value)) => value,
-            Some(Err(payload)) => resume_unwind(payload),
-            None => panic!("blocking operation was cancelled during runtime teardown"),
+    receive_blocking(receiver)
+}
+
+async fn receive_blocking<T: Send + 'static>(receiver: OneShotReceiver<BlockingOutcome<T>>) -> T {
+    let mut receiver = DisposingReceiver::new(receiver);
+    match poll_fn(|context| receiver.poll_receive(context)).await {
+        Some(Ok(value)) => value,
+        Some(Err(payload)) => resume_unwind(payload),
+        None => panic!("blocking operation was cancelled during runtime teardown"),
+    }
+}
+
+/// Gives one rejected job to a native fallback thread.
+///
+/// The injected spawner makes the failure ownership edge directly testable:
+/// `std::thread::Builder::spawn` consumes and destroys its closure before it
+/// returns `Err`, so either spawner outcome has consumed `worker`. The
+/// submitter's `job` reference remains authoritative until this function
+/// returns.
+fn spawn_blocking_fallback_with<F, T>(
+    job: &Arc<BlockingJob<F, T>>,
+    spawn: impl FnOnce(Arc<BlockingJob<F, T>>) -> std::io::Result<std::thread::JoinHandle<()>>,
+) where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let worker = Arc::clone(job);
+    match spawn(worker) {
+        Ok(handle) => drop(handle),
+        Err(error) => {
+            // `job` still owns the operation. Its Drop implementation routes
+            // the captured closure through disposal, which retries isolation
+            // independently and closes the completion lane if it cannot run.
+            drop(error);
         }
     }
 }
@@ -212,11 +235,21 @@ where
             return;
         };
         let outcome = catch_panic(operation);
-        if let Err(unclaimed) = completion.send(outcome) {
-            // The returned future was dropped. We are already on a blocking
-            // worker, but still contain a hostile result/panic-payload
-            // destructor so it cannot unwind through the worker entry point.
-            discard_panic(catch_panic(|| drop(unclaimed)).err());
+        match catch_panic(|| completion.send(outcome)) {
+            Ok(Ok(())) => {}
+            Ok(Err(unclaimed)) => {
+                // The returned future was dropped. We are already on a
+                // blocking worker, but still contain a hostile
+                // result/panic-payload destructor so it cannot unwind through
+                // the worker entry point.
+                discard_panic(catch_panic(|| drop(unclaimed)).err());
+            }
+            Err(waker_panic) => {
+                // Tokio publishes the value before waking the receiver. A
+                // hostile executor waker must not unwind this detached worker;
+                // the receiver still owns the authoritative outcome.
+                discard_panic(Some(waker_panic));
+            }
         }
     }
 
@@ -472,7 +505,13 @@ impl Default for JitterRng {
 #[cfg(test)]
 mod tests {
     use std::{
-        sync::{Arc, Condvar, Mutex, mpsc},
+        panic,
+        sync::{
+            Arc, Condvar, Mutex,
+            atomic::{AtomicUsize, Ordering},
+            mpsc,
+        },
+        task::{Context, Poll, Wake, Waker},
         thread::{self, ThreadId},
         time::{Duration, Instant},
     };
@@ -506,6 +545,36 @@ mod tests {
                     .expect("release mutex available")
                     .0;
             }
+        }
+    }
+
+    struct RecordingDrop(mpsc::Sender<ThreadDescription>);
+
+    impl Drop for RecordingDrop {
+        fn drop(&mut self) {
+            let _ = self.0.send(describe_current_thread());
+        }
+    }
+
+    struct PanickingDrop(mpsc::Sender<()>);
+
+    impl Drop for PanickingDrop {
+        fn drop(&mut self) {
+            let _ = self.0.send(());
+            panic!("hostile blocking outcome destructor");
+        }
+    }
+
+    struct PanicWake(Arc<AtomicUsize>);
+
+    impl Wake for PanicWake {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            panic!("hostile blocking-result waker");
         }
     }
 
@@ -570,6 +639,184 @@ mod tests {
                 message: Some(message)
             } if message == "blocking work panic"
         ));
+    }
+
+    #[test]
+    fn fallback_detection_distinguishes_owned_pending_and_completed_jobs() {
+        let (accepted_completion, _accepted_receiver) = super::oneshot();
+        let accepted = super::BlockingJob::new(|| 1_u8, accepted_completion);
+        let accepted_worker = Arc::clone(&accepted);
+        assert!(
+            !super::blocking_spawn_needs_fallback(&accepted),
+            "an accepted closure still owned by Tokio must stay on its blocking pool"
+        );
+        drop(accepted_worker);
+
+        let (rejected_completion, _rejected_receiver) = super::oneshot();
+        let rejected = super::BlockingJob::new(|| 2_u8, rejected_completion);
+        let rejected_worker = Arc::clone(&rejected);
+        drop(rejected_worker);
+        assert!(
+            super::blocking_spawn_needs_fallback(&rejected),
+            "a synchronously dropped closure must move to the fallback thread"
+        );
+
+        let (completed_completion, _completed_receiver) = super::oneshot();
+        let completed = super::BlockingJob::new(|| 3_u8, completed_completion);
+        let completed_worker = Arc::clone(&completed);
+        completed_worker.run();
+        drop(completed_worker);
+        assert!(
+            !super::blocking_spawn_needs_fallback(&completed),
+            "a fast completed closure must not enqueue an empty job"
+        );
+    }
+
+    #[test]
+    fn completion_contains_a_panicking_receiver_waker() {
+        let (completion, mut receiver) = super::oneshot();
+        let job = super::BlockingJob::new(|| 42_u8, completion);
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let waker = Waker::from(Arc::new(PanicWake(Arc::clone(&wakes))));
+        assert!(matches!(
+            receiver.poll_receive(&mut Context::from_waker(&waker)),
+            Poll::Pending
+        ));
+
+        assert!(
+            super::catch_panic(|| job.run()).is_ok(),
+            "a receiver waker cannot unwind the detached worker"
+        );
+        assert_eq!(wakes.load(Ordering::SeqCst), 1);
+        assert!(matches!(
+            receiver.poll_receive(&mut Context::from_waker(Waker::noop())),
+            Poll::Ready(Some(Ok(42)))
+        ));
+    }
+
+    #[test]
+    fn unclaimed_result_and_panic_payload_destructors_are_contained() {
+        let (result_dropped, result_dropped_rx) = mpsc::channel();
+        let (result_completion, result_receiver) = super::oneshot();
+        drop(result_receiver);
+        let result_job =
+            super::BlockingJob::new(move || PanickingDrop(result_dropped), result_completion);
+        assert!(
+            super::catch_panic(|| result_job.run()).is_ok(),
+            "an unclaimed result destructor cannot unwind the worker"
+        );
+        result_dropped_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the unclaimed result is destroyed");
+
+        let (payload_dropped, payload_dropped_rx) = mpsc::channel();
+        let (panic_completion, panic_receiver) = super::oneshot();
+        drop(panic_receiver);
+        let panic_job = super::BlockingJob::new(
+            move || -> () { panic::panic_any(PanickingDrop(payload_dropped)) },
+            panic_completion,
+        );
+        assert!(
+            super::catch_panic(|| panic_job.run()).is_ok(),
+            "an unclaimed panic-payload destructor cannot unwind the worker"
+        );
+        payload_dropped_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the unclaimed panic payload is destroyed");
+    }
+
+    #[test]
+    fn accepted_then_cancelled_job_isolates_capture_and_reports_teardown() {
+        let (captured_dropped, captured_dropped_rx) = mpsc::channel();
+        let captured = RecordingDrop(captured_dropped);
+        let (completion, receiver) = super::oneshot();
+        let job = super::BlockingJob::new(
+            move || {
+                drop(captured);
+                42_u8
+            },
+            completion,
+        );
+        let accepted_worker = Arc::clone(&job);
+        drop(job);
+
+        let (cancelled_on, cancelled_on_rx) = mpsc::channel();
+        thread::Builder::new()
+            .name("tokio-canceller".to_owned())
+            .spawn(move || {
+                cancelled_on
+                    .send(thread::current().id())
+                    .expect("test observes cancellation");
+                drop(accepted_worker);
+            })
+            .expect("cancellation thread starts")
+            .join()
+            .expect("cancellation thread completes");
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("consumer runtime");
+        let cancellation =
+            super::catch_panic(|| runtime.block_on(super::receive_blocking(receiver)))
+                .expect_err("an unstarted accepted job reports cancellation");
+        assert_eq!(
+            cancellation.downcast_ref::<&'static str>().copied(),
+            Some("blocking operation was cancelled during runtime teardown")
+        );
+
+        let cancellation_thread = cancelled_on_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the cancellation thread is recorded");
+        let (destructor_thread, destructor_name) = captured_dropped_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the cancelled capture reaches disposal");
+        assert_ne!(destructor_thread, cancellation_thread);
+        assert_eq!(
+            destructor_name.as_deref(),
+            Some("shelterwood-disposal"),
+            "accepted cancellation must isolate closure destruction"
+        );
+    }
+
+    #[test]
+    fn failed_native_fallback_isolates_capture_and_reports_teardown() {
+        let submitting_thread = thread::current().id();
+        let (captured_dropped, captured_dropped_rx) = mpsc::channel();
+        let captured = RecordingDrop(captured_dropped);
+        let (completion, receiver) = super::oneshot();
+        let job = super::BlockingJob::new(
+            move || {
+                drop(captured);
+                42_u8
+            },
+            completion,
+        );
+
+        super::spawn_blocking_fallback_with(&job, |_worker| {
+            Err(std::io::Error::other("injected native thread exhaustion"))
+        });
+        drop(job);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("consumer runtime");
+        let cancellation =
+            super::catch_panic(|| runtime.block_on(super::receive_blocking(receiver)))
+                .expect_err("a fallback that cannot start reports cancellation");
+        assert_eq!(
+            cancellation.downcast_ref::<&'static str>().copied(),
+            Some("blocking operation was cancelled during runtime teardown")
+        );
+
+        let (destructor_thread, destructor_name) = captured_dropped_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the unstartable capture reaches disposal");
+        assert_ne!(destructor_thread, submitting_thread);
+        assert_eq!(
+            destructor_name.as_deref(),
+            Some("shelterwood-disposal"),
+            "native fallback failure must retry through disposal isolation"
+        );
     }
 
     #[test]

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -135,21 +135,8 @@ pub fn spawn_blocking_work<T: Send + 'static>(
 ) -> impl Future<Output = T> + Send {
     let (completion, receiver) = oneshot();
     let job = BlockingJob::new(operation, completion);
-    let worker = Arc::clone(&job);
 
-    let mut needs_fallback = true;
-    match catch_panic(|| task::spawn_blocking(move || worker.run())) {
-        Ok(handle) => {
-            drop(handle);
-            // Tokio returns a handle even when the blocking pool is already
-            // shutting down. In that case it synchronously destroys the
-            // closure, leaving `job` as the only reference with pending work.
-            needs_fallback = blocking_spawn_needs_fallback(&job);
-        }
-        Err(payload) => discard_panic(Some(payload)),
-    }
-
-    if needs_fallback {
+    if !submit_blocking_job(&job) {
         // A blocking operation cannot share disposal's single fallback queue:
         // one legitimately long operation would strand every later job. This
         // path exists only for runtime teardown, so one detached thread per
@@ -165,12 +152,23 @@ pub fn spawn_blocking_work<T: Send + 'static>(
     receive_blocking(receiver)
 }
 
-async fn receive_blocking<T: Send + 'static>(receiver: OneShotReceiver<BlockingOutcome<T>>) -> T {
-    let mut receiver = DisposingReceiver::new(receiver);
-    match poll_fn(|context| receiver.poll_receive(context)).await {
-        Some(Ok(value)) => value,
-        Some(Err(payload)) => resume_unwind(payload),
-        None => panic!("blocking operation was cancelled during runtime teardown"),
+/// Awaits one blocking outcome, disposing it if the awaiting future is dropped.
+///
+/// The disposing wrapper is taken here rather than inside the returned future
+/// because a future dropped before its first poll never runs its own body: the
+/// operation can still have stored a user value by then, and reclaiming it
+/// would run that user destructor in the awaiting task's drop glue.
+fn receive_blocking<T: Send + 'static>(
+    receiver: OneShotReceiver<BlockingOutcome<T>>,
+) -> impl Future<Output = T> + Send {
+    let receiver = DisposingReceiver::new(receiver);
+    async move {
+        let mut receiver = receiver;
+        match poll_fn(|context| receiver.poll_receive(context)).await {
+            Some(Ok(value)) => value,
+            Some(Err(payload)) => resume_unwind(payload),
+            None => panic!("blocking operation was cancelled during runtime teardown"),
+        }
     }
 }
 
@@ -224,7 +222,13 @@ where
             pending: Mutex::new(Some((operation, completion))),
         })
     }
+}
 
+impl<F, T> BlockingPoolJob for BlockingJob<F, T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
     fn run(&self) {
         let Some((operation, completion)) = self
             .pending
@@ -282,17 +286,54 @@ where
     }
 }
 
-/// Returns whether Tokio synchronously rejected a blocking work submission.
+/// Work held behind a shared owner so its submitter can tell whether Tokio
+/// took it.
+pub(crate) trait BlockingPoolJob: Send + Sync + 'static {
+    /// Runs the pending work, if this job still holds any.
+    fn run(&self);
+
+    /// Reports whether the work is still waiting to be run.
+    fn is_pending(&self) -> bool;
+}
+
+/// Submits `job` to Tokio's blocking pool, reporting whether Tokio took it.
 ///
-/// Sole ownership proves that Tokio no longer holds the submitted closure;
-/// the pending check distinguishes rejection from a fast task that completed
-/// before the submitter sampled the reference count.
-fn blocking_spawn_needs_fallback<F, T>(job: &Arc<BlockingJob<F, T>>) -> bool
-where
-    F: FnOnce() -> T + Send + 'static,
-    T: Send + 'static,
-{
-    Arc::strong_count(job) == 1 && job.is_pending()
+/// On `false` the caller is the sole owner of still-pending work and must
+/// place it elsewhere.
+pub(crate) fn submit_blocking_job<J: BlockingPoolJob>(job: &Arc<J>) -> bool {
+    if !is_available() {
+        return false;
+    }
+    let worker = Arc::clone(job);
+    match catch_panic(|| task::spawn_blocking(move || worker.run())) {
+        Ok(handle) => {
+            drop(handle);
+            blocking_pool_accepted(job)
+        }
+        Err(payload) => {
+            discard_panic(Some(payload));
+            false
+        }
+    }
+}
+
+/// Returns whether Tokio took ownership of a submitted blocking job.
+///
+/// Tokio returns a join handle even when the blocking pool is already shutting
+/// down, having synchronously destroyed the submitted closure. Ownership, not
+/// the handle, is therefore the acceptance signal: sole ownership proves Tokio
+/// no longer holds the closure, and the pending check distinguishes that
+/// rejection from a job that ran to completion before the submitter sampled
+/// the reference count — rerouting the latter would place already-empty jobs
+/// behind live ones.
+///
+/// This pins Tokio's `spawn_task` shutdown path: a rejected closure is
+/// destroyed synchronously, before `spawn_blocking` returns. A future Tokio
+/// that deferred that drop would leave the count at two and degrade fail-safe
+/// to the old inline behavior rather than misroute a live closure. The
+/// end-to-end regressions in this crate pin the behavior we rely on.
+pub(crate) fn blocking_pool_accepted<J: BlockingPoolJob>(job: &Arc<J>) -> bool {
+    Arc::strong_count(job) > 1 || !job.is_pending()
 }
 
 /// A spawned operation owned by the library.
@@ -516,6 +557,8 @@ mod tests {
         time::{Duration, Instant},
     };
 
+    use super::BlockingPoolJob;
+
     const WAIT: Duration = Duration::from_secs(5);
 
     type ThreadDescription = (ThreadId, Option<String>);
@@ -647,7 +690,7 @@ mod tests {
         let accepted = super::BlockingJob::new(|| 1_u8, accepted_completion);
         let accepted_worker = Arc::clone(&accepted);
         assert!(
-            !super::blocking_spawn_needs_fallback(&accepted),
+            super::blocking_pool_accepted(&accepted),
             "an accepted closure still owned by Tokio must stay on its blocking pool"
         );
         drop(accepted_worker);
@@ -657,7 +700,7 @@ mod tests {
         let rejected_worker = Arc::clone(&rejected);
         drop(rejected_worker);
         assert!(
-            super::blocking_spawn_needs_fallback(&rejected),
+            !super::blocking_pool_accepted(&rejected),
             "a synchronously dropped closure must move to the fallback thread"
         );
 
@@ -667,7 +710,7 @@ mod tests {
         completed_worker.run();
         drop(completed_worker);
         assert!(
-            !super::blocking_spawn_needs_fallback(&completed),
+            super::blocking_pool_accepted(&completed),
             "a fast completed closure must not enqueue an empty job"
         );
     }
@@ -723,6 +766,32 @@ mod tests {
         payload_dropped_rx
             .recv_timeout(Duration::from_secs(1))
             .expect("the unclaimed panic payload is destroyed");
+    }
+
+    #[test]
+    fn dropping_an_unpolled_future_isolates_a_stored_outcome() {
+        let waiter_thread = thread::current().id();
+        let (result_dropped, result_dropped_rx) = mpsc::channel();
+        let (completion, receiver) = super::oneshot();
+        let job = super::BlockingJob::new(move || RecordingDrop(result_dropped), completion);
+        let worker = Arc::clone(&job);
+        drop(job);
+
+        // The awaiting future is built but never polled, so only its own
+        // construction can decide who destroys an outcome that lands first.
+        let future = super::receive_blocking(receiver);
+        worker.run();
+        drop(future);
+
+        let (destructor_thread, destructor_name) = result_dropped_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the unclaimed result is destroyed");
+        assert_ne!(destructor_thread, waiter_thread);
+        assert_eq!(
+            destructor_name.as_deref(),
+            Some("shelterwood-disposal"),
+            "an unclaimed result must not be destroyed on the awaiting task's thread"
+        );
     }
 
     #[test]

--- a/crates/shelterwood/doctests/docs/shutdown-and-resources.md
+++ b/crates/shelterwood/doctests/docs/shutdown-and-resources.md
@@ -93,9 +93,12 @@ exclusive process resources indefinitely.
 If Tokio has already closed its blocking pool during runtime teardown,
 Shelterwood reroutes a rejected `run_blocking` operation to a detached
 Shelterwood-owned thread. This keeps both the operation and destruction of its
-captured state off the submitting runtime thread. If neither Tokio nor a native
-fallback thread can start the operation, its captured state still goes through
-isolated disposal and awaiting the future reports runtime-teardown cancellation.
+captured state off the submitting runtime thread. If that native fallback
+cannot start, its captured state transfers to detached disposal and awaiting
+the future reports runtime-teardown cancellation. If the system cannot create
+the disposal worker either, disposal destroys the state synchronously rather
+than lose it; native thread exhaustion is the sole exception to the isolation
+guarantee.
 
 Async offloads are different: they are incarnation-owned, are cancelled at the
 stop freeze, and never outlive the incarnation. They are intentionally absent

--- a/crates/shelterwood/doctests/docs/shutdown-and-resources.md
+++ b/crates/shelterwood/doctests/docs/shutdown-and-resources.md
@@ -90,6 +90,13 @@ A late return value or panic is discarded if its future was dropped. Therefore
 blocking operations must be safe to outlive the actor and must not retain
 exclusive process resources indefinitely.
 
+If Tokio has already closed its blocking pool during runtime teardown,
+Shelterwood reroutes a rejected `run_blocking` operation to a detached
+Shelterwood-owned thread. This keeps both the operation and destruction of its
+captured state off the submitting runtime thread. If neither Tokio nor a native
+fallback thread can start the operation, its captured state still goes through
+isolated disposal and awaiting the future reports runtime-teardown cancellation.
+
 Async offloads are different: they are incarnation-owned, are cancelled at the
 stop freeze, and never outlive the incarnation. They are intentionally absent
 from `StopContext`.

--- a/crates/shelterwood/doctests/docs/shutdown-and-resources.md
+++ b/crates/shelterwood/doctests/docs/shutdown-and-resources.md
@@ -93,12 +93,13 @@ exclusive process resources indefinitely.
 If Tokio has already closed its blocking pool during runtime teardown,
 Shelterwood reroutes a rejected `run_blocking` operation to a detached
 Shelterwood-owned thread. This keeps both the operation and destruction of its
-captured state off the submitting runtime thread. If that native fallback
-cannot start, its captured state transfers to detached disposal and awaiting
-the future reports runtime-teardown cancellation. If the system cannot create
-the disposal worker either, disposal destroys the state synchronously rather
-than lose it; native thread exhaustion is the sole exception to the isolation
-guarantee.
+captured state off the submitting runtime thread. An operation that never runs
+at all — Tokio discarded an already-accepted submission as the runtime went
+away, or the native fallback could not start — transfers its captured state to
+detached disposal, and awaiting the future reports runtime-teardown
+cancellation. If the system cannot create the disposal worker either, disposal
+destroys the state synchronously rather than lose it; native thread exhaustion
+is the sole exception to the isolation guarantee.
 
 Async offloads are different: they are incarnation-owned, are cancelled at the
 stop freeze, and never outlive the incarnation. They are intentionally absent

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -91,6 +91,10 @@ macro_rules! actor_context_forwarders {
         ///
         /// Cancellation is cooperative; a hard-aborted operation's OS thread
         /// detaches and may outlive this actor incarnation.
+        /// A blocking-pool rejection during runtime teardown uses a detached
+        /// Shelterwood thread; inability to start one makes the returned
+        /// future panic with a runtime-teardown cancellation diagnostic when
+        /// awaited.
         pub fn run_blocking<F, T>(&self, operation: F) -> Blocking<T>
         where
             F: FnOnce(CancellationToken) -> T + Send + 'static,

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -92,9 +92,10 @@ macro_rules! actor_context_forwarders {
         /// Cancellation is cooperative; a hard-aborted operation's OS thread
         /// detaches and may outlive this actor incarnation.
         /// A blocking-pool rejection during runtime teardown uses a detached
-        /// Shelterwood thread; inability to start one makes the returned
-        /// future panic with a runtime-teardown cancellation diagnostic when
-        /// awaited.
+        /// Shelterwood thread; an operation that never runs — cancelled with
+        /// the runtime, or with no thread left to start it — makes the
+        /// returned future panic with a runtime-teardown cancellation
+        /// diagnostic when awaited.
         pub fn run_blocking<F, T>(&self, operation: F) -> Blocking<T>
         where
             F: FnOnce(CancellationToken) -> T + Send + 'static,

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -129,7 +129,10 @@ impl Drop for Guard {
 /// Cancellation cannot forcibly stop a blocking thread. Dropping this future
 /// or hard-aborting its actor detaches the thread after requesting cooperative
 /// cancellation; Shelterwood does not join it, and any later value or panic is
-/// discarded. The operation must therefore be safe to outlive its actor.
+/// discarded. A submission rejected during runtime teardown moves to a
+/// detached Shelterwood thread; if no execution thread can start, awaiting the
+/// future panics with a runtime-teardown cancellation diagnostic. The
+/// operation must therefore be safe to outlive its actor.
 #[must_use = "dropping this future requests cooperative cancellation and detaches the thread"]
 pub struct Blocking<T> {
     future: Pin<Box<dyn Future<Output = T> + Send + 'static>>,
@@ -1382,6 +1385,9 @@ impl<M: Send + 'static> RawContext<M> {
     ///
     /// Cancellation is cooperative. If this future is dropped or its actor is
     /// hard-aborted, the OS thread detaches and can outlive the incarnation.
+    /// A blocking-pool rejection during runtime teardown uses a detached
+    /// Shelterwood thread; inability to start one makes the returned future
+    /// panic with a runtime-teardown cancellation diagnostic when awaited.
     pub fn run_blocking<F, T>(&self, operation: F) -> Blocking<T>
     where
         F: FnOnce(CancellationToken) -> T + Send + 'static,

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -129,10 +129,11 @@ impl Drop for Guard {
 /// Cancellation cannot forcibly stop a blocking thread. Dropping this future
 /// or hard-aborting its actor detaches the thread after requesting cooperative
 /// cancellation; Shelterwood does not join it, and any later value or panic is
-/// discarded. A submission rejected during runtime teardown moves to a
-/// detached Shelterwood thread; if no execution thread can start, awaiting the
-/// future panics with a runtime-teardown cancellation diagnostic. The
-/// operation must therefore be safe to outlive its actor.
+/// discarded through detached disposal. A submission rejected during runtime
+/// teardown moves to a detached Shelterwood thread; an operation that never
+/// runs — cancelled with the runtime, or with no thread left to start it —
+/// makes awaiting the future panic with a runtime-teardown cancellation
+/// diagnostic. The operation must therefore be safe to outlive its actor.
 #[must_use = "dropping this future requests cooperative cancellation and detaches the thread"]
 pub struct Blocking<T> {
     future: Pin<Box<dyn Future<Output = T> + Send + 'static>>,
@@ -1386,8 +1387,10 @@ impl<M: Send + 'static> RawContext<M> {
     /// Cancellation is cooperative. If this future is dropped or its actor is
     /// hard-aborted, the OS thread detaches and can outlive the incarnation.
     /// A blocking-pool rejection during runtime teardown uses a detached
-    /// Shelterwood thread; inability to start one makes the returned future
-    /// panic with a runtime-teardown cancellation diagnostic when awaited.
+    /// Shelterwood thread; an operation that never runs — cancelled with the
+    /// runtime, or with no thread left to start it — makes the returned
+    /// future panic with a runtime-teardown cancellation diagnostic when
+    /// awaited.
     pub fn run_blocking<F, T>(&self, operation: F) -> Blocking<T>
     where
         F: FnOnce(CancellationToken) -> T + Send + 'static,

--- a/docs/shutdown-and-resources.md
+++ b/docs/shutdown-and-resources.md
@@ -93,9 +93,12 @@ exclusive process resources indefinitely.
 If Tokio has already closed its blocking pool during runtime teardown,
 Shelterwood reroutes a rejected `run_blocking` operation to a detached
 Shelterwood-owned thread. This keeps both the operation and destruction of its
-captured state off the submitting runtime thread. If neither Tokio nor a native
-fallback thread can start the operation, its captured state still goes through
-isolated disposal and awaiting the future reports runtime-teardown cancellation.
+captured state off the submitting runtime thread. If that native fallback
+cannot start, its captured state transfers to detached disposal and awaiting
+the future reports runtime-teardown cancellation. If the system cannot create
+the disposal worker either, disposal destroys the state synchronously rather
+than lose it; native thread exhaustion is the sole exception to the isolation
+guarantee.
 
 Async offloads are different: they are incarnation-owned, are cancelled at the
 stop freeze, and never outlive the incarnation. They are intentionally absent

--- a/docs/shutdown-and-resources.md
+++ b/docs/shutdown-and-resources.md
@@ -90,6 +90,13 @@ A late return value or panic is discarded if its future was dropped. Therefore
 blocking operations must be safe to outlive the actor and must not retain
 exclusive process resources indefinitely.
 
+If Tokio has already closed its blocking pool during runtime teardown,
+Shelterwood reroutes a rejected `run_blocking` operation to a detached
+Shelterwood-owned thread. This keeps both the operation and destruction of its
+captured state off the submitting runtime thread. If neither Tokio nor a native
+fallback thread can start the operation, its captured state still goes through
+isolated disposal and awaiting the future reports runtime-teardown cancellation.
+
 Async offloads are different: they are incarnation-owned, are cancelled at the
 stop freeze, and never outlive the incarnation. They are intentionally absent
 from `StopContext`.

--- a/docs/shutdown-and-resources.md
+++ b/docs/shutdown-and-resources.md
@@ -93,12 +93,13 @@ exclusive process resources indefinitely.
 If Tokio has already closed its blocking pool during runtime teardown,
 Shelterwood reroutes a rejected `run_blocking` operation to a detached
 Shelterwood-owned thread. This keeps both the operation and destruction of its
-captured state off the submitting runtime thread. If that native fallback
-cannot start, its captured state transfers to detached disposal and awaiting
-the future reports runtime-teardown cancellation. If the system cannot create
-the disposal worker either, disposal destroys the state synchronously rather
-than lose it; native thread exhaustion is the sole exception to the isolation
-guarantee.
+captured state off the submitting runtime thread. An operation that never runs
+at all — Tokio discarded an already-accepted submission as the runtime went
+away, or the native fallback could not start — transfers its captured state to
+detached disposal, and awaiting the future reports runtime-teardown
+cancellation. If the system cannot create the disposal worker either, disposal
+destroys the state synchronously rather than lose it; native thread exhaustion
+is the sole exception to the isolation guarantee.
 
 Async offloads are different: they are incarnation-owned, are cancelled at the
 stop freeze, and never outlive the incarnation. They are intentionally absent


### PR DESCRIPTION
Closes #222.
Closes #205.

## Summary

- retain each `run_blocking` closure behind a single-owner-detectable job so Tokio cannot destroy captured user state on the submitting thread when its blocking pool rejects a shutdown-time submission
- reroute synchronously rejected work to a detached `shelterwood-blocking` fallback thread and preserve ordinary return-value and panic propagation through an owned completion lane
- isolate pending closure destruction when accepted work is cancelled or the dedicated fallback cannot start, and replace the misleading internal-invariant panic with a runtime-teardown cancellation diagnostic
- contain panics raised while waking the receiver, plus unclaimed result/panic-payload destructors, at the detached worker boundary
- record the `run_blocking` shutdown contract in the public API docs, normative spec, and synchronized shutdown guide, including disposal's final synchronous no-loss fallback when the system cannot create any isolation worker

## Root cause and impact

Tokio returns a `JoinHandle` even when a shutting-down blocking pool synchronously destroys the submitted closure. The old `spawn_blocking_work` passed the user closure directly to Tokio and unconditionally awaited that handle. Rejection therefore destroyed user captures on the submitting runtime thread and later turned the legitimate cancelled handle into `library-owned operation task was unexpectedly cancelled`.

The job wrapper gives the submitter an ownership signal analogous to the disposal fix from #219. A sole, still-pending job means Tokio rejected it synchronously; Shelterwood moves that same operation to a detached native thread. The completion lane also makes a dropped future dispose an unclaimed result or panic payload away from its drop glue. If the dedicated fallback cannot start, the job transfers its closure to disposal and closes the lane; disposal retries isolation independently. Only total native-thread exhaustion reaches disposal's existing synchronous no-loss fallback.

This completes the remaining shutdown-time blocking-submission class paired with #205. The disposal fallback, runtime-lifetime documentation, and root-driver cancellation regression named by #205 are already present on `main`; this PR records the corresponding `run_blocking` decision and closes both issues together as planned.

## Validation

- `./tools/dev cargo test -p shelterwood-runtime spawn::tests -- --nocapture` — 9 passed
- end-to-end regression occupies Tokio's only blocking worker, begins shutdown, submits nested blocking work from the draining queue, and proves the captured hostile destructor runs on `shelterwood-blocking`, does not delay submission return, and the returned future still yields its value
- adversarial unit coverage pins sole-owner detection, accepted-then-cancelled destruction, injected native fallback failure, panicking receiver wakers, and unclaimed hostile result/panic-payload destructors
- mutation check: forcing rejection detection to return false makes the end-to-end shutdown regression fail with the runtime-teardown cancellation diagnostic; restoring it passes
- `./tools/dev just ci` — passed, including formatting, Clippy with warnings denied, 635 tests, doctests, rustdoc, API/runtime path checks, package verification, and Nix formatting


## Review round (d672c2b)

- fix an isolation hole this PR introduced: `receive_blocking` built its `DisposingReceiver` inside an `async fn` body, which runs only on first poll, so a `Blocking<T>` future dropped before it was ever polled reclaimed an already-stored return value or panic payload in its own drop glue — on the awaiting actor's thread. The wrapper is now built with the future; `dropping_an_unpolled_future_isolates_a_stored_outcome` fails on the previous ownership
- unify the Tokio rejection protocol: one `BlockingPoolJob` trait with `submit_blocking_job`/`blocking_pool_accepted` in `spawn.rs`, used by both `spawn_blocking_work` and `dispatch_disposal` (which also folds in the old `QueuedDisposal` erasure), so the `spawn_task` contract has one home and `spawn_blocking_work` picks up the `is_available` guard it lacked
- correct the teardown-cancellation docs in SPEC, both guide copies, and both `run_blocking` surfaces: Tokio discarding an already-accepted submission during teardown reaches the same panic, not only a fallback thread that cannot start

Rebased on `main` (through #245/#248/#249). `./tools/dev just ci` on the combined tree: 643 tests, all green.
