### PR TITLE
Resume offload panics before stop teardown

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -994,8 +994,11 @@ the drain, leaving the handled log a proper prefix of the accepted one.
 non-failed actor: on every cooperative stop path above, whether or not a
 drain preceded it. It does not run when `init` failed (no actor value
 exists), when a handler — live or draining — returned `Err` or panicked
-(the incarnation is failed; cleanup is the crash-only path, `Drop`), or
-on hard abort (the future is destroyed). Grace bounds drain plus
+(the incarnation is failed; cleanup is the crash-only path, `Drop`), when an
+incarnation-owned offload panic resumes at a receive boundary (including one
+entering stop or drain), or on hard abort (the future is destroyed). An
+offload panic therefore fails the incarnation before any further delivery or
+`on_stop`. Grace bounds drain plus
 `on_stop` together (§10) — including after a local `ctx.stop()`, which
 arms the child's own configured ladder (§10).
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -994,13 +994,21 @@ the drain, leaving the handled log a proper prefix of the accepted one.
 non-failed actor: on every cooperative stop path above, whether or not a
 drain preceded it. It does not run when `init` failed (no actor value
 exists), when a handler — live or draining — returned `Err` or panicked
-(the incarnation is failed; cleanup is the crash-only path, `Drop`), when an
-incarnation-owned offload panic resumes at a receive boundary (including one
-entering stop or drain), or on hard abort (the future is destroyed). An
-offload panic therefore fails the incarnation before any further delivery or
-`on_stop`. Grace bounds drain plus
-`on_stop` together (§10) — including after a local `ctx.stop()`, which
-arms the child's own configured ladder (§10).
+(the incarnation is failed; cleanup is the crash-only path, `Drop`), when
+any incarnation-owned disposal panic is observed at a receive boundary
+(including one entering stop or drain), or on hard abort (the future is
+destroyed). Incarnation-owned disposal is §5.5's resource funnel — the
+offloaded future and its continuation closure, plus the queued
+continuations, armed timers and queued offload completions released at
+the intake freeze; the frozen mailbox prefix's own detached disposal
+above is not part of it and stays a disposal fault. A disposal panic
+**already retained when a receive boundary is reached** therefore fails
+the incarnation before any further delivery or `on_stop`. As with
+`Guard::finished()` (§5.5) this is not a join: a panic that lands after
+the last receive boundary is still the incarnation's exit, but cannot
+suppress `on_stop`. Grace bounds drain plus `on_stop` together (§10) —
+including after a local `ctx.stop()`, which arms the child's own
+configured ladder (§10).
 
 ### 5.3 One timer facility
 
@@ -1123,7 +1131,12 @@ handlers non-blocking. Contracts:
   `Guard::is_finished` / `finished()` report either ordinary work
   completion or an incarnation-teardown cancellation request. They are not
   a join guarantee: a hard-aborted task can still be unwinding after the
-  notification.
+  notification. Ordinary completion does retain a panicking future's
+  payload *before* the notification fires, so a `finished()` await that
+  observed completion guarantees the panic is retained for §5.2's next
+  receive boundary; a teardown cancellation fires the same notification
+  without that ordering, which is why §5.2 conditions its guarantee on
+  retention rather than on the panic having happened.
 - Any higher-level helper that composes `call` inside `offload` MUST
   preserve: incarnation ownership; completion through the actor loop; a
   total timeout continuation; and no await inside the handler.

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -1407,12 +1407,20 @@ impl<M: Send + 'static> RawContext<M> {
 
     /// Receives the next accepted message, biased toward shutdown.
     ///
-    /// A retained offload-work panic resumes from this receive path before
-    /// another event is delivered or a stop is reported. A panic in an
-    /// offload's continuation closure — the `FnOnce` that builds the message
-    /// from the offload result, not a [`continue_with`](Self::continue_with)
-    /// continuation, which is a plain stored message and cannot panic here —
-    /// surfaces directly from this receive call.
+    /// Any incarnation-owned disposal panic retained by the time this path
+    /// runs resumes here before another event is delivered or a stop is
+    /// reported: an offload-work panic, and — because the stop branches
+    /// freeze first — a destructor panic from the queued continuations,
+    /// armed timers, queued offload completions and offload futures that the
+    /// freeze releases. Retention is the guarantee, not a join: a payload
+    /// recorded after this check is still the incarnation's exit, but is
+    /// classified by the epilogue and cannot suppress `on_stop`.
+    ///
+    /// A panic in an offload's continuation closure — the `FnOnce` that
+    /// builds the message from the offload result, not a
+    /// [`continue_with`](Self::continue_with) continuation, which is a plain
+    /// stored message whose construction cannot panic here — surfaces
+    /// directly from this receive call.
     pub async fn recv(&mut self) -> Option<M> {
         loop {
             if self.local_stop.is_fired() {
@@ -1446,13 +1454,18 @@ impl<M: Send + 'static> RawContext<M> {
 
     /// Receives one ready event without awaiting or consulting shutdown.
     ///
-    /// Outside shutdown drain, this resumes a retained offload-work panic
-    /// before returning another event; a panic in an offload's continuation
-    /// closure (the message-building `FnOnce`, not a
+    /// Outside shutdown drain, this resumes a retained disposal panic before
+    /// returning another event; a panic in an offload's continuation closure
+    /// (the message-building `FnOnce`, not a
     /// [`continue_with`](Self::continue_with) continuation, which is a plain
-    /// stored message) surfaces directly from this call. During drain it first
-    /// resumes any retained offload-work panic, then reads the frozen accepted
-    /// mailbox prefix directly.
+    /// stored message) surfaces directly from this call. During drain it
+    /// freezes first, then resumes any incarnation-owned disposal panic
+    /// retained by that point — an offload-work panic, or a destructor panic
+    /// from the continuations, timers, queued completions and offload futures
+    /// the freeze releases — before reading the frozen accepted mailbox
+    /// prefix. Retention is the guarantee, not a join: a payload recorded
+    /// after the check is still the incarnation's exit, but is classified by
+    /// the epilogue and cannot suppress `on_stop`.
     pub fn try_recv(&mut self) -> Option<M> {
         if self.is_stopping() {
             self.freeze_and_report();

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -1407,8 +1407,8 @@ impl<M: Send + 'static> RawContext<M> {
 
     /// Receives the next accepted message, biased toward shutdown.
     ///
-    /// While the incarnation is running, a retained offload-work panic resumes
-    /// from this receive path before another event is delivered. A panic in an
+    /// A retained offload-work panic resumes from this receive path before
+    /// another event is delivered or a stop is reported. A panic in an
     /// offload's continuation closure — the `FnOnce` that builds the message
     /// from the offload result, not a [`continue_with`](Self::continue_with)
     /// continuation, which is a plain stored message and cannot panic here —
@@ -1425,6 +1425,7 @@ impl<M: Send + 'static> RawContext<M> {
                 // ending the raw loop; removing this await would let a local
                 // stop bypass that cross-task handshake.
                 self.shutdown.cancelled().await;
+                self.resources.resume_pending_panic();
                 return None;
             }
             if self.shutdown.is_cancelled() {
@@ -1433,6 +1434,7 @@ impl<M: Send + 'static> RawContext<M> {
                 // what makes the frozen accepted prefix a complete drain
                 // boundary once cancellation is observable here.
                 self.freeze_and_report();
+                self.resources.resume_pending_panic();
                 return None;
             }
             if let Some(message) = self.next_ready() {
@@ -1448,11 +1450,13 @@ impl<M: Send + 'static> RawContext<M> {
     /// before returning another event; a panic in an offload's continuation
     /// closure (the message-building `FnOnce`, not a
     /// [`continue_with`](Self::continue_with) continuation, which is a plain
-    /// stored message) surfaces directly from this call. During drain it reads
-    /// the frozen accepted mailbox prefix directly.
+    /// stored message) surfaces directly from this call. During drain it first
+    /// resumes any retained offload-work panic, then reads the frozen accepted
+    /// mailbox prefix directly.
     pub fn try_recv(&mut self) -> Option<M> {
         if self.is_stopping() {
             self.freeze_and_report();
+            self.resources.resume_pending_panic();
             self.receiver.try_recv()
         } else {
             self.next_ready()

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -11,8 +11,8 @@ use std::{
 use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
-    Guard, LifecycleEventKind, LifecycleItem, Mailbox, Readiness, Shutdown, StartupError,
-    StartupFailureCause, Tree,
+    Guard, Handler, LifecycleEventKind, LifecycleItem, Mailbox, RawActor, RawContext, RawOnceDef,
+    Readiness, Shutdown, StartupError, StartupFailureCause, StopContext, Tree,
 };
 
 enum ZeroMessage {
@@ -1324,6 +1324,188 @@ async fn assert_queued_panic_beats_orderly_exit(mode: QueuedPanicMode) {
 async fn queued_offload_panic_survives_stop_and_handler_error() {
     assert_queued_panic_beats_orderly_exit(QueuedPanicMode::Stop).await;
     assert_queued_panic_beats_orderly_exit(QueuedPanicMode::HandlerError).await;
+}
+
+struct StopPathPanicObservations {
+    on_stop_ran: AtomicBool,
+    further_delivery_ran: AtomicBool,
+    decorator_result: Mutex<Option<&'static str>>,
+}
+
+struct StopPathPanicActor {
+    observations: Arc<StopPathPanicObservations>,
+}
+
+impl Actor for StopPathPanicActor {
+    type Msg = PanicMessage;
+    type Args = (Arc<StopPathPanicObservations>, ReleaseGate);
+
+    async fn init(
+        (observations, release): Self::Args,
+        _: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        release.wait().await;
+        Ok(Self { observations })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            PanicMessage::Trigger => {
+                let guard = context
+                    .offload_scoped(
+                        async {
+                            panic!("stop-path offload panic");
+                        },
+                        |_| PanicMessage::Delivery,
+                        Duration::MAX,
+                    )
+                    .expect("offload accepted");
+                guard.finished().await;
+                context.stop();
+            }
+            PanicMessage::Delivery => {
+                self.observations
+                    .further_delivery_ran
+                    .store(true, Ordering::SeqCst);
+            }
+        }
+        Ok(())
+    }
+
+    async fn on_stop(&mut self, _: &mut StopContext<'_, Self>) {
+        self.observations.on_stop_ran.store(true, Ordering::SeqCst);
+    }
+}
+
+struct StopPathPanicDecorator {
+    inner: Handler<StopPathPanicActor>,
+    observations: Arc<StopPathPanicObservations>,
+}
+
+impl RawActor for StopPathPanicDecorator {
+    type Msg = PanicMessage;
+
+    fn readiness() -> Readiness {
+        Readiness::Manual
+    }
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        let result = self.inner.run(context).await;
+        *self
+            .observations
+            .decorator_result
+            .lock()
+            .expect("decorator result mutex poisoned") =
+            Some(if result.is_ok() { "ok" } else { "err" });
+        result
+    }
+}
+
+#[tokio::test]
+async fn pending_offload_panic_stops_before_drain_on_stop_and_decorator_resume() {
+    let release_init = ReleaseGate::default();
+    let observations = Arc::new(StopPathPanicObservations {
+        on_stop_ran: AtomicBool::new(false),
+        further_delivery_ran: AtomicBool::new(false),
+        decorator_result: Mutex::new(None),
+    });
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "stop-path-panic",
+            RawOnceDef::new(StopPathPanicDecorator {
+                inner: Handler::new((Arc::clone(&observations), release_init.clone())),
+                observations: Arc::clone(&observations),
+            }),
+        )
+        .expect("valid decorated actor");
+    let system = tree.spawn().expect("runtime is available");
+    actor
+        .send(PanicMessage::Trigger)
+        .await
+        .expect("mailbox accepts before readiness");
+    actor
+        .send(PanicMessage::Delivery)
+        .await
+        .expect("frozen prefix message is accepted before readiness");
+    release_init.release();
+
+    let message = startup_panic_message(
+        system
+            .wait_started()
+            .await
+            .expect_err("the queued offload panic fails startup"),
+    );
+    assert_eq!(message.as_deref(), Some("stop-path offload panic"));
+    assert!(
+        !observations.on_stop_ran.load(Ordering::SeqCst),
+        "on_stop must not run after an incarnation-owned panic"
+    );
+    assert!(
+        !observations.further_delivery_ran.load(Ordering::SeqCst),
+        "the frozen prefix must not drain after an incarnation-owned panic"
+    );
+    assert_eq!(
+        *observations
+            .decorator_result
+            .lock()
+            .expect("decorator result mutex poisoned"),
+        None,
+        "the offload panic must unwind through the Handler composition point"
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed root shuts down");
+}
+
+struct StoppingTryRecvPanicActor;
+
+impl RawActor for StoppingTryRecvPanicActor {
+    type Msg = ();
+
+    fn readiness() -> Readiness {
+        Readiness::Manual
+    }
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        let guard = context
+            .offload_scoped(
+                async {
+                    panic!("stopping try_recv offload panic");
+                },
+                |_| (),
+                Duration::MAX,
+            )
+            .expect("offload accepted");
+        guard.finished().await;
+        context.stop();
+        let _ = context.try_recv();
+        unreachable!("stopping try_recv must resume the retained offload panic")
+    }
+}
+
+#[tokio::test]
+async fn stopping_try_recv_resumes_a_pending_offload_panic_before_drain() {
+    let mut tree = Tree::new();
+    tree.add_raw_once(
+        "stopping-try-recv-panic",
+        RawOnceDef::new(StoppingTryRecvPanicActor),
+    )
+    .expect("valid raw actor");
+    let system = tree.spawn().expect("runtime is available");
+
+    let message = startup_panic_message(
+        system
+            .wait_started()
+            .await
+            .expect_err("the queued offload panic fails startup"),
+    );
+    assert_eq!(message.as_deref(), Some("stopping try_recv offload panic"));
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed root shuts down");
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -1672,8 +1672,9 @@ impl Actor for DiscardedContinuationPanicActor {
     }
 }
 
-#[tokio::test]
-async fn discarded_continuation_destructor_panic_resumes_before_stop_teardown() {
+async fn assert_discarded_continuation_panic_stops_before_handler_teardown(
+    mailbox_shutdown: MailboxShutdown,
+) {
     let observations = StopPathPanicObservations::new();
     let mut tree = Tree::new();
     let actor = tree
@@ -1682,7 +1683,8 @@ async fn discarded_continuation_destructor_panic_resumes_before_stop_teardown() 
             RawOnceDef::new(StopPathPanicDecorator {
                 inner: Handler::<DiscardedContinuationPanicActor>::new(Arc::clone(&observations)),
                 observations: Arc::clone(&observations),
-            }),
+            })
+            .mailbox_shutdown(mailbox_shutdown),
         )
         .expect("valid decorated actor");
     let system = tree.spawn().expect("runtime is available");
@@ -1722,6 +1724,19 @@ async fn discarded_continuation_destructor_panic_resumes_before_stop_teardown() 
         .shutdown(Duration::from_secs(1))
         .await
         .expect("failed root shuts down");
+}
+
+#[tokio::test]
+async fn discarded_continuation_destructor_panic_resumes_before_drain_teardown() {
+    assert_discarded_continuation_panic_stops_before_handler_teardown(MailboxShutdown::Drain).await;
+}
+
+#[tokio::test]
+async fn discarded_continuation_destructor_panic_resumes_before_discard_teardown() {
+    // Discard skips Handler's `try_recv` drain, so only `recv`'s local-stop
+    // branch can carry the freeze-time destructor panic out of the loop.
+    assert_discarded_continuation_panic_stops_before_handler_teardown(MailboxShutdown::Discard)
+        .await;
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -11,8 +11,9 @@ use std::{
 use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
-    Guard, Handler, LifecycleEventKind, LifecycleItem, Mailbox, RawActor, RawContext, RawOnceDef,
-    Readiness, Shutdown, StartupError, StartupFailureCause, StopContext, Tree,
+    Guard, Handler, LifecycleEventKind, LifecycleItem, Mailbox, MailboxShutdown, RawActor,
+    RawContext, RawOnceDef, Readiness, Shutdown, StartupError, StartupFailureCause, StopContext,
+    Tree,
 };
 
 enum ZeroMessage {
@@ -1401,8 +1402,9 @@ impl RawActor for StopPathPanicDecorator {
     }
 }
 
-#[tokio::test]
-async fn pending_offload_panic_stops_before_drain_on_stop_and_decorator_resume() {
+async fn assert_pending_offload_panic_stops_before_handler_teardown(
+    mailbox_shutdown: MailboxShutdown,
+) {
     let release_init = ReleaseGate::default();
     let observations = Arc::new(StopPathPanicObservations {
         on_stop_ran: AtomicBool::new(false),
@@ -1416,7 +1418,8 @@ async fn pending_offload_panic_stops_before_drain_on_stop_and_decorator_resume()
             RawOnceDef::new(StopPathPanicDecorator {
                 inner: Handler::new((Arc::clone(&observations), release_init.clone())),
                 observations: Arc::clone(&observations),
-            }),
+            })
+            .mailbox_shutdown(mailbox_shutdown),
         )
         .expect("valid decorated actor");
     let system = tree.spawn().expect("runtime is available");
@@ -1459,7 +1462,89 @@ async fn pending_offload_panic_stops_before_drain_on_stop_and_decorator_resume()
         .expect("failed root shuts down");
 }
 
-struct StoppingTryRecvPanicActor;
+#[tokio::test]
+async fn pending_offload_panic_stops_before_drain_on_stop_and_decorator_resume() {
+    assert_pending_offload_panic_stops_before_handler_teardown(MailboxShutdown::Drain).await;
+}
+
+#[tokio::test]
+async fn pending_offload_panic_resumes_from_local_recv_before_discard_teardown() {
+    // Discard bypasses Handler's `try_recv` drain. This pins the local-stop
+    // branch of `recv` independently of the separate draining check.
+    assert_pending_offload_panic_stops_before_handler_teardown(MailboxShutdown::Discard).await;
+}
+
+struct ExternalStoppingRecvPanicActor {
+    panic_queued: Arc<AtomicBool>,
+}
+
+impl RawActor for ExternalStoppingRecvPanicActor {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        let guard = context
+            .offload_scoped(
+                async {
+                    panic!("external-stop recv offload panic");
+                },
+                |_| (),
+                Duration::MAX,
+            )
+            .expect("offload accepted");
+        guard.finished().await;
+        self.panic_queued.store(true, Ordering::SeqCst);
+        context.shutdown_token().cancelled().await;
+        let _ = context.recv().await;
+        unreachable!("externally stopped recv must resume the retained offload panic")
+    }
+}
+
+#[tokio::test]
+async fn externally_stopped_recv_resumes_a_pending_offload_panic() {
+    let panic_queued = Arc::new(AtomicBool::new(false));
+    let mut tree = Tree::new();
+    tree.add_raw_once(
+        "external-stop-recv-panic",
+        RawOnceDef::new(ExternalStoppingRecvPanicActor {
+            panic_queued: Arc::clone(&panic_queued),
+        }),
+    )
+    .expect("valid raw actor");
+    let system = tree.spawn().expect("runtime is available");
+    let mut events = system.scope().subscribe_lifecycle();
+    system.wait_started().await.expect("raw actor starts");
+    assert_eventually!(
+        || panic_queued.load(Ordering::SeqCst),
+        "offload panic is queued before external shutdown"
+    )
+    .await;
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed actor shuts down");
+
+    let mut panic_message = None;
+    while let Some(item) = events.recv().await {
+        let LifecycleItem::Event(event) = item else {
+            panic!("small fixture must not lag");
+        };
+        if let LifecycleEventKind::Exited { id, exit, .. } = event.kind
+            && id.as_str() == "external-stop-recv-panic"
+            && let ExitKind::Panicked { message } = exit.kind()
+        {
+            panic_message = message.clone();
+        }
+    }
+    assert_eq!(
+        panic_message.as_deref(),
+        Some("external-stop recv offload panic")
+    );
+}
+
+struct StoppingTryRecvPanicActor {
+    enter: ReleaseGate,
+}
 
 impl RawActor for StoppingTryRecvPanicActor {
     type Msg = ();
@@ -1469,6 +1554,7 @@ impl RawActor for StoppingTryRecvPanicActor {
     }
 
     async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        self.enter.wait().await;
         let guard = context
             .offload_scoped(
                 async {
@@ -1487,13 +1573,22 @@ impl RawActor for StoppingTryRecvPanicActor {
 
 #[tokio::test]
 async fn stopping_try_recv_resumes_a_pending_offload_panic_before_drain() {
+    let enter = ReleaseGate::default();
     let mut tree = Tree::new();
-    tree.add_raw_once(
-        "stopping-try-recv-panic",
-        RawOnceDef::new(StoppingTryRecvPanicActor),
-    )
-    .expect("valid raw actor");
+    let actor = tree
+        .add_raw_once(
+            "stopping-try-recv-panic",
+            RawOnceDef::new(StoppingTryRecvPanicActor {
+                enter: enter.clone(),
+            }),
+        )
+        .expect("valid raw actor");
     let system = tree.spawn().expect("runtime is available");
+    actor
+        .send(())
+        .await
+        .expect("frozen prefix message is accepted before readiness");
+    enter.release();
 
     let message = startup_panic_message(
         system

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet};
+use crate::common::{POLL_TIMEOUT, PanicOnDrop, ReleaseGate, assert_eventually, assert_quiet};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
     Guard, Handler, LifecycleEventKind, LifecycleItem, Mailbox, MailboxShutdown, RawActor,
@@ -1330,7 +1330,19 @@ async fn queued_offload_panic_survives_stop_and_handler_error() {
 struct StopPathPanicObservations {
     on_stop_ran: AtomicBool,
     further_delivery_ran: AtomicBool,
+    continuation_queued: AtomicBool,
     decorator_result: Mutex<Option<&'static str>>,
+}
+
+impl StopPathPanicObservations {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            on_stop_ran: AtomicBool::new(false),
+            further_delivery_ran: AtomicBool::new(false),
+            continuation_queued: AtomicBool::new(false),
+            decorator_result: Mutex::new(None),
+        })
+    }
 }
 
 struct StopPathPanicActor {
@@ -1378,13 +1390,13 @@ impl Actor for StopPathPanicActor {
     }
 }
 
-struct StopPathPanicDecorator {
-    inner: Handler<StopPathPanicActor>,
+struct StopPathPanicDecorator<A: Actor> {
+    inner: Handler<A>,
     observations: Arc<StopPathPanicObservations>,
 }
 
-impl RawActor for StopPathPanicDecorator {
-    type Msg = PanicMessage;
+impl<A: Actor> RawActor for StopPathPanicDecorator<A> {
+    type Msg = A::Msg;
 
     fn readiness() -> Readiness {
         Readiness::Manual
@@ -1406,17 +1418,16 @@ async fn assert_pending_offload_panic_stops_before_handler_teardown(
     mailbox_shutdown: MailboxShutdown,
 ) {
     let release_init = ReleaseGate::default();
-    let observations = Arc::new(StopPathPanicObservations {
-        on_stop_ran: AtomicBool::new(false),
-        further_delivery_ran: AtomicBool::new(false),
-        decorator_result: Mutex::new(None),
-    });
+    let observations = StopPathPanicObservations::new();
     let mut tree = Tree::new();
     let actor = tree
         .add_raw_once(
             "stop-path-panic",
             RawOnceDef::new(StopPathPanicDecorator {
-                inner: Handler::new((Arc::clone(&observations), release_init.clone())),
+                inner: Handler::<StopPathPanicActor>::new((
+                    Arc::clone(&observations),
+                    release_init.clone(),
+                )),
                 observations: Arc::clone(&observations),
             })
             .mailbox_shutdown(mailbox_shutdown),
@@ -1597,6 +1608,116 @@ async fn stopping_try_recv_resumes_a_pending_offload_panic_before_drain() {
             .expect_err("the queued offload panic fails startup"),
     );
     assert_eq!(message.as_deref(), Some("stopping try_recv offload panic"));
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed root shuts down");
+}
+
+const DISCARDED_CONTINUATION_PANIC: &str = "discarded continuation destructor panic";
+
+enum DiscardedContinuationMessage {
+    Trigger,
+    Continuation(PanicOnDrop),
+}
+
+/// Queues a continuation whose destructor panics, then stops. The stop's
+/// freeze discards the continuation into the incarnation's shared disposal
+/// slot, which the following receive boundary resumes: SPEC §5.2's exclusion
+/// covers any incarnation-owned disposal panic, not offload work alone.
+struct DiscardedContinuationPanicActor {
+    observations: Arc<StopPathPanicObservations>,
+}
+
+impl Actor for DiscardedContinuationPanicActor {
+    type Msg = DiscardedContinuationMessage;
+    type Args = Arc<StopPathPanicObservations>;
+
+    async fn init(observations: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self { observations })
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            DiscardedContinuationMessage::Trigger => {
+                let queued = context.continue_with(DiscardedContinuationMessage::Continuation(
+                    PanicOnDrop::new(DISCARDED_CONTINUATION_PANIC),
+                ));
+                self.observations
+                    .continuation_queued
+                    .store(queued.is_ok(), Ordering::SeqCst);
+                // A rejection would hand the panicking payload back here; leak
+                // it rather than unwinding inside the handler, and let the test
+                // body judge the published flag.
+                if let Err(rejected) = queued {
+                    std::mem::forget(rejected);
+                }
+                context.stop();
+            }
+            DiscardedContinuationMessage::Continuation(payload) => {
+                self.observations
+                    .further_delivery_ran
+                    .store(true, Ordering::SeqCst);
+                // Unreachable: the freeze inside `stop` discards queued
+                // continuations. Leak the payload so a regression reports
+                // through the flag instead of a second panic from in here.
+                std::mem::forget(payload);
+            }
+        }
+        Ok(())
+    }
+
+    async fn on_stop(&mut self, _: &mut StopContext<'_, Self>) {
+        self.observations.on_stop_ran.store(true, Ordering::SeqCst);
+    }
+}
+
+#[tokio::test]
+async fn discarded_continuation_destructor_panic_resumes_before_stop_teardown() {
+    let observations = StopPathPanicObservations::new();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "discarded-continuation-panic",
+            RawOnceDef::new(StopPathPanicDecorator {
+                inner: Handler::<DiscardedContinuationPanicActor>::new(Arc::clone(&observations)),
+                observations: Arc::clone(&observations),
+            }),
+        )
+        .expect("valid decorated actor");
+    let system = tree.spawn().expect("runtime is available");
+    actor
+        .send(DiscardedContinuationMessage::Trigger)
+        .await
+        .expect("mailbox accepts before readiness");
+
+    let message = startup_panic_message(
+        system
+            .wait_started()
+            .await
+            .expect_err("the discarded continuation destructor panic fails startup"),
+    );
+    assert_eq!(message.as_deref(), Some(DISCARDED_CONTINUATION_PANIC));
+    assert!(
+        observations.continuation_queued.load(Ordering::SeqCst),
+        "the continuation must be queued before the stop freezes it"
+    );
+    assert!(
+        !observations.on_stop_ran.load(Ordering::SeqCst),
+        "on_stop must not run after an incarnation-owned disposal panic"
+    );
+    assert!(
+        !observations.further_delivery_ran.load(Ordering::SeqCst),
+        "a discarded continuation must never be delivered"
+    );
+    assert_eq!(
+        *observations
+            .decorator_result
+            .lock()
+            .expect("decorator result mutex poisoned"),
+        None,
+        "the disposal panic must unwind through the Handler composition point"
+    );
     system
         .shutdown(Duration::from_secs(1))
         .await


### PR DESCRIPTION
## Summary

- resume a retained offload panic before either `recv` stop branch can return `None`
- resume the same panic before `try_recv` starts draining a frozen accepted prefix
- pin the stop-path contract through user-visible handler/decorator observations
- adjudicate SPEC §5.2 so incarnation-owned offload panics are failed incarnations that skip delivery and `on_stop`

## Root cause

Offload panics were retained in the incarnation resources, but the receive-side resume lived only in the normal `next_ready` path. Stop and drain branches bypassed it, allowing further handler work and clean-stop hooks to run before the outer incarnation runner finally re-raised the panic.

## Impact

An offload panic pending when stop begins now unwinds through the handler composition point immediately. No later accepted message is delivered, `on_stop` does not run, and a raw decorator cannot observe a false `Ok(())`.

## Validation

- focused `recv`/decorator and stopping-`try_recv` regressions
- full offload suite: 27/27 passed
- `./tools/dev just ci` — 658 workspace tests plus Clippy, doctests, rustdoc, API reachability, formatting, and packaged-doc checks

Closes #263