### PR TITLE
Consolidate driver test fixtures

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -55,7 +55,7 @@ use crate::{
     plan::{
         BuilderCore, ChildConstruction, ChildPlan, LowerError, ScopeFactory, ScopePlan, SlotCell,
     },
-    policy::{DefaultsInheritance, ResolvedDefaults, ScopeFlavor},
+    policy::{DefaultsInheritance, Intensity, ResolvedDefaults, ScopeFlavor},
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
     runtime::{self, CompletionGatedLatch, Latch},
     task::{TaskContext, TaskContextLatches, TaskFactory},
@@ -248,6 +248,33 @@ struct ScopeRuntime {
     retained_exits: Vec<RetainedExit>,
 }
 
+struct ScopeRuntimeWiring {
+    root: Arc<ScopeCell>,
+    defaults: ResolvedDefaults,
+    intensity_policy: Intensity,
+    children: ChildResources<ChildRuntime>,
+    supervisor: SupervisorState,
+    supervisor_effects: Vec<SupervisorEffect>,
+    events: runtime::UnboundedMpscSender<DriverEvent>,
+    disposal_events: runtime::UnboundedMpscSender<DriverEvent>,
+    disposal_event_receiver: runtime::UnboundedMpscReceiver<DriverEvent>,
+    role: ScopeRole,
+    dynamic: Option<Arc<DynamicControl>>,
+}
+
+#[cfg(test)]
+struct ScopeRuntimeTestWiring {
+    root: Arc<ScopeCell>,
+    defaults: ResolvedDefaults,
+    intensity_policy: Intensity,
+    children: Vec<(ChildKey, ChildRuntime)>,
+    lifecycle: ScopeLifecycle,
+    next_ordered_start: Option<Option<ChildKey>>,
+    events: runtime::UnboundedMpscSender<DriverEvent>,
+    dynamic: Option<Arc<DynamicControl>>,
+    hard_forced: bool,
+}
+
 struct ChildResources<T>(BTreeMap<ChildKey, T>);
 
 impl<T> Default for ChildResources<T> {
@@ -395,6 +422,110 @@ impl Drop for ScopeRuntime {
 }
 
 impl ScopeRuntime {
+    fn new(wiring: ScopeRuntimeWiring, epoch: ScopeEpochGuard) -> Self {
+        Self {
+            root: wiring.root,
+            defaults: wiring.defaults,
+            intensity_policy: wiring.intensity_policy,
+            intensity: IntensityState::default(),
+            children: wiring.children,
+            supervisor: wiring.supervisor,
+            supervisor_effects: wiring.supervisor_effects,
+            restart_shutdown_retries: Vec::new(),
+            events: wiring.events,
+            disposal_events: wiring.disposal_events,
+            disposal_event_receiver: wiring.disposal_event_receiver,
+            arrived_disposal_panics: BTreeMap::new(),
+            deadlines: DeadlineQueue::default(),
+            jitter: runtime::JitterRng::new(),
+            role: wiring.role,
+            dynamic: wiring.dynamic,
+            pending_startup_removals: Vec::new(),
+            ancestor_shutdown_seen: false,
+            ancestor_abort_seen: false,
+            completion: None,
+            finished: None,
+            retained_exits: Vec::new(),
+            // Transfer last: every fallible setup expression above remains
+            // covered by the pre-driver guard, and completed construction
+            // moves the raw epoch directly into ScopeRuntime's synchronous
+            // epilogue.
+            epoch: epoch.transfer(),
+        }
+    }
+
+    #[cfg(test)]
+    fn for_test(wiring: ScopeRuntimeTestWiring, epoch: ScopeEpochGuard) -> Self {
+        let mut supervisor = SupervisorState::new(wiring.root.flavor, wiring.lifecycle);
+        let mut supervisor_effects = Vec::new();
+        let mut children = ChildResources::default();
+        for (expected, child) in wiring.children {
+            supervisor_step(
+                &mut supervisor,
+                SupervisorEvent::Admit {
+                    membership: child.slot.member.membership(),
+                    initial: true,
+                    start_immediately: false,
+                },
+                &mut supervisor_effects,
+            );
+            let Some(SupervisorEffect::Admitted { child: actual }) = supervisor_effects.pop()
+            else {
+                panic!("fixture admission produces one key")
+            };
+            assert_eq!(actual, expected);
+            let replaced = children.insert(actual, child);
+            assert!(replaced.is_none(), "fixture child keys are unique");
+        }
+        if let Some(next) = wiring.next_ordered_start {
+            supervisor.set_next_ordered_start_for_test(next);
+        }
+        supervisor.set_hard_forced_for_test(wiring.hard_forced);
+        if let Some(control) = &wiring.dynamic {
+            wiring.root.with_observation_gate(|txn| {
+                control
+                    .register_initial(children.iter().map(|(key, child)| (&child.slot, key)), txn);
+            });
+        }
+        let (disposal_events, disposal_event_receiver) = runtime::unbounded_mpsc();
+        Self::new(
+            ScopeRuntimeWiring {
+                root: wiring.root,
+                defaults: wiring.defaults,
+                intensity_policy: wiring.intensity_policy,
+                children,
+                supervisor,
+                supervisor_effects,
+                events: wiring.events,
+                disposal_events,
+                disposal_event_receiver,
+                role: ScopeRole::Root,
+                dynamic: wiring.dynamic,
+            },
+            epoch,
+        )
+    }
+
+    fn publish_initial_children(&self) {
+        // ScopeRuntime owns teardown before the route becomes public. If
+        // either route notification or initial-child publication unwinds, its
+        // epilogue closes dynamic state, terminalizes every child, and clears
+        // any resident prefix. Install the fully keyed route before publishing
+        // Added so a synchronous observer never sees membership without its
+        // control plane.
+        if let Some(control) = &self.dynamic {
+            self.root.set_dynamic_route(Some(control.clone()));
+        }
+        self.root.set_admitted_children(
+            self.children
+                .values()
+                .map(|child| resident_projection(&child.slot))
+                .collect(),
+        );
+        #[cfg(test)]
+        self.record_storage();
+    }
+
     /// Moves the payload of every construction-disposal completion in a
     /// collected batch onto the scope.
     ///
@@ -932,53 +1063,24 @@ async fn run_scope_incarnation(
             control.register_initial(children.iter().map(|(key, child)| (&child.slot, key)), txn);
         });
     }
-    let mut scope = ScopeRuntime {
-        root: Arc::clone(&root),
-        defaults: plan.defaults.clone(),
-        intensity_policy: plan.intensity_policy(),
-        intensity: IntensityState::default(),
-        children,
-        supervisor,
-        supervisor_effects,
-        restart_shutdown_retries: Vec::new(),
-        events,
-        disposal_events,
-        disposal_event_receiver,
-        arrived_disposal_panics: BTreeMap::new(),
-        deadlines: DeadlineQueue::default(),
-        jitter: runtime::JitterRng::new(),
-        role,
-        dynamic,
-        pending_startup_removals: Vec::new(),
-        ancestor_shutdown_seen: false,
-        ancestor_abort_seen: false,
-        completion: None,
-        finished: None,
-        retained_exits: Vec::new(),
-        // Transfer last: every fallible setup expression above remains
-        // covered by the pre-driver guard, and completed construction moves
-        // the raw epoch directly into ScopeRuntime's synchronous epilogue.
-        epoch: epoch.transfer(),
-    };
-    plan.finish_transfer();
-
-    // ScopeRuntime owns teardown before the route becomes public. If either
-    // route notification or initial-child publication unwinds, its epilogue
-    // closes dynamic state, terminalizes every child, and clears any resident
-    // prefix. Install the fully keyed route before publishing Added so a
-    // synchronous observer never sees membership without its control plane.
-    if let Some(control) = &scope.dynamic {
-        scope.root.set_dynamic_route(Some(control.clone()));
-    }
-    scope.root.set_admitted_children(
-        scope
-            .children
-            .values()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
+    let mut scope = ScopeRuntime::new(
+        ScopeRuntimeWiring {
+            root: Arc::clone(&root),
+            defaults: plan.defaults.clone(),
+            intensity_policy: plan.intensity_policy(),
+            children,
+            supervisor,
+            supervisor_effects,
+            events,
+            disposal_events,
+            disposal_event_receiver,
+            role,
+            dynamic,
+        },
+        epoch,
     );
-    #[cfg(test)]
-    scope.record_storage();
+    plan.finish_transfer();
+    scope.publish_initial_children();
 
     scope.settle_supervisor();
 

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -87,39 +87,20 @@ async fn latched_removal_suppresses_a_queued_start_effect() {
     let (mut scope, _events, mut dynamic_events, control) = running_dynamic_fixture();
     let root = Arc::clone(&scope.root);
     let starts = Arc::new(AtomicUsize::new(0));
-    let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
-        .expect("running dynamic scope reserves the child");
-    reservation
-        .slot
-        .define(ChildConstruction::Task(TaskDef::new({
+    let (reservation, key) = insert_dynamic_fixture(
+        &mut scope,
+        &control,
+        "worker",
+        ChildConstruction::Task(TaskDef::new({
             let starts = Arc::clone(&starts);
             move |_| {
                 starts.fetch_add(1, Ordering::SeqCst);
                 future::pending()
             }
-        })));
-    let (definition, resolved) = reservation
-        .slot
-        .resolve_and_take_defined(&scope.defaults)
-        .expect("the slot is defined");
-    let plan =
-        crate::plan::ChildPlan::with_options(Arc::clone(&reservation.slot), definition, resolved);
-    let child = ChildRuntime::from_plan(plan, &root);
-    let key = root.with_observation_gate(|txn| {
-        let key = scope
-            .insert_child(child, false)
-            .unwrap_or_else(|_| panic!("the empty arena accepts its first child"));
-        control
-            .state
-            .lock()
-            .expect("dynamic-state mutex poisoned")
-            .entries
-            .get_mut(reservation.slot.member.id())
-            .expect("the reservation remains registered")
-            .promote(key, None, txn);
-        root.admit_child_locked(resident_projection(&reservation.slot), txn);
-        key
-    });
+        })),
+        |_| {},
+        DynamicFixtureState::Resident,
+    );
 
     let _removal = super::super::remove_dynamic(
         &root,
@@ -376,35 +357,15 @@ fn dynamic_removal_waits_for_the_observation_gate_before_mutating_state() {
 async fn final_removal_holds_the_id_until_removed_publication_commits() {
     let (mut scope, _events, _dynamic_events, control) = running_dynamic_fixture();
     let root = Arc::clone(&scope.root);
-    let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
-        .expect("running dynamic scope reserves the child");
+    let (reservation, key) = insert_dynamic_fixture(
+        &mut scope,
+        &control,
+        "worker",
+        ChildConstruction::Task(TaskDef::new(|_| future::pending())),
+        |_| {},
+        DynamicFixtureState::Resident,
+    );
     let member = Arc::clone(&reservation.slot.member);
-    reservation
-        .slot
-        .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
-    let (definition, resolved) = reservation
-        .slot
-        .resolve_and_take_defined(&scope.defaults)
-        .expect("the slot is defined");
-    let plan =
-        crate::plan::ChildPlan::with_options(Arc::clone(&reservation.slot), definition, resolved);
-    let child = ChildRuntime::from_plan(plan, &root);
-    let key = root.with_observation_gate(|txn| {
-        let key = match scope.insert_child(child, false) {
-            Ok(key) => key,
-            Err(_) => panic!("the empty arena accepts its first child"),
-        };
-        control
-            .state
-            .lock()
-            .expect("dynamic-state mutex poisoned")
-            .entries
-            .get_mut(member.id())
-            .expect("the reservation remains registered")
-            .promote(key, None, txn);
-        root.admit_child_locked(resident_projection(&reservation.slot), txn);
-        key
-    });
     assert!(scope.terminalize_child(
         key,
         Exit::never_started(),
@@ -463,45 +424,19 @@ async fn final_removal_holds_the_id_until_removed_publication_commits() {
 async fn removal_tolerates_synchronous_reclaim_from_the_stop_funnel() {
     let (mut scope, _events, _dynamic_events, control) = running_dynamic_fixture();
     let root = Arc::clone(&scope.root);
-    let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
-        .expect("running dynamic scope reserves the child");
-    let member = Arc::clone(&reservation.slot.member);
-    reservation
-        .slot
-        .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
-    let (definition, resolved) = reservation
-        .slot
-        .resolve_and_take_defined(&scope.defaults)
-        .expect("the slot is defined");
-    let plan =
-        crate::plan::ChildPlan::with_options(Arc::clone(&reservation.slot), definition, resolved);
-    let mut child = ChildRuntime::from_plan(plan, &root);
-    // Model the latent restart-gap shape: there is no active incarnation and
-    // no retained construction, so a hard-force stop can terminalize and
-    // reclaim this Removing member synchronously from `begin_stop_child`.
-    drop(child.construction.take());
-    let key = root.with_observation_gate(|txn| {
-        let key = scope
-            .insert_child(child, false)
-            .unwrap_or_else(|_| panic!("the empty arena accepts its first child"));
-        {
-            let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-            let entry = state
-                .entries
-                .get_mut(member.id())
-                .expect("the reservation remains registered");
-            entry.promote(key, None, txn);
-            // Removal requests are now published at the authoritative
-            // `Resident -> Removing` transition rather than by the driver, so
-            // drive the entry through it exactly as `remove_dynamic` would
-            // before the synthetic request below reaches `handle_removal`.
-            entry
-                .mark_removing(txn)
-                .expect("the promoted resident transitions to Removing");
-        }
-        root.admit_child_locked(resident_projection(&reservation.slot), txn);
-        key
-    });
+    let (_reservation, key) = insert_dynamic_fixture(
+        &mut scope,
+        &control,
+        "worker",
+        ChildConstruction::Task(TaskDef::new(|_| future::pending())),
+        |child| {
+            // Model the latent restart-gap shape: there is no active
+            // incarnation and no retained construction, so a hard-force stop
+            // can terminalize and reclaim this Removing member synchronously.
+            drop(child.construction.take());
+        },
+        DynamicFixtureState::Removing,
+    );
     scope.supervisor.set_hard_forced_for_test(true);
 
     scope.handle_removal(RemovalRequest { key });
@@ -615,24 +550,19 @@ async fn removal_from_a_foreign_thread_reaches_the_driver() {
     .join()
     .expect("foreign-thread removal signaling succeeds");
 
-    let event = match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, event_receiver.recv()).await {
-        crate::runtime::Timeout::Completed(event) => event.expect("the driver lane remains open"),
-        crate::runtime::Timeout::Elapsed => {
-            panic!("the off-runtime removal edge must not be lost")
-        }
-    };
-    let DriverEvent::Removal(observed) = event else {
-        panic!("the queued event is the requested removal");
-    };
+    let observed = recv_removal(
+        &mut event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "the off-runtime removal edge",
+    )
+    .await;
     assert_eq!(observed.key, key);
 }
 
 #[crate::runtime::test]
 async fn admission_conversion_panic_does_not_poison_dynamic_cleanup() {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
+    let epoch = ScopeEpochGuard::begin(&root).expect("test scope epoch is available");
     root.member
         .update(|record| record.stage = MemberStage::Running);
     root.set_state(ScopeState::Running);
@@ -640,8 +570,6 @@ async fn admission_conversion_panic_does_not_poison_dynamic_cleanup() {
 
     let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events.clone());
-    root.set_dynamic_route(Some(control.clone()));
-    root.set_admitted_children(Vec::new());
     let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_lifecycle(ScopeLifecycle::running())
         .with_dynamic(Some(control.clone()))
@@ -819,12 +747,12 @@ async fn annulment_after_promotion_is_inert_and_supervision_owns_the_exit() {
 
     let removal_response =
         super::super::remove_dynamic(&root, member.id(), Some(member.membership()));
-    let removal =
-        match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, dynamic_event_receiver.recv()).await {
-            crate::runtime::Timeout::Completed(Some(DriverEvent::Removal(removal))) => removal,
-            crate::runtime::Timeout::Completed(_) => panic!("the removal reaches the driver"),
-            crate::runtime::Timeout::Elapsed => panic!("the removal must reach the driver"),
-        };
+    let removal = recv_removal(
+        &mut dynamic_event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "the removal reaches the driver",
+    )
+    .await;
     scope.handle_removal(removal);
     recv_child_exit(
         &mut event_receiver,
@@ -833,17 +761,12 @@ async fn annulment_after_promotion_is_inert_and_supervision_owns_the_exit() {
     )
     .await
     .dispatch(&mut scope);
-    let disposal =
-        match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, scope.disposal_event_receiver.recv())
-            .await
-        {
-            crate::runtime::Timeout::Completed(Some(event)) => event,
-            crate::runtime::Timeout::Completed(None) => panic!("the disposal lane remains open"),
-            crate::runtime::Timeout::Elapsed => panic!("retained construction disposal completes"),
-        };
-    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = disposal else {
-        panic!("the stop path reports retained construction disposal")
-    };
+    let (child, panic) = recv_construction_disposed(
+        &mut scope.disposal_event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "retained construction disposal completes",
+    )
+    .await;
     scope.handle_construction_disposed(child, panic);
     assert_eq!(
         removal_response.receive().await,
@@ -1206,13 +1129,12 @@ async fn exercise_coalesced_removal(source: RemovalSource) {
         ));
     }
 
-    let removal = match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, dynamic_event_receiver.recv())
-        .await
-    {
-        crate::runtime::Timeout::Completed(Some(DriverEvent::Removal(removal))) => removal,
-        crate::runtime::Timeout::Completed(_) => panic!("one removal request reaches the driver"),
-        crate::runtime::Timeout::Elapsed => panic!("the removal request reaches the driver"),
-    };
+    let removal = recv_removal(
+        &mut dynamic_event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "one removal request reaches the driver",
+    )
+    .await;
     assert_eq!(removal.key, key);
     if source == RemovalSource::FusedAndExplicit {
         assert!(
@@ -1270,21 +1192,12 @@ async fn exercise_coalesced_removal(source: RemovalSource) {
         );
     }
 
-    let disposal =
-        match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, scope.disposal_event_receiver.recv())
-            .await
-        {
-            crate::runtime::Timeout::Completed(Some(event)) => event,
-            crate::runtime::Timeout::Completed(None) => {
-                panic!("the disposal lane remains open")
-            }
-            crate::runtime::Timeout::Elapsed => {
-                panic!("retained construction disposal completes")
-            }
-        };
-    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = disposal else {
-        panic!("the stop path reports retained construction disposal")
-    };
+    let (child, panic) = recv_construction_disposed(
+        &mut scope.disposal_event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "retained construction disposal completes",
+    )
+    .await;
     assert_eq!(child, key);
     scope.handle_construction_disposed(child, panic);
 
@@ -1329,9 +1242,7 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
     A: Future,
 {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
+    let epoch = ScopeEpochGuard::begin(&root).expect("test scope epoch is available");
     root.member
         .update(|record| record.stage = MemberStage::Running);
     root.set_state(ScopeState::Running);
@@ -1339,8 +1250,6 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
 
     let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events.clone());
-    root.set_dynamic_route(Some(control.clone()));
-    root.set_admitted_children(Vec::new());
     let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_lifecycle(ScopeLifecycle::running())
         .with_dynamic(Some(control.clone()))
@@ -1452,22 +1361,20 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
         Some(DriverEvent::Removal(queued))
             if queued.key == ChildKey::fixture(u64::MAX - 1)
     ));
-    let forwarded = match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, event_receiver.recv()).await
-    {
-        crate::runtime::Timeout::Completed(Some(event)) => event,
-        crate::runtime::Timeout::Completed(None) => panic!("the driver lane remains open"),
-        crate::runtime::Timeout::Elapsed => panic!("the fused removal edge is forwarded"),
-    };
-    let DriverEvent::Removal(removal) = forwarded else {
-        panic!("the queued event is the fused removal")
-    };
+    let removal = recv_removal(
+        &mut event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "the fused removal edge",
+    )
+    .await;
     assert_eq!(removal.key, key);
     scope.handle_removal(removal);
-    let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
-        scope.disposal_event_receiver.recv().await
-    else {
-        panic!("removal joins retained construction disposal")
-    };
+    let (child, panic) = recv_construction_disposed(
+        &mut scope.disposal_event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "removal joins retained construction disposal",
+    )
+    .await;
     scope.handle_construction_disposed(child, panic);
     assert!(scope.children.get(key).is_none());
 }

--- a/crates/shelterwood/src/driver/tests/events.rs
+++ b/crates/shelterwood/src/driver/tests/events.rs
@@ -155,9 +155,7 @@ fn every_event_lane_is_capped_and_a_saturated_lane_forces_a_yield() {
 #[crate::runtime::test]
 async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_scheduling() {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
+    let epoch = ScopeEpochGuard::begin(&root).expect("test scope epoch is available");
     root.member
         .update(|record| record.stage = MemberStage::Running);
     root.set_state(ScopeState::Running);
@@ -165,8 +163,6 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
 
     let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events.clone());
-    root.set_dynamic_route(Some(control.clone()));
-    root.set_admitted_children(Vec::new());
     let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_lifecycle(ScopeLifecycle::running())
         .with_dynamic(Some(control.clone()))
@@ -252,22 +248,20 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
         "the restart deadline arm rechecks level-triggered stop sources"
     );
 
-    let forwarded = match crate::runtime::timeout(DRIVER_PROGRESS_WAIT, event_receiver.recv()).await
-    {
-        crate::runtime::Timeout::Completed(Some(event)) => event,
-        crate::runtime::Timeout::Completed(None) => panic!("the driver lane remains open"),
-        crate::runtime::Timeout::Elapsed => panic!("the fused removal edge is forwarded"),
-    };
-    let DriverEvent::Removal(removal) = forwarded else {
-        panic!("the queued event is the fused removal");
-    };
+    let removal = recv_removal(
+        &mut event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "the fused removal edge",
+    )
+    .await;
     assert_eq!(removal.key, key);
     scope.handle_removal(removal);
-    let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
-        scope.disposal_event_receiver.recv().await
-    else {
-        panic!("removal joins retained construction disposal")
-    };
+    let (child, panic) = recv_construction_disposed(
+        &mut scope.disposal_event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "removal joins retained construction disposal",
+    )
+    .await;
     scope.handle_construction_disposed(child, panic);
     assert!(scope.children.get(key).is_none());
 }

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -96,31 +96,13 @@ async fn incarnation_exhaustion_uses_post_disposal_retention_routing() {
         TaskDef::new(|_| future::pending::<crate::ExitResult>()).retention(Retention::Remove),
     )
     .expect("valid task");
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
-    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
-    let mut children = ChildArena::default();
-    let key = children
-        .insert(child)
-        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_intensity_policy(plan.intensity_policy())
-        .with_children(children)
+    let fixture = OrderedScopeFixture::new(tree);
+    let root = Arc::clone(&fixture.root);
+    let key = fixture.children.keys().next().expect("one child plan");
+    let (mut scope, mut event_receiver) = fixture
         .with_lifecycle(ScopeLifecycle::running())
         .with_next_ordered_start(Some(key))
         .build();
-    plan.finish_transfer();
 
     scope.children[key].incarnations =
         IncarnationCounter::near_exhaustion(scope.children[key].slot.member.membership());
@@ -163,14 +145,12 @@ async fn incarnation_exhaustion_uses_post_disposal_retention_routing() {
     ));
     assert_eq!(root.snapshot().children.len(), 1);
 
-    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = scope
-        .disposal_event_receiver
-        .recv()
-        .await
-        .expect("disposal reports completion")
-    else {
-        panic!("only construction disposal was armed")
-    };
+    let (child, panic) = recv_construction_disposed(
+        &mut scope.disposal_event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "the construction disposal completion",
+    )
+    .await;
     assert!(matches!(
         event_receiver.try_recv(),
         Ok(DriverEvent::Child(ChildEvent::Ready { .. }))
@@ -201,30 +181,10 @@ async fn first_spawn_exhaustion_stops_without_reporting_a_startup_abort() {
         TaskDef::new(|_| future::pending::<crate::ExitResult>()),
     )
     .expect("valid task");
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
-    let mut children = ChildArena::default();
-    let key = children
-        .insert(child)
-        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_intensity_policy(plan.intensity_policy())
-        .with_children(children)
-        .with_next_ordered_start(Some(key))
-        .build();
-    plan.finish_transfer();
+    let fixture = OrderedScopeFixture::new(tree);
+    let root = Arc::clone(&fixture.root);
+    let key = fixture.children.keys().next().expect("one child plan");
+    let (mut scope, _event_receiver) = fixture.with_next_ordered_start(Some(key)).build();
 
     // Burn the counter's last usable generation without touching the
     // member record: the child is still an unspawned initial member, so
@@ -242,14 +202,12 @@ async fn first_spawn_exhaustion_stops_without_reporting_a_startup_abort() {
     scope.spawn_child(key);
     assert!(scope.children[key].is_disposing());
 
-    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = scope
-        .disposal_event_receiver
-        .recv()
-        .await
-        .expect("disposal reports completion")
-    else {
-        panic!("only construction disposal was armed")
-    };
+    let (child, panic) = recv_construction_disposed(
+        &mut scope.disposal_event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "the construction disposal completion",
+    )
+    .await;
     scope.handle_construction_disposed(child, panic);
 
     assert!(matches!(
@@ -298,30 +256,10 @@ async fn latched_shutdown_keeps_the_startup_verdict_for_its_follow_up_event() {
             .expect("manual readiness is valid"),
     )
     .expect("valid task");
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();
-    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
-    let mut children = ChildArena::default();
-    let key = children
-        .insert(child)
-        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_intensity_policy(plan.intensity_policy())
-        .with_children(children)
-        .with_next_ordered_start(Some(key))
-        .build();
-    plan.finish_transfer();
+    let fixture = OrderedScopeFixture::new(tree);
+    let root = Arc::clone(&fixture.root);
+    let key = fixture.children.keys().next().expect("one child plan");
+    let (mut scope, mut event_receiver) = fixture.with_next_ordered_start(Some(key)).build();
 
     assert!(scope.supervisor.is_initial(key));
     scope.spawn_child(key);
@@ -368,11 +306,12 @@ async fn latched_shutdown_keeps_the_startup_verdict_for_its_follow_up_event() {
     );
     assert!(scope.children[key].restart_deadline.is_none());
 
-    let Some(DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic })) =
-        scope.disposal_event_receiver.recv().await
-    else {
-        panic!("only construction disposal was armed")
-    };
+    let (child, panic) = recv_construction_disposed(
+        &mut scope.disposal_event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "the construction disposal completion",
+    )
+    .await;
     scope.handle_construction_disposed(child, panic);
     assert!(matches!(
         scope.children[key].slot.member.record().stage,
@@ -690,30 +629,9 @@ async fn settlement_terminates_when_the_first_spawn_exhausts_incarnations() {
         TaskDef::new(|_| future::pending::<crate::ExitResult>()),
     )
     .expect("valid task");
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
-    let mut children = ChildArena::default();
-    let key = children
-        .insert(child)
-        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_intensity_policy(plan.intensity_policy())
-        .with_children(children)
-        .with_next_ordered_start(Some(key))
-        .build();
-    plan.finish_transfer();
+    let fixture = OrderedScopeFixture::new(tree);
+    let key = fixture.children.keys().next().expect("one child plan");
+    let (mut scope, _event_receiver) = fixture.with_next_ordered_start(Some(key)).build();
 
     scope.children[key].incarnations =
         IncarnationCounter::near_exhaustion(scope.children[key].slot.member.membership());
@@ -732,14 +650,12 @@ async fn settlement_terminates_when_the_first_spawn_exhausts_incarnations() {
     // membership gates ordered startup, but can no longer be constructed.
     scope.settle_supervisor();
 
-    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = scope
-        .disposal_event_receiver
-        .recv()
-        .await
-        .expect("disposal reports completion")
-    else {
-        panic!("only construction disposal was armed")
-    };
+    let (child, panic) = recv_construction_disposed(
+        &mut scope.disposal_event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "the construction disposal completion",
+    )
+    .await;
     scope.handle_construction_disposed(child, panic);
     scope.settle_supervisor();
     assert!(

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -393,9 +393,7 @@ impl AbortedNestedDriverFixture {
         let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
         parent.set_admitted_children(vec![resident_projection(&slot)]);
 
-        let epoch = nested
-            .begin_incarnation(ScopeState::Starting)
-            .expect("nested scope epoch is available");
+        let epoch = ScopeEpochGuard::begin(&nested).expect("nested scope epoch is available");
         let mut incarnations = IncarnationCounter::fixture(nested.member.membership());
         let incarnation = incarnations.mint().expect("child incarnation is available");
         nested.member.update(|record| {
@@ -404,8 +402,6 @@ impl AbortedNestedDriverFixture {
             record.last_incarnation = Some(incarnation);
         });
         nested.set_state(ScopeState::Running);
-        nested.set_admitted_children(Vec::new());
-
         let (events, events_receiver) = crate::runtime::unbounded_mpsc();
         let driver = ScopeRuntimeBuilder::new(Arc::clone(&nested), epoch, events)
             .with_lifecycle(ScopeLifecycle::running())

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -36,33 +36,14 @@ async fn scope_with_arrived_factory_disposal_panic() -> (ScopeRuntime, ChildKey,
         .retention(Retention::Retain),
     )
     .expect("valid task");
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
+    let fixture = OrderedScopeFixture::new(tree);
+    let root = Arc::clone(&fixture.root);
     root.member
         .update(|record| record.stage = MemberStage::Running);
     root.set_state_and_startup(ScopeState::Running, Ok(()));
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
-    let member = Arc::clone(&child.slot.member);
-    let mut children = ChildArena::default();
-    let key = children
-        .insert(child)
-        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(root, epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_children(children)
-        .with_lifecycle(ScopeLifecycle::running())
-        .build();
-    plan.finish_transfer();
+    let key = fixture.children.keys().next().expect("one child plan");
+    let member = Arc::clone(&fixture.children[key].slot.member);
+    let (mut scope, _event_receiver) = fixture.with_lifecycle(ScopeLifecycle::running()).build();
 
     scope.spawn_child(key);
     let active = scope.children[key]
@@ -300,32 +281,12 @@ async fn latched_shutdown_upgrades_an_intensity_drain() {
         TaskDef::new(|_| future::pending::<crate::ExitResult>()),
     )
     .expect("valid task");
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
+    let fixture = OrderedScopeFixture::new(tree);
+    let root = Arc::clone(&fixture.root);
     root.set_state(ScopeState::Running);
     root.set_startup(Ok(()));
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
-    let mut children = ChildArena::default();
-    let key = children
-        .insert(child)
-        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_intensity_policy(plan.intensity_policy())
-        .with_children(children)
-        .with_lifecycle(ScopeLifecycle::running())
-        .build();
-    plan.finish_transfer();
+    let key = fixture.children.keys().next().expect("one child plan");
+    let (mut scope, _event_receiver) = fixture.with_lifecycle(ScopeLifecycle::running()).build();
 
     scope.spawn_child(key);
     let active = scope.children[key]
@@ -372,32 +333,12 @@ async fn force_upgrades_an_intensity_drain_to_shutdown_requested() {
         TaskDef::new(|_| future::pending::<crate::ExitResult>()),
     )
     .expect("valid task");
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
+    let fixture = OrderedScopeFixture::new(tree);
+    let root = Arc::clone(&fixture.root);
     root.set_state(ScopeState::Running);
     root.set_startup(Ok(()));
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
-    let mut children = ChildArena::default();
-    let key = children
-        .insert(child)
-        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_intensity_policy(plan.intensity_policy())
-        .with_children(children)
-        .with_lifecycle(ScopeLifecycle::running())
-        .build();
-    plan.finish_transfer();
+    let key = fixture.children.keys().next().expect("one child plan");
+    let (mut scope, _event_receiver) = fixture.with_lifecycle(ScopeLifecycle::running()).build();
 
     scope.spawn_child(key);
     let active = scope.children[key]
@@ -445,33 +386,9 @@ async fn force_uses_the_stop_funnel_for_every_ordered_child() {
     let second = tree
         .add_raw("second", crate::RawDef::factory(|| PendingRaw))
         .expect("valid second actor");
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let mut children = ChildArena::default();
-    plan.children.reverse();
-    while let Some(child) = plan.children.pop() {
-        children
-            .insert(ChildRuntime::from_plan(child, &root))
-            .unwrap_or_else(|_| panic!("the fixture fits in the child-key domain"));
-    }
-    let keys = children.keys().collect::<Vec<_>>();
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_intensity_policy(plan.intensity_policy())
-        .with_children(children)
-        .with_lifecycle(ScopeLifecycle::running())
-        .build();
-    plan.finish_transfer();
+    let fixture = OrderedScopeFixture::new(tree);
+    let keys = fixture.children.keys().collect::<Vec<_>>();
+    let (mut scope, _event_receiver) = fixture.with_lifecycle(ScopeLifecycle::running()).build();
 
     for key in &keys {
         scope.spawn_child(*key);
@@ -554,39 +471,17 @@ fn forced_ordered_drain_advances_an_inactive_suffix_iteratively() {
         )
         .expect("unique child declaration");
     }
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let mut children = ChildArena::default();
-    plan.children.reverse();
-    while let Some(child) = plan.children.pop() {
-        children
-            .insert(ChildRuntime::from_plan(child, &root))
-            .unwrap_or_else(|_| panic!("the fixture fits in the child-key domain"));
-    }
+    let mut fixture = OrderedScopeFixture::new(tree);
     // Model restart-window children: no incarnation and no retained
     // construction remains, so forced terminalization completes inline.
     // This used to re-enter `stop_next_ordered` once per child.
-    for child in children.values_mut() {
+    for child in fixture.children.values_mut() {
         drop(child.construction.take());
     }
-    let mut scope = ScopeRuntimeBuilder::new(root, epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_intensity_policy(plan.intensity_policy())
-        .with_children(children)
+    let (mut scope, _event_receiver) = fixture
         .with_lifecycle(ScopeLifecycle::running())
         .with_hard_forced(true)
         .build();
-    plan.finish_transfer();
 
     scope.begin_drain(StopReason::ShutdownRequested);
 

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -65,10 +65,11 @@ async fn pre_admission_restart_shutdown_does_not_expedite_the_following_incarnat
         )),
     )
     .expect("valid subtree");
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
+    let fixture = OrderedScopeFixture::new(tree);
+    let root = Arc::clone(&fixture.root);
+    let key = fixture.children.keys().next().expect("one child plan");
     let nested = Arc::clone(
-        plan.children[0]
+        fixture.children[key]
             .slot
             .scope
             .as_ref()
@@ -77,27 +78,7 @@ async fn pre_admission_restart_shutdown_does_not_expedite_the_following_incarnat
     let target = nested
         .request_shutdown()
         .expect("the pre-admission shutdown targets the first epoch");
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
-    let mut children = ChildArena::default();
-    let key = children
-        .insert(child)
-        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_lifecycle(ScopeLifecycle::running())
-        .with_children(children)
-        .build();
-    plan.finish_transfer();
+    let (mut scope, _event_receiver) = fixture.with_lifecycle(ScopeLifecycle::running()).build();
 
     scope.spawn_child(key);
     let first = scope.children[key]
@@ -159,42 +140,23 @@ async fn expedited_restart_progresses_synchronous_readiness() {
     let mut tree = Tree::new();
     tree.add_subtree("nested", SubtreeDef::factory(pending_tree))
         .expect("valid subtree");
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
+    let mut fixture = OrderedScopeFixture::new(tree);
+    let root = Arc::clone(&fixture.root);
+    let key = fixture.children.keys().next().expect("one child plan");
     let nested_cell = Arc::clone(
-        plan.children[0]
+        fixture.children[key]
             .slot
             .scope
             .as_ref()
             .expect("nested scope cell"),
     );
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let mut child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
     // Scope definitions currently resolve to Manual and expose no public
     // readiness setter. Model that API invariant changing: the expedited
     // restart must still release ordered startup when configuration produces
     // an immediate readiness effect.
-    child.options.readiness = Readiness::Immediate;
-    let mut children = ChildArena::default();
-    let key = children
-        .insert(child)
-        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_children(children)
-        .with_next_ordered_start(Some(key))
-        .build();
+    fixture.children[key].options.readiness = Readiness::Immediate;
+    let (mut scope, _event_receiver) = fixture.with_next_ordered_start(Some(key)).build();
     scope.reduce(SupervisorEvent::Spawned { child: key });
-    plan.finish_transfer();
     let target = nested_cell
         .request_shutdown()
         .expect("the shutdown targets the pending nested incarnation");
@@ -238,10 +200,16 @@ async fn early_restart_shutdown_does_not_expedite_a_never_started_ordered_child(
     )
     .expect("valid subtree");
 
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
+    let fixture = OrderedScopeFixture::new(tree);
+    let root = Arc::clone(&fixture.root);
+    let first = fixture.children.keys().next().expect("first ordered child");
+    let nested = fixture
+        .children
+        .keys()
+        .find(|key| fixture.children[*key].slot.member.id().as_str() == "nested")
+        .expect("nested child key");
     let nested_cell = Arc::clone(
-        plan.children[1]
+        fixture.children[nested]
             .slot
             .scope
             .as_ref()
@@ -250,34 +218,7 @@ async fn early_restart_shutdown_does_not_expedite_a_never_started_ordered_child(
     let target = nested_cell
         .request_shutdown()
         .expect("the pre-admission shutdown targets the first epoch");
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let mut children = ChildArena::default();
-    plan.children.reverse();
-    while let Some(child) = plan.children.pop() {
-        children
-            .insert(ChildRuntime::from_plan(child, &root))
-            .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    }
-    let first = children.keys().next().expect("first ordered child");
-    let nested = children
-        .keys()
-        .find(|key| children[*key].slot.member.id().as_str() == "nested")
-        .expect("nested child key");
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_children(children)
-        .with_next_ordered_start(Some(first))
-        .build();
-    plan.finish_transfer();
+    let (mut scope, _event_receiver) = fixture.with_next_ordered_start(Some(first)).build();
 
     // Ordered startup spawns "a" and parks on its (never-fired) readiness.
     scope.progress_startup();
@@ -332,29 +273,9 @@ async fn restart_shutdown_arriving_before_exit_is_retried_after_the_child_become
         )),
     )
     .expect("valid subtree");
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
-    let mut children = ChildArena::default();
-    let key = children
-        .insert(child)
-        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_lifecycle(ScopeLifecycle::running())
-        .with_children(children)
-        .build();
-    plan.finish_transfer();
+    let fixture = OrderedScopeFixture::new(tree);
+    let key = fixture.children.keys().next().expect("one child plan");
+    let (mut scope, _event_receiver) = fixture.with_lifecycle(ScopeLifecycle::running()).build();
 
     let target = scope.children[key]
         .slot
@@ -429,42 +350,23 @@ async fn same_batch_intensity_exit_suppresses_real_expedited_factory() {
     tree.add_task("trip", TaskDef::new(|_| future::pending()))
         .expect("valid task");
 
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let mut children = ChildArena::default();
-    plan.children.reverse();
-    while let Some(child) = plan.children.pop() {
-        children
-            .insert(ChildRuntime::from_plan(child, &root))
-            .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    }
-    let nested = children
+    let fixture = OrderedScopeFixture::new(tree);
+    let root = Arc::clone(&fixture.root);
+    let nested = fixture
+        .children
         .keys()
-        .find(|key| children[*key].slot.member.id().as_str() == "nested")
+        .find(|key| fixture.children[*key].slot.member.id().as_str() == "nested")
         .expect("nested child key");
-    let trip = children
+    let trip = fixture
+        .children
         .keys()
-        .find(|key| children[*key].slot.member.id().as_str() == "trip")
+        .find(|key| fixture.children[*key].slot.member.id().as_str() == "trip")
         .expect("tripping child key");
-    let next_ordered_start = children.keys().next();
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_intensity_policy(plan.intensity_policy())
-        .with_children(children)
+    let next_ordered_start = fixture.children.keys().next();
+    let (mut scope, _event_receiver) = fixture
         .with_lifecycle(ScopeLifecycle::running())
         .with_next_ordered_start(next_ordered_start)
         .build();
-    plan.finish_transfer();
 
     root.transition_child(
         &scope.children[nested].slot.member,
@@ -589,42 +491,22 @@ async fn same_batch_intensity_exit_suppresses_retained_expedite_retry() {
     tree.add_task("trip", TaskDef::new(|_| future::pending()))
         .expect("valid task");
 
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let mut children = ChildArena::default();
-    plan.children.reverse();
-    while let Some(child) = plan.children.pop() {
-        children
-            .insert(ChildRuntime::from_plan(child, &root))
-            .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    }
-    let nested = children
+    let fixture = OrderedScopeFixture::new(tree);
+    let nested = fixture
+        .children
         .keys()
-        .find(|key| children[*key].slot.member.id().as_str() == "nested")
+        .find(|key| fixture.children[*key].slot.member.id().as_str() == "nested")
         .expect("nested child key");
-    let trip = children
+    let trip = fixture
+        .children
         .keys()
-        .find(|key| children[*key].slot.member.id().as_str() == "trip")
+        .find(|key| fixture.children[*key].slot.member.id().as_str() == "trip")
         .expect("tripping child key");
-    let next_ordered_start = children.keys().next();
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_intensity_policy(plan.intensity_policy())
-        .with_children(children)
+    let next_ordered_start = fixture.children.keys().next();
+    let (mut scope, _event_receiver) = fixture
         .with_lifecycle(ScopeLifecycle::running())
         .with_next_ordered_start(next_ordered_start)
         .build();
-    plan.finish_transfer();
 
     let target = scope.children[nested]
         .slot
@@ -751,30 +633,10 @@ async fn same_batch_self_stop_preserves_fired_readiness_for_startup() {
             .readiness_deadline(ReadinessDeadline::Unbounded),
     )
     .expect("valid task");
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
-    let mut children = ChildArena::default();
-    let key = children
-        .insert(child)
-        .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_intensity_policy(plan.intensity_policy())
-        .with_children(children)
-        .with_next_ordered_start(Some(key))
-        .build();
-    plan.finish_transfer();
+    let fixture = OrderedScopeFixture::new(tree);
+    let root = Arc::clone(&fixture.root);
+    let key = fixture.children.keys().next().expect("one child plan");
+    let (mut scope, _event_receiver) = fixture.with_next_ordered_start(Some(key)).build();
 
     scope.spawn_child(key);
     let active = scope.children[key]
@@ -832,14 +694,12 @@ async fn same_batch_self_stop_preserves_fired_readiness_for_startup() {
         }
     }
 
-    let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = scope
-        .disposal_event_receiver
-        .recv()
-        .await
-        .expect("disposal reports completion")
-    else {
-        panic!("only construction disposal was armed")
-    };
+    let (child, panic) = recv_construction_disposed(
+        &mut scope.disposal_event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "the construction disposal completion",
+    )
+    .await;
     scope.handle_construction_disposed(child, panic);
 
     assert!(
@@ -888,33 +748,14 @@ async fn ordered_startup_advances_past_a_reclaimed_cursor() {
     )
     .expect("valid task");
 
-    let mut plan = tree.lower_for_test();
-    let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
-    let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
-    let mut children = ChildArena::default();
-    plan.children.reverse();
-    while let Some(child) = plan.children.pop() {
-        children
-            .insert(ChildRuntime::from_plan(child, &root))
-            .unwrap_or_else(|_| panic!("the test fixture fits in the child-key domain"));
-    }
-    let gone = children.keys().next().expect("first ordered child");
-    let next = children.keys().nth(1).expect("second ordered child");
-    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
-        .with_defaults(plan.defaults.clone())
-        .with_children(children)
-        .with_next_ordered_start(Some(gone))
-        .build();
-    plan.finish_transfer();
+    let fixture = OrderedScopeFixture::new(tree);
+    let gone = fixture.children.keys().next().expect("first ordered child");
+    let next = fixture
+        .children
+        .keys()
+        .nth(1)
+        .expect("second ordered child");
+    let (mut scope, _event_receiver) = fixture.with_next_ordered_start(Some(gone)).build();
 
     // Retire the authoritative record and runtime resource together, exactly
     // as production reclaim does, without disturbing the child that follows.
@@ -960,36 +801,22 @@ async fn startup_removal_response_follows_aggregate_recomputation() {
 
     let mut plan = tree.lower_for_test();
     let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
+    let epoch = ScopeEpochGuard::begin(&root).expect("test scope epoch is available");
     root.member
         .update(|record| record.stage = MemberStage::Running);
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
     let (control_events, _control_event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(control_events);
     let mut children = ChildArena::default();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
-    let key = children
-        .insert(child)
-        .unwrap_or_else(|_| panic!("the fixture fits in the child-key domain"));
-    root.with_observation_gate(|txn| {
-        control.register_initial(children.iter().map(|(key, child)| (&child.slot, key)), txn);
-    });
-    root.set_dynamic_route(Some(control.clone()));
+    let key = children.insert(child);
     let member = Arc::clone(&children[key].slot.member);
     let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_children(children)
         .with_dynamic(Some(control))
+        .with_transferred_plan(plan)
         .build();
-    plan.finish_transfer();
 
     assert!(scope.terminalize_child(
         key,
@@ -1035,36 +862,22 @@ async fn queued_removal_suppresses_replayed_self_stop_readiness() {
 
     let mut plan = tree.lower_for_test();
     let root = Arc::clone(&plan.root);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
+    let epoch = ScopeEpochGuard::begin(&root).expect("test scope epoch is available");
     root.member
         .update(|record| record.stage = MemberStage::Running);
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
-    );
     let (events, _event_receiver) = crate::runtime::unbounded_mpsc();
     let (control_events, mut control_event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(control_events);
     let mut children = ChildArena::default();
     let child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
-    let key = children
-        .insert(child)
-        .unwrap_or_else(|_| panic!("the fixture fits in the child-key domain"));
-    root.with_observation_gate(|txn| {
-        control.register_initial(children.iter().map(|(key, child)| (&child.slot, key)), txn);
-    });
-    root.set_dynamic_route(Some(control.clone()));
+    let key = children.insert(child);
     let member = Arc::clone(&children[key].slot.member);
     let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
         .with_defaults(plan.defaults.clone())
         .with_children(children)
         .with_dynamic(Some(control))
+        .with_transferred_plan(plan)
         .build();
-    plan.finish_transfer();
 
     scope.spawn_child(key);
     let active = scope.children[key]

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -19,10 +19,7 @@ pub(super) use crate::{
     ReadinessDeadline, RemoveOutcome, ReserveError, RestartCondition, RestartCount, RestartPolicy,
     Retention, ScopeRef, ScopeState, SendErrorKind, StartupError, StartupFailure,
     StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
-    engine::{
-        ChildKey, Effect as SupervisorEffect, Epoch, Event as SupervisorEvent, ScopeLifecycle,
-        StopLadder, SupervisorState, arbitrate, step as supervisor_step,
-    },
+    engine::{ChildKey, Epoch, Event as SupervisorEvent, ScopeLifecycle, StopLadder, arbitrate},
     exit::RecordedOutcome,
     identity::{IncarnationCounter, ScopeIdentity},
     mailbox::{MailboxCell, actor_ref_from_parts},
@@ -53,20 +50,45 @@ impl ObservedExit {
     }
 }
 
+pub(super) async fn recv_driver_event(
+    receiver: &mut crate::runtime::UnboundedMpscReceiver<DriverEvent>,
+    timeout: Duration,
+    expectation: &str,
+) -> DriverEvent {
+    match crate::runtime::timeout(timeout, receiver.recv()).await {
+        crate::runtime::Timeout::Completed(Some(event)) => event,
+        crate::runtime::Timeout::Completed(None) => {
+            panic!("event lane closed while waiting for {expectation}")
+        }
+        crate::runtime::Timeout::Elapsed => panic!("timed out waiting for {expectation}"),
+    }
+}
+
+pub(super) async fn recv_child_event(
+    receiver: &mut crate::runtime::UnboundedMpscReceiver<DriverEvent>,
+    timeout: Duration,
+    expectation: &str,
+) -> ChildEvent {
+    let DriverEvent::Child(event) = recv_driver_event(receiver, timeout, expectation).await else {
+        panic!("expected {expectation}")
+    };
+    event
+}
+
 pub(super) async fn recv_child_exit(
     receiver: &mut crate::runtime::UnboundedMpscReceiver<DriverEvent>,
     timeout: Duration,
     expectation: &str,
 ) -> ObservedExit {
-    match crate::runtime::timeout(timeout, receiver.recv()).await {
-        crate::runtime::Timeout::Completed(Some(DriverEvent::Child(ChildEvent::Exited {
+    match recv_child_event(receiver, timeout, expectation).await {
+        ChildEvent::Exited {
             child,
             incarnation,
             recorded,
             join,
             cancellation,
             readiness_signal_seen,
-        }))) => ObservedExit {
+        } => ObservedExit {
             child,
             incarnation,
             recorded,
@@ -74,17 +96,41 @@ pub(super) async fn recv_child_exit(
             cancellation,
             readiness_signal_seen,
         },
-        crate::runtime::Timeout::Completed(_) => panic!("expected {expectation}"),
-        crate::runtime::Timeout::Elapsed => panic!("timed out waiting for {expectation}"),
+        _ => panic!("expected {expectation}"),
     }
 }
 
+pub(super) async fn recv_removal(
+    receiver: &mut crate::runtime::UnboundedMpscReceiver<DriverEvent>,
+    timeout: Duration,
+    expectation: &str,
+) -> RemovalRequest {
+    let DriverEvent::Removal(removal) = recv_driver_event(receiver, timeout, expectation).await
+    else {
+        panic!("expected {expectation}")
+    };
+    removal
+}
+
+pub(super) async fn recv_construction_disposed(
+    receiver: &mut crate::runtime::UnboundedMpscReceiver<DriverEvent>,
+    timeout: Duration,
+    expectation: &str,
+) -> (ChildKey, Option<crate::runtime::DisposalPanic>) {
+    let ChildEvent::ConstructionDisposed { child, panic } =
+        recv_child_event(receiver, timeout, expectation).await
+    else {
+        panic!("expected {expectation}")
+    };
+    (child, panic)
+}
+
 pub(super) use super::super::{
-    AdmissionRequest, AncestorCommandLatches, ChildEvent, ChildResources, ChildRuntime,
-    ChildTerminality, DriverEvent, DynamicControl, DynamicEntry, DynamicReservation, GateCapture,
-    MemberCell, MemberStage, MemberTransition, NestedScopeLatches, Pending, RemovalRequest,
-    RemovalResponses, ResidentProjection, RuntimeStorage, ScopeCell, ScopeControlEvent,
-    ScopeEpochGuard, ScopeFlavor, ScopeRole, ScopeRuntime, StartupDisposition,
+    AdmissionRequest, AncestorCommandLatches, ChildEvent, ChildRuntime, ChildTerminality,
+    DriverEvent, DynamicControl, DynamicEntry, DynamicReservation, GateCapture, MemberCell,
+    MemberStage, MemberTransition, NestedScopeLatches, Pending, RemovalRequest, RemovalResponses,
+    ResidentProjection, RuntimeStorage, ScopeCell, ScopeControlEvent, ScopeEpochGuard, ScopeFlavor,
+    ScopeRole, ScopeRuntime, ScopeRuntimeTestWiring, StartupDisposition,
     cancel_dynamic_reservation, discharge_child_terminality, events::collect_driver_events,
     monitor_root_driver, report_slot, reserve_dynamic, resident_projection, restart_shutdown_work,
     run_nested_factory, run_nested_tree, run_scope, run_scope_incarnation, storage::Obligation,
@@ -110,6 +156,54 @@ pub(super) async fn begin_admission(
     (response, request)
 }
 
+pub(super) enum DynamicFixtureState {
+    Resident,
+    Removing,
+}
+
+pub(super) fn insert_dynamic_fixture(
+    scope: &mut ScopeRuntime,
+    control: &Arc<DynamicControl>,
+    id: impl Into<ChildId>,
+    construction: ChildConstruction,
+    prepare: impl FnOnce(&mut ChildRuntime),
+    state: DynamicFixtureState,
+) -> (DynamicReservation, ChildKey) {
+    let root = Arc::clone(&scope.root);
+    let reservation = reserve_dynamic(&root, id.into(), None)
+        .expect("running dynamic scope reserves the fixture child");
+    reservation.slot.define(construction);
+    let (definition, resolved) = reservation
+        .slot
+        .resolve_and_take_defined(&scope.defaults)
+        .expect("the fixture slot is defined");
+    let plan =
+        crate::plan::ChildPlan::with_options(Arc::clone(&reservation.slot), definition, resolved);
+    let mut child = ChildRuntime::from_plan(plan, &root);
+    prepare(&mut child);
+    let key = root.with_observation_gate(|txn| {
+        let key = scope
+            .insert_child(child, false)
+            .unwrap_or_else(|_| panic!("the fixture child-key domain is available"));
+        {
+            let mut dynamic = control.state.lock().expect("dynamic-state mutex poisoned");
+            let entry = dynamic
+                .entries
+                .get_mut(reservation.slot.member.id())
+                .expect("the fixture reservation remains registered");
+            entry.promote(key, None, txn);
+            if matches!(state, DynamicFixtureState::Removing) {
+                entry
+                    .mark_removing(txn)
+                    .expect("the promoted fixture resident transitions to Removing");
+            }
+        }
+        root.admit_child_locked(resident_projection(&reservation.slot), txn);
+        key
+    });
+    (reservation, key)
+}
+
 pub(super) struct ChildArena<T> {
     children: BTreeMap<ChildKey, T>,
     next: u64,
@@ -125,11 +219,11 @@ impl<T> Default for ChildArena<T> {
 }
 
 impl<T> ChildArena<T> {
-    pub(super) fn insert(&mut self, child: T) -> Result<ChildKey, Box<T>> {
+    pub(super) fn insert(&mut self, child: T) -> ChildKey {
         self.next += 1;
         let key = ChildKey::fixture(self.next);
         self.children.insert(key, child);
-        Ok(key)
+        key
     }
 
     pub(super) fn keys(&self) -> impl DoubleEndedIterator<Item = ChildKey> + '_ {
@@ -138,10 +232,6 @@ impl<T> ChildArena<T> {
 
     pub(super) fn values_mut(&mut self) -> impl Iterator<Item = &mut T> {
         self.children.values_mut()
-    }
-
-    pub(super) fn iter(&self) -> impl Iterator<Item = (ChildKey, &T)> {
-        self.children.iter().map(|(key, child)| (*key, child))
     }
 
     fn into_iter(self) -> impl Iterator<Item = (ChildKey, T)> {
@@ -165,10 +255,8 @@ impl<T> IndexMut<ChildKey> for ChildArena<T> {
 
 pub(super) struct ScopeRuntimeBuilder {
     root: Arc<ScopeCell>,
-    epoch: Epoch,
+    epoch: ScopeEpochGuard,
     events: crate::runtime::UnboundedMpscSender<DriverEvent>,
-    disposal_events: crate::runtime::UnboundedMpscSender<DriverEvent>,
-    disposal_event_receiver: crate::runtime::UnboundedMpscReceiver<DriverEvent>,
     defaults: ResolvedDefaults,
     intensity_policy: Intensity,
     children: ChildArena<ChildRuntime>,
@@ -176,21 +264,19 @@ pub(super) struct ScopeRuntimeBuilder {
     next_ordered_start: Option<Option<ChildKey>>,
     dynamic: Option<Arc<DynamicControl>>,
     hard_forced: bool,
+    transferred_plan: Option<crate::plan::ScopePlan>,
 }
 
 impl ScopeRuntimeBuilder {
     pub(super) fn new(
         root: Arc<ScopeCell>,
-        epoch: Epoch,
+        epoch: ScopeEpochGuard,
         events: crate::runtime::UnboundedMpscSender<DriverEvent>,
     ) -> Self {
-        let (disposal_events, disposal_event_receiver) = crate::runtime::unbounded_mpsc();
         Self {
             root,
             epoch,
             events,
-            disposal_events,
-            disposal_event_receiver,
             defaults: ResolvedDefaults::default(),
             intensity_policy: Intensity::default(),
             children: ChildArena::default(),
@@ -198,6 +284,7 @@ impl ScopeRuntimeBuilder {
             next_ordered_start: None,
             dynamic: None,
             hard_forced: false,
+            transferred_plan: None,
         }
     }
 
@@ -236,56 +323,104 @@ impl ScopeRuntimeBuilder {
         self
     }
 
+    pub(super) fn with_transferred_plan(mut self, plan: crate::plan::ScopePlan) -> Self {
+        self.transferred_plan = Some(plan);
+        self
+    }
+
     pub(super) fn build(self) -> ScopeRuntime {
-        let mut supervisor = SupervisorState::new(self.root.flavor, self.lifecycle);
-        let mut supervisor_effects = Vec::new();
-        let mut children = ChildResources::default();
-        for (expected, child) in self.children.into_iter() {
-            supervisor_step(
-                &mut supervisor,
-                SupervisorEvent::Admit {
-                    membership: child.slot.member.membership(),
-                    initial: true,
-                    start_immediately: false,
-                },
-                &mut supervisor_effects,
-            );
-            let Some(SupervisorEffect::Admitted { child: actual }) = supervisor_effects.pop()
-            else {
-                panic!("fixture admission produces one key")
-            };
-            assert_eq!(actual, expected);
-            children.insert(actual, child);
+        let scope = ScopeRuntime::for_test(
+            ScopeRuntimeTestWiring {
+                root: self.root,
+                defaults: self.defaults,
+                intensity_policy: self.intensity_policy,
+                children: self.children.into_iter().collect(),
+                lifecycle: self.lifecycle,
+                next_ordered_start: self.next_ordered_start,
+                events: self.events,
+                dynamic: self.dynamic,
+                hard_forced: self.hard_forced,
+            },
+            self.epoch,
+        );
+        if let Some(plan) = self.transferred_plan {
+            plan.finish_transfer();
         }
-        if let Some(next) = self.next_ordered_start {
-            supervisor.set_next_ordered_start_for_test(next);
+        scope.publish_initial_children();
+        scope
+    }
+}
+
+pub(super) struct OrderedScopeFixture {
+    pub(super) root: Arc<ScopeCell>,
+    pub(super) children: ChildArena<ChildRuntime>,
+    plan: crate::plan::ScopePlan,
+    epoch: ScopeEpochGuard,
+    events: crate::runtime::UnboundedMpscSender<DriverEvent>,
+    event_receiver: crate::runtime::UnboundedMpscReceiver<DriverEvent>,
+    lifecycle: ScopeLifecycle,
+    next_ordered_start: Option<Option<ChildKey>>,
+    hard_forced: bool,
+}
+
+impl OrderedScopeFixture {
+    pub(super) fn new(tree: Tree) -> Self {
+        let mut plan = tree.lower_for_test();
+        assert_eq!(plan.root.flavor, ScopeFlavor::Ordered);
+        let root = Arc::clone(&plan.root);
+        let epoch = ScopeEpochGuard::begin(&root).expect("test scope epoch is available");
+        let (events, event_receiver) = crate::runtime::unbounded_mpsc();
+        let mut children = ChildArena::default();
+        plan.children.reverse();
+        while let Some(child) = plan.children.pop() {
+            children.insert(ChildRuntime::from_plan(child, &root));
         }
-        supervisor.set_hard_forced_for_test(self.hard_forced);
-        ScopeRuntime {
-            root: self.root,
-            defaults: self.defaults,
-            intensity_policy: self.intensity_policy,
-            intensity: super::super::IntensityState::default(),
-            restart_shutdown_retries: Vec::new(),
+        Self {
+            root,
             children,
-            supervisor,
-            supervisor_effects,
-            events: self.events,
-            disposal_events: self.disposal_events,
-            disposal_event_receiver: self.disposal_event_receiver,
-            arrived_disposal_panics: BTreeMap::new(),
-            deadlines: super::super::DeadlineQueue::default(),
-            jitter: crate::runtime::JitterRng::new(),
-            role: ScopeRole::Root,
-            dynamic: self.dynamic,
-            pending_startup_removals: Vec::new(),
-            epoch: self.epoch,
-            ancestor_shutdown_seen: false,
-            ancestor_abort_seen: false,
-            completion: None,
-            finished: None,
-            retained_exits: Vec::new(),
+            plan,
+            epoch,
+            events,
+            event_receiver,
+            lifecycle: ScopeLifecycle::starting(),
+            next_ordered_start: None,
+            hard_forced: false,
         }
+    }
+
+    pub(super) fn with_lifecycle(mut self, lifecycle: ScopeLifecycle) -> Self {
+        self.lifecycle = lifecycle;
+        self
+    }
+
+    pub(super) fn with_next_ordered_start(mut self, next: Option<ChildKey>) -> Self {
+        self.next_ordered_start = Some(next);
+        self
+    }
+
+    pub(super) fn with_hard_forced(mut self, hard_forced: bool) -> Self {
+        self.hard_forced = hard_forced;
+        self
+    }
+
+    pub(super) fn build(
+        self,
+    ) -> (
+        ScopeRuntime,
+        crate::runtime::UnboundedMpscReceiver<DriverEvent>,
+    ) {
+        let mut builder = ScopeRuntimeBuilder::new(Arc::clone(&self.root), self.epoch, self.events)
+            .with_defaults(self.plan.defaults.clone())
+            .with_intensity_policy(self.plan.intensity_policy())
+            .with_children(self.children)
+            .with_lifecycle(self.lifecycle)
+            .with_hard_forced(self.hard_forced)
+            .with_transferred_plan(self.plan);
+        if let Some(next) = self.next_ordered_start {
+            builder = builder.with_next_ordered_start(next);
+        }
+        let scope = builder.build();
+        (scope, self.event_receiver)
     }
 }
 
@@ -321,9 +456,7 @@ pub(super) fn running_dynamic_fixture() -> (
     Arc<DynamicControl>,
 ) {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
-    let epoch = root
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
+    let epoch = ScopeEpochGuard::begin(&root).expect("test scope epoch is available");
     root.member
         .update(|record| record.stage = MemberStage::Running);
     root.set_state(ScopeState::Running);
@@ -332,8 +465,6 @@ pub(super) fn running_dynamic_fixture() -> (
     let (events, event_receiver) = crate::runtime::unbounded_mpsc();
     let (dynamic_events, dynamic_event_receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(dynamic_events);
-    root.set_dynamic_route(Some(control.clone()));
-    root.set_admitted_children(Vec::new());
     let scope = ScopeRuntimeBuilder::new(root, epoch, events)
         .with_lifecycle(ScopeLifecycle::running())
         .with_dynamic(Some(control.clone()))

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -136,9 +136,8 @@ async fn terminal_stop_paths_share_one_complete_observation_transition() {
 #[crate::runtime::test]
 async fn root_driver_panic_mid_drain_upgrades_to_the_join_monitor_verdict() {
     let scope = isolated_scope("root", ScopeFlavor::Ordered);
-    let epoch = scope
-        .begin_incarnation(ScopeState::Starting)
-        .expect("test scope epoch is available");
+    let epoch = ScopeEpochGuard::begin(&scope).expect("test scope epoch is available");
+    let epoch_id = epoch.epoch();
     scope
         .member
         .update(|record| record.stage = MemberStage::Running);
@@ -189,7 +188,7 @@ async fn root_driver_panic_mid_drain_upgrades_to_the_join_monitor_verdict() {
         "the unwind epilogue leaves root terminality to the join monitor"
     );
     assert!(
-        scope.settled(Some(epoch)),
+        scope.settled(Some(epoch_id)),
         "the unwind epilogue retires its epoch, so the join monitor must take \
          the no-live-epoch fallback this test is named for"
     );


### PR DESCRIPTION
Part of #282 and the #284 test-debt sequence.

## What changed

- Introduces the canonical `ScopeRuntime` construction path used by tests.
- Replaces repeated ordered-plan setup, dynamic admission setup, and event-wait loops with shared fixtures.
- Makes `ChildArena::insert` return its key directly.
- Preserves epoch transfer and route-before-`Added` publication ordering.

Net change: 247 lines removed across nine files.

Validation: driver tests passed 138/138, and `./tools/dev just ci` passed (674 tests plus all documentation/API/external-consumer lanes).

Stack: based on #296 / issue #281 so fixture cleanup cannot hide weak assertions.