### PR TITLE
Preserve pending terminal exits on driver teardown

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2292,12 +2292,15 @@ framework contract**. No other normative shutdown paragraph is unmapped.
   final event. An inactive child in the classified-but-unpublished terminal-
   disposal state is not coarsened: teardown publishes its stored exit before
   discharging terminality, without waiting for the retained user-state
-  disposal, so that classified verdict wins. First publication wins: an
-  orderly post-join report that already landed is never overwritten. §7's
-  post-join precision is an orderly-path property, deliberately traded for
-  promptness on the kill path — the future was destroyed, so "what would it
-  have reported" is unknowable in bounded time; this is the same trade
-  `brutal_kill` → `killed` makes, decided here once rather than per call site.
+  disposal, so that classified verdict wins. A retained-construction
+  destructor panic is not folded in on this path, whether still in flight or
+  already reported but undispatched: teardown consumes the stored verdict as
+  classified at join. First publication wins: an orderly post-join report
+  that already landed is never overwritten. §7's post-join precision is an
+  orderly-path property, deliberately traded for promptness on the kill
+  path — the future was destroyed, so "what would it have reported" is
+  unknowable in bounded time; this is the same trade `brutal_kill` →
+  `killed` makes, decided here once rather than per call site.
 - "Drained" has exactly one definition, derived from child state (no
   hand-maintained live counter).
 - Child exits are consumed through one funnel regardless of which await

--- a/SPEC.md
+++ b/SPEC.md
@@ -2289,12 +2289,15 @@ framework contract**. No other normative shutdown paragraph is unmapped.
   terminalize (sends fail `Terminated`, exit-awaiting surfaces resolve),
   in-flight admissions and removals resolve their enumerated rejections,
   and every `Added` is paired with its `Removed` before the scope's own
-  final event. First publication wins: an orderly post-join report that
-  already landed is never overwritten. §7's post-join precision is an
-  orderly-path property, deliberately traded for promptness on the kill
-  path — the future was destroyed, so "what would it have reported"
-  is unknowable in bounded time; this is the same trade `brutal_kill` →
-  `killed` makes, decided here once rather than per call site.
+  final event. An inactive child in the classified-but-unpublished terminal-
+  disposal state is not coarsened: teardown publishes its stored exit before
+  discharging terminality, without waiting for the retained user-state
+  disposal, so that classified verdict wins. First publication wins: an
+  orderly post-join report that already landed is never overwritten. §7's
+  post-join precision is an orderly-path property, deliberately traded for
+  promptness on the kill path — the future was destroyed, so "what would it
+  have reported" is unknowable in bounded time; this is the same trade
+  `brutal_kill` → `killed` makes, decided here once rather than per call site.
 - "Drained" has exactly one definition, derived from child state (no
   hand-maintained live counter).
 - Child exits are consumed through one funnel regardless of which await

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -354,8 +354,12 @@ impl Drop for ScopeRuntime {
         // to finish disposal. Its exit is already classified, so driver death
         // must publish that verdict before the terminality fallback gets a
         // chance to synthesize a coarse cancellation. The disposal job stays
-        // detached; as on hard escalation, teardown does not wait for it or
-        // incorporate a destructor panic that arrives after publication.
+        // detached; as on hard escalation, teardown does not wait for it and
+        // does not incorporate a destructor panic that has not been
+        // dispatched at publication — including a completion already queued
+        // on the disposal lane but not yet dispatched. Consuming that arrived
+        // half is issue #291, which covers this site and the matching discard
+        // in `force_child`.
         let child_keys: Vec<_> = self.children.iter().map(|(key, _)| key).collect();
         for key in child_keys {
             if self

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -290,10 +290,6 @@ impl<T> ChildResources<T> {
         self.0.values()
     }
 
-    fn values_mut(&mut self) -> impl Iterator<Item = &mut T> {
-        self.0.values_mut()
-    }
-
     #[cfg(test)]
     fn len(&self) -> usize {
         self.0.len()
@@ -354,7 +350,27 @@ impl Drop for ScopeRuntime {
         } else {
             None
         };
-        for child in self.children.values_mut() {
+        // An exited child can be waiting only for retained user construction
+        // to finish disposal. Its exit is already classified, so driver death
+        // must publish that verdict before the terminality fallback gets a
+        // chance to synthesize a coarse cancellation. The disposal job stays
+        // detached; as on hard escalation, teardown does not wait for it or
+        // incorporate a destructor panic that arrives after publication.
+        let child_keys: Vec<_> = self.children.iter().map(|(key, _)| key).collect();
+        for key in child_keys {
+            if self
+                .children
+                .get(key)
+                .is_some_and(|child| child.pending_terminal.is_some())
+            {
+                self.handle_construction_disposed(key, None);
+            }
+            let Some(child) = self.children.get_mut(key) else {
+                // Terminal publication can reclaim a remove-retained dynamic
+                // child; its terminality obligation was completed in that
+                // path, so there is no fallback left to discharge here.
+                continue;
+            };
             if let Some(active) = child.active.take() {
                 if let Some(mailbox) = &child.mailbox {
                     mailbox.freeze(active.incarnation);

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -1,5 +1,13 @@
 use super::support::*;
 
+struct BlockingFactoryDrop(Arc<FactoryGate>);
+
+impl Drop for BlockingFactoryDrop {
+    fn drop(&mut self) {
+        self.0.block();
+    }
+}
+
 #[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
 async fn runtime_teardown_finishes_the_cancelled_root_driver() {
     let plan = DynamicTree::new().lower_for_test();
@@ -41,6 +49,98 @@ async fn runtime_teardown_finishes_the_cancelled_root_driver() {
         root.member.record().stage,
         MemberStage::Terminal(ref exit) if exit.cancellation() == Cancellation::Observed
     ));
+}
+
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+async fn runtime_teardown_publishes_the_exit_awaiting_factory_disposal() {
+    const FAILURE: &str = "distinctive application failure";
+
+    let gate = Arc::new(FactoryGate::default());
+    let mut tree = Tree::new();
+    let task = tree
+        .add_task(
+            "worker",
+            TaskDef::new({
+                let capture = BlockingFactoryDrop(Arc::clone(&gate));
+                move |_| {
+                    let _ = &capture;
+                    async { Err(ExitError::message(FAILURE)) }
+                }
+            })
+            .restart(RestartPolicy::new(
+                RestartCondition::Never,
+                Backoff::Immediate,
+            ))
+            .retention(Retention::Retain),
+        )
+        .expect("valid task");
+    let plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let mut events = root.subscribe_lifecycle();
+    let (hosted, driver) = DedicatedRuntime::spawn(run_scope(plan, ScopeRole::Root));
+
+    root.wait_started().await.expect("root starts");
+    assert!(matches!(
+        crate::runtime::timeout(DRIVER_PROGRESS_WAIT, gate.wait_entered()).await,
+        crate::runtime::Timeout::Completed(())
+    ));
+    let pending = task.cell.record();
+
+    // Dropping this dedicated runtime destroys the scope-driver future while
+    // the blocking pool remains held in the retained factory's destructor.
+    // Run teardown concurrently so the test can observe the synchronous
+    // driver epilogue before allowing that destructor to finish.
+    let teardown = crate::runtime::spawn(hosted.shutdown());
+    let publication = crate::runtime::timeout(DRIVER_PROGRESS_WAIT, async {
+        let terminal = task.wait().await;
+        let lifecycle = loop {
+            let Some(item) = events.recv().await else {
+                panic!("driver teardown closed lifecycle without an Exited event")
+            };
+            if let LifecycleItem::Event(event) = item
+                && let LifecycleEventKind::Exited { id, exit, .. } = event.kind
+                && id.as_str() == "worker"
+            {
+                break exit;
+            }
+        };
+        (terminal, lifecycle, task.cell.record())
+    })
+    .await;
+
+    // Always unblock the runtime thread before asserting the publication, so
+    // a regression fails promptly rather than waiting for the gate backstop.
+    gate.release();
+    let teardown =
+        crate::runtime::timeout(DRIVER_PROGRESS_WAIT, crate::runtime::join(teardown)).await;
+    let driver = crate::runtime::timeout(DRIVER_PROGRESS_WAIT, crate::runtime::join(driver)).await;
+
+    assert!(matches!(
+        teardown,
+        crate::runtime::Timeout::Completed(crate::runtime::JoinOutcome::Ok { value: () })
+    ));
+    assert!(matches!(
+        driver,
+        crate::runtime::Timeout::Completed(crate::runtime::JoinOutcome::Cancelled)
+    ));
+    assert!(matches!(pending.stage, MemberStage::Running));
+    assert_eq!(pending.last_exit, None);
+    let crate::runtime::Timeout::Completed((terminal, lifecycle, record)) = publication else {
+        panic!("driver teardown did not publish the pending terminal exit")
+    };
+    let MemberStage::Terminal(recorded) = record.stage else {
+        panic!("driver teardown did not terminalize the child membership")
+    };
+    for exit in [&terminal, &lifecycle, &recorded] {
+        assert!(matches!(
+            exit.kind(),
+            ExitKind::Failed(error) if error.to_string() == FAILURE
+        ));
+        assert_eq!(exit.cancellation(), Cancellation::NotObserved);
+    }
+    assert_eq!(lifecycle, terminal);
+    assert_eq!(recorded, terminal);
+    assert_eq!(record.last_exit, Some(terminal));
 }
 
 #[crate::runtime::test]


### PR DESCRIPTION
## Summary

- publish a child's stored `pending_terminal` exit before the driver teardown fallback can synthesize a coarse cancellation
- route publication through the existing construction-disposed path without waiting for detached user-state disposal
- define the classified-but-unpublished teardown state in SPEC §10
- add a deterministic runtime-destruction regression covering every terminal observation surface

## Root cause

Once an incarnation had joined, its classified exit could wait behind retained construction disposal. Destroying the scope-driver future ignored that state and discharged terminality as an unknown cancellation, even though the exact verdict was already retained.

## Impact

Driver-future destruction now preserves the classified exit in lifecycle events, terminal waits, `MemberStage::Terminal`, and `last_exit`. Truly active or otherwise unknown descendants still receive the coarse teardown verdict described by SPEC §10.

## Validation

- focused pending-terminal runtime-destruction regression
- `./tools/dev cargo test -p shelterwood --lib` — 175 passed
- `./tools/dev just ci` — 657 workspace tests plus formatting, Clippy lanes, doctests, rustdoc/API reachability, docs, and Nix checks

Closes #264