### PR TITLE
Close the default-feature dead-code lint gap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,10 @@ name = "shelterwood"
 
 # Enforced in every lane that compiles the workspace -- plain `cargo check`
 # included -- rather than by appending a flag to one CI clippy invocation.
-# `-D warnings` escalates these to errors in `just lint` and the Nix
-# `cargo-clippy` check, so the template's check definition stays unforked.
+# `dead_code` is denied directly so feature-specific gaps fail wherever they
+# surface. `-D warnings` escalates `unreachable_pub` in the Clippy lanes.
 [workspace.lints.rust]
+dead_code = "deny"
 unreachable_pub = "warn"
 
 [workspace.dependencies]

--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -1265,22 +1265,6 @@ impl ScopeCell {
         });
     }
 
-    fn update_child_record(
-        &self,
-        member: &MemberCell,
-        update: impl FnOnce(&mut MemberRecord),
-        event: Option<LifecycleEventKind>,
-    ) {
-        self.with_observation_gate(|wakes| {
-            member.update_locked(wakes, update);
-            if let Some(event) = event {
-                self.emit_locked(wakes, event);
-            } else {
-                self.publish_snapshot_chain_locked(wakes);
-            }
-        });
-    }
-
     pub fn set_child_removing_locked(&self, member: &MemberCell, txn: &mut ObservationTxn<'_>) {
         if member.record().membership_status == MembershipStatus::Removing {
             return;
@@ -1298,7 +1282,14 @@ impl ScopeCell {
         update: impl FnOnce(&mut MemberRecord),
         event: Option<LifecycleEventKind>,
     ) {
-        self.update_child_record(member, update, event);
+        self.with_observation_gate(|wakes| {
+            member.update_locked(wakes, update);
+            if let Some(event) = event {
+                self.emit_locked(wakes, event);
+            } else {
+                self.publish_snapshot_chain_locked(wakes);
+            }
+        });
     }
 
     pub fn transition_child_stage(
@@ -1307,7 +1298,7 @@ impl ScopeCell {
         transition: MemberTransition,
         event: Option<LifecycleEventKind>,
     ) {
-        // Routed through `transition_locked` rather than `update_child_record`
+        // Routed through `transition_locked` rather than a record-only update
         // so a restart schedule's displaced exit leaves the gate on this path
         // too.
         self.with_observation_gate(|wakes| {

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,16 @@
           ...
         }:
         {
+          cargo-clippy-default = craneLibNightly.cargoClippy (
+            commonArgs
+            // {
+              cargoArtifacts = cargoArtifactsNightly;
+              cargoExtraArgs = "--locked";
+              cargoClippyExtraArgs = "--workspace --lib -- -D warnings";
+              doInstallCargoArtifacts = false;
+            }
+          );
+
           api-enforcement = craneLibNightly.mkCargoDerivation (
             commonArgs
             // {

--- a/justfile
+++ b/justfile
@@ -11,6 +11,9 @@ fmt:
 lint:
     cargo +nightly clippy --locked --workspace --all-targets --all-features -- -D warnings
 
+lint-default:
+    cargo +nightly clippy --locked --workspace --lib -- -D warnings
+
 check:
     cargo check --locked --workspace --all-targets --all-features
 
@@ -48,7 +51,7 @@ nixfmt-check:
 
 # Fast local CI mirror — reuses the local cargo cache and incremental builds.
 # The clean Nix lane retains the explicit all-target build for non-test codegen coverage.
-ci: fmt lint test doc-check runtime-api-check packaged-docs-check nixfmt-check
+ci: fmt lint lint-default test doc-check runtime-api-check packaged-docs-check nixfmt-check
 
 # Full clean Nix CI lane; use before pushing or when touching Nix files.
 ci-nix:


### PR DESCRIPTION
Closes #258

## What changed

- inline the test-only `ScopeCell::update_child_record` helper into its sole caller
- deny `dead_code` through the workspace Rust lint configuration
- add a default-feature, library-only Clippy lane alongside the existing all-targets/all-features lane
- mirror the new lane in the Nix flake checks as `cargo-clippy-default`

## Why

The existing Clippy gate always enabled every feature, so private items used only behind `test-util` could appear live there while remaining dead in ordinary builds. The only default-feature build was incidental to API enforcement and did not deny dependency warnings.

The explicit default-feature lane makes that coverage intentional, while the workspace lint turns future occurrences into failures wherever they surface.

## Validation

- `./tools/dev just ci`
- `./tools/dev just ci-nix`
- `./tools/dev cargo check --locked --workspace --lib --no-default-features`
