### PR TITLE
Make drain-entry straggler sampling atomic

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2771,6 +2771,14 @@ dynamic removal: the removed id becomes reusable (and a repeated `remove`
 reports `AlreadyAbsent`) only at the commit that withdraws the member
 from residency and publishes its `Removed` edge — §2's
 resident-membership uniqueness holds at every observable cut.
+Drain entry follows the same rule: publishing `Draining` includes the
+terminal-disposal intent for every inactive child selected to stop in that
+same driver step. A zero-budget shutdown's straggler sample cannot split that
+entry step, so restart-window cleanup already committed by it is not a
+straggler; an active child, or an ordered sibling whose stop has not yet been
+selected, remains reportable. This ruling is pinned on a multi-thread runtime
+by
+`integration::restart_window_cleanup_is_isolated_without_reclassifying_the_recorded_exit`.
 
 `tracing` spans emit from one choke point (the optional `metrics` surface
 is Part II §20). Everything else observational — peer monitoring, actor

--- a/SPEC.md
+++ b/SPEC.md
@@ -2775,9 +2775,12 @@ Drain entry follows the same rule: publishing `Draining` includes the
 terminal-disposal intent for every inactive child selected to stop in that
 same driver step. A zero-budget shutdown's straggler sample cannot split that
 entry step, so restart-window cleanup already committed by it is not a
-straggler; an active child, or an ordered sibling whose stop has not yet been
-selected, remains reportable. This ruling is pinned on a multi-thread runtime
-by
+straggler; an active child, or an ordered sibling whose stop has not yet
+been selected, remains reportable. The guarantee covers that entry step
+only: an ordered scope stops its children one step at a time, and every
+step after entry races the sample by design, so whether a later sibling
+has already terminalized when the sample runs is schedule-dependent and
+both outcomes conform. This ruling is pinned on a multi-thread runtime by
 `integration::restart_window_cleanup_is_isolated_without_reclassifying_the_recorded_exit`.
 
 `tracing` spans emit from one choke point (the optional `metrics` surface

--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -509,10 +509,41 @@ impl MemberCell {
         };
     }
 
+    /// Reads the drain-entry terminal-disposal marker.
+    ///
+    /// `Acquire` pairs with the `Release` store in
+    /// [`Self::set_terminal_disposal_pending`]. Two separate edges make a
+    /// zero-budget straggler sample (the driver's `collect_stragglers`)
+    /// correct, and both rest on these atomics alone: the sample is *not*
+    /// incidentally serialized by the observation gate, because
+    /// [`ScopeCell::resident_projections`] takes `observation.current_children`
+    /// — a different mutex from the gate `publish_drain` holds.
+    ///
+    /// * A load that observes the *clear* synchronizes with the store the
+    ///   driver issues after `terminalize_child` published
+    ///   `MemberStage::Terminal`, so the sampler's following record read is
+    ///   ordered after that publication. It cannot pair a stale nonterminal
+    ///   projection with an already-cleared marker.
+    /// * A load cannot return a stale `false` from *before* the marker was
+    ///   set. A sampler reaches this call only after reading
+    ///   `ScopeState::Draining` out of the scope record, and
+    ///   [`Self::set_terminal_disposal_pending`] stores every drain-entry
+    ///   marker *before* `publish_drain` writes that record. The record
+    ///   write/read pair supplies happens-before, and coherence then forbids
+    ///   this load from returning a value preceding `true` in the marker's
+    ///   modification order.
     pub fn terminal_disposal_pending(&self) -> bool {
         self.terminal_disposal_pending.load(Ordering::Acquire)
     }
 
+    /// Installs or clears the drain-entry terminal-disposal marker.
+    ///
+    /// `Release` publishes everything the caller sequenced before it. The
+    /// clearing store at terminal publication therefore carries
+    /// `MemberStage::Terminal` to any sampler whose `Acquire` load reads it;
+    /// the setting store is made visible by the `Draining` record write that
+    /// `publish_drain` performs afterwards. See
+    /// [`Self::terminal_disposal_pending`] for the full argument.
     pub fn set_terminal_disposal_pending(&self, pending: bool) {
         self.terminal_disposal_pending
             .store(pending, Ordering::Release);
@@ -1450,6 +1481,18 @@ impl ScopeCell {
     ) {
         debug_assert!(matches!(state, ScopeState::Draining));
         self.with_observation_gate(|txn| {
+            // Statement order is load-bearing: every marker must be stored
+            // *before* `set_state_locked` writes `Draining` into the scope
+            // record. A zero-budget sampler reads that record first, so the
+            // `Draining` read is the release edge that makes the markers
+            // visible to it. Publishing the state first reopens #270: the
+            // driver writes `Draining` with no marker yet stored, a sampler on
+            // another worker reads `Draining`, then reads `false` for a child
+            // this very step is disposing, then reads that child's still
+            // nonterminal record, and reports a spurious
+            // `Err(ShutdownTimeout)`. No test holds this order — moving the
+            // loop below `set_state_locked` leaves the suite green — so this
+            // comment is the only guard.
             for member in terminal_disposals {
                 debug_assert!(
                     self.current_observation_gate()

--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -1435,6 +1435,36 @@ impl ScopeCell {
         });
     }
 
+    /// Publishes drain entry together with terminal-cleanup intent selected by
+    /// the same driver step.
+    ///
+    /// A zero-budget shutdown waiter wakes from the state publication and
+    /// immediately samples descendants. Installing these markers under the
+    /// shared observation gate keeps that sample from splitting drain entry
+    /// between the scope transition and an inactive child's cleanup.
+    pub fn publish_drain(
+        &self,
+        state: ScopeState,
+        startup: Option<Result<(), StartupError>>,
+        terminal_disposals: &[Arc<MemberCell>],
+    ) {
+        debug_assert!(matches!(state, ScopeState::Draining));
+        self.with_observation_gate(|txn| {
+            for member in terminal_disposals {
+                debug_assert!(
+                    self.current_observation_gate()
+                        .same_gate(&member.current_observation_gate()),
+                    "a drain entry may mark only a resident member on its observation gate"
+                );
+                member.set_terminal_disposal_pending(true);
+            }
+            if let Some(startup) = startup {
+                self.set_startup_locked(startup, txn);
+            }
+            self.set_state_locked(state, txn);
+        });
+    }
+
     fn set_state_locked(&self, state: ScopeState, txn: &mut ObservationTxn<'_>) {
         let mut transient_retained = Vec::new();
         RetainedExit::retain_scope_state(&mut transient_retained, &state);

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -8,7 +8,7 @@ mod shutdown;
 mod startup;
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     ops::{Index, IndexMut},
     sync::{Arc, OnceLock},
     time::Instant,

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -33,8 +33,8 @@ use crate::{
     ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure, StartupFailureCause,
     admission::{NotAdmittingCause, ReserveError},
     cells::{
-        MemberStage, MemberTransition, ResidentProjection, RetainedExit, RetainedStopReason,
-        ScopeCell, ScopeControlEvent, StartupDisposition,
+        MemberCell, MemberStage, MemberTransition, ResidentProjection, RetainedExit,
+        RetainedStopReason, ScopeCell, ScopeControlEvent, StartupDisposition,
     },
     deadline::Deadline,
     engine::{
@@ -71,7 +71,7 @@ pub(crate) use admission_control::{
 };
 
 #[cfg(test)]
-use crate::cells::{GateCapture, MemberCell, RuntimeStorage};
+use crate::cells::{GateCapture, RuntimeStorage};
 #[cfg(test)]
 use admission_control::RemovalResponses;
 

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -1138,6 +1138,10 @@ impl ScopeRuntime {
         // Keep the marker installed until terminal publication has committed.
         // A concurrent shutdown sampler then sees either pending cleanup or a
         // terminal member, never the gap between those two representations.
+        //
+        // Argued, not pinned: clearing the marker before `terminalize_child`
+        // reopens that gap for a few instructions, which no test in the suite
+        // can provoke deterministically.
         member.set_terminal_disposal_pending(false);
         if self.supervisor.membership_status(key) == MembershipStatus::Removing {
             self.flush_supervisor_effects();

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -1111,7 +1111,7 @@ impl ScopeRuntime {
         let Some(terminal) = child.pending_terminal.take() else {
             return;
         };
-        child.slot.member.set_terminal_disposal_pending(false);
+        let member = Arc::clone(&child.slot.member);
         let mut exit = terminal.exit.into_exit();
         if terminal.exited_incarnation.is_some()
             && let Some(runtime::DisposalPanic { message }) = panic
@@ -1135,6 +1135,10 @@ impl ScopeRuntime {
             StartupDisposition::NotAborted
         };
         self.terminalize_child(key, exit.clone(), terminal.exited_incarnation, startup);
+        // Keep the marker installed until terminal publication has committed.
+        // A concurrent shutdown sampler then sees either pending cleanup or a
+        // terminal member, never the gap between those two representations.
+        member.set_terminal_disposal_pending(false);
         if self.supervisor.membership_status(key) == MembershipStatus::Removing {
             self.flush_supervisor_effects();
         } else if terminal.startup == StartupDisposition::Aborted

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -81,6 +81,36 @@ pub(crate) async fn shutdown_scope(
 }
 
 impl ScopeRuntime {
+    fn drain_entry_terminal_disposals(&self, effects: &[SupervisorEffect]) -> Vec<Arc<MemberCell>> {
+        let mut keys = Vec::new();
+        for effect in effects {
+            let key = match effect {
+                SupervisorEffect::StopChild { child } | SupervisorEffect::ForceChild { child } => {
+                    *child
+                }
+                _ => continue,
+            };
+            if keys.contains(&key)
+                || self.supervisor.membership_terminal(key)
+                || self.supervisor.is_disposing(key)
+                || self
+                    .children
+                    .get(key)
+                    .is_none_or(|child| child.active.is_some())
+            {
+                continue;
+            }
+            keys.push(key);
+        }
+        keys.into_iter()
+            .filter_map(|key| {
+                self.children
+                    .get(key)
+                    .map(|child| Arc::clone(&child.slot.member))
+            })
+            .collect()
+    }
+
     pub(super) fn begin_drain(&mut self, reason: StopReason) {
         let startup = self
             .supervisor
@@ -125,12 +155,16 @@ impl ScopeRuntime {
         else {
             unreachable!()
         };
-        if let Some(startup) = startup {
-            self.root.set_state_and_startup(state, startup);
-        } else {
-            debug_assert!(!startup_pending);
-            self.root.set_state(state);
-        }
+        debug_assert!(startup.is_some() || !startup_pending);
+        // Ordered drain exposes its first stop only through `Settle`; derive
+        // that command before publication so both scope flavors can commit an
+        // inactive child's terminal-cleanup intent with the `Draining` edge.
+        // Later ordered siblings are deliberately absent: their cooperative
+        // stop has not begun and a zero-budget sample must still report them.
+        self.reduce(SupervisorEvent::Settle);
+        let terminal_disposals =
+            self.drain_entry_terminal_disposals(&self.supervisor_effects[before..]);
+        self.root.publish_drain(state, startup, &terminal_disposals);
         self.flush_supervisor_effects();
         self.settle_supervisor();
     }
@@ -150,12 +184,14 @@ impl ScopeRuntime {
             else {
                 unreachable!()
             };
-            if startup_pending {
-                self.root
-                    .set_state_and_startup(state, Err(StartupError::ShutdownRequested));
-            } else {
-                self.root.set_state(state);
-            }
+            self.reduce(SupervisorEvent::Settle);
+            let terminal_disposals =
+                self.drain_entry_terminal_disposals(&self.supervisor_effects[before..]);
+            self.root.publish_drain(
+                state,
+                startup_pending.then_some(Err(StartupError::ShutdownRequested)),
+                &terminal_disposals,
+            );
         }
         self.flush_supervisor_effects();
         self.settle_supervisor();

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -3,8 +3,14 @@ use super::*;
 fn collect_stragglers(scope: &ScopeCell, prefix: &[ChildId], out: &mut Vec<ShutdownStraggler>) {
     let children = scope.resident_projections();
     for child in children {
-        if matches!(child.member.record().stage, MemberStage::Terminal(_))
-            || child.member.terminal_disposal_pending()
+        // Read the release/acquire marker before the terminal projection. If
+        // terminal publication has already cleared it, that acquire orders
+        // the following record read after publication; if cleanup is still
+        // pending, the marker itself excludes the child. Reading the record
+        // first could pair a stale nonterminal projection with the later
+        // cleared marker and recreate a narrow trailing gap.
+        if child.member.terminal_disposal_pending()
+            || matches!(child.member.record().stage, MemberStage::Terminal(_))
         {
             continue;
         }
@@ -82,7 +88,7 @@ pub(crate) async fn shutdown_scope(
 
 impl ScopeRuntime {
     fn drain_entry_terminal_disposals(&self, effects: &[SupervisorEffect]) -> Vec<Arc<MemberCell>> {
-        let mut keys = Vec::new();
+        let mut keys = BTreeSet::new();
         for effect in effects {
             let key = match effect {
                 SupervisorEffect::StopChild { child } | SupervisorEffect::ForceChild { child } => {
@@ -90,8 +96,7 @@ impl ScopeRuntime {
                 }
                 _ => continue,
             };
-            if keys.contains(&key)
-                || self.supervisor.membership_terminal(key)
+            if self.supervisor.membership_terminal(key)
                 || self.supervisor.is_disposing(key)
                 || self
                     .children
@@ -100,7 +105,7 @@ impl ScopeRuntime {
             {
                 continue;
             }
-            keys.push(key);
+            keys.insert(key);
         }
         keys.into_iter()
             .filter_map(|key| {

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -9,6 +9,10 @@ fn collect_stragglers(scope: &ScopeCell, prefix: &[ChildId], out: &mut Vec<Shutd
         // pending, the marker itself excludes the child. Reading the record
         // first could pair a stale nonterminal projection with the later
         // cleared marker and recreate a narrow trailing gap.
+        //
+        // Argued, not pinned: the window is too narrow to provoke
+        // deterministically, and reverting to record-first leaves the suite
+        // green.
         if child.member.terminal_disposal_pending()
             || matches!(child.member.record().stage, MemberStage::Terminal(_))
         {
@@ -189,7 +193,11 @@ impl ScopeRuntime {
             else {
                 unreachable!()
             };
-            self.reduce(SupervisorEvent::Settle);
+            // No pre-`Settle` here, unlike `begin_drain_transition`.
+            // `SupervisorEvent::Force` already pushes `ForceChild` for every
+            // non-joined child, a strict superset of the single `StopChild` an
+            // ordered scope's `Settle` could add, so settling early cannot
+            // contribute a member this selection would otherwise miss.
             let terminal_disposals =
                 self.drain_entry_terminal_disposals(&self.supervisor_effects[before..]);
             self.root.publish_drain(

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -20,7 +20,7 @@ use shelterwood::{
     Backoff, CallErrorKind, Cancellation, ChildState, DynamicTree, ExitError, ExitKind, ExitResult,
     Jitter, LifecycleEventKind, LifecycleItem, Mailbox, RawActor, RawContext, RawDef, RawOnceDef,
     Readiness, ReadinessDeadline, RemoveOutcome, Reply, ReserveError, RestartCondition,
-    RestartPolicy, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
+    RestartPolicy, ScopeState, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
 };
 
 struct DropProbe {
@@ -1070,6 +1070,15 @@ async fn restart_window_cleanup_is_isolated_without_reclassifying_the_recorded_e
     let mut shutdown = Box::pin(system.shutdown(Duration::ZERO));
     assert!(poll_once(shutdown.as_mut()).is_pending());
     wait_for_destructor(&snapshot_wake_gate).await;
+    // `BlockingWake` is one-shot, so it parks the driver at whichever
+    // snapshot pulse arrives first. Pin the parked cut: without this the
+    // second `poll_once` below could report `Pending` merely because the
+    // shutdown future is still waiting to observe `Draining`, and the test
+    // would pass having exercised nothing.
+    assert!(
+        matches!(scope.snapshot().state, ScopeState::Draining),
+        "the driver must be parked on the drain publication, not an earlier pulse"
+    );
     assert!(
         poll_once(shutdown.as_mut()).is_pending(),
         "the zero-budget sample escalates before the blocked driver continues"

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -4,17 +4,17 @@ use std::{
     future::{Future, poll_fn},
     marker::PhantomData,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     },
-    task::Poll,
+    task::{Context, Poll, Wake, Waker},
     thread::{self, ThreadId},
     time::Duration,
 };
 
 use crate::common::{
     DestructorBlocker, DestructorGate, POLL_TIMEOUT, PanicOnDrop, ReleaseGate, assert_eventually,
-    policy::never,
+    policy::never, poll_once,
 };
 use shelterwood::{
     Backoff, CallErrorKind, Cancellation, ChildState, DynamicTree, ExitError, ExitKind, ExitResult,
@@ -73,6 +73,33 @@ impl BlockingDropProbe {
 impl Drop for BlockingDropProbe {
     fn drop(&mut self) {
         let _ = self.dropped.send(thread::current().id());
+    }
+}
+
+struct BlockingWake {
+    blocker: Mutex<Option<DestructorBlocker>>,
+}
+
+impl BlockingWake {
+    fn new(blocker: DestructorBlocker) -> Self {
+        Self {
+            blocker: Mutex::new(Some(blocker)),
+        }
+    }
+}
+
+impl Wake for BlockingWake {
+    fn wake(self: Arc<Self>) {
+        self.wake_by_ref();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        let blocker = self
+            .blocker
+            .lock()
+            .expect("blocking waker mutex is available")
+            .take();
+        drop(blocker);
     }
 }
 
@@ -988,7 +1015,7 @@ async fn hard_shutdown_detaches_failed_nested_lowering_disposal() {
     assert!(result.is_err(), "the still-live subtree is a straggler");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn restart_window_cleanup_is_isolated_without_reclassifying_the_recorded_exit() {
     let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
     let mut tree = Tree::new();
@@ -1022,8 +1049,33 @@ async fn restart_window_cleanup_is_isolated_without_reclassifying_the_recorded_e
         )
         .await
         .expect("task enters restart backoff");
-    system
-        .shutdown(Duration::ZERO)
+
+    // Park the driver inside the wake flush for its `Draining` snapshot. The
+    // shutdown future can then sample the published cut on the other worker
+    // before the driver proceeds to its queued `StopChild` effect. This makes
+    // the multi-thread race deterministic: drain publication must already
+    // include the restart-window child's terminal-disposal intent.
+    let snapshot_wake_gate = DestructorGate::default();
+    let snapshot_waker = Waker::from(Arc::new(BlockingWake::new(snapshot_wake_gate.blocker())));
+    let mut snapshots = scope.subscribe_snapshots();
+    let mut snapshot_change = Box::pin(snapshots.changed());
+    let mut snapshot_context = Context::from_waker(&snapshot_waker);
+    assert!(
+        snapshot_change
+            .as_mut()
+            .poll(&mut snapshot_context)
+            .is_pending()
+    );
+
+    let mut shutdown = Box::pin(system.shutdown(Duration::ZERO));
+    assert!(poll_once(shutdown.as_mut()).is_pending());
+    wait_for_destructor(&snapshot_wake_gate).await;
+    assert!(
+        poll_once(shutdown.as_mut()).is_pending(),
+        "the zero-budget sample escalates before the blocked driver continues"
+    );
+    snapshot_wake_gate.release();
+    shutdown
         .await
         .expect("restart-window cleanup does not become a shutdown straggler");
     assert_disposed_off_current(&mut drops, "restart-window factory was disposed").await;


### PR DESCRIPTION
## Ruling

Choose option 2: a zero-budget shutdown may sample a committed drain-entry cut, but it may not split the logical driver step that publishes `Draining` from the inactive-child cleanup selected by that same step.

## Summary

- publish `Draining` and selected terminal-disposal markers under one observation-gate transaction
- pre-settle the pure supervisor reducer so ordered scopes expose the exact first stop selected at drain entry
- cover ordinary drain and initial force entry
- retain the pending marker until terminal publication commits, removing the corresponding trailing gap
- pin the ruling with a deterministic multi-thread regression and SPEC text

## Why

The public `Draining` edge wakes a zero-budget waiter. Letting that waiter observe the entry batch halfway through made the same restart-window child alternate between success and `ShutdownTimeout` based only on runtime scheduling.

## Impact

Restart-window cleanup already selected at drain entry is not reported as a straggler. Active children and ordered siblings whose stop has not yet been selected remain reportable, preserving the zero-budget budget semantics. The guarantee covers the entry step only — later ordered stop steps race the sample by design, which SPEC §12 now states explicitly.

## Validation

Pinned by tests:

- focused deterministic multi-thread straggler regression; deleting the marker store, or the `begin_drain_transition` pre-`Settle`, makes it fail
- full disposal target: 36 passed
- driver shutdown tests: 6 passed
- `./tools/dev just ci` — exit 0, 656 tests plus Clippy, doctests, rustdoc/API reachability, docs sync, and Nix formatting

Argued, not pinned (no test in the suite provokes either window; both are defended by a comment at the site):

- the `collect_stragglers` marker-before-record read order (`driver/shutdown.rs`) — reverting to record-first leaves the suite green
- retaining the marker until after `terminalize_child` commits (`driver/child.rs`) — clearing early leaves the suite green
- the statement order inside `publish_drain` (markers before the `Draining` record write) — moving the loop after `set_state_locked` leaves the suite green, yet the swap reopens #270

Closes #270
