### PR TITLE
Finish teardown after hostile waker panics

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -347,16 +347,19 @@ struct ScopeCompletion {
 
 impl Drop for ScopeRuntime {
     fn drop(&mut self) {
-        let dynamic_entries = if let Some(dynamic) = &self.dynamic {
-            let entries = self.root.with_observation_gate(|txn| {
-                let entries = dynamic.close(&self.root, txn);
-                self.root.set_dynamic_route_locked(None, txn);
-                entries
+        let mut panics = runtime::PanicAccumulator::default();
+        let mut dynamic_entries = None;
+        if let Some(dynamic) = &self.dynamic {
+            panics.run(|| {
+                self.root.with_observation_gate(|txn| {
+                    // Retain the entries before the transaction flushes its
+                    // wakes. If one is hostile, removal completion must still
+                    // remain ordered after terminality and residency cleanup.
+                    dynamic_entries = Some(dynamic.close(&self.root, txn));
+                    self.root.set_dynamic_route_locked(None, txn);
+                });
             });
-            Some(entries)
-        } else {
-            None
-        };
+        }
         // An exited child can be waiting only for retained user construction
         // to finish disposal. Its exit is already classified, so driver death
         // must publish that verdict before the terminality fallback gets a
@@ -366,7 +369,7 @@ impl Drop for ScopeRuntime {
         // publication. A completion that has already been reported is
         // available without waiting, however, so fold everything reported
         // before falling back to the stored verdict.
-        self.drain_arrived_disposal_events();
+        self.drain_arrived_disposal_events(&mut panics);
         let child_keys: Vec<_> = self.children.iter().map(|(key, _)| key).collect();
         for key in child_keys {
             if self
@@ -374,7 +377,7 @@ impl Drop for ScopeRuntime {
                 .get(key)
                 .is_some_and(|child| child.pending_terminal.is_some())
             {
-                self.handle_construction_disposed(key, None);
+                panics.run(|| self.handle_construction_disposed(key, None));
             }
             let Some(child) = self.children.get_mut(key) else {
                 // Terminal publication can reclaim a remove-retained dynamic
@@ -384,27 +387,33 @@ impl Drop for ScopeRuntime {
             };
             if let Some(active) = child.active.take() {
                 if let Some(mailbox) = &child.mailbox {
-                    mailbox.freeze(active.incarnation);
-                    if let Some(teardown) = mailbox.close(active.incarnation) {
+                    panics.run(|| mailbox.freeze(active.incarnation));
+                    let mut teardown = None;
+                    panics.run(|| teardown = mailbox.close(active.incarnation));
+                    if let Some(teardown) = teardown {
                         runtime::dispose_detached(teardown);
                     }
                 }
-                active.shutdown.fire();
-                active.abort.fire();
-                active.abort_handle.abort();
+                panics.run(|| {
+                    active.shutdown.fire();
+                });
+                panics.run(|| {
+                    active.abort.fire();
+                });
+                panics.run(|| active.abort_handle.abort());
             }
             // Driver destruction consumes the same owned terminality
             // completion as the orderly path. Its fallback publishes the
             // coarse kill verdict synchronously.
-            child.terminality.discharge();
+            panics.run(|| child.terminality.discharge());
         }
         // Residency owns the matching Removed edges. Clearing the set after
         // terminality discharges them all before the scope's final event.
-        self.root.clear_residents();
+        panics.run(|| self.root.clear_residents());
         // Dynamic entries own removal completions. Keep them armed until the
         // corresponding members are terminal and no longer resident.
-        drop(dynamic_entries);
-        self.children.clear();
+        panics.run(|| drop(dynamic_entries.take()));
+        panics.run(|| self.children.clear());
         // Unconditional: the publisher is the idempotence point, joining this
         // verdict into the stopped-reason lattice, but epoch retirement is not
         // idempotent and has no other owner. Skipping the call on an
@@ -415,12 +424,14 @@ impl Drop for ScopeRuntime {
             .map(|completion| completion.reason.as_reason().clone())
             .or_else(|| self.supervisor.lifecycle().draining_reason().cloned())
             .unwrap_or(StopReason::ShutdownRequested);
-        if let Some(exit) = completion.and_then(|completion| completion.root_exit) {
-            self.root
-                .finish_root_incarnation(self.epoch, reason, exit.into_exit());
-        } else {
-            self.root.finish_incarnation(self.epoch, reason);
-        }
+        panics.run(|| {
+            if let Some(exit) = completion.and_then(|completion| completion.root_exit) {
+                self.root
+                    .finish_root_incarnation(self.epoch, reason, exit.into_exit());
+            } else {
+                self.root.finish_incarnation(self.epoch, reason);
+            }
+        });
     }
 }
 
@@ -462,7 +473,7 @@ impl ScopeRuntime {
     /// Non-blocking by construction, so a disposal still running on the
     /// blocking pool stays detached and its unknowable result cannot delay
     /// the kill path.
-    fn drain_arrived_disposal_events(&mut self) {
+    fn drain_arrived_disposal_events(&mut self, panics: &mut runtime::PanicAccumulator) {
         while let Some(event) = runtime::unbounded_mpsc_try_recv(&mut self.disposal_event_receiver)
         {
             // The lane has one producer, which sends exactly one variant.
@@ -486,7 +497,7 @@ impl ScopeRuntime {
         // `pending_terminal`.
         while let Some(child) = self.arrived_disposal_panics.keys().next().copied() {
             let panic = self.take_arrived_disposal_panic(child);
-            self.handle_construction_disposed(child, panic);
+            panics.run(|| self.handle_construction_disposed(child, panic));
         }
     }
 

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -38,8 +38,11 @@ impl RemovalResponses {
     }
 
     fn complete(self, outcome: RemoveOutcome) {
+        let mut panics = runtime::PanicAccumulator::default();
         for sender in self.0 {
-            let _ = sender.send(outcome);
+            panics.run(|| {
+                let _ = sender.send(outcome);
+            });
         }
     }
 }
@@ -644,9 +647,35 @@ fn dispose_definition_then(
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        task::{Context, Wake, Waker},
+    };
+
     use crate::RemoveOutcome;
 
     use super::RemovalResponses;
+
+    struct CountedPanicWake {
+        message: &'static str,
+        wakes: Arc<AtomicUsize>,
+    }
+
+    impl Wake for CountedPanicWake {
+        fn wake(self: Arc<Self>) {
+            self.wakes.fetch_add(1, Ordering::SeqCst);
+            std::panic::panic_any(self.message);
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.wakes.fetch_add(1, Ordering::SeqCst);
+            std::panic::panic_any(self.message);
+        }
+    }
 
     #[test]
     fn removal_subscription_discards_abandoned_waiters() {
@@ -662,5 +691,48 @@ mod tests {
         );
         responses.complete(RemoveOutcome::Removed);
         assert_eq!(retained.try_receive(), Some(RemoveOutcome::Removed));
+    }
+
+    #[test]
+    fn removal_completion_delivers_to_two_hostile_waiters_before_resuming() {
+        const FIRST_PANIC: &str = "injected first removal wake panic";
+
+        let mut responses = RemovalResponses::default();
+        let mut first = responses.subscribe();
+        let mut second = responses.subscribe();
+        let first_wakes = Arc::new(AtomicUsize::new(0));
+        let second_wakes = Arc::new(AtomicUsize::new(0));
+        let first_waker = Waker::from(Arc::new(CountedPanicWake {
+            message: FIRST_PANIC,
+            wakes: Arc::clone(&first_wakes),
+        }));
+        let second_waker = Waker::from(Arc::new(CountedPanicWake {
+            message: "injected second removal wake panic",
+            wakes: Arc::clone(&second_wakes),
+        }));
+        assert!(
+            first
+                .poll_receive(&mut Context::from_waker(&first_waker))
+                .is_pending()
+        );
+        assert!(
+            second
+                .poll_receive(&mut Context::from_waker(&second_waker))
+                .is_pending()
+        );
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            responses.complete(RemoveOutcome::Removed);
+        }));
+
+        let payload = result.expect_err("the first hostile removal wake still surfaces");
+        assert_eq!(
+            payload.downcast_ref::<&'static str>().copied(),
+            Some(FIRST_PANIC)
+        );
+        assert_eq!(first_wakes.load(Ordering::SeqCst), 1);
+        assert_eq!(second_wakes.load(Ordering::SeqCst), 1);
+        assert_eq!(first.try_receive(), Some(RemoveOutcome::Removed));
+        assert_eq!(second.try_receive(), Some(RemoveOutcome::Removed));
     }
 }

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -228,7 +228,8 @@ impl ScopeRuntime {
         // though its disposal event has not reached ordinary dispatch. Fold
         // every arrived completion before the hard-force fallback; the drain
         // is non-blocking, so still-running disposal remains detached.
-        self.drain_arrived_disposal_events();
+        let mut panics = runtime::PanicAccumulator::default();
+        self.drain_arrived_disposal_events(&mut panics);
         if self.supervisor.is_disposing(key) {
             // The incarnation has already exited; only its retained factory
             // remains, and the fold above found no completion reported for

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -235,7 +235,7 @@ impl ScopeRuntime {
             // remains, and the fold above found no completion reported for
             // it. Hard escalation detaches that cleanup and keeps the
             // recorded verdict.
-            self.handle_construction_disposed(key, None);
+            panics.run(|| self.handle_construction_disposed(key, None));
         }
     }
 

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -50,7 +50,7 @@ async fn scope_with_arrived_factory_disposal_panic() -> (ScopeRuntime, ChildKey,
             .map(|child| resident_projection(&child.slot))
             .collect(),
     );
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
+    let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     let member = Arc::clone(&child.slot.member);
     let mut children = ChildArena::default();
@@ -71,6 +71,16 @@ async fn scope_with_arrived_factory_disposal_panic() -> (ScopeRuntime, ChildKey,
         .expect("worker is active");
     let incarnation = active.incarnation;
     active.abort_handle.abort();
+    let _joined = recv_child_exit(
+        &mut event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "the aborted fixture task to join",
+    )
+    .await;
+    // `handle_exit` is a post-join operation in production. Wait for that
+    // boundary before injecting the synthetic application verdict so the
+    // spawned body has released its factory clone and retained-construction
+    // disposal is the sole owner whose panic this fixture observes.
     scope.handle_exit(
         key,
         incarnation,

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -301,6 +301,148 @@ async fn hard_force_folds_an_arrived_factory_disposal_panic() {
     assert_arrived_disposal_panic_published(&member);
 }
 
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hard_force_preserves_the_first_terminal_observer_panic_across_its_fallback() {
+    const FIRST_PANIC: &str = "arrived disposal terminal observer panic";
+    const SECOND_PANIC: &str = "hard-force fallback terminal observer panic";
+
+    let gate = Arc::new(FactoryGate::default());
+    let mut tree = Tree::new();
+    tree.add_task(
+        "arrived",
+        TaskDef::new({
+            let capture = PanickingFactoryDrop;
+            move |_| {
+                let _ = &capture;
+                future::pending::<crate::ExitResult>()
+            }
+        })
+        .restart(RestartPolicy::new(
+            RestartCondition::Never,
+            Backoff::Immediate,
+        ))
+        .retention(Retention::Retain),
+    )
+    .expect("valid arrived child");
+    tree.add_task(
+        "fallback",
+        TaskDef::new({
+            let capture = BlockingFactoryDrop(Arc::clone(&gate));
+            move |_| {
+                let _ = &capture;
+                future::pending::<crate::ExitResult>()
+            }
+        })
+        .restart(RestartPolicy::new(
+            RestartCondition::Never,
+            Backoff::Immediate,
+        ))
+        .retention(Retention::Retain),
+    )
+    .expect("valid fallback child");
+
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.member
+        .update(|record| record.stage = MemberStage::Running);
+    root.set_state_and_startup(ScopeState::Running, Ok(()));
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
+    let mut children = ChildArena::default();
+    let mut arrived = None;
+    let mut fallback = None;
+    for child in plan.children.drain(..) {
+        let id = child.slot.member.id().as_str().to_owned();
+        let member = Arc::clone(&child.slot.member);
+        let key = children
+            .insert(ChildRuntime::from_plan(child, &root))
+            .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
+        match id.as_str() {
+            "arrived" => arrived = Some((key, member)),
+            "fallback" => fallback = Some((key, member)),
+            _ => unreachable!("the fixture declares exactly two known children"),
+        }
+    }
+    let (arrived_key, arrived_member) = arrived.expect("arrived child is present");
+    let (fallback_key, fallback_member) = fallback.expect("fallback child is present");
+    let mut scope = ScopeRuntimeBuilder::new(root, epoch, events)
+        .with_defaults(plan.defaults.clone())
+        .with_children(children)
+        .with_lifecycle(ScopeLifecycle::running())
+        .build();
+    plan.finish_transfer();
+
+    for key in [arrived_key, fallback_key] {
+        scope.spawn_child(key);
+        scope.children[key]
+            .active
+            .as_ref()
+            .expect("child is active")
+            .abort_handle
+            .abort();
+    }
+    for _ in 0..2 {
+        recv_child_exit(
+            &mut event_receiver,
+            DRIVER_PROGRESS_WAIT,
+            "an aborted fixture child to join",
+        )
+        .await
+        .dispatch(&mut scope);
+    }
+    gate.wait_entered().await;
+    let arrived_completion = crate::runtime::timeout(DRIVER_PROGRESS_WAIT, async {
+        while crate::runtime::unbounded_mpsc_is_empty(&scope.disposal_event_receiver) {
+            crate::runtime::yield_now().await;
+        }
+    })
+    .await;
+    assert!(matches!(
+        arrived_completion,
+        crate::runtime::Timeout::Completed(())
+    ));
+
+    let mut arrived_terminal = Box::pin(arrived_member.wait_terminal());
+    let mut fallback_terminal = Box::pin(fallback_member.wait_terminal());
+    assert!(
+        arrived_terminal
+            .as_mut()
+            .poll(&mut Context::from_waker(&Waker::from(Arc::new(PanicWake(
+                FIRST_PANIC
+            )))))
+            .is_pending()
+    );
+    assert!(
+        fallback_terminal
+            .as_mut()
+            .poll(&mut Context::from_waker(&Waker::from(Arc::new(PanicWake(
+                SECOND_PANIC
+            )))))
+            .is_pending()
+    );
+
+    let result = catch_unwind(AssertUnwindSafe(|| scope.force_child(fallback_key)));
+    gate.release();
+
+    let payload = result.expect_err("both hostile terminal wakes are contained");
+    assert_eq!(
+        payload.downcast_ref::<&'static str>().copied(),
+        Some(FIRST_PANIC),
+        "the earlier arrived-disposal panic remains primary"
+    );
+    for member in [&arrived_member, &fallback_member] {
+        assert!(matches!(member.record().stage, MemberStage::Terminal(_)));
+    }
+}
+
 #[crate::runtime::test]
 async fn latched_shutdown_upgrades_an_intensity_drain() {
     let mut tree = Tree::new();

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -232,6 +232,118 @@ async fn root_driver_panic_mid_drain_upgrades_to_the_join_monitor_verdict() {
     assert!(snapshots.changed().await.is_err());
 }
 
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scope_runtime_drop_finishes_every_child_and_epoch_after_a_hostile_wake() {
+    const PANIC: &str = "injected child shutdown wake panic";
+
+    let mut tree = Tree::new();
+    for id in ["first", "second"] {
+        tree.add_task(id, TaskDef::new(|_| future::pending()))
+            .expect("the child declaration is valid");
+    }
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("the test scope has a live epoch");
+    root.member
+        .update(|record| record.stage = MemberStage::Running);
+    root.set_state_and_startup(ScopeState::Running, Ok(()));
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    let members = plan
+        .children
+        .iter()
+        .map(|child| Arc::clone(&child.slot.member))
+        .collect::<Vec<_>>();
+    let mut children = ChildArena::default();
+    plan.children.reverse();
+    while let Some(child) = plan.children.pop() {
+        children
+            .insert(ChildRuntime::from_plan(child, &root))
+            .unwrap_or_else(|_| panic!("the fixture fits in the child-key domain"));
+    }
+    let keys = children.keys().collect::<Vec<_>>();
+    let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
+        .with_defaults(plan.defaults.clone())
+        .with_children(children)
+        .with_lifecycle(ScopeLifecycle::running())
+        .build();
+    plan.finish_transfer();
+    for key in &keys {
+        scope.spawn_child(*key);
+    }
+    let cancellation = keys
+        .iter()
+        .map(|key| {
+            let active = scope.children[*key]
+                .active
+                .as_ref()
+                .expect("the child is active");
+            (active.shutdown.clone(), active.abort.clone())
+        })
+        .collect::<Vec<_>>();
+    let mut hostile_waiter = Box::pin(cancellation[0].0.fired());
+    let hostile = Waker::from(Arc::new(PanicWake(PANIC)));
+    assert!(
+        hostile_waiter
+            .as_mut()
+            .poll(&mut Context::from_waker(&hostile))
+            .is_pending()
+    );
+
+    let result = catch_unwind(AssertUnwindSafe(|| drop(scope)));
+
+    let payload = result.expect_err("the first hostile shutdown wake still surfaces");
+    assert_eq!(payload.downcast_ref::<&'static str>().copied(), Some(PANIC));
+    for (shutdown, abort) in &cancellation {
+        assert!(shutdown.is_fired(), "every child receives shutdown");
+        assert!(abort.is_fired(), "every child receives forced cancellation");
+    }
+    for member in &members {
+        assert!(
+            matches!(member.record().stage, MemberStage::Terminal(_)),
+            "every child terminality obligation is discharged"
+        );
+    }
+    assert!(
+        root.snapshot().children.is_empty(),
+        "resident clearing runs after every child terminalizes"
+    );
+    assert!(
+        root.settled(Some(epoch)),
+        "the scope epoch retires after child and residency teardown"
+    );
+    assert!(matches!(
+        root.record().state,
+        ScopeState::Stopped {
+            reason: StopReason::ShutdownRequested
+        }
+    ));
+
+    let exits = crate::runtime::timeout(DRIVER_PROGRESS_WAIT, async {
+        let mut exits = 0;
+        while exits < members.len() {
+            match event_receiver.recv().await {
+                Some(DriverEvent::Child(ChildEvent::Exited { .. })) => exits += 1,
+                Some(_) => {}
+                None => break,
+            }
+        }
+        exits
+    })
+    .await;
+    assert!(
+        matches!(exits, crate::runtime::Timeout::Completed(count) if count == members.len()),
+        "every child task is aborted even when an earlier shutdown waiter panics"
+    );
+}
+
 /// Drives one pair of competing stopped publications through the shared
 /// publisher and reports the settled record plus every `ScopeState` edge the
 /// lifecycle stream carried.

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -160,6 +160,11 @@ impl SlotCell {
     /// terminal predecessor. Taking the owning scope here keeps the pairing
     /// structural instead of repeated at each call site.
     pub(crate) fn terminalize_never_started(&self, owner: &ScopeCell) {
+        self.publish_never_started();
+        owner.evict_child_identity(&self.member);
+    }
+
+    fn publish_never_started(&self) {
         if let Some(scope) = &self.scope {
             scope.terminalize_never_started();
         } else {
@@ -168,7 +173,17 @@ impl SlotCell {
                 crate::cells::StartupDisposition::Unchanged,
             );
         }
-        owner.evict_child_identity(&self.member);
+    }
+
+    fn terminalize_never_started_contained(
+        &self,
+        owner: &ScopeCell,
+        panics: &mut runtime::PanicAccumulator,
+    ) {
+        // Publication can resume a hostile observer. Identity eviction is a
+        // distinct teardown effect and must still run before the next slot.
+        panics.run(|| self.publish_never_started());
+        panics.run(|| owner.evict_child_identity(&self.member));
     }
 
     pub(crate) fn terminalize_never_started_locked(
@@ -434,10 +449,11 @@ impl BuilderCore {
         // Slots past the failure point never left `self.root`'s map, so their
         // eviction from the override is a fence-mismatch no-op (fail closed).
         let identity_root = self.adopting_root.as_ref().unwrap_or(&self.root);
+        let mut panics = runtime::PanicAccumulator::default();
         for slot in &self.slots {
-            slot.terminalize_never_started(identity_root);
+            slot.terminalize_never_started_contained(identity_root, &mut panics);
         }
-        self.root.terminalize_never_started();
+        panics.run(|| self.root.terminalize_never_started());
     }
 }
 
@@ -472,15 +488,20 @@ fn terminalize_plan(
     terminality: &mut Option<ScopePlanTerminality>,
 ) {
     if terminality.take().is_some() {
+        let mut panics = runtime::PanicAccumulator::default();
         for child in children {
-            child.slot.terminalize_never_started(root);
+            child
+                .slot
+                .terminalize_never_started_contained(root, &mut panics);
         }
-        root.with_observation_gate(|txn| {
-            // Lowering can publish the planned children before ScopeRuntime
-            // takes ownership. The plan fallback commits residency withdrawal
-            // and root closure as one root-scope observation.
-            root.clear_residents_locked(txn);
-            root.terminalize_never_started_locked(txn);
+        panics.run(|| {
+            root.with_observation_gate(|txn| {
+                // Lowering can publish the planned children before ScopeRuntime
+                // takes ownership. The plan fallback commits residency withdrawal
+                // and root closure as one root-scope observation.
+                root.clear_residents_locked(txn);
+                root.terminalize_never_started_locked(txn);
+            });
         });
     }
 }
@@ -577,17 +598,20 @@ pub(crate) fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError
 #[cfg(test)]
 mod tests {
     use std::{
+        future::Future,
+        panic::{AssertUnwindSafe, catch_unwind},
         sync::{
             Arc, Barrier,
             atomic::{AtomicBool, Ordering},
         },
+        task::{Context, Wake, Waker},
         time::Duration,
     };
 
     use crate::{
         Backoff, ChildId, DefaultsInheritance, ExitError, Readiness, RestartCondition,
         RestartPolicy, Retention, Shutdown, TaskOnceDef,
-        cells::{MemberCell, ScopeCell},
+        cells::{MemberCell, MemberStage, ResidentProjection, ScopeCell},
         definition::DefinitionSource,
         identity::ScopeIdentity,
         policy::{CommonOptions, ResolvedDefaults, ScopeFlavor},
@@ -611,6 +635,104 @@ mod tests {
             .readiness(Readiness::Manual)
             .expect("manual task readiness is valid")
             .retention(Retention::Remove)
+    }
+
+    struct PanicWake(&'static str);
+
+    impl Wake for PanicWake {
+        fn wake(self: Arc<Self>) {
+            std::panic::panic_any(self.0);
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            std::panic::panic_any(self.0);
+        }
+    }
+
+    fn two_slot_builder() -> (BuilderCore, Vec<Arc<SlotCell>>) {
+        let mut builder = BuilderCore::new(ScopeFlavor::Ordered);
+        let mut slots = Vec::new();
+        for id in ["first", "second"] {
+            let slot = builder.reserve(id, None).expect("reservation succeeds");
+            slot.define(ChildConstruction::Task(configured_task()));
+            slots.push(slot);
+        }
+        (builder, slots)
+    }
+
+    #[test]
+    fn builder_drop_terminalizes_every_slot_and_root_after_a_hostile_wake() {
+        const PANIC: &str = "injected builder terminalization wake panic";
+
+        let (builder, slots) = two_slot_builder();
+        let root = Arc::clone(&builder.root);
+        let mut first_terminal = Box::pin(slots[0].member.wait_terminal());
+        let hostile = Waker::from(Arc::new(PanicWake(PANIC)));
+        assert!(
+            first_terminal
+                .as_mut()
+                .poll(&mut Context::from_waker(&hostile))
+                .is_pending()
+        );
+
+        let result = catch_unwind(AssertUnwindSafe(|| drop(builder)));
+
+        let payload = result.expect_err("the first hostile slot wake still surfaces");
+        assert_eq!(payload.downcast_ref::<&'static str>().copied(), Some(PANIC));
+        for slot in &slots {
+            assert!(
+                matches!(slot.member.record().stage, MemberStage::Terminal(_)),
+                "builder teardown terminalizes every declared slot"
+            );
+        }
+        assert!(
+            matches!(root.member.record().stage, MemberStage::Terminal(_)),
+            "builder teardown terminalizes its root after every slot"
+        );
+    }
+
+    #[test]
+    fn plan_drop_terminalizes_every_child_and_root_after_a_hostile_wake() {
+        const PANIC: &str = "injected plan terminalization wake panic";
+
+        let (builder, slots) = two_slot_builder();
+        let plan = builder
+            .lower(ResolvedDefaults::default(), None)
+            .expect("the defined builder lowers");
+        let root = Arc::clone(&plan.root);
+        root.set_admitted_children(
+            plan.children
+                .iter()
+                .map(|child| ResidentProjection::new(Arc::clone(&child.slot.member), None))
+                .collect(),
+        );
+        let mut first_terminal = Box::pin(slots[0].member.wait_terminal());
+        let hostile = Waker::from(Arc::new(PanicWake(PANIC)));
+        assert!(
+            first_terminal
+                .as_mut()
+                .poll(&mut Context::from_waker(&hostile))
+                .is_pending()
+        );
+
+        let result = catch_unwind(AssertUnwindSafe(|| drop(plan)));
+
+        let payload = result.expect_err("the first hostile child wake still surfaces");
+        assert_eq!(payload.downcast_ref::<&'static str>().copied(), Some(PANIC));
+        for slot in &slots {
+            assert!(
+                matches!(slot.member.record().stage, MemberStage::Terminal(_)),
+                "plan teardown terminalizes every transferred child"
+            );
+        }
+        assert!(
+            matches!(root.member.record().stage, MemberStage::Terminal(_)),
+            "plan teardown closes the root after every child"
+        );
+        assert!(
+            root.snapshot().children.is_empty(),
+            "plan teardown withdraws every published residency before root closure"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #266.

## What changed

- add one outer `PanicAccumulator` to `ScopeRuntime::drop`, preserving all child cancellation, terminality, residency, dynamic-removal, child-clear, and epoch-retirement work before resuming the first panic
- contain every slot and root terminalization in `BuilderCore` and `ScopePlan` teardown
- separate never-started publication from identity eviction so a hostile publication wake cannot skip eviction
- contain every `RemovalResponses::complete` send independently
- keep arrived-disposal draining compatible with contained teardown
- add one hostile-waker regression for each loop, including two simultaneously hostile removal receivers

## Root cause

Each individual transaction correctly unlocked before resuming a waker panic, but the surrounding multi-item teardown loops had no outer containment boundary. The first hostile waiter could therefore skip later children, root closure, resident clearing, epoch retirement, or removal outcomes.

Each independent teardown action now runs to completion; only then does the first accumulated panic resume.

## Validation

- focused teardown-loop regressions, with all verdicts judged outside `catch_unwind`
- complete `shelterwood` library suite (186 passed)
- `./tools/dev just ci` (681 nextest tests plus clippy, formatting, doctests, docs, API reachability, external consumer, and Nix checks)
- `git diff --check`

One inherited arrived-disposal fixture was corrected to wait for the real child join before invoking its synthetic post-join handler, matching the production invariant.

## Stack

Targets #297 (`agent/issue-267`). #265 will target this branch.