### PR TITLE
Preserve arrived construction-disposal panics during teardown

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2309,11 +2309,14 @@ framework contract**. No other normative shutdown paragraph is unmapped.
   disposal state is not coarsened: teardown publishes its stored exit before
   discharging terminality, without waiting for the retained user-state
   disposal, so that classified verdict wins. A retained-construction
-  destructor panic already reported on the disposal lane is folded into that
+  destructor panic still queued on the disposal lane is folded into that
   exit before publication, just as on orderly dispatch. Teardown drains only
-  the arrived prefix and never waits: a disposal still in flight remains
-  detached, and its unknowable result cannot delay the kill path. First
-  publication wins, so a later completion cannot overwrite the bounded
+  what the lane already holds and never waits: a disposal still in flight
+  remains detached, and its unknowable result cannot delay the kill path. A
+  completion the driver already lifted out of the lane into its current
+  arbitrated batch is likewise not folded — the teardown transition sorts
+  ahead of it — so the fold is a promptness improvement, not a guarantee.
+  First publication wins, so a later completion cannot overwrite the bounded
   fallback. This is the same precision boundary `brutal_kill` → `killed`
   makes, decided here once rather than per call site.
 - "Drained" has exactly one definition, derived from child state (no

--- a/SPEC.md
+++ b/SPEC.md
@@ -2309,14 +2309,13 @@ framework contract**. No other normative shutdown paragraph is unmapped.
   disposal state is not coarsened: teardown publishes its stored exit before
   discharging terminality, without waiting for the retained user-state
   disposal, so that classified verdict wins. A retained-construction
-  destructor panic is not folded in on this path, whether still in flight or
-  already reported but undispatched: teardown consumes the stored verdict as
-  classified at join. First publication wins: an orderly post-join report
-  that already landed is never overwritten. §7's post-join precision is an
-  orderly-path property, deliberately traded for promptness on the kill
-  path — the future was destroyed, so "what would it have reported" is
-  unknowable in bounded time; this is the same trade `brutal_kill` →
-  `killed` makes, decided here once rather than per call site.
+  destructor panic already reported on the disposal lane is folded into that
+  exit before publication, just as on orderly dispatch. Teardown drains only
+  the arrived prefix and never waits: a disposal still in flight remains
+  detached, and its unknowable result cannot delay the kill path. First
+  publication wins, so a later completion cannot overwrite the bounded
+  fallback. This is the same precision boundary `brutal_kill` → `killed`
+  makes, decided here once rather than per call site.
 - "Drained" has exactly one definition, derived from child state (no
   hand-maintained live counter).
 - Child exits are consumed through one funnel regardless of which await

--- a/SPEC.md
+++ b/SPEC.md
@@ -2309,13 +2309,12 @@ framework contract**. No other normative shutdown paragraph is unmapped.
   disposal state is not coarsened: teardown publishes its stored exit before
   discharging terminality, without waiting for the retained user-state
   disposal, so that classified verdict wins. A retained-construction
-  destructor panic still queued on the disposal lane is folded into that
-  exit before publication, just as on orderly dispatch. Teardown drains only
-  what the lane already holds and never waits: a disposal still in flight
-  remains detached, and its unknowable result cannot delay the kill path. A
-  completion the driver already lifted out of the lane into its current
-  arbitrated batch is likewise not folded — the teardown transition sorts
-  ahead of it — so the fold is a promptness improvement, not a guarantee.
+  destructor panic that has already been reported is folded into that exit
+  before publication, just as on orderly dispatch — whether it is still
+  queued on the disposal lane or was already collected into the driver's
+  current event batch, which a teardown transition outranks. Teardown folds
+  only what has been reported and never waits: a disposal still in flight
+  remains detached, and its unknowable result cannot delay the kill path.
   First publication wins, so a later completion cannot overwrite the bounded
   fallback. This is the same precision boundary `brutal_kill` → `killed`
   makes, decided here once rather than per call site.

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -462,6 +462,10 @@ pub fn unbounded_mpsc_try_recv<T>(receiver: &mut UnboundedMpscReceiver<T>) -> Op
     receiver.try_recv().ok()
 }
 
+pub fn unbounded_mpsc_is_empty<T>(receiver: &UnboundedMpscReceiver<T>) -> bool {
+    receiver.is_empty()
+}
+
 pub enum ScopeWake<T> {
     Signal,
     ParentShutdown,

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -363,8 +363,8 @@ impl Drop for ScopeRuntime {
         // chance to synthesize a coarse cancellation. The disposal job stays
         // detached; as on hard escalation, teardown does not wait for it and
         // cannot incorporate a destructor panic that has not completed at
-        // publication. A completion already queued on the disposal lane is
-        // available without waiting, however, so consume that arrived prefix
+        // publication. A completion that has already been reported is
+        // available without waiting, however, so fold everything reported
         // before falling back to the stored verdict.
         self.drain_arrived_disposal_events();
         let child_keys: Vec<_> = self.children.iter().map(|(key, _)| key).collect();

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -419,11 +419,30 @@ impl Drop for ScopeRuntime {
 }
 
 impl ScopeRuntime {
+    /// Folds every construction-disposal completion the lane already holds.
+    ///
+    /// Non-blocking by construction, so a disposal still running on the
+    /// blocking pool stays detached. A completion the driver already lifted
+    /// out of this lane into the current arbitrated batch is out of reach
+    /// here; SPEC records that limit and #293 tracks closing it.
     fn drain_arrived_disposal_events(&mut self) {
-        while let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
-            runtime::unbounded_mpsc_try_recv(&mut self.disposal_event_receiver)
+        while let Some(event) = runtime::unbounded_mpsc_try_recv(&mut self.disposal_event_receiver)
         {
-            self.handle_construction_disposed(child, panic);
+            // The lane has one producer, which sends exactly one variant.
+            // Assert rather than let a pattern-matching loop condition drop
+            // an unexpected event and silently abandon the rest of the
+            // drain; teardown runs this during an unwind, where a panic
+            // would abort.
+            debug_assert!(
+                matches!(
+                    event,
+                    DriverEvent::Child(ChildEvent::ConstructionDisposed { .. })
+                ),
+                "the disposal lane carries only construction-disposal completions"
+            );
+            if let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = event {
+                self.handle_construction_disposed(child, panic);
+            }
         }
     }
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -221,6 +221,12 @@ struct ScopeRuntime {
     events: runtime::UnboundedMpscSender<DriverEvent>,
     disposal_events: runtime::UnboundedMpscSender<DriverEvent>,
     disposal_event_receiver: runtime::UnboundedMpscReceiver<DriverEvent>,
+    /// Construction-disposal payloads lifted off the lane but not yet
+    /// folded. Collection empties the lane into the arbitrated batch, so
+    /// this is the only place a teardown transition sorted ahead of that
+    /// batch can still find them. Plain framework data — the completion
+    /// carries a message, never a user value.
+    arrived_disposal_panics: BTreeMap<ChildKey, Option<runtime::DisposalPanic>>,
     deadlines: DeadlineQueue<DeadlineKind>,
     jitter: runtime::JitterRng,
     role: ScopeRole,
@@ -419,12 +425,43 @@ impl Drop for ScopeRuntime {
 }
 
 impl ScopeRuntime {
-    /// Folds every construction-disposal completion the lane already holds.
+    /// Moves the payload of every construction-disposal completion in a
+    /// collected batch onto the scope.
+    ///
+    /// Arbitration dispatches a scope-shutdown transition ahead of the
+    /// `ChildExit` class this completion belongs to, so the fallback in
+    /// `force_child` runs while the completion is still undispatched. Once
+    /// staged here it is reachable from that fallback; the batch entry keeps
+    /// its position and dispatches the staged payload in arbitration order
+    /// when no teardown claimed it first.
+    fn stage_batch_disposal_panics(&mut self, pending: &mut [(ArbitrationClass, Pending)]) {
+        for (_, event) in pending {
+            if let Pending::Child(ChildEvent::ConstructionDisposed { child, panic }) = event {
+                let panic = panic.take();
+                self.stage_disposal_panic(*child, panic);
+            }
+        }
+    }
+
+    fn stage_disposal_panic(&mut self, child: ChildKey, panic: Option<runtime::DisposalPanic>) {
+        let replaced = self.arrived_disposal_panics.insert(child, panic);
+        debug_assert!(
+            replaced.is_none(),
+            "a terminal disposes its retained construction once, under a never-reused key"
+        );
+    }
+
+    fn take_arrived_disposal_panic(&mut self, child: ChildKey) -> Option<runtime::DisposalPanic> {
+        self.arrived_disposal_panics.remove(&child).flatten()
+    }
+
+    /// Folds every construction-disposal completion already reported,
+    /// whether it is still on the lane or was staged out of the current
+    /// batch.
     ///
     /// Non-blocking by construction, so a disposal still running on the
-    /// blocking pool stays detached. A completion the driver already lifted
-    /// out of this lane into the current arbitrated batch is out of reach
-    /// here; SPEC records that limit and #293 tracks closing it.
+    /// blocking pool stays detached and its unknowable result cannot delay
+    /// the kill path.
     fn drain_arrived_disposal_events(&mut self) {
         while let Some(event) = runtime::unbounded_mpsc_try_recv(&mut self.disposal_event_receiver)
         {
@@ -441,8 +478,15 @@ impl ScopeRuntime {
                 "the disposal lane carries only construction-disposal completions"
             );
             if let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = event {
-                self.handle_construction_disposed(child, panic);
+                self.stage_disposal_panic(child, panic);
             }
+        }
+        // Folding empties the staging map, so the batch entries these
+        // completions came from dispatch as no-ops against an already-taken
+        // `pending_terminal`.
+        while let Some(child) = self.arrived_disposal_panics.keys().next().copied() {
+            let panic = self.take_arrived_disposal_panic(child);
+            self.handle_construction_disposed(child, panic);
         }
     }
 
@@ -930,6 +974,7 @@ async fn run_scope_incarnation(
         events,
         disposal_events,
         disposal_event_receiver,
+        arrived_disposal_panics: BTreeMap::new(),
         deadlines: DeadlineQueue::default(),
         jitter: runtime::JitterRng::new(),
         role,
@@ -1081,6 +1126,10 @@ async fn run_scope_incarnation(
             continue;
         }
 
+        // Collection emptied the disposal lane into this batch. Stage the
+        // completion payloads on the scope before arbitration hands a
+        // teardown transition the chance to publish first.
+        scope.stage_batch_disposal_panics(&mut pending);
         arbitrate(&mut pending);
         for (_, event) in pending.drain(..) {
             match event {
@@ -1136,6 +1185,9 @@ async fn run_scope_incarnation(
                     readiness_signal_seen,
                 ),
                 Pending::Child(ChildEvent::ConstructionDisposed { child, panic }) => {
+                    // Staging emptied the event; a teardown that folded this
+                    // completion first leaves nothing to take.
+                    let panic = panic.or_else(|| scope.take_arrived_disposal_panic(child));
                     scope.handle_construction_disposed(child, panic);
                 }
                 Pending::Deadline(deadline) => scope.handle_deadline(deadline),

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -220,6 +220,7 @@ struct ScopeRuntime {
     restart_shutdown_retries: Vec<(ChildKey, Epoch)>,
     events: runtime::UnboundedMpscSender<DriverEvent>,
     disposal_events: runtime::UnboundedMpscSender<DriverEvent>,
+    disposal_event_receiver: runtime::UnboundedMpscReceiver<DriverEvent>,
     deadlines: DeadlineQueue<DeadlineKind>,
     jitter: runtime::JitterRng,
     role: ScopeRole,
@@ -355,11 +356,11 @@ impl Drop for ScopeRuntime {
         // must publish that verdict before the terminality fallback gets a
         // chance to synthesize a coarse cancellation. The disposal job stays
         // detached; as on hard escalation, teardown does not wait for it and
-        // does not incorporate a destructor panic that has not been
-        // dispatched at publication — including a completion already queued
-        // on the disposal lane but not yet dispatched. Consuming that arrived
-        // half is issue #291, which covers this site and the matching discard
-        // in `force_child`.
+        // cannot incorporate a destructor panic that has not completed at
+        // publication. A completion already queued on the disposal lane is
+        // available without waiting, however, so consume that arrived prefix
+        // before falling back to the stored verdict.
+        self.drain_arrived_disposal_events();
         let child_keys: Vec<_> = self.children.iter().map(|(key, _)| key).collect();
         for key in child_keys {
             if self
@@ -418,6 +419,14 @@ impl Drop for ScopeRuntime {
 }
 
 impl ScopeRuntime {
+    fn drain_arrived_disposal_events(&mut self) {
+        while let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
+            runtime::unbounded_mpsc_try_recv(&mut self.disposal_event_receiver)
+        {
+            self.handle_construction_disposed(child, panic);
+        }
+    }
+
     fn reduce(&mut self, event: SupervisorEvent) {
         supervisor_step(&mut self.supervisor, event, &mut self.supervisor_effects);
     }
@@ -852,7 +861,7 @@ async fn run_scope_incarnation(
         .saturating_mul(3)
         .max(MIN_EVENT_BATCH_LIMIT);
     let (events, mut event_receiver) = runtime::unbounded_mpsc();
-    let (disposal_events, mut disposal_event_receiver) = runtime::unbounded_mpsc();
+    let (disposal_events, disposal_event_receiver) = runtime::unbounded_mpsc();
     let (dynamic, mut dynamic_event_receiver) = if plan.root.flavor == ScopeFlavor::Dynamic {
         let (dynamic_events, receiver) = runtime::unbounded_mpsc();
         (Some(DynamicControl::new(dynamic_events)), Some(receiver))
@@ -901,6 +910,7 @@ async fn run_scope_incarnation(
         restart_shutdown_retries: Vec::new(),
         events,
         disposal_events,
+        disposal_event_receiver,
         deadlines: DeadlineQueue::default(),
         jitter: runtime::JitterRng::new(),
         role,
@@ -982,7 +992,7 @@ async fn run_scope_incarnation(
             EventLanes {
                 primary: &mut event_receiver,
                 control: dynamic_event_receiver.as_mut(),
-                disposal: &mut disposal_event_receiver,
+                disposal: &mut scope.disposal_event_receiver,
             },
             event_batch_limit,
             &mut pending,

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -224,10 +224,15 @@ impl ScopeRuntime {
             ladder.force(now);
         }
         self.advance_ladder(key, now);
+        // A retained-factory destructor may already have completed even
+        // though its disposal event has not reached ordinary dispatch. Fold
+        // every arrived completion before the hard-force fallback; the drain
+        // is non-blocking, so still-running disposal remains detached.
+        self.drain_arrived_disposal_events();
         if self.supervisor.is_disposing(key) {
             // The incarnation has already exited; only its retained factory
-            // remains. Hard escalation detaches that cleanup, but must not
-            // rewrite the actor's recorded verdict.
+            // remains and its disposal completion has not arrived. Hard
+            // escalation detaches that cleanup and keeps the recorded verdict.
             self.handle_construction_disposed(key, None);
         }
     }

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -231,9 +231,9 @@ impl ScopeRuntime {
         self.drain_arrived_disposal_events();
         if self.supervisor.is_disposing(key) {
             // The incarnation has already exited; only its retained factory
-            // remains, and the drain above found no completion queued for it.
-            // Hard escalation detaches that cleanup and keeps the recorded
-            // verdict.
+            // remains, and the fold above found no completion reported for
+            // it. Hard escalation detaches that cleanup and keeps the
+            // recorded verdict.
             self.handle_construction_disposed(key, None);
         }
     }

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -231,8 +231,9 @@ impl ScopeRuntime {
         self.drain_arrived_disposal_events();
         if self.supervisor.is_disposing(key) {
             // The incarnation has already exited; only its retained factory
-            // remains and its disposal completion has not arrived. Hard
-            // escalation detaches that cleanup and keeps the recorded verdict.
+            // remains, and the drain above found no completion queued for it.
+            // Hard escalation detaches that cleanup and keeps the recorded
+            // verdict.
             self.handle_construction_disposed(key, None);
         }
     }

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -79,8 +79,7 @@ async fn dynamic_high_cycle_add_remove_keeps_only_live_runtime_storage() {
 /// left queued here, so arbitration cannot be what suppresses the start.
 #[crate::runtime::test]
 async fn latched_removal_suppresses_a_queued_start_effect() {
-    let (mut scope, _events, mut dynamic_events, _disposal_events, control) =
-        running_dynamic_fixture();
+    let (mut scope, _events, mut dynamic_events, control) = running_dynamic_fixture();
     let root = Arc::clone(&scope.root);
     let starts = Arc::new(AtomicUsize::new(0));
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
@@ -366,8 +365,7 @@ fn dynamic_removal_waits_for_the_observation_gate_before_mutating_state() {
 
 #[crate::runtime::test]
 async fn final_removal_holds_the_id_until_removed_publication_commits() {
-    let (mut scope, _events, _dynamic_events, _disposal_events, control) =
-        running_dynamic_fixture();
+    let (mut scope, _events, _dynamic_events, control) = running_dynamic_fixture();
     let root = Arc::clone(&scope.root);
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
@@ -454,8 +452,7 @@ async fn final_removal_holds_the_id_until_removed_publication_commits() {
 
 #[crate::runtime::test]
 async fn removal_tolerates_synchronous_reclaim_from_the_stop_funnel() {
-    let (mut scope, _events, _dynamic_events, _disposal_events, control) =
-        running_dynamic_fixture();
+    let (mut scope, _events, _dynamic_events, control) = running_dynamic_fixture();
     let root = Arc::clone(&scope.root);
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
@@ -633,11 +630,10 @@ async fn admission_conversion_panic_does_not_poison_dynamic_cleanup() {
     root.set_startup(Ok(()));
 
     let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events.clone());
     root.set_dynamic_route(Some(control.clone()));
     root.set_admitted_children(Vec::new());
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_lifecycle(ScopeLifecycle::running())
         .with_dynamic(Some(control.clone()))
         .build();
@@ -696,7 +692,7 @@ async fn admission_conversion_panic_does_not_poison_dynamic_cleanup() {
 
 #[crate::runtime::test]
 async fn annulment_before_admission_owns_never_started_terminality() {
-    let (mut scope, _event_receiver, mut dynamic_event_receiver, _disposal_event_receiver, control) =
+    let (mut scope, _event_receiver, mut dynamic_event_receiver, control) =
         running_dynamic_fixture();
     let root = Arc::clone(&scope.root);
     let mut lifecycle = root.subscribe_lifecycle();
@@ -759,13 +755,8 @@ async fn annulment_before_admission_owns_never_started_terminality() {
 
 #[crate::runtime::test]
 async fn annulment_after_promotion_is_inert_and_supervision_owns_the_exit() {
-    let (
-        mut scope,
-        mut event_receiver,
-        mut dynamic_event_receiver,
-        mut disposal_event_receiver,
-        control,
-    ) = running_dynamic_fixture();
+    let (mut scope, mut event_receiver, mut dynamic_event_receiver, control) =
+        running_dynamic_fixture();
     let root = Arc::clone(&scope.root);
     let mut lifecycle = root.subscribe_lifecycle();
     let started = Latch::default();
@@ -838,7 +829,8 @@ async fn annulment_after_promotion_is_inert_and_supervision_owns_the_exit() {
     .await
     .dispatch(&mut scope);
     let disposal =
-        match crate::runtime::timeout(Duration::from_secs(2), disposal_event_receiver.recv()).await
+        match crate::runtime::timeout(Duration::from_secs(2), scope.disposal_event_receiver.recv())
+            .await
         {
             crate::runtime::Timeout::Completed(Some(event)) => event,
             crate::runtime::Timeout::Completed(None) => panic!("the disposal lane remains open"),
@@ -878,13 +870,8 @@ async fn annulment_after_promotion_is_inert_and_supervision_owns_the_exit() {
 #[crate::runtime::test]
 async fn annulment_racing_admission_resolves_to_one_terminalization_owner() {
     for _ in 0..64 {
-        let (
-            mut scope,
-            _event_receiver,
-            mut dynamic_event_receiver,
-            _disposal_event_receiver,
-            control,
-        ) = running_dynamic_fixture();
+        let (mut scope, _event_receiver, mut dynamic_event_receiver, control) =
+            running_dynamic_fixture();
         let root = Arc::clone(&scope.root);
         let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
             .expect("running dynamic scope reserves the child");
@@ -982,7 +969,7 @@ async fn annulment_racing_admission_resolves_to_one_terminalization_owner() {
 
 #[crate::runtime::test]
 async fn fused_cancellation_overtaking_admission_rejects_before_conversion() {
-    let (mut scope, _event_receiver, mut dynamic_event_receiver, _disposal_event_receiver, control) =
+    let (mut scope, _event_receiver, mut dynamic_event_receiver, control) =
         running_dynamic_fixture();
     let root = Arc::clone(&scope.root);
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
@@ -1049,7 +1036,7 @@ async fn fused_cancellation_overtaking_admission_rejects_before_conversion() {
 
 #[crate::runtime::test]
 async fn fused_cancellation_during_conversion_is_rejected_by_the_under_lock_recheck() {
-    let (mut scope, _event_receiver, mut dynamic_event_receiver, _disposal_event_receiver, control) =
+    let (mut scope, _event_receiver, mut dynamic_event_receiver, control) =
         running_dynamic_fixture();
     let root = Arc::clone(&scope.root);
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
@@ -1141,13 +1128,8 @@ enum RemovalSource {
 }
 
 async fn exercise_coalesced_removal(source: RemovalSource) {
-    let (
-        mut scope,
-        mut event_receiver,
-        mut dynamic_event_receiver,
-        mut disposal_event_receiver,
-        control,
-    ) = running_dynamic_fixture();
+    let (mut scope, mut event_receiver, mut dynamic_event_receiver, control) =
+        running_dynamic_fixture();
     let root = Arc::clone(&scope.root);
     let mut lifecycle = root.subscribe_lifecycle();
     let started = Latch::default();
@@ -1284,7 +1266,8 @@ async fn exercise_coalesced_removal(source: RemovalSource) {
     }
 
     let disposal =
-        match crate::runtime::timeout(Duration::from_secs(2), disposal_event_receiver.recv()).await
+        match crate::runtime::timeout(Duration::from_secs(2), scope.disposal_event_receiver.recv())
+            .await
         {
             crate::runtime::Timeout::Completed(Some(event)) => event,
             crate::runtime::Timeout::Completed(None) => {
@@ -1350,11 +1333,10 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
     root.set_startup(Ok(()));
 
     let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events.clone());
     root.set_dynamic_route(Some(control.clone()));
     root.set_admitted_children(Vec::new());
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_lifecycle(ScopeLifecycle::running())
         .with_dynamic(Some(control.clone()))
         .build();
@@ -1477,7 +1459,7 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
     assert_eq!(removal.key, key);
     scope.handle_removal(removal);
     let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
-        disposal_event_receiver.recv().await
+        scope.disposal_event_receiver.recv().await
     else {
         panic!("removal joins retained construction disposal")
     };

--- a/crates/shelterwood/src/driver/tests/events.rs
+++ b/crates/shelterwood/src/driver/tests/events.rs
@@ -164,11 +164,10 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
     root.set_startup(Ok(()));
 
     let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events.clone());
     root.set_dynamic_route(Some(control.clone()));
     root.set_admitted_children(Vec::new());
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_lifecycle(ScopeLifecycle::running())
         .with_dynamic(Some(control.clone()))
         .build();
@@ -265,7 +264,7 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
     assert_eq!(removal.key, key);
     scope.handle_removal(removal);
     let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
-        disposal_event_receiver.recv().await
+        scope.disposal_event_receiver.recv().await
     else {
         panic!("removal joins retained construction disposal")
     };

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -108,13 +108,12 @@ async fn incarnation_exhaustion_uses_post_disposal_retention_routing() {
             .collect(),
     );
     let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     let mut children = ChildArena::default();
     let key = children
         .insert(child)
         .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_intensity_policy(plan.intensity_policy())
         .with_children(children)
@@ -164,11 +163,11 @@ async fn incarnation_exhaustion_uses_post_disposal_retention_routing() {
     ));
     assert_eq!(root.snapshot().children.len(), 1);
 
-    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) =
-        disposal_event_receiver
-            .recv()
-            .await
-            .expect("disposal reports completion")
+    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = scope
+        .disposal_event_receiver
+        .recv()
+        .await
+        .expect("disposal reports completion")
     else {
         panic!("only construction disposal was armed")
     };
@@ -214,13 +213,12 @@ async fn first_spawn_exhaustion_stops_without_reporting_a_startup_abort() {
             .collect(),
     );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     let mut children = ChildArena::default();
     let key = children
         .insert(child)
         .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_intensity_policy(plan.intensity_policy())
         .with_children(children)
@@ -244,11 +242,11 @@ async fn first_spawn_exhaustion_stops_without_reporting_a_startup_abort() {
     scope.spawn_child(key);
     assert!(scope.children[key].is_disposing());
 
-    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) =
-        disposal_event_receiver
-            .recv()
-            .await
-            .expect("disposal reports completion")
+    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = scope
+        .disposal_event_receiver
+        .recv()
+        .await
+        .expect("disposal reports completion")
     else {
         panic!("only construction disposal was armed")
     };
@@ -312,13 +310,12 @@ async fn latched_shutdown_keeps_the_startup_verdict_for_its_follow_up_event() {
             .collect(),
     );
     let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     let mut children = ChildArena::default();
     let key = children
         .insert(child)
         .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_intensity_policy(plan.intensity_policy())
         .with_children(children)
@@ -372,7 +369,7 @@ async fn latched_shutdown_keeps_the_startup_verdict_for_its_follow_up_event() {
     assert!(scope.children[key].restart_deadline.is_none());
 
     let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
-        disposal_event_receiver.recv().await
+        scope.disposal_event_receiver.recv().await
     else {
         panic!("only construction disposal was armed")
     };
@@ -705,13 +702,12 @@ async fn settlement_terminates_when_the_first_spawn_exhausts_incarnations() {
             .collect(),
     );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     let mut children = ChildArena::default();
     let key = children
         .insert(child)
         .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_intensity_policy(plan.intensity_policy())
         .with_children(children)
@@ -736,11 +732,11 @@ async fn settlement_terminates_when_the_first_spawn_exhausts_incarnations() {
     // membership gates ordered startup, but can no longer be constructed.
     scope.settle_supervisor();
 
-    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) =
-        disposal_event_receiver
-            .recv()
-            .await
-            .expect("disposal reports completion")
+    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = scope
+        .disposal_event_receiver
+        .recv()
+        .await
+        .expect("disposal reports completion")
     else {
         panic!("only construction disposal was armed")
     };

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -348,7 +348,6 @@ struct AbortedNestedDriverFixture {
     incarnation: crate::identity::Incarnation,
     driver: ScopeRuntime,
     _events: crate::runtime::UnboundedMpscReceiver<DriverEvent>,
-    _disposal_events: crate::runtime::UnboundedMpscReceiver<DriverEvent>,
 }
 
 impl AbortedNestedDriverFixture {
@@ -372,8 +371,7 @@ impl AbortedNestedDriverFixture {
         nested.set_admitted_children(Vec::new());
 
         let (events, events_receiver) = crate::runtime::unbounded_mpsc();
-        let (disposal_events, disposal_receiver) = crate::runtime::unbounded_mpsc();
-        let driver = ScopeRuntimeBuilder::new(Arc::clone(&nested), epoch, events, disposal_events)
+        let driver = ScopeRuntimeBuilder::new(Arc::clone(&nested), epoch, events)
             .with_lifecycle(ScopeLifecycle::running())
             .build();
         Self {
@@ -382,7 +380,6 @@ impl AbortedNestedDriverFixture {
             incarnation,
             driver,
             _events: events_receiver,
-            _disposal_events: disposal_receiver,
         }
     }
 

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -234,6 +234,10 @@ async fn runtime_teardown_folds_an_arrived_factory_disposal_panic() {
 
     drop(scope);
 
+    assert_arrived_disposal_panic_published(&member);
+}
+
+fn assert_arrived_disposal_panic_published(member: &Arc<MemberCell>) {
     assert!(matches!(
         member.record().stage,
         MemberStage::Terminal(ref exit)
@@ -245,6 +249,38 @@ async fn runtime_teardown_folds_an_arrived_factory_disposal_panic() {
     ));
 }
 
+/// The lane is empty by the time a forced batch dispatches: collection
+/// already moved the completion into the batch, where `Pending::Force`
+/// (`ScopeShutdown`) outranks it (`ChildExit`). Staging is what keeps it
+/// reachable from the hard-force fallback.
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hard_force_folds_a_batch_collected_factory_disposal_panic() {
+    let (mut scope, key, member) = scope_with_arrived_factory_disposal_panic().await;
+
+    let mut pending = vec![Pending::Force.classified()];
+    collect_driver_events(&mut scope.disposal_event_receiver, 8, &mut pending);
+    scope.stage_batch_disposal_panics(&mut pending);
+    arbitrate(&mut pending);
+    let mut batch = pending.into_iter().map(|(_, event)| event);
+    assert!(matches!(batch.next(), Some(Pending::Force)));
+
+    scope.force_all();
+
+    assert!(!scope.supervisor.is_disposing(key));
+    assert_arrived_disposal_panic_published(&member);
+
+    // The batch's own entry still dispatches, against an already-taken
+    // `pending_terminal`, and must not disturb the published verdict.
+    let Some(Pending::Child(ChildEvent::ConstructionDisposed { child, panic })) = batch.next()
+    else {
+        panic!("the batch collected the construction-disposal completion")
+    };
+    assert_eq!(child, key);
+    let panic = panic.or_else(|| scope.take_arrived_disposal_panic(child));
+    scope.handle_construction_disposed(child, panic);
+    assert_arrived_disposal_panic_published(&member);
+}
+
 #[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
 async fn hard_force_folds_an_arrived_factory_disposal_panic() {
     let (mut scope, key, member) = scope_with_arrived_factory_disposal_panic().await;
@@ -252,15 +288,7 @@ async fn hard_force_folds_an_arrived_factory_disposal_panic() {
     scope.force_all();
 
     assert!(!scope.supervisor.is_disposing(key));
-    assert!(matches!(
-        member.record().stage,
-        MemberStage::Terminal(ref exit)
-            if matches!(
-                exit.kind(),
-                ExitKind::Panicked { message }
-                    if message.as_deref() == Some(ARRIVED_FACTORY_DISPOSAL_PANIC)
-            )
-    ));
+    assert_arrived_disposal_panic_published(&member);
 }
 
 #[crate::runtime::test]

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -84,7 +84,7 @@ async fn scope_with_arrived_factory_disposal_panic() -> (ScopeRuntime, ChildKey,
     assert!(scope.children[key].pending_terminal.is_some());
 
     let arrived = crate::runtime::timeout(DRIVER_PROGRESS_WAIT, async {
-        while scope.disposal_event_receiver.is_empty() {
+        while crate::runtime::unbounded_mpsc_is_empty(&scope.disposal_event_receiver) {
             crate::runtime::yield_now().await;
         }
     })

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -8,6 +8,91 @@ impl Drop for BlockingFactoryDrop {
     }
 }
 
+const ARRIVED_FACTORY_DISPOSAL_PANIC: &str = "arrived factory disposal panic";
+
+struct PanickingFactoryDrop;
+
+impl Drop for PanickingFactoryDrop {
+    fn drop(&mut self) {
+        panic!("{ARRIVED_FACTORY_DISPOSAL_PANIC}");
+    }
+}
+
+async fn scope_with_arrived_factory_disposal_panic() -> (ScopeRuntime, ChildKey, Arc<MemberCell>) {
+    let mut tree = Tree::new();
+    tree.add_task(
+        "worker",
+        TaskDef::new({
+            let capture = PanickingFactoryDrop;
+            move |_| {
+                let _ = &capture;
+                future::pending::<crate::ExitResult>()
+            }
+        })
+        .restart(RestartPolicy::new(
+            RestartCondition::Never,
+            Backoff::Immediate,
+        ))
+        .retention(Retention::Retain),
+    )
+    .expect("valid task");
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.member
+        .update(|record| record.stage = MemberStage::Running);
+    root.set_state_and_startup(ScopeState::Running, Ok(()));
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
+    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+    let member = Arc::clone(&child.slot.member);
+    let mut children = ChildArena::default();
+    let key = children
+        .insert(child)
+        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+    let mut scope = ScopeRuntimeBuilder::new(root, epoch, events)
+        .with_defaults(plan.defaults.clone())
+        .with_children(children)
+        .with_lifecycle(ScopeLifecycle::running())
+        .build();
+    plan.finish_transfer();
+
+    scope.spawn_child(key);
+    let active = scope.children[key]
+        .active
+        .as_ref()
+        .expect("worker is active");
+    let incarnation = active.incarnation;
+    active.abort_handle.abort();
+    scope.handle_exit(
+        key,
+        incarnation,
+        Some(RecordedOutcome::returned(Err(ExitError::message(
+            "application failure",
+        )))),
+        crate::runtime::JoinOutcome::Ok { value: () },
+        Cancellation::NotObserved,
+        false,
+    );
+    assert!(scope.children[key].pending_terminal.is_some());
+
+    let arrived = crate::runtime::timeout(DRIVER_PROGRESS_WAIT, async {
+        while scope.disposal_event_receiver.is_empty() {
+            crate::runtime::yield_now().await;
+        }
+    })
+    .await;
+    assert!(matches!(arrived, crate::runtime::Timeout::Completed(())));
+    (scope, key, member)
+}
+
 #[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
 async fn runtime_teardown_finishes_the_cancelled_root_driver() {
     let plan = DynamicTree::new().lower_for_test();
@@ -143,6 +228,41 @@ async fn runtime_teardown_publishes_the_exit_awaiting_factory_disposal() {
     assert_eq!(record.last_exit, Some(terminal));
 }
 
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+async fn runtime_teardown_folds_an_arrived_factory_disposal_panic() {
+    let (scope, _key, member) = scope_with_arrived_factory_disposal_panic().await;
+
+    drop(scope);
+
+    assert!(matches!(
+        member.record().stage,
+        MemberStage::Terminal(ref exit)
+            if matches!(
+                exit.kind(),
+                ExitKind::Panicked { message }
+                    if message.as_deref() == Some(ARRIVED_FACTORY_DISPOSAL_PANIC)
+            )
+    ));
+}
+
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hard_force_folds_an_arrived_factory_disposal_panic() {
+    let (mut scope, key, member) = scope_with_arrived_factory_disposal_panic().await;
+
+    scope.force_all();
+
+    assert!(!scope.supervisor.is_disposing(key));
+    assert!(matches!(
+        member.record().stage,
+        MemberStage::Terminal(ref exit)
+            if matches!(
+                exit.kind(),
+                ExitKind::Panicked { message }
+                    if message.as_deref() == Some(ARRIVED_FACTORY_DISPOSAL_PANIC)
+            )
+    ));
+}
+
 #[crate::runtime::test]
 async fn latched_shutdown_upgrades_an_intensity_drain() {
     let mut tree = Tree::new();
@@ -166,13 +286,12 @@ async fn latched_shutdown_upgrades_an_intensity_drain() {
     root.set_state(ScopeState::Running);
     root.set_startup(Ok(()));
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     let mut children = ChildArena::default();
     let key = children
         .insert(child)
         .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_intensity_policy(plan.intensity_policy())
         .with_children(children)
@@ -239,13 +358,12 @@ async fn force_upgrades_an_intensity_drain_to_shutdown_requested() {
     root.set_state(ScopeState::Running);
     root.set_startup(Ok(()));
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     let mut children = ChildArena::default();
     let key = children
         .insert(child)
         .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_intensity_policy(plan.intensity_policy())
         .with_children(children)
@@ -311,7 +429,6 @@ async fn force_uses_the_stop_funnel_for_every_ordered_child() {
             .collect(),
     );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let mut children = ChildArena::default();
     plan.children.reverse();
     while let Some(child) = plan.children.pop() {
@@ -320,7 +437,7 @@ async fn force_uses_the_stop_funnel_for_every_ordered_child() {
             .unwrap_or_else(|_| panic!("the fixture fits in the child-key domain"));
     }
     let keys = children.keys().collect::<Vec<_>>();
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_intensity_policy(plan.intensity_policy())
         .with_children(children)
@@ -421,7 +538,6 @@ fn forced_ordered_drain_advances_an_inactive_suffix_iteratively() {
             .collect(),
     );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let mut children = ChildArena::default();
     plan.children.reverse();
     while let Some(child) = plan.children.pop() {
@@ -435,7 +551,7 @@ fn forced_ordered_drain_advances_an_inactive_suffix_iteratively() {
     for child in children.values_mut() {
         drop(child.construction.take());
     }
-    let mut scope = ScopeRuntimeBuilder::new(root, epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(root, epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_intensity_policy(plan.intensity_policy())
         .with_children(children)

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -87,13 +87,12 @@ async fn pre_admission_restart_shutdown_does_not_expedite_the_following_incarnat
             .collect(),
     );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     let mut children = ChildArena::default();
     let key = children
         .insert(child)
         .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_lifecycle(ScopeLifecycle::running())
         .with_children(children)
@@ -179,7 +178,6 @@ async fn expedited_restart_progresses_synchronous_readiness() {
             .collect(),
     );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let mut child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     // Scope definitions currently resolve to Manual and expose no public
     // readiness setter. Model that API invariant changing: the expedited
@@ -190,7 +188,7 @@ async fn expedited_restart_progresses_synchronous_readiness() {
     let key = children
         .insert(child)
         .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_children(children)
         .with_next_ordered_start(Some(key))
@@ -262,7 +260,6 @@ async fn early_restart_shutdown_does_not_expedite_a_never_started_ordered_child(
             .collect(),
     );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let mut children = ChildArena::default();
     plan.children.reverse();
     while let Some(child) = plan.children.pop() {
@@ -275,7 +272,7 @@ async fn early_restart_shutdown_does_not_expedite_a_never_started_ordered_child(
         .keys()
         .find(|key| children[*key].slot.member.id().as_str() == "nested")
         .expect("nested child key");
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_children(children)
         .with_next_ordered_start(Some(first))
@@ -347,13 +344,12 @@ async fn restart_shutdown_arriving_before_exit_is_retried_after_the_child_become
             .collect(),
     );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     let mut children = ChildArena::default();
     let key = children
         .insert(child)
         .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_lifecycle(ScopeLifecycle::running())
         .with_children(children)
@@ -445,7 +441,6 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
             .collect(),
     );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let mut children = ChildArena::default();
     plan.children.reverse();
     while let Some(child) = plan.children.pop() {
@@ -462,7 +457,7 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
         .find(|key| children[*key].slot.member.id().as_str() == "trip")
         .expect("tripping child key");
     let next_ordered_start = children.keys().next();
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_intensity_policy(plan.intensity_policy())
         .with_children(children)
@@ -606,7 +601,6 @@ async fn same_batch_intensity_exit_suppresses_retained_expedite_retry() {
             .collect(),
     );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let mut children = ChildArena::default();
     plan.children.reverse();
     while let Some(child) = plan.children.pop() {
@@ -623,7 +617,7 @@ async fn same_batch_intensity_exit_suppresses_retained_expedite_retry() {
         .find(|key| children[*key].slot.member.id().as_str() == "trip")
         .expect("tripping child key");
     let next_ordered_start = children.keys().next();
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_intensity_policy(plan.intensity_policy())
         .with_children(children)
@@ -769,13 +763,12 @@ async fn same_batch_self_stop_preserves_fired_readiness_for_startup() {
             .collect(),
     );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, mut disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     let mut children = ChildArena::default();
     let key = children
         .insert(child)
         .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_intensity_policy(plan.intensity_policy())
         .with_children(children)
@@ -839,11 +832,11 @@ async fn same_batch_self_stop_preserves_fired_readiness_for_startup() {
         }
     }
 
-    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) =
-        disposal_event_receiver
-            .recv()
-            .await
-            .expect("disposal reports completion")
+    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = scope
+        .disposal_event_receiver
+        .recv()
+        .await
+        .expect("disposal reports completion")
     else {
         panic!("only construction disposal was armed")
     };
@@ -907,7 +900,6 @@ async fn ordered_startup_advances_past_a_reclaimed_cursor() {
             .collect(),
     );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let mut children = ChildArena::default();
     plan.children.reverse();
     while let Some(child) = plan.children.pop() {
@@ -917,7 +909,7 @@ async fn ordered_startup_advances_past_a_reclaimed_cursor() {
     }
     let gone = children.keys().next().expect("first ordered child");
     let next = children.keys().nth(1).expect("second ordered child");
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_children(children)
         .with_next_ordered_start(Some(gone))
@@ -981,7 +973,6 @@ async fn startup_removal_response_follows_aggregate_recomputation() {
     );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
     let (control_events, _control_event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(control_events);
     let mut children = ChildArena::default();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
@@ -993,7 +984,7 @@ async fn startup_removal_response_follows_aggregate_recomputation() {
     });
     root.set_dynamic_route(Some(control.clone()));
     let member = Arc::clone(&children[key].slot.member);
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_children(children)
         .with_dynamic(Some(control))
@@ -1057,7 +1048,6 @@ async fn queued_removal_suppresses_replayed_self_stop_readiness() {
     );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
     let (control_events, mut control_event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, _disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(control_events);
     let mut children = ChildArena::default();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
@@ -1069,7 +1059,7 @@ async fn queued_removal_suppresses_replayed_self_stop_readiness() {
     });
     root.set_dynamic_route(Some(control.clone()));
     let member = Arc::clone(&children[key].slot.member);
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events, disposal_events)
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_children(children)
         .with_dynamic(Some(control))

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -85,10 +85,9 @@ pub(super) use super::super::{
     MemberCell, MemberStage, MemberTransition, NestedScopeLatches, Pending, RemovalRequest,
     RemovalResponses, ResidentProjection, RuntimeStorage, ScopeCell, ScopeControlEvent,
     ScopeEpochGuard, ScopeFlavor, ScopeRole, ScopeRuntime, StartupDisposition,
-    cancel_dynamic_reservation, discharge_child_terminality,
-    events::collect_driver_events, monitor_root_driver, report_slot,
-    reserve_dynamic, resident_projection, restart_shutdown_work, run_nested_factory,
-    run_nested_tree, run_scope, run_scope_incarnation, storage::Obligation,
+    cancel_dynamic_reservation, discharge_child_terminality, events::collect_driver_events,
+    monitor_root_driver, report_slot, reserve_dynamic, resident_projection, restart_shutdown_work,
+    run_nested_factory, run_nested_tree, run_scope, run_scope_incarnation, storage::Obligation,
 };
 
 pub(super) async fn begin_admission(

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -85,7 +85,8 @@ pub(super) use super::super::{
     MemberCell, MemberStage, MemberTransition, NestedScopeLatches, Pending, RemovalRequest,
     RemovalResponses, ResidentProjection, RuntimeStorage, ScopeCell, ScopeControlEvent,
     ScopeEpochGuard, ScopeFlavor, ScopeRole, ScopeRuntime, StartupDisposition,
-    cancel_dynamic_reservation, discharge_child_terminality, monitor_root_driver, report_slot,
+    cancel_dynamic_reservation, discharge_child_terminality,
+    events::collect_driver_events, monitor_root_driver, report_slot,
     reserve_dynamic, resident_projection, restart_shutdown_work, run_nested_factory,
     run_nested_tree, run_scope, run_scope_incarnation, storage::Obligation,
 };
@@ -273,6 +274,7 @@ impl ScopeRuntimeBuilder {
             events: self.events,
             disposal_events: self.disposal_events,
             disposal_event_receiver: self.disposal_event_receiver,
+            arrived_disposal_panics: BTreeMap::new(),
             deadlines: super::super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::new(),
             role: ScopeRole::Root,

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -168,6 +168,7 @@ pub(super) struct ScopeRuntimeBuilder {
     epoch: Epoch,
     events: crate::runtime::UnboundedMpscSender<DriverEvent>,
     disposal_events: crate::runtime::UnboundedMpscSender<DriverEvent>,
+    disposal_event_receiver: crate::runtime::UnboundedMpscReceiver<DriverEvent>,
     defaults: ResolvedDefaults,
     intensity_policy: Intensity,
     children: ChildArena<ChildRuntime>,
@@ -182,13 +183,14 @@ impl ScopeRuntimeBuilder {
         root: Arc<ScopeCell>,
         epoch: Epoch,
         events: crate::runtime::UnboundedMpscSender<DriverEvent>,
-        disposal_events: crate::runtime::UnboundedMpscSender<DriverEvent>,
     ) -> Self {
+        let (disposal_events, disposal_event_receiver) = crate::runtime::unbounded_mpsc();
         Self {
             root,
             epoch,
             events,
             disposal_events,
+            disposal_event_receiver,
             defaults: ResolvedDefaults::default(),
             intensity_policy: Intensity::default(),
             children: ChildArena::default(),
@@ -270,6 +272,7 @@ impl ScopeRuntimeBuilder {
             supervisor_effects,
             events: self.events,
             disposal_events: self.disposal_events,
+            disposal_event_receiver: self.disposal_event_receiver,
             deadlines: super::super::DeadlineQueue::default(),
             jitter: crate::runtime::JitterRng::new(),
             role: ScopeRole::Root,
@@ -314,7 +317,6 @@ pub(super) fn running_dynamic_fixture() -> (
     ScopeRuntime,
     crate::runtime::UnboundedMpscReceiver<DriverEvent>,
     crate::runtime::UnboundedMpscReceiver<DriverEvent>,
-    crate::runtime::UnboundedMpscReceiver<DriverEvent>,
     Arc<DynamicControl>,
 ) {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
@@ -328,21 +330,14 @@ pub(super) fn running_dynamic_fixture() -> (
 
     let (events, event_receiver) = crate::runtime::unbounded_mpsc();
     let (dynamic_events, dynamic_event_receiver) = crate::runtime::unbounded_mpsc();
-    let (disposal_events, disposal_event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(dynamic_events);
     root.set_dynamic_route(Some(control.clone()));
     root.set_admitted_children(Vec::new());
-    let scope = ScopeRuntimeBuilder::new(root, epoch, events, disposal_events)
+    let scope = ScopeRuntimeBuilder::new(root, epoch, events)
         .with_lifecycle(ScopeLifecycle::running())
         .with_dynamic(Some(control.clone()))
         .build();
-    (
-        scope,
-        event_receiver,
-        dynamic_event_receiver,
-        disposal_event_receiver,
-        control,
-    )
+    (scope, event_receiver, dynamic_event_receiver, control)
 }
 
 #[derive(Debug, Default)]

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -158,11 +158,10 @@ async fn root_driver_panic_mid_drain_upgrades_to_the_join_monitor_verdict() {
     let mut events = handle.subscribe_lifecycle();
 
     let (events_tx, _events_rx) = crate::runtime::unbounded_mpsc();
-    let (disposal_events_tx, _disposal_events_rx) = crate::runtime::unbounded_mpsc();
     let driver = crate::runtime::spawn({
         let scope = Arc::clone(&scope);
         async move {
-            let _runtime = ScopeRuntimeBuilder::new(scope, epoch, events_tx, disposal_events_tx)
+            let _runtime = ScopeRuntimeBuilder::new(scope, epoch, events_tx)
                 .with_lifecycle(lifecycle)
                 .build();
             panic!("root driver panicked mid-drain");


### PR DESCRIPTION
## Summary

- move the construction-disposal receiver into `ScopeRuntime` so synchronous teardown can inspect the same lane as orderly dispatch
- non-blockingly drain already-arrived disposal completions before both driver-drop and hard-force fallbacks publish stored exits
- retain bounded teardown for disposal work that is still in flight
- update the shutdown contract and add regressions for both discard sites

## Root cause

Both teardown paths called `handle_construction_disposed(key, None)` without checking whether the retained factory's disposal completion was already queued. Because the receiver lived only as a local in `run_scope_incarnation`, teardown could not recover the queued panic and published the provisional classified exit instead of applying the normal `Panicked` precedence upgrade.

## Impact

Already-reported retained-construction destructor panics now reach terminal child records and lifecycle exits consistently at hard-force and driver-death boundaries. Teardown remains non-blocking and does not wait for still-running user destruction.

## Validation

- `./tools/dev just ci`

Fixes #291