### PR TITLE
Make mailbox effects structural and runtime-neutral

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,7 @@ name = "shelterwood-mailbox"
 version = "0.1.0"
 dependencies = [
  "shelterwood-core",
+ "shelterwood-runtime",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,6 @@ name = "shelterwood-mailbox"
 version = "0.1.0"
 dependencies = [
  "shelterwood-core",
- "shelterwood-runtime",
  "tokio",
 ]
 
@@ -145,6 +144,7 @@ version = "0.1.0"
 dependencies = [
  "fastrand",
  "shelterwood-core",
+ "shelterwood-mailbox",
  "tokio",
 ]
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -803,14 +803,34 @@ Delivery is at-most-once (§1 principle 6). Send flavors on `ActorRef`
   a pending acknowledgement; dropping it is observable to the caller as
   `ReplyDropped`. A successful `call` exposes the accepting incarnation
   alongside the reply value — §3.3's retry discipline needs it on success
-  as much as on failure. `Reply::channel()` exists as the split escape
+  as much as on failure. `ActorRef::reply_channel()` exists as the split escape
   hatch when the reply must be awaited elsewhere: it yields the `Reply`
   plus a `ReplyReceiver<T>`, whose `recv(deadline)` (trailing deadline
   covering only the response wait — acceptance evidence is the
   accompanying send's result) resolves per B.3. Awaiting `call` on
   `myself()` inside `handle` is a guaranteed deadlock — the reply needs
   the very handler being blocked; use `continue_with`, or
-  `Reply::channel()` with an offload (documented hazard).
+  `ActorRef::reply_channel()` with an offload (documented hazard).
+
+**Mailbox transition boundary.** Mailbox and send-operation mutexes protect
+only synchronous state transitions. A transition records signal pulses,
+waker wake/drop actions, displaced payloads, and isolated disposal requests in
+an effects sink paired with its guard; the guard is released before that sink
+can flush. No `RawWaker` vtable, message destructor, signal callback, or
+runtime-disposal capability runs under either mutex, including unwind paths.
+The registered-waker slot exposes no operation that returns or replaces a
+`Waker` without an effects sink, making the #202 failure shape structurally
+unrepresentable rather than a call-site convention. Cancellation returns one
+withdrawal outcome plus its post-unlock effects object, never a tuple carrying
+a raw waker across the boundary.
+
+The mailbox crate is runtime-neutral in its production dependency graph. Each
+mailbox receives one type-erased runtime capability object from the public
+façade; it supplies one-shot delivery, change signals, isolated disposal, and
+the clock/timer pair. The same object flows through reply channels and deadline
+futures, so virtual-time and disposal semantics cannot silently switch
+adapters. Runtime choice is deliberately absent from `ActorRef<M>`'s type
+parameters.
 
 **Binding.** The mailbox binding is membership-owned: created at insertion,
 outliving incarnations and actor destruction (§5.5). *Bound* — accepting
@@ -4011,7 +4031,8 @@ implied on all; error/outcome types are B.3 and B.8):
   graceful shutdown.
 - **`ActorRef<M>`**: cheap `Clone`, membership-addressed (§2); `send` /
   `try_send` / `send_timeout` (each resolving to the accepting
-  `Incarnation`) and `call` per §5.1, error and success shapes per B.3;
+  `Incarnation`), `call`, and `reply_channel` per §5.1, error and success
+  shapes per B.3;
   `contramap` *(II §17)*, `pinned` *(II §15)*.
 - **`ScopeRef`**: `snapshot()`, `subscribe_snapshots()` (conflating
   watch), `subscribe_lifecycle()` (B.4), the `wait_for_child` helper

--- a/SPEC.md
+++ b/SPEC.md
@@ -816,8 +816,13 @@ Delivery is at-most-once (§1 principle 6). Send flavors on `ActorRef`
 only synchronous state transitions. A transition records signal pulses,
 waker wake/drop actions, displaced payloads, and isolated disposal requests in
 an effects sink paired with its guard; the guard is released before that sink
-can flush. No `RawWaker` vtable, message destructor, signal callback, or
-runtime-disposal capability runs under either mutex, including unwind paths.
+can flush. On every path a transition can complete — acceptance, rejection,
+withdrawal, terminal teardown, and an unwind out of any of them — no `RawWaker`
+vtable, message destructor, signal callback, or runtime-disposal capability
+runs under either mutex. The one carve-out is a framework invariant break
+(identity-space exhaustion or an unreachable binding state): those unwind with
+the payload still under the guard, and they poison the mutex regardless, so the
+transition is abandoned rather than completed.
 The registered-waker slot exposes no operation that returns or replaces a
 `Waker` without an effects sink, making the #202 failure shape structurally
 unrepresentable rather than a call-site convention. Cancellation returns one

--- a/crates/shelterwood-mailbox/Cargo.toml
+++ b/crates/shelterwood-mailbox/Cargo.toml
@@ -16,4 +16,7 @@ shelterwood-core.workspace = true
 
 [dev-dependencies]
 shelterwood-core = { workspace = true, features = ["test-util"] }
-tokio = { workspace = true, features = ["test-util"] }
+shelterwood-runtime = { workspace = true, features = ["test-util"] }
+# The adapter's re-exported `#[test]` attribute expands to unqualified `tokio`
+# paths, so the macro's own crate must be linkable. No source here names it.
+tokio.workspace = true

--- a/crates/shelterwood-mailbox/Cargo.toml
+++ b/crates/shelterwood-mailbox/Cargo.toml
@@ -13,9 +13,7 @@ workspace = true
 
 [dependencies]
 shelterwood-core.workspace = true
-shelterwood-runtime.workspace = true
 
 [dev-dependencies]
 shelterwood-core = { workspace = true, features = ["test-util"] }
-shelterwood-runtime = { workspace = true, features = ["test-util"] }
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/shelterwood-mailbox/src/capability.rs
+++ b/crates/shelterwood-mailbox/src/capability.rs
@@ -148,7 +148,7 @@ impl<T> OneShotReceiver<T> {
     }
 }
 
-fn dispose_value<T: Send + 'static>(runtime: &dyn MailboxRuntime, value: T) {
+pub(crate) fn dispose_value<T: Send + 'static>(runtime: &dyn MailboxRuntime, value: T) {
     runtime.dispose(Box::new(value));
 }
 
@@ -196,207 +196,137 @@ impl<T> Drop for DisposingReceiver<T> {
     }
 }
 
+/// The capability object this crate's own tests run against.
+///
+/// `shelterwood-runtime` depends on this crate, so its `mailbox_runtime()`
+/// implements the trait belonging to the *non-test* build of this crate and
+/// cannot satisfy the `cfg(test)` one. The binding is therefore rebuilt here,
+/// but only as delegation to the same adapter primitives production uses:
+/// restating one-shot, signal, or clock semantics in a hand-written double
+/// would let a divergence from the adapter read as a passing test.
+///
+/// The dev-dependency does not weaken the inversion, which is a claim about
+/// the production graph — `cargo tree -p shelterwood-mailbox -e normal`.
 #[cfg(test)]
 pub(crate) mod tests {
     use std::{
         future::Future,
         pin::Pin,
-        sync::{
-            Arc,
-            atomic::{AtomicU8, Ordering},
-        },
+        sync::Arc,
         task::{Context, Poll},
         time::Instant,
     };
 
-    use tokio::sync::{oneshot, watch};
+    use crate::runtime::{
+        OneShotClose, OneShotReceiver, OneShotSender, Signal, SignalWatcher, dispose_detached, now,
+        oneshot, sleep_until,
+    };
 
     use super::{
         BoxedSleep, ErasedOneShotClose, ErasedOneShotReceiver, ErasedOneShotSender, ErasedValue,
         MailboxRuntime, MailboxSignal, MailboxSignalWatcher,
     };
 
-    const OPEN: u8 = 0;
-    const SENDING: u8 = 1;
-    const SENT: u8 = 2;
-    const SENDER_CLOSED: u8 = 3;
-    const RECEIVER_CLOSED: u8 = 4;
+    struct AdapterRuntime;
 
-    struct TestSender {
-        channel: Option<oneshot::Sender<ErasedValue>>,
-        state: Arc<AtomicU8>,
-    }
-
-    impl ErasedOneShotSender for TestSender {
-        fn send(mut self: Box<Self>, value: ErasedValue) -> Result<(), ErasedValue> {
-            if self
-                .state
-                .compare_exchange(OPEN, SENDING, Ordering::AcqRel, Ordering::Acquire)
-                .is_err()
-            {
-                return Err(value);
-            }
-            match self
-                .channel
-                .take()
-                .expect("a live test sender retains its channel")
-                .send(value)
-            {
-                Ok(()) => {
-                    self.state.store(SENT, Ordering::Release);
-                    Ok(())
-                }
-                Err(value) => {
-                    self.state.store(RECEIVER_CLOSED, Ordering::Release);
-                    Err(value)
-                }
-            }
-        }
-
-        fn is_closed(&self) -> bool {
-            self.channel.as_ref().is_none_or(oneshot::Sender::is_closed)
-        }
-    }
-
-    impl Drop for TestSender {
-        fn drop(&mut self) {
-            if self.channel.is_some() {
-                let _ = self.state.compare_exchange(
-                    OPEN,
-                    SENDER_CLOSED,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                );
-            }
-        }
-    }
-
-    struct TestReceiver {
-        channel: oneshot::Receiver<ErasedValue>,
-        state: Arc<AtomicU8>,
-    }
-
-    impl ErasedOneShotReceiver for TestReceiver {
-        fn poll_receive(
-            mut self: Pin<&mut Self>,
-            context: &mut Context<'_>,
-        ) -> Poll<Option<ErasedValue>> {
-            Pin::new(&mut self.channel).poll(context).map(Result::ok)
-        }
-
-        fn close_and_poll_receive(
-            mut self: Pin<&mut Self>,
-            context: &mut Context<'_>,
-        ) -> ErasedOneShotClose {
-            match self.state.compare_exchange(
-                OPEN,
-                RECEIVER_CLOSED,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => {
-                    self.channel.close();
-                    ErasedOneShotClose::Empty
-                }
-                Err(SENDER_CLOSED) => ErasedOneShotClose::SenderClosed,
-                Err(SENDING) | Err(SENT) => match Pin::new(&mut self.channel).poll(context) {
-                    Poll::Ready(Ok(value)) => ErasedOneShotClose::Value(value),
-                    Poll::Ready(Err(_)) => ErasedOneShotClose::SenderClosed,
-                    Poll::Pending => ErasedOneShotClose::Pending,
-                },
-                Err(RECEIVER_CLOSED) => ErasedOneShotClose::Empty,
-                Err(other) => unreachable!("unknown test one-shot state {other}"),
-            }
-        }
-
-        fn close(mut self: Pin<&mut Self>) {
-            let _ = self.state.compare_exchange(
-                OPEN,
-                RECEIVER_CLOSED,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            );
-            self.channel.close();
-        }
-
-        fn close_and_take(mut self: Pin<&mut Self>) -> Option<ErasedValue> {
-            self.as_mut().close();
-            self.channel.try_recv().ok()
-        }
-    }
-
-    struct TestSignal(watch::Sender<()>);
-
-    impl MailboxSignal for TestSignal {
-        fn pulse(&self) {
-            self.0.send_modify(|_| {});
-        }
-
-        fn watcher(&self) -> Box<dyn MailboxSignalWatcher> {
-            Box::new(TestWatcher(self.0.subscribe()))
-        }
-    }
-
-    struct TestWatcher(watch::Receiver<()>);
-
-    impl MailboxSignalWatcher for TestWatcher {
-        fn changed(&mut self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-            Box::pin(async move {
-                let _ = self.0.changed().await;
-            })
-        }
-    }
-
-    #[derive(Debug)]
-    struct TestRuntime;
-
-    impl MailboxRuntime for TestRuntime {
+    impl MailboxRuntime for AdapterRuntime {
         fn oneshot(
             &self,
         ) -> (
             Box<dyn ErasedOneShotSender>,
             Pin<Box<dyn ErasedOneShotReceiver>>,
         ) {
-            let (sender, receiver) = oneshot::channel();
-            let state = Arc::new(AtomicU8::new(OPEN));
+            let (sender, receiver) = oneshot();
             (
-                Box::new(TestSender {
-                    channel: Some(sender),
-                    state: Arc::clone(&state),
-                }),
-                Box::pin(TestReceiver {
-                    channel: receiver,
-                    state,
-                }),
+                Box::new(AdapterOneShotSender(sender)),
+                Box::pin(AdapterOneShotReceiver(receiver)),
             )
         }
 
         fn signal(&self) -> Arc<dyn MailboxSignal> {
-            Arc::new(TestSignal(watch::channel(()).0))
+            Arc::new(AdapterSignal(Signal::default()))
         }
 
         fn dispose(&self, value: Box<dyn Send + 'static>) {
-            let worker = std::thread::spawn(move || {
-                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop(value)));
-            });
-            drop(worker);
+            dispose_detached(value);
         }
 
         fn now(&self) -> Instant {
-            tokio::time::Instant::now().into_std()
+            now()
         }
 
         fn sleep_until(&self, deadline: Option<Instant>) -> BoxedSleep {
-            Box::pin(async move {
-                match deadline {
-                    Some(deadline) => tokio::time::sleep_until(deadline.into()).await,
-                    None => std::future::pending().await,
-                }
-            })
+            deadline.map_or_else(
+                || Box::pin(std::future::pending()) as BoxedSleep,
+                sleep_until,
+            )
+        }
+    }
+
+    struct AdapterOneShotSender(OneShotSender<ErasedValue>);
+
+    impl ErasedOneShotSender for AdapterOneShotSender {
+        fn send(self: Box<Self>, value: ErasedValue) -> Result<(), ErasedValue> {
+            self.0.send(value)
+        }
+
+        fn is_closed(&self) -> bool {
+            self.0.is_closed()
+        }
+    }
+
+    struct AdapterOneShotReceiver(OneShotReceiver<ErasedValue>);
+
+    impl ErasedOneShotReceiver for AdapterOneShotReceiver {
+        fn poll_receive(
+            mut self: Pin<&mut Self>,
+            context: &mut Context<'_>,
+        ) -> Poll<Option<ErasedValue>> {
+            self.0.poll_receive(context)
+        }
+
+        fn close_and_poll_receive(
+            mut self: Pin<&mut Self>,
+            context: &mut Context<'_>,
+        ) -> ErasedOneShotClose {
+            match self.0.close_and_poll_receive(context) {
+                OneShotClose::Value(value) => ErasedOneShotClose::Value(value),
+                OneShotClose::SenderClosed => ErasedOneShotClose::SenderClosed,
+                OneShotClose::Empty => ErasedOneShotClose::Empty,
+                OneShotClose::Pending => ErasedOneShotClose::Pending,
+            }
+        }
+
+        fn close(mut self: Pin<&mut Self>) {
+            self.0.close();
+        }
+
+        fn close_and_take(mut self: Pin<&mut Self>) -> Option<ErasedValue> {
+            self.0.close_and_take()
+        }
+    }
+
+    struct AdapterSignal(Signal);
+
+    impl MailboxSignal for AdapterSignal {
+        fn pulse(&self) {
+            self.0.pulse();
+        }
+
+        fn watcher(&self) -> Box<dyn MailboxSignalWatcher> {
+            Box::new(AdapterSignalWatcher(self.0.watcher()))
+        }
+    }
+
+    struct AdapterSignalWatcher(SignalWatcher);
+
+    impl MailboxSignalWatcher for AdapterSignalWatcher {
+        fn changed(&mut self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            Box::pin(self.0.changed())
         }
     }
 
     pub(crate) fn runtime() -> Arc<dyn MailboxRuntime> {
-        Arc::new(TestRuntime)
+        Arc::new(AdapterRuntime)
     }
 }

--- a/crates/shelterwood-mailbox/src/capability.rs
+++ b/crates/shelterwood-mailbox/src/capability.rs
@@ -1,0 +1,402 @@
+use std::{
+    any::Any,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Instant,
+};
+
+pub type BoxedSleep = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+pub type ErasedValue = Box<dyn Any + Send + 'static>;
+
+/// Runtime-neutral single-delivery send capability.
+#[doc(hidden)]
+pub trait ErasedOneShotSender: Send {
+    fn send(self: Box<Self>, value: ErasedValue) -> Result<(), ErasedValue>;
+    fn is_closed(&self) -> bool;
+}
+
+/// Runtime-neutral single-delivery receive capability.
+#[doc(hidden)]
+pub trait ErasedOneShotReceiver: Send {
+    fn poll_receive(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<ErasedValue>>;
+    fn close_and_poll_receive(
+        self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> ErasedOneShotClose;
+    fn close(self: Pin<&mut Self>);
+    fn close_and_take(self: Pin<&mut Self>) -> Option<ErasedValue>;
+}
+
+#[doc(hidden)]
+pub enum ErasedOneShotClose {
+    Value(ErasedValue),
+    SenderClosed,
+    Empty,
+    Pending,
+}
+
+/// Runtime-neutral one-shot change notification.
+#[doc(hidden)]
+pub trait MailboxSignal: Send + Sync {
+    fn pulse(&self);
+    fn watcher(&self) -> Box<dyn MailboxSignalWatcher>;
+}
+
+/// Runtime-neutral wait side of [`MailboxSignal`].
+#[doc(hidden)]
+pub trait MailboxSignalWatcher: Send {
+    fn changed(&mut self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+}
+
+/// The four runtime capabilities needed by the mailbox shell.
+///
+/// The public façade installs one object per mailbox. Type erasure keeps the
+/// adapter out of `ActorRef`'s type parameters while this crate remains free of
+/// Tokio and every other concrete executor.
+#[doc(hidden)]
+pub trait MailboxRuntime: Send + Sync {
+    fn oneshot(
+        &self,
+    ) -> (
+        Box<dyn ErasedOneShotSender>,
+        Pin<Box<dyn ErasedOneShotReceiver>>,
+    );
+    fn signal(&self) -> Arc<dyn MailboxSignal>;
+    fn dispose(&self, value: Box<dyn Send + 'static>);
+    fn now(&self) -> Instant;
+    fn sleep_until(&self, deadline: Option<Instant>) -> BoxedSleep;
+}
+
+fn downcast<T: Send + 'static>(value: ErasedValue) -> T {
+    *value
+        .downcast::<T>()
+        .unwrap_or_else(|_| panic!("mailbox runtime returned a mismatched one-shot value"))
+}
+
+pub(crate) struct OneShotSender<T> {
+    inner: Box<dyn ErasedOneShotSender>,
+    marker: PhantomData<fn(T)>,
+}
+
+pub(crate) struct OneShotReceiver<T> {
+    inner: Pin<Box<dyn ErasedOneShotReceiver>>,
+    marker: PhantomData<fn(T)>,
+}
+
+pub(crate) enum OneShotClose<T> {
+    Value(T),
+    SenderClosed,
+    Empty,
+    Pending,
+}
+
+pub(crate) fn oneshot<T: Send + 'static>(
+    runtime: &Arc<dyn MailboxRuntime>,
+) -> (OneShotSender<T>, OneShotReceiver<T>) {
+    let (sender, receiver) = runtime.oneshot();
+    (
+        OneShotSender {
+            inner: sender,
+            marker: PhantomData,
+        },
+        OneShotReceiver {
+            inner: receiver,
+            marker: PhantomData,
+        },
+    )
+}
+
+impl<T: Send + 'static> OneShotSender<T> {
+    pub(crate) fn send(self, value: T) -> Result<(), T> {
+        self.inner.send(Box::new(value)).map_err(downcast::<T>)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_closed(&self) -> bool {
+        self.inner.is_closed()
+    }
+}
+
+impl<T: Send + 'static> OneShotReceiver<T> {
+    pub(crate) fn poll_receive(&mut self, context: &mut Context<'_>) -> Poll<Option<T>> {
+        self.inner
+            .as_mut()
+            .poll_receive(context)
+            .map(|value| value.map(downcast::<T>))
+    }
+
+    pub(crate) fn close_and_poll_receive(&mut self, context: &mut Context<'_>) -> OneShotClose<T> {
+        match self.inner.as_mut().close_and_poll_receive(context) {
+            ErasedOneShotClose::Value(value) => OneShotClose::Value(downcast(value)),
+            ErasedOneShotClose::SenderClosed => OneShotClose::SenderClosed,
+            ErasedOneShotClose::Empty => OneShotClose::Empty,
+            ErasedOneShotClose::Pending => OneShotClose::Pending,
+        }
+    }
+}
+
+impl<T> OneShotReceiver<T> {
+    pub(crate) fn close(&mut self) {
+        self.inner.as_mut().close();
+    }
+
+    fn close_and_take_erased(&mut self) -> Option<ErasedValue> {
+        self.inner.as_mut().close_and_take()
+    }
+}
+
+fn dispose_value<T: Send + 'static>(runtime: &dyn MailboxRuntime, value: T) {
+    runtime.dispose(Box::new(value));
+}
+
+pub(crate) fn dispose<T: Send + 'static>(runtime: &Arc<dyn MailboxRuntime>, value: T) {
+    dispose_value(runtime.as_ref(), value);
+}
+
+/// Receive state that keeps an unclaimed user value out of holder drop glue.
+pub(crate) struct DisposingReceiver<T> {
+    inner: OneShotReceiver<T>,
+    runtime: Arc<dyn MailboxRuntime>,
+}
+
+impl<T: Send + 'static> DisposingReceiver<T> {
+    pub(crate) fn new(inner: OneShotReceiver<T>, runtime: Arc<dyn MailboxRuntime>) -> Self {
+        Self { inner, runtime }
+    }
+}
+
+impl<T> DisposingReceiver<T> {
+    pub(crate) fn runtime(&self) -> Arc<dyn MailboxRuntime> {
+        Arc::clone(&self.runtime)
+    }
+
+    pub(crate) fn close(&mut self) {
+        self.inner.close();
+    }
+}
+
+impl<T: Send + 'static> DisposingReceiver<T> {
+    pub(crate) fn poll_receive(&mut self, context: &mut Context<'_>) -> Poll<Option<T>> {
+        self.inner.poll_receive(context)
+    }
+
+    pub(crate) fn close_and_poll_receive(&mut self, context: &mut Context<'_>) -> OneShotClose<T> {
+        self.inner.close_and_poll_receive(context)
+    }
+}
+
+impl<T> Drop for DisposingReceiver<T> {
+    fn drop(&mut self) {
+        if let Some(value) = self.inner.close_and_take_erased() {
+            self.runtime.dispose(value);
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::{
+        future::Future,
+        pin::Pin,
+        sync::{
+            Arc,
+            atomic::{AtomicU8, Ordering},
+        },
+        task::{Context, Poll},
+        time::Instant,
+    };
+
+    use tokio::sync::{oneshot, watch};
+
+    use super::{
+        BoxedSleep, ErasedOneShotClose, ErasedOneShotReceiver, ErasedOneShotSender, ErasedValue,
+        MailboxRuntime, MailboxSignal, MailboxSignalWatcher,
+    };
+
+    const OPEN: u8 = 0;
+    const SENDING: u8 = 1;
+    const SENT: u8 = 2;
+    const SENDER_CLOSED: u8 = 3;
+    const RECEIVER_CLOSED: u8 = 4;
+
+    struct TestSender {
+        channel: Option<oneshot::Sender<ErasedValue>>,
+        state: Arc<AtomicU8>,
+    }
+
+    impl ErasedOneShotSender for TestSender {
+        fn send(mut self: Box<Self>, value: ErasedValue) -> Result<(), ErasedValue> {
+            if self
+                .state
+                .compare_exchange(OPEN, SENDING, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+            {
+                return Err(value);
+            }
+            match self
+                .channel
+                .take()
+                .expect("a live test sender retains its channel")
+                .send(value)
+            {
+                Ok(()) => {
+                    self.state.store(SENT, Ordering::Release);
+                    Ok(())
+                }
+                Err(value) => {
+                    self.state.store(RECEIVER_CLOSED, Ordering::Release);
+                    Err(value)
+                }
+            }
+        }
+
+        fn is_closed(&self) -> bool {
+            self.channel.as_ref().is_none_or(oneshot::Sender::is_closed)
+        }
+    }
+
+    impl Drop for TestSender {
+        fn drop(&mut self) {
+            if self.channel.is_some() {
+                let _ = self.state.compare_exchange(
+                    OPEN,
+                    SENDER_CLOSED,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                );
+            }
+        }
+    }
+
+    struct TestReceiver {
+        channel: oneshot::Receiver<ErasedValue>,
+        state: Arc<AtomicU8>,
+    }
+
+    impl ErasedOneShotReceiver for TestReceiver {
+        fn poll_receive(
+            mut self: Pin<&mut Self>,
+            context: &mut Context<'_>,
+        ) -> Poll<Option<ErasedValue>> {
+            Pin::new(&mut self.channel).poll(context).map(Result::ok)
+        }
+
+        fn close_and_poll_receive(
+            mut self: Pin<&mut Self>,
+            context: &mut Context<'_>,
+        ) -> ErasedOneShotClose {
+            match self.state.compare_exchange(
+                OPEN,
+                RECEIVER_CLOSED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    self.channel.close();
+                    ErasedOneShotClose::Empty
+                }
+                Err(SENDER_CLOSED) => ErasedOneShotClose::SenderClosed,
+                Err(SENDING) | Err(SENT) => match Pin::new(&mut self.channel).poll(context) {
+                    Poll::Ready(Ok(value)) => ErasedOneShotClose::Value(value),
+                    Poll::Ready(Err(_)) => ErasedOneShotClose::SenderClosed,
+                    Poll::Pending => ErasedOneShotClose::Pending,
+                },
+                Err(RECEIVER_CLOSED) => ErasedOneShotClose::Empty,
+                Err(other) => unreachable!("unknown test one-shot state {other}"),
+            }
+        }
+
+        fn close(mut self: Pin<&mut Self>) {
+            let _ = self.state.compare_exchange(
+                OPEN,
+                RECEIVER_CLOSED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            );
+            self.channel.close();
+        }
+
+        fn close_and_take(mut self: Pin<&mut Self>) -> Option<ErasedValue> {
+            self.as_mut().close();
+            self.channel.try_recv().ok()
+        }
+    }
+
+    struct TestSignal(watch::Sender<()>);
+
+    impl MailboxSignal for TestSignal {
+        fn pulse(&self) {
+            self.0.send_modify(|_| {});
+        }
+
+        fn watcher(&self) -> Box<dyn MailboxSignalWatcher> {
+            Box::new(TestWatcher(self.0.subscribe()))
+        }
+    }
+
+    struct TestWatcher(watch::Receiver<()>);
+
+    impl MailboxSignalWatcher for TestWatcher {
+        fn changed(&mut self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            Box::pin(async move {
+                let _ = self.0.changed().await;
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestRuntime;
+
+    impl MailboxRuntime for TestRuntime {
+        fn oneshot(
+            &self,
+        ) -> (
+            Box<dyn ErasedOneShotSender>,
+            Pin<Box<dyn ErasedOneShotReceiver>>,
+        ) {
+            let (sender, receiver) = oneshot::channel();
+            let state = Arc::new(AtomicU8::new(OPEN));
+            (
+                Box::new(TestSender {
+                    channel: Some(sender),
+                    state: Arc::clone(&state),
+                }),
+                Box::pin(TestReceiver {
+                    channel: receiver,
+                    state,
+                }),
+            )
+        }
+
+        fn signal(&self) -> Arc<dyn MailboxSignal> {
+            Arc::new(TestSignal(watch::channel(()).0))
+        }
+
+        fn dispose(&self, value: Box<dyn Send + 'static>) {
+            let worker = std::thread::spawn(move || {
+                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop(value)));
+            });
+            drop(worker);
+        }
+
+        fn now(&self) -> Instant {
+            tokio::time::Instant::now().into_std()
+        }
+
+        fn sleep_until(&self, deadline: Option<Instant>) -> BoxedSleep {
+            Box::pin(async move {
+                match deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline.into()).await,
+                    None => std::future::pending().await,
+                }
+            })
+        }
+    }
+
+    pub(crate) fn runtime() -> Arc<dyn MailboxRuntime> {
+        Arc::new(TestRuntime)
+    }
+}

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -2,16 +2,17 @@ use std::{
     collections::{BTreeMap, VecDeque},
     fmt,
     num::NonZeroUsize,
-    sync::{Arc, Mutex, atomic::Ordering},
-    task::Waker,
+    ops::{Deref, DerefMut},
+    sync::{Arc, Mutex, MutexGuard, atomic::Ordering},
 };
 
 use crate::{
-    ChildId, Incarnation, MailboxControl, MailboxDisposal, MailboxTermination,
+    ChildId, Incarnation, MailboxControl, MailboxDisposal, MailboxRuntime, MailboxSignal,
+    MailboxSignalWatcher, MailboxTermination,
+    capability::dispose,
     identity::{AtomicPoisonedCounter, PoisonedCounter},
     panic::{PanicAccumulator, PanicPayload, resume_panic},
     policy::ResolvedMailbox,
-    runtime::{Signal, SignalWatcher},
 };
 
 use super::{SendError, SendErrorKind};
@@ -89,12 +90,106 @@ pub(super) enum OperationOutcome<M> {
 
 pub(super) struct OperationState<M> {
     pub(super) outcome: OperationOutcome<M>,
-    pub(super) waker: Option<Waker>,
+    waker: WakerSlot,
     registration: Option<WaiterId>,
 }
 
+mod waker_slot {
+    use std::{sync::Arc, task::Waker};
+
+    use crate::{MailboxRuntime, capability::dispose, panic::PanicAccumulator};
+
+    /// The only storage surface for a caller-owned waker.
+    ///
+    /// Its value is private even from the parent mailbox module, and every
+    /// mutating operation requires an effects sink. The old #202 spelling --
+    /// replacing or taking an `Option<Waker>` and accidentally dropping it
+    /// beside a guard -- therefore does not type-check.
+    #[derive(Default)]
+    pub(super) struct WakerSlot(Option<Waker>);
+
+    pub(super) enum WakerAction {
+        Wake,
+        DropInline,
+        Dispose(Arc<dyn MailboxRuntime>),
+    }
+
+    enum WakerEffect {
+        Wake(Waker),
+        DropInline(Waker),
+        Dispose(Arc<dyn MailboxRuntime>, Waker),
+    }
+
+    #[derive(Default)]
+    pub(super) struct WakerEffects(Vec<WakerEffect>);
+
+    impl WakerSlot {
+        pub(super) fn will_wake(&self, waker: &Waker) -> bool {
+            self.0
+                .as_ref()
+                .is_some_and(|registered| registered.will_wake(waker))
+        }
+
+        pub(super) fn replace(&mut self, waker: Waker, effects: &mut WakerEffects) {
+            if let Some(displaced) = self.0.replace(waker) {
+                effects.push(displaced, WakerAction::DropInline);
+            }
+        }
+
+        pub(super) fn take(&mut self, action: WakerAction, effects: &mut WakerEffects) {
+            if let Some(waker) = self.0.take() {
+                effects.push(waker, action);
+            }
+        }
+
+        pub(super) fn is_empty(&self) -> bool {
+            self.0.is_none()
+        }
+    }
+
+    impl WakerEffects {
+        fn push(&mut self, waker: Waker, action: WakerAction) {
+            self.0.push(match action {
+                WakerAction::Wake => WakerEffect::Wake(waker),
+                WakerAction::DropInline => WakerEffect::DropInline(waker),
+                WakerAction::Dispose(runtime) => WakerEffect::Dispose(runtime, waker),
+            });
+        }
+
+        pub(super) fn flush(&mut self, panics: &mut PanicAccumulator) {
+            for effect in self.0.drain(..) {
+                match effect {
+                    WakerEffect::Wake(waker) => panics.run(|| waker.wake()),
+                    WakerEffect::DropInline(waker) => panics.run(|| drop(waker)),
+                    WakerEffect::Dispose(runtime, waker) => {
+                        panics.run(|| dispose(&runtime, waker));
+                    }
+                }
+            }
+        }
+    }
+
+    impl Drop for WakerEffects {
+        fn drop(&mut self) {
+            self.flush(&mut PanicAccumulator::default());
+        }
+    }
+}
+
+use waker_slot::{WakerAction, WakerEffects, WakerSlot};
+
 pub(super) struct SendOperation<M> {
     pub(super) state: Mutex<OperationState<M>>,
+}
+
+pub(super) enum OperationPoll<M> {
+    Accepted(Incarnation),
+    Terminated {
+        message: M,
+        final_incarnation: Option<Incarnation>,
+    },
+    Pending,
+    NeedsWakerClone,
 }
 
 // Lock order is mailbox state, then send-operation state. Code that starts
@@ -111,7 +206,7 @@ impl<M> SendOperation<M> {
                     message: Some(message),
                     newest_observed: None,
                 },
-                waker: None,
+                waker: WakerSlot::default(),
                 registration: None,
             }),
         })
@@ -145,21 +240,22 @@ impl<M> SendOperation<M> {
         }
     }
 
-    fn accept(&self, incarnation: Incarnation) -> Option<(M, Option<Waker>)> {
-        let (message, wake) = {
+    fn accept(&self, incarnation: Incarnation, effects: &mut WakerEffects) -> Option<M> {
+        {
             let mut state = self.state.lock().expect("send operation mutex poisoned");
             let OperationOutcome::Waiting { message, .. } = &mut state.outcome else {
                 return None;
             };
             let message = message.take()?;
             state.outcome = OperationOutcome::Accepted(incarnation);
-            (message, state.waker.take())
-        };
-        Some((message, wake))
+            state.waker.take(WakerAction::Wake, effects);
+            Some(message)
+        }
     }
 
     fn terminate(&self, final_incarnation: Option<Incarnation>) {
-        let wake = {
+        let mut effects = WakerEffects::default();
+        {
             let mut state = self.state.lock().expect("send operation mutex poisoned");
             let OperationOutcome::Waiting { message, .. } = &mut state.outcome else {
                 return;
@@ -169,10 +265,54 @@ impl<M> SendOperation<M> {
                 message,
                 final_incarnation,
             };
-            state.waker.take()
+            state.waker.take(WakerAction::Wake, &mut effects);
+        }
+    }
+
+    pub(super) fn poll(
+        &self,
+        replacement: Option<std::task::Waker>,
+        current: &std::task::Waker,
+    ) -> OperationPoll<M> {
+        // Effects precede the guard, so even an unwind drops the guard before
+        // invoking a displaced RawWaker vtable.
+        let mut effects = WakerEffects::default();
+        let result = {
+            let mut state = self.state.lock().expect("send operation mutex poisoned");
+            match &mut state.outcome {
+                OperationOutcome::Accepted(incarnation) => OperationPoll::Accepted(*incarnation),
+                OperationOutcome::Terminated {
+                    message,
+                    final_incarnation,
+                } => OperationPoll::Terminated {
+                    message: message
+                        .take()
+                        .expect("a terminal operation retains its message until observed"),
+                    final_incarnation: *final_incarnation,
+                },
+                OperationOutcome::Waiting { .. } => {
+                    if let Some(replacement) = replacement {
+                        state.waker.replace(replacement, &mut effects);
+                        OperationPoll::Pending
+                    } else if state.waker.will_wake(current) {
+                        OperationPoll::Pending
+                    } else {
+                        OperationPoll::NeedsWakerClone
+                    }
+                }
+                OperationOutcome::Withdrawn => panic!("a withdrawn send future was polled"),
+            }
         };
-        if let Some(waker) = wake {
-            waker.wake();
+        drop(effects);
+        result
+    }
+
+    #[cfg(test)]
+    fn install_test_waker(&self, waker: std::task::Waker) {
+        let mut effects = WakerEffects::default();
+        {
+            let mut state = self.state.lock().expect("send operation mutex poisoned");
+            state.waker.replace(waker, &mut effects);
         }
     }
 }
@@ -371,76 +511,135 @@ impl<M> WaiterQueue<M> {
     }
 }
 
-/// A completed locked acceptance whose user payload must be destroyed only
-/// after the mailbox mutex is released.
-#[must_use = "finish accepted delivery after releasing the mailbox lock"]
-struct Acceptance<M> {
-    incarnation: Incarnation,
-    displaced: Option<Envelope<M>>,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum RejectionReason {
-    NotAccepting,
-    Unconfigured,
-    Full,
-}
-
-struct Rejected<M> {
-    message: M,
-    reason: RejectionReason,
-}
-
-impl<M> Acceptance<M> {
-    fn finish(self, changed: &Signal) -> Incarnation {
-        changed.pulse();
-        drop(self.displaced);
-        self.incarnation
-    }
-}
-
-struct Promotion<M: Send + 'static> {
+/// User-controlled effects produced while reducing one mailbox transition.
+///
+/// `MailboxTxn` owns this sink beside the guard and drops the guard first.
+/// Locked transition code can only enqueue effects; pulse callbacks, waker
+/// vtables, payload destructors, and runtime disposal all run during flush.
+struct MailboxEffects<M: Send + 'static> {
+    runtime: Arc<dyn MailboxRuntime>,
+    changed: Arc<dyn MailboxSignal>,
+    pulse: bool,
     displaced: Vec<Envelope<M>>,
-    wakers: Vec<Waker>,
+    isolate_displaced: bool,
+    wakers: WakerEffects,
+    returned: Option<M>,
 }
 
-impl<M: Send + 'static> Default for Promotion<M> {
-    fn default() -> Self {
+impl<M: Send + 'static> MailboxEffects<M> {
+    fn new(cell: &MailboxCell<M>) -> Self {
         Self {
+            runtime: Arc::clone(&cell.runtime),
+            changed: Arc::clone(&cell.changed),
+            pulse: false,
             displaced: Vec::new(),
-            wakers: Vec::new(),
+            isolate_displaced: false,
+            wakers: WakerEffects::default(),
+            returned: None,
         }
+    }
+
+    fn pulse(&mut self) {
+        self.pulse = true;
+    }
+
+    fn isolate_displaced(&mut self) {
+        self.isolate_displaced = true;
     }
 }
 
-impl<M: Send + 'static> Promotion<M> {
-    // Drop is the completion path on every ownership edge. `finish` only
-    // names the intentional consume point; its Drop still wakes all accepted
-    // senders and panic-contains each displaced-message destructor inline.
-    fn finish(self) {}
-
-    fn finish_isolated(mut self) {
-        let displaced = std::mem::take(&mut self.displaced);
-        if !displaced.is_empty() {
-            crate::runtime::dispose_detached(MailboxPayload {
-                queue: Some(displaced.into()),
-                latest: None,
-                retired: Vec::new(),
-            });
-        }
-        self.finish();
-    }
-}
-
-impl<M: Send + 'static> Drop for Promotion<M> {
+impl<M: Send + 'static> Drop for MailboxEffects<M> {
     fn drop(&mut self) {
         let mut panics = PanicAccumulator::default();
-        for waker in self.wakers.drain(..) {
-            panics.run(|| waker.wake());
+        if self.pulse {
+            panics.run(|| self.changed.pulse());
         }
-        for displaced in self.displaced.drain(..) {
-            panics.run(|| drop(displaced));
+        self.wakers.flush(&mut panics);
+        if self.isolate_displaced && !self.displaced.is_empty() {
+            let displaced = std::mem::take(&mut self.displaced);
+            panics.run(|| {
+                dispose(
+                    &self.runtime,
+                    MailboxPayload {
+                        queue: Some(displaced.into()),
+                        latest: None,
+                        retired: Vec::new(),
+                    },
+                );
+            });
+        } else {
+            for displaced in self.displaced.drain(..) {
+                panics.run(|| drop(displaced));
+            }
         }
+        if let Some(returned) = self.returned.take() {
+            panics.run(|| drop(returned));
+        }
+    }
+}
+
+/// A mailbox transition guard paired with its mandatory post-unlock effects.
+struct MailboxTxn<'a, M: Send + 'static> {
+    state: Option<MutexGuard<'a, MailboxState<M>>>,
+    effects: MailboxEffects<M>,
+}
+
+impl<'a, M: Send + 'static> MailboxTxn<'a, M> {
+    fn new(cell: &'a MailboxCell<M>) -> Self {
+        let effects = MailboxEffects::new(cell);
+        let state = cell.state.lock().expect("mailbox mutex poisoned");
+        Self {
+            state: Some(state),
+            effects,
+        }
+    }
+
+    fn parts(&mut self) -> (&mut MailboxState<M>, &mut MailboxEffects<M>) {
+        (
+            self.state
+                .as_deref_mut()
+                .expect("a live mailbox transaction retains its guard"),
+            &mut self.effects,
+        )
+    }
+
+    fn finish<R>(mut self, output: R) -> R {
+        drop(self.state.take());
+        drop(self);
+        output
+    }
+
+    fn finish_returned(mut self) -> Option<M> {
+        drop(self.state.take());
+        let output = self.effects.returned.take();
+        drop(self);
+        output
+    }
+}
+
+impl<M: Send + 'static> Deref for MailboxTxn<'_, M> {
+    type Target = MailboxState<M>;
+
+    fn deref(&self) -> &Self::Target {
+        self.state
+            .as_deref()
+            .expect("a live mailbox transaction retains its guard")
+    }
+}
+
+impl<M: Send + 'static> DerefMut for MailboxTxn<'_, M> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.state
+            .as_deref_mut()
+            .expect("a live mailbox transaction retains its guard")
+    }
+}
+
+impl<M: Send + 'static> Drop for MailboxTxn<'_, M> {
+    fn drop(&mut self) {
+        // Rust drops fields after this body. Empty the guard field here so the
+        // effects field necessarily flushes with no mailbox mutex held.
+        drop(self.state.take());
     }
 }
 
@@ -490,8 +689,9 @@ impl<M> Drop for MailboxPayload<M> {
 }
 
 struct MailboxTeardown<M: Send + 'static> {
-    changed: Option<Signal>,
-    payload: crate::runtime::Isolated<MailboxPayload<M>>,
+    runtime: Arc<dyn MailboxRuntime>,
+    changed: Option<Arc<dyn MailboxSignal>>,
+    payload: Option<MailboxPayload<M>>,
     termination: Option<Termination<M>>,
 }
 
@@ -502,7 +702,15 @@ impl<M: Send + 'static> MailboxTeardown<M> {
             panics.run(|| changed.pulse());
         }
         if let Some(mut termination) = self.termination.take() {
-            panics.record(termination.finish(&mut self.payload.get_mut().retired));
+            panics.record(
+                termination.finish(
+                    &mut self
+                        .payload
+                        .as_mut()
+                        .expect("mailbox teardown retains its payload")
+                        .retired,
+                ),
+            );
         }
         panics.take()
     }
@@ -517,7 +725,7 @@ impl<M: Send + 'static> MailboxTermination for MailboxTeardown<M> {
             .map(|payload| Box::new(payload) as MailboxDisposal);
         if let Some(panic) = panic {
             if let Some(payload) = payload {
-                crate::runtime::dispose_detached(payload);
+                dispose(&self.runtime, payload);
             }
             resume_panic(panic);
         }
@@ -530,7 +738,7 @@ impl<M: Send + 'static> Drop for MailboxTeardown<M> {
         let mut panics = PanicAccumulator::default();
         panics.record(self.finish_framework());
         if let Some(payload) = self.payload.take() {
-            crate::runtime::dispose_detached(payload);
+            dispose(&self.runtime, payload);
         }
     }
 }
@@ -539,7 +747,8 @@ pub struct MailboxCell<M> {
     pub(super) actor_id: ChildId,
     pub(super) state: Mutex<MailboxState<M>>,
     accepted: AtomicPoisonedCounter,
-    changed: Signal,
+    runtime: Arc<dyn MailboxRuntime>,
+    changed: Arc<dyn MailboxSignal>,
 }
 
 impl<M> fmt::Debug for MailboxCell<M> {
@@ -552,7 +761,8 @@ impl<M> fmt::Debug for MailboxCell<M> {
 }
 
 impl<M: Send + 'static> MailboxCell<M> {
-    pub fn new(actor_id: ChildId) -> Arc<Self> {
+    pub fn new(actor_id: ChildId, runtime: Arc<dyn MailboxRuntime>) -> Arc<Self> {
+        let changed = runtime.signal();
         Arc::new(Self {
             actor_id,
             state: Mutex::new(MailboxState {
@@ -563,39 +773,29 @@ impl<M: Send + 'static> MailboxCell<M> {
                 latest: None,
             }),
             accepted: AtomicPoisonedCounter::new(),
-            changed: Signal::default(),
+            runtime,
+            changed,
         })
     }
 
     pub(super) fn submit(&self, message: M) -> Submission<M> {
-        let mut state = self.state.lock().expect("mailbox mutex poisoned");
-        match state.status() {
+        let mut transaction = MailboxTxn::new(self);
+        let submission = match transaction.status() {
             BindingStatus::Terminal(final_incarnation) => Submission::Terminated {
                 message,
                 final_incarnation,
             },
             BindingStatus::Bound(incarnation) => {
-                match accept_locked(&mut state, message, &self.accepted) {
-                    Ok(acceptance) => {
-                        drop(state);
-                        Submission::Accepted(acceptance.finish(&self.changed))
-                    }
-                    Err(Rejected { message, reason }) => {
-                        if !matches!(reason, RejectionReason::Full) {
-                            // `Full` is the only rejection a bound, configured
-                            // mailbox can produce. Follow `bind`'s convention
-                            // and release the lock before panicking, so an
-                            // invariant break stays on this thread instead of
-                            // poisoning the mutex under every other sender --
-                            // and so the rejected payload's destructor does not
-                            // run under it either.
-                            drop(state);
-                            drop(message);
-                            unreachable!("a bound configured mailbox rejected as {reason:?}");
-                        }
+                let accepted = {
+                    let (state, effects) = transaction.parts();
+                    accept_locked(state, incarnation, message, &self.accepted, effects)
+                };
+                match accepted {
+                    Ok(incarnation) => Submission::Accepted(incarnation),
+                    Err(message) => {
                         let operation = SendOperation::new(message);
                         operation.observe(incarnation);
-                        state.park(&operation);
+                        transaction.park(&operation);
                         Submission::Parked(operation)
                     }
                 }
@@ -603,20 +803,21 @@ impl<M: Send + 'static> MailboxCell<M> {
             BindingStatus::Frozen(incarnation) => {
                 let operation = SendOperation::new(message);
                 operation.observe(incarnation);
-                state.park(&operation);
+                transaction.park(&operation);
                 Submission::Parked(operation)
             }
             BindingStatus::Unbound => {
                 let operation = SendOperation::new(message);
-                state.park(&operation);
+                transaction.park(&operation);
                 Submission::Parked(operation)
             }
-        }
+        };
+        transaction.finish(submission)
     }
 
     pub(super) fn try_send(&self, message: M) -> Result<Incarnation, SendError<M>> {
-        let mut state = self.state.lock().expect("mailbox mutex poisoned");
-        match state.status() {
+        let mut transaction = MailboxTxn::new(self);
+        let result = match transaction.status() {
             BindingStatus::Terminal(final_incarnation) => Err(SendError {
                 actor_id: self.actor_id.clone(),
                 incarnation_observed: final_incarnation,
@@ -636,30 +837,22 @@ impl<M: Send + 'static> MailboxCell<M> {
                 kind: SendErrorKind::NotRunning,
             }),
             BindingStatus::Bound(incarnation) => {
-                match accept_locked(&mut state, message, &self.accepted) {
-                    Ok(acceptance) => {
-                        drop(state);
-                        Ok(acceptance.finish(&self.changed))
-                    }
-                    Err(Rejected { message, reason }) => Err(SendError {
+                let accepted = {
+                    let (state, effects) = transaction.parts();
+                    accept_locked(state, incarnation, message, &self.accepted, effects)
+                };
+                match accepted {
+                    Ok(incarnation) => Ok(incarnation),
+                    Err(message) => Err(SendError {
                         actor_id: self.actor_id.clone(),
-                        incarnation_observed: match reason {
-                            RejectionReason::Full | RejectionReason::NotAccepting => {
-                                Some(incarnation)
-                            }
-                            RejectionReason::Unconfigured => None,
-                        },
+                        incarnation_observed: Some(incarnation),
                         message,
-                        kind: match reason {
-                            RejectionReason::Full => SendErrorKind::Full,
-                            RejectionReason::Unconfigured | RejectionReason::NotAccepting => {
-                                SendErrorKind::NotRunning
-                            }
-                        },
+                        kind: SendErrorKind::Full,
                     }),
                 }
             }
-        }
+        };
+        transaction.finish(result)
     }
 
     fn receive(
@@ -668,8 +861,8 @@ impl<M: Send + 'static> MailboxCell<M> {
         mode: ReceiveMode,
         accepted_through: Option<AcceptedSequence>,
     ) -> Option<M> {
-        let mut state = self.state.lock().expect("mailbox mutex poisoned");
-        let eligible = match state.status() {
+        let mut transaction = MailboxTxn::new(self);
+        let eligible = match transaction.status() {
             BindingStatus::Bound(current) => current == incarnation,
             BindingStatus::Frozen(current) => {
                 mode == ReceiveMode::IncludeFrozen && current == incarnation
@@ -677,40 +870,32 @@ impl<M: Send + 'static> MailboxCell<M> {
             BindingStatus::Unbound | BindingStatus::Terminal(_) => false,
         };
         if !eligible {
-            return None;
+            return transaction.finish(None);
         }
-        let message = match state.kind {
+        let envelope = match transaction.kind {
             Some(MailboxKind::Queue(_)) => {
-                let eligible = state.queue.front().is_some_and(|item| {
+                let eligible = transaction.queue.front().is_some_and(|item| {
                     accepted_through.is_none_or(|limit| item.accepted_sequence <= limit)
                 });
-                eligible
-                    .then(|| state.queue.pop_front())
-                    .flatten()
-                    .map(|item| item.message)
+                eligible.then(|| transaction.queue.pop_front()).flatten()
             }
             Some(MailboxKind::Latest) => {
-                let eligible = state.latest.as_ref().is_some_and(|item| {
+                let eligible = transaction.latest.as_ref().is_some_and(|item| {
                     accepted_through.is_none_or(|limit| item.accepted_sequence <= limit)
                 });
-                eligible
-                    .then(|| state.latest.take())
-                    .flatten()
-                    .map(|item| item.message)
+                eligible.then(|| transaction.latest.take()).flatten()
             }
             None => None,
         };
-        let promotion = if message.is_some() && matches!(state.status(), BindingStatus::Bound(_)) {
-            promote_waiters(&mut state, &self.accepted)
-        } else {
-            Promotion::default()
-        };
-        drop(state);
-        if message.is_some() {
-            self.changed.pulse();
+        if let Some(envelope) = envelope {
+            transaction.effects.returned = Some(envelope.message);
+            if matches!(transaction.status(), BindingStatus::Bound(_)) {
+                let (state, effects) = transaction.parts();
+                promote_waiters(state, &self.accepted, effects);
+            }
+            transaction.effects.pulse();
         }
-        promotion.finish();
-        message
+        transaction.finish_returned()
     }
 
     pub(super) fn current_observation(&self) -> Option<Incarnation> {
@@ -722,7 +907,7 @@ impl<M: Send + 'static> MailboxCell<M> {
         }
     }
 
-    fn watcher(&self) -> SignalWatcher {
+    fn watcher(&self) -> Box<dyn MailboxSignalWatcher> {
         self.changed.watcher()
     }
 
@@ -732,26 +917,34 @@ impl<M: Send + 'static> MailboxCell<M> {
 }
 
 impl<M> MailboxCell<M> {
-    /// Withdraws a send operation and releases the waker it had registered.
+    pub(super) fn runtime(&self) -> Arc<dyn MailboxRuntime> {
+        Arc::clone(&self.runtime)
+    }
+}
+
+impl<M: Send + 'static> MailboxCell<M> {
+    /// Withdraws a send operation into an explicit post-unlock effect set.
     ///
-    /// The waker is returned rather than destroyed here: a `RawWaker` vtable is
-    /// caller code, so only the caller knows whether its destructor may run
-    /// inline. Withdrawal guarantees only that neither core lock is held once
-    /// the waker is handed back, and that the recovered message is handed over
-    /// first, so a hostile waker destructor can neither poison a core mutex nor
-    /// divert the message from the caller's chosen disposal route.
+    /// The registered waker is never returned as a raw value. `WakerSlot`
+    /// transfers it directly to this operation's effects, and callers choose
+    /// inline or isolated destruction before the locked transition begins.
     pub(super) fn withdraw(
         &self,
         operation: &Arc<SendOperation<M>>,
-    ) -> (Withdrawal<M>, Option<Waker>) {
-        let mut mailbox = self.state.lock().expect("mailbox mutex poisoned");
-        let current_observation = match mailbox.status() {
+        disposition: WithdrawalDisposition,
+    ) -> Withdrawal<M> {
+        // Declare waker effects before the transaction. On every unwind the
+        // operation guard drops first, then the mailbox transaction releases
+        // its guard, and only then can these effects run.
+        let mut waker_effects = WakerEffects::default();
+        let mut transaction = MailboxTxn::new(self);
+        let current_observation = match transaction.status() {
             BindingStatus::Bound(incarnation) | BindingStatus::Frozen(incarnation) => {
                 Some(incarnation)
             }
             BindingStatus::Unbound | BindingStatus::Terminal(_) => None,
         };
-        let (result, registration, waker) = {
+        let (outcome, registration) = {
             let mut state = operation
                 .state
                 .lock()
@@ -777,10 +970,18 @@ impl<M> MailboxCell<M> {
                     // (including zero-duration) deadline poll.
                     let observed = (*newest_observed).or(current_observation);
                     state.outcome = OperationOutcome::Withdrawn;
+                    state.waker.take(
+                        match disposition {
+                            WithdrawalDisposition::Inline => WakerAction::DropInline,
+                            WithdrawalDisposition::Isolated => {
+                                WakerAction::Dispose(Arc::clone(&self.runtime))
+                            }
+                        },
+                        &mut waker_effects,
+                    );
                     (
-                        Withdrawal::Withdrawn { message, observed },
+                        WithdrawalOutcome::Withdrawn { message, observed },
                         state.registration.take(),
-                        state.waker.take(),
                     )
                 }
                 OperationOutcome::Accepted(incarnation) => {
@@ -788,11 +989,10 @@ impl<M> MailboxCell<M> {
                     // Acceptance took the waker in the same critical section
                     // that published this outcome, so no registration survives
                     // it for withdrawal to release.
-                    debug_assert!(state.waker.is_none());
+                    debug_assert!(state.waker.is_empty());
                     (
-                        Withdrawal::Accepted(incarnation),
+                        WithdrawalOutcome::Accepted(incarnation),
                         state.registration.take(),
-                        None,
                     )
                 }
                 OperationOutcome::Terminated {
@@ -804,11 +1004,10 @@ impl<M> MailboxCell<M> {
                         .expect("a terminal operation must retain its message");
                     let observed = *final_incarnation;
                     // Termination likewise took the waker before publishing.
-                    debug_assert!(state.waker.is_none());
+                    debug_assert!(state.waker.is_empty());
                     (
-                        Withdrawal::Terminated { message, observed },
+                        WithdrawalOutcome::Terminated { message, observed },
                         state.registration.take(),
-                        None,
                     )
                 }
                 OperationOutcome::Withdrawn => {
@@ -817,14 +1016,16 @@ impl<M> MailboxCell<M> {
             }
         };
         if let Some(registration) = registration {
-            if let Some(removed) = mailbox.remove_waiter(registration) {
+            if let Some(removed) = transaction.remove_waiter(registration) {
                 debug_assert!(Arc::ptr_eq(&removed, operation));
             } else {
-                debug_assert!(matches!(mailbox.status(), BindingStatus::Terminal(_)));
+                debug_assert!(matches!(transaction.status(), BindingStatus::Terminal(_)));
             }
         }
-        drop(mailbox);
-        (result, waker)
+        transaction.finish(Withdrawal {
+            outcome: Some(outcome),
+            _waker_effects: waker_effects,
+        })
     }
 }
 
@@ -834,39 +1035,46 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             ResolvedMailbox::Queue(capacity) => MailboxKind::Queue(capacity),
             ResolvedMailbox::Latest => MailboxKind::Latest,
         };
-        let mut state = self.state.lock().expect("mailbox mutex poisoned");
-        match state.kind {
-            Some(existing) => debug_assert_eq!(existing, kind),
-            None => state.kind = Some(kind),
+        let mut transaction = MailboxTxn::new(self);
+        let mismatch = match transaction.kind {
+            Some(existing) => (existing != kind).then_some(existing),
+            None => {
+                transaction.kind = Some(kind);
+                None
+            }
+        };
+        transaction.finish(());
+        if let Some(existing) = mismatch {
+            panic!(
+                "mailbox configuration changed from {existing:?} to {kind:?} after initialization"
+            );
         }
     }
 
     fn bind(&self, incarnation: Incarnation) {
-        let mut state = self.state.lock().expect("mailbox mutex poisoned");
-        if matches!(state.status(), BindingStatus::Terminal(_)) {
-            return;
+        let mut transaction = MailboxTxn::new(self);
+        if matches!(transaction.status(), BindingStatus::Terminal(_)) {
+            return transaction.finish(());
         }
-        // Driver-contract violations release the lock before panicking so the
-        // failure stays on the driver thread instead of poisoning the mutex
-        // under every sender.
-        let Some(kind) = state.kind else {
-            drop(state);
-            panic!("mailbox must be configured before its first bind");
+        let Some(kind) = transaction.kind else {
+            transaction.finish(());
+            panic!("mailbox must be configured before its first bind")
         };
-        if !matches!(state.status(), BindingStatus::Unbound) {
-            drop(state);
-            panic!("mailbox must close the prior incarnation before rebinding");
+        if !matches!(transaction.status(), BindingStatus::Unbound) {
+            transaction.finish(());
+            panic!("mailbox must close the prior incarnation before rebinding")
         }
-        let mut waiters = state.take_waiters();
-        state.last_bound = Some(incarnation);
+        let mut waiters = transaction.take_waiters();
+        transaction.last_bound = Some(incarnation);
         // Binding is an observation edge for every operation that remained
         // parked through it, including FIFO overflow that cannot be promoted
         // into the current capacity. Withdrawal takes the mailbox lock before
         // the operation lock, so a concurrent timeout sees either the prior
         // evidence or this incarnation consistently with which edge won.
         waiters.observe_all(incarnation);
-        let promotion = {
-            let MailboxState { queue, latest, .. } = &mut *state;
+        {
+            let (state, effects) = transaction.parts();
+            let MailboxState { queue, latest, .. } = state;
             promote_waiter_queue(
                 kind,
                 incarnation,
@@ -874,89 +1082,91 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
                 queue,
                 latest,
                 &self.accepted,
-            )
-        };
+                effects,
+            );
+        }
         if waiters.is_empty() {
-            state.binding = MailboxBinding::Bound(BoundState::Available(incarnation));
+            transaction.binding = MailboxBinding::Bound(BoundState::Available(incarnation));
         } else {
             let MailboxKind::Queue(capacity) = kind else {
                 unreachable!("a latest mailbox finishes all waiting submissions")
             };
-            debug_assert_eq!(state.queue.len(), capacity.get());
-            state.binding = MailboxBinding::Bound(BoundState::Full {
+            debug_assert_eq!(transaction.queue.len(), capacity.get());
+            transaction.binding = MailboxBinding::Bound(BoundState::Full {
                 incarnation,
                 waiters,
             });
         }
-        drop(state);
-        self.changed.pulse();
-        promotion.finish_isolated();
+        transaction.effects.pulse();
+        transaction.effects.isolate_displaced();
+        transaction.finish(())
     }
 
     fn freeze(&self, incarnation: Incarnation) {
-        let mut state = self.state.lock().expect("mailbox mutex poisoned");
-        if state.status() != BindingStatus::Bound(incarnation) {
-            return;
+        let mut transaction = MailboxTxn::new(self);
+        if transaction.status() != BindingStatus::Bound(incarnation) {
+            return transaction.finish(());
         }
-        let waiters = state.take_waiters();
-        state.binding = MailboxBinding::Frozen {
+        let waiters = transaction.take_waiters();
+        transaction.binding = MailboxBinding::Frozen {
             incarnation,
             waiters,
         };
-        drop(state);
-        self.changed.pulse();
+        transaction.effects.pulse();
+        transaction.finish(())
     }
 
     fn close(&self, incarnation: Incarnation) -> Option<MailboxDisposal> {
-        let mut state = self.state.lock().expect("mailbox mutex poisoned");
+        let mut transaction = MailboxTxn::new(self);
         if !matches!(
-            state.status(),
+            transaction.status(),
             BindingStatus::Bound(current) | BindingStatus::Frozen(current)
                 if current == incarnation
         ) {
-            return None;
+            return transaction.finish(None);
         }
-        let waiters = state.take_waiters();
-        state.binding = MailboxBinding::Unbound(waiters);
-        let queue = std::mem::take(&mut state.queue);
-        let latest = state.latest.take();
-        drop(state);
-        self.changed.pulse();
-        Some(Box::new(MailboxPayload {
+        let waiters = transaction.take_waiters();
+        transaction.binding = MailboxBinding::Unbound(waiters);
+        let queue = std::mem::take(&mut transaction.queue);
+        let latest = transaction.latest.take();
+        transaction.effects.pulse();
+        let disposal = Some(Box::new(MailboxPayload {
             queue: Some(queue),
             latest,
             retired: Vec::new(),
-        }) as MailboxDisposal)
+        }) as MailboxDisposal);
+        transaction.finish(disposal)
     }
 
     fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>> {
-        let mut state = self.state.lock().expect("mailbox mutex poisoned");
-        if matches!(state.status(), BindingStatus::Terminal(_)) {
-            return None;
+        let mut transaction = MailboxTxn::new(self);
+        if matches!(transaction.status(), BindingStatus::Terminal(_)) {
+            return transaction.finish(None);
         }
-        let final_incarnation = state.last_bound;
-        let waiters = state.take_waiters();
+        let final_incarnation = transaction.last_bound;
+        let waiters = transaction.take_waiters();
         // This binding transition linearizes mailbox terminality. Each
         // detached waiter is decided separately by its `Waiting ->` outcome
         // transition, so an already-expired withdrawal may beat the deferred
         // discharge even after this mailbox-wide transition.
-        state.binding = MailboxBinding::Terminal(final_incarnation);
-        let queue = std::mem::take(&mut state.queue);
-        let latest = state.latest.take();
+        transaction.binding = MailboxBinding::Terminal(final_incarnation);
+        let queue = std::mem::take(&mut transaction.queue);
+        let latest = transaction.latest.take();
         let termination = Termination {
             waiters,
             final_incarnation,
         };
-        drop(state);
-        Some(Box::new(MailboxTeardown {
-            changed: Some(self.changed.clone()),
-            payload: crate::runtime::Isolated::new(MailboxPayload {
+        let teardown = Some(Box::new(MailboxTeardown {
+            runtime: Arc::clone(&self.runtime),
+            changed: Some(Arc::clone(&self.changed)),
+            payload: Some(MailboxPayload {
                 queue: Some(queue),
                 latest,
                 retired: Vec::new(),
             }),
             termination: Some(termination),
-        }))
+        }) as Box<dyn MailboxTermination>);
+        transaction.finish(teardown)
     }
 
     #[cfg(debug_assertions)]
@@ -980,91 +1190,89 @@ fn mint_accepted_sequence(accepted: &AtomicPoisonedCounter) -> AcceptedSequence 
 
 fn accept_locked<M>(
     state: &mut MailboxState<M>,
+    incarnation: Incarnation,
     message: M,
     accepted: &AtomicPoisonedCounter,
-) -> Result<Acceptance<M>, Rejected<M>> {
-    let incarnation = match &state.binding {
-        MailboxBinding::Bound(BoundState::Available(incarnation)) => *incarnation,
-        MailboxBinding::Bound(BoundState::Full { .. }) => {
-            return Err(Rejected {
-                message,
-                reason: RejectionReason::Full,
-            });
+    effects: &mut MailboxEffects<M>,
+) -> Result<Incarnation, M>
+where
+    M: Send + 'static,
+{
+    match &state.binding {
+        MailboxBinding::Bound(BoundState::Available(current)) => {
+            debug_assert_eq!(*current, incarnation);
+        }
+        MailboxBinding::Bound(BoundState::Full {
+            incarnation: current,
+            ..
+        }) => {
+            debug_assert_eq!(*current, incarnation);
+            return Err(message);
         }
         MailboxBinding::Unbound(_)
         | MailboxBinding::Frozen { .. }
         | MailboxBinding::Terminal(_) => {
-            return Err(Rejected {
-                message,
-                reason: RejectionReason::NotAccepting,
-            });
+            unreachable!("accept_locked is entered only from a bound mailbox")
         }
-    };
+    }
     let kind = match state.kind {
         Some(MailboxKind::Queue(capacity)) if state.queue.len() < capacity.get() => {
             MailboxKind::Queue(capacity)
         }
         Some(MailboxKind::Latest) => MailboxKind::Latest,
-        Some(MailboxKind::Queue(_)) => {
-            return Err(Rejected {
-                message,
-                reason: RejectionReason::Full,
-            });
-        }
-        None => {
-            return Err(Rejected {
-                message,
-                reason: RejectionReason::Unconfigured,
-            });
-        }
+        Some(MailboxKind::Queue(_)) => return Err(message),
+        None => unreachable!("a bound mailbox is always configured"),
     };
     let accepted_sequence = mint_accepted_sequence(accepted);
-    let displaced = match kind {
+    match kind {
         MailboxKind::Queue(_) => {
             state.queue.push_back(Envelope {
                 message,
                 accepted_sequence,
             });
-            None
         }
-        MailboxKind::Latest => state.latest.replace(Envelope {
-            message,
-            accepted_sequence,
-        }),
-    };
-    Ok(Acceptance {
-        incarnation,
-        displaced,
-    })
+        MailboxKind::Latest => {
+            let displaced = state.latest.replace(Envelope {
+                message,
+                accepted_sequence,
+            });
+            if let Some(displaced) = displaced {
+                effects.displaced.push(displaced);
+            }
+        }
+    }
+    effects.pulse();
+    Ok(incarnation)
 }
 
 fn promote_waiters<M: Send + 'static>(
     state: &mut MailboxState<M>,
     accepted_sequence: &AtomicPoisonedCounter,
-) -> Promotion<M> {
+    effects: &mut MailboxEffects<M>,
+) {
     let Some(kind) = state.kind else {
-        return Promotion::default();
+        return;
     };
     let MailboxBinding::Bound(BoundState::Full {
         incarnation,
         waiters,
     }) = &mut state.binding
     else {
-        return Promotion::default();
+        return;
     };
     let incarnation = *incarnation;
-    let promotion = promote_waiter_queue(
+    promote_waiter_queue(
         kind,
         incarnation,
         waiters,
         &mut state.queue,
         &mut state.latest,
         accepted_sequence,
+        effects,
     );
     if waiters.is_empty() {
         state.binding = MailboxBinding::Bound(BoundState::Available(incarnation));
     }
-    promotion
 }
 
 fn promote_waiter_queue<M: Send + 'static>(
@@ -1074,8 +1282,8 @@ fn promote_waiter_queue<M: Send + 'static>(
     queue: &mut VecDeque<Envelope<M>>,
     latest: &mut Option<Envelope<M>>,
     accepted_sequence: &AtomicPoisonedCounter,
-) -> Promotion<M> {
-    let mut promotion = Promotion::default();
+    effects: &mut MailboxEffects<M>,
+) {
     let available = match kind {
         MailboxKind::Queue(capacity) => capacity.get().saturating_sub(queue.len()),
         MailboxKind::Latest => usize::MAX,
@@ -1087,12 +1295,9 @@ fn promote_waiter_queue<M: Send + 'static>(
         };
         operation.clear_registration(registration);
         operation.observe(incarnation);
-        let Some((message, wake)) = operation.accept(incarnation) else {
+        let Some(message) = operation.accept(incarnation, &mut effects.wakers) else {
             continue;
         };
-        if let Some(waker) = wake {
-            promotion.wakers.push(waker);
-        }
         let accepted_sequence = mint_accepted_sequence(accepted_sequence);
         match kind {
             MailboxKind::Queue(_) => queue.push_back(Envelope {
@@ -1104,16 +1309,43 @@ fn promote_waiter_queue<M: Send + 'static>(
                     message,
                     accepted_sequence,
                 }) {
-                    promotion.displaced.push(displaced);
+                    effects.displaced.push(displaced);
                 }
             }
         }
         accepted += 1;
     }
-    promotion
 }
 
-pub(super) enum Withdrawal<M> {
+#[derive(Clone, Copy)]
+pub(super) enum WithdrawalDisposition {
+    Inline,
+    Isolated,
+}
+
+pub(super) struct Withdrawal<M> {
+    outcome: Option<WithdrawalOutcome<M>>,
+    _waker_effects: WakerEffects,
+}
+
+impl<M> Withdrawal<M> {
+    pub(super) fn without_effects(outcome: WithdrawalOutcome<M>) -> Self {
+        Self {
+            outcome: Some(outcome),
+            _waker_effects: WakerEffects::default(),
+        }
+    }
+
+    pub(super) fn take_outcome(&mut self) -> WithdrawalOutcome<M> {
+        self.outcome
+            .take()
+            .expect("a withdrawal outcome is consumed exactly once")
+    }
+
+    pub(super) fn finish(self) {}
+}
+
+pub(super) enum WithdrawalOutcome<M> {
     Withdrawn {
         message: M,
         observed: Option<Incarnation>,
@@ -1127,7 +1359,7 @@ pub(super) enum Withdrawal<M> {
 pub struct MailboxReceiver<M> {
     mailbox: Arc<MailboxCell<M>>,
     incarnation: Incarnation,
-    watcher: SignalWatcher,
+    watcher: Box<dyn MailboxSignalWatcher>,
 }
 
 impl<M: Send + 'static> MailboxReceiver<M> {
@@ -1275,7 +1507,7 @@ pub(super) mod tests {
                 .into_pair()
                 .0,
         });
-        let mailbox = MailboxCell::new(id);
+        let mailbox = MailboxCell::new(id, crate::capability::tests::runtime());
         (
             Arc::clone(&mailbox),
             crate::actor_ref_from_parts(member, mailbox),
@@ -1303,6 +1535,37 @@ pub(super) mod tests {
         let incarnation = incarnations.mint().expect("incarnation available");
 
         MailboxControl::bind(&*mailbox, incarnation);
+    }
+
+    #[test]
+    fn configuration_mismatch_panics_after_releasing_the_mailbox_lock() {
+        let (mailbox, _) = actor();
+        let queue = ResolvedMailbox::Queue(
+            std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
+        );
+        MailboxControl::configure(&*mailbox, queue);
+        MailboxControl::configure(&*mailbox, queue);
+
+        let Err(panic) = catch_unwind(AssertUnwindSafe(|| {
+            MailboxControl::configure(&*mailbox, ResolvedMailbox::Latest);
+        })) else {
+            panic!("changing mailbox kind must trip the driver contract")
+        };
+        assert!(
+            panic
+                .downcast_ref::<String>()
+                .is_some_and(|message| message.contains("mailbox configuration changed"))
+        );
+        assert_eq!(
+            mailbox
+                .state
+                .lock()
+                .expect("configuration panic occurs after unlocking")
+                .kind,
+            Some(super::MailboxKind::Queue(
+                std::num::NonZeroUsize::new(1).expect("non-zero queue capacity")
+            ))
+        );
     }
 
     #[test]
@@ -1355,10 +1618,12 @@ pub(super) mod tests {
                 if !waiters.is_empty()
         ));
 
+        let mut withdrawal = mailbox.withdraw(&operation, super::WithdrawalDisposition::Inline);
         assert!(matches!(
-            mailbox.withdraw(&operation),
-            (super::Withdrawal::Withdrawn { message: 2, .. }, None)
+            withdrawal.take_outcome(),
+            super::WithdrawalOutcome::Withdrawn { message: 2, .. }
         ));
+        withdrawal.finish();
         assert!(matches!(
             mailbox.state.lock().expect("mailbox mutex poisoned").binding,
             super::MailboxBinding::Bound(super::BoundState::Available(bound))
@@ -1477,29 +1742,23 @@ pub(super) mod tests {
             operation: Arc::downgrade(&operation),
             drops: Arc::clone(&drops),
         }));
-        operation
-            .state
-            .lock()
-            .expect("send operation mutex poisoned")
-            .waker = Some(hostile.clone());
+        operation.install_test_waker(hostile.clone());
         drop(hostile);
 
-        let (withdrawal, waker) = mailbox.withdraw(&operation);
+        let mut withdrawal = mailbox.withdraw(&operation, super::WithdrawalDisposition::Inline);
         assert!(matches!(
-            withdrawal,
-            super::Withdrawal::Withdrawn { message: 1, .. }
+            withdrawal.take_outcome(),
+            super::WithdrawalOutcome::Withdrawn { message: 1, .. }
         ));
         assert_eq!(
             drops.load(Ordering::SeqCst),
             0,
             "withdrawal releases the waker rather than running its destructor"
         );
-        let waker = waker.expect("withdrawal releases the waker the operation had registered");
-
-        // Whoever accepts the released waker runs its destructor with neither
-        // core lock held, so the reentrant probe inside it succeeds and its
-        // panic reaches only that owner.
-        let Err(panic) = catch_unwind(AssertUnwindSafe(move || drop(waker))) else {
+        // Finishing the explicit effect set runs its waker destructor with
+        // neither core lock held, so the reentrant probe inside it succeeds
+        // and its panic reaches only that owner.
+        let Err(panic) = catch_unwind(AssertUnwindSafe(move || withdrawal.finish())) else {
             panic!("the hostile waker drop panic reaches whoever destroys it")
         };
         assert_eq!(

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -554,7 +554,10 @@ impl<M: Send + 'static> Drop for MailboxEffects<M> {
         if self.pulse {
             panics.run(|| self.changed.pulse());
         }
-        self.wakers.flush(&mut panics);
+        // Binding a latest-value mailbox historically handed displaced
+        // payloads to isolated disposal before accepted senders were woken.
+        // Preserve that observable ownership edge: a woken sender may run
+        // immediately and must not race ahead of disposal submission.
         if self.isolate_displaced && !self.displaced.is_empty() {
             let displaced = std::mem::take(&mut self.displaced);
             panics.run(|| {
@@ -567,7 +570,9 @@ impl<M: Send + 'static> Drop for MailboxEffects<M> {
                     },
                 );
             });
-        } else {
+        }
+        self.wakers.flush(&mut panics);
+        if !self.isolate_displaced {
             for displaced in self.displaced.drain(..) {
                 panics.run(|| drop(displaced));
             }
@@ -1403,12 +1408,13 @@ pub(super) mod tests {
     use std::{
         future::Future,
         panic::{AssertUnwindSafe, catch_unwind},
+        pin::Pin,
         sync::{
-            Arc, Weak,
+            Arc, Mutex, Weak,
             atomic::{AtomicUsize, Ordering},
         },
         task::{Context, Poll, Wake, Waker},
-        time::Duration,
+        time::{Duration, Instant},
     };
 
     use crate::{
@@ -1432,6 +1438,82 @@ pub(super) mod tests {
     impl Wake for CountWake {
         fn wake(self: Arc<Self>) {
             self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum BindEffectEvent {
+        SignalPulsed,
+        DisposalSubmitted,
+        SenderWoken,
+    }
+
+    struct BindOrderingRuntime {
+        inner: Arc<dyn crate::MailboxRuntime>,
+        events: Arc<Mutex<Vec<BindEffectEvent>>>,
+    }
+
+    impl crate::MailboxRuntime for BindOrderingRuntime {
+        fn oneshot(
+            &self,
+        ) -> (
+            Box<dyn crate::ErasedOneShotSender>,
+            Pin<Box<dyn crate::ErasedOneShotReceiver>>,
+        ) {
+            self.inner.oneshot()
+        }
+
+        fn signal(&self) -> Arc<dyn crate::MailboxSignal> {
+            Arc::new(BindOrderingSignal {
+                inner: self.inner.signal(),
+                events: Arc::clone(&self.events),
+            })
+        }
+
+        fn dispose(&self, value: Box<dyn Send + 'static>) {
+            self.events
+                .lock()
+                .expect("bind effect recorder mutex")
+                .push(BindEffectEvent::DisposalSubmitted);
+            self.inner.dispose(value);
+        }
+
+        fn now(&self) -> Instant {
+            self.inner.now()
+        }
+
+        fn sleep_until(&self, deadline: Option<Instant>) -> crate::BoxedSleep {
+            self.inner.sleep_until(deadline)
+        }
+    }
+
+    struct BindOrderingSignal {
+        inner: Arc<dyn crate::MailboxSignal>,
+        events: Arc<Mutex<Vec<BindEffectEvent>>>,
+    }
+
+    impl crate::MailboxSignal for BindOrderingSignal {
+        fn pulse(&self) {
+            self.events
+                .lock()
+                .expect("bind effect recorder mutex")
+                .push(BindEffectEvent::SignalPulsed);
+            self.inner.pulse();
+        }
+
+        fn watcher(&self) -> Box<dyn crate::MailboxSignalWatcher> {
+            self.inner.watcher()
+        }
+    }
+
+    struct BindOrderingWake(Arc<Mutex<Vec<BindEffectEvent>>>);
+
+    impl Wake for BindOrderingWake {
+        fn wake(self: Arc<Self>) {
+            self.0
+                .lock()
+                .expect("bind effect recorder mutex")
+                .push(BindEffectEvent::SenderWoken);
         }
     }
 
@@ -1829,6 +1911,53 @@ pub(super) mod tests {
             third.as_mut().poll(&mut Context::from_waker(Waker::noop())),
             Poll::Ready(Ok(_))
         ));
+    }
+
+    #[test]
+    fn bind_submits_displaced_payloads_for_disposal_before_waking_senders() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let runtime = Arc::new(BindOrderingRuntime {
+            inner: crate::capability::tests::runtime(),
+            events: Arc::clone(&events),
+        });
+        let mailbox = MailboxCell::new(ChildId::from("actor"), runtime);
+        MailboxControl::configure(&*mailbox, ResolvedMailbox::Latest);
+
+        let first = match mailbox.submit(1) {
+            super::Submission::Parked(operation) => operation,
+            super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+                panic!("an unbound mailbox parks its send")
+            }
+        };
+        let second = match mailbox.submit(2) {
+            super::Submission::Parked(operation) => operation,
+            super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+                panic!("an unbound mailbox parks its send")
+            }
+        };
+        first.install_test_waker(Waker::from(Arc::new(BindOrderingWake(Arc::clone(&events)))));
+        second.install_test_waker(Waker::from(Arc::new(BindOrderingWake(Arc::clone(&events)))));
+
+        let mut identity = ScopeIdentity::new();
+        let (_, mut incarnations) = identity
+            .mint_membership(&ChildId::from("actor"))
+            .expect("membership available")
+            .into_pair();
+        MailboxControl::bind(
+            &*mailbox,
+            incarnations.mint().expect("incarnation available"),
+        );
+
+        assert_eq!(
+            *events.lock().expect("bind effect recorder mutex"),
+            [
+                BindEffectEvent::SignalPulsed,
+                BindEffectEvent::DisposalSubmitted,
+                BindEffectEvent::SenderWoken,
+                BindEffectEvent::SenderWoken,
+            ],
+            "binding preserves pulse, disposal-submission, then wake ordering"
+        );
     }
 
     #[test]

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::{
     ChildId, Incarnation, MailboxControl, MailboxDisposal, MailboxRuntime, MailboxSignal,
     MailboxSignalWatcher, MailboxTermination,
-    capability::dispose,
+    capability::{dispose, dispose_value},
     identity::{AtomicPoisonedCounter, PoisonedCounter},
     panic::{PanicAccumulator, PanicPayload, resume_panic},
     policy::ResolvedMailbox,
@@ -516,9 +516,12 @@ impl<M> WaiterQueue<M> {
 /// `MailboxTxn` owns this sink beside the guard and drops the guard first.
 /// Locked transition code can only enqueue effects; pulse callbacks, waker
 /// vtables, payload destructors, and runtime disposal all run during flush.
-struct MailboxEffects<M: Send + 'static> {
-    runtime: Arc<dyn MailboxRuntime>,
-    changed: Arc<dyn MailboxSignal>,
+/// The sink borrows its mailbox rather than cloning the capability handles out
+/// of it: it never outlives the `MailboxTxn` that owns it, and every mailbox
+/// transition — including the per-message receive path — would otherwise pay
+/// two atomic refcount pairs to restate what the transaction already holds.
+struct MailboxEffects<'a, M: Send + 'static> {
+    cell: &'a MailboxCell<M>,
     pulse: bool,
     displaced: Vec<Envelope<M>>,
     isolate_displaced: bool,
@@ -526,11 +529,10 @@ struct MailboxEffects<M: Send + 'static> {
     returned: Option<M>,
 }
 
-impl<M: Send + 'static> MailboxEffects<M> {
-    fn new(cell: &MailboxCell<M>) -> Self {
+impl<'a, M: Send + 'static> MailboxEffects<'a, M> {
+    fn new(cell: &'a MailboxCell<M>) -> Self {
         Self {
-            runtime: Arc::clone(&cell.runtime),
-            changed: Arc::clone(&cell.changed),
+            cell,
             pulse: false,
             displaced: Vec::new(),
             isolate_displaced: false,
@@ -548,11 +550,11 @@ impl<M: Send + 'static> MailboxEffects<M> {
     }
 }
 
-impl<M: Send + 'static> Drop for MailboxEffects<M> {
+impl<M: Send + 'static> Drop for MailboxEffects<'_, M> {
     fn drop(&mut self) {
         let mut panics = PanicAccumulator::default();
         if self.pulse {
-            panics.run(|| self.changed.pulse());
+            panics.run(|| self.cell.changed.pulse());
         }
         // Binding a latest-value mailbox historically handed displaced
         // payloads to isolated disposal before accepted senders were woken.
@@ -561,8 +563,8 @@ impl<M: Send + 'static> Drop for MailboxEffects<M> {
         if self.isolate_displaced && !self.displaced.is_empty() {
             let displaced = std::mem::take(&mut self.displaced);
             panics.run(|| {
-                dispose(
-                    &self.runtime,
+                dispose_value(
+                    self.cell.runtime.as_ref(),
                     MailboxPayload {
                         queue: Some(displaced.into()),
                         latest: None,
@@ -586,7 +588,7 @@ impl<M: Send + 'static> Drop for MailboxEffects<M> {
 /// A mailbox transition guard paired with its mandatory post-unlock effects.
 struct MailboxTxn<'a, M: Send + 'static> {
     state: Option<MutexGuard<'a, MailboxState<M>>>,
-    effects: MailboxEffects<M>,
+    effects: MailboxEffects<'a, M>,
 }
 
 impl<'a, M: Send + 'static> MailboxTxn<'a, M> {
@@ -599,7 +601,7 @@ impl<'a, M: Send + 'static> MailboxTxn<'a, M> {
         }
     }
 
-    fn parts(&mut self) -> (&mut MailboxState<M>, &mut MailboxEffects<M>) {
+    fn parts(&mut self) -> (&mut MailboxState<M>, &mut MailboxEffects<'a, M>) {
         (
             self.state
                 .as_deref_mut()
@@ -1198,7 +1200,7 @@ fn accept_locked<M>(
     incarnation: Incarnation,
     message: M,
     accepted: &AtomicPoisonedCounter,
-    effects: &mut MailboxEffects<M>,
+    effects: &mut MailboxEffects<'_, M>,
 ) -> Result<Incarnation, M>
 where
     M: Send + 'static,
@@ -1253,7 +1255,7 @@ where
 fn promote_waiters<M: Send + 'static>(
     state: &mut MailboxState<M>,
     accepted_sequence: &AtomicPoisonedCounter,
-    effects: &mut MailboxEffects<M>,
+    effects: &mut MailboxEffects<'_, M>,
 ) {
     let Some(kind) = state.kind else {
         return;
@@ -1287,7 +1289,7 @@ fn promote_waiter_queue<M: Send + 'static>(
     queue: &mut VecDeque<Envelope<M>>,
     latest: &mut Option<Envelope<M>>,
     accepted_sequence: &AtomicPoisonedCounter,
-    effects: &mut MailboxEffects<M>,
+    effects: &mut MailboxEffects<'_, M>,
 ) {
     let available = match kind {
         MailboxKind::Queue(capacity) => capacity.get().saturating_sub(queue.len()),

--- a/crates/shelterwood-mailbox/src/deadline.rs
+++ b/crates/shelterwood-mailbox/src/deadline.rs
@@ -1,10 +1,13 @@
 use std::{
     future::Future,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
 use shelterwood_core::DeadlineBudget;
+
+use crate::{BoxedSleep, MailboxRuntime};
 
 pub(crate) use shelterwood_core::deadline::Deadline;
 
@@ -52,9 +55,10 @@ pub(super) trait DeadlineOperation {
 /// First-poll deadline capture shared by every public mailbox deadline future.
 pub(super) struct Deadlined<F> {
     pub(super) operation: F,
+    runtime: Arc<dyn MailboxRuntime>,
     budget_width: DeadlineBudget,
     budget: Option<crate::deadline::Deadline>,
-    timer: Option<crate::runtime::BoxedSleep>,
+    timer: Option<BoxedSleep>,
     pub(super) started: bool,
     phase: DeadlinePhase,
 }
@@ -62,9 +66,14 @@ pub(super) struct Deadlined<F> {
 impl<F> Deadlined<F> {
     /// Constructs the shared no-attempt deadline policy used by public
     /// mailbox operations.
-    pub(super) fn no_attempt(operation: F, budget_width: impl Into<DeadlineBudget>) -> Self {
+    pub(super) fn no_attempt(
+        operation: F,
+        budget_width: impl Into<DeadlineBudget>,
+        runtime: Arc<dyn MailboxRuntime>,
+    ) -> Self {
         Self {
             operation,
+            runtime,
             budget_width: budget_width.into(),
             budget: None,
             timer: None,
@@ -81,10 +90,11 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
         let this = self.as_mut().get_mut();
         if !this.started {
             this.started = true;
-            let budget = crate::runtime::deadline(this.budget_width.duration());
+            let budget =
+                crate::deadline::Deadline::after(this.runtime.now(), this.budget_width.duration());
             this.budget = Some(budget);
             if !this.budget_width.is_zero() {
-                this.timer = Some(crate::runtime::sleep_deadline(budget));
+                this.timer = Some(this.runtime.sleep_until(budget.instant()));
             }
         }
         // A zero budget short-circuits: the operation is never attempted, so
@@ -170,6 +180,7 @@ mod tests {
         let mut future = Box::pin(super::Deadlined::no_attempt(
             PendingOnFirstExpiry::default(),
             width,
+            crate::capability::tests::runtime(),
         ));
         let waker = Waker::noop();
         let mut context = Context::from_waker(waker);
@@ -188,6 +199,7 @@ mod tests {
         let mut future = Box::pin(super::Deadlined::no_attempt(
             PendingOnFirstExpiry::default(),
             shelterwood_core::DeadlineBudget::ZERO,
+            crate::capability::tests::runtime(),
         ));
         let waker = Waker::noop();
         let mut context = Context::from_waker(waker);

--- a/crates/shelterwood-mailbox/src/futures.rs
+++ b/crates/shelterwood-mailbox/src/futures.rs
@@ -4,19 +4,22 @@ use std::{
     hash::{Hash, Hasher},
     pin::Pin,
     sync::Arc,
-    task::{Context, Poll, Waker},
+    task::{Context, Poll},
 };
 
 use shelterwood_core::DeadlineBudget;
 
 use crate::{
-    ActorIdentity, ChildId, Incarnation, Membership,
-    runtime::{DisposingReceiver, dispose_detached},
+    ActorIdentity, ChildId, Incarnation, MailboxRuntime, Membership,
+    capability::{DisposingReceiver, dispose},
 };
 
 use super::{
     CallError, CallErrorKind, Replied, Reply, ReplyError, SendError, SendErrorKind,
-    cell::{MailboxCell, OperationOutcome, SendOperation, Submission, Withdrawal},
+    cell::{
+        MailboxCell, OperationPoll, SendOperation, Submission, Withdrawal, WithdrawalDisposition,
+        WithdrawalOutcome,
+    },
     deadline::{DeadlineOperation, DeadlinePhase, Deadlined},
     reply::{ReplyOperation, ReplyPoll, poll_reply},
 };
@@ -61,6 +64,10 @@ impl<M> ActorRef<M> {
     pub fn membership(&self) -> Membership {
         self.member.membership()
     }
+
+    pub(super) fn runtime(&self) -> Arc<dyn MailboxRuntime> {
+        self.mailbox.runtime()
+    }
 }
 
 /// Builds the façade's actor handle from its cross-crate identity and mailbox
@@ -101,14 +108,22 @@ impl<M: Send + 'static> ActorRef<M> {
     /// A zero budget makes no acceptance attempt and returns the unaccepted
     /// message with [`SendErrorKind::TimedOut`].
     pub fn send_timeout(&self, message: M, deadline: impl Into<DeadlineBudget>) -> SendTimeout<M> {
+        let runtime = self.mailbox.runtime();
         SendTimeout {
             deadlined: Deadlined::no_attempt(
                 TimedSend {
                     send: self.send(message),
                 },
                 deadline,
+                runtime,
             ),
         }
+    }
+
+    /// Creates a reply capability using this actor handle's installed runtime.
+    #[must_use]
+    pub fn reply_channel<T: Send + 'static>(&self) -> (Reply<T>, crate::ReplyReceiver<T>) {
+        Reply::channel(self.runtime())
     }
 
     /// Sends a request built around one reply capability and awaits its reply.
@@ -133,17 +148,20 @@ impl<M: Send + 'static> ActorRef<M> {
         make_msg: impl FnOnce(Reply<T>) -> M + Send + 'static,
         deadline: impl Into<DeadlineBudget>,
     ) -> CallFuture<M, T> {
+        let runtime = self.mailbox.runtime();
         CallFuture {
             deadlined: Deadlined::no_attempt(
                 CallOperation {
                     actor: self.clone(),
+                    runtime: Arc::clone(&runtime),
                     make_msg: Some(Box::new(make_msg)),
                     send: None,
                     reply: None,
                     accepted: None,
-                    dispose_constructor: dispose_detached::<MessageConstructor<M, T>>,
+                    dispose_constructor: dispose::<MessageConstructor<M, T>>,
                 },
                 deadline,
+                runtime,
             ),
         }
     }
@@ -188,11 +206,16 @@ impl<M> Hash for ActorRef<M> {
 #[must_use]
 pub struct SendFuture<M> {
     mailbox: Arc<MailboxCell<M>>,
+    runtime: Arc<dyn MailboxRuntime>,
     state: SendFutureState<M>,
     // Captured where `M: Send + 'static` holds so the unbounded `Drop` impl
     // can route a withdrawn message through isolated disposal.
-    dispose: fn(M),
+    dispose: fn(&Arc<dyn MailboxRuntime>, M),
+    withdraw_operation: WithdrawOperation<M>,
 }
+
+type WithdrawOperation<M> =
+    fn(&MailboxCell<M>, &Arc<SendOperation<M>>, WithdrawalDisposition) -> Withdrawal<M>;
 
 enum SendFutureState<M> {
     Immediate(Option<M>),
@@ -210,30 +233,31 @@ impl<M> Unpin for SendFuture<M> {}
 
 impl<M: Send + 'static> SendFuture<M> {
     fn new(mailbox: Arc<MailboxCell<M>>, message: M) -> Self {
+        let runtime = mailbox.runtime();
         Self {
             mailbox,
+            runtime,
             state: SendFutureState::Immediate(Some(message)),
-            dispose: dispose_detached::<M>,
+            dispose: dispose::<M>,
+            withdraw_operation: MailboxCell::withdraw,
         }
     }
 
-    /// Withdraws this send, also releasing any waker it had registered.
-    ///
-    /// The waker travels back to the caller unchanged: only the caller knows
-    /// whether a `RawWaker` destructor may run on its thread.
-    fn withdraw(&mut self) -> (Withdrawal<M>, Option<Waker>) {
+    /// Withdraws this send into a post-unlock effect set.
+    fn withdraw(&mut self, disposition: WithdrawalDisposition) -> Withdrawal<M> {
         match std::mem::replace(&mut self.state, SendFutureState::Done) {
-            SendFutureState::Immediate(mut message) => (
-                Withdrawal::Withdrawn {
+            SendFutureState::Immediate(mut message) => {
+                Withdrawal::without_effects(WithdrawalOutcome::Withdrawn {
                     message: message
                         .take()
                         .expect("an unsubmitted send retains its message"),
                     observed: self.mailbox.current_observation(),
-                },
-                None,
-            ),
-            SendFutureState::Parked(operation) => self.mailbox.withdraw(&operation),
-            SendFutureState::Sent(incarnation) => (Withdrawal::Accepted(incarnation), None),
+                })
+            }
+            SendFutureState::Parked(operation) => self.mailbox.withdraw(&operation, disposition),
+            SendFutureState::Sent(incarnation) => {
+                Withdrawal::without_effects(WithdrawalOutcome::Accepted(incarnation))
+            }
             SendFutureState::Done => panic!("a completed send was withdrawn"),
         }
     }
@@ -307,53 +331,30 @@ impl<M: Send + 'static> Future for SendFuture<M> {
         // lock in `SendOperation::accept`/`terminate`, so installing after that
         // re-read cannot lose a wakeup: any completion ordered after it takes
         // the waker this poll registered.
-        let mut cloned_waker: Option<Waker> = None;
+        let mut cloned_waker = None;
         loop {
-            let mut operation_state = operation
-                .state
-                .lock()
-                .expect("send operation mutex poisoned");
-            match &mut operation_state.outcome {
-                OperationOutcome::Accepted(incarnation) => {
-                    let incarnation = *incarnation;
-                    drop(operation_state);
+            match operation.poll(cloned_waker.take(), context.waker()) {
+                OperationPoll::Accepted(incarnation) => {
                     this.state = SendFutureState::Sent(incarnation);
                     return Poll::Ready(Ok(incarnation));
                 }
-                OperationOutcome::Terminated {
+                OperationPoll::Terminated {
                     message,
                     final_incarnation,
                 } => {
                     let error = SendError {
                         actor_id: this.mailbox.actor_id.clone(),
-                        incarnation_observed: *final_incarnation,
-                        message: message
-                            .take()
-                            .expect("a terminal operation retains its message until observed"),
+                        incarnation_observed: final_incarnation,
+                        message,
                         kind: SendErrorKind::Terminated,
                     };
-                    drop(operation_state);
                     this.state = SendFutureState::Done;
                     return Poll::Ready(Err(error));
                 }
-                OperationOutcome::Waiting { .. } => {
-                    if let Some(next_waker) = cloned_waker.take() {
-                        let stale_waker = operation_state.waker.replace(next_waker);
-                        drop(operation_state);
-                        drop(stale_waker);
-                        return Poll::Pending;
-                    }
-                    if operation_state
-                        .waker
-                        .as_ref()
-                        .is_some_and(|registered| registered.will_wake(context.waker()))
-                    {
-                        return Poll::Pending;
-                    }
-                    drop(operation_state);
+                OperationPoll::Pending => return Poll::Pending,
+                OperationPoll::NeedsWakerClone => {
                     cloned_waker = Some(context.waker().clone());
                 }
-                OperationOutcome::Withdrawn => panic!("a withdrawn send future was polled"),
             }
         }
     }
@@ -368,17 +369,21 @@ impl<M> Drop for SendFuture<M> {
         match std::mem::replace(&mut self.state, SendFutureState::Done) {
             SendFutureState::Immediate(mut message) => {
                 if let Some(message) = message.take() {
-                    (self.dispose)(message);
+                    (self.dispose)(&self.runtime, message);
                 }
             }
             SendFutureState::Parked(operation) => {
-                let (withdrawal, waker) = self.mailbox.withdraw(&operation);
-                match withdrawal {
-                    Withdrawal::Withdrawn { message, .. }
-                    | Withdrawal::Terminated { message, .. } => {
-                        (self.dispose)(message);
+                let mut withdrawal = (self.withdraw_operation)(
+                    &self.mailbox,
+                    &operation,
+                    WithdrawalDisposition::Isolated,
+                );
+                match withdrawal.take_outcome() {
+                    WithdrawalOutcome::Withdrawn { message, .. }
+                    | WithdrawalOutcome::Terminated { message, .. } => {
+                        (self.dispose)(&self.runtime, message);
                     }
-                    Withdrawal::Accepted(_) => {}
+                    WithdrawalOutcome::Accepted(_) => {}
                 }
                 // A RawWaker vtable is caller code and there is no caller left
                 // to surface a panic to. Destroying it inline would run a
@@ -387,9 +392,7 @@ impl<M> Drop for SendFuture<M> {
                 // -- so route it through isolated disposal like the message.
                 // Sequencing it after the message also keeps a hostile waker
                 // destructor from diverting the message from that route.
-                if let Some(waker) = waker {
-                    dispose_detached(waker);
-                }
+                withdrawal.finish();
             }
             SendFutureState::Sent(_) | SendFutureState::Done => {}
         }
@@ -417,16 +420,16 @@ impl<M> fmt::Debug for SendTimeout<M> {
 
 fn withdraw_send<M: Send + 'static>(send: &mut SendFuture<M>) -> Result<Incarnation, SendError<M>> {
     let actor_id = send.mailbox.actor_id.clone();
-    let (withdrawal, waker) = send.withdraw();
-    let result = match withdrawal {
-        Withdrawal::Withdrawn { message, observed } => Err(SendError {
+    let mut withdrawal = send.withdraw(WithdrawalDisposition::Inline);
+    let result = match withdrawal.take_outcome() {
+        WithdrawalOutcome::Withdrawn { message, observed } => Err(SendError {
             actor_id,
             incarnation_observed: observed,
             message,
             kind: SendErrorKind::TimedOut,
         }),
-        Withdrawal::Accepted(incarnation) => Ok(incarnation),
-        Withdrawal::Terminated { message, observed } => Err(SendError {
+        WithdrawalOutcome::Accepted(incarnation) => Ok(incarnation),
+        WithdrawalOutcome::Terminated { message, observed } => Err(SendError {
             actor_id,
             incarnation_observed: observed,
             message,
@@ -437,7 +440,7 @@ fn withdraw_send<M: Send + 'static>(send: &mut SendFuture<M>) -> Result<Incarnat
     // task, so the caller's waker destructor stays inline and its panic stays
     // visible; no core lock is held and the recovered message already belongs
     // to `result`.
-    drop(waker);
+    withdrawal.finish();
     result
 }
 
@@ -486,6 +489,7 @@ type MessageConstructor<M, T> = Box<dyn FnOnce(Reply<T>) -> M + Send + 'static>;
 
 struct CallOperation<M, T> {
     actor: ActorRef<M>,
+    runtime: Arc<dyn MailboxRuntime>,
     make_msg: Option<MessageConstructor<M, T>>,
     send: Option<SendFuture<M>>,
     reply: Option<DisposingReceiver<T>>,
@@ -493,7 +497,7 @@ struct CallOperation<M, T> {
     // Captured where `M: Send + 'static` holds so the unbounded `Drop` impl
     // can route an unused constructor and its captures through isolated
     // disposal.
-    dispose_constructor: fn(MessageConstructor<M, T>),
+    dispose_constructor: fn(&Arc<dyn MailboxRuntime>, MessageConstructor<M, T>),
 }
 
 impl<M, T> Drop for CallOperation<M, T> {
@@ -503,7 +507,7 @@ impl<M, T> Drop for CallOperation<M, T> {
             // without ever building a message. Destroying the captures inline
             // would run possibly blocking or panicking user destructors in
             // this drop glue, so route them through isolated disposal.
-            (self.dispose_constructor)(make_msg);
+            (self.dispose_constructor)(&self.runtime, make_msg);
         }
     }
 }
@@ -518,7 +522,7 @@ impl<M, T> fmt::Debug for CallFuture<M, T> {
     }
 }
 
-impl<M, T> CallOperation<M, T> {
+impl<M, T: Send + 'static> CallOperation<M, T> {
     fn poll_reply(
         &mut self,
         context: &mut Context<'_>,
@@ -568,7 +572,7 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
             // Capture the one overall budget before invoking user code. A
             // slow message constructor consumes acceptance/response time. The
             // shared scaffold captured `budget` before this callback runs.
-            let (reply, receiver) = Reply::channel();
+            let (reply, receiver) = self.actor.reply_channel();
             let message =
                 self.make_msg
                     .take()
@@ -577,11 +581,11 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
             // at the exact deadline win. Construction is different: no send
             // existed before it completed, so do not start one after the
             // captured budget is strictly in the past.
-            if budget.is_overdue(crate::runtime::now()) {
+            if budget.is_overdue(self.runtime.now()) {
                 // Construction completed, but timeout cleanup owns the
                 // unsubmitted message. Keep its potentially blocking or
                 // panicking destructor off the caller task.
-                dispose_detached(message);
+                dispose(&self.runtime, message);
                 return Poll::Ready(self.short_circuit());
             }
             self.reply = Some(receiver.receiver);
@@ -603,7 +607,7 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
                     // The call surface has no way to hand the recovered
                     // message back; route the discard through isolated
                     // disposal.
-                    dispose_detached(error.message);
+                    dispose(&self.runtime, error.message);
                     return Poll::Ready(Err(CallError {
                         actor_id: error.actor_id,
                         incarnation_observed: error.incarnation_observed,
@@ -642,7 +646,7 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
                 self.close_reply();
                 // The call surface has no way to hand the recovered message
                 // back; route the discard through isolated disposal.
-                dispose_detached(error.message);
+                dispose(&self.runtime, error.message);
                 Poll::Ready(Err(CallError {
                     actor_id: error.actor_id,
                     incarnation_observed: error.incarnation_observed,

--- a/crates/shelterwood-mailbox/src/lib.rs
+++ b/crates/shelterwood-mailbox/src/lib.rs
@@ -11,12 +11,18 @@ use std::{fmt, sync::Arc};
 use shelterwood_core::policy::ResolvedMailbox;
 pub use shelterwood_core::{ChildId, Incarnation, Membership};
 
+mod capability;
 mod cell;
 mod deadline;
 mod errors;
 mod futures;
 mod reply;
 
+#[doc(hidden)]
+pub use capability::{
+    BoxedSleep, ErasedOneShotClose, ErasedOneShotReceiver, ErasedOneShotSender, ErasedValue,
+    MailboxRuntime, MailboxSignal, MailboxSignalWatcher,
+};
 pub use cell::*;
 pub use errors::*;
 pub use futures::*;
@@ -32,10 +38,6 @@ mod panic {
 
 mod policy {
     pub(crate) use shelterwood_core::policy::*;
-}
-
-mod runtime {
-    pub(crate) use shelterwood_runtime::*;
 }
 
 /// Isolated payload returned after mailbox termination has synchronously
@@ -57,7 +59,8 @@ pub trait MailboxTermination: Send {
 /// intentionally ignored.
 pub trait MailboxControl: fmt::Debug + Send + Sync {
     /// Installs the declaration-time mailbox policy before the first bind.
-    /// Reconfiguration may only repeat the same resolved policy.
+    /// Reconfiguration may only repeat the same resolved policy; a mismatch
+    /// panics after the mailbox lock has been released.
     fn configure(&self, mailbox: ResolvedMailbox);
     /// Makes one incarnation live after configuration and prior-close cleanup.
     /// A bind after terminal preparation is deliberately ignored because
@@ -92,4 +95,9 @@ impl<T: ActorIdentity + ?Sized> ActorIdentity for Arc<T> {
     fn membership(&self) -> Membership {
         (**self).membership()
     }
+}
+
+#[cfg(test)]
+mod runtime {
+    pub(crate) use tokio::{test, time::advance};
 }

--- a/crates/shelterwood-mailbox/src/lib.rs
+++ b/crates/shelterwood-mailbox/src/lib.rs
@@ -2,9 +2,10 @@
 
 //! Mailbox state machines and public messaging primitives.
 //!
-//! Tokio details remain behind `shelterwood-runtime`; this crate names only
-//! the adapter operations its futures need. Cross-crate lifecycle and identity
-//! capabilities are public implementation seams, not supported façade API.
+//! Tokio details remain behind `shelterwood-runtime`: this crate declares the
+//! runtime capabilities its futures need and never names an executor, in tests
+//! as well as in production. Cross-crate lifecycle and identity capabilities
+//! are public implementation seams, not supported façade API.
 
 use std::{fmt, sync::Arc};
 
@@ -97,7 +98,14 @@ impl<T: ActorIdentity + ?Sized> ActorIdentity for Arc<T> {
     }
 }
 
+/// The Tokio adapter, reachable only as a dev-dependency.
+///
+/// `shelterwood-runtime` depends on this crate, so this is a dev-only cycle
+/// that leaves the production graph inverted (`cargo tree -e normal` shows
+/// `shelterwood-core` alone). Tests take their capability object and their
+/// runtime attribute from the real adapter rather than a stand-in, keeping
+/// tokio unnamed here.
 #[cfg(test)]
 mod runtime {
-    pub(crate) use tokio::{test, time::advance};
+    pub(crate) use shelterwood_runtime::*;
 }

--- a/crates/shelterwood-mailbox/src/reply.rs
+++ b/crates/shelterwood-mailbox/src/reply.rs
@@ -1,11 +1,15 @@
 use std::{
     fmt,
+    sync::Arc,
     task::{Context, Poll},
 };
 
 use shelterwood_core::DeadlineBudget;
 
-use crate::runtime::{DisposingReceiver, OneShotClose, OneShotSender, dispose_detached};
+use crate::{
+    MailboxRuntime,
+    capability::{DisposingReceiver, OneShotClose, OneShotSender, dispose, oneshot},
+};
 
 use super::{
     ReplyError, ReplyReceive,
@@ -20,6 +24,7 @@ use super::{
 /// isolated disposal.
 pub struct Reply<T> {
     sender: OneShotSender<T>,
+    runtime: Arc<dyn MailboxRuntime>,
 }
 
 impl<T> fmt::Debug for Reply<T> {
@@ -35,14 +40,15 @@ impl<T> fmt::Debug for Reply<T> {
 }
 
 impl<T: Send + 'static> Reply<T> {
-    /// Creates a reply capability and its single owned receiver.
-    #[must_use]
-    pub fn channel() -> (Self, ReplyReceiver<T>) {
-        let (sender, receiver) = crate::runtime::oneshot();
+    pub(crate) fn channel(runtime: Arc<dyn MailboxRuntime>) -> (Self, ReplyReceiver<T>) {
+        let (sender, receiver) = oneshot(&runtime);
         (
-            Self { sender },
+            Self {
+                sender,
+                runtime: Arc::clone(&runtime),
+            },
             ReplyReceiver {
-                receiver: DisposingReceiver::new(receiver),
+                receiver: DisposingReceiver::new(receiver, runtime),
             },
         )
     }
@@ -53,12 +59,13 @@ impl<T: Send + 'static> Reply<T> {
         // run a possibly blocking or panicking user destructor on the replying
         // actor; route the discard through isolated disposal instead.
         if let Err(unclaimed) = self.sender.send(value) {
-            dispose_detached(unclaimed);
+            dispose(&self.runtime, unclaimed);
         }
     }
 }
 
-/// The owned, non-cloneable receive half of [`Reply::channel`].
+/// The owned, non-cloneable receive half of
+/// [`ActorRef::reply_channel`](crate::ActorRef::reply_channel).
 pub struct ReplyReceiver<T> {
     pub(super) receiver: DisposingReceiver<T>,
 }
@@ -77,12 +84,14 @@ impl<T: Send + 'static> ReplyReceiver<T> {
     /// A zero budget does not observe an already-published response; it closes
     /// this receive capability and reports [`ReplyError::Timeout`].
     pub fn recv(self, deadline: impl Into<DeadlineBudget>) -> ReplyReceive<T> {
+        let runtime = self.receiver.runtime();
         ReplyReceive {
             deadlined: Deadlined::no_attempt(
                 ReplyOperation {
                     receiver: self.receiver,
                 },
                 deadline,
+                runtime,
             ),
         }
     }
@@ -98,7 +107,7 @@ pub(super) enum ReplyPoll<T> {
     TimedOut,
 }
 
-pub(super) fn poll_reply<T>(
+pub(super) fn poll_reply<T: Send + 'static>(
     receiver: &mut DisposingReceiver<T>,
     context: &mut Context<'_>,
     phase: DeadlinePhase,
@@ -118,7 +127,7 @@ pub(super) fn poll_reply<T>(
     }
 }
 
-impl<T> DeadlineOperation for ReplyOperation<T> {
+impl<T: Send + 'static> DeadlineOperation for ReplyOperation<T> {
     type Output = Result<T, ReplyError>;
 
     fn poll_deadlined(
@@ -143,9 +152,12 @@ impl<T> DeadlineOperation for ReplyOperation<T> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::cell::tests::actor;
+
     #[test]
     fn reply_debug_still_reports_the_derived_unanswered_state() {
-        let (reply, receiver) = super::Reply::<u8>::channel();
+        let (_, actor) = actor();
+        let (reply, receiver) = actor.reply_channel::<u8>();
 
         let rendered = format!("{reply:?}");
         assert!(rendered.contains("Reply"));
@@ -160,19 +172,20 @@ mod tests {
     #[crate::runtime::test]
     async fn reply_halves_preserve_success_drop_and_cancellation_lifecycles() {
         let deadline = std::time::Duration::from_secs(1);
+        let (_, actor) = actor();
 
-        let (reply, receiver) = super::Reply::channel();
+        let (reply, receiver) = actor.reply_channel();
         reply.send(7_u8);
         assert_eq!(receiver.recv(deadline).await, Ok(7));
 
-        let (reply, receiver) = super::Reply::<u8>::channel();
+        let (reply, receiver) = actor.reply_channel::<u8>();
         drop(reply);
         assert_eq!(
             receiver.recv(deadline).await,
             Err(super::ReplyError::Dropped)
         );
 
-        let (reply, receiver) = super::Reply::<u8>::channel();
+        let (reply, receiver) = actor.reply_channel::<u8>();
         drop(receiver);
         assert!(reply.sender.is_closed());
         reply.send(9);

--- a/crates/shelterwood-runtime/Cargo.toml
+++ b/crates/shelterwood-runtime/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [dependencies]
 fastrand.workspace = true
 shelterwood-core.workspace = true
+shelterwood-mailbox.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]

--- a/crates/shelterwood-runtime/src/lib.rs
+++ b/crates/shelterwood-runtime/src/lib.rs
@@ -6,11 +6,13 @@
 //! types remain unreachable from the supported `shelterwood` public API.
 
 mod disposal;
+mod mailbox;
 mod spawn;
 mod sync;
 mod timer;
 
 pub use disposal::*;
+pub use mailbox::*;
 // Unwind handling is plain `std::panic`, so it lives in the runtime-neutral
 // core. Re-exported here because the adapter's own modules and the façade
 // reach it as a runtime facility.

--- a/crates/shelterwood-runtime/src/mailbox.rs
+++ b/crates/shelterwood-runtime/src/mailbox.rs
@@ -1,0 +1,122 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, OnceLock},
+    task::{Context, Poll},
+    time::Instant,
+};
+
+use shelterwood_mailbox::{
+    BoxedSleep, ErasedOneShotClose, ErasedOneShotReceiver, ErasedOneShotSender, ErasedValue,
+    MailboxRuntime, MailboxSignal, MailboxSignalWatcher,
+};
+
+use crate::{
+    OneShotClose, OneShotReceiver, OneShotSender, Signal, SignalWatcher, dispose_detached, now,
+    oneshot, sleep_until,
+};
+
+struct TokioMailboxRuntime;
+
+/// Returns the Tokio capability object installed into façade-owned mailboxes.
+pub fn mailbox_runtime() -> Arc<dyn MailboxRuntime> {
+    static RUNTIME: OnceLock<Arc<dyn MailboxRuntime>> = OnceLock::new();
+    Arc::clone(RUNTIME.get_or_init(|| Arc::new(TokioMailboxRuntime)))
+}
+
+impl MailboxRuntime for TokioMailboxRuntime {
+    fn oneshot(
+        &self,
+    ) -> (
+        Box<dyn ErasedOneShotSender>,
+        Pin<Box<dyn ErasedOneShotReceiver>>,
+    ) {
+        let (sender, receiver) = oneshot();
+        (
+            Box::new(TokioOneShotSender(sender)),
+            Box::pin(TokioOneShotReceiver(receiver)),
+        )
+    }
+
+    fn signal(&self) -> Arc<dyn MailboxSignal> {
+        Arc::new(TokioSignal(Signal::default()))
+    }
+
+    fn dispose(&self, value: Box<dyn Send + 'static>) {
+        dispose_detached(value);
+    }
+
+    fn now(&self) -> Instant {
+        now()
+    }
+
+    fn sleep_until(&self, deadline: Option<Instant>) -> BoxedSleep {
+        deadline.map_or_else(
+            || Box::pin(std::future::pending()) as BoxedSleep,
+            sleep_until,
+        )
+    }
+}
+
+struct TokioOneShotSender(OneShotSender<ErasedValue>);
+
+impl ErasedOneShotSender for TokioOneShotSender {
+    fn send(self: Box<Self>, value: ErasedValue) -> Result<(), ErasedValue> {
+        self.0.send(value)
+    }
+
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
+}
+
+struct TokioOneShotReceiver(OneShotReceiver<ErasedValue>);
+
+impl ErasedOneShotReceiver for TokioOneShotReceiver {
+    fn poll_receive(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Option<ErasedValue>> {
+        self.0.poll_receive(context)
+    }
+
+    fn close_and_poll_receive(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> ErasedOneShotClose {
+        match self.0.close_and_poll_receive(context) {
+            OneShotClose::Value(value) => ErasedOneShotClose::Value(value),
+            OneShotClose::SenderClosed => ErasedOneShotClose::SenderClosed,
+            OneShotClose::Empty => ErasedOneShotClose::Empty,
+            OneShotClose::Pending => ErasedOneShotClose::Pending,
+        }
+    }
+
+    fn close(mut self: Pin<&mut Self>) {
+        self.0.close();
+    }
+
+    fn close_and_take(mut self: Pin<&mut Self>) -> Option<ErasedValue> {
+        self.0.close_and_take()
+    }
+}
+
+struct TokioSignal(Signal);
+
+impl MailboxSignal for TokioSignal {
+    fn pulse(&self) {
+        self.0.pulse();
+    }
+
+    fn watcher(&self) -> Box<dyn MailboxSignalWatcher> {
+        Box::new(TokioSignalWatcher(self.0.watcher()))
+    }
+}
+
+struct TokioSignalWatcher(SignalWatcher);
+
+impl MailboxSignalWatcher for TokioSignalWatcher {
+    fn changed(&mut self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(self.0.changed())
+    }
+}

--- a/crates/shelterwood/doctests/docs/retry-and-ordering.md
+++ b/crates/shelterwood/doctests/docs/retry-and-ordering.md
@@ -91,8 +91,9 @@ of these shapes instead:
 - call another actor through an incarnation-owned `offload`, returning the
   result as a continuation message; or
 - split `actor.reply_channel()`, `try_send` the request from the handler
-  (handling `Full`/`NotRunning` — a plain `send` future is lazy, so constructing it
-  without awaiting it sends nothing), and await the receiver from an offload.
+  (handling `Full`/`NotRunning` — a plain `send` future is lazy, so
+  constructing it without awaiting it sends nothing), and await the receiver
+  from an offload.
 
 Offloads use one deadline and their completion returns through the actor loop.
 Cancellation suppresses the continuation, so no offload extends the actor

--- a/crates/shelterwood/doctests/docs/retry-and-ordering.md
+++ b/crates/shelterwood/doctests/docs/retry-and-ordering.md
@@ -90,8 +90,8 @@ of these shapes instead:
 - `continue_with` for a later step on the same actor;
 - call another actor through an incarnation-owned `offload`, returning the
   result as a continuation message; or
-- split `Reply::channel()`, `try_send` the request from the handler (handling
-  `Full`/`NotRunning` — a plain `send` future is lazy, so constructing it
+- split `actor.reply_channel()`, `try_send` the request from the handler
+  (handling `Full`/`NotRunning` — a plain `send` future is lazy, so constructing it
   without awaiting it sends nothing), and await the receiver from an offload.
 
 Offloads use one deadline and their completion returns through the actor loop.

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -18,7 +18,8 @@ fn handle_identity_is_stable_across_membership_rebase() {
         id.clone(),
         identity.mint_membership(&id).expect("membership available"),
     );
-    let mailbox: Arc<MailboxCell<u8>> = MailboxCell::new(member.id().clone());
+    let mailbox: Arc<MailboxCell<u8>> =
+        MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), mailbox);
     let peer = actor.clone();
     let task = crate::TaskRef::new(Arc::clone(&member));
@@ -56,7 +57,7 @@ async fn attaching_after_terminality_closes_the_mailbox() {
         id.clone(),
         identity.mint_membership(&id).expect("membership available"),
     );
-    let mailbox = MailboxCell::new(member.id().clone());
+    let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     let mut parked = Box::pin(actor.send(1));
     let first_poll =

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -380,7 +380,7 @@ fn stopped_publication_keeps_mailbox_panic_primary_and_finishes_observation() {
         cell: Arc::clone(&scope),
     };
     let mut events = handle.subscribe_lifecycle();
-    let mailbox = MailboxCell::new(scope.member.id().clone());
+    let mailbox = MailboxCell::new(scope.member.id().clone(), crate::runtime::mailbox_runtime());
     let actor: ActorRef<u8> = actor_ref_from_parts(Arc::clone(&scope.member), Arc::clone(&mailbox));
     scope.member.attach_mailbox(mailbox);
 
@@ -456,7 +456,7 @@ fn panicking_mailbox_waker_cannot_skip_the_terminal_pulse() {
         id.clone(),
         identity.mint_membership(&id).expect("membership available"),
     );
-    let mailbox = MailboxCell::new(member.id().clone());
+    let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     member.attach_mailbox(mailbox);
 
@@ -510,7 +510,7 @@ fn mailbox_teardown_panic_precedes_a_terminal_pulse_panic() {
         id.clone(),
         identity.mint_membership(&id).expect("membership available"),
     );
-    let mailbox = MailboxCell::new(member.id().clone());
+    let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     member.attach_mailbox(mailbox);
 
@@ -668,7 +668,7 @@ fn terminality_signal_follows_mailbox_termination() {
         id.clone(),
         identity.mint_membership(&id).expect("membership available"),
     );
-    let mailbox = MailboxCell::new(member.id().clone());
+    let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     member.attach_mailbox(mailbox);
 
@@ -701,7 +701,7 @@ fn supervised_terminality_pulse_follows_mailbox_termination() {
         identity.mint_membership(&id).expect("membership available"),
     );
     root.admit_child(ResidentProjection::new(Arc::clone(&member), None));
-    let mailbox = MailboxCell::new(member.id().clone());
+    let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     member.attach_mailbox(mailbox);
 
@@ -765,7 +765,7 @@ fn supervised_mailbox_teardown_panic_precedes_terminal_pulse_panic() {
         identity.mint_membership(&id).expect("membership available"),
     );
     root.admit_child(ResidentProjection::new(Arc::clone(&member), None));
-    let mailbox = MailboxCell::new(member.id().clone());
+    let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     member.attach_mailbox(mailbox);
 
@@ -836,7 +836,7 @@ fn mailbox_wake_observes_terminal_record_and_reentrant_terminality_is_idempotent
         id.clone(),
         identity.mint_membership(&id).expect("membership available"),
     );
-    let mailbox = MailboxCell::new(member.id().clone());
+    let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     member.attach_mailbox(mailbox);
     let first_exit = Exit::never_started();
@@ -877,7 +877,7 @@ fn attach_during_terminal_publication_finishes_record_before_mailbox_wake() {
         id.clone(),
         identity.mint_membership(&id).expect("membership available"),
     );
-    let mailbox = MailboxCell::new(member.id().clone());
+    let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     let first_exit = Exit::never_started();
     member.stage_terminal_before_mailbox(first_exit.clone());

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -2165,7 +2165,7 @@ mod tests {
             id.clone(),
             identity.mint_membership(&id).expect("membership available"),
         );
-        let mailbox = MailboxCell::new(id.clone());
+        let mailbox = MailboxCell::new(id.clone(), crate::runtime::mailbox_runtime());
         member.attach_mailbox(mailbox.clone());
         MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox);
         let incarnation = member

--- a/crates/shelterwood/src/tree/builders.rs
+++ b/crates/shelterwood/src/tree/builders.rs
@@ -46,7 +46,7 @@ pub(super) fn dispose_rejected<D: Send + 'static>(
 }
 
 fn attach_actor_slot<M: Send + 'static>(slot: Arc<SlotCell>) -> ActorSlot<M> {
-    let mailbox = MailboxCell::new(slot.member.id().clone());
+    let mailbox = MailboxCell::new(slot.member.id().clone(), crate::runtime::mailbox_runtime());
     slot.member.attach_mailbox(mailbox.clone());
     ActorSlot {
         core: ActorSlotCore::new(StaticSlotEndpoint(slot), mailbox),

--- a/crates/shelterwood/src/tree/dynamic_api.rs
+++ b/crates/shelterwood/src/tree/dynamic_api.rs
@@ -66,7 +66,10 @@ impl DynamicScopeRef {
         ownership: AdmissionOwnership,
     ) -> Result<DynamicActorSlot<M>, ReserveError> {
         crate::driver::reserve_dynamic(&self.0.cell, id.into(), None).map(|reservation| {
-            let mailbox = MailboxCell::new(reservation.slot.member.id().clone());
+            let mailbox = MailboxCell::new(
+                reservation.slot.member.id().clone(),
+                crate::runtime::mailbox_runtime(),
+            );
             reservation.slot.member.attach_mailbox(mailbox.clone());
             DynamicActorSlot {
                 core: ActorSlotCore::new(DynamicSlotEndpoint::new(reservation, ownership), mailbox),

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -396,10 +396,10 @@ fn raw_types_obey_error_and_future_trait_contracts() {
         },
         DeadlineBudget::new(Duration::from_secs(1)),
     ));
-    let (reply, receiver) = Reply::<Cell<()>>::channel();
+    let (reply, receiver) = actor.reply_channel::<Cell<()>>();
     assert_send(reply);
     assert_send(receiver);
-    let (_reply, receiver) = Reply::<Cell<()>>::channel();
+    let (_reply, receiver) = actor.reply_channel::<Cell<()>>();
     assert_send(receiver.recv(DeadlineBudget::new(Duration::from_secs(1))));
 }
 

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -146,7 +146,7 @@ async fn maximum_mailbox_deadlines_are_unbounded_waits() {
 
     let mut send = Box::pin(actor.send_timeout(Message::Value(1), Duration::MAX));
     let mut call = Box::pin(actor.call(Message::Ask, Duration::MAX));
-    let (reply, receiver) = Reply::channel();
+    let (reply, receiver) = actor.reply_channel();
     let mut receive = Box::pin(receiver.recv(Duration::MAX));
     assert!(poll_once(send.as_mut()).is_pending());
     assert!(poll_once(call.as_mut()).is_pending());
@@ -616,18 +616,28 @@ async fn zero_duration_wait_observes_an_already_satisfied_child() {
 
 #[tokio::test]
 async fn reply_receiver_reports_drop_and_is_safe_to_abandon() {
-    let (reply, receiver) = Reply::<usize>::channel();
+    let values = Arc::new(Mutex::new(Vec::new()));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "reply-runtime",
+            RawOnceDef::new(boundary_actor(None, &values, &calls, false)),
+        )
+        .expect("valid actor");
+
+    let (reply, receiver) = actor.reply_channel::<usize>();
     drop(reply);
     assert_eq!(
         receiver.recv(Duration::from_secs(1)).await,
         Err(ReplyError::Dropped)
     );
 
-    let (reply, receiver) = Reply::<usize>::channel();
+    let (reply, receiver) = actor.reply_channel::<usize>();
     drop(receiver);
     reply.send(1);
 
-    let (reply, receiver) = Reply::channel();
+    let (reply, receiver) = actor.reply_channel();
     reply.send(2);
     assert_eq!(
         receiver.recv(Duration::ZERO).await,
@@ -638,8 +648,17 @@ async fn reply_receiver_reports_drop_and_is_safe_to_abandon() {
 
 #[tokio::test(start_paused = true)]
 async fn reply_completion_wins_at_the_exact_deadline() {
+    let values = Arc::new(Mutex::new(Vec::new()));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "reply-deadline-runtime",
+            RawOnceDef::new(boundary_actor(None, &values, &calls, false)),
+        )
+        .expect("valid actor");
     let width = Duration::from_secs(10);
-    let (reply, receiver) = Reply::channel();
+    let (reply, receiver) = actor.reply_channel();
     let mut receive = Box::pin(receiver.recv(width));
     assert!(poll_once(receive.as_mut()).is_pending());
 

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -1322,7 +1322,11 @@ async fn cancelled_call_disposes_stored_reply_off_the_caller() {
 #[tokio::test]
 async fn dropped_reply_receiver_disposes_stored_value_through_isolated_disposal() {
     let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
-    let (reply, receiver) = Reply::<DropProbe>::channel();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once("reply-runtime", RawOnceDef::new(Unread::<()>::default()))
+        .expect("valid actor");
+    let (reply, receiver) = actor.reply_channel::<DropProbe>();
     reply.send(DropProbe::panicking(dropped, "unclaimed reply destructor"));
     drop(receiver);
     assert_ne!(
@@ -1551,7 +1555,11 @@ async fn dropped_unstarted_call_disposes_constructor_off_the_caller() {
 async fn late_reply_send_disposes_unclaimed_value_off_the_sender() {
     let gate = DestructorGate::default();
     let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
-    let (reply, receiver) = Reply::<BlockingDropProbe>::channel();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once("reply-runtime", RawOnceDef::new(Unread::<()>::default()))
+        .expect("valid actor");
+    let (reply, receiver) = actor.reply_channel::<BlockingDropProbe>();
     drop(receiver);
     reply.send(BlockingDropProbe::new(&gate, dropped));
     wait_for_destructor(&gate).await;

--- a/crates/shelterwood/tests/mailbox.rs
+++ b/crates/shelterwood/tests/mailbox.rs
@@ -331,15 +331,24 @@ async fn call_distinguishes_success_drop_and_response_timeout() {
 
 #[tokio::test(start_paused = true)]
 async fn reply_receiver_is_consuming_and_late_replies_are_discarded() {
+    let values = Arc::new(Mutex::new(Vec::new()));
+    let asks = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "reply-runtime",
+            shelterwood::RawOnceDef::new(recorder(None, &values, &asks, ReplyMode::Answer)),
+        )
+        .expect("valid actor");
     let width = Duration::from_secs(10);
-    let (reply, receiver) = Reply::channel();
+    let (reply, receiver) = actor.reply_channel();
     let mut waiter = Box::pin(receiver.recv(width));
     assert!(poll_once(waiter.as_mut()).is_pending());
     advance_time(width).await;
     assert_eq!(waiter.await, Err(ReplyError::Timeout));
     reply.send(1);
 
-    let (reply, receiver) = Reply::<usize>::channel();
+    let (reply, receiver) = actor.reply_channel::<usize>();
     drop(receiver);
     reply.send(2);
 }

--- a/docs/retry-and-ordering.md
+++ b/docs/retry-and-ordering.md
@@ -91,8 +91,9 @@ of these shapes instead:
 - call another actor through an incarnation-owned `offload`, returning the
   result as a continuation message; or
 - split `actor.reply_channel()`, `try_send` the request from the handler
-  (handling `Full`/`NotRunning` — a plain `send` future is lazy, so constructing it
-  without awaiting it sends nothing), and await the receiver from an offload.
+  (handling `Full`/`NotRunning` — a plain `send` future is lazy, so
+  constructing it without awaiting it sends nothing), and await the receiver
+  from an offload.
 
 Offloads use one deadline and their completion returns through the actor loop.
 Cancellation suppresses the continuation, so no offload extends the actor

--- a/docs/retry-and-ordering.md
+++ b/docs/retry-and-ordering.md
@@ -90,8 +90,8 @@ of these shapes instead:
 - `continue_with` for a later step on the same actor;
 - call another actor through an incarnation-owned `offload`, returning the
   result as a continuation message; or
-- split `Reply::channel()`, `try_send` the request from the handler (handling
-  `Full`/`NotRunning` — a plain `send` future is lazy, so constructing it
+- split `actor.reply_channel()`, `try_send` the request from the handler
+  (handling `Full`/`NotRunning` — a plain `send` future is lazy, so constructing it
   without awaiting it sends nothing), and await the receiver from an offload.
 
 Offloads use one deadline and their completion returns through the actor loop.


### PR DESCRIPTION
Closes #236.
Closes #209.

## Summary

- replace mailbox transition handoffs with `MailboxTxn` + `MailboxEffects`: the transaction owns the mutex guard and drops it before pulses, waker vtables, payload destructors, or disposal capabilities can run
- replace the raw `Option<Waker>` surface with a private `WakerSlot` whose take/replace operations require an effects sink; cancellation now returns a withdrawal outcome plus deferred effects instead of the old `(outcome, waker)` tuple
- remove `RejectionReason::{NotAccepting, Unconfigured}` and make bound acceptance return only the reachable full case
- make a mailbox configuration-kind mismatch panic in release builds after unlocking, matching the bind-contract convention
- invert the remaining mailbox/runtime dependency through one façade-installed `dyn MailboxRuntime` capability covering one-shot delivery, signals, isolated disposal, and clock/timers; `ActorRef<M>` gains no runtime type parameter
- move split reply construction to `actor.reply_channel()` so standalone reply deadlines and disposal use the same injected capability as the actor

## Structural guarantee

The old #202 spelling no longer type-checks. `OperationState::waker` is a `WakerSlot`, not an `Option<Waker>`; its storage is private even from the parent module. Calling the old `state.waker.replace(next_waker)` or `state.waker.take()` form fails because every mutator requires an explicit `WakerEffects` sink (and take also requires a wake/drop/dispose action). Locked code cannot obtain a raw displaced waker to accidentally destroy beside either core guard.

All mutable mailbox transitions now enter through `MailboxTxn`. Its `Drop` empties the guard field before Rust drops the effects field, including on unwind. The remaining direct state locks are read-only snapshots or operation-state helpers whose waker actions flow into an effects sink declared outside the guard.

## Runtime inversion

`shelterwood-mailbox` no longer has a production dependency on `shelterwood-runtime`; its normal dependency tree is only `shelterwood-core` (plus core's dependencies). The Tokio implementation lives in `shelterwood-runtime::mailbox`, and the façade supplies it at every `MailboxCell` construction site. Reply and deadline state retain that same object so paused Tokio time and disposal behavior remain coherent.

This deliberately changes the no-user split-reply surface from `Reply::channel()` to `ActorRef::reply_channel()`: without an actor (or another façade-owned capability source), a runtime-neutral mailbox crate cannot select the correct clock/disposal adapter without a global ambient runtime.

## Validation

- `./tools/dev cargo tree -p shelterwood-mailbox -e normal` — only `shelterwood-core`; no runtime adapter or Tokio
- existing hostile-waker wake, replacement, cancellation, unwind, reentrancy, and termination tests all pass
- added `configuration_mismatch_panics_after_releasing_the_mailbox_lock`, which verifies the panic and proves the mutex remains unpoisoned
- added `bind_submits_displaced_payloads_for_disposal_before_waking_senders`, which pins the existing pulse → disposal-submission → promoted-sender wake order through an injected runtime capability
- `./tools/dev just ci` — passed: formatting, Clippy with warnings denied, 630 tests, doctests, rustdoc, all public API reachability lanes, packaged-doc sync, and Nix formatting
