### PR TITLE
Keep raw timer state coherent across caught panics

### DIFF
--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -749,6 +749,25 @@ impl<M> TimerStore<M> {
         }
     }
 
+    fn rearm_interval(&mut self, arming_order: ArmingOrder, now: Instant) -> Option<M> {
+        let (message, deadline) = {
+            let entry = self.entry_mut(arming_order)?;
+            let period = entry.period?;
+            let deadline = crate::deadline::Deadline::after(now, period).instant();
+            let TimerMessage::Interval(message, clone_message) = &entry.message else {
+                unreachable!("an interval timer must own a message factory")
+            };
+            // Cloning is user code. Keep the entry's prior deadline intact
+            // until it succeeds so the fired batch can retry this arming if
+            // the panic escapes `recv` and the raw actor catches it.
+            let message = clone_message(message);
+            entry.deadline = deadline;
+            (message, deadline)
+        };
+        self.arm_deadline(arming_order, deadline);
+        Some(message)
+    }
+
     fn next_deadline(&self) -> Option<Instant> {
         self.deadlines.first().map(|(deadline, _)| *deadline)
     }
@@ -1658,7 +1677,10 @@ impl<M: Send + 'static> RawContext<M> {
                     .events
                     .pop_through(&mut batch.offloads_remaining)
                 {
-                    if let Some(message) = self.materialize_event(event) {
+                    let (restored, message) = self
+                        .with_ready_batch_installed(batch, |this| this.materialize_event(event));
+                    batch = restored;
+                    if let Some(message) = message {
                         self.resources.continuation_needs_external = false;
                         self.resources.ready_batch = Some(batch);
                         return Some(message);
@@ -1693,8 +1715,13 @@ impl<M: Send + 'static> RawContext<M> {
             }
             batch.continuations_remaining = 0;
 
-            while let Some(arming) = batch.armings.pop_front() {
-                if let Some(message) = self.deliver_timer(arming) {
+            while let Some(arming) = batch.armings.front().copied() {
+                let (restored, message) =
+                    self.with_ready_batch_installed(batch, |this| this.deliver_timer(arming));
+                batch = restored;
+                let removed = batch.armings.pop_front();
+                debug_assert_eq!(removed, Some(arming));
+                if let Some(message) = message {
                     self.resources.continuation_needs_external = false;
                     self.resources.ready_batch = Some(batch);
                     return Some(message);
@@ -1717,6 +1744,25 @@ impl<M: Send + 'static> RawContext<M> {
             }
             return None;
         }
+    }
+
+    /// Runs a callback-capable selection step while the authoritative batch
+    /// remains installed. If user code unwinds, the next caught receive sees
+    /// the same cutoffs and any not-yet-committed timer armings.
+    fn with_ready_batch_installed<R>(
+        &mut self,
+        batch: ReadyBatch,
+        operation: impl FnOnce(&mut Self) -> R,
+    ) -> (ReadyBatch, R) {
+        debug_assert!(self.resources.ready_batch.is_none());
+        self.resources.ready_batch = Some(batch);
+        let result = operation(self);
+        let batch = self
+            .resources
+            .ready_batch
+            .take()
+            .expect("callback-capable selection keeps its ready batch installed");
+        (batch, result)
     }
 
     fn materialize_event(&self, event: QueuedEvent<M>) -> Option<M> {
@@ -1762,15 +1808,7 @@ impl<M: Send + 'static> RawContext<M> {
     }
 
     fn deliver_timer(&mut self, arming: ArmingOrder) -> Option<M> {
-        let entry = self.resources.timers.entry_mut(arming)?;
-        if let Some(period) = entry.period {
-            let deadline = crate::deadline::Deadline::after(runtime::now(), period).instant();
-            entry.deadline = deadline;
-            let TimerMessage::Interval(message, clone_message) = &entry.message else {
-                unreachable!("an interval timer must own a message factory")
-            };
-            let message = clone_message(message);
-            self.resources.timers.arm_deadline(arming, deadline);
+        if let Some(message) = self.resources.timers.rearm_interval(arming, runtime::now()) {
             return Some(message);
         }
 
@@ -2182,7 +2220,7 @@ mod tests {
 
     /// Builds a live raw incarnation context whose mailbox is configured and
     /// bound, so `next_ready` can take the busy path without a driver.
-    fn bound_raw_context() -> (RawContext<u8>, ActorRef<u8>) {
+    fn bound_raw_context_for<M: Send + 'static>() -> (RawContext<M>, ActorRef<M>) {
         let mut identity = ScopeIdentity::new();
         let id = ChildId::from("raw-actor");
         let member = MemberCell::new(
@@ -2226,6 +2264,10 @@ mod tests {
             Readiness::Immediate,
         );
         (context, myself)
+    }
+
+    fn bound_raw_context() -> (RawContext<u8>, ActorRef<u8>) {
+        bound_raw_context_for()
     }
 
     fn marker(value: usize) -> QueuedEvent<usize> {
@@ -2303,6 +2345,24 @@ mod tests {
     struct CountedDrop {
         drops: Arc<AtomicUsize>,
         panic_on_drop: bool,
+    }
+
+    #[derive(Debug)]
+    struct PanicOnceClone {
+        clones: Arc<AtomicUsize>,
+        value: u8,
+    }
+
+    impl Clone for PanicOnceClone {
+        fn clone(&self) -> Self {
+            if self.clones.fetch_add(1, Ordering::SeqCst) == 0 {
+                panic!("interval message clone panic");
+            }
+            Self {
+                clones: Arc::clone(&self.clones),
+                value: self.value,
+            }
+        }
     }
 
     impl Drop for CountedDrop {
@@ -2641,6 +2701,81 @@ mod tests {
     }
 
     #[test]
+    fn a_caught_interval_clone_panic_preserves_the_fired_batch_for_retry() {
+        let clones = Arc::new(AtomicUsize::new(0));
+        let mut context = bound_raw_context_for::<PanicOnceClone>().0;
+        let arming = ArmingOrder(1);
+        let now = crate::runtime::now();
+        context.resources.timers.replace(
+            "interval",
+            Some(now),
+            arming,
+            TimerMessage::Interval(
+                PanicOnceClone {
+                    clones: Arc::clone(&clones),
+                    value: 7,
+                },
+                Clone::clone,
+            ),
+            Some(Duration::from_secs(1)),
+        );
+
+        let panic = catch_unwind(AssertUnwindSafe(|| context.try_recv()))
+            .expect_err("the first interval clone panic escapes the receive call");
+        assert_eq!(panic_message(&panic), Some("interval message clone panic"));
+        assert!(
+            context
+                .resources
+                .ready_batch
+                .as_ref()
+                .is_some_and(|batch| batch.armings.front() == Some(&arming)),
+            "the caught panic leaves the due arming in its installed batch"
+        );
+
+        let message = context
+            .try_recv()
+            .expect("the next receive retries the same interval firing");
+        assert_eq!(message.value, 7);
+        assert_eq!(clones.load(Ordering::SeqCst), 2);
+        assert!(
+            context.resources.timers.next_deadline().is_some(),
+            "a successful retry rearms the interval"
+        );
+    }
+
+    #[test]
+    fn a_caught_offload_continuation_panic_preserves_later_fired_work() {
+        let mut context = bound_raw_context_for::<u8>().0;
+        let arming = ArmingOrder(1);
+        let now = crate::runtime::now();
+        context
+            .resources
+            .timers
+            .replace("timer", Some(now), arming, TimerMessage::Once(7), None);
+        context.resources.events.push(QueuedEvent {
+            cancellation: Latch::default(),
+            make_message: Box::new(|| panic!("offload continuation panic")),
+        });
+
+        let panic = catch_unwind(AssertUnwindSafe(|| context.try_recv()))
+            .expect_err("the offload continuation panic escapes the receive call");
+        assert_eq!(panic_message(&panic), Some("offload continuation panic"));
+        assert!(
+            context
+                .resources
+                .ready_batch
+                .as_ref()
+                .is_some_and(|batch| batch.armings.front() == Some(&arming)),
+            "the caught continuation panic leaves later timer work in the batch"
+        );
+        assert_eq!(
+            context.try_recv(),
+            Some(7),
+            "the next receive completes the fired batch instead of losing it"
+        );
+    }
+
+    #[test]
     fn resident_raw_collections_do_not_clone_disposal_per_element() {
         let mut resources = RawResources::<()>::default();
         let baseline = Arc::strong_count(&resources.disposal.panic);
@@ -2924,6 +3059,42 @@ mod timer_store_tests {
             "new-u8"
         );
         assert!(timers.is_empty());
+    }
+
+    #[test]
+    fn interval_rearm_overflow_makes_the_live_entry_dormant() {
+        let now = Instant::now();
+        let arming = order(1);
+        let mut timers = TimerStore::default();
+        // Construct the delivery-time edge directly: the interval already
+        // fired at a representable deadline, but its next period does not fit
+        // in the clock domain.
+        timers.replace(
+            "interval",
+            Some(now),
+            arming,
+            TimerMessage::Interval("tick", Clone::clone),
+            Some(Duration::MAX),
+        );
+        assert_eq!(timers.take_due(now), [arming]);
+
+        assert_eq!(timers.rearm_interval(arming, now), Some("tick"));
+        assert_eq!(
+            timers
+                .entry_mut(arming)
+                .expect("the dormant interval remains clearable")
+                .deadline,
+            None
+        );
+        assert_eq!(
+            timers.next_deadline(),
+            None,
+            "overflow never substitutes an immediate delivery"
+        );
+        assert!(
+            timers.take(&"interval").is_some(),
+            "overflow dormancy does not erase the keyed interval"
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -1450,6 +1450,14 @@ impl<M: Send + 'static> RawContext<M> {
     /// [`continue_with`](Self::continue_with) continuation, which is a plain
     /// stored message whose construction cannot panic here — surfaces
     /// directly from this receive call.
+    ///
+    /// A panic escaping this call leaves the fired selection cut installed,
+    /// so the next receive retries the same timer arming rather than
+    /// discarding the remaining batch. A raw loop that catches such a panic
+    /// and receives again therefore repeats an interval whose user `Clone`
+    /// panics deterministically; clear that key with
+    /// [`clear_timer`](Self::clear_timer) — or [`stop`](Self::stop) — before
+    /// resuming the loop.
     pub async fn recv(&mut self) -> Option<M> {
         loop {
             if self.local_stop.is_fired() {
@@ -1495,6 +1503,14 @@ impl<M: Send + 'static> RawContext<M> {
     /// prefix. Retention is the guarantee, not a join: a payload recorded
     /// after the check is still the incarnation's exit, but is classified by
     /// the epilogue and cannot suppress `on_stop`.
+    ///
+    /// A panic escaping this call leaves the fired selection cut installed,
+    /// so the next receive retries the same timer arming rather than
+    /// discarding the remaining batch. A raw loop that catches such a panic
+    /// and receives again therefore repeats an interval whose user `Clone`
+    /// panics deterministically; clear that key with
+    /// [`clear_timer`](Self::clear_timer) — or [`stop`](Self::stop) — before
+    /// resuming the loop.
     pub fn try_recv(&mut self) -> Option<M> {
         if self.is_stopping() {
             self.freeze_and_report();

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -532,6 +532,12 @@ struct TimerEntry<M> {
     period: Option<Duration>,
 }
 
+enum IntervalRearm<M> {
+    Missing,
+    OneShot,
+    Interval(M),
+}
+
 /// Type-aware keyed timer lookup paired with an independently ordered
 /// deadline index.
 ///
@@ -749,10 +755,14 @@ impl<M> TimerStore<M> {
         }
     }
 
-    fn rearm_interval(&mut self, arming_order: ArmingOrder, now: Instant) -> Option<M> {
+    fn rearm_interval(&mut self, arming_order: ArmingOrder, now: Instant) -> IntervalRearm<M> {
         let (message, deadline) = {
-            let entry = self.entry_mut(arming_order)?;
-            let period = entry.period?;
+            let Some(entry) = self.entry_mut(arming_order) else {
+                return IntervalRearm::Missing;
+            };
+            let Some(period) = entry.period else {
+                return IntervalRearm::OneShot;
+            };
             let deadline = crate::deadline::Deadline::after(now, period).instant();
             let TimerMessage::Interval(message, clone_message) = &entry.message else {
                 unreachable!("an interval timer must own a message factory")
@@ -765,7 +775,7 @@ impl<M> TimerStore<M> {
             (message, deadline)
         };
         self.arm_deadline(arming_order, deadline);
-        Some(message)
+        IntervalRearm::Interval(message)
     }
 
     fn next_deadline(&self) -> Option<Instant> {
@@ -1808,8 +1818,10 @@ impl<M: Send + 'static> RawContext<M> {
     }
 
     fn deliver_timer(&mut self, arming: ArmingOrder) -> Option<M> {
-        if let Some(message) = self.resources.timers.rearm_interval(arming, runtime::now()) {
-            return Some(message);
+        match self.resources.timers.rearm_interval(arming, runtime::now()) {
+            IntervalRearm::Missing => return None,
+            IntervalRearm::OneShot => {}
+            IntervalRearm::Interval(message) => return Some(message),
         }
 
         let entry = self
@@ -2776,6 +2788,37 @@ mod tests {
     }
 
     #[test]
+    fn clearing_an_elapsed_undelivered_timer_skips_its_captured_arming() {
+        let mut context = bound_raw_context_for::<u8>().0;
+        let now = crate::runtime::now();
+        context.resources.timers.replace(
+            "first",
+            Some(now),
+            ArmingOrder(1),
+            TimerMessage::Once(1),
+            None,
+        );
+        context.resources.timers.replace(
+            "second",
+            Some(now),
+            ArmingOrder(2),
+            TimerMessage::Once(2),
+            None,
+        );
+
+        assert_eq!(context.try_recv(), Some(1));
+        assert!(
+            context.clear_timer(&"second"),
+            "an elapsed timer remains clearable before delivery"
+        );
+        assert_eq!(
+            context.try_recv(),
+            None,
+            "the fired batch skips an arming removed after its cut was captured"
+        );
+    }
+
+    #[test]
     fn resident_raw_collections_do_not_clone_disposal_per_element() {
         let mut resources = RawResources::<()>::default();
         let baseline = Arc::strong_count(&resources.disposal.panic);
@@ -2923,7 +2966,7 @@ mod timer_store_tests {
         time::{Duration, Instant},
     };
 
-    use super::{ArmingOrder, TimerMessage, TimerStore};
+    use super::{ArmingOrder, IntervalRearm, TimerMessage, TimerStore};
 
     fn order(value: u64) -> ArmingOrder {
         ArmingOrder(value)
@@ -3078,7 +3121,10 @@ mod timer_store_tests {
         );
         assert_eq!(timers.take_due(now), [arming]);
 
-        assert_eq!(timers.rearm_interval(arming, now), Some("tick"));
+        assert!(matches!(
+            timers.rearm_interval(arming, now),
+            IntervalRearm::Interval("tick")
+        ));
         assert_eq!(
             timers
                 .entry_mut(arming)


### PR DESCRIPTION
Closes #268.

## What changed

- keep the authoritative `ReadyBatch` installed while offload continuations and timer delivery invoke user code
- leave due timer armings queued until delivery succeeds
- clone interval messages before mutating the timer entry or deadline index
- pin delivery-time rearm overflow leaving a live, dormant, clearable interval (already the behaviour on `main`; this PR adds the regression #268 asked for)
- add regressions for a caught interval-clone panic, a caught continuation panic with later fired work, and interval rearm overflow

## Root cause

`next_ready` removed its `ReadyBatch` before callback-capable work, while `deliver_timer` updated the entry deadline before invoking the user `Clone`. A caught panic could therefore discard the remaining fired cut or leave an interval claiming a deadline absent from the deadline index.

The callback step is now effect-last: the batch remains recoverable during unwind, and timer state changes only after cloning succeeds.

## Validation

- `./tools/dev cargo test -p shelterwood raw:: --lib` (23 passed)
- `./tools/dev cargo test -p shelterwood --test events` (13 passed)
- `./tools/dev just ci` (677 nextest tests plus clippy, docs, API reachability, external consumer, and nix formatting)
- `git diff --check`

This PR is independent of #269/#294 and should land before #279 splits `raw.rs`.
