### PR TITLE
Make terminalizer races first-wins and lock-safe

### DIFF
--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -2127,8 +2127,12 @@ impl ScopeCell {
                     self.close_observation_locked(wakes);
                 }
                 // `StopReason::StartupFailed` recursively owns the failed
-                // child's user error. A stale verdict is unused, but it still
-                // leaves only after the observation gate is released.
+                // child's user error. A stale verdict is unused, but the
+                // framework still owns this copy: retaining it before the
+                // deferred drop sends a possibly-blocking or panicking user
+                // destructor to `dispose_critical` instead of running it
+                // inline on the committing thread once the gate is released.
+                let reason = RetainedStopReason::new(reason);
                 wakes.defer(move || drop(reason));
                 return;
             }
@@ -2687,6 +2691,68 @@ mod tests {
             disposal_thread, retiring_thread,
             "a losing failed exit must not run its user destructor on the committing thread"
         );
+    }
+
+    #[test]
+    fn a_stale_scope_verdict_disposes_its_nested_exit_off_the_finishing_thread() {
+        let finishing_thread = std::thread::current().id();
+        let mut identity = ScopeIdentity::new();
+        let root_id = ChildId::from("root");
+        let root = MemberCell::new(
+            root_id.clone(),
+            identity
+                .mint_membership(&root_id)
+                .expect("root membership is available"),
+        );
+        let scope = ScopeCell::new(root, ScopeFlavor::Ordered, ScopeIdentity::new());
+        let child_id = ChildId::from("worker");
+        let child = MemberCell::new(
+            child_id.clone(),
+            identity
+                .mint_membership(&child_id)
+                .expect("child membership is available"),
+        );
+
+        let stale = scope
+            .begin_incarnation(ScopeState::Starting)
+            .expect("first scope epoch is available");
+        scope.finish_incarnation(stale, StopReason::Finished);
+        let live = scope
+            .begin_incarnation(ScopeState::Starting)
+            .expect("second scope epoch is available");
+
+        // The stale epoch is declined, so this structured verdict is never
+        // published — but the framework still owns the failed child `Exit` it
+        // recursively carries, and must not run that user destructor inline.
+        let (dropped, observed) = mpsc::sync_channel(1);
+        scope.finish_incarnation(
+            stale,
+            StopReason::StartupFailed(StartupFailure {
+                cause: StartupFailureCause::Child {
+                    id: child_id,
+                    membership: child.membership(),
+                    exit: Exit::new(
+                        ExitKind::Failed(ExitError::from(ThreadProbe(dropped))),
+                        Cancellation::NotObserved,
+                    ),
+                },
+            }),
+        );
+
+        let disposal_thread = observed
+            .recv_timeout(Duration::from_secs(10))
+            .expect("the stale verdict's nested exit is destroyed");
+        assert_ne!(
+            disposal_thread, finishing_thread,
+            "a declined stop reason must not run its nested user destructor on the \
+             finishing thread"
+        );
+        assert_eq!(
+            scope.record().state,
+            ScopeState::Starting,
+            "the stale verdict must not rewrite the newer incarnation"
+        );
+        scope.finish_incarnation(live, StopReason::Finished);
     }
 
     #[test]

--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -759,16 +759,20 @@ impl MemberCell {
             }
         };
         if let Some(losing_exit) = losing_exit {
+            // This is framework-retained ownership, not a value returned to a
+            // user. Route a failed exit's possibly-blocking user destructor
+            // through the critical-disposal lane after the gate is released.
+            let losing_exit = RetainedExit::new(losing_exit);
             txn.defer(move || drop(losing_exit));
         }
         let mut published = false;
         self.record.modify_silently(|record| {
-            match startup {
-                StartupDisposition::Unchanged => {}
-                StartupDisposition::NotAborted => record.startup_aborted = false,
-                StartupDisposition::Aborted => record.startup_aborted = true,
-            }
             if !matches!(record.stage, MemberStage::Terminal(_)) {
+                match startup {
+                    StartupDisposition::Unchanged => {}
+                    StartupDisposition::NotAborted => record.startup_aborted = false,
+                    StartupDisposition::Aborted => record.startup_aborted = true,
+                }
                 record.incarnation = None;
                 record.restart_at = None;
                 record.last_exit = Some(terminal_exit.clone());
@@ -780,7 +784,6 @@ impl MemberCell {
             // keeps the inline drops refcount-only.
             record.refresh_retained_exits();
         });
-        let record_changed = published || startup != StartupDisposition::Unchanged;
         // Store before discharge so reentrant mailbox wakers observe the
         // winning exit. Notification-driven readers still see
         // discharge-before-pulse; tree-scoped publication defers both until
@@ -798,10 +801,10 @@ impl MemberCell {
                 }
             });
         }
-        // A supervised terminal edge updates `startup_aborted` even if a
-        // competing terminalizer won the stage transition. Its record pulse
-        // remains required, but mailbox discharge must lead it.
-        if record_changed {
+        // First terminalizer wins. A losing edge neither reclassifies startup
+        // nor publishes a second record edge; a future caller that needs
+        // different semantics must make that race explicit at its boundary.
+        if published {
             txn.pulse(&self.record);
         }
         terminal_exit
@@ -1689,6 +1692,13 @@ impl ScopeCell {
         self.with_observation_gate(|wakes| {
             let record = member.record();
             if matches!(record.stage, MemberStage::Terminal(_)) {
+                // The outer guard defines losing supervised terminalization:
+                // no record or lifecycle edge is published. Keep the incoming
+                // failed exit behind the same isolated-disposal boundary as a
+                // losing direct terminalizer, and do not destroy it under the
+                // observation gate.
+                let exit = RetainedExit::new(exit);
+                wakes.defer(move || drop(exit));
                 return false;
             }
             // Nested publication and closure are reached only through this
@@ -2116,6 +2126,10 @@ impl ScopeCell {
                     wakes.pulse(&self.observation.record);
                     self.close_observation_locked(wakes);
                 }
+                // `StopReason::StartupFailed` recursively owns the failed
+                // child's user error. A stale verdict is unused, but it still
+                // leaves only after the observation gate is released.
+                wakes.defer(move || drop(reason));
                 return;
             }
             if control
@@ -2638,6 +2652,40 @@ mod tests {
         assert_ne!(
             disposal_thread, retiring_thread,
             "a retained failed exit must not run its user destructor inline"
+        );
+    }
+
+    #[test]
+    fn a_losing_failed_terminal_exit_disposes_off_the_retiring_thread() {
+        let retiring_thread = std::thread::current().id();
+        let mut identity = ScopeIdentity::new();
+        let id = ChildId::from("worker");
+        let member = MemberCell::new(
+            id.clone(),
+            identity
+                .mint_membership(&id)
+                .expect("membership is available"),
+        );
+        member.terminalize(
+            Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+            StartupDisposition::Unchanged,
+        );
+        let (dropped, observed) = mpsc::sync_channel(1);
+
+        member.terminalize(
+            Exit::new(
+                ExitKind::Failed(ExitError::from(ThreadProbe(dropped))),
+                Cancellation::NotObserved,
+            ),
+            StartupDisposition::Unchanged,
+        );
+
+        let disposal_thread = observed
+            .recv_timeout(Duration::from_secs(10))
+            .expect("losing exit disposal completes");
+        assert_ne!(
+            disposal_thread, retiring_thread,
+            "a losing failed exit must not run its user destructor on the committing thread"
         );
     }
 

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -167,6 +167,42 @@ fn stale_scope_driver_cannot_stop_a_newer_live_incarnation_projection() {
 }
 
 #[test]
+fn a_stale_scope_verdict_destroys_its_nested_exit_outside_the_gate() {
+    let scope = isolated_scope("scope", ScopeFlavor::Ordered);
+    let first = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("first scope epoch is available");
+    scope.finish_incarnation(first, StopReason::Finished);
+    let second = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("second scope epoch is available");
+    scope.set_state(ScopeState::Running);
+
+    let (exit, held_at_drop) = gate_probe_exit(&scope);
+    scope.finish_incarnation(
+        first,
+        StopReason::StartupFailed(StartupFailure {
+            cause: StartupFailureCause::Child {
+                id: ChildId::from("worker"),
+                membership: scope.member.membership(),
+                exit,
+            },
+        }),
+    );
+
+    assert!(
+        !wait_for_gate_probe(&held_at_drop),
+        "a stale structured stop reason must outlive the observation gate"
+    );
+    assert_eq!(
+        scope.record().state,
+        ScopeState::Running,
+        "the stale verdict must not rewrite the newer incarnation"
+    );
+    scope.finish_incarnation(second, StopReason::Finished);
+}
+
+#[test]
 fn a_new_incarnation_owns_an_unpublished_startup_verdict() {
     let scope = isolated_scope("scope", ScopeFlavor::Ordered);
     let first = scope
@@ -1350,6 +1386,46 @@ fn a_losing_terminal_exit_payload_is_destroyed_outside_the_gate() {
     assert!(
         !wait_for_gate_probe(&held_at_drop),
         "a competing terminalizer's exit payload must outlive the gate"
+    );
+}
+
+#[test]
+fn a_losing_supervised_terminal_exit_is_a_complete_noop_outside_the_gate() {
+    let root = isolated_scope("root", ScopeFlavor::Ordered);
+    let child_id = ChildId::from("worker");
+    let member = MemberCell::new(
+        child_id.clone(),
+        root.mint_membership(&child_id)
+            .expect("child membership available"),
+    );
+    resolve_fixture_options(&member);
+    root.admit_child(ResidentProjection::new(Arc::clone(&member), None));
+    member.terminalize(
+        Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+        StartupDisposition::NotAborted,
+    );
+    let winning_record = member.record();
+    let mut events = root.subscribe_lifecycle();
+
+    let (losing, held_at_drop) = gate_probe_exit(&root);
+    assert!(
+        !root.terminalize_child(&member, losing, None, StartupDisposition::Aborted),
+        "the outer guard rejects a losing supervised terminalizer"
+    );
+
+    assert!(
+        !wait_for_gate_probe(&held_at_drop),
+        "the rejected exit payload must leave through post-gate disposal"
+    );
+    assert_eq!(
+        member.record(),
+        winning_record,
+        "the rejected edge cannot reclassify the winning terminal record"
+    );
+    assert_eq!(
+        events.try_recv(),
+        Err(LifecycleTryRecvError::Empty),
+        "the rejected edge publishes no Exited event"
     );
 }
 

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -947,6 +947,47 @@ fn concurrent_terminalizers_return_after_one_consistent_record_is_visible() {
 }
 
 #[test]
+fn a_losing_terminalizer_does_not_reclassify_or_republish_startup() {
+    let mut identity = ScopeIdentity::new();
+    let id = ChildId::from("worker");
+    let member = MemberCell::new(
+        id.clone(),
+        identity.mint_membership(&id).expect("membership available"),
+    );
+    let winner = Exit::new(ExitKind::Completed, Cancellation::NotObserved);
+    member.terminalize(winner, StartupDisposition::NotAborted);
+    let winning_record = member.record();
+
+    let mut watcher = member.record_watcher();
+    let mut changed = Box::pin(watcher.changed());
+    assert!(
+        changed
+            .as_mut()
+            .poll(&mut Context::from_waker(Waker::noop()))
+            .is_pending(),
+        "the watcher starts at the winning terminal publication"
+    );
+
+    member.terminalize(
+        Exit::new(ExitKind::NeverStarted, Cancellation::NotObserved),
+        StartupDisposition::Aborted,
+    );
+
+    assert_eq!(
+        member.record(),
+        winning_record,
+        "first terminalizer wins the whole terminal record, including startup classification"
+    );
+    assert!(
+        changed
+            .as_mut()
+            .poll(&mut Context::from_waker(Waker::noop()))
+            .is_pending(),
+        "a losing terminalizer publishes no second record edge"
+    );
+}
+
+#[test]
 fn terminal_startup_wake_follows_member_and_incarnation_publication() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("root");


### PR DESCRIPTION
Closes #269.

## What changed

- make the first terminalizer own the complete terminal record, including startup classification
- prevent losing terminalizers from republishing a record edge
- route losing failed exits through `RetainedExit` so user payload destruction is isolated
- defer losing supervised exits and stale structured stop reasons until after the observation gate unlocks
- add direct regressions for the losing member path, the supervised outer guard, and stale scope epochs

## Why

`ScopeCell::terminalize_child` already rejected an already-terminal child, while `MemberCell::terminalize_locked` still contained dead logic that could update `startup_aborted` after a competing terminalizer won. The same trace exposed three paths whose safety depended on non-local ownership proofs for user-owning exits and stop reasons.

The resulting contract is explicit: the outer guard is authoritative, first terminalizer wins, and rejected values leave through post-unlock or isolated disposal.

## Validation

- mutation-checked all four repaired paths against their focused regressions
- `./tools/dev cargo test -p shelterwood-cells` (25 passed)
- `./tools/dev cargo test -p shelterwood --lib` (183 passed)
- `./tools/dev just ci` (678 nextest tests plus docs, API reachability, external consumer, and nix formatting)
- `git diff --check`

## Stack

This is the base for the #272 lock-rule hardening PR.