### PR TITLE
Drop the unused closedness probe from the one-shot seam

### DIFF
--- a/crates/shelterwood-mailbox/src/capability.rs
+++ b/crates/shelterwood-mailbox/src/capability.rs
@@ -15,7 +15,6 @@ pub type ErasedValue = Box<dyn Any + Send + 'static>;
 #[doc(hidden)]
 pub trait ErasedOneShotSender: Send {
     fn send(self: Box<Self>, value: ErasedValue) -> Result<(), ErasedValue>;
-    fn is_closed(&self) -> bool;
 }
 
 /// Runtime-neutral single-delivery receive capability.
@@ -112,11 +111,6 @@ pub(crate) fn oneshot<T: Send + 'static>(
 impl<T: Send + 'static> OneShotSender<T> {
     pub(crate) fn send(self, value: T) -> Result<(), T> {
         self.inner.send(Box::new(value)).map_err(downcast::<T>)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn is_closed(&self) -> bool {
-        self.inner.is_closed()
     }
 }
 
@@ -268,10 +262,6 @@ pub(crate) mod tests {
     impl ErasedOneShotSender for AdapterOneShotSender {
         fn send(self: Box<Self>, value: ErasedValue) -> Result<(), ErasedValue> {
             self.0.send(value)
-        }
-
-        fn is_closed(&self) -> bool {
-            self.0.is_closed()
         }
     }
 

--- a/crates/shelterwood-mailbox/src/reply.rs
+++ b/crates/shelterwood-mailbox/src/reply.rs
@@ -185,9 +185,13 @@ mod tests {
             Err(super::ReplyError::Dropped)
         );
 
+        // Exercises `Reply::send`'s rejection branch for a panic only: the
+        // value it discards is unobservable from here. That the discard runs
+        // through isolated disposal rather than inline is asserted in
+        // `late_reply_send_disposes_unclaimed_value_off_the_sender`
+        // (`crates/shelterwood/tests/disposal.rs`), which owns that claim.
         let (reply, receiver) = actor.reply_channel::<u8>();
         drop(receiver);
-        assert!(reply.sender.is_closed());
         reply.send(9);
     }
 }

--- a/crates/shelterwood-runtime/src/mailbox.rs
+++ b/crates/shelterwood-runtime/src/mailbox.rs
@@ -64,10 +64,6 @@ impl ErasedOneShotSender for TokioOneShotSender {
     fn send(self: Box<Self>, value: ErasedValue) -> Result<(), ErasedValue> {
         self.0.send(value)
     }
-
-    fn is_closed(&self) -> bool {
-        self.0.is_closed()
-    }
 }
 
 struct TokioOneShotReceiver(OneShotReceiver<ErasedValue>);


### PR DESCRIPTION
Closes #253 via option 1.

`ErasedOneShotSender::is_closed` is required of every `MailboxRuntime` implementor and has no production caller: its only path to one is the `cfg(test)` forwarder `OneShotSender::is_closed`, whose single caller was one assertion in `reply.rs`. In a non-test build of `shelterwood-mailbox` the method has no caller at all, which makes the production adapter's impl (`shelterwood-runtime/src/mailbox.rs`) unreachable by construction rather than merely unexercised.

## The checks the issue asked for

**Mutation check.** Both impls flipped to return `false`, full workspace, `--no-fail-fast`: 645 tests, 644 passed, one failure — `reply.rs:190`, the assertion under review. Nothing else observes closedness.

**Is it pinning a distinct transition?** No. The probe would pin sender-side visibility of the receiver's drop *before* a send, but no production path asks a sender whether it is closed. `Reply::send` learns closedness only from `send`'s `Err`, so there is no behavior a second `MailboxRuntime` implementor could get wrong here independently of `send` — it is not separable contract surface, which is what option 2 would have required.

**Is the consequence covered?** Yes, in exactly this order: `late_reply_send_disposes_unclaimed_value_off_the_sender` (`crates/shelterwood/tests/disposal.rs`) does `drop(receiver)` → `reply.send(BlockingDropProbe)` → asserts the destructor ran off the caller's thread. `dropped_reply_receiver_disposes_stored_value_through_isolated_disposal` covers the reverse order through `DisposingReceiver::drop`.

## The test stanza

Deleting only the assertion would have left `drop(receiver); reply.send(9);` — a leg that cannot fail except by panicking, inside a test whose name promises it pins a cancellation lifecycle. The line is kept, because it does execute `Reply::send`'s rejection branch, with a comment saying it is a no-panic exercise and naming the disposal test that owns the real claim.

`shelterwood_runtime::sync::OneShotSender::is_closed` is untouched — it has a live production caller in `driver/admission_control.rs`. Only the erased seam method and its two forwarding impls go.

`just ci` green.