### PR TITLE
Harden framework lock boundaries structurally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,15 +65,22 @@ rests on:
   owner of a mailbox containing unread user messages, which `RetainedExit`
   does not cover.
 - **Framework `dyn` seams.** `MailboxControl`, `MailboxTermination`,
-  `MailboxRuntime`, `ActorIdentity` and `DynamicRoute` are implementation seams
+  `MailboxRuntime`, `MailboxEffectSink`, `ActorIdentity` and `DynamicRoute` are
+  implementation seams
   with framework-only impls, not user traits; where the framework invokes one
   under a lock, no caller code runs. `MailboxControl` and
   `MailboxTermination` are private-supertrait sealed because their legitimate
-  implementations live in the defining mailbox crate. The other three hold
+  implementations live in the defining mailbox crate. The other four hold
   their boundary by convention rather than by construction, and so do the
   sub-capabilities `MailboxRuntime` mints: `MailboxSignal`,
   `MailboxSignalWatcher` and the `ErasedOneShot*` family are public unsealed
-  cross-crate traits for the same reason and ride under the same ruling. Rust
+  cross-crate traits for the same reason and ride under the same ruling.
+  `MailboxEffectSink` is the sharpest case: the framework calls
+  `defer_mailbox_effect` while holding both the resident-tree observation gate
+  and `MemberCell::mailbox`, and its `MailboxEffectQueue` implementation is
+  `pub` and `Default`, so an unsupported direct dependent could both construct
+  a sink and supply its own. The supported façade re-exports neither, which is
+  what keeps the ruling true. Rust
   cannot private-seal a trait in the lower crate while permitting its
   legitimate implementation in a downstream sibling, and a public capability
   token would be obtainable by the same unsupported direct dependent. The

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,10 @@ rests on:
   traffic and only the last clone submits disposal. Scope state and startup
   results need that protection too: a structured startup failure recursively
   owns the triggering child's `Exit`.
-  `ScopeCell::clear_residents_locked` and `prune_child_locked` may therefore
-  release their `Arc<MemberCell>`s under the gate without relying on driver
-  field-drop order to keep a user error alive.
+  `ScopeCell::clear_residents_locked` and `prune_child_locked` still defer
+  displaced `Arc<MemberCell>`s: the last member owner can also be the last
+  owner of a mailbox containing unread user messages, which `RetainedExit`
+  does not cover.
 - **Framework `dyn` seams.** `MailboxControl`, `MailboxTermination`,
   `MailboxRuntime`, `ActorIdentity` and `DynamicRoute` are implementation seams
   with framework-only impls, not user traits; where the framework invokes one

--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -788,20 +788,23 @@ impl MemberCell {
         // winning exit. Notification-driven readers still see
         // discharge-before-pulse; tree-scoped publication defers both until
         // the complete observation transaction has released its gate.
+        let mut nonterminal_mailbox = false;
         let teardown = match &mut *self.mailbox.lock().expect("member mailbox mutex poisoned") {
             MemberMailbox::Terminal { teardown, .. } => teardown.take(),
             MemberMailbox::Unattached | MemberMailbox::Attached(_) => {
                 // Panicking here would poison the member mailbox and can
-                // retire a retained user exit during unwind. Diagnose the
-                // internal invariant in debug builds and keep release builds
-                // in the already-published terminal state.
-                debug_assert!(
-                    false,
-                    "terminal publication requires terminal mailbox state"
-                );
+                // retire a retained user exit during unwind. Compute the
+                // verdict under the lock and raise it below, once the guard
+                // has been released; release builds keep the already-published
+                // terminal state.
+                nonterminal_mailbox = true;
                 None
             }
         };
+        debug_assert!(
+            !nonterminal_mailbox,
+            "terminal publication requires terminal mailbox state"
+        );
         if let Some(teardown) = teardown {
             txn.defer(move || {
                 if let Some(payload) = teardown.finish() {
@@ -2011,6 +2014,11 @@ impl ScopeCell {
             child_id = ancestor.member.id().clone();
             ancestor.observation.lifecycle.publish(wakes, event.clone());
         }
+        // The producer's own copy still owns a retained exit. Retiring it here
+        // would submit a disposal job — and can start a native thread — with
+        // the observation gate held. This caller owns an effects sink, so it
+        // takes the preferred path and retires after unlock.
+        wakes.defer(move || drop(event));
     }
 
     fn close_observation_locked(&self, wakes: &mut ObservationTxn<'_>) {
@@ -3056,8 +3064,7 @@ mod tests {
             state: ScopeState::Running,
         });
         let (dropped, observed) = mpsc::sync_channel(1);
-
-        scope.emit(LifecycleEventKind::Exited {
+        let exhausted = LifecycleEventKind::Exited {
             id,
             membership,
             incarnation: incarnations.mint().expect("incarnation available"),
@@ -3065,7 +3072,23 @@ mod tests {
                 ExitKind::Failed(ExitError::from(GateDropError { gate, dropped })),
                 Cancellation::NotObserved,
             ),
+        };
+
+        // Retiring a `RetainedExit` never destroys the user error inline: it
+        // always submits the value to isolated disposal, so the destructor
+        // runs on a worker thread in either arrangement and its own view of
+        // the gate is a race. What the deferral changes is *when the
+        // submission happens*. Hold the gate open across the emit: nothing
+        // can arrive on this channel unless the submission already happened
+        // under the gate.
+        let retired_under_gate = scope.with_observation_gate(|wakes| {
+            scope.emit_locked(wakes, exhausted);
+            observed.recv_timeout(Duration::from_millis(500)).is_ok()
         });
+        assert!(
+            !retired_under_gate,
+            "an unsequenced exit must not be submitted for disposal under the observation gate"
+        );
 
         assert!(
             observed

--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -29,11 +29,11 @@ use crate::{
         stop_reason_precedence,
     },
     identity::{AtomicPoisonedCounter, IncarnationCounter, MintedMembership, ScopeIdentity},
-    mailbox::{ActorIdentity, MailboxControl, MailboxTermination},
+    mailbox::{ActorIdentity, MailboxControl, MailboxEffectSink, MailboxTermination},
     observe::{
-        ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
-        LifecycleHub, LifecycleSeq, RetainedScopeSnapshot, ScopeKind, ScopeSnapshot, SnapshotHub,
-        SnapshotPublication, SnapshotReceiver,
+        ChildSnapshot, ChildState, LifecycleEventKind, LifecycleEvents, LifecycleHub, LifecycleSeq,
+        RetainedLifecycleEvent, RetainedLifecycleEventKind, RetainedScopeSnapshot, ScopeKind,
+        ScopeSnapshot, SnapshotHub, SnapshotPublication, SnapshotReceiver,
     },
     policy::{ResolvedCommonOptions, ScopeFlavor},
     runtime::{self, Latch},
@@ -679,7 +679,7 @@ impl MemberCell {
                         teardown,
                     } => {
                         debug_assert!(teardown.is_none());
-                        *teardown = mailbox.prepare_termination();
+                        *teardown = mailbox.prepare_termination(txn);
                         *control = Some(mailbox);
                         Some(exit.as_exit().clone())
                     }
@@ -748,7 +748,7 @@ impl MemberCell {
                 }
                 MemberMailbox::Attached(control) => {
                     let control = Arc::clone(control);
-                    let teardown = control.prepare_termination();
+                    let teardown = control.prepare_termination(txn);
                     *state = MemberMailbox::Terminal {
                         control: Some(control),
                         exit: RetainedExit::new(exit.clone()),
@@ -791,7 +791,15 @@ impl MemberCell {
         let teardown = match &mut *self.mailbox.lock().expect("member mailbox mutex poisoned") {
             MemberMailbox::Terminal { teardown, .. } => teardown.take(),
             MemberMailbox::Unattached | MemberMailbox::Attached(_) => {
-                unreachable!("terminal publication requires terminal mailbox state")
+                // Panicking here would poison the member mailbox and can
+                // retire a retained user exit during unwind. Diagnose the
+                // internal invariant in debug builds and keep release builds
+                // in the already-published terminal state.
+                debug_assert!(
+                    false,
+                    "terminal publication requires terminal mailbox state"
+                );
+                None
             }
         };
         if let Some(teardown) = teardown {
@@ -1040,6 +1048,12 @@ impl Drop for ObservationTxn<'_> {
     }
 }
 
+impl MailboxEffectSink for ObservationTxn<'_> {
+    fn defer_mailbox_effect(&mut self, effect: Box<dyn FnOnce()>) {
+        self.effects.push(effect);
+    }
+}
+
 /// Driver-independent view of one declaration slot while its membership is
 /// resident in a running scope.
 #[derive(Clone)]
@@ -1092,11 +1106,15 @@ impl ResidentChild {
                 },
             );
         }
+        // The projection can carry the last member/mailbox owner. Retire it
+        // only after the resident-tree observation gate is released.
+        txn.defer(move || drop(completion));
     }
 
     fn complete_removal(mut self, txn: &mut ObservationTxn<'_>) {
         let completion = self.disarm_removal();
         Self::publish_removal(completion, txn);
+        txn.defer(move || drop(self));
     }
 }
 
@@ -1956,6 +1974,10 @@ impl ScopeCell {
     }
 
     fn emit_locked(&self, wakes: &mut ObservationTxn<'_>, kind: LifecycleEventKind) {
+        // Convert every user-error-bearing edge to retained form before any
+        // fallible framework bookkeeping. A sequence-exhaustion path can now
+        // defer the retained value instead of unwinding with a raw `Exit`.
+        let kind = RetainedLifecycleEventKind::new(kind);
         // Parent links cannot change under the resident-tree observation gate.
         // Resolve them once for snapshot and lifecycle propagation so one leaf
         // edge does not repeatedly lock every ancestor's parent mutex.
@@ -1970,6 +1992,7 @@ impl ScopeCell {
             .lifecycle_seq
             .mint(Ordering::Release, Ordering::Relaxed);
         let Some(seq) = seq.map(LifecycleSeq::new) else {
+            wakes.defer(move || drop(kind));
             self.publish_snapshot_chain_through_locked(wakes, &ancestors);
             self.observation.lifecycle.publish_lagged(wakes, 1);
             for ancestor in &ancestors {
@@ -1980,23 +2003,18 @@ impl ScopeCell {
         self.publish_snapshot_chain_through_locked(wakes, &ancestors);
 
         let scope = self.member.membership();
-        let mut event = LifecycleEvent {
-            scope_path: Vec::new(),
-            scope,
-            seq,
-            kind,
-        };
+        let mut event = RetainedLifecycleEvent::from_retained_kind(scope, seq, kind);
         self.observation.lifecycle.publish(wakes, event.clone());
         let mut child_id = self.member.id().clone();
         for ancestor in ancestors {
-            event.scope_path.insert(0, child_id);
+            event.prepend_scope(child_id);
             child_id = ancestor.member.id().clone();
             ancestor.observation.lifecycle.publish(wakes, event.clone());
         }
     }
 
     fn close_observation_locked(&self, wakes: &mut ObservationTxn<'_>) {
-        if self.observation.closed.swap(true, Ordering::AcqRel) {
+        if self.observation.closed.load(Ordering::Acquire) {
             return;
         }
         // Closure follows the final state/snapshot/event publication performed
@@ -2006,6 +2024,9 @@ impl ScopeCell {
             .snapshots
             .close(wakes, move || scope.snapshot_locked());
         self.observation.lifecycle.close(wakes);
+        // Both hub closures are idempotent. Set the aggregate marker last so
+        // an unexpected panic leaves the operation retryable.
+        self.observation.closed.store(true, Ordering::Release);
     }
 
     #[cfg(any(test, feature = "test-util"))]
@@ -2427,7 +2448,7 @@ impl ScopeCell {
             .iter_mut()
             .map(ResidentChild::disarm_removal)
             .collect::<Vec<_>>();
-        drop(residents);
+        wakes.defer(move || drop(residents));
         for completion in completions {
             ResidentChild::publish_removal(completion, wakes);
         }
@@ -2598,12 +2619,14 @@ impl ScopeCell {
 mod tests {
     use std::{
         fmt,
+        future::Future,
         panic::{AssertUnwindSafe, catch_unwind},
         sync::{
             Arc,
             atomic::{AtomicBool, Ordering},
             mpsc,
         },
+        task::{Context, Poll, Wake, Waker},
         time::Duration,
     };
 
@@ -2613,11 +2636,64 @@ mod tests {
     };
 
     use crate::{
-        ChildId, MemberCell, RetainedExit, RetainedStopReason, ScopeCell, StartupDisposition,
-        identity::ScopeIdentity, policy::ScopeFlavor,
+        ChildId, LifecycleEventKind, MemberCell, ResidentProjection, RetainedExit,
+        RetainedStopReason, ScopeCell, StartupDisposition,
+        identity::ScopeIdentity,
+        mailbox::{
+            MailboxCell, MailboxControl, MailboxEffectQueue, MailboxReceiver, actor_ref_from_parts,
+        },
+        policy::{ResolvedMailbox, ScopeFlavor},
     };
 
     struct ThreadProbe(mpsc::SyncSender<std::thread::ThreadId>);
+
+    struct GateCheckingWake {
+        gate: super::ObservationGate,
+        woke_after_unlock: Arc<AtomicBool>,
+    }
+
+    impl Wake for GateCheckingWake {
+        fn wake(self: Arc<Self>) {
+            self.woke_after_unlock
+                .store(!self.gate.is_held(), Ordering::SeqCst);
+        }
+    }
+
+    struct GateDropError {
+        gate: super::ObservationGate,
+        dropped: mpsc::SyncSender<bool>,
+    }
+
+    impl fmt::Debug for GateDropError {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("GateDropError")
+        }
+    }
+
+    impl fmt::Display for GateDropError {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("gate drop probe")
+        }
+    }
+
+    impl std::error::Error for GateDropError {}
+
+    impl Drop for GateDropError {
+        fn drop(&mut self) {
+            let _ = self.dropped.send(!self.gate.is_held());
+        }
+    }
+
+    struct GateDropMessage {
+        gate: super::ObservationGate,
+        dropped: mpsc::SyncSender<bool>,
+    }
+
+    impl Drop for GateDropMessage {
+        fn drop(&mut self) {
+            let _ = self.dropped.send(!self.gate.is_held());
+        }
+    }
 
     impl fmt::Debug for ThreadProbe {
         fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -2921,5 +2997,130 @@ mod tests {
         );
 
         assert!(scope.request_shutdown_ignoring_poison().is_some());
+    }
+
+    #[test]
+    fn mailbox_control_wakes_are_deferred_past_the_observation_gate() {
+        let id = ChildId::from("root");
+        let mut identity = ScopeIdentity::new();
+        let member = MemberCell::new(
+            id.clone(),
+            identity
+                .mint_membership(&id)
+                .expect("root membership is available"),
+        );
+        let mut incarnations = member.take_incarnation_counter();
+        let incarnation = incarnations.mint().expect("incarnation available");
+        let scope = ScopeCell::new(member, ScopeFlavor::Dynamic, ScopeIdentity::new());
+        let gate = scope.observation_gate();
+        let mailbox = MailboxCell::<u8>::new(id, crate::runtime::mailbox_runtime());
+        let mut effects = MailboxEffectQueue::default();
+        let token = MailboxControl::configure(&*mailbox, ResolvedMailbox::Latest, &mut effects);
+        MailboxControl::bind(&*mailbox, token, incarnation, &mut effects);
+        drop(effects);
+        let mut receiver = MailboxReceiver::new(Arc::clone(&mailbox), incarnation);
+        let woke_after_unlock = Arc::new(AtomicBool::new(false));
+        let waker = Waker::from(Arc::new(GateCheckingWake {
+            gate: gate.clone(),
+            woke_after_unlock: Arc::clone(&woke_after_unlock),
+        }));
+        let mut changed = Box::pin(receiver.changed());
+        assert!(matches!(
+            changed.as_mut().poll(&mut Context::from_waker(&waker)),
+            Poll::Pending
+        ));
+
+        scope.with_observation_gate(|txn| {
+            MailboxControl::freeze(&*mailbox, incarnation, txn);
+        });
+
+        assert!(woke_after_unlock.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn lifecycle_sequence_exhaustion_retires_the_exit_after_unlock() {
+        let id = ChildId::from("root");
+        let mut identity = ScopeIdentity::new();
+        let member = MemberCell::new(
+            id.clone(),
+            identity
+                .mint_membership(&id)
+                .expect("root membership is available"),
+        );
+        let membership = member.membership();
+        let mut incarnations = member.take_incarnation_counter();
+        let scope = ScopeCell::new(member, ScopeFlavor::Dynamic, ScopeIdentity::new());
+        let gate = scope.observation_gate();
+        scope.set_lifecycle_sequence(u64::MAX - 2);
+        scope.emit(LifecycleEventKind::ScopeState {
+            state: ScopeState::Running,
+        });
+        let (dropped, observed) = mpsc::sync_channel(1);
+
+        scope.emit(LifecycleEventKind::Exited {
+            id,
+            membership,
+            incarnation: incarnations.mint().expect("incarnation available"),
+            exit: Exit::new(
+                ExitKind::Failed(ExitError::from(GateDropError { gate, dropped })),
+                Cancellation::NotObserved,
+            ),
+        });
+
+        assert!(
+            observed
+                .recv_timeout(Duration::from_secs(10))
+                .expect("retained exit destructor reports"),
+            "an unsequenced exit is retired after the observation gate unlocks"
+        );
+    }
+
+    #[test]
+    fn clearing_residents_releases_the_last_mailbox_owner_after_unlock() {
+        let root_id = ChildId::from("root");
+        let mut root_identity = ScopeIdentity::new();
+        let root_member = MemberCell::new(
+            root_id.clone(),
+            root_identity
+                .mint_membership(&root_id)
+                .expect("root membership is available"),
+        );
+        let scope = ScopeCell::new(root_member, ScopeFlavor::Dynamic, ScopeIdentity::new());
+        let gate = scope.observation_gate();
+
+        let child_id = ChildId::from("child");
+        let mut child_identity = ScopeIdentity::new();
+        let child = MemberCell::new(
+            child_id.clone(),
+            child_identity
+                .mint_membership(&child_id)
+                .expect("child membership is available"),
+        );
+        let mut incarnations = child.take_incarnation_counter();
+        let incarnation = incarnations.mint().expect("incarnation available");
+        let mailbox = MailboxCell::new(child_id, crate::runtime::mailbox_runtime());
+        child.attach_mailbox(mailbox.clone());
+        let actor = actor_ref_from_parts(Arc::clone(&child), Arc::clone(&mailbox));
+        let mut effects = MailboxEffectQueue::default();
+        let token = MailboxControl::configure(&*mailbox, ResolvedMailbox::Latest, &mut effects);
+        MailboxControl::bind(&*mailbox, token, incarnation, &mut effects);
+        drop(effects);
+        let (dropped, observed) = mpsc::sync_channel(1);
+        actor
+            .try_send(GateDropMessage { gate, dropped })
+            .expect("bound mailbox accepts the probe");
+        scope.admit_child(ResidentProjection::new(Arc::clone(&child), None));
+        drop(actor);
+        drop(mailbox);
+        drop(child);
+
+        scope.clear_residents();
+
+        assert!(
+            observed
+                .recv_timeout(Duration::from_secs(10))
+                .expect("resident mailbox payload destructor reports"),
+            "the displaced resident owner is released after the gate unlocks"
+        );
     }
 }

--- a/crates/shelterwood-cells/src/observe.rs
+++ b/crates/shelterwood-cells/src/observe.rs
@@ -72,7 +72,7 @@ pub struct LifecycleEvent {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct RetainedLifecycleEvent {
+pub(crate) struct RetainedLifecycleEvent {
     scope_path: Vec<ChildId>,
     scope: Membership,
     seq: LifecycleSeq,
@@ -97,10 +97,33 @@ impl RetainedLifecycleEvent {
             kind: self.kind.into_public(),
         }
     }
+
+    pub(crate) fn from_retained_kind(
+        scope: Membership,
+        seq: LifecycleSeq,
+        kind: RetainedLifecycleEventKind,
+    ) -> Self {
+        Self {
+            scope_path: Vec::new(),
+            scope,
+            seq,
+            kind,
+        }
+    }
+
+    pub(crate) fn prepend_scope(&mut self, id: ChildId) {
+        self.scope_path.insert(0, id);
+    }
+}
+
+impl From<LifecycleEvent> for RetainedLifecycleEvent {
+    fn from(event: LifecycleEvent) -> Self {
+        Self::new(event)
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-enum RetainedLifecycleEventKind {
+pub(crate) enum RetainedLifecycleEventKind {
     Added {
         id: ChildId,
         membership: Membership,
@@ -139,7 +162,7 @@ enum RetainedLifecycleEventKind {
 }
 
 impl RetainedLifecycleEventKind {
-    fn new(kind: LifecycleEventKind) -> Self {
+    pub(crate) fn new(kind: LifecycleEventKind) -> Self {
         match kind {
             LifecycleEventKind::Added { id, membership } => Self::Added { id, membership },
             LifecycleEventKind::Started {
@@ -1035,9 +1058,9 @@ impl LifecycleHub {
     pub(crate) fn publish(
         &self,
         txn: &mut crate::cells::ObservationTxn<'_>,
-        event: LifecycleEvent,
+        event: impl Into<RetainedLifecycleEvent>,
     ) {
-        let event = RetainedLifecycleEvent::new(event);
+        let event = event.into();
         let mut published = false;
         let mut undelivered = None;
         self.channels.signal.modify_silently(|signal| {

--- a/crates/shelterwood-core/src/engine.rs
+++ b/crates/shelterwood-core/src/engine.rs
@@ -278,6 +278,7 @@ impl Default for IntensityState {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct IntensityCharge {
+    policy: Intensity,
     in_window: u64,
     total_restarts: TotalRestarts,
     tripped: bool,
@@ -306,6 +307,7 @@ impl IntensityState {
         self.total_restarts = self.total_restarts.bump();
         let in_window = u64::try_from(self.charges.len()).unwrap_or(u64::MAX);
         IntensityCharge {
+            policy,
             in_window,
             total_restarts: self.total_restarts,
             tripped: in_window > policy.max_restarts(),
@@ -395,10 +397,10 @@ impl RestartDecision {
         self.charge.total_restarts
     }
 
-    pub fn intensity_trip(&self, policy: Intensity) -> Option<IntensityTrip> {
+    pub fn intensity_trip(&self) -> Option<IntensityTrip> {
         self.charge
             .tripped
-            .then(|| IntensityTrip::new(policy, self.charge))
+            .then(|| IntensityTrip::new(self.charge.policy, self.charge))
     }
 }
 
@@ -1440,6 +1442,10 @@ mod tests {
         assert_eq!(decision.restart_at, Some(now));
         assert_eq!(decision.charge.total_restarts, TotalRestarts::ZERO.bump());
         assert!(decision.charge.tripped);
+        assert_eq!(
+            decision.intensity_trip(),
+            Some(crate::IntensityTrip::new(intensity_policy, decision.charge))
+        );
     }
 
     #[test]

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -3,12 +3,16 @@ use std::{
     fmt,
     num::NonZeroUsize,
     ops::{Deref, DerefMut},
-    sync::{Arc, Mutex, MutexGuard, atomic::Ordering},
+    sync::{
+        Arc, Mutex, MutexGuard,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use crate::{
-    ChildId, Incarnation, MailboxControl, MailboxDisposal, MailboxRuntime, MailboxSignal,
-    MailboxSignalWatcher, MailboxTermination,
+    ChildId, Incarnation, MailboxBindToken, MailboxClose, MailboxControl, MailboxDisposal,
+    MailboxEffectQueue, MailboxEffectSink, MailboxRuntime, MailboxSignal, MailboxSignalWatcher,
+    MailboxTermination,
     capability::{dispose, dispose_value},
     identity::{AtomicPoisonedCounter, PoisonedCounter},
     panic::{PanicAccumulator, PanicPayload, resume_panic},
@@ -319,6 +323,7 @@ impl<M> SendOperation<M> {
 
 pub(super) struct MailboxState<M> {
     kind: Option<MailboxKind>,
+    bind_permit: Arc<AtomicBool>,
     binding: MailboxBinding<M>,
     last_bound: Option<Incarnation>,
     pub(super) queue: VecDeque<Envelope<M>>,
@@ -335,12 +340,12 @@ impl<M> MailboxState<M> {
         }
     }
 
-    fn park(&mut self, operation: &Arc<SendOperation<M>>) {
+    fn park(&mut self, operation: &Arc<SendOperation<M>>) -> bool {
         match &mut self.binding {
             MailboxBinding::Unbound(waiters)
             | MailboxBinding::Frozen { waiters, .. }
             | MailboxBinding::Bound(BoundState::Full { waiters, .. }) => {
-                waiters.park(operation);
+                return waiters.park(operation);
             }
             MailboxBinding::Bound(BoundState::Available(incarnation)) => {
                 let Some(MailboxKind::Queue(capacity)) = self.kind else {
@@ -349,7 +354,9 @@ impl<M> MailboxState<M> {
                 debug_assert_eq!(self.queue.len(), capacity.get());
                 let incarnation = *incarnation;
                 let mut waiters = WaiterQueue::default();
-                waiters.park(operation);
+                if !waiters.park(operation) {
+                    return false;
+                }
                 self.binding = MailboxBinding::Bound(BoundState::Full {
                     incarnation,
                     waiters,
@@ -359,6 +366,7 @@ impl<M> MailboxState<M> {
                 unreachable!("terminal submissions return their payload directly")
             }
         }
+        true
     }
 
     /// Detaches every waiter from a non-terminal binding before a transition.
@@ -426,6 +434,23 @@ pub(super) enum Submission<M> {
     },
 }
 
+enum SubmitTransition<M> {
+    Complete(Submission<M>),
+    WaiterIdentityExhausted(Arc<SendOperation<M>>),
+    AcceptedSequenceExhausted(M),
+}
+
+enum AcceptTransition<M> {
+    Accepted(Incarnation),
+    Full(M),
+    Exhausted(M),
+}
+
+enum TrySendTransition<M> {
+    Complete(Result<Incarnation, SendError<M>>),
+    AcceptedSequenceExhausted(M),
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct WaiterId(u64);
 
@@ -470,20 +495,19 @@ impl<M> WaiterQueue<M> {
         self.entries.len()
     }
 
-    fn push_back(&mut self, operation: Arc<SendOperation<M>>) -> WaiterId {
-        let next = WaiterId(
-            self.ids
-                .mint()
-                .expect("mailbox waiter identity space exhausted"),
-        );
+    fn push_back(&mut self, operation: Arc<SendOperation<M>>) -> Option<WaiterId> {
+        let next = WaiterId(self.ids.mint()?);
         let replaced = self.entries.insert(next, operation);
         debug_assert!(replaced.is_none());
-        next
+        Some(next)
     }
 
-    fn park(&mut self, operation: &Arc<SendOperation<M>>) {
-        let registration = self.push_back(Arc::clone(operation));
+    fn park(&mut self, operation: &Arc<SendOperation<M>>) -> bool {
+        let Some(registration) = self.push_back(Arc::clone(operation)) else {
+            return false;
+        };
         operation.register(registration);
+        true
     }
 
     fn observe_all(&self, incarnation: Incarnation) {
@@ -520,24 +544,41 @@ impl<M> WaiterQueue<M> {
 /// of it: it never outlives the `MailboxTxn` that owns it, and every mailbox
 /// transition — including the per-message receive path — would otherwise pay
 /// two atomic refcount pairs to restate what the transaction already holds.
-struct MailboxEffects<'a, M: Send + 'static> {
+struct MailboxEffects<'a, 's, M: Send + 'static> {
     cell: &'a MailboxCell<M>,
+    external: Option<&'s mut dyn MailboxEffectSink>,
     pulse: bool,
     displaced: Vec<Envelope<M>>,
     isolate_displaced: bool,
     wakers: WakerEffects,
     returned: Option<M>,
+    accepted_sequence_exhausted: bool,
 }
 
-impl<'a, M: Send + 'static> MailboxEffects<'a, M> {
+impl<'a, 's, M: Send + 'static> MailboxEffects<'a, 's, M> {
     fn new(cell: &'a MailboxCell<M>) -> Self {
         Self {
             cell,
+            external: None,
             pulse: false,
             displaced: Vec::new(),
             isolate_displaced: false,
             wakers: WakerEffects::default(),
             returned: None,
+            accepted_sequence_exhausted: false,
+        }
+    }
+
+    fn deferred(cell: &'a MailboxCell<M>, external: &'s mut dyn MailboxEffectSink) -> Self {
+        Self {
+            cell,
+            external: Some(external),
+            pulse: false,
+            displaced: Vec::new(),
+            isolate_displaced: false,
+            wakers: WakerEffects::default(),
+            returned: None,
+            accepted_sequence_exhausted: false,
         }
     }
 
@@ -550,23 +591,56 @@ impl<'a, M: Send + 'static> MailboxEffects<'a, M> {
     }
 }
 
-impl<M: Send + 'static> Drop for MailboxEffects<'_, M> {
+impl<M: Send + 'static> Drop for MailboxEffects<'_, '_, M> {
     fn drop(&mut self) {
+        let batch = MailboxEffectBatch {
+            changed: Arc::clone(&self.cell.changed),
+            runtime: Arc::clone(&self.cell.runtime),
+            pulse: self.pulse,
+            displaced: std::mem::take(&mut self.displaced),
+            isolate_displaced: self.isolate_displaced,
+            wakers: std::mem::take(&mut self.wakers),
+            returned: self.returned.take(),
+            accepted_sequence_exhausted: self.accepted_sequence_exhausted,
+        };
+        if let Some(external) = self.external.take() {
+            external.defer_mailbox_effect(Box::new(move || {
+                batch.flush();
+            }));
+            return;
+        }
+        batch.flush();
+    }
+}
+
+struct MailboxEffectBatch<M> {
+    changed: Arc<dyn MailboxSignal>,
+    runtime: Arc<dyn MailboxRuntime>,
+    pulse: bool,
+    displaced: Vec<Envelope<M>>,
+    isolate_displaced: bool,
+    wakers: WakerEffects,
+    returned: Option<M>,
+    accepted_sequence_exhausted: bool,
+}
+
+impl<M: Send + 'static> MailboxEffectBatch<M> {
+    fn flush(mut self) {
         let mut panics = PanicAccumulator::default();
         if self.pulse {
-            panics.run(|| self.cell.changed.pulse());
+            panics.run(|| self.changed.pulse());
         }
         // Binding a latest-value mailbox historically handed displaced
         // payloads to isolated disposal before accepted senders were woken.
         // Preserve that observable ownership edge: a woken sender may run
         // immediately and must not race ahead of disposal submission.
         if self.isolate_displaced && !self.displaced.is_empty() {
-            let displaced = std::mem::take(&mut self.displaced);
+            let isolated = std::mem::take(&mut self.displaced);
             panics.run(|| {
                 dispose_value(
-                    self.cell.runtime.as_ref(),
+                    self.runtime.as_ref(),
                     MailboxPayload {
-                        queue: Some(displaced.into()),
+                        queue: Some(isolated.into()),
                         latest: None,
                         retired: Vec::new(),
                     },
@@ -575,23 +649,26 @@ impl<M: Send + 'static> Drop for MailboxEffects<'_, M> {
         }
         self.wakers.flush(&mut panics);
         if !self.isolate_displaced {
-            for displaced in self.displaced.drain(..) {
-                panics.run(|| drop(displaced));
+            for envelope in self.displaced.drain(..) {
+                panics.run(|| drop(envelope));
             }
         }
         if let Some(returned) = self.returned.take() {
             panics.run(|| drop(returned));
         }
+        if self.accepted_sequence_exhausted {
+            panics.run(|| panic!("mailbox accepted-sequence space exhausted"));
+        }
     }
 }
 
 /// A mailbox transition guard paired with its mandatory post-unlock effects.
-struct MailboxTxn<'a, M: Send + 'static> {
+struct MailboxTxn<'a, 's, M: Send + 'static> {
     state: Option<MutexGuard<'a, MailboxState<M>>>,
-    effects: MailboxEffects<'a, M>,
+    effects: MailboxEffects<'a, 's, M>,
 }
 
-impl<'a, M: Send + 'static> MailboxTxn<'a, M> {
+impl<'a, M: Send + 'static> MailboxTxn<'a, 'static, M> {
     fn new(cell: &'a MailboxCell<M>) -> Self {
         let effects = MailboxEffects::new(cell);
         let state = cell.state.lock().expect("mailbox mutex poisoned");
@@ -600,8 +677,19 @@ impl<'a, M: Send + 'static> MailboxTxn<'a, M> {
             effects,
         }
     }
+}
 
-    fn parts(&mut self) -> (&mut MailboxState<M>, &mut MailboxEffects<'a, M>) {
+impl<'a, 's, M: Send + 'static> MailboxTxn<'a, 's, M> {
+    fn deferred(cell: &'a MailboxCell<M>, effects: &'s mut dyn MailboxEffectSink) -> Self {
+        let effects = MailboxEffects::deferred(cell, effects);
+        let state = cell.state.lock().expect("mailbox mutex poisoned");
+        Self {
+            state: Some(state),
+            effects,
+        }
+    }
+
+    fn parts(&mut self) -> (&mut MailboxState<M>, &mut MailboxEffects<'a, 's, M>) {
         (
             self.state
                 .as_deref_mut()
@@ -624,7 +712,7 @@ impl<'a, M: Send + 'static> MailboxTxn<'a, M> {
     }
 }
 
-impl<M: Send + 'static> Deref for MailboxTxn<'_, M> {
+impl<M: Send + 'static> Deref for MailboxTxn<'_, '_, M> {
     type Target = MailboxState<M>;
 
     fn deref(&self) -> &Self::Target {
@@ -634,7 +722,7 @@ impl<M: Send + 'static> Deref for MailboxTxn<'_, M> {
     }
 }
 
-impl<M: Send + 'static> DerefMut for MailboxTxn<'_, M> {
+impl<M: Send + 'static> DerefMut for MailboxTxn<'_, '_, M> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.state
             .as_deref_mut()
@@ -642,7 +730,7 @@ impl<M: Send + 'static> DerefMut for MailboxTxn<'_, M> {
     }
 }
 
-impl<M: Send + 'static> Drop for MailboxTxn<'_, M> {
+impl<M: Send + 'static> Drop for MailboxTxn<'_, '_, M> {
     fn drop(&mut self) {
         // Rust drops fields after this body. Empty the guard field here so the
         // effects field necessarily flushes with no mailbox mutex held.
@@ -752,6 +840,11 @@ impl<M: Send + 'static> Drop for MailboxTeardown<M> {
     }
 }
 
+/// Restart-stable mailbox state for one actor membership.
+///
+/// Dropping the last handle can destroy unread user payloads. Framework owners
+/// must therefore close or terminalize the cell and transfer its payload to
+/// isolated disposal before releasing their final handle.
 pub struct MailboxCell<M> {
     pub(super) actor_id: ChildId,
     pub(super) state: Mutex<MailboxState<M>>,
@@ -776,6 +869,7 @@ impl<M: Send + 'static> MailboxCell<M> {
             actor_id,
             state: Mutex::new(MailboxState {
                 kind: None,
+                bind_permit: Arc::new(AtomicBool::new(false)),
                 binding: MailboxBinding::Unbound(WaiterQueue::default()),
                 last_bound: None,
                 queue: VecDeque::new(),
@@ -789,79 +883,120 @@ impl<M: Send + 'static> MailboxCell<M> {
 
     pub(super) fn submit(&self, message: M) -> Submission<M> {
         let mut transaction = MailboxTxn::new(self);
-        let submission = match transaction.status() {
-            BindingStatus::Terminal(final_incarnation) => Submission::Terminated {
-                message,
-                final_incarnation,
-            },
+        let transition = match transaction.status() {
+            BindingStatus::Terminal(final_incarnation) => {
+                SubmitTransition::Complete(Submission::Terminated {
+                    message,
+                    final_incarnation,
+                })
+            }
             BindingStatus::Bound(incarnation) => {
                 let accepted = {
                     let (state, effects) = transaction.parts();
                     accept_locked(state, incarnation, message, &self.accepted, effects)
                 };
                 match accepted {
-                    Ok(incarnation) => Submission::Accepted(incarnation),
-                    Err(message) => {
+                    AcceptTransition::Accepted(incarnation) => {
+                        SubmitTransition::Complete(Submission::Accepted(incarnation))
+                    }
+                    AcceptTransition::Full(message) => {
                         let operation = SendOperation::new(message);
                         operation.observe(incarnation);
-                        transaction.park(&operation);
-                        Submission::Parked(operation)
+                        if transaction.park(&operation) {
+                            SubmitTransition::Complete(Submission::Parked(operation))
+                        } else {
+                            SubmitTransition::WaiterIdentityExhausted(operation)
+                        }
+                    }
+                    AcceptTransition::Exhausted(message) => {
+                        SubmitTransition::AcceptedSequenceExhausted(message)
                     }
                 }
             }
             BindingStatus::Frozen(incarnation) => {
                 let operation = SendOperation::new(message);
                 operation.observe(incarnation);
-                transaction.park(&operation);
-                Submission::Parked(operation)
+                if transaction.park(&operation) {
+                    SubmitTransition::Complete(Submission::Parked(operation))
+                } else {
+                    SubmitTransition::WaiterIdentityExhausted(operation)
+                }
             }
             BindingStatus::Unbound => {
                 let operation = SendOperation::new(message);
-                transaction.park(&operation);
-                Submission::Parked(operation)
+                if transaction.park(&operation) {
+                    SubmitTransition::Complete(Submission::Parked(operation))
+                } else {
+                    SubmitTransition::WaiterIdentityExhausted(operation)
+                }
             }
         };
-        transaction.finish(submission)
+        match transaction.finish(transition) {
+            SubmitTransition::Complete(submission) => submission,
+            SubmitTransition::WaiterIdentityExhausted(operation) => {
+                dispose(&self.runtime, operation);
+                panic!("mailbox waiter identity space exhausted");
+            }
+            SubmitTransition::AcceptedSequenceExhausted(message) => {
+                dispose(&self.runtime, message);
+                panic!("mailbox accepted-sequence space exhausted");
+            }
+        }
     }
 
     pub(super) fn try_send(&self, message: M) -> Result<Incarnation, SendError<M>> {
         let mut transaction = MailboxTxn::new(self);
-        let result = match transaction.status() {
-            BindingStatus::Terminal(final_incarnation) => Err(SendError {
-                actor_id: self.actor_id.clone(),
-                incarnation_observed: final_incarnation,
-                message,
-                kind: SendErrorKind::Terminated,
-            }),
-            BindingStatus::Unbound => Err(SendError {
+        let transition = match transaction.status() {
+            BindingStatus::Terminal(final_incarnation) => {
+                TrySendTransition::Complete(Err(SendError {
+                    actor_id: self.actor_id.clone(),
+                    incarnation_observed: final_incarnation,
+                    message,
+                    kind: SendErrorKind::Terminated,
+                }))
+            }
+            BindingStatus::Unbound => TrySendTransition::Complete(Err(SendError {
                 actor_id: self.actor_id.clone(),
                 incarnation_observed: None,
                 message,
                 kind: SendErrorKind::NotRunning,
-            }),
-            BindingStatus::Frozen(incarnation) => Err(SendError {
+            })),
+            BindingStatus::Frozen(incarnation) => TrySendTransition::Complete(Err(SendError {
                 actor_id: self.actor_id.clone(),
                 incarnation_observed: Some(incarnation),
                 message,
                 kind: SendErrorKind::NotRunning,
-            }),
+            })),
             BindingStatus::Bound(incarnation) => {
                 let accepted = {
                     let (state, effects) = transaction.parts();
                     accept_locked(state, incarnation, message, &self.accepted, effects)
                 };
                 match accepted {
-                    Ok(incarnation) => Ok(incarnation),
-                    Err(message) => Err(SendError {
-                        actor_id: self.actor_id.clone(),
-                        incarnation_observed: Some(incarnation),
-                        message,
-                        kind: SendErrorKind::Full,
-                    }),
+                    AcceptTransition::Accepted(incarnation) => {
+                        TrySendTransition::Complete(Ok(incarnation))
+                    }
+                    AcceptTransition::Full(message) => {
+                        TrySendTransition::Complete(Err(SendError {
+                            actor_id: self.actor_id.clone(),
+                            incarnation_observed: Some(incarnation),
+                            message,
+                            kind: SendErrorKind::Full,
+                        }))
+                    }
+                    AcceptTransition::Exhausted(message) => {
+                        TrySendTransition::AcceptedSequenceExhausted(message)
+                    }
                 }
             }
         };
-        transaction.finish(result)
+        match transaction.finish(transition) {
+            TrySendTransition::Complete(result) => result,
+            TrySendTransition::AcceptedSequenceExhausted(message) => {
+                dispose(&self.runtime, message);
+                panic!("mailbox accepted-sequence space exhausted");
+            }
+        }
     }
 
     fn receive(
@@ -1039,12 +1174,16 @@ impl<M: Send + 'static> MailboxCell<M> {
 }
 
 impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
-    fn configure(&self, mailbox: ResolvedMailbox) {
+    fn configure(
+        &self,
+        mailbox: ResolvedMailbox,
+        effects: &mut dyn MailboxEffectSink,
+    ) -> MailboxBindToken {
         let kind = match mailbox {
             ResolvedMailbox::Queue(capacity) => MailboxKind::Queue(capacity),
             ResolvedMailbox::Latest => MailboxKind::Latest,
         };
-        let mut transaction = MailboxTxn::new(self);
+        let mut transaction = MailboxTxn::deferred(self, effects);
         let mismatch = match transaction.kind {
             Some(existing) => (existing != kind).then_some(existing),
             None => {
@@ -1052,16 +1191,23 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
                 None
             }
         };
+        let token = MailboxBindToken::new(Arc::clone(&transaction.bind_permit));
         transaction.finish(());
         if let Some(existing) = mismatch {
             panic!(
                 "mailbox configuration changed from {existing:?} to {kind:?} after initialization"
             );
         }
+        token
     }
 
-    fn bind(&self, incarnation: Incarnation) {
-        let mut transaction = MailboxTxn::new(self);
+    fn bind(
+        &self,
+        token: MailboxBindToken,
+        incarnation: Incarnation,
+        effects: &mut dyn MailboxEffectSink,
+    ) {
+        let mut transaction = MailboxTxn::deferred(self, effects);
         if matches!(transaction.status(), BindingStatus::Terminal(_)) {
             return transaction.finish(());
         }
@@ -1072,6 +1218,10 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         if !matches!(transaction.status(), BindingStatus::Unbound) {
             transaction.finish(());
             panic!("mailbox must close the prior incarnation before rebinding")
+        }
+        if !token.claim(&transaction.bind_permit) {
+            transaction.finish(());
+            panic!("mailbox bind token is foreign or was already consumed")
         }
         let mut waiters = transaction.take_waiters();
         transaction.last_bound = Some(incarnation);
@@ -1111,8 +1261,8 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         transaction.finish(())
     }
 
-    fn freeze(&self, incarnation: Incarnation) {
-        let mut transaction = MailboxTxn::new(self);
+    fn freeze(&self, incarnation: Incarnation, effects: &mut dyn MailboxEffectSink) {
+        let mut transaction = MailboxTxn::deferred(self, effects);
         if transaction.status() != BindingStatus::Bound(incarnation) {
             return transaction.finish(());
         }
@@ -1125,8 +1275,12 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         transaction.finish(())
     }
 
-    fn close(&self, incarnation: Incarnation) -> Option<MailboxDisposal> {
-        let mut transaction = MailboxTxn::new(self);
+    fn close(
+        &self,
+        incarnation: Incarnation,
+        effects: &mut dyn MailboxEffectSink,
+    ) -> Option<MailboxClose> {
+        let mut transaction = MailboxTxn::deferred(self, effects);
         if !matches!(
             transaction.status(),
             BindingStatus::Bound(current) | BindingStatus::Frozen(current)
@@ -1136,19 +1290,24 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         }
         let waiters = transaction.take_waiters();
         transaction.binding = MailboxBinding::Unbound(waiters);
+        transaction.bind_permit = Arc::new(AtomicBool::new(false));
         let queue = std::mem::take(&mut transaction.queue);
         let latest = transaction.latest.take();
         transaction.effects.pulse();
-        let disposal = Some(Box::new(MailboxPayload {
+        let disposal = Box::new(MailboxPayload {
             queue: Some(queue),
             latest,
             retired: Vec::new(),
-        }) as MailboxDisposal);
-        transaction.finish(disposal)
+        }) as MailboxDisposal;
+        let token = MailboxBindToken::new(Arc::clone(&transaction.bind_permit));
+        transaction.finish(Some(MailboxClose::new(token, disposal)))
     }
 
-    fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>> {
-        let mut transaction = MailboxTxn::new(self);
+    fn prepare_termination(
+        &self,
+        effects: &mut dyn MailboxEffectSink,
+    ) -> Option<Box<dyn MailboxTermination>> {
+        let mut transaction = MailboxTxn::deferred(self, effects);
         if matches!(transaction.status(), BindingStatus::Terminal(_)) {
             return transaction.finish(None);
         }
@@ -1177,26 +1336,14 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         }) as Box<dyn MailboxTermination>);
         transaction.finish(teardown)
     }
-
-    #[cfg(debug_assertions)]
-    fn bind_order_valid(&self) -> bool {
-        let state = self.state.lock().expect("mailbox mutex poisoned");
-        state.kind.is_some()
-            && matches!(
-                state.status(),
-                BindingStatus::Unbound | BindingStatus::Terminal(_)
-            )
-    }
 }
 
 impl<M: Send + 'static> crate::private::SealedMailboxControl for MailboxCell<M> {}
 
-fn mint_accepted_sequence(accepted: &AtomicPoisonedCounter) -> AcceptedSequence {
-    AcceptedSequence(
-        accepted
-            .mint(Ordering::Release, Ordering::Relaxed)
-            .expect("mailbox accepted-sequence space exhausted"),
-    )
+fn mint_accepted_sequence(accepted: &AtomicPoisonedCounter) -> Option<AcceptedSequence> {
+    accepted
+        .mint(Ordering::Release, Ordering::Relaxed)
+        .map(AcceptedSequence)
 }
 
 fn accept_locked<M>(
@@ -1204,8 +1351,8 @@ fn accept_locked<M>(
     incarnation: Incarnation,
     message: M,
     accepted: &AtomicPoisonedCounter,
-    effects: &mut MailboxEffects<'_, M>,
-) -> Result<Incarnation, M>
+    effects: &mut MailboxEffects<'_, '_, M>,
+) -> AcceptTransition<M>
 where
     M: Send + 'static,
 {
@@ -1218,7 +1365,7 @@ where
             ..
         }) => {
             debug_assert_eq!(*current, incarnation);
-            return Err(message);
+            return AcceptTransition::Full(message);
         }
         MailboxBinding::Unbound(_)
         | MailboxBinding::Frozen { .. }
@@ -1231,10 +1378,12 @@ where
             MailboxKind::Queue(capacity)
         }
         Some(MailboxKind::Latest) => MailboxKind::Latest,
-        Some(MailboxKind::Queue(_)) => return Err(message),
+        Some(MailboxKind::Queue(_)) => return AcceptTransition::Full(message),
         None => unreachable!("a bound mailbox is always configured"),
     };
-    let accepted_sequence = mint_accepted_sequence(accepted);
+    let Some(accepted_sequence) = mint_accepted_sequence(accepted) else {
+        return AcceptTransition::Exhausted(message);
+    };
     match kind {
         MailboxKind::Queue(_) => {
             state.queue.push_back(Envelope {
@@ -1253,13 +1402,13 @@ where
         }
     }
     effects.pulse();
-    Ok(incarnation)
+    AcceptTransition::Accepted(incarnation)
 }
 
 fn promote_waiters<M: Send + 'static>(
     state: &mut MailboxState<M>,
     accepted_sequence: &AtomicPoisonedCounter,
-    effects: &mut MailboxEffects<'_, M>,
+    effects: &mut MailboxEffects<'_, '_, M>,
 ) {
     let Some(kind) = state.kind else {
         return;
@@ -1293,7 +1442,7 @@ fn promote_waiter_queue<M: Send + 'static>(
     queue: &mut VecDeque<Envelope<M>>,
     latest: &mut Option<Envelope<M>>,
     accepted_sequence: &AtomicPoisonedCounter,
-    effects: &mut MailboxEffects<'_, M>,
+    effects: &mut MailboxEffects<'_, '_, M>,
 ) {
     let available = match kind {
         MailboxKind::Queue(capacity) => capacity.get().saturating_sub(queue.len()),
@@ -1301,6 +1450,13 @@ fn promote_waiter_queue<M: Send + 'static>(
     };
     let mut accepted = 0usize;
     while accepted < available {
+        if waiters.is_empty() {
+            break;
+        }
+        let Some(accepted_sequence) = mint_accepted_sequence(accepted_sequence) else {
+            effects.accepted_sequence_exhausted = true;
+            break;
+        };
         let Some((registration, operation)) = waiters.pop_front() else {
             break;
         };
@@ -1309,7 +1465,6 @@ fn promote_waiter_queue<M: Send + 'static>(
         let Some(message) = operation.accept(incarnation, &mut effects.wakers) else {
             continue;
         };
-        let accepted_sequence = mint_accepted_sequence(accepted_sequence);
         match kind {
             MailboxKind::Queue(_) => queue.push_back(Envelope {
                 message,
@@ -1401,7 +1556,8 @@ impl<M: Send + 'static> MailboxReceiver<M> {
     }
 
     pub fn freeze(&self) {
-        self.mailbox.freeze(self.incarnation);
+        let mut effects = MailboxEffectQueue::default();
+        self.mailbox.freeze(self.incarnation, &mut effects);
     }
 
     pub async fn changed(&mut self) {
@@ -1418,13 +1574,15 @@ pub(super) mod tests {
         sync::{
             Arc, Mutex, Weak,
             atomic::{AtomicUsize, Ordering},
+            mpsc,
         },
         task::{Context, Poll, Wake, Waker},
         time::{Duration, Instant},
     };
 
     use crate::{
-        ActorIdentity, ActorRef, ChildId, MailboxControl, MailboxReceiver, SendErrorKind,
+        ActorIdentity, ActorRef, ChildId, Incarnation, MailboxControl, MailboxReceiver,
+        SendErrorKind,
         identity::ScopeIdentity,
         policy::{ResolvedDefaults, ResolvedMailbox},
     };
@@ -1440,6 +1598,24 @@ pub(super) mod tests {
     }
 
     struct CountWake(Arc<AtomicUsize>);
+
+    struct LockCheckingMessage {
+        mailbox: Weak<MailboxCell<LockCheckingMessage>>,
+        dropped: Option<mpsc::Sender<bool>>,
+    }
+
+    impl Drop for LockCheckingMessage {
+        fn drop(&mut self) {
+            let Some(dropped) = self.dropped.take() else {
+                return;
+            };
+            let unlocked = self
+                .mailbox
+                .upgrade()
+                .is_none_or(|mailbox| mailbox.state.try_lock().is_ok());
+            let _ = dropped.send(unlocked);
+        }
+    }
 
     impl Wake for CountWake {
         fn wake(self: Arc<Self>) {
@@ -1606,23 +1782,33 @@ pub(super) mod tests {
         actor_for()
     }
 
+    fn configure<M: Send + 'static>(
+        mailbox: &MailboxCell<M>,
+        policy: ResolvedMailbox,
+    ) -> crate::MailboxBindToken {
+        let mut effects = crate::MailboxEffectQueue::default();
+        MailboxControl::configure(mailbox, policy, &mut effects)
+    }
+
+    fn bind<M: Send + 'static>(
+        mailbox: &MailboxCell<M>,
+        token: crate::MailboxBindToken,
+        incarnation: Incarnation,
+    ) {
+        let mut effects = crate::MailboxEffectQueue::default();
+        MailboxControl::bind(mailbox, token, incarnation, &mut effects);
+    }
+
+    fn prepare_termination<M: Send + 'static>(
+        mailbox: &MailboxCell<M>,
+    ) -> Option<Box<dyn crate::MailboxTermination>> {
+        let mut effects = crate::MailboxEffectQueue::default();
+        MailboxControl::prepare_termination(mailbox, &mut effects)
+    }
+
     fn park_with(future: &mut std::pin::Pin<Box<crate::SendFuture<u8>>>, waker: &Waker) {
         let mut context = Context::from_waker(waker);
         assert!(future.as_mut().poll(&mut context).is_pending());
-    }
-
-    #[test]
-    #[should_panic(expected = "mailbox must be configured before its first bind")]
-    fn binding_before_configuration_trips_the_driver_contract() {
-        let (mailbox, _) = actor();
-        let mut identity = ScopeIdentity::new();
-        let (_, mut incarnations) = identity
-            .mint_membership(&ChildId::from("actor"))
-            .expect("membership available")
-            .into_pair();
-        let incarnation = incarnations.mint().expect("incarnation available");
-
-        MailboxControl::bind(&*mailbox, incarnation);
     }
 
     #[test]
@@ -1631,11 +1817,11 @@ pub(super) mod tests {
         let queue = ResolvedMailbox::Queue(
             std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
         );
-        MailboxControl::configure(&*mailbox, queue);
-        MailboxControl::configure(&*mailbox, queue);
+        let _ = configure(&mailbox, queue);
+        let _ = configure(&mailbox, queue);
 
         let Err(panic) = catch_unwind(AssertUnwindSafe(|| {
-            MailboxControl::configure(&*mailbox, ResolvedMailbox::Latest);
+            let _ = configure(&mailbox, ResolvedMailbox::Latest);
         })) else {
             panic!("changing mailbox kind must trip the driver contract")
         };
@@ -1657,27 +1843,10 @@ pub(super) mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "mailbox must close the prior incarnation before rebinding")]
-    fn rebinding_before_close_trips_the_driver_contract() {
-        let (mailbox, _) = actor();
-        MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox);
-        let mut identity = ScopeIdentity::new();
-        let (_, mut incarnations) = identity
-            .mint_membership(&ChildId::from("actor"))
-            .expect("membership available")
-            .into_pair();
-        let first = incarnations.mint().expect("first incarnation available");
-        let second = incarnations.mint().expect("second incarnation available");
-
-        MailboxControl::bind(&*mailbox, first);
-        MailboxControl::bind(&*mailbox, second);
-    }
-
-    #[test]
     fn bound_waiters_exist_only_in_the_full_state() {
         let (mailbox, _) = actor();
-        MailboxControl::configure(
-            &*mailbox,
+        let token = configure(
+            &mailbox,
             ResolvedMailbox::Queue(
                 std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
             ),
@@ -1688,7 +1857,7 @@ pub(super) mod tests {
             .expect("membership available")
             .into_pair();
         let incarnation = incarnations.mint().expect("incarnation available");
-        MailboxControl::bind(&*mailbox, incarnation);
+        bind(&mailbox, token, incarnation);
 
         assert!(matches!(
             mailbox.submit(1),
@@ -1722,8 +1891,8 @@ pub(super) mod tests {
     #[test]
     fn receive_promotes_multiple_parked_senders_in_fifo_order() {
         let (mailbox, actor) = actor();
-        MailboxControl::configure(
-            &*mailbox,
+        let token = configure(
+            &mailbox,
             ResolvedMailbox::Queue(
                 std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
             ),
@@ -1734,7 +1903,7 @@ pub(super) mod tests {
             .expect("membership available")
             .into_pair();
         let incarnation = incarnations.mint().expect("incarnation available");
-        MailboxControl::bind(&*mailbox, incarnation);
+        bind(&mailbox, token, incarnation);
         let receiver = MailboxReceiver::new(Arc::clone(&mailbox), incarnation);
 
         assert!(matches!(actor.try_send(0), Ok(bound) if bound == incarnation));
@@ -1885,7 +2054,7 @@ pub(super) mod tests {
         park_with(&mut first, &first_panicking);
         park_with(&mut second, &second_panicking);
         park_with(&mut third, &counting);
-        MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox);
+        let token = configure(&mailbox, ResolvedDefaults::default().mailbox);
         let mut generations = {
             let mut identity = ScopeIdentity::new();
             let (_, generations) = identity
@@ -1898,7 +2067,7 @@ pub(super) mod tests {
 
         assert!(
             catch_unwind(AssertUnwindSafe(|| {
-                MailboxControl::bind(&*mailbox, incarnation);
+                bind(&mailbox, token, incarnation);
             }))
             .is_err()
         );
@@ -1927,7 +2096,7 @@ pub(super) mod tests {
             events: Arc::clone(&events),
         });
         let mailbox = MailboxCell::new(ChildId::from("actor"), runtime);
-        MailboxControl::configure(&*mailbox, ResolvedMailbox::Latest);
+        let token = configure(&mailbox, ResolvedMailbox::Latest);
 
         let first = match mailbox.submit(1) {
             super::Submission::Parked(operation) => operation,
@@ -1949,8 +2118,9 @@ pub(super) mod tests {
             .mint_membership(&ChildId::from("actor"))
             .expect("membership available")
             .into_pair();
-        MailboxControl::bind(
-            &*mailbox,
+        bind(
+            &mailbox,
+            token,
             incarnations.mint().expect("incarnation available"),
         );
 
@@ -1982,7 +2152,7 @@ pub(super) mod tests {
 
         assert!(
             catch_unwind(AssertUnwindSafe(|| {
-                drop(MailboxControl::prepare_termination(&*mailbox));
+                drop(prepare_termination(&mailbox));
             }))
             .is_err()
         );
@@ -2004,8 +2174,8 @@ pub(super) mod tests {
         let mut send = Box::pin(actor.send(1));
         park_with(&mut send, Waker::noop());
 
-        let teardown = MailboxControl::prepare_termination(&*mailbox)
-            .expect("live mailbox prepares terminal teardown");
+        let teardown =
+            prepare_termination(&mailbox).expect("live mailbox prepares terminal teardown");
         // Teardown is deliberately retained: cancellation sees terminal state
         // after the waiter queue was detached but before it was discharged.
         drop(send);
@@ -2033,8 +2203,8 @@ pub(super) mod tests {
         );
         crate::runtime::advance(width * 2).await;
 
-        let teardown = MailboxControl::prepare_termination(&*mailbox)
-            .expect("live mailbox prepares terminal teardown");
+        let teardown =
+            prepare_termination(&mailbox).expect("live mailbox prepares terminal teardown");
         // Teardown remains retained: timeout sees terminal binding after the
         // waiter queue was detached but before its waiter was discharged.
         let Poll::Ready(Err(error)) = send.as_mut().poll(&mut Context::from_waker(Waker::noop()))
@@ -2056,13 +2226,17 @@ pub(super) mod tests {
     fn stale_waiter_id_cannot_unlink_a_later_registration() {
         let mut waiters = super::WaiterQueue::default();
         let first = super::SendOperation::new(1_u8);
-        let first_id = waiters.push_back(Arc::clone(&first));
+        let first_id = waiters
+            .push_back(Arc::clone(&first))
+            .expect("first waiter id available");
         first.register(first_id);
         let removed = waiters.remove(first_id).expect("first waiter is live");
         removed.clear_registration(first_id);
 
         let second = super::SendOperation::new(2_u8);
-        let second_id = waiters.push_back(Arc::clone(&second));
+        let second_id = waiters
+            .push_back(Arc::clone(&second))
+            .expect("second waiter id available");
         second.register(second_id);
         assert_ne!(first_id, second_id, "waiter identities are never reused");
         assert!(
@@ -2083,9 +2257,9 @@ pub(super) mod tests {
         let first = super::SendOperation::new(1_u8);
         let second = super::SendOperation::new(2_u8);
         let third = super::SendOperation::new(3_u8);
-        let first_id = waiters.push_back(Arc::clone(&first));
-        let second_id = waiters.push_back(Arc::clone(&second));
-        let third_id = waiters.push_back(Arc::clone(&third));
+        let first_id = waiters.push_back(Arc::clone(&first)).expect("first id");
+        let second_id = waiters.push_back(Arc::clone(&second)).expect("second id");
+        let third_id = waiters.push_back(Arc::clone(&third)).expect("third id");
 
         assert!(Arc::ptr_eq(
             &waiters.remove(second_id).expect("middle waiter is live"),
@@ -2107,24 +2281,12 @@ pub(super) mod tests {
             ..super::WaiterQueue::default()
         };
         let last = waiters.push_back(super::SendOperation::new(1_u8));
-        assert_eq!(last, super::WaiterId(u64::MAX - 1));
+        assert_eq!(last, Some(super::WaiterId(u64::MAX - 1)));
 
-        assert!(
-            catch_unwind(AssertUnwindSafe(|| {
-                waiters.push_back(super::SendOperation::new(2_u8));
-            }))
-            .is_err(),
-            "the poison key is never minted"
-        );
+        assert_eq!(waiters.push_back(super::SendOperation::new(2_u8)), None);
         assert!(waiters.ids.is_poisoned());
         assert!(!waiters.entries.contains_key(&super::WaiterId::POISON));
-        assert!(
-            catch_unwind(AssertUnwindSafe(|| {
-                waiters.push_back(super::SendOperation::new(3_u8));
-            }))
-            .is_err(),
-            "the exhausted domain stays poisoned"
-        );
+        assert_eq!(waiters.push_back(super::SendOperation::new(3_u8)), None);
     }
 
     #[test]
@@ -2132,20 +2294,130 @@ pub(super) mod tests {
         let accepted = crate::identity::AtomicPoisonedCounter::near_exhaustion();
         assert_eq!(
             super::mint_accepted_sequence(&accepted),
-            super::AcceptedSequence(u64::MAX - 1)
+            Some(super::AcceptedSequence(u64::MAX - 1))
         );
+        assert_eq!(super::mint_accepted_sequence(&accepted), None);
+        assert_eq!(super::mint_accepted_sequence(&accepted), None);
+    }
+
+    #[test]
+    fn waiter_identity_exhaustion_drops_the_message_after_unlock() {
+        let mailbox = MailboxCell::new(ChildId::from("actor"), crate::capability::tests::runtime());
+        mailbox.state.lock().expect("mailbox state").binding =
+            super::MailboxBinding::Unbound(super::WaiterQueue {
+                ids: crate::identity::PoisonedCounter::near_exhaustion(),
+                ..super::WaiterQueue::default()
+            });
+        let weak = Arc::downgrade(&mailbox);
+        assert!(matches!(
+            mailbox.submit(LockCheckingMessage {
+                mailbox: Weak::clone(&weak),
+                dropped: None,
+            }),
+            super::Submission::Parked(_)
+        ));
+        let (dropped, observed) = mpsc::channel();
+
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            let _ = mailbox.submit(LockCheckingMessage {
+                mailbox: weak,
+                dropped: Some(dropped),
+            });
+        }));
+        assert!(panic.is_err(), "exhaustion is reported to the caller");
         assert!(
-            catch_unwind(AssertUnwindSafe(|| {
-                super::mint_accepted_sequence(&accepted);
-            }))
-            .is_err()
+            observed
+                .recv_timeout(Duration::from_secs(5))
+                .expect("isolated message destructor reports"),
+            "the exhausted message is destroyed outside the mailbox mutex"
         );
+    }
+
+    #[test]
+    fn accepted_sequence_exhaustion_drops_the_message_after_unlock() {
+        let mut mailbox =
+            MailboxCell::new(ChildId::from("actor"), crate::capability::tests::runtime());
+        Arc::get_mut(&mut mailbox)
+            .expect("mailbox is uniquely owned")
+            .accepted = crate::identity::AtomicPoisonedCounter::near_exhaustion();
+        let token = configure(&mailbox, ResolvedMailbox::Latest);
+        let mut identity = ScopeIdentity::new();
+        let (_, mut incarnations) = identity
+            .mint_membership(&ChildId::from("actor"))
+            .expect("membership available")
+            .into_pair();
+        bind(
+            &mailbox,
+            token,
+            incarnations.mint().expect("incarnation available"),
+        );
+        let weak = Arc::downgrade(&mailbox);
+        assert!(matches!(
+            mailbox.submit(LockCheckingMessage {
+                mailbox: Weak::clone(&weak),
+                dropped: None,
+            }),
+            super::Submission::Accepted(_)
+        ));
+        let (dropped, observed) = mpsc::channel();
+
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            let _ = mailbox.submit(LockCheckingMessage {
+                mailbox: weak,
+                dropped: Some(dropped),
+            });
+        }));
+        assert!(panic.is_err(), "exhaustion is reported to the caller");
         assert!(
-            catch_unwind(AssertUnwindSafe(|| {
-                super::mint_accepted_sequence(&accepted);
-            }))
-            .is_err(),
-            "the accepted-sequence domain stays poisoned"
+            observed
+                .recv_timeout(Duration::from_secs(5))
+                .expect("isolated message destructor reports"),
+            "the exhausted message is destroyed outside the mailbox mutex"
         );
+    }
+
+    #[test]
+    fn promotion_sequence_exhaustion_panics_after_unlock_without_poisoning() {
+        let mut mailbox =
+            MailboxCell::new(ChildId::from("actor"), crate::capability::tests::runtime());
+        Arc::get_mut(&mut mailbox)
+            .expect("mailbox is uniquely owned")
+            .accepted = crate::identity::AtomicPoisonedCounter::near_exhaustion();
+        let token = configure(
+            &mailbox,
+            ResolvedMailbox::Queue(std::num::NonZeroUsize::new(1).expect("non-zero capacity")),
+        );
+        let mut identity = ScopeIdentity::new();
+        let (_, mut incarnations) = identity
+            .mint_membership(&ChildId::from("actor"))
+            .expect("membership available")
+            .into_pair();
+        let incarnation = incarnations.mint().expect("incarnation available");
+        bind(&mailbox, token, incarnation);
+        assert!(matches!(
+            mailbox.submit(1_u8),
+            super::Submission::Accepted(_)
+        ));
+        let operation = match mailbox.submit(2_u8) {
+            super::Submission::Parked(operation) => operation,
+            super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+                panic!("the full queue parks the second message")
+            }
+        };
+        let receiver = MailboxReceiver::new(Arc::clone(&mailbox), incarnation);
+
+        assert!(catch_unwind(AssertUnwindSafe(|| receiver.try_recv())).is_err());
+        drop(
+            mailbox
+                .state
+                .lock()
+                .expect("the exhaustion panic occurs after mailbox unlock"),
+        );
+        let mut withdrawal = mailbox.withdraw(&operation, super::WithdrawalDisposition::Inline);
+        assert!(matches!(
+            withdrawal.take_outcome(),
+            super::WithdrawalOutcome::Withdrawn { message: 2, .. }
+        ));
+        withdrawal.finish();
     }
 }

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -624,6 +624,33 @@ struct MailboxEffectBatch<M> {
     accepted_sequence_exhausted: bool,
 }
 
+/// A received message remains isolated until every post-unlock effect has
+/// flushed successfully. If a pulse, waker, displaced payload, or exhaustion
+/// verdict panics, unwinding submits the message for detached disposal instead
+/// of destroying it on the mailbox caller's stack.
+struct ReturnedMessage<M: Send + 'static> {
+    value: Option<M>,
+    runtime: Arc<dyn MailboxRuntime>,
+}
+
+impl<M: Send + 'static> ReturnedMessage<M> {
+    fn new(value: Option<M>, runtime: Arc<dyn MailboxRuntime>) -> Self {
+        Self { value, runtime }
+    }
+
+    fn take(&mut self) -> Option<M> {
+        self.value.take()
+    }
+}
+
+impl<M: Send + 'static> Drop for ReturnedMessage<M> {
+    fn drop(&mut self) {
+        if let Some(value) = self.value.take() {
+            dispose(&self.runtime, value);
+        }
+    }
+}
+
 impl<M: Send + 'static> MailboxEffectBatch<M> {
     fn flush(mut self) {
         let mut panics = PanicAccumulator::default();
@@ -706,9 +733,12 @@ impl<'a, 's, M: Send + 'static> MailboxTxn<'a, 's, M> {
 
     fn finish_returned(mut self) -> Option<M> {
         drop(self.state.take());
-        let output = self.effects.returned.take();
+        let mut output = ReturnedMessage::new(
+            self.effects.returned.take(),
+            Arc::clone(&self.effects.cell.runtime),
+        );
         drop(self);
-        output
+        output.take()
     }
 }
 
@@ -2377,9 +2407,13 @@ pub(super) mod tests {
     }
 
     #[test]
-    fn promotion_sequence_exhaustion_panics_after_unlock_without_poisoning() {
-        let mut mailbox =
-            MailboxCell::new(ChildId::from("actor"), crate::capability::tests::runtime());
+    fn promotion_sequence_exhaustion_isolates_the_received_message_before_panicking() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let runtime = Arc::new(BindOrderingRuntime {
+            inner: crate::capability::tests::runtime(),
+            events: Arc::clone(&events),
+        });
+        let mut mailbox = MailboxCell::new(ChildId::from("actor"), runtime);
         Arc::get_mut(&mut mailbox)
             .expect("mailbox is uniquely owned")
             .accepted = crate::identity::AtomicPoisonedCounter::near_exhaustion();
@@ -2394,11 +2428,19 @@ pub(super) mod tests {
             .into_pair();
         let incarnation = incarnations.mint().expect("incarnation available");
         bind(&mailbox, token, incarnation);
+        let weak = Arc::downgrade(&mailbox);
+        let (dropped, observed) = mpsc::channel();
         assert!(matches!(
-            mailbox.submit(1_u8),
+            mailbox.submit(LockCheckingMessage {
+                mailbox: Weak::clone(&weak),
+                dropped: Some(dropped),
+            }),
             super::Submission::Accepted(_)
         ));
-        let operation = match mailbox.submit(2_u8) {
+        let operation = match mailbox.submit(LockCheckingMessage {
+            mailbox: weak,
+            dropped: None,
+        }) {
             super::Submission::Parked(operation) => operation,
             super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
                 panic!("the full queue parks the second message")
@@ -2413,10 +2455,23 @@ pub(super) mod tests {
                 .lock()
                 .expect("the exhaustion panic occurs after mailbox unlock"),
         );
+        assert!(
+            events
+                .lock()
+                .expect("effect recorder mutex")
+                .contains(&BindEffectEvent::DisposalSubmitted),
+            "the live return value is submitted for isolated disposal before unwind"
+        );
+        assert!(
+            observed
+                .recv_timeout(Duration::from_secs(5))
+                .expect("isolated returned-message destructor reports"),
+            "the returned message is destroyed outside the mailbox mutex"
+        );
         let mut withdrawal = mailbox.withdraw(&operation, super::WithdrawalDisposition::Inline);
         assert!(matches!(
             withdrawal.take_outcome(),
-            super::WithdrawalOutcome::Withdrawn { message: 2, .. }
+            super::WithdrawalOutcome::Withdrawn { .. }
         ));
         withdrawal.finish();
     }

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -1274,7 +1274,21 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
                 effects,
             );
         }
-        if waiters.is_empty() {
+        if transaction.effects.accepted_sequence_exhausted {
+            // Exhaustion is the one way promotion stops early, so neither
+            // derived verdict below holds: a latest mailbox can still owe
+            // waiters and a queue mailbox can still have free capacity.
+            // Freezing is the honest state — no further acceptance is
+            // possible on this counter — and it keeps the parked senders in
+            // mailbox-owned state. Destroying them here would run user
+            // message destructors under the mailbox mutex during the
+            // exhaustion panic's own unwind; the post-unlock effect raises
+            // that panic instead.
+            transaction.binding = MailboxBinding::Frozen {
+                incarnation,
+                waiters,
+            };
+        } else if waiters.is_empty() {
             transaction.binding = MailboxBinding::Bound(BoundState::Available(incarnation));
         } else {
             let MailboxKind::Queue(capacity) = kind else {
@@ -1330,7 +1344,11 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             retired: Vec::new(),
         }) as MailboxDisposal;
         let token = MailboxBindToken::new(Arc::clone(&transaction.bind_permit));
-        transaction.finish(Some(MailboxClose::new(token, disposal)))
+        // The close result outlives this transaction's effect flush at every
+        // caller, so it carries the disposal capability that isolates the
+        // unread payload if that flush unwinds.
+        let runtime = Arc::clone(&transaction.effects.cell.runtime);
+        transaction.finish(Some(MailboxClose::new(token, disposal, runtime)))
     }
 
     fn prepare_termination(
@@ -1696,6 +1714,73 @@ pub(super) mod tests {
 
         fn sleep_until(&self, deadline: Option<Instant>) -> crate::BoxedSleep {
             self.inner.sleep_until(deadline)
+        }
+    }
+
+    /// Runtime whose change signal panics once armed, so a mailbox effect
+    /// flush can be made to unwind on demand.
+    struct PanickingPulseRuntime {
+        inner: Arc<dyn crate::MailboxRuntime>,
+        armed: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl crate::MailboxRuntime for PanickingPulseRuntime {
+        fn oneshot(
+            &self,
+        ) -> (
+            Box<dyn crate::ErasedOneShotSender>,
+            Pin<Box<dyn crate::ErasedOneShotReceiver>>,
+        ) {
+            self.inner.oneshot()
+        }
+
+        fn signal(&self) -> Arc<dyn crate::MailboxSignal> {
+            Arc::new(PanickingPulseSignal {
+                inner: self.inner.signal(),
+                armed: Arc::clone(&self.armed),
+            })
+        }
+
+        fn dispose(&self, value: Box<dyn Send + 'static>) {
+            self.inner.dispose(value);
+        }
+
+        fn now(&self) -> Instant {
+            self.inner.now()
+        }
+
+        fn sleep_until(&self, deadline: Option<Instant>) -> crate::BoxedSleep {
+            self.inner.sleep_until(deadline)
+        }
+    }
+
+    struct PanickingPulseSignal {
+        inner: Arc<dyn crate::MailboxSignal>,
+        armed: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl crate::MailboxSignal for PanickingPulseSignal {
+        fn pulse(&self) {
+            assert!(
+                !self.armed.load(Ordering::SeqCst),
+                "injected mailbox pulse panic"
+            );
+            self.inner.pulse();
+        }
+
+        fn watcher(&self) -> Box<dyn crate::MailboxSignalWatcher> {
+            self.inner.watcher()
+        }
+    }
+
+    /// User message recording the thread its destructor ran on.
+    struct ThreadRecordingMessage(Option<mpsc::Sender<std::thread::ThreadId>>);
+
+    impl Drop for ThreadRecordingMessage {
+        fn drop(&mut self) {
+            if let Some(sender) = self.0.take() {
+                let _ = sender.send(std::thread::current().id());
+            }
         }
     }
 
@@ -2474,5 +2559,123 @@ pub(super) mod tests {
             super::WithdrawalOutcome::Withdrawn { .. }
         ));
         withdrawal.finish();
+    }
+
+    #[test]
+    fn a_panicking_close_flush_isolates_the_unread_payload() {
+        let armed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let runtime = Arc::new(PanickingPulseRuntime {
+            inner: crate::capability::tests::runtime(),
+            armed: Arc::clone(&armed),
+        });
+        let mailbox = MailboxCell::new(ChildId::from("actor"), runtime);
+        let token = configure(&mailbox, ResolvedMailbox::Latest);
+        let mut identity = ScopeIdentity::new();
+        let (_, mut incarnations) = identity
+            .mint_membership(&ChildId::from("actor"))
+            .expect("membership available")
+            .into_pair();
+        let incarnation = incarnations.mint().expect("incarnation available");
+        bind(&mailbox, token, incarnation);
+        let (dropped, observed) = mpsc::channel();
+        assert!(matches!(
+            mailbox.submit(ThreadRecordingMessage(Some(dropped))),
+            super::Submission::Accepted(_)
+        ));
+        armed.store(true, Ordering::SeqCst);
+
+        // The driver shape: the close result is a live local across the
+        // effects flush, which wakes registered wakers synchronously and can
+        // therefore unwind on user code.
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            let mut effects = crate::MailboxEffectQueue::default();
+            let closed = MailboxControl::close(&*mailbox, incarnation, &mut effects);
+            drop(effects);
+            if let Some(closed) = closed {
+                let (_token, disposal) = closed.into_parts();
+                drop(disposal);
+            }
+        }));
+        assert!(panic.is_err(), "the flush panic reaches the caller");
+
+        let destructor = observed
+            .recv_timeout(Duration::from_secs(5))
+            .expect("the unread message destructor reports");
+        assert_ne!(
+            destructor,
+            std::thread::current().id(),
+            "an unwinding close flush must not destroy unread user messages on the caller's thread"
+        );
+    }
+
+    #[test]
+    fn bind_sequence_exhaustion_retains_parked_senders_after_unlock() {
+        let mut mailbox =
+            MailboxCell::new(ChildId::from("actor"), crate::capability::tests::runtime());
+        Arc::get_mut(&mut mailbox)
+            .expect("mailbox is uniquely owned")
+            .accepted = crate::identity::AtomicPoisonedCounter::near_exhaustion();
+        let token = configure(&mailbox, ResolvedMailbox::Latest);
+        let weak = Arc::downgrade(&mailbox);
+        let first = match mailbox.submit(LockCheckingMessage {
+            mailbox: Weak::clone(&weak),
+            dropped: None,
+        }) {
+            super::Submission::Parked(operation) => operation,
+            super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+                panic!("an unbound mailbox parks its send")
+            }
+        };
+        let (dropped, observed) = mpsc::channel();
+        let second = match mailbox.submit(LockCheckingMessage {
+            mailbox: weak,
+            dropped: Some(dropped),
+        }) {
+            super::Submission::Parked(operation) => operation,
+            super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+                panic!("an unbound mailbox parks its send")
+            }
+        };
+        let mut identity = ScopeIdentity::new();
+        let (_, mut incarnations) = identity
+            .mint_membership(&ChildId::from("actor"))
+            .expect("membership available")
+            .into_pair();
+        let incarnation = incarnations.mint().expect("incarnation available");
+
+        // Promotion mints one accepted sequence and then runs out, leaving a
+        // latest mailbox with a waiter still parked.
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            bind(&mailbox, token, incarnation);
+        }));
+        assert!(panic.is_err(), "exhaustion is reported to the caller");
+        drop(
+            mailbox
+                .state
+                .lock()
+                .expect("the exhaustion panic occurs after mailbox unlock"),
+        );
+
+        let receiver = MailboxReceiver::new(Arc::clone(&mailbox), incarnation);
+        assert!(
+            receiver.try_recv().is_some(),
+            "the promoted message survives the exhaustion verdict"
+        );
+        let mut withdrawal = mailbox.withdraw(&second, super::WithdrawalDisposition::Inline);
+        assert!(
+            matches!(
+                withdrawal.take_outcome(),
+                super::WithdrawalOutcome::Withdrawn { .. }
+            ),
+            "the unpromotable sender still owns its message"
+        );
+        withdrawal.finish();
+        assert!(
+            observed
+                .recv_timeout(Duration::from_secs(5))
+                .expect("the parked message destructor reports"),
+            "the parked message is destroyed outside the mailbox mutex"
+        );
+        drop(first);
     }
 }

--- a/crates/shelterwood-mailbox/src/futures.rs
+++ b/crates/shelterwood-mailbox/src/futures.rs
@@ -706,7 +706,7 @@ mod tests {
         time::Duration,
     };
 
-    use crate::{ChildId, MailboxControl, identity::ScopeIdentity};
+    use crate::{ChildId, MailboxControl, MailboxEffectQueue, identity::ScopeIdentity};
 
     use super::{
         super::cell::tests::{actor, actor_for},
@@ -787,9 +787,11 @@ mod tests {
     #[test]
     fn an_accepted_send_reports_acceptance_on_every_poll() {
         let (mailbox, actor) = actor();
-        MailboxControl::configure(
+        let mut effects = MailboxEffectQueue::default();
+        let token = MailboxControl::configure(
             &*mailbox,
             crate::policy::ResolvedDefaults::default().mailbox,
+            &mut effects,
         );
         let mut identity = ScopeIdentity::new();
         let (_, mut incarnations) = identity
@@ -797,7 +799,7 @@ mod tests {
             .expect("membership available")
             .into_pair();
         let incarnation = incarnations.mint().expect("incarnation available");
-        MailboxControl::bind(&*mailbox, incarnation);
+        MailboxControl::bind(&*mailbox, token, incarnation, &mut effects);
 
         let mut send = Box::pin(actor.send(1));
         let mut context = Context::from_waker(Waker::noop());
@@ -1014,8 +1016,9 @@ mod tests {
                 panic!("an unbound mailbox parks its send")
             }
         };
-        let teardown =
-            MailboxControl::prepare_termination(&*mailbox).expect("the mailbox terminates once");
+        let mut effects = MailboxEffectQueue::default();
+        let teardown = MailboxControl::prepare_termination(&*mailbox, &mut effects)
+            .expect("the mailbox terminates once");
         let _ = teardown.finish();
 
         let calls = Arc::new(WakerVtableCalls::default());

--- a/crates/shelterwood-mailbox/src/lib.rs
+++ b/crates/shelterwood-mailbox/src/lib.rs
@@ -89,19 +89,51 @@ impl MailboxBindToken {
 }
 
 /// Result of successfully closing one incarnation.
+///
+/// The unread payload stays isolated until the caller has taken it apart.
+/// Closing rides a non-empty effect batch — at minimum the change pulse that
+/// wakes registered wakers synchronously — and callers hold this value across
+/// that flush. If any effect panics, unwinding submits the payload for
+/// detached disposal instead of destroying every unread user message on the
+/// caller's stack, which for the driver is the driver task itself.
 #[must_use = "closing returns both the next bind permission and unread payload disposal"]
 pub struct MailboxClose {
-    bind: MailboxBindToken,
-    disposal: MailboxDisposal,
+    bind: Option<MailboxBindToken>,
+    disposal: Option<MailboxDisposal>,
+    runtime: Arc<dyn MailboxRuntime>,
 }
 
 impl MailboxClose {
-    pub(crate) fn new(bind: MailboxBindToken, disposal: MailboxDisposal) -> Self {
-        Self { bind, disposal }
+    pub(crate) fn new(
+        bind: MailboxBindToken,
+        disposal: MailboxDisposal,
+        runtime: Arc<dyn MailboxRuntime>,
+    ) -> Self {
+        Self {
+            bind: Some(bind),
+            disposal: Some(disposal),
+            runtime,
+        }
     }
 
-    pub fn into_parts(self) -> (MailboxBindToken, MailboxDisposal) {
-        (self.bind, self.disposal)
+    pub fn into_parts(mut self) -> (MailboxBindToken, MailboxDisposal) {
+        let bind = self
+            .bind
+            .take()
+            .expect("a mailbox close is taken apart exactly once");
+        let disposal = self
+            .disposal
+            .take()
+            .expect("a mailbox close is taken apart exactly once");
+        (bind, disposal)
+    }
+}
+
+impl Drop for MailboxClose {
+    fn drop(&mut self) {
+        if let Some(disposal) = self.disposal.take() {
+            self.runtime.dispose(disposal);
+        }
     }
 }
 

--- a/crates/shelterwood-mailbox/src/lib.rs
+++ b/crates/shelterwood-mailbox/src/lib.rs
@@ -15,7 +15,13 @@
 //! foreign implementations may be called from framework critical sections and
 //! therefore invalidate the framework's lock-rule guarantees.
 
-use std::{fmt, sync::Arc};
+use std::{
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use shelterwood_core::policy::ResolvedMailbox;
 pub use shelterwood_core::{ChildId, Incarnation, Membership};
@@ -58,6 +64,77 @@ mod policy {
 /// published all waiter outcomes.
 pub type MailboxDisposal = Box<dyn Send>;
 
+/// Linear permission to bind one mailbox incarnation.
+///
+/// Configuration mints the initial permission and a successful close returns
+/// the next one. The token is intentionally neither `Clone` nor constructible
+/// outside the mailbox crate.
+#[must_use = "binding permission must be consumed by the next mailbox bind"]
+pub struct MailboxBindToken {
+    permit: Arc<AtomicBool>,
+}
+
+impl MailboxBindToken {
+    pub(crate) fn new(permit: Arc<AtomicBool>) -> Self {
+        Self { permit }
+    }
+
+    pub(crate) fn claim(&self, expected: &Arc<AtomicBool>) -> bool {
+        Arc::ptr_eq(&self.permit, expected)
+            && self
+                .permit
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+    }
+}
+
+/// Result of successfully closing one incarnation.
+#[must_use = "closing returns both the next bind permission and unread payload disposal"]
+pub struct MailboxClose {
+    bind: MailboxBindToken,
+    disposal: MailboxDisposal,
+}
+
+impl MailboxClose {
+    pub(crate) fn new(bind: MailboxBindToken, disposal: MailboxDisposal) -> Self {
+        Self { bind, disposal }
+    }
+
+    pub fn into_parts(self) -> (MailboxBindToken, MailboxDisposal) {
+        (self.bind, self.disposal)
+    }
+}
+
+/// Post-unlock destination for effects produced by mailbox control changes.
+///
+/// Control callers that hold a wider framework lock implement this trait on
+/// that lock's transaction. Callers without a wider lock use
+/// [`MailboxEffectQueue`], whose drop flushes every effect after the mailbox
+/// operation has returned.
+pub trait MailboxEffectSink {
+    fn defer_mailbox_effect(&mut self, effect: Box<dyn FnOnce()>);
+}
+
+/// Immediate-scope mailbox effect sink for callers holding no wider lock.
+#[must_use = "mailbox effects flush when the queue is dropped"]
+#[derive(Default)]
+pub struct MailboxEffectQueue(Vec<Box<dyn FnOnce()>>);
+
+impl MailboxEffectSink for MailboxEffectQueue {
+    fn defer_mailbox_effect(&mut self, effect: Box<dyn FnOnce()>) {
+        self.0.push(effect);
+    }
+}
+
+impl Drop for MailboxEffectQueue {
+    fn drop(&mut self) {
+        let mut panics = crate::panic::PanicAccumulator::default();
+        for effect in self.0.drain(..) {
+            panics.run(effect);
+        }
+    }
+}
+
 /// Prepared terminal mailbox transition. Finishing it wakes terminal waiters
 /// before returning unread payload ownership for detached disposal.
 ///
@@ -87,24 +164,36 @@ pub trait MailboxControl: private::SealedMailboxControl + fmt::Debug + Send + Sy
     /// Installs the declaration-time mailbox policy before the first bind.
     /// Reconfiguration may only repeat the same resolved policy; a mismatch
     /// panics after the mailbox lock has been released.
-    fn configure(&self, mailbox: ResolvedMailbox);
+    fn configure(
+        &self,
+        mailbox: ResolvedMailbox,
+        effects: &mut dyn MailboxEffectSink,
+    ) -> MailboxBindToken;
     /// Makes one incarnation live after configuration and prior-close cleanup.
     /// A bind after terminal preparation is deliberately ignored because
     /// terminality wins that race permanently.
-    fn bind(&self, incarnation: Incarnation);
+    fn bind(
+        &self,
+        token: MailboxBindToken,
+        incarnation: Incarnation,
+        effects: &mut dyn MailboxEffectSink,
+    );
     /// Stops new acceptance for the matching live incarnation.
-    fn freeze(&self, incarnation: Incarnation);
+    fn freeze(&self, incarnation: Incarnation, effects: &mut dyn MailboxEffectSink);
     /// Unbinds the matching incarnation and returns its unread payload.
     /// Every successful bind must be followed by this close before a rebind;
     /// skipping it would deliver the old incarnation's messages to the new.
-    fn close(&self, incarnation: Incarnation) -> Option<MailboxDisposal>;
+    fn close(
+        &self,
+        incarnation: Incarnation,
+        effects: &mut dyn MailboxEffectSink,
+    ) -> Option<MailboxClose>;
     /// Irreversibly terminalizes the membership and prepares synchronous
     /// waiter completion followed by isolated unread-payload disposal.
-    fn prepare_termination(&self) -> Option<Box<dyn MailboxTermination>>;
-
-    /// Debug-only check for the driver's configure/close-before-bind contract.
-    #[cfg(debug_assertions)]
-    fn bind_order_valid(&self) -> bool;
+    fn prepare_termination(
+        &self,
+        effects: &mut dyn MailboxEffectSink,
+    ) -> Option<Box<dyn MailboxTermination>>;
 }
 
 /// Restart-stable identity capability retained by an actor handle.

--- a/crates/shelterwood-runtime/src/disposal.rs
+++ b/crates/shelterwood-runtime/src/disposal.rs
@@ -69,6 +69,12 @@ where
     T: Send + 'static,
     C: FnOnce(Option<DisposalPanic>) + Send + 'static,
 {
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, Option<(T, C)>> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
     fn new(value: T, completion: C) -> Arc<Self> {
         Self::with_criticality(value, completion, false)
     }
@@ -91,10 +97,7 @@ where
     /// is taking the payload out, and the critical drop path below must stay
     /// panic-free because it can run inside an unwind.
     fn take_pending(&self) -> Option<(T, C)> {
-        self.state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take()
+        self.lock_state().take()
     }
 
     fn finish(&self) {
@@ -149,10 +152,7 @@ where
     }
 
     fn is_pending(&self) -> bool {
-        self.state
-            .lock()
-            .expect("disposal job mutex poisoned")
-            .is_some()
+        self.lock_state().is_some()
     }
 }
 
@@ -213,7 +213,9 @@ fn enqueue_fallback_disposal_with(
     // The push and this pop share one guard, so the reclaimed entry is exactly
     // the job just appended even when older critical jobs are still queued.
     let rejected = state.queue.pop_back();
+    drop(state);
     debug_assert!(rejected.is_some());
+    drop(rejected);
     false
 }
 
@@ -369,7 +371,7 @@ mod tests {
     use std::{
         sync::{
             Arc, Condvar, Mutex,
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
             mpsc,
         },
         thread::{self, ThreadId},
@@ -378,7 +380,7 @@ mod tests {
 
     use super::{
         DisposalJob, DisposalPanic, FallbackDisposals, Isolated, dispose_detached,
-        retain_fallback_disposal_with,
+        enqueue_fallback_disposal_with, retain_fallback_disposal_with,
     };
     use crate::spawn::{BlockingPoolJob, blocking_pool_accepted};
 
@@ -401,6 +403,26 @@ mod tests {
     }
 
     struct PanickingDrop(Arc<AtomicUsize>);
+
+    struct LockCheckingJob {
+        disposals: Arc<Mutex<FallbackDisposals>>,
+        dropped_after_unlock: Arc<AtomicBool>,
+    }
+
+    impl Drop for LockCheckingJob {
+        fn drop(&mut self) {
+            self.dropped_after_unlock
+                .store(self.disposals.try_lock().is_ok(), Ordering::SeqCst);
+        }
+    }
+
+    impl BlockingPoolJob for LockCheckingJob {
+        fn run(&self) {}
+
+        fn is_pending(&self) -> bool {
+            true
+        }
+    }
 
     impl Drop for PanickingDrop {
         fn drop(&mut self) {
@@ -458,6 +480,32 @@ mod tests {
             .expect("failed spawn keeps critical disposal queued");
         queued.run();
         assert_eq!(drops.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn rejected_fallback_job_is_released_after_unlock() {
+        let disposals = Arc::new(Mutex::new(FallbackDisposals::default()));
+        let dropped_after_unlock = Arc::new(AtomicBool::new(false));
+        let job = Arc::new(LockCheckingJob {
+            disposals: Arc::clone(&disposals),
+            dropped_after_unlock: Arc::clone(&dropped_after_unlock),
+        });
+
+        assert!(!enqueue_fallback_disposal_with(&disposals, job, || Err(
+            std::io::Error::other("injected thread exhaustion")
+        ),));
+        assert!(dropped_after_unlock.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn pending_query_tolerates_a_poisoned_disposal_job() {
+        let job = DisposalJob::new((), |_| {});
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = job.state.lock().expect("state starts healthy");
+            panic!("inject disposal state poison");
+        }));
+
+        assert!(job.is_pending());
     }
 
     struct ReportingDrop(mpsc::Sender<DestructorThread>);

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -548,21 +548,19 @@ impl<T: Clone> WatchReceiver<T> {
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for WatchSender<T> {
+impl<T> fmt::Debug for WatchSender<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("WatchSender")
-            .field("value", &*self.0.borrow())
             .field("receivers", &self.0.receiver_count())
             .finish()
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for WatchReceiver<T> {
+impl<T> fmt::Debug for WatchReceiver<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("WatchReceiver")
-            .field("value", &*self.0.borrow())
             .finish_non_exhaustive()
     }
 }
@@ -657,6 +655,15 @@ mod tests {
 
     struct CountWake(Arc<AtomicUsize>);
 
+    struct DebugProbe(Arc<AtomicUsize>);
+
+    impl std::fmt::Debug for DebugProbe {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            formatter.write_str("DebugProbe")
+        }
+    }
+
     impl Wake for CountWake {
         fn wake(self: Arc<Self>) {
             self.0.fetch_add(1, Ordering::SeqCst);
@@ -722,6 +729,24 @@ mod tests {
         let mut changed = Box::pin(receiver.changed_or_closed());
         let mut context = Context::from_waker(Waker::noop());
         assert_eq!(changed.as_mut().poll(&mut context), Poll::Ready(false));
+    }
+
+    #[test]
+    fn watch_sender_debug_never_formats_the_guarded_value() {
+        let formats = Arc::new(AtomicUsize::new(0));
+        let (sender, _receiver) = super::watch(DebugProbe(Arc::clone(&formats)));
+
+        assert_eq!(format!("{sender:?}"), "WatchSender { receivers: 1 }");
+        assert_eq!(formats.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn watch_receiver_debug_never_formats_the_guarded_value() {
+        let formats = Arc::new(AtomicUsize::new(0));
+        let (_sender, receiver) = super::watch(DebugProbe(Arc::clone(&formats)));
+
+        assert_eq!(format!("{receiver:?}"), "WatchReceiver { .. }");
+        assert_eq!(formats.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -50,7 +50,7 @@ use crate::{
         structured_startup_failure_error,
     },
     identity::IncarnationCounter,
-    mailbox::MailboxControl,
+    mailbox::{MailboxBindToken, MailboxControl, MailboxEffectQueue},
     observe::LifecycleEventKind,
     plan::{
         BuilderCore, ChildConstruction, ChildPlan, LowerError, ScopeFactory, ScopePlan, SlotCell,
@@ -384,8 +384,12 @@ impl Drop for ScopeRuntime {
             };
             if let Some(active) = child.active.take() {
                 if let Some(mailbox) = &child.mailbox {
-                    mailbox.freeze(active.incarnation);
-                    if let Some(teardown) = mailbox.close(active.incarnation) {
+                    let mut effects = MailboxEffectQueue::default();
+                    mailbox.freeze(active.incarnation, &mut effects);
+                    let closed = mailbox.close(active.incarnation, &mut effects);
+                    drop(effects);
+                    if let Some(closed) = closed {
+                        let (_token, teardown) = closed.into_parts();
                         runtime::dispose_detached(teardown);
                     }
                 }

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -156,6 +156,7 @@ pub(super) fn discharge_child_terminality(completion: ChildTerminality) {
 pub(super) struct ChildRuntime {
     pub(super) slot: Arc<SlotCell>,
     pub(super) mailbox: Option<Arc<dyn MailboxControl>>,
+    pub(super) mailbox_bind: Option<MailboxBindToken>,
     pub(super) terminality: Obligation<ChildTerminality>,
     pub(super) construction: runtime::Isolated<ChildConstruction>,
     pub(super) pending_terminal: Option<PendingTerminal>,
@@ -192,13 +193,17 @@ impl ChildRuntime {
         );
         let incarnations = slot.member.take_incarnation_counter();
         let mailbox = slot.member.mailbox();
-        if let Some(mailbox) = &mailbox {
-            mailbox.configure(options.mailbox);
-        }
+        let mailbox_bind = if let Some(mailbox) = &mailbox {
+            let mut effects = MailboxEffectQueue::default();
+            Some(mailbox.configure(options.mailbox, &mut effects))
+        } else {
+            None
+        };
         Self {
             terminality,
             slot,
             mailbox,
+            mailbox_bind,
             construction,
             pending_terminal: None,
             options,
@@ -635,12 +640,12 @@ impl ScopeRuntime {
         } = dispatch_child_construction(child, &self.root, &self.defaults, incarnation, &latches);
         let now = runtime::now();
         if let Some(mailbox) = &child.mailbox {
-            #[cfg(debug_assertions)]
-            debug_assert!(
-                mailbox.bind_order_valid(),
-                "driver must configure before bind and close before rebind"
-            );
-            mailbox.bind(incarnation);
+            let mut effects = MailboxEffectQueue::default();
+            let token = child
+                .mailbox_bind
+                .take()
+                .expect("configuration or close supplies each bind token");
+            mailbox.bind(token, incarnation, &mut effects);
         }
         self.root.transition_child_stage(
             &child.slot.member,
@@ -742,7 +747,8 @@ impl ScopeRuntime {
             self.root
                 .transition_child_stage(&child.slot.member, MemberTransition::Stopping, None);
             if let Some(mailbox) = &child.mailbox {
-                mailbox.freeze(active.incarnation);
+                let mut effects = MailboxEffectQueue::default();
+                mailbox.freeze(active.incarnation, &mut effects);
             }
             active.forced_outcome = forced;
             if let Some(deadline) = active.readiness_deadline.take() {
@@ -904,10 +910,15 @@ impl ScopeRuntime {
         if let Some(deadline) = active.stop_deadline.take() {
             self.deadlines.cancel(deadline);
         }
-        if let Some(mailbox) = &child.mailbox
-            && let Some(teardown) = mailbox.close(incarnation)
-        {
-            runtime::dispose_detached(teardown);
+        if let Some(mailbox) = &child.mailbox {
+            let mut effects = MailboxEffectQueue::default();
+            let closed = mailbox.close(incarnation, &mut effects);
+            drop(effects);
+            if let Some(closed) = closed {
+                let (token, teardown) = closed.into_parts();
+                child.mailbox_bind = Some(token);
+                runtime::dispose_detached(teardown);
+            }
         }
         let recorded = reconcile_recorded_outcomes(recorded, active.forced_outcome);
         let exit = classify_exit(recorded, join, active.hard_abort_phase, cancellation);
@@ -994,7 +1005,7 @@ impl ScopeRuntime {
                         delay: decision.delay(),
                     },
                 );
-                let trip = decision.intensity_trip(self.intensity_policy);
+                let trip = decision.intensity_trip();
                 if trip.is_none()
                     && let Some(restart_at) = decision.restart_at()
                 {

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -13,5 +13,6 @@ pub use shelterwood_mailbox::{
 };
 
 pub(crate) use shelterwood_mailbox::{
-    AcceptedSequence, MailboxCell, MailboxControl, MailboxReceiver, actor_ref_from_parts,
+    AcceptedSequence, MailboxBindToken, MailboxCell, MailboxControl, MailboxEffectQueue,
+    MailboxReceiver, actor_ref_from_parts,
 };

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -20,7 +20,8 @@ use crate::{
     definition::DefinitionSource,
     identity::PoisonedCounter,
     mailbox::{
-        AcceptedSequence, MailboxCell, MailboxControl, MailboxReceiver, actor_ref_from_parts,
+        AcceptedSequence, MailboxCell, MailboxControl, MailboxEffectQueue, MailboxReceiver,
+        actor_ref_from_parts,
     },
     policy::{ChildMode, CommonOptions},
     runtime::{
@@ -1424,6 +1425,7 @@ impl<M: Send + 'static> RawContext<M> {
     pub async fn recv(&mut self) -> Option<M> {
         loop {
             if self.local_stop.is_fired() {
+                self.receiver.freeze();
                 self.freeze_and_report();
                 // `stop()` originates on this task, but the configured
                 // shutdown ladder is owned by the driver. The driver's helper
@@ -1437,10 +1439,10 @@ impl<M: Send + 'static> RawContext<M> {
                 return None;
             }
             if self.shutdown.is_cancelled() {
-                // Every driver path freezes (or closes) this incarnation's
-                // mailbox before firing its shutdown token. That ordering is
-                // what makes the frozen accepted prefix a complete drain
-                // boundary once cancellation is observable here.
+                // Freeze locally as part of observing shutdown. The driver
+                // also freezes before cancellation, but correctness of this
+                // receive boundary does not depend on that remote ordering.
+                self.receiver.freeze();
                 self.freeze_and_report();
                 self.resources.resume_pending_panic();
                 return None;
@@ -2039,7 +2041,11 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
                     None
                 }
             };
-            let mailbox_freeze_panic = catch_panic(|| mailbox.freeze(incarnation)).err();
+            let mailbox_freeze_panic = catch_panic(|| {
+                let mut effects = MailboxEffectQueue::default();
+                mailbox.freeze(incarnation, &mut effects);
+            })
+            .err();
             let resource_freeze_panic = catch_panic(|| owner.raw().freeze_resources()).err();
             let mut cleanup_panic = owner.raw().take_resource_panic();
             keep_first_panic(&mut cleanup_panic, mailbox_freeze_panic);
@@ -2171,7 +2177,9 @@ mod tests {
         ChildId, MailboxShutdown, Readiness,
         cells::{MemberCell, ScopeCell},
         identity::ScopeIdentity,
-        mailbox::{ActorRef, MailboxCell, MailboxControl, actor_ref_from_parts},
+        mailbox::{
+            ActorRef, MailboxCell, MailboxControl, MailboxEffectQueue, actor_ref_from_parts,
+        },
         policy::{ResolvedDefaults, ScopeFlavor},
         runtime::{
             CompletionGatedLatch, Latch, PanicPayload, Signal, UnwindPanics,
@@ -2183,6 +2191,11 @@ mod tests {
     /// Builds a live raw incarnation context whose mailbox is configured and
     /// bound, so `next_ready` can take the busy path without a driver.
     fn bound_raw_context() -> (RawContext<u8>, ActorRef<u8>) {
+        let (context, actor, _shutdown) = bound_raw_context_with_shutdown();
+        (context, actor)
+    }
+
+    fn bound_raw_context_with_shutdown() -> (RawContext<u8>, ActorRef<u8>, Latch) {
         let mut identity = ScopeIdentity::new();
         let id = ChildId::from("raw-actor");
         let member = MemberCell::new(
@@ -2191,12 +2204,14 @@ mod tests {
         );
         let mailbox = MailboxCell::new(id.clone(), crate::runtime::mailbox_runtime());
         member.attach_mailbox(mailbox.clone());
-        MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox);
+        let mut effects = MailboxEffectQueue::default();
+        let token =
+            MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox, &mut effects);
         let incarnation = member
             .take_incarnation_counter()
             .mint()
             .expect("incarnation available");
-        MailboxControl::bind(&*mailbox, incarnation);
+        MailboxControl::bind(&*mailbox, token, incarnation, &mut effects);
 
         let mut scope_identity = ScopeIdentity::new();
         let scope_id = ChildId::from("scope");
@@ -2209,13 +2224,14 @@ mod tests {
         let scope = ScopeCell::new(scope_member, ScopeFlavor::Ordered, ScopeIdentity::new());
 
         let myself = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
+        let shutdown = Latch::default();
         let context = RawContext::new(
             RawRunContext {
                 id,
                 incarnation,
                 member,
                 scope: ScopeRef { cell: scope },
-                shutdown: Latch::default(),
+                shutdown: shutdown.clone(),
                 abort: Latch::default(),
                 ready: CompletionGatedLatch::default(),
                 local_stop: Latch::default(),
@@ -2225,7 +2241,7 @@ mod tests {
             mailbox,
             Readiness::Immediate,
         );
-        (context, myself)
+        (context, myself, shutdown)
     }
 
     fn marker(value: usize) -> QueuedEvent<usize> {
@@ -2638,6 +2654,24 @@ mod tests {
             "the ready-selection turn reclaimed both finished ledger entries"
         );
         assert!(!context.resources.offloads[0].finished.is_fired());
+    }
+
+    #[crate::runtime::test]
+    async fn recv_freezes_its_mailbox_when_it_observes_shutdown() {
+        let (mut context, actor, shutdown) = bound_raw_context_with_shutdown();
+        actor
+            .try_send(1)
+            .expect("the live mailbox accepts before shutdown");
+        shutdown.fire();
+
+        assert_eq!(context.recv().await, None);
+        assert_eq!(
+            actor
+                .try_send(2)
+                .expect_err("recv's local freeze closes the acceptance boundary")
+                .kind,
+            crate::SendErrorKind::NotRunning
+        );
     }
 
     #[test]


### PR DESCRIPTION
Part of the #284 hardening sequence. Closes #272.

## What changed

- Makes watch debugging metadata-only and moves mailbox exhaustion panics/effects beyond framework locks.
- Threads mailbox effects through observation transactions and adds a mailbox-bound, single-use bind token.
- Defers resident retirement and lifecycle payload release past the observation gate.
- Makes observation closure retry-safe, interval charge policy self-contained, fallback disposal poison-tolerant, and raw receive shutdown freezing local.
- Documents the last-handle mailbox payload protocol and updates the lock-rule guidance.

## Evidence

Added targeted regressions for hostile Debug, all mailbox exhaustion paths, effect deferral, resident payload retirement, lifecycle exhaustion, disposal rejection/poisoning, bind-token ordering, and local raw freezing.

Validation: targeted crate suites and `./tools/dev just ci` passed (687 tests plus formatting, clippy, doctests, docs, API reachability, external consumer, and Nix formatting).

Stack: based on #294 / issue #269 because both touch terminalization lock boundaries.