### PR TITLE
Make regression assertions externally observable

### DIFF
--- a/crates/shelterwood-mailbox/src/futures.rs
+++ b/crates/shelterwood-mailbox/src/futures.rs
@@ -700,6 +700,7 @@ mod tests {
         sync::{
             Arc, Mutex, Weak,
             atomic::{AtomicUsize, Ordering},
+            mpsc,
         },
         task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker},
         thread::ThreadId,
@@ -712,6 +713,8 @@ mod tests {
         super::cell::tests::{actor, actor_for},
         ActorRef, MailboxCell, SendFuture, SendFutureState, SendOperation,
     };
+
+    const DISPOSAL_WAIT: Duration = Duration::from_secs(5);
 
     #[derive(Default)]
     struct WakerVtableCalls {
@@ -851,11 +854,15 @@ mod tests {
         );
     }
 
-    struct CountedDrop(Arc<AtomicUsize>);
+    struct CountedDrop {
+        drops: Arc<AtomicUsize>,
+        disposed: mpsc::Sender<()>,
+    }
 
     impl Drop for CountedDrop {
         fn drop(&mut self) {
-            self.0.fetch_add(1, Ordering::SeqCst);
+            self.drops.fetch_add(1, Ordering::SeqCst);
+            let _ = self.disposed.send(());
         }
     }
 
@@ -863,17 +870,18 @@ mod tests {
     fn dropping_a_never_polled_send_disposes_the_message_exactly_once() {
         let (mailbox, actor): (Arc<MailboxCell<CountedDrop>>, ActorRef<CountedDrop>) = actor_for();
         let drops = Arc::new(AtomicUsize::new(0));
+        let (disposed, disposal) = mpsc::channel();
 
-        drop(actor.send(CountedDrop(Arc::clone(&drops))));
+        drop(actor.send(CountedDrop {
+            drops: Arc::clone(&drops),
+            disposed,
+        }));
 
         // The never-submitted message routes through detached isolated
         // disposal on another thread, so acknowledge it with a bounded wait.
-        for _ in 0..1_000 {
-            if drops.load(Ordering::SeqCst) == 1 {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(5));
-        }
+        disposal
+            .recv_timeout(DISPOSAL_WAIT)
+            .expect("isolated disposal destroys the never-submitted message");
         assert_eq!(drops.load(Ordering::SeqCst), 1);
         let state = mailbox.state.lock().expect("mailbox mutex poisoned");
         assert!(state.queue.is_empty());
@@ -882,20 +890,38 @@ mod tests {
 
     /// Records the thread a destructor ran on, so a test can tell an inline
     /// destructor apart from one that reached isolated disposal.
-    type DisposalThread = Arc<Mutex<Option<ThreadId>>>;
+    #[derive(Clone)]
+    struct DisposalThread {
+        recorded: Arc<Mutex<Option<ThreadId>>>,
+        notification: mpsc::Sender<ThreadId>,
+        receiver: Arc<Mutex<mpsc::Receiver<ThreadId>>>,
+    }
 
     fn disposal_thread() -> DisposalThread {
-        Arc::new(Mutex::new(None))
+        let (notification, receiver) = mpsc::channel();
+        DisposalThread {
+            recorded: Arc::new(Mutex::new(None)),
+            notification,
+            receiver: Arc::new(Mutex::new(receiver)),
+        }
     }
 
     fn await_disposal(recorder: &DisposalThread) -> ThreadId {
-        for _ in 0..1_000 {
-            if let Some(thread) = *recorder.lock().expect("disposal recorder mutex") {
-                return thread;
-            }
-            std::thread::sleep(Duration::from_millis(5));
+        if let Some(thread) = *recorder.recorded.lock().expect("disposal recorder mutex") {
+            return thread;
         }
-        panic!("isolated disposal never destroyed the value")
+        recorder
+            .receiver
+            .lock()
+            .expect("disposal notification receiver mutex")
+            .recv_timeout(DISPOSAL_WAIT)
+            .expect("isolated disposal destroys the value")
+    }
+
+    fn record_disposal(recorder: &DisposalThread) {
+        let thread = std::thread::current().id();
+        *recorder.recorded.lock().expect("disposal recorder mutex") = Some(thread);
+        let _ = recorder.notification.send(thread);
     }
 
     /// A caller waker whose destructor records itself and then panics.
@@ -909,7 +935,7 @@ mod tests {
 
     impl Drop for HostileWakerDrop {
         fn drop(&mut self) {
-            *self.0.lock().expect("disposal recorder mutex") = Some(std::thread::current().id());
+            record_disposal(&self.0);
             panic!("injected waker drop panic");
         }
     }
@@ -918,7 +944,7 @@ mod tests {
 
     impl Drop for ThreadRecordingDrop {
         fn drop(&mut self) {
-            *self.0.lock().expect("disposal recorder mutex") = Some(std::thread::current().id());
+            record_disposal(&self.0);
         }
     }
 
@@ -928,7 +954,7 @@ mod tests {
         send: &mut std::pin::Pin<Box<SendFuture<M>>>,
         recorder: &DisposalThread,
     ) {
-        let hostile = Waker::from(Arc::new(HostileWakerDrop(Arc::clone(recorder))));
+        let hostile = Waker::from(Arc::new(HostileWakerDrop(recorder.clone())));
         assert!(
             send.as_mut()
                 .poll(&mut Context::from_waker(&hostile))
@@ -985,7 +1011,7 @@ mod tests {
 
         let message_thread = disposal_thread();
         let waker_thread = disposal_thread();
-        let mut send = Box::pin(actor.send(ThreadRecordingDrop(Arc::clone(&message_thread))));
+        let mut send = Box::pin(actor.send(ThreadRecordingDrop(message_thread.clone())));
         park_behind_hostile_waker(&mut send, &waker_thread);
 
         drop(send);

--- a/crates/shelterwood-runtime/src/timer.rs
+++ b/crates/shelterwood-runtime/src/timer.rs
@@ -164,6 +164,28 @@ mod tests {
         assert!(sleep.as_mut().poll(&mut context).is_pending());
     }
 
+    /// Reports an `Instant` domain too narrow for Tokio's u64-millisecond tick
+    /// boundary, roughly 584 million years out.
+    ///
+    /// Linux's `Instant` is a `timespec` whose seconds field spans that;
+    /// targets counting nanoseconds in a `u64` overflow long before. CI runs
+    /// Linux only, so there the skip is a defect rather than a platform fact
+    /// and must be loud: nextest prints captured output for failing tests
+    /// only, so a bare diagnostic on a supported target reports as an
+    /// ordinary pass and hides the lost coverage.
+    fn skip_unrepresentable_tick_boundary(test: &str) {
+        #[cfg(target_os = "linux")]
+        panic!(
+            "{test}: this target's Instant must represent Tokio's \
+             u64-millisecond boundary, so it must be exercised, not skipped"
+        );
+        #[cfg(not(target_os = "linux"))]
+        eprintln!(
+            "skipping {test}: this platform's Instant cannot represent \
+             Tokio's u64-millisecond boundary"
+        );
+    }
+
     #[test]
     fn deadline_beyond_tokios_tick_range_is_armed_in_a_bounded_slice() {
         // Tokio 1.53 reserves the top three u64 millisecond ticks. The exact
@@ -174,9 +196,8 @@ mod tests {
         let Some(requested) = current.checked_add(beyond_tokio_ticks) else {
             // Some platforms have a narrower Instant domain than Tokio's
             // u64 millisecond tick range, so this boundary cannot be tested.
-            eprintln!(
-                "skipping deadline_beyond_tokios_tick_range_is_armed_in_a_bounded_slice: \
-                 this platform's Instant cannot represent Tokio's u64-millisecond boundary"
+            skip_unrepresentable_tick_boundary(
+                "deadline_beyond_tokios_tick_range_is_armed_in_a_bounded_slice",
             );
             return;
         };
@@ -192,9 +213,8 @@ mod tests {
         let current = super::now();
         let Some(requested) = current.checked_add(Duration::from_millis(u64::MAX - 2)) else {
             // See `deadline_beyond_tokios_tick_range_is_armed_in_a_bounded_slice`.
-            eprintln!(
-                "skipping deadline_beyond_tokios_tick_range_does_not_fire_at_the_first_slice: \
-                 this platform's Instant cannot represent Tokio's u64-millisecond boundary"
+            skip_unrepresentable_tick_boundary(
+                "deadline_beyond_tokios_tick_range_does_not_fire_at_the_first_slice",
             );
             return;
         };

--- a/crates/shelterwood-runtime/src/timer.rs
+++ b/crates/shelterwood-runtime/src/timer.rs
@@ -174,6 +174,10 @@ mod tests {
         let Some(requested) = current.checked_add(beyond_tokio_ticks) else {
             // Some platforms have a narrower Instant domain than Tokio's
             // u64 millisecond tick range, so this boundary cannot be tested.
+            eprintln!(
+                "skipping deadline_beyond_tokios_tick_range_is_armed_in_a_bounded_slice: \
+                 this platform's Instant cannot represent Tokio's u64-millisecond boundary"
+            );
             return;
         };
 
@@ -188,6 +192,10 @@ mod tests {
         let current = super::now();
         let Some(requested) = current.checked_add(Duration::from_millis(u64::MAX - 2)) else {
             // See `deadline_beyond_tokios_tick_range_is_armed_in_a_bounded_slice`.
+            eprintln!(
+                "skipping deadline_beyond_tokios_tick_range_does_not_fire_at_the_first_slice: \
+                 this platform's Instant cannot represent Tokio's u64-millisecond boundary"
+            );
             return;
         };
         let mut sleep = std::pin::pin!(super::sleep_until_std(requested));

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -24,16 +24,21 @@ async fn dynamic_high_cycle_add_remove_keeps_only_live_runtime_storage() {
             )
             .await
             .expect("task admission");
-        let storage = cell.runtime_storage();
+        // `deadline_slots` is exact, not a band: every removal cancels through
+        // `DeadlineQueue::cancel`, which always compacts because one stale
+        // heap entry exceeds twice the zero remaining registrations. A stale
+        // cancelled entry surviving a cycle is exactly the leak this asserts
+        // against, so widening this to `deadlines..=deadlines * 2` would
+        // admit it.
         assert_eq!(
-            (storage.children, storage.child_slots, storage.deadlines),
-            (1, 1, 1),
+            cell.runtime_storage(),
+            RuntimeStorage {
+                children: 1,
+                child_slots: 1,
+                deadlines: 1,
+                deadline_slots: 1,
+            },
             "cycle {cycle} stores exactly the live child and readiness deadline"
-        );
-        assert!(
-            storage.deadline_slots >= storage.deadlines
-                && storage.deadline_slots <= storage.deadlines * 2,
-            "cycle {cycle} bounds raw deadline storage by the live heap policy: {storage:?}"
         );
 
         assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -24,12 +24,11 @@ async fn dynamic_high_cycle_add_remove_keeps_only_live_runtime_storage() {
             )
             .await
             .expect("task admission");
-        // `deadline_slots` is exact, not a band: every removal cancels through
-        // `DeadlineQueue::cancel`, which always compacts because one stale
-        // heap entry exceeds twice the zero remaining registrations. A stale
-        // cancelled entry surviving a cycle is exactly the leak this asserts
-        // against, so widening this to `deadlines..=deadlines * 2` would
-        // admit it.
+        // `deadline_slots` is exact, not a band. The removal below pins the
+        // queue empty, and arming one readiness deadline pushes exactly one
+        // heap entry, so two slots here means the arm leaked a second,
+        // never-registered entry — the leak this cycle exists to catch, and
+        // one that `deadlines..=deadlines * 2` would admit unnoticed.
         assert_eq!(
             cell.runtime_storage(),
             RuntimeStorage {

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -24,15 +24,16 @@ async fn dynamic_high_cycle_add_remove_keeps_only_live_runtime_storage() {
             )
             .await
             .expect("task admission");
+        let storage = cell.runtime_storage();
         assert_eq!(
-            cell.runtime_storage(),
-            RuntimeStorage {
-                children: 1,
-                child_slots: 1,
-                deadlines: 1,
-                deadline_slots: 1,
-            },
-            "cycle {cycle} stores only the live child"
+            (storage.children, storage.child_slots, storage.deadlines),
+            (1, 1, 1),
+            "cycle {cycle} stores exactly the live child and readiness deadline"
+        );
+        assert!(
+            storage.deadline_slots >= storage.deadlines
+                && storage.deadline_slots <= storage.deadlines * 2,
+            "cycle {cycle} bounds raw deadline storage by the live heap policy: {storage:?}"
         );
 
         assert_eq!(scope.remove_task(&task).await, RemoveOutcome::Removed);
@@ -215,6 +216,10 @@ fn dynamic_close_evicts_a_terminal_reservation_before_readd() {
         .expect("the first incarnation reserves the child");
     let first_membership = first.slot.member.membership();
     let retained = root.with_observation_gate(|txn| control.close(&root, txn));
+    assert!(matches!(
+        first.slot.member.record().stage,
+        MemberStage::Terminal(exit) if matches!(exit.kind(), ExitKind::NeverStarted)
+    ));
     assert!(
         retained.is_empty(),
         "reservations are terminalized on close"
@@ -606,7 +611,7 @@ async fn removal_from_a_foreign_thread_reaches_the_driver() {
     .join()
     .expect("foreign-thread removal signaling succeeds");
 
-    let event = match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
+    let event = match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, event_receiver.recv()).await {
         crate::runtime::Timeout::Completed(event) => event.expect("the driver lane remains open"),
         crate::runtime::Timeout::Elapsed => {
             panic!("the off-runtime removal edge must not be lost")
@@ -781,7 +786,7 @@ async fn annulment_after_promotion_is_inert_and_supervision_owns_the_exit() {
     scope.handle_admission(request);
     assert!(matches!(response.try_receive(), Some(Ok(()))));
     assert!(matches!(
-        crate::runtime::timeout(Duration::from_secs(2), started.fired()).await,
+        crate::runtime::timeout(DRIVER_PROGRESS_WAIT, started.fired()).await,
         crate::runtime::Timeout::Completed(())
     ));
 
@@ -810,26 +815,22 @@ async fn annulment_after_promotion_is_inert_and_supervision_owns_the_exit() {
 
     let removal_response =
         super::super::remove_dynamic(&root, member.id(), Some(member.membership()));
-    let removal = match crate::runtime::timeout(
-        Duration::from_secs(2),
-        dynamic_event_receiver.recv(),
-    )
-    .await
-    {
-        crate::runtime::Timeout::Completed(Some(DriverEvent::Removal(removal))) => removal,
-        crate::runtime::Timeout::Completed(_) => panic!("the removal reaches the driver"),
-        crate::runtime::Timeout::Elapsed => panic!("the removal must reach the driver"),
-    };
+    let removal =
+        match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, dynamic_event_receiver.recv()).await {
+            crate::runtime::Timeout::Completed(Some(DriverEvent::Removal(removal))) => removal,
+            crate::runtime::Timeout::Completed(_) => panic!("the removal reaches the driver"),
+            crate::runtime::Timeout::Elapsed => panic!("the removal must reach the driver"),
+        };
     scope.handle_removal(removal);
     recv_child_exit(
         &mut event_receiver,
-        Duration::from_secs(2),
+        DRIVER_PROGRESS_WAIT,
         "the stopped child exit",
     )
     .await
     .dispatch(&mut scope);
     let disposal =
-        match crate::runtime::timeout(Duration::from_secs(2), scope.disposal_event_receiver.recv())
+        match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, scope.disposal_event_receiver.recv())
             .await
         {
             crate::runtime::Timeout::Completed(Some(event)) => event,
@@ -888,43 +889,46 @@ async fn annulment_racing_admission_resolves_to_one_terminalization_owner() {
             .state
             .lock()
             .expect("dynamic-state mutex remains healthy");
-        let runtime = tokio::runtime::Handle::current();
-        let (scope, annul) = std::thread::scope(|threads| {
-            let annul_ready = contender_ready.clone();
-            let annul_control = Arc::clone(&reservation.control);
-            let annul_slot = Arc::clone(&reservation.slot);
-            let annul_scope = Arc::clone(&reservation.scope);
-            let annul = threads.spawn(move || {
-                annul_ready
-                    .send(())
-                    .expect("the race coordinator remains available");
-                cancel_dynamic_reservation(&annul_scope, annul_control.as_ref(), &annul_slot);
-            });
-            let admission = threads.spawn(move || {
-                let _runtime = runtime.enter();
-                contender_ready
-                    .send(())
-                    .expect("the race coordinator remains available");
-                scope.handle_admission(request);
-                scope
-            });
-            // Both contenders are running before the dynamic-state mutex is
-            // released, so neither can finish ahead of the other: the guard,
-            // not the rendezvous, is what forces them to overlap. The
-            // rendezvous only proves each thread reached its send — the
-            // channel is shared, so neither receive names a contender.
-            contenders_ready
-                .recv()
-                .expect("a contender starts before the mutex is released");
-            contenders_ready
-                .recv()
-                .expect("both contenders start before the mutex is released");
-            drop(state);
-            let annul = annul.join();
-            let scope = admission.join().expect("the admission contender completes");
-            (scope, annul)
+        let annul_ready = contender_ready.clone();
+        let annul_control = Arc::clone(&reservation.control);
+        let annul_slot = Arc::clone(&reservation.slot);
+        let annul_scope = Arc::clone(&reservation.scope);
+        let annul = std::thread::spawn(move || {
+            annul_ready
+                .send(())
+                .expect("the race coordinator remains available");
+            cancel_dynamic_reservation(&annul_scope, annul_control.as_ref(), &annul_slot);
         });
-        annul.expect("the annul contender completes");
+        let (admission_runtime, admission) = DedicatedRuntime::spawn(async move {
+            contender_ready
+                .send(())
+                .expect("the race coordinator remains available");
+            scope.handle_admission(request);
+            scope
+        });
+        // Both contenders are running before the dynamic-state mutex is
+        // released, so neither can finish ahead of the other: the guard,
+        // not the rendezvous, is what forces them to overlap. The
+        // rendezvous only proves each contender reached its send — the
+        // channel is shared, so neither receive names a contender.
+        contenders_ready
+            .recv()
+            .expect("a contender starts before the mutex is released");
+        contenders_ready
+            .recv()
+            .expect("both contenders start before the mutex is released");
+        drop(state);
+        annul.join().expect("the annul contender completes");
+        let scope = match crate::runtime::join(admission).await {
+            crate::runtime::JoinOutcome::Ok { value } => value,
+            crate::runtime::JoinOutcome::Panic { message } => {
+                panic!("the admission contender panicked: {message:?}")
+            }
+            crate::runtime::JoinOutcome::Cancelled => {
+                panic!("the admission contender was cancelled")
+            }
+        };
+        admission_runtime.shutdown().await;
 
         // Whichever side won the dynamic-state mutex, exactly one owner
         // published terminality (or none, if the admission won): the record,
@@ -1159,7 +1163,7 @@ async fn exercise_coalesced_removal(source: RemovalSource) {
     scope.handle_admission(request);
     assert!(matches!(admission_response.try_receive(), Some(Ok(()))));
     assert!(matches!(
-        crate::runtime::timeout(Duration::from_secs(2), started.fired()).await,
+        crate::runtime::timeout(DRIVER_PROGRESS_WAIT, started.fired()).await,
         crate::runtime::Timeout::Completed(())
     ));
 
@@ -1198,11 +1202,8 @@ async fn exercise_coalesced_removal(source: RemovalSource) {
         ));
     }
 
-    let removal = match crate::runtime::timeout(
-        Duration::from_secs(2),
-        dynamic_event_receiver.recv(),
-    )
-    .await
+    let removal = match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, dynamic_event_receiver.recv())
+        .await
     {
         crate::runtime::Timeout::Completed(Some(DriverEvent::Removal(removal))) => removal,
         crate::runtime::Timeout::Completed(_) => panic!("one removal request reaches the driver"),
@@ -1250,7 +1251,7 @@ async fn exercise_coalesced_removal(source: RemovalSource) {
 
     recv_child_exit(
         &mut event_receiver,
-        Duration::from_secs(2),
+        DRIVER_PROGRESS_WAIT,
         "the stopped child exit",
     )
     .await
@@ -1266,7 +1267,7 @@ async fn exercise_coalesced_removal(source: RemovalSource) {
     }
 
     let disposal =
-        match crate::runtime::timeout(Duration::from_secs(2), scope.disposal_event_receiver.recv())
+        match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, scope.disposal_event_receiver.recv())
             .await
         {
             crate::runtime::Timeout::Completed(Some(event)) => event,
@@ -1388,7 +1389,7 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
     release_failure.fire();
     let exit = recv_child_exit(
         &mut event_receiver,
-        Duration::from_secs(2),
+        DRIVER_PROGRESS_WAIT,
         "the first incarnation exit",
     )
     .await;
@@ -1447,12 +1448,12 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
         Some(DriverEvent::Removal(queued))
             if queued.key == ChildKey::fixture(u64::MAX - 1)
     ));
-    let forwarded =
-        match crate::runtime::timeout(Duration::from_secs(2), event_receiver.recv()).await {
-            crate::runtime::Timeout::Completed(Some(event)) => event,
-            crate::runtime::Timeout::Completed(None) => panic!("the driver lane remains open"),
-            crate::runtime::Timeout::Elapsed => panic!("the fused removal edge is forwarded"),
-        };
+    let forwarded = match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, event_receiver.recv()).await
+    {
+        crate::runtime::Timeout::Completed(Some(event)) => event,
+        crate::runtime::Timeout::Completed(None) => panic!("the driver lane remains open"),
+        crate::runtime::Timeout::Elapsed => panic!("the fused removal edge is forwarded"),
+    };
     let DriverEvent::Removal(removal) = forwarded else {
         panic!("the queued event is the fused removal")
     };

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -29,7 +29,7 @@ fn independent_systems_do_not_share_an_observation_critical_section() {
         second.set_state(ScopeState::Starting);
         completed.send(()).expect("test receiver remains available");
     });
-    let result = receiver.recv_timeout(Duration::from_secs(2));
+    let result = receiver.recv_timeout(CAPTURE_PROBE_WAIT);
     drop(held);
     worker.join().expect("independent transition succeeds");
     assert_eq!(
@@ -55,7 +55,7 @@ fn snapshot_subscription_waker_can_reenter_snapshot() {
 
     let publisher = std::thread::spawn(move || scope.set_state(ScopeState::Starting));
     assert_eq!(
-        observed.recv_timeout(Duration::from_secs(2)),
+        observed.recv_timeout(CAPTURE_PROBE_WAIT),
         Ok(ScopeState::Starting),
         "the watch waker must run only after snapshot can reacquire the gate"
     );
@@ -84,7 +84,7 @@ fn lifecycle_subscription_waker_can_reenter_snapshot() {
 
     let publisher = std::thread::spawn(move || scope.set_state(ScopeState::Starting));
     assert_eq!(
-        observed.recv_timeout(Duration::from_secs(2)),
+        observed.recv_timeout(CAPTURE_PROBE_WAIT),
         Ok(ScopeState::Starting),
         "the lifecycle waker must run only after snapshot can reacquire the gate"
     );
@@ -112,7 +112,7 @@ fn scope_wait_waker_can_reenter_snapshot_at_terminality() {
 
     let terminalizer = std::thread::spawn(move || scope.terminalize_never_started());
     assert!(matches!(
-        stopped_observed.recv_timeout(Duration::from_secs(2)),
+        stopped_observed.recv_timeout(CAPTURE_PROBE_WAIT),
         Ok(ScopeState::Stopped { .. })
     ));
     terminalizer.join().expect("terminal publication completes");
@@ -457,7 +457,7 @@ async fn aborted_nested_driver_epilogue_wakes_a_parked_shutdown_task() {
     crate::runtime::yield_now().await;
     drop(fixture.driver);
 
-    match crate::runtime::timeout(Duration::from_secs(5), crate::runtime::join(waiter)).await {
+    match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, crate::runtime::join(waiter)).await {
         crate::runtime::Timeout::Completed(crate::runtime::JoinOutcome::Ok { value }) => {
             value.expect("the target incarnation settled");
         }
@@ -650,7 +650,7 @@ async fn blocked_initial_scope_factory_owns_its_stop_epilogue() {
     let abort = driver.abort_handle();
 
     assert!(matches!(
-        crate::runtime::timeout(Duration::from_secs(2), gate.wait_entered()).await,
+        crate::runtime::timeout(DRIVER_PROGRESS_WAIT, gate.wait_entered()).await,
         crate::runtime::Timeout::Completed(())
     ));
     let factory_state = nested.snapshot().state.clone();
@@ -671,7 +671,7 @@ async fn blocked_initial_scope_factory_owns_its_stop_epilogue() {
         "an executing initial factory still owns the final scope epilogue"
     );
     assert!(matches!(
-        crate::runtime::timeout(Duration::from_secs(2), waiter).await,
+        crate::runtime::timeout(DRIVER_PROGRESS_WAIT, waiter).await,
         crate::runtime::Timeout::Completed(StopReason::ShutdownRequested)
     ));
 }
@@ -702,7 +702,7 @@ async fn hard_aborted_incarnation_fences_shutdown_and_wait_without_arming_its_bu
     let driver = crate::runtime::spawn(run_scope_incarnation(plan, ScopeRole::Root, epoch));
     let abort = driver.abort_handle();
     assert!(matches!(
-        crate::runtime::timeout(Duration::from_secs(2), gate.wait_entered()).await,
+        crate::runtime::timeout(DRIVER_PROGRESS_WAIT, gate.wait_entered()).await,
         crate::runtime::Timeout::Completed(())
     ));
 
@@ -724,7 +724,7 @@ async fn hard_aborted_incarnation_fences_shutdown_and_wait_without_arming_its_bu
         "shutdown_and_wait resolved inside the terminal-before-epilogue window"
     );
     assert!(matches!(
-        crate::runtime::timeout(Duration::from_secs(5), shutdown).await,
+        crate::runtime::timeout(DRIVER_PROGRESS_WAIT, shutdown).await,
         crate::runtime::Timeout::Completed(Ok(()))
     ));
     assert!(matches!(
@@ -766,7 +766,7 @@ async fn blocked_restart_scope_factory_supersedes_the_stale_stopped_projection()
     let abort = driver.abort_handle();
 
     assert!(matches!(
-        crate::runtime::timeout(Duration::from_secs(2), gate.wait_entered()).await,
+        crate::runtime::timeout(DRIVER_PROGRESS_WAIT, gate.wait_entered()).await,
         crate::runtime::Timeout::Completed(())
     ));
     let factory_calls = calls.load(Ordering::SeqCst);
@@ -793,7 +793,7 @@ async fn blocked_restart_scope_factory_supersedes_the_stale_stopped_projection()
         "an executing restart factory still owns the final scope epilogue"
     );
     assert!(matches!(
-        crate::runtime::timeout(Duration::from_secs(2), waiter).await,
+        crate::runtime::timeout(DRIVER_PROGRESS_WAIT, waiter).await,
         crate::runtime::Timeout::Completed(StopReason::ShutdownRequested)
     ));
 }

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -610,26 +610,24 @@ async fn mailbox_waker_panic_is_contained_without_wedging_system_completion() {
     waiter_started.fired().await;
     exit.fire();
 
-    let member_exit = match crate::runtime::timeout(
-        Duration::from_secs(2),
-        crate::runtime::join(terminal_waiter),
-    )
-    .await
-    {
-        crate::runtime::Timeout::Completed(crate::runtime::JoinOutcome::Ok { value }) => value,
-        crate::runtime::Timeout::Completed(crate::runtime::JoinOutcome::Panic { message }) => {
-            panic!("the terminal waiter panicked: {message:?}")
-        }
-        crate::runtime::Timeout::Completed(crate::runtime::JoinOutcome::Cancelled) => {
-            panic!("the terminal waiter was cancelled")
-        }
-        crate::runtime::Timeout::Elapsed => {
-            panic!("the terminal waiter was not pulsed after the mailbox panic")
-        }
-    };
+    let member_exit =
+        match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, crate::runtime::join(terminal_waiter))
+            .await
+        {
+            crate::runtime::Timeout::Completed(crate::runtime::JoinOutcome::Ok { value }) => value,
+            crate::runtime::Timeout::Completed(crate::runtime::JoinOutcome::Panic { message }) => {
+                panic!("the terminal waiter panicked: {message:?}")
+            }
+            crate::runtime::Timeout::Completed(crate::runtime::JoinOutcome::Cancelled) => {
+                panic!("the terminal waiter was cancelled")
+            }
+            crate::runtime::Timeout::Elapsed => {
+                panic!("the terminal waiter was not pulsed after the mailbox panic")
+            }
+        };
     assert!(matches!(member_exit.kind(), ExitKind::Completed));
 
-    let reason = match crate::runtime::timeout(Duration::from_secs(2), system.wait()).await {
+    let reason = match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, system.wait()).await {
         crate::runtime::Timeout::Completed(reason) => reason,
         crate::runtime::Timeout::Elapsed => {
             panic!("the system monitor did not contain the driver unwind")

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -24,9 +24,42 @@ enum Message {
     Offload,
 }
 
+/// Publishes a handler's `is_draining()` observations for judgement in the
+/// test body.
+///
+/// An assertion inside a supervised handler is inert: supervision catches the
+/// panic and the test reads a later, weaker symptom. Recording every visit
+/// instead keeps the verdict in the test, and the recorded count is itself
+/// evidence — an empty log never satisfies an expectation, so no default can
+/// stand in for an observation that never happened.
+#[derive(Clone, Default)]
+struct DrainingProbe(Arc<Mutex<Vec<bool>>>);
+
+impl DrainingProbe {
+    fn record(&self, draining: bool) {
+        self.0
+            .lock()
+            .expect("draining probe mutex poisoned")
+            .push(draining);
+    }
+
+    fn observations(&self) -> Vec<bool> {
+        self.0
+            .lock()
+            .expect("draining probe mutex poisoned")
+            .clone()
+    }
+
+    #[track_caller]
+    fn assert_observed(&self, expected: &[bool], context: &str) {
+        assert_eq!(self.observations(), expected, "{context}");
+    }
+}
+
 struct Args {
     stop_entered: Arc<AtomicBool>,
-    stop_was_draining: Arc<AtomicBool>,
+    stop_draining: DrainingProbe,
+    value_draining: DrainingProbe,
     allow_stop: ReleaseGate,
     drain_entered: Arc<AtomicBool>,
     allow_drain: ReleaseGate,
@@ -47,16 +80,14 @@ impl Actor for DrainActor {
     async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
         match message {
             Message::Stop => {
-                self.0
-                    .stop_was_draining
-                    .store(context.is_draining(), Ordering::SeqCst);
+                self.0.stop_draining.record(context.is_draining());
                 self.0.log.lock().expect("log mutex poisoned").push(0);
                 self.0.stop_entered.store(true, Ordering::SeqCst);
                 self.0.allow_stop.wait().await;
                 context.stop();
             }
             Message::Value(value) => {
-                assert!(context.is_draining());
+                self.0.value_draining.record(context.is_draining());
                 self.0.log.lock().expect("log mutex poisoned").push(value);
                 if !self.0.drain_entered.swap(true, Ordering::SeqCst) {
                     let continuation = context
@@ -122,7 +153,8 @@ impl Actor for DrainActor {
 
 async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
     let stop_entered = Arc::new(AtomicBool::new(false));
-    let stop_was_draining = Arc::new(AtomicBool::new(false));
+    let stop_draining = DrainingProbe::default();
+    let value_draining = DrainingProbe::default();
     let allow_stop = ReleaseGate::default();
     let drain_entered = Arc::new(AtomicBool::new(false));
     let allow_drain = ReleaseGate::default();
@@ -135,7 +167,8 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
             "drain",
             ActorOnceDef::<DrainActor>::new(Args {
                 stop_entered: Arc::clone(&stop_entered),
-                stop_was_draining: Arc::clone(&stop_was_draining),
+                stop_draining: stop_draining.clone(),
+                value_draining: value_draining.clone(),
                 allow_stop: allow_stop.clone(),
                 drain_entered: Arc::clone(&drain_entered),
                 allow_drain: allow_drain.clone(),
@@ -150,6 +183,10 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
 
     let accepting_incarnation = actor.send(Message::Stop).await.expect("stop accepted");
     assert_eventually!(|| stop_entered.load(Ordering::SeqCst)).await;
+    stop_draining.assert_observed(
+        &[false],
+        "the initiating handler runs before mailbox drain begins",
+    );
     actor
         .send(Message::Value(1))
         .await
@@ -159,10 +196,6 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
         .await
         .expect("prefix accepted");
     allow_stop.release();
-    assert!(
-        !stop_was_draining.load(Ordering::SeqCst),
-        "the initiating handler runs before mailbox drain begins"
-    );
 
     assert_eventually!(|| drain_entered.load(Ordering::SeqCst)).await;
     let rejection = actor
@@ -195,6 +228,12 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
         .expect_err("one-shot membership terminalizes");
     assert_eq!(terminal.kind, SendErrorKind::Terminated);
     assert_eq!(*log.lock().expect("log mutex poisoned"), expected);
+    // Every entry after the initiating `Stop` is one drained `Value`, and
+    // each of those handlers must have seen the draining phase.
+    value_draining.assert_observed(
+        &vec![true; expected.len() - 1],
+        "every drained delivery observes the draining phase",
+    );
     assert!(!deferred_ran.load(Ordering::SeqCst));
 }
 
@@ -239,7 +278,8 @@ struct FaultArgs {
     mode: FaultMode,
     hold_entered: ReleaseGate,
     hold_release: ReleaseGate,
-    hold_was_draining: Arc<AtomicBool>,
+    hold_draining: DrainingProbe,
+    fault_draining: DrainingProbe,
     shutdown_seen: ReleaseGate,
     drain_entered: ReleaseGate,
     stop_entered: Arc<AtomicBool>,
@@ -266,15 +306,13 @@ impl Actor for FaultActor {
     async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
         match message {
             FaultMessage::Hold => {
-                self.0
-                    .hold_was_draining
-                    .store(context.is_draining(), Ordering::SeqCst);
+                self.0.hold_draining.record(context.is_draining());
                 self.0.hold_entered.release();
                 self.0.hold_release.wait().await;
                 Ok(())
             }
             FaultMessage::Fault => {
-                assert!(context.is_draining());
+                self.0.fault_draining.record(context.is_draining());
                 self.0.drained.fetch_add(1, Ordering::SeqCst);
                 self.0.drain_entered.release();
                 match self.0.mode {
@@ -344,7 +382,8 @@ async fn run_fault_fixture(
 ) -> FaultOutcome {
     let hold_entered = ReleaseGate::default();
     let hold_release = ReleaseGate::default();
-    let hold_was_draining = Arc::new(AtomicBool::new(false));
+    let hold_draining = DrainingProbe::default();
+    let fault_draining = DrainingProbe::default();
     let shutdown_seen = ReleaseGate::default();
     let drain_entered = ReleaseGate::default();
     let stop_entered = Arc::new(AtomicBool::new(false));
@@ -358,7 +397,8 @@ async fn run_fault_fixture(
                 mode,
                 hold_entered: hold_entered.clone(),
                 hold_release: hold_release.clone(),
-                hold_was_draining: Arc::clone(&hold_was_draining),
+                hold_draining: hold_draining.clone(),
+                fault_draining: fault_draining.clone(),
                 shutdown_seen: shutdown_seen.clone(),
                 drain_entered: drain_entered.clone(),
                 stop_entered: Arc::clone(&stop_entered),
@@ -377,6 +417,10 @@ async fn run_fault_fixture(
         .await
         .expect("hold message is accepted");
     hold_entered.wait().await;
+    hold_draining.assert_observed(
+        &[false],
+        "the held handler observes live delivery before its gate is released",
+    );
     if let Some(message) = queued {
         actor
             .send(message)
@@ -388,10 +432,6 @@ async fn run_fault_fixture(
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(30)));
     shutdown_seen.wait().await;
     hold_release.release();
-    assert!(
-        !hold_was_draining.load(Ordering::SeqCst),
-        "the held handler observes live delivery before its gate is released"
-    );
     if matches!(mode, FaultMode::SharedGrace) {
         drain_entered.wait().await;
         assert!(
@@ -408,11 +448,18 @@ async fn run_fault_fixture(
         .expect("the child policy bounds shutdown");
     let elapsed = tokio::time::Instant::now() - started_at;
     let exit = exited_actor(&mut events).await;
+    let drained = drained.load(Ordering::SeqCst);
+    // Tying the observation count to `drained` keeps an absent handler from
+    // passing: a mode that never drains records nothing and expects nothing.
+    fault_draining.assert_observed(
+        &vec![true; drained],
+        "every drained fault handler observes the draining phase",
+    );
     FaultOutcome {
         exit,
         elapsed,
         stop_entered: stop_entered.load(Ordering::SeqCst),
-        drained: drained.load(Ordering::SeqCst),
+        drained,
         blocking_result: blocking_result.load(Ordering::SeqCst),
     }
 }

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -26,6 +26,7 @@ enum Message {
 
 struct Args {
     stop_entered: Arc<AtomicBool>,
+    stop_was_draining: Arc<AtomicBool>,
     allow_stop: ReleaseGate,
     drain_entered: Arc<AtomicBool>,
     allow_drain: ReleaseGate,
@@ -46,7 +47,9 @@ impl Actor for DrainActor {
     async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
         match message {
             Message::Stop => {
-                assert!(!context.is_draining());
+                self.0
+                    .stop_was_draining
+                    .store(context.is_draining(), Ordering::SeqCst);
                 self.0.log.lock().expect("log mutex poisoned").push(0);
                 self.0.stop_entered.store(true, Ordering::SeqCst);
                 self.0.allow_stop.wait().await;
@@ -119,6 +122,7 @@ impl Actor for DrainActor {
 
 async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
     let stop_entered = Arc::new(AtomicBool::new(false));
+    let stop_was_draining = Arc::new(AtomicBool::new(false));
     let allow_stop = ReleaseGate::default();
     let drain_entered = Arc::new(AtomicBool::new(false));
     let allow_drain = ReleaseGate::default();
@@ -131,6 +135,7 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
             "drain",
             ActorOnceDef::<DrainActor>::new(Args {
                 stop_entered: Arc::clone(&stop_entered),
+                stop_was_draining: Arc::clone(&stop_was_draining),
                 allow_stop: allow_stop.clone(),
                 drain_entered: Arc::clone(&drain_entered),
                 allow_drain: allow_drain.clone(),
@@ -154,6 +159,10 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
         .await
         .expect("prefix accepted");
     allow_stop.release();
+    assert!(
+        !stop_was_draining.load(Ordering::SeqCst),
+        "the initiating handler runs before mailbox drain begins"
+    );
 
     assert_eventually!(|| drain_entered.load(Ordering::SeqCst)).await;
     let rejection = actor
@@ -230,6 +239,7 @@ struct FaultArgs {
     mode: FaultMode,
     hold_entered: ReleaseGate,
     hold_release: ReleaseGate,
+    hold_was_draining: Arc<AtomicBool>,
     shutdown_seen: ReleaseGate,
     drain_entered: ReleaseGate,
     stop_entered: Arc<AtomicBool>,
@@ -256,7 +266,9 @@ impl Actor for FaultActor {
     async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
         match message {
             FaultMessage::Hold => {
-                assert!(!context.is_draining());
+                self.0
+                    .hold_was_draining
+                    .store(context.is_draining(), Ordering::SeqCst);
                 self.0.hold_entered.release();
                 self.0.hold_release.wait().await;
                 Ok(())
@@ -332,6 +344,7 @@ async fn run_fault_fixture(
 ) -> FaultOutcome {
     let hold_entered = ReleaseGate::default();
     let hold_release = ReleaseGate::default();
+    let hold_was_draining = Arc::new(AtomicBool::new(false));
     let shutdown_seen = ReleaseGate::default();
     let drain_entered = ReleaseGate::default();
     let stop_entered = Arc::new(AtomicBool::new(false));
@@ -345,6 +358,7 @@ async fn run_fault_fixture(
                 mode,
                 hold_entered: hold_entered.clone(),
                 hold_release: hold_release.clone(),
+                hold_was_draining: Arc::clone(&hold_was_draining),
                 shutdown_seen: shutdown_seen.clone(),
                 drain_entered: drain_entered.clone(),
                 stop_entered: Arc::clone(&stop_entered),
@@ -374,6 +388,10 @@ async fn run_fault_fixture(
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(30)));
     shutdown_seen.wait().await;
     hold_release.release();
+    assert!(
+        !hold_was_draining.load(Ordering::SeqCst),
+        "the held handler observes live delivery before its gate is released"
+    );
     if matches!(mode, FaultMode::SharedGrace) {
         drain_entered.wait().await;
         assert!(

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -417,10 +417,6 @@ async fn run_fault_fixture(
         .await
         .expect("hold message is accepted");
     hold_entered.wait().await;
-    hold_draining.assert_observed(
-        &[false],
-        "the held handler observes live delivery before its gate is released",
-    );
     if let Some(message) = queued {
         actor
             .send(message)
@@ -432,6 +428,14 @@ async fn run_fault_fixture(
     let shutdown = tokio::spawn(system.shutdown(Duration::from_secs(30)));
     shutdown_seen.wait().await;
     hold_release.release();
+    // `hold_entered` published this observation before the test resumed, so
+    // the verdict was fixed well before here; it is judged only once the
+    // queued payload belongs to the actor, so a failure unwinds the test
+    // rather than aborting inside a panicking payload destructor.
+    hold_draining.assert_observed(
+        &[false],
+        "the held handler observes live delivery before its gate is released",
+    );
     if matches!(mode, FaultMode::SharedGrace) {
         drain_entered.wait().await;
         assert!(

--- a/crates/shelterwood/tests/mailbox.rs
+++ b/crates/shelterwood/tests/mailbox.rs
@@ -32,6 +32,14 @@ enum ReplyMode {
     Hold,
 }
 
+struct CountedReplyDrop(Arc<AtomicUsize>);
+
+impl Drop for CountedReplyDrop {
+    fn drop(&mut self) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
 struct Recorder {
     gate: Option<ReleaseGate>,
     values: Arc<Mutex<Vec<usize>>>,
@@ -318,14 +326,23 @@ async fn reply_receiver_is_consuming_and_late_replies_are_discarded() {
         )
         .expect("valid actor");
     let width = Duration::from_secs(10);
+    let timed_out_reply_drops = Arc::new(AtomicUsize::new(0));
     let (reply, receiver) = actor.reply_channel();
     let mut waiter = Box::pin(receiver.recv(width));
     assert!(poll_once(waiter.as_mut()).is_pending());
     advance_time(width).await;
-    assert_eq!(waiter.await, Err(ReplyError::Timeout));
-    reply.send(1);
+    assert!(matches!(waiter.await, Err(ReplyError::Timeout)));
+    reply.send(CountedReplyDrop(Arc::clone(&timed_out_reply_drops)));
+    assert_eventually!(|| timed_out_reply_drops.load(Ordering::SeqCst) == 1).await;
 
-    let (reply, receiver) = actor.reply_channel::<usize>();
+    let dropped_receiver_reply_drops = Arc::new(AtomicUsize::new(0));
+    let (reply, receiver) = actor.reply_channel::<CountedReplyDrop>();
     drop(receiver);
-    reply.send(2);
+    reply.send(CountedReplyDrop(Arc::clone(&dropped_receiver_reply_drops)));
+    assert_eventually!(|| dropped_receiver_reply_drops.load(Ordering::SeqCst) == 1).await;
+    assert_quiet(Duration::from_millis(20), || {
+        timed_out_reply_drops.load(Ordering::SeqCst) != 1
+            || dropped_receiver_reply_drops.load(Ordering::SeqCst) != 1
+    })
+    .await;
 }

--- a/crates/shelterwood/tests/mailbox.rs
+++ b/crates/shelterwood/tests/mailbox.rs
@@ -4,6 +4,7 @@ use std::{
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
+        mpsc,
     },
     time::Duration,
 };
@@ -32,11 +33,22 @@ enum ReplyMode {
     Hold,
 }
 
-struct CountedReplyDrop(Arc<AtomicUsize>);
+/// A discarded reply payload that publishes its own destruction.
+///
+/// Both the counter and the notification are shared across every instance, so
+/// the test can judge the exact total and then watch one real-time window for
+/// a duplicate rather than re-reading a per-value counter that no correct or
+/// incorrect run could move again.
+struct CountedReplyDrop {
+    drops: Arc<AtomicUsize>,
+    disposed: mpsc::Sender<&'static str>,
+    label: &'static str,
+}
 
 impl Drop for CountedReplyDrop {
     fn drop(&mut self) {
-        self.0.fetch_add(1, Ordering::SeqCst);
+        self.drops.fetch_add(1, Ordering::SeqCst);
+        let _ = self.disposed.send(self.label);
     }
 }
 
@@ -326,23 +338,60 @@ async fn reply_receiver_is_consuming_and_late_replies_are_discarded() {
         )
         .expect("valid actor");
     let width = Duration::from_secs(10);
-    let timed_out_reply_drops = Arc::new(AtomicUsize::new(0));
+    // Both discards are destroyed off-runtime by isolated disposal, which
+    // costs a blocking-pool or fallback thread start. A polling wait would be
+    // worthless here: this test runs on a paused clock, where every
+    // `tokio::time::sleep` auto-advances the moment the runtime idles, so a
+    // nominal five-second poll budget collapses to milliseconds of wall time.
+    // Wait on the destructor's own notification in real time instead.
+    const DISPOSAL_WAIT: Duration = Duration::from_secs(5);
+    // The test keeps `disposed` alive, so this window is a real-time wait for
+    // a third notification and not an immediate `Disconnected`.
+    const DUPLICATE_DISPOSAL_WINDOW: Duration = Duration::from_millis(50);
+    let drops = Arc::new(AtomicUsize::new(0));
+    let (disposed, disposals) = mpsc::channel();
+
     let (reply, receiver) = actor.reply_channel();
     let mut waiter = Box::pin(receiver.recv(width));
     assert!(poll_once(waiter.as_mut()).is_pending());
     advance_time(width).await;
     assert!(matches!(waiter.await, Err(ReplyError::Timeout)));
-    reply.send(CountedReplyDrop(Arc::clone(&timed_out_reply_drops)));
-    assert_eventually!(|| timed_out_reply_drops.load(Ordering::SeqCst) == 1).await;
+    reply.send(CountedReplyDrop {
+        drops: Arc::clone(&drops),
+        disposed: disposed.clone(),
+        label: "timed-out receiver",
+    });
+    assert_eq!(
+        disposals
+            .recv_timeout(DISPOSAL_WAIT)
+            .expect("isolated disposal destroys the reply a timed-out receiver rejected"),
+        "timed-out receiver"
+    );
 
-    let dropped_receiver_reply_drops = Arc::new(AtomicUsize::new(0));
     let (reply, receiver) = actor.reply_channel::<CountedReplyDrop>();
     drop(receiver);
-    reply.send(CountedReplyDrop(Arc::clone(&dropped_receiver_reply_drops)));
-    assert_eventually!(|| dropped_receiver_reply_drops.load(Ordering::SeqCst) == 1).await;
-    assert_quiet(Duration::from_millis(20), || {
-        timed_out_reply_drops.load(Ordering::SeqCst) != 1
-            || dropped_receiver_reply_drops.load(Ordering::SeqCst) != 1
-    })
-    .await;
+    reply.send(CountedReplyDrop {
+        drops: Arc::clone(&drops),
+        disposed: disposed.clone(),
+        label: "dropped receiver",
+    });
+    assert_eq!(
+        disposals
+            .recv_timeout(DISPOSAL_WAIT)
+            .expect("isolated disposal destroys the reply a dropped receiver rejected"),
+        "dropped receiver"
+    );
+
+    assert_eq!(
+        drops.load(Ordering::SeqCst),
+        2,
+        "each discarded reply is destroyed exactly once"
+    );
+    assert!(
+        matches!(
+            disposals.recv_timeout(DUPLICATE_DISPOSAL_WINDOW),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ),
+        "no reply is disposed twice"
+    );
 }

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -25,7 +25,13 @@ struct ZeroDeadlineActor;
 #[derive(Debug, Eq, PartialEq)]
 struct ZeroDeadlineObservation {
     result: Result<usize, DeadlineElapsed>,
-    continuation_task_matches: bool,
+    /// The tasks `init` and the continuation ran on. `tokio::task::Id` is
+    /// `Copy + Eq`, so both ids travel whole rather than as a pre-collapsed
+    /// comparison: a failure then names the two tasks instead of printing
+    /// `false`, and the judgement does not rest on `Debug` output this
+    /// repository treats as non-contractual.
+    actor_task: tokio::task::Id,
+    continuation_task: tokio::task::Id,
 }
 
 struct ZeroDeadlinePanickingDrop {
@@ -65,7 +71,7 @@ impl Actor for ZeroDeadlineActor {
         (polled, observed): Self::Args,
         context: &mut Context<'_, Self>,
     ) -> Result<Self, ExitError> {
-        let actor_task = format!("{:?}", tokio::task::id());
+        let actor_task = tokio::task::id();
         context
             .offload(
                 async move {
@@ -76,8 +82,8 @@ impl Actor for ZeroDeadlineActor {
                     observed
                         .send(ZeroDeadlineObservation {
                             result,
-                            continuation_task_matches: format!("{:?}", tokio::task::id())
-                                == actor_task,
+                            actor_task,
+                            continuation_task: tokio::task::id(),
                         })
                         .expect("the test retains the observation receiver");
                     ZeroMessage::Done
@@ -136,17 +142,27 @@ async fn zero_budget_offload_never_polls_work_and_times_out_on_actor_task() {
     )
     .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
-    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
-    assert!(!polled.load(Ordering::SeqCst));
+    // The actor stops only on receipt of the continuation's message, so a
+    // dropped completion would park here forever and report as a harness
+    // timeout instead of a failed assertion.
     assert_eq!(
-        observations
-            .recv_timeout(POLL_TIMEOUT)
-            .expect("the continuation publishes its result"),
-        ZeroDeadlineObservation {
-            result: Err(DeadlineElapsed),
-            continuation_task_matches: true,
-        },
-        "a zero-budget offload times out without polling and its continuation runs on the actor task"
+        tokio::time::timeout(POLL_TIMEOUT, system.wait())
+            .await
+            .expect("the zero-budget continuation is delivered"),
+        shelterwood::StopReason::Finished
+    );
+    assert!(!polled.load(Ordering::SeqCst));
+    let observation = observations
+        .recv_timeout(POLL_TIMEOUT)
+        .expect("the continuation publishes its result");
+    assert_eq!(
+        observation.result,
+        Err(DeadlineElapsed),
+        "a zero-budget offload times out without polling its work"
+    );
+    assert_eq!(
+        observation.continuation_task, observation.actor_task,
+        "the continuation runs on the actor task"
     );
     assert!(
         observations.try_recv().is_err(),

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -22,6 +22,12 @@ enum ZeroMessage {
 
 struct ZeroDeadlineActor;
 
+#[derive(Debug, Eq, PartialEq)]
+struct ZeroDeadlineObservation {
+    result: Result<usize, DeadlineElapsed>,
+    continuation_task_matches: bool,
+}
+
 struct ZeroDeadlinePanickingDrop {
     polled: Arc<AtomicBool>,
     drops: Arc<AtomicUsize>,
@@ -50,9 +56,15 @@ struct ZeroDeadlinePanickingDropActor;
 
 impl Actor for ZeroDeadlineActor {
     type Msg = ZeroMessage;
-    type Args = Arc<AtomicBool>;
+    type Args = (
+        Arc<AtomicBool>,
+        std::sync::mpsc::Sender<ZeroDeadlineObservation>,
+    );
 
-    async fn init(polled: Self::Args, context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+    async fn init(
+        (polled, observed): Self::Args,
+        context: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
         let actor_task = format!("{:?}", tokio::task::id());
         context
             .offload(
@@ -61,8 +73,13 @@ impl Actor for ZeroDeadlineActor {
                     7usize
                 },
                 move |result| {
-                    assert_eq!(result, Err(DeadlineElapsed));
-                    assert_eq!(format!("{:?}", tokio::task::id()), actor_task);
+                    observed
+                        .send(ZeroDeadlineObservation {
+                            result,
+                            continuation_task_matches: format!("{:?}", tokio::task::id())
+                                == actor_task,
+                        })
+                        .expect("the test retains the observation receiver");
                     ZeroMessage::Done
                 },
                 Duration::ZERO,
@@ -111,15 +128,30 @@ impl Actor for ZeroDeadlinePanickingDropActor {
 #[tokio::test]
 async fn zero_budget_offload_never_polls_work_and_times_out_on_actor_task() {
     let polled = Arc::new(AtomicBool::new(false));
+    let (observed, observations) = std::sync::mpsc::channel();
     let mut tree = Tree::new();
     tree.add_actor_once(
         "zero",
-        ActorOnceDef::<ZeroDeadlineActor>::new(Arc::clone(&polled)),
+        ActorOnceDef::<ZeroDeadlineActor>::new((Arc::clone(&polled), observed)),
     )
     .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert!(!polled.load(Ordering::SeqCst));
+    assert_eq!(
+        observations
+            .recv_timeout(POLL_TIMEOUT)
+            .expect("the continuation publishes its result"),
+        ZeroDeadlineObservation {
+            result: Err(DeadlineElapsed),
+            continuation_task_matches: true,
+        },
+        "a zero-budget offload times out without polling and its continuation runs on the actor task"
+    );
+    assert!(
+        observations.try_recv().is_err(),
+        "the continuation publishes exactly one observation"
+    );
 }
 
 #[tokio::test]
@@ -2001,22 +2033,22 @@ enum FloodMessage {
 }
 
 struct FloodActor {
-    seen: Vec<bool>,
     delivered: usize,
     completed_work: Arc<AtomicUsize>,
+    delivered_indices: Arc<Mutex<Vec<usize>>>,
     release: ReleaseGate,
 }
 
 impl Actor for FloodActor {
     type Msg = FloodMessage;
-    type Args = (Arc<AtomicUsize>, ReleaseGate);
+    type Args = (Arc<AtomicUsize>, Arc<Mutex<Vec<usize>>>, ReleaseGate);
 
     async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
         Ok(Self {
-            seen: vec![false; FLOOD],
             delivered: 0,
             completed_work: args.0,
-            release: args.1,
+            delivered_indices: args.1,
+            release: args.2,
         })
     }
 
@@ -2047,11 +2079,10 @@ impl Actor for FloodActor {
                 Ok(())
             }
             FloodMessage::Completed(index) => {
-                assert!(
-                    !self.seen[index],
-                    "each flooded completion is delivered exactly once"
-                );
-                self.seen[index] = true;
+                self.delivered_indices
+                    .lock()
+                    .expect("delivery evidence mutex remains healthy")
+                    .push(index);
                 self.delivered += 1;
                 if self.delivered == FLOOD {
                     context.stop();
@@ -2068,12 +2099,17 @@ impl Actor for FloodActor {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn offload_completion_flood_is_absorbed_and_fully_delivered() {
     let completed_work = Arc::new(AtomicUsize::new(0));
+    let delivered_indices = Arc::new(Mutex::new(Vec::new()));
     let release = ReleaseGate::default();
     let mut tree = Tree::new();
     let actor = tree
         .add_actor_once(
             "flood",
-            ActorOnceDef::<FloodActor>::new((Arc::clone(&completed_work), release.clone())),
+            ActorOnceDef::<FloodActor>::new((
+                Arc::clone(&completed_work),
+                Arc::clone(&delivered_indices),
+                release.clone(),
+            )),
         )
         .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
@@ -2081,7 +2117,22 @@ async fn offload_completion_flood_is_absorbed_and_fully_delivered() {
     actor.send(FloodMessage::Start).await.expect("actor live");
     assert_eventually!(|| completed_work.load(Ordering::SeqCst) == FLOOD).await;
     release.release();
-    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert_eq!(
+        tokio::time::timeout(POLL_TIMEOUT, system.wait())
+            .await
+            .expect("every flooded completion is delivered"),
+        shelterwood::StopReason::Finished
+    );
+    let mut delivered = delivered_indices
+        .lock()
+        .expect("delivery evidence mutex remains healthy")
+        .clone();
+    delivered.sort_unstable();
+    assert_eq!(
+        delivered,
+        (0..FLOOD).collect::<Vec<_>>(),
+        "every flooded completion identity is delivered exactly once"
+    );
 }
 
 const CYCLES: usize = 64;
@@ -2093,6 +2144,7 @@ enum CycleMessage {
 
 struct CycleActor {
     next: usize,
+    delivered: Arc<Mutex<Vec<usize>>>,
 }
 
 impl CycleActor {
@@ -2110,17 +2162,20 @@ impl CycleActor {
 
 impl Actor for CycleActor {
     type Msg = CycleMessage;
-    type Args = ();
+    type Args = Arc<Mutex<Vec<usize>>>;
 
-    async fn init((): Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
-        Ok(Self { next: 0 })
+    async fn init(delivered: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self { next: 0, delivered })
     }
 
     async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
         match message {
             CycleMessage::Start => self.offload_next(context),
             CycleMessage::Completed(value) => {
-                assert_eq!(value, self.next, "steady-state cycles deliver in order");
+                self.delivered
+                    .lock()
+                    .expect("cycle evidence mutex remains healthy")
+                    .push(value);
                 self.next += 1;
                 if self.next == CYCLES {
                     context.stop();
@@ -2139,14 +2194,30 @@ impl Actor for CycleActor {
 /// cycle's completion is delivered.
 #[tokio::test]
 async fn sequential_offload_cycles_deliver_every_completion() {
+    let delivered = Arc::new(Mutex::new(Vec::new()));
     let mut tree = Tree::new();
     let actor = tree
-        .add_actor_once("cycles", ActorOnceDef::<CycleActor>::new(()))
+        .add_actor_once(
+            "cycles",
+            ActorOnceDef::<CycleActor>::new(Arc::clone(&delivered)),
+        )
         .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("actor starts");
     actor.send(CycleMessage::Start).await.expect("actor live");
-    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert_eq!(
+        tokio::time::timeout(POLL_TIMEOUT, system.wait())
+            .await
+            .expect("every sequential completion is delivered"),
+        shelterwood::StopReason::Finished
+    );
+    assert_eq!(
+        *delivered
+            .lock()
+            .expect("cycle evidence mutex remains healthy"),
+        (0..CYCLES).collect::<Vec<_>>(),
+        "steady-state cycles deliver every completion exactly once and in order"
+    );
 }
 
 const SATURATE: usize = 64;
@@ -2160,11 +2231,12 @@ struct SaturatedActor {
     issued: usize,
     delivered: usize,
     peak_backlog: Arc<AtomicUsize>,
+    timed_out: Arc<AtomicUsize>,
 }
 
 impl Actor for SaturatedActor {
     type Msg = SaturateMessage;
-    type Args = (ReleaseGate, Arc<AtomicUsize>);
+    type Args = (ReleaseGate, Arc<AtomicUsize>, Arc<AtomicUsize>);
 
     async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
         args.0.wait().await;
@@ -2172,6 +2244,7 @@ impl Actor for SaturatedActor {
             issued: 0,
             delivered: 0,
             peak_backlog: args.1,
+            timed_out: args.2,
         })
     }
 
@@ -2181,11 +2254,14 @@ impl Actor for SaturatedActor {
                 self.peak_backlog
                     .fetch_max(self.issued - self.delivered, Ordering::SeqCst);
                 self.issued += 1;
+                let timed_out = Arc::clone(&self.timed_out);
                 context
                     .offload(
                         async {},
-                        |result| {
-                            assert_eq!(result, Err(DeadlineElapsed));
+                        move |result| {
+                            if result == Err(DeadlineElapsed) {
+                                timed_out.fetch_add(1, Ordering::SeqCst);
+                            }
                             SaturateMessage::Completed
                         },
                         Duration::ZERO,
@@ -2214,12 +2290,17 @@ impl Actor for SaturatedActor {
 async fn saturated_mailbox_does_not_grow_the_completion_backlog() {
     let gate = ReleaseGate::default();
     let peak_backlog = Arc::new(AtomicUsize::new(0));
+    let timed_out = Arc::new(AtomicUsize::new(0));
     let mut tree = Tree::new();
     let actor = tree
         .add_actor_once(
             "saturated",
-            ActorOnceDef::<SaturatedActor>::new((gate.clone(), Arc::clone(&peak_backlog)))
-                .mailbox(Mailbox::queue(SATURATE).expect("non-zero capacity")),
+            ActorOnceDef::<SaturatedActor>::new((
+                gate.clone(),
+                Arc::clone(&peak_backlog),
+                Arc::clone(&timed_out),
+            ))
+            .mailbox(Mailbox::queue(SATURATE).expect("non-zero capacity")),
         )
         .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
@@ -2237,6 +2318,11 @@ async fn saturated_mailbox_does_not_grow_the_completion_backlog() {
     assert!(
         peak_backlog.load(Ordering::SeqCst) < SATURATE - 1,
         "the completion backlog must not reach the queued mailbox history"
+    );
+    assert_eq!(
+        timed_out.load(Ordering::SeqCst),
+        SATURATE,
+        "every zero-budget offload is classified as deadline elapsed"
     );
 }
 


### PR DESCRIPTION
Closes #281.

## What changed

- move offload timeout, task-affinity, exactly-once, and ordering assertions out of actor continuations into test bodies
- publish and judge pre-drain state after releasing handler gates
- make late-reply disposal observable and exact
- preserve exact leak-zero storage assertions while bounding raw deadline heap slack to its documented policy
- use shared driver wait constants instead of ad-hoc shorter real-clock bounds
- replace mailbox disposal polling sleeps with a bounded channel handshake
- assert reservation terminalization directly
- route the admission race through the runtime test fixture instead of entering Tokio directly
- make platform-specific timer boundary skips explicit

## Why

Several regressions repeated the PR #249 failure mode: an assertion inside supervised user code could panic the actor while the outer test still passed. Other tests pinned implementation details more tightly than their contract or used timing/runtime fixtures inconsistent with the rest of the suite.

The tests now publish evidence outward and judge it where supervision cannot swallow the assertion.

## Validation

- mutation probes fail for a dropped offload completion, retained late reply, skipped reservation terminalization, and unbounded deadline storage
- affected integration suites: 45 tests
- driver unit suite: 135 tests
- mailbox unit suite: 28 tests
- runtime timer suite: 7 tests
- `./tools/dev just ci` (674 nextest tests plus clippy, doctests, docs, API reachability, external consumer, and Nix formatting)
- nightly format check and `git diff --check`

This should land before #282 consolidates fixtures and before #279 moves the deadline queue.