### PR TITLE
Isolate payloads across panic-resuming waker effects

### DIFF
--- a/crates/shelterwood-mailbox/src/futures.rs
+++ b/crates/shelterwood-mailbox/src/futures.rs
@@ -153,6 +153,12 @@ impl<M: Send + 'static> ActorRef<M> {
     /// actor handler deadlocks because the blocked handler is also the only code
     /// that can produce the reply; use an actor-local continuation or an
     /// incarnation-owned offload instead.
+    ///
+    /// A timeout before acceptance has no caller to hand the request back to,
+    /// so it destroys both the recovered request and the waker it registered
+    /// through isolated disposal, as cancelling a parked [`send`](Self::send)
+    /// does. A panicking waker destructor is contained there rather than
+    /// resuming on the awaiting task.
     pub fn call<T: Send + 'static>(
         &self,
         make_msg: impl FnOnce(Reply<T>) -> M + Send + 'static,
@@ -428,6 +434,13 @@ impl<M> fmt::Debug for SendTimeout<M> {
     }
 }
 
+/// Withdraws an unaccepted send and classifies its outcome under the
+/// caller's chosen waker disposition.
+///
+/// The outcome is taken before `finish()` releases the registered waker, so
+/// under either disposition the recovered message already belongs to
+/// `result` and a hostile waker destructor can neither divert nor destroy
+/// it.
 fn withdraw_send_with<M: Send + 'static>(
     send: &mut SendFuture<M>,
     disposition: WithdrawalDisposition,
@@ -454,12 +467,11 @@ fn withdraw_send_with<M: Send + 'static>(
 }
 
 fn withdraw_send<M: Send + 'static>(send: &mut SendFuture<M>) -> Result<Incarnation, SendError<M>> {
-    let result = withdraw_send_with(send, WithdrawalDisposition::Inline);
     // Unlike the cancellation path this is a normal return on the caller's own
-    // task, so the caller's waker destructor stays inline and its panic stays
-    // visible; no core lock is held and the recovered message already belongs
-    // to `result`.
-    result
+    // task, and the recovered message goes back to that same caller. No core
+    // lock is held, so the caller's waker destructor stays inline and its
+    // panic stays visible.
+    withdraw_send_with(send, WithdrawalDisposition::Inline)
 }
 
 impl<M: Send + 'static> DeadlineOperation for TimedSend<M> {

--- a/crates/shelterwood-mailbox/src/futures.rs
+++ b/crates/shelterwood-mailbox/src/futures.rs
@@ -428,9 +428,12 @@ impl<M> fmt::Debug for SendTimeout<M> {
     }
 }
 
-fn withdraw_send<M: Send + 'static>(send: &mut SendFuture<M>) -> Result<Incarnation, SendError<M>> {
+fn withdraw_send_with<M: Send + 'static>(
+    send: &mut SendFuture<M>,
+    disposition: WithdrawalDisposition,
+) -> Result<Incarnation, SendError<M>> {
     let actor_id = send.mailbox.actor_id.clone();
-    let mut withdrawal = send.withdraw(WithdrawalDisposition::Inline);
+    let mut withdrawal = send.withdraw(disposition);
     let result = match withdrawal.take_outcome() {
         WithdrawalOutcome::Withdrawn { message, observed } => Err(SendError {
             actor_id,
@@ -446,11 +449,16 @@ fn withdraw_send<M: Send + 'static>(send: &mut SendFuture<M>) -> Result<Incarnat
             kind: SendErrorKind::Terminated,
         }),
     };
+    withdrawal.finish();
+    result
+}
+
+fn withdraw_send<M: Send + 'static>(send: &mut SendFuture<M>) -> Result<Incarnation, SendError<M>> {
+    let result = withdraw_send_with(send, WithdrawalDisposition::Inline);
     // Unlike the cancellation path this is a normal return on the caller's own
     // task, so the caller's waker destructor stays inline and its panic stays
     // visible; no core lock is held and the recovered message already belongs
     // to `result`.
-    withdrawal.finish();
     result
 }
 
@@ -641,10 +649,14 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
             return Poll::Pending;
         }
 
-        let result = withdraw_send(
+        // A call cannot return a recovered message to its caller. Isolate the
+        // registered waker before taking that message so a hostile waker
+        // destructor cannot unwind through and destroy the message inline.
+        let result = withdraw_send_with(
             self.send
                 .as_mut()
                 .expect("an unaccepted call retains its send future"),
+            WithdrawalDisposition::Isolated,
         );
         self.send = None;
         match result {
@@ -710,7 +722,8 @@ mod tests {
 
     use super::{
         super::cell::tests::{actor, actor_for},
-        ActorRef, MailboxCell, SendFuture, SendFutureState, SendOperation,
+        ActorRef, DeadlineOperation, DeadlinePhase, MailboxCell, SendFuture, SendFutureState,
+        SendOperation,
     };
 
     #[derive(Default)]
@@ -922,6 +935,56 @@ mod tests {
         }
     }
 
+    struct CallMessage {
+        _reply: crate::Reply<u8>,
+        _payload: ThreadRecordingDrop,
+    }
+
+    struct EveryWakerDropPanics(DisposalThread);
+
+    unsafe fn clone_panicking_drop_waker(data: *const ()) -> RawWaker {
+        // SAFETY: every pointer using this vtable came from an Arc of the
+        // matching type. ManuallyDrop preserves the reference represented by
+        // `data`; the returned raw waker owns only the new clone.
+        let probe =
+            ManuallyDrop::new(unsafe { Arc::<EveryWakerDropPanics>::from_raw(data.cast()) });
+        RawWaker::new(
+            Arc::into_raw(Arc::clone(&probe)).cast(),
+            &PANICKING_DROP_WAKER_VTABLE,
+        )
+    }
+
+    unsafe fn wake_panicking_drop_waker(data: *const ()) {
+        // SAFETY: wake consumes the reference represented by this raw waker.
+        drop(unsafe { Arc::<EveryWakerDropPanics>::from_raw(data.cast()) });
+    }
+
+    unsafe fn wake_by_ref_panicking_drop_waker(_data: *const ()) {}
+
+    unsafe fn drop_panicking_drop_waker(data: *const ()) {
+        // SAFETY: drop consumes the reference represented by this raw waker.
+        let probe = unsafe { Arc::<EveryWakerDropPanics>::from_raw(data.cast()) };
+        *probe.0.lock().expect("waker disposal recorder mutex") = Some(std::thread::current().id());
+        panic!("injected call waker drop panic");
+    }
+
+    static PANICKING_DROP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+        clone_panicking_drop_waker,
+        wake_panicking_drop_waker,
+        wake_by_ref_panicking_drop_waker,
+        drop_panicking_drop_waker,
+    );
+
+    fn panicking_drop_waker(recorder: DisposalThread) -> Waker {
+        let raw = RawWaker::new(
+            Arc::into_raw(Arc::new(EveryWakerDropPanics(recorder))).cast(),
+            &PANICKING_DROP_WAKER_VTABLE,
+        );
+        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+        // ownership across clone, wake, and drop.
+        unsafe { Waker::from_raw(raw) }
+    }
+
     /// Parks `send` behind a hostile waker and releases the caller's own
     /// reference, leaving the registered clone as the last owner.
     fn park_behind_hostile_waker<M: Send + 'static>(
@@ -997,6 +1060,68 @@ mod tests {
             "a hostile waker destructor cannot divert the message from isolated disposal"
         );
         assert_ne!(await_disposal(&waker_thread), here);
+    }
+
+    #[test]
+    fn call_acceptance_timeout_isolates_message_before_hostile_waker_drop() {
+        let (_mailbox, actor): (Arc<MailboxCell<CallMessage>>, ActorRef<CallMessage>) = actor_for();
+        let message_thread = disposal_thread();
+        let waker_thread = disposal_thread();
+        let mut call = Box::pin(actor.call(
+            {
+                let message_thread = Arc::clone(&message_thread);
+                move |reply| CallMessage {
+                    _reply: reply,
+                    _payload: ThreadRecordingDrop(message_thread),
+                }
+            },
+            Duration::from_secs(1),
+        ));
+        let hostile = panicking_drop_waker(Arc::clone(&waker_thread));
+        let mut context = Context::from_waker(&hostile);
+        let deadline = crate::deadline::Deadline::after(
+            crate::capability::tests::runtime().now(),
+            Duration::from_secs(1),
+        );
+
+        assert!(
+            call.deadlined
+                .operation
+                .poll_deadlined(&mut context, deadline, DeadlinePhase::InitialAttempt)
+                .is_pending()
+        );
+        let polling_thread = std::thread::current().id();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            call.deadlined.operation.poll_deadlined(
+                &mut context,
+                deadline,
+                DeadlinePhase::TimeoutArbitration,
+            )
+        }));
+        // The context's raw waker is deliberately leaked: its separately
+        // registered clone is the object whose disposal boundary this test
+        // observes, and dropping this caller-owned instance would invoke the
+        // same intentionally hostile vtable on the test thread.
+        std::mem::forget(hostile);
+
+        let outcome = result.expect("isolated withdrawal contains the hostile waker destructor");
+        assert!(matches!(
+            outcome,
+            Poll::Ready(Err(crate::CallError {
+                kind: crate::CallErrorKind::AcceptanceTimedOut,
+                ..
+            }))
+        ));
+        assert_ne!(
+            await_disposal(&waker_thread),
+            polling_thread,
+            "the pre-acceptance withdrawal disposes its registered waker off the polling task"
+        );
+        assert_ne!(
+            await_disposal(&message_thread),
+            polling_thread,
+            "the recovered call message reaches isolated disposal before any waker panic can unwind"
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -272,8 +272,36 @@ enum SpawnBody {
     },
 }
 
+enum PendingSpawnBody {
+    /// Restartable bodies hold only framework data and clones of state that
+    /// remains retained by `ChildConstruction`, so unwinding can only release
+    /// a non-last owner.
+    Retained(SpawnBody),
+    /// One-shot bodies carry the sole user-owned construction payload.
+    Isolated(runtime::Isolated<SpawnBody>),
+}
+
+impl PendingSpawnBody {
+    fn restartable(body: SpawnBody) -> Self {
+        Self::Retained(body)
+    }
+
+    fn one_shot(body: SpawnBody) -> Self {
+        Self::Isolated(runtime::Isolated::new(body))
+    }
+
+    fn into_body(self) -> SpawnBody {
+        match self {
+            Self::Retained(body) => body,
+            Self::Isolated(mut body) => body
+                .take()
+                .expect("a child spawn retains its one-shot construction body"),
+        }
+    }
+}
+
 struct SpawnDispatch {
-    body: SpawnBody,
+    body: PendingSpawnBody,
     construction_spent: bool,
 }
 
@@ -354,39 +382,44 @@ fn dispatch_child_construction(
     match construction {
         ChildConstruction::Raw(definition) => {
             let construction_spent = definition.one_shot();
-            SpawnDispatch {
-                body: SpawnBody::Raw {
-                    spawn: definition.take_spawn(),
-                    context: RawRunContext {
-                        id,
-                        incarnation,
-                        member: Arc::clone(&child.slot.member),
-                        scope: crate::scope::ScopeRef {
-                            cell: Arc::clone(root),
-                        },
-                        shutdown: latches.shutdown.clone(),
-                        abort: latches.abort.clone(),
-                        ready: latches.ready.clone(),
-                        local_stop: latches.local_stop.clone(),
-                        mailbox_shutdown: child.options.mailbox_shutdown,
+            let body = SpawnBody::Raw {
+                spawn: definition.take_spawn(),
+                context: RawRunContext {
+                    id,
+                    incarnation,
+                    member: Arc::clone(&child.slot.member),
+                    scope: crate::scope::ScopeRef {
+                        cell: Arc::clone(root),
                     },
-                    readiness: child.options.readiness,
+                    shutdown: latches.shutdown.clone(),
+                    abort: latches.abort.clone(),
+                    ready: latches.ready.clone(),
+                    local_stop: latches.local_stop.clone(),
+                    mailbox_shutdown: child.options.mailbox_shutdown,
+                },
+                readiness: child.options.readiness,
+            };
+            SpawnDispatch {
+                body: if construction_spent {
+                    PendingSpawnBody::one_shot(body)
+                } else {
+                    PendingSpawnBody::restartable(body)
                 },
                 construction_spent,
             }
         }
         ChildConstruction::Task(definition) => SpawnDispatch {
-            body: SpawnBody::TaskRestartable {
+            body: PendingSpawnBody::restartable(SpawnBody::TaskRestartable {
                 factory: Arc::clone(&definition.factory),
                 context: TaskContext::new(id, incarnation, latches.task_context()),
-            },
+            }),
             construction_spent: false,
         },
         ChildConstruction::TaskOnce(definition) => SpawnDispatch {
-            body: SpawnBody::TaskOnce {
+            body: PendingSpawnBody::one_shot(SpawnBody::TaskOnce {
                 body: definition.take_body(),
                 context: TaskContext::new(id, incarnation, latches.task_context()),
-            },
+            }),
             construction_spent: true,
         },
         ChildConstruction::Scope(definition) => {
@@ -425,7 +458,11 @@ fn dispatch_child_construction(
                 )
             };
             SpawnDispatch {
-                body,
+                body: if construction_spent {
+                    PendingSpawnBody::one_shot(body)
+                } else {
+                    PendingSpawnBody::restartable(body)
+                },
                 construction_spent,
             }
         }
@@ -670,6 +707,11 @@ impl ScopeRuntime {
             // terminal publication or restart-window arbitration.
             drop(child.construction.take());
         }
+        // Binding and Started publication can both resume hostile waker
+        // panics. Keep one-shot construction state behind isolated disposal
+        // until those effects have completed, then transfer it at the task
+        // launch boundary.
+        let body = body.into_body();
         let abort_handle = spawn_child_tasks(ChildTaskLaunch {
             events: self.events.clone(),
             key,

--- a/crates/shelterwood/src/driver/tests.rs
+++ b/crates/shelterwood/src/driver/tests.rs
@@ -3,6 +3,7 @@ mod dynamic;
 mod events;
 mod exhaustion;
 mod observation;
+mod payload;
 mod reports;
 mod shutdown;
 mod startup;

--- a/crates/shelterwood/src/driver/tests/payload.rs
+++ b/crates/shelterwood/src/driver/tests/payload.rs
@@ -1,0 +1,156 @@
+use super::support::*;
+
+struct ThreadRecordingRaw {
+    dropped: crate::runtime::UnboundedMpscSender<std::thread::ThreadId>,
+}
+
+impl Drop for ThreadRecordingRaw {
+    fn drop(&mut self) {
+        let _ = crate::runtime::unbounded_mpsc_send(&self.dropped, std::thread::current().id());
+    }
+}
+
+impl crate::RawActor for ThreadRecordingRaw {
+    type Msg = u8;
+
+    fn readiness() -> Readiness {
+        Readiness::Manual
+    }
+
+    async fn run(&mut self, _: &mut crate::RawContext<Self::Msg>) -> crate::ExitResult {
+        future::pending().await
+    }
+}
+
+fn one_shot_raw_scope(
+    dropped: crate::runtime::UnboundedMpscSender<std::thread::ThreadId>,
+) -> (ScopeRuntime, ChildKey, Arc<MemberCell>, ActorRef<u8>) {
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once("worker", RawOnceDef::new(ThreadRecordingRaw { dropped }))
+        .expect("the one-shot raw actor is valid");
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let member = Arc::clone(&plan.children[0].slot.member);
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("the test scope has a live epoch");
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+    let mut children = ChildArena::default();
+    let key = children
+        .insert(child)
+        .unwrap_or_else(|_| panic!("the fixture fits in the child-key domain"));
+    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
+    let scope = ScopeRuntimeBuilder::new(root, epoch, events)
+        .with_defaults(plan.defaults.clone())
+        .with_lifecycle(ScopeLifecycle::running())
+        .with_children(children)
+        .build();
+    plan.finish_transfer();
+    (scope, key, member, actor)
+}
+
+async fn disposed_thread(
+    receiver: &mut crate::runtime::UnboundedMpscReceiver<std::thread::ThreadId>,
+) -> std::thread::ThreadId {
+    match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, receiver.recv()).await {
+        crate::runtime::Timeout::Completed(Some(thread)) => thread,
+        crate::runtime::Timeout::Completed(None) => {
+            panic!("the disposal recorder closed before the payload was destroyed")
+        }
+        crate::runtime::Timeout::Elapsed => panic!("isolated payload disposal did not complete"),
+    }
+}
+
+fn assert_waker_panic(payload: Box<dyn std::any::Any + Send>, expected: &'static str) {
+    assert_eq!(
+        payload.downcast_ref::<&'static str>().copied(),
+        Some(expected),
+        "the hostile observer's panic remains the surfaced diagnostic"
+    );
+}
+
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+async fn started_waker_panic_keeps_one_shot_body_isolated() {
+    const PANIC: &str = "injected Started observer panic";
+
+    let (dropped, mut drops) = crate::runtime::unbounded_mpsc();
+    let (mut scope, key, member, _actor) = one_shot_raw_scope(dropped);
+    let mut record = member.record_watcher();
+    let mut started = Box::pin(record.changed());
+    let hostile = Waker::from(Arc::new(PanicWake(PANIC)));
+    assert!(
+        started
+            .as_mut()
+            .poll(&mut Context::from_waker(&hostile))
+            .is_pending()
+    );
+
+    let driver_thread = std::thread::current().id();
+    let result = catch_unwind(AssertUnwindSafe(|| scope.spawn_child(key)));
+
+    let payload = result.expect_err("the hostile Started observer still surfaces");
+    assert_waker_panic(payload, PANIC);
+    assert_ne!(
+        disposed_thread(&mut drops).await,
+        driver_thread,
+        "the extracted one-shot body must reach isolated disposal, not the driver unwind"
+    );
+}
+
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rebind_waker_panic_keeps_one_shot_body_isolated() {
+    const PANIC: &str = "injected rebind sender panic";
+
+    let (dropped, mut drops) = crate::runtime::unbounded_mpsc();
+    let (mut scope, key, _member, actor) = one_shot_raw_scope(dropped);
+
+    // Give the mailbox a prior, fully closed incarnation so the spawn below
+    // exercises the restart/rebind edge rather than the first-bind edge.
+    let child = scope.children.get_mut(key).expect("the child remains live");
+    let prior = child
+        .incarnations
+        .mint()
+        .expect("a prior incarnation is available");
+    let mailbox = child.mailbox.as_ref().expect("raw actors own a mailbox");
+    mailbox.bind(prior);
+    mailbox.freeze(prior);
+    if let Some(teardown) = mailbox.close(prior) {
+        crate::runtime::dispose_detached(teardown);
+    }
+
+    let hostile = Waker::from(Arc::new(PanicWake(PANIC)));
+    let mut parked = Box::pin(actor.send(1));
+    assert!(
+        parked
+            .as_mut()
+            .poll(&mut Context::from_waker(&hostile))
+            .is_pending()
+    );
+
+    let driver_thread = std::thread::current().id();
+    let result = catch_unwind(AssertUnwindSafe(|| scope.spawn_child(key)));
+
+    let payload = result.expect_err("the hostile parked sender still surfaces during rebind");
+    assert_waker_panic(payload, PANIC);
+    assert_ne!(
+        disposed_thread(&mut drops).await,
+        driver_thread,
+        "the extracted one-shot body must reach isolated disposal, not the rebind unwind"
+    );
+    assert!(
+        matches!(
+            parked
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Ready(Ok(_))
+        ),
+        "rebind accepted the parked send before its waker panic resumed"
+    );
+}


### PR DESCRIPTION
Closes #267.

## What changed

- keep one-shot raw, task, and scope spawn bodies inside `runtime::Isolated` from construction extraction through mailbox bind and Started publication
- release the isolated body only at the `spawn_child_tasks` ownership handoff
- give call acceptance-timeout withdrawal an isolated disposition while preserving `SendTimeout`'s documented inline semantics
- add hostile Started-observer, rebind sender, and call-timeout waker regressions

## Root cause

Two post-unlock effect flush windows could resume arbitrary waker panics while a sole user payload was held as a plain local. Unwinding then destroyed that payload inline on the driver or polling task, violating the detached-disposal convention even though no framework lock remained held.

The payload now stays behind isolated disposal until each risky flush is complete. Call withdrawal likewise isolates its registered waker before recovering a message the call surface cannot return.

## Validation

- focused spawn-payload regressions (2 passed)
- hostile pre-acceptance call-timeout regression
- all mailbox futures tests (9 passed)
- pre-existing teardown/factory-disposal regressions
- `./tools/dev just ci`
- nightly formatting and `git diff --check`

## Stack

This is the base of the hostile-waker series. #266 will target this branch; #265 will target #266.