### PR TITLE
Treat integration:: as a suite label, not a Cargo target

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ scope, and subtrees compose both recursively.
 - [Embedding Shelterwood in a host process](docs/embedding.md)
 
 The executable application-scale examples live in the M5 acceptance tests:
-[shard store](crates/shelterwood/tests/acceptance/shard_store.rs),
-[sidecar](crates/shelterwood/tests/acceptance/sidecar.rs), and
-[assistant control plane](crates/shelterwood/tests/acceptance/assistant.rs).
+[shard store](crates/shelterwood/tests/acceptance_shard_store.rs),
+[sidecar](crates/shelterwood/tests/acceptance_sidecar.rs), and
+[assistant control plane](crates/shelterwood/tests/acceptance_assistant.rs).
 
 ## Operational preconditions
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1169,8 +1169,9 @@ polled** — never inferred from poll order.
 ### 6.1 Reducer invariants and transitions
 
 These rules are normative over `SupervisorState`, `Event`, and `Effect`.
-Bracketed names are the checked evidence; `integration::…` names the public
-integration suite and `supervisor::…` names the pure reducer suite.
+Bracketed names are the checked evidence; `integration::…` labels a test
+function under `crates/shelterwood/tests` — not a Cargo `--test` target —
+and `supervisor::…` names the pure reducer suite.
 
 1. **R1 — initial-only aggregate.** Only an `Initial { ready }` membership
    gates scope startup. A runtime admission never enters the aggregate.

--- a/crates/shelterwood/doctests/README.md
+++ b/crates/shelterwood/doctests/README.md
@@ -63,9 +63,9 @@ scope, and subtrees compose both recursively.
 - [Embedding Shelterwood in a host process](docs/embedding.md)
 
 The executable application-scale examples live in the M5 acceptance tests:
-[shard store](crates/shelterwood/tests/acceptance/shard_store.rs),
-[sidecar](crates/shelterwood/tests/acceptance/sidecar.rs), and
-[assistant control plane](crates/shelterwood/tests/acceptance/assistant.rs).
+[shard store](crates/shelterwood/tests/acceptance_shard_store.rs),
+[sidecar](crates/shelterwood/tests/acceptance_sidecar.rs), and
+[assistant control plane](crates/shelterwood/tests/acceptance_assistant.rs).
 
 ## Operational preconditions
 


### PR DESCRIPTION
## Summary

- keep the per-file `tests/*.rs` layout from #260
- redefine SPEC's `integration::…` prefix as a suite label for a function under `crates/shelterwood/tests`, not a Cargo `--test` target
- fix the README (and packaged copy) links to the acceptance files #260 promoted

## Why

#261 proposed collapsing the suite back into `tests/integration/main.rs` so `--test integration` would match the spec's evidence names again. The rustfmt fix never required that collapse: #260 already uses the layout The Book teaches (`tests/*.rs` plus `tests/common/mod.rs`).

The leftover nits are documentation. The 319 integration test names are globally unique, so `cargo test <name>` and `nextest -E 'test(<name>)'` already select every cited function. Tying those citations to a Cargo target is what makes a file move, or a split, look like spec churn. The `#![allow(dead_code)]` on `common` is the documented cost of that shared module, not a reason to re-merge 24 crates.

The collapse itself is declined. A source-scanning registration guard would be the same class of invention as `register_test_modules!`.

## Validation

- `./tools/dev just packaged-docs-sync` / `packaged-docs-check`

Closes #261