### PR TITLE
Make core compile-fail fences non-vacuous

### DIFF
--- a/crates/shelterwood-core/src/policy.rs
+++ b/crates/shelterwood-core/src/policy.rs
@@ -107,7 +107,7 @@ pub const DEFAULT_READINESS_DEADLINE: Duration = Duration::from_secs(30);
 ///
 /// ```compile_fail,E0423
 /// use std::time::Duration;
-/// use shelterwood::NonZeroDuration;
+/// use shelterwood_core::policy::NonZeroDuration;
 ///
 /// let _invalid = NonZeroDuration(Duration::ZERO);
 /// ```
@@ -230,7 +230,7 @@ impl std::hash::Hash for BackoffFactor {
 ///
 /// ```compile_fail,E0451
 /// use std::time::Duration;
-/// use shelterwood::{Backoff, FixedBackoff, Jitter};
+/// use shelterwood_core::policy::{Backoff, FixedBackoff, Jitter};
 ///
 /// let _ = Backoff::Fixed(FixedBackoff {
 ///     delay: Duration::ZERO,
@@ -242,7 +242,7 @@ impl std::hash::Hash for BackoffFactor {
 ///
 /// ```compile_fail,E0451
 /// use std::time::Duration;
-/// use shelterwood::{Backoff, BackoffFactor, ExponentialBackoff, Jitter};
+/// use shelterwood_core::policy::{Backoff, BackoffFactor, ExponentialBackoff, Jitter};
 ///
 /// let _ = Backoff::Exponential(ExponentialBackoff {
 ///     base: Duration::ZERO,
@@ -553,9 +553,12 @@ pub enum ReadinessDeadline {
 ///
 /// ```compile_fail,E0423
 /// use std::time::Duration;
-/// use shelterwood::{BoundedReadinessDeadline, ReadinessDeadline};
+/// use shelterwood_core::policy::{
+///     BoundedReadinessDeadline, NonZeroDuration, ReadinessDeadline,
+/// };
 ///
-/// let _ = ReadinessDeadline::Bounded(BoundedReadinessDeadline(Duration::ZERO));
+/// let duration = NonZeroDuration::new(Duration::from_secs(1)).unwrap();
+/// let _ = ReadinessDeadline::Bounded(BoundedReadinessDeadline(duration));
 /// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct BoundedReadinessDeadline(NonZeroDuration);
@@ -585,7 +588,7 @@ impl ReadinessDeadline {
 ///
 /// ```compile_fail,E0451
 /// use std::time::Duration;
-/// use shelterwood::Intensity;
+/// use shelterwood_core::policy::Intensity;
 ///
 /// let _ = Intensity {
 ///     max_restarts: 1,

--- a/crates/shelterwood-core/src/policy.rs
+++ b/crates/shelterwood-core/src/policy.rs
@@ -265,6 +265,20 @@ pub enum Backoff {
 ///
 /// Values are created by [`Backoff::fixed`], which guarantees a non-zero
 /// delay. The private representation prevents invalid fixed-backoff literals.
+///
+/// The literal fence on [`Backoff`] is satisfied by any one surviving private
+/// field, so the invariant-bearing field is fenced on its own: reading
+/// `delay` off a constructor-validated payload must not compile. `E0616`
+/// records the privacy failure this proof depends on:
+///
+/// ```compile_fail,E0616
+/// use std::time::Duration;
+/// use shelterwood_core::policy::{Backoff, Jitter};
+///
+/// let Backoff::Fixed(fixed) = Backoff::fixed(Duration::from_secs(1), Jitter::None).unwrap()
+/// else { unreachable!() };
+/// let _ = fixed.delay;
+/// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct FixedBackoff {
     delay: Duration,
@@ -289,6 +303,53 @@ impl FixedBackoff {
 ///
 /// Values are created by [`Backoff::exponential`], which guarantees non-zero
 /// delays, a valid factor, and a maximum no shorter than the base.
+///
+/// The literal fence on [`Backoff`] is satisfied by any one surviving private
+/// field, so each invariant-bearing field is fenced on its own: reading
+/// `base`, `factor`, or `max` off a constructor-validated payload must not
+/// compile. `E0616` records the privacy failure these proofs depend on:
+///
+/// ```compile_fail,E0616
+/// use std::time::Duration;
+/// use shelterwood_core::policy::{Backoff, BackoffFactor, Jitter};
+///
+/// let Backoff::Exponential(exponential) = Backoff::exponential(
+///     Duration::from_secs(1),
+///     BackoffFactor::new(2.0).unwrap(),
+///     Duration::from_secs(2),
+///     Jitter::None,
+/// )
+/// .unwrap() else { unreachable!() };
+/// let _ = exponential.base;
+/// ```
+///
+/// ```compile_fail,E0616
+/// use std::time::Duration;
+/// use shelterwood_core::policy::{Backoff, BackoffFactor, Jitter};
+///
+/// let Backoff::Exponential(exponential) = Backoff::exponential(
+///     Duration::from_secs(1),
+///     BackoffFactor::new(2.0).unwrap(),
+///     Duration::from_secs(2),
+///     Jitter::None,
+/// )
+/// .unwrap() else { unreachable!() };
+/// let _ = exponential.factor;
+/// ```
+///
+/// ```compile_fail,E0616
+/// use std::time::Duration;
+/// use shelterwood_core::policy::{Backoff, BackoffFactor, Jitter};
+///
+/// let Backoff::Exponential(exponential) = Backoff::exponential(
+///     Duration::from_secs(1),
+///     BackoffFactor::new(2.0).unwrap(),
+///     Duration::from_secs(2),
+///     Jitter::None,
+/// )
+/// .unwrap() else { unreachable!() };
+/// let _ = exponential.max;
+/// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ExponentialBackoff {
     base: Duration,
@@ -594,6 +655,19 @@ impl ReadinessDeadline {
 ///     max_restarts: 1,
 ///     within: Duration::ZERO,
 /// };
+/// ```
+///
+/// That literal fence is satisfied by either private field, so the
+/// invariant-bearing field is fenced on its own: reading `within` off a
+/// constructor-validated budget must not compile. `E0616` records the privacy
+/// failure this proof depends on:
+///
+/// ```compile_fail,E0616
+/// use std::time::Duration;
+/// use shelterwood_core::policy::Intensity;
+///
+/// let intensity = Intensity::new(1, Duration::from_secs(1)).unwrap();
+/// let _ = intensity.within;
 /// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Intensity {

--- a/crates/shelterwood/tests/policy_validation.rs
+++ b/crates/shelterwood/tests/policy_validation.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use shelterwood::{
     Backoff, BackoffFactor, BoundedReadinessDeadline, ExponentialBackoff, FixedBackoff, Intensity,
-    Jitter, Mailbox, NonZeroDuration, PolicyError, ReadinessDeadline,
+    Jitter, Mailbox, PolicyError, ReadinessDeadline,
 };
 
 #[test]
@@ -59,16 +59,14 @@ fn other_policy_constructors_reject_zero_values() {
 
 /// Every binding here is type-annotated on purpose. The sealing proofs in
 /// `policy.rs` are `compile_fail` fences, which pass for *any* compilation
-/// error; naming each payload type in a test that must compile keeps them
-/// exported and nameable, so the only failure those fences can be resting on
-/// is the private-field one they claim.
+/// error, so each one rests on the payload type staying exported under the
+/// name it uses. That nameability is pinned by the façade's `pub use` list
+/// (`shelterwood::policy`, re-exported from `lib.rs`), which would stop
+/// compiling on a rename or a removal; what this test adds is the other half
+/// of the claim — that the only way through those private fields is a
+/// validating constructor, and that the accessors report what it validated.
 #[test]
 fn sealed_payloads_expose_only_constructor_validated_values() {
-    let duration = Duration::from_nanos(1);
-    let duration: NonZeroDuration =
-        NonZeroDuration::new(duration).expect("the duration is non-zero");
-    assert_eq!(duration.get(), Duration::from_nanos(1));
-
     let fixed_delay = Duration::from_millis(10);
     let Backoff::Fixed(fixed) =
         Backoff::fixed(fixed_delay, Jitter::Equal).expect("the delay is non-zero")

--- a/crates/shelterwood/tests/policy_validation.rs
+++ b/crates/shelterwood/tests/policy_validation.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use shelterwood::{
     Backoff, BackoffFactor, BoundedReadinessDeadline, ExponentialBackoff, FixedBackoff, Intensity,
-    Jitter, Mailbox, PolicyError, ReadinessDeadline,
+    Jitter, Mailbox, NonZeroDuration, PolicyError, ReadinessDeadline,
 };
 
 #[test]
@@ -64,6 +64,11 @@ fn other_policy_constructors_reject_zero_values() {
 /// is the private-field one they claim.
 #[test]
 fn sealed_payloads_expose_only_constructor_validated_values() {
+    let duration = Duration::from_nanos(1);
+    let duration: NonZeroDuration =
+        NonZeroDuration::new(duration).expect("the duration is non-zero");
+    assert_eq!(duration.get(), Duration::from_nanos(1));
+
     let fixed_delay = Duration::from_millis(10);
     let Backoff::Fixed(fixed) =
         Backoff::fixed(fixed_delay, Jitter::Equal).expect("the delay is non-zero")


### PR DESCRIPTION
## Summary

- point all five `shelterwood-core` compile-fail doctests at the crate that owns their target types
- make the bounded-readiness example type-correct so field privacy is its only failure
- preserve the façade-level nameability pins

## Root cause

The snippets imported `shelterwood`, but `shelterwood-core` does not depend on the façade crate. Rustdoc therefore accepted each compile-fail block because of an unresolved import instead of the privacy error the fence claimed to prove.

## Impact

The doctests now fail for E0423/E0451 as documented, and they fail the test suite if the corresponding privacy barriers are removed.

## Validation

- extracted all five snippets and confirmed their documented E0423/E0451 error classes
- temporarily made each targeted privacy barrier public; every compile-fail doctest then failed with “Test compiled successfully”; restored all mutations
- `./tools/dev cargo test --locked -p shelterwood-core --all-features`
- façade policy nameability test
- formatting, core documentation build, and `git diff --check`

Closes #280