### PR TITLE
Consolidate integration test fixtures

### DIFF
--- a/crates/shelterwood/tests/acceptance_assistant.rs
+++ b/crates/shelterwood/tests/acceptance_assistant.rs
@@ -643,6 +643,11 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
     let mut saw_control_restart = false;
     let mut saw_tool_restart = false;
     let mut saw_gateway_restart = false;
+    // Lag here is a fixture defect, not load: this trace publishes a bounded
+    // number of edges — three restarts and one temporary child on top of a
+    // fixed tree — against the 128-event subscriber capacity, and nothing but
+    // this drain and the wait above reads it. A marker would mean dropped
+    // edges silently deciding the flags below, so it fails loudly instead.
     while let Ok(item) = lifecycle.try_recv() {
         let LifecycleItem::Event(event) = item else {
             panic!("the bounded assistant trace must not lag")

--- a/crates/shelterwood/tests/acceptance_assistant.rs
+++ b/crates/shelterwood/tests/acceptance_assistant.rs
@@ -6,12 +6,12 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet};
+use crate::common::{POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet, next_event};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, ActorRef, ChildState, Context, DeadlineElapsed, DynamicScopeRef,
-    DynamicTree, ExitError, ExitResult, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
-    LifecycleItem, Mailbox, Membership, RemoveOutcome, Reply, ReserveError, RestartCount,
-    RestartPolicy, ScopeState, StopContext, SubtreeOnceDef, Tree,
+    DynamicTree, ExitError, ExitResult, LifecycleEvent, LifecycleEventKind, LifecycleItem, Mailbox,
+    Membership, RemoveOutcome, Reply, ReserveError, RestartCount, RestartPolicy, ScopeState,
+    StopContext, SubtreeOnceDef, Tree,
 };
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
@@ -24,18 +24,6 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 // tighter bound anywhere only relocates the flake rather than removing it.
 // The idle-eviction test further down runs on `start_paused` and keeps its
 // virtual durations, which are load-bearing rather than defensive.
-
-async fn next_event(events: &mut LifecycleEvents) -> LifecycleEvent {
-    loop {
-        let item = tokio::time::timeout(POLL_TIMEOUT, events.recv())
-            .await
-            .expect("lifecycle wait is bounded")
-            .expect("lifecycle stream remains open");
-        if let LifecycleItem::Event(event) = item {
-            return event;
-        }
-    }
-}
 
 #[derive(Clone)]
 struct TransportState {
@@ -657,7 +645,7 @@ async fn assistant_control_plane_composes_nested_recovery_redelivery_streaming_a
     let mut saw_gateway_restart = false;
     while let Ok(item) = lifecycle.try_recv() {
         let LifecycleItem::Event(event) = item else {
-            continue;
+            panic!("the bounded assistant trace must not lag")
         };
         saw_control_restart |= event_is_restart_for(&event, control.membership());
         saw_tool_restart |= event_is_restart_for(&event, tool.membership());

--- a/crates/shelterwood/tests/common/lifecycle.rs
+++ b/crates/shelterwood/tests/common/lifecycle.rs
@@ -1,0 +1,17 @@
+use shelterwood::{LifecycleEvent, LifecycleEvents, LifecycleItem};
+
+pub(crate) async fn next_item(events: &mut LifecycleEvents) -> LifecycleItem {
+    tokio::time::timeout(super::POLL_TIMEOUT, events.recv())
+        .await
+        .expect("lifecycle receive is bounded")
+        .expect("lifecycle stream remains open")
+}
+
+pub(crate) async fn next_event(events: &mut LifecycleEvents) -> LifecycleEvent {
+    match next_item(events).await {
+        LifecycleItem::Event(event) => event,
+        LifecycleItem::Lagged { dropped } => {
+            panic!("unexpected lifecycle lag marker dropping {dropped}")
+        }
+    }
+}

--- a/crates/shelterwood/tests/common/lifecycle.rs
+++ b/crates/shelterwood/tests/common/lifecycle.rs
@@ -1,4 +1,4 @@
-use shelterwood::{LifecycleEvent, LifecycleEvents, LifecycleItem};
+use shelterwood::{ExitKind, LifecycleEvent, LifecycleEventKind, LifecycleEvents, LifecycleItem};
 
 pub(crate) async fn next_item(events: &mut LifecycleEvents) -> LifecycleItem {
     tokio::time::timeout(super::POLL_TIMEOUT, events.recv())
@@ -7,6 +7,15 @@ pub(crate) async fn next_item(events: &mut LifecycleEvents) -> LifecycleItem {
         .expect("lifecycle stream remains open")
 }
 
+/// The next lifecycle event, treating a lag marker as a fixture defect.
+///
+/// Every caller subscribes to a fixture whose whole event volume is bounded by
+/// its own construction — a handful of children, a fixed number of restarts —
+/// and reads far more often than the 128-event per-subscriber capacity. Lag is
+/// therefore a function of what the fixture publishes, not of scheduling, so a
+/// marker means the fixture outgrew its subscription rather than that the
+/// machine was busy. Tolerating it would let dropped events silently decide a
+/// `saw_x` flag or hide the very edge under test, so it panics here instead.
 pub(crate) async fn next_event(events: &mut LifecycleEvents) -> LifecycleEvent {
     match next_item(events).await {
         LifecycleItem::Event(event) => event,
@@ -14,4 +23,35 @@ pub(crate) async fn next_event(events: &mut LifecycleEvents) -> LifecycleEvent {
             panic!("unexpected lifecycle lag marker dropping {dropped}")
         }
     }
+}
+
+/// The message of the last `Panicked` exit published for `id`, after draining
+/// the lifecycle stream to closure.
+///
+/// Draining to closure rather than stopping at the first match is what the
+/// exit-scanning tests rely on: it proves the stream ends, and it keeps the
+/// *final* panic exit, so a child that produced more than one incarnation
+/// cannot pass by matching an earlier one. `None` means no such exit was
+/// published, or the last one carried no message.
+pub(crate) async fn last_panic_message(events: &mut LifecycleEvents, id: &str) -> Option<String> {
+    let drain = async {
+        let mut message = None;
+        while let Some(item) = events.recv().await {
+            let LifecycleItem::Event(event) = item else {
+                panic!("unexpected lifecycle lag marker while draining exits for {id}")
+            };
+            if let LifecycleEventKind::Exited {
+                id: exited, exit, ..
+            } = event.kind
+                && exited.as_str() == id
+                && let ExitKind::Panicked { message: panicked } = exit.kind()
+            {
+                message = panicked.clone();
+            }
+        }
+        message
+    };
+    tokio::time::timeout(super::POLL_TIMEOUT, drain)
+        .await
+        .expect("the lifecycle stream closes once the fixture has stopped")
 }

--- a/crates/shelterwood/tests/common/mod.rs
+++ b/crates/shelterwood/tests/common/mod.rs
@@ -12,7 +12,7 @@ mod timing;
 pub(crate) mod waiting;
 
 pub(crate) use gates::{DestructorBlocker, DestructorGate, ReleaseGate};
-pub(crate) use lifecycle::{next_event, next_item};
+pub(crate) use lifecycle::{last_panic_message, next_event, next_item};
 pub(crate) use ownership::{ConsumeCount, ConsumeGuard, LiveFlag, PanicOnDrop};
 pub(crate) use recorder::{GatedRecorder, MessageRecorder};
 pub(crate) use startup::startup_failed_child;

--- a/crates/shelterwood/tests/common/mod.rs
+++ b/crates/shelterwood/tests/common/mod.rs
@@ -3,13 +3,19 @@
 #![allow(dead_code, unused_imports, unused_macros)]
 
 mod gates;
+mod lifecycle;
 mod ownership;
 pub(crate) mod policy;
+mod recorder;
+mod startup;
 mod timing;
 pub(crate) mod waiting;
 
 pub(crate) use gates::{DestructorBlocker, DestructorGate, ReleaseGate};
+pub(crate) use lifecycle::{next_event, next_item};
 pub(crate) use ownership::{ConsumeCount, ConsumeGuard, LiveFlag, PanicOnDrop};
+pub(crate) use recorder::{GatedRecorder, MessageRecorder};
+pub(crate) use startup::startup_failed_child;
 pub(crate) use timing::{
     POLL_TIMEOUT, advance_time, assert_eventually_predicate, assert_quiet, poll_once, poll_until,
 };

--- a/crates/shelterwood/tests/common/recorder.rs
+++ b/crates/shelterwood/tests/common/recorder.rs
@@ -1,0 +1,47 @@
+use shelterwood::{ExitResult, MailboxShutdown, RawActor, RawContext};
+
+pub(crate) trait MessageRecorder: Send + 'static {
+    type Message: Send + 'static;
+
+    fn record(&mut self, message: Self::Message);
+}
+
+pub(crate) struct GatedRecorder<R> {
+    gate: Option<super::ReleaseGate>,
+    recorder: R,
+    drain: bool,
+}
+
+impl<R> GatedRecorder<R> {
+    pub(crate) fn new(gate: Option<super::ReleaseGate>, recorder: R) -> Self {
+        Self {
+            gate,
+            recorder,
+            drain: false,
+        }
+    }
+
+    pub(crate) fn drain_on_shutdown(mut self) -> Self {
+        self.drain = true;
+        self
+    }
+}
+
+impl<R: MessageRecorder> RawActor for GatedRecorder<R> {
+    type Msg = R::Message;
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        if let Some(gate) = self.gate.take() {
+            gate.wait().await;
+        }
+        while let Some(message) = context.recv().await {
+            self.recorder.record(message);
+        }
+        if self.drain && context.mailbox_shutdown() == MailboxShutdown::Drain {
+            while let Some(message) = context.try_recv() {
+                self.recorder.record(message);
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/shelterwood/tests/common/startup.rs
+++ b/crates/shelterwood/tests/common/startup.rs
@@ -1,0 +1,11 @@
+use shelterwood::{ChildId, Exit, StartupError, StartupFailureCause};
+
+pub(crate) fn startup_failed_child(error: StartupError) -> (ChildId, Exit) {
+    let StartupError::StartupFailed(failure) = error else {
+        panic!("expected structured startup failure, got {error:?}")
+    };
+    match failure.cause {
+        StartupFailureCause::Child { id, exit, .. } => (id, exit),
+        cause => panic!("expected child startup failure, got {cause:?}"),
+    }
+}

--- a/crates/shelterwood/tests/common/waiting.rs
+++ b/crates/shelterwood/tests/common/waiting.rs
@@ -55,6 +55,14 @@ pub(crate) fn signalled_waiting_task(
     })
 }
 
+pub(crate) fn start_signalled_waiting_task(started: Arc<AtomicBool>) -> TaskDef {
+    signalled_waiting_task(started, Arc::new(AtomicBool::new(false)))
+}
+
+pub(crate) fn cancellation_signalled_waiting_task(cancelled: Arc<AtomicBool>) -> TaskDef {
+    signalled_waiting_task(Arc::new(AtomicBool::new(false)), cancelled)
+}
+
 /// [`signalled_waiting_task`] plus a liveness probe.
 ///
 /// The task races its shutdown token against `liveness_gate` with a biased

--- a/crates/shelterwood/tests/common/waiting.rs
+++ b/crates/shelterwood/tests/common/waiting.rs
@@ -3,7 +3,9 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
-use shelterwood::{CancellationToken, Readiness, TaskDef, Tree};
+use shelterwood::{
+    CancellationToken, ExitResult, Readiness, TaskContext, TaskDef, TaskOnceDef, Tree,
+};
 
 pub(crate) async fn liveness_probe(shutdown: CancellationToken, gate: super::ReleaseGate) -> bool {
     tokio::select! {
@@ -39,20 +41,50 @@ pub(crate) fn task() -> TaskDef {
     })
 }
 
+/// The body every signalled waiting fixture shares.
+///
+/// `liveness`, when present, races the shutdown token against a release gate
+/// before the task parks, so a released gate proves the incarnation is still
+/// being polled rather than merely un-cancelled.
+async fn signalled_waiting_body(
+    context: TaskContext,
+    started: Arc<AtomicBool>,
+    cancelled: Arc<AtomicBool>,
+    liveness: Option<(super::ReleaseGate, Arc<AtomicBool>)>,
+) -> ExitResult {
+    started.store(true, Ordering::SeqCst);
+    if let Some((gate, seen)) = liveness {
+        if !liveness_probe(context.shutdown_token(), gate).await {
+            cancelled.store(true, Ordering::SeqCst);
+            return Ok(());
+        }
+        seen.store(true, Ordering::SeqCst);
+    }
+    context.shutdown_token().cancelled().await;
+    cancelled.store(true, Ordering::SeqCst);
+    Ok(())
+}
+
 pub(crate) fn signalled_waiting_task(
     started: Arc<AtomicBool>,
     cancelled: Arc<AtomicBool>,
 ) -> TaskDef {
     TaskDef::new(move |context| {
-        let started = Arc::clone(&started);
-        let cancelled = Arc::clone(&cancelled);
-        async move {
-            started.store(true, Ordering::SeqCst);
-            context.shutdown_token().cancelled().await;
-            cancelled.store(true, Ordering::SeqCst);
-            Ok(())
-        }
+        signalled_waiting_body(context, Arc::clone(&started), Arc::clone(&cancelled), None)
     })
+}
+
+/// [`signalled_waiting_task`] as a consuming one-shot definition.
+///
+/// One-shot is the child *kind*, not a detail: it has no restart edge and its
+/// completion claim is the caller's, which is what fixtures proving handle
+/// ownership depend on.
+pub(crate) fn signalled_waiting_once_task(
+    started: Arc<AtomicBool>,
+    cancelled: Arc<AtomicBool>,
+    liveness: Option<(super::ReleaseGate, Arc<AtomicBool>)>,
+) -> TaskOnceDef<()> {
+    TaskOnceDef::new(move |context| signalled_waiting_body(context, started, cancelled, liveness))
 }
 
 pub(crate) fn start_signalled_waiting_task(started: Arc<AtomicBool>) -> TaskDef {
@@ -61,6 +93,25 @@ pub(crate) fn start_signalled_waiting_task(started: Arc<AtomicBool>) -> TaskDef 
 
 pub(crate) fn cancellation_signalled_waiting_task(cancelled: Arc<AtomicBool>) -> TaskDef {
     signalled_waiting_task(Arc::new(AtomicBool::new(false)), cancelled)
+}
+
+/// A waiting task that signals `constructed` from its *factory*, not from the
+/// body.
+///
+/// [`signalled_waiting_task`] stores at the first poll of the task future,
+/// which is a later and scheduler-dependent moment: a caller that only knows
+/// the child was spawned cannot assert the flag without polling for it. The
+/// factory instead runs synchronously while the driver starts the child, so a
+/// caller that has observed startup advance past this child may assert the
+/// flag outright.
+pub(crate) fn construction_signalled_waiting_task(constructed: Arc<AtomicBool>) -> TaskDef {
+    TaskDef::new(move |context| {
+        constructed.store(true, Ordering::SeqCst);
+        async move {
+            context.shutdown_token().cancelled().await;
+            Ok(())
+        }
+    })
 }
 
 /// [`signalled_waiting_task`] plus a liveness probe.
@@ -77,21 +128,12 @@ pub(crate) fn liveness_probed_waiting_task(
     liveness_seen: Arc<AtomicBool>,
 ) -> TaskDef {
     TaskDef::new(move |context| {
-        let started = Arc::clone(&started);
-        let cancelled = Arc::clone(&cancelled);
-        let liveness_gate = liveness_gate.clone();
-        let liveness_seen = Arc::clone(&liveness_seen);
-        async move {
-            started.store(true, Ordering::SeqCst);
-            if !liveness_probe(context.shutdown_token(), liveness_gate).await {
-                cancelled.store(true, Ordering::SeqCst);
-                return Ok(());
-            }
-            liveness_seen.store(true, Ordering::SeqCst);
-            context.shutdown_token().cancelled().await;
-            cancelled.store(true, Ordering::SeqCst);
-            Ok(())
-        }
+        signalled_waiting_body(
+            context,
+            Arc::clone(&started),
+            Arc::clone(&cancelled),
+            Some((liveness_gate.clone(), Arc::clone(&liveness_seen))),
+        )
     })
 }
 

--- a/crates/shelterwood/tests/deadlines.rs
+++ b/crates/shelterwood/tests/deadlines.rs
@@ -10,13 +10,13 @@ use std::{
 };
 
 use crate::common::{
-    ReleaseGate, advance_time, assert_eventually, assert_quiet, poll_once,
-    waiting::task as waiting_task,
+    GatedRecorder, MessageRecorder, ReleaseGate, advance_time, assert_eventually, assert_quiet,
+    poll_once, waiting::task as waiting_task,
 };
 use shelterwood::{
-    Backoff, CallErrorKind, ChildState, ExitError, ExitResult, Jitter, Mailbox, RawActor,
-    RawContext, RawOnceDef, Readiness, ReadinessDeadline, Reply, ReplyError, RestartCondition,
-    RestartPolicy, SendErrorKind, Shutdown, TaskDef, Tree,
+    Backoff, CallErrorKind, ChildState, ExitError, ExitResult, Jitter, Mailbox, RawOnceDef,
+    Readiness, ReadinessDeadline, Reply, ReplyError, RestartCondition, RestartPolicy,
+    SendErrorKind, Shutdown, TaskDef, Tree,
 };
 
 #[derive(Debug)]
@@ -26,7 +26,6 @@ enum Message {
 }
 
 struct BoundaryActor {
-    gate: Option<ReleaseGate>,
     call_seen: Option<ReleaseGate>,
     values: Arc<Mutex<Vec<usize>>>,
     calls: Arc<AtomicUsize>,
@@ -42,34 +41,28 @@ impl Drop for DropFlag {
     }
 }
 
-impl RawActor for BoundaryActor {
-    type Msg = Message;
+impl MessageRecorder for BoundaryActor {
+    type Message = Message;
 
-    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
-        if let Some(gate) = self.gate.take() {
-            gate.wait().await;
-        }
-        while let Some(message) = context.recv().await {
-            match message {
-                Message::Value(value) => self
-                    .values
-                    .lock()
-                    .expect("values mutex poisoned")
-                    .push(value),
-                Message::Ask(reply) => {
-                    self.calls.fetch_add(1, Ordering::SeqCst);
-                    if let Some(call_seen) = &self.call_seen {
-                        call_seen.release();
-                    }
-                    if self.hold_reply {
-                        self.held = Some(reply);
-                    } else {
-                        reply.send(17);
-                    }
+    fn record(&mut self, message: Message) {
+        match message {
+            Message::Value(value) => self
+                .values
+                .lock()
+                .expect("values mutex poisoned")
+                .push(value),
+            Message::Ask(reply) => {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                if let Some(call_seen) = &self.call_seen {
+                    call_seen.release();
+                }
+                if self.hold_reply {
+                    self.held = Some(reply);
+                } else {
+                    reply.send(17);
                 }
             }
         }
-        Ok(())
     }
 }
 
@@ -78,15 +71,27 @@ fn boundary_actor(
     values: &Arc<Mutex<Vec<usize>>>,
     calls: &Arc<AtomicUsize>,
     hold_reply: bool,
-) -> BoundaryActor {
-    BoundaryActor {
+) -> GatedRecorder<BoundaryActor> {
+    boundary_actor_with_call_seen(gate, values, calls, hold_reply, None)
+}
+
+fn boundary_actor_with_call_seen(
+    gate: Option<ReleaseGate>,
+    values: &Arc<Mutex<Vec<usize>>>,
+    calls: &Arc<AtomicUsize>,
+    hold_reply: bool,
+    call_seen: Option<ReleaseGate>,
+) -> GatedRecorder<BoundaryActor> {
+    GatedRecorder::new(
         gate,
-        call_seen: None,
-        values: Arc::clone(values),
-        calls: Arc::clone(calls),
-        hold_reply,
-        held: None,
-    }
+        BoundaryActor {
+            call_seen,
+            values: Arc::clone(values),
+            calls: Arc::clone(calls),
+            hold_reply,
+            held: None,
+        },
+    )
 }
 
 #[tokio::test(start_paused = true)]
@@ -357,8 +362,13 @@ async fn call_uses_one_budget_across_acceptance_and_response() {
     let values = Arc::new(Mutex::new(Vec::new()));
     let calls = Arc::new(AtomicUsize::new(0));
     let mut tree = Tree::new();
-    let mut definition = boundary_actor(Some(gate.clone()), &values, &calls, true);
-    definition.call_seen = Some(call_seen.clone());
+    let definition = boundary_actor_with_call_seen(
+        Some(gate.clone()),
+        &values,
+        &calls,
+        true,
+        Some(call_seen.clone()),
+    );
     let actor = tree
         .add_raw_once(
             "one-budget",

--- a/crates/shelterwood/tests/delivery.rs
+++ b/crates/shelterwood/tests/delivery.rs
@@ -9,7 +9,7 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, assert_eventually, poll_once};
+use crate::common::{GatedRecorder, MessageRecorder, ReleaseGate, assert_eventually, poll_once};
 use shelterwood::{
     CallErrorKind, ExitError, ExitResult, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Reply,
     SendErrorKind, Shutdown, SubtreeOnceDef, Tree,
@@ -259,23 +259,27 @@ async fn queue_preserves_per_sender_fifo_under_interleaved_senders() {
 }
 
 struct CallRecorder {
-    gate: ReleaseGate,
     calls: Arc<AtomicUsize>,
 }
 
-impl RawActor for CallRecorder {
-    type Msg = CallMessage;
+impl MessageRecorder for CallRecorder {
+    type Message = CallMessage;
 
-    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
-        self.gate.wait().await;
-        while let Some(message) = context.recv().await {
-            if let CallMessage::Ask(reply) = message {
-                self.calls.fetch_add(1, Ordering::SeqCst);
-                reply.send(7);
-            }
+    fn record(&mut self, message: CallMessage) {
+        if let CallMessage::Ask(reply) = message {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            reply.send(7);
         }
-        Ok(())
     }
+}
+
+fn call_recorder(gate: ReleaseGate, calls: &Arc<AtomicUsize>) -> GatedRecorder<CallRecorder> {
+    GatedRecorder::new(
+        Some(gate),
+        CallRecorder {
+            calls: Arc::clone(calls),
+        },
+    )
 }
 
 #[tokio::test]
@@ -286,11 +290,7 @@ async fn latest_conflation_drops_replaced_call_and_keeps_newest_value() {
     let actor = tree
         .add_raw_once(
             "latest-call",
-            RawOnceDef::new(CallRecorder {
-                gate: gate.clone(),
-                calls: Arc::clone(&calls),
-            })
-            .mailbox(Mailbox::latest()),
+            RawOnceDef::new(call_recorder(gate.clone(), &calls)).mailbox(Mailbox::latest()),
         )
         .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
@@ -381,11 +381,8 @@ async fn call_cancellation_withdraws_before_acceptance_but_processes_after() {
         let actor = tree
             .add_raw_once(
                 "cancel-call",
-                RawOnceDef::new(CallRecorder {
-                    gate: gate.clone(),
-                    calls: Arc::clone(&calls),
-                })
-                .mailbox(Mailbox::queue(1).expect("non-zero capacity")),
+                RawOnceDef::new(call_recorder(gate.clone(), &calls))
+                    .mailbox(Mailbox::queue(1).expect("non-zero capacity")),
             )
             .expect("valid actor");
         let system = tree.spawn().expect("runtime is available");

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -14,13 +14,13 @@ use std::{
 
 use crate::common::{
     DestructorBlocker, DestructorGate, POLL_TIMEOUT, PanicOnDrop, ReleaseGate, assert_eventually,
-    policy::never, poll_once,
+    next_event, policy::never, poll_once,
 };
 use shelterwood::{
     Backoff, CallErrorKind, Cancellation, ChildState, DynamicTree, ExitError, ExitKind, ExitResult,
-    Jitter, LifecycleEventKind, LifecycleItem, Mailbox, RawActor, RawContext, RawDef, RawOnceDef,
-    Readiness, ReadinessDeadline, RemoveOutcome, Reply, ReserveError, RestartCondition,
-    RestartPolicy, ScopeState, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
+    Jitter, LifecycleEventKind, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
+    ReadinessDeadline, RemoveOutcome, Reply, ReserveError, RestartCondition, RestartPolicy,
+    ScopeState, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
 };
 
 struct DropProbe {
@@ -294,11 +294,7 @@ async fn panicking_unread_messages_are_all_disposed_without_reclassifying_the_ac
     )
     .await;
     let exit = loop {
-        let Some(item) = lifecycle.recv().await else {
-            panic!("actor exit was not published")
-        };
-        if let LifecycleItem::Event(event) = item
-            && let LifecycleEventKind::Exited { id, exit, .. } = event.kind
+        if let LifecycleEventKind::Exited { id, exit, .. } = next_event(&mut lifecycle).await.kind
             && id.as_str() == "unread"
         {
             break exit;
@@ -1602,11 +1598,7 @@ async fn blocking_offload_panic_remains_primary_over_factory_destructor_panic() 
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
 
     let exit = loop {
-        let Some(item) = lifecycle.recv().await else {
-            panic!("actor exit was not published")
-        };
-        if let LifecycleItem::Event(event) = item
-            && let LifecycleEventKind::Exited { id, exit, .. } = event.kind
+        if let LifecycleEventKind::Exited { id, exit, .. } = next_event(&mut lifecycle).await.kind
             && id.as_str() == "offload-precedence"
         {
             break exit;

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -8,11 +8,11 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, assert_eventually, assert_quiet, poll_until};
+use crate::common::{ReleaseGate, assert_eventually, assert_quiet, next_event, poll_until};
 use shelterwood::{
     Actor, ActorOnceDef, Cancellation, Context, Exit, ExitError, ExitKind, ExitResult, GracePhase,
-    LifecycleEventKind, LifecycleEvents, LifecycleItem, Mailbox, MailboxShutdown, SendErrorKind,
-    Shutdown, StopContext, Tree,
+    LifecycleEventKind, LifecycleEvents, Mailbox, MailboxShutdown, SendErrorKind, Shutdown,
+    StopContext, Tree,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -363,15 +363,13 @@ struct FaultOutcome {
 }
 
 async fn exited_actor(events: &mut LifecycleEvents) -> Exit {
-    while let Some(item) = events.recv().await {
-        if let LifecycleItem::Event(event) = item
-            && let LifecycleEventKind::Exited { id, exit, .. } = event.kind
+    loop {
+        if let LifecycleEventKind::Exited { id, exit, .. } = next_event(events).await.kind
             && id.as_str() == "actor"
         {
             return exit;
         }
     }
-    panic!("actor exit must precede lifecycle closure");
 }
 
 async fn run_fault_fixture(

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -13,8 +13,8 @@ use crate::common::{
     policy::never,
     poll_once,
     waiting::{
-        liveness_probe, liveness_probed_waiting_task, signalled_waiting_task, task as waiting_task,
-        tree as waiting_tree,
+        liveness_probe, liveness_probed_waiting_task, signalled_waiting_once_task,
+        signalled_waiting_task, task as waiting_task, tree as waiting_tree,
     },
 };
 use shelterwood::{
@@ -150,11 +150,13 @@ fn signalled_waiting_tree(
     liveness: Option<(ReleaseGate, Arc<AtomicBool>)>,
 ) -> Tree {
     let mut tree = Tree::new();
-    let task = match liveness {
-        Some((gate, observed)) => liveness_probed_waiting_task(started, cancelled, gate, observed),
-        None => signalled_waiting_task(started, cancelled),
-    };
-    tree.add_task("worker", task).expect("valid signalled task");
+    let (_, completion) = tree
+        .add_task_once(
+            "worker",
+            signalled_waiting_once_task(started, cancelled, liveness),
+        )
+        .expect("valid signalled task");
+    drop(completion);
     tree
 }
 

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -150,25 +150,11 @@ fn signalled_waiting_tree(
     liveness: Option<(ReleaseGate, Arc<AtomicBool>)>,
 ) -> Tree {
     let mut tree = Tree::new();
-    let (_, completion) = tree
-        .add_task_once(
-            "worker",
-            TaskOnceDef::new(move |context| async move {
-                started.store(true, Ordering::SeqCst);
-                if let Some((gate, observed)) = liveness {
-                    if !liveness_probe(context.shutdown_token(), gate).await {
-                        cancelled.store(true, Ordering::SeqCst);
-                        return Ok::<_, ExitError>(());
-                    }
-                    observed.store(true, Ordering::SeqCst);
-                }
-                context.shutdown_token().cancelled().await;
-                cancelled.store(true, Ordering::SeqCst);
-                Ok::<_, ExitError>(())
-            }),
-        )
-        .expect("valid signalled task");
-    drop(completion);
+    let task = match liveness {
+        Some((gate, observed)) => liveness_probed_waiting_task(started, cancelled, gate, observed),
+        None => signalled_waiting_task(started, cancelled),
+    };
+    tree.add_task("worker", task).expect("valid signalled task");
     tree
 }
 

--- a/crates/shelterwood/tests/lifecycle.rs
+++ b/crates/shelterwood/tests/lifecycle.rs
@@ -12,8 +12,10 @@ use std::{
 };
 
 use crate::common::{
-    POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet, policy::never, poll_once,
-    waiting::task as waiting_task,
+    POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet, next_event,
+    policy::never,
+    poll_once,
+    waiting::{cancellation_signalled_waiting_task, task as waiting_task},
 };
 use shelterwood::{
     Actor, ActorOnceDef, Cancellation, Context, DynamicTree, ExitError, ExitKind, ExitResult,
@@ -43,17 +45,7 @@ async fn non_owners_are_quiet_and_an_empty_root_needs_its_owner() {
     let task = tree
         .add_task(
             "worker",
-            TaskDef::new({
-                let cancelled = Arc::clone(&cancelled);
-                move |context| {
-                    let cancelled = Arc::clone(&cancelled);
-                    async move {
-                        context.shutdown_token().cancelled().await;
-                        cancelled.store(true, Ordering::SeqCst);
-                        Ok(())
-                    }
-                }
-            }),
+            cancellation_signalled_waiting_task(Arc::clone(&cancelled)),
         )
         .expect("valid task");
     let spare = task.clone();
@@ -444,17 +436,7 @@ async fn ordered_teardown_keeps_its_frontier_when_an_earlier_child_exits() {
     let mut tree = Tree::new();
     tree.add_task(
         "first",
-        TaskDef::new({
-            let first_stopping = Arc::clone(&first_stopping);
-            move |context| {
-                let first_stopping = Arc::clone(&first_stopping);
-                async move {
-                    context.shutdown_token().cancelled().await;
-                    first_stopping.store(true, Ordering::SeqCst);
-                    Ok(())
-                }
-            }
-        }),
+        cancellation_signalled_waiting_task(Arc::clone(&first_stopping)),
     )
     .expect("valid first task");
     let middle = tree
@@ -583,13 +565,7 @@ async fn concurrent_initial_failures_publish_one_startup_failed_scope_edge() {
     let mut exits = 0;
     let mut startup_failed_edges = 0;
     while exits < 2 {
-        let item = tokio::time::timeout(Duration::from_secs(2), lifecycle.recv())
-            .await
-            .expect("both concurrent exits are bounded")
-            .expect("the root lifecycle remains open");
-        let LifecycleItem::Event(event) = item else {
-            panic!("the small fixture cannot lag");
-        };
+        let event = next_event(&mut lifecycle).await;
         match event.kind {
             LifecycleEventKind::Exited { .. } => exits += 1,
             LifecycleEventKind::ScopeState {
@@ -599,14 +575,17 @@ async fn concurrent_initial_failures_publish_one_startup_failed_scope_edge() {
         }
     }
     while let Ok(item) = lifecycle.try_recv() {
+        let LifecycleItem::Event(event) = item else {
+            panic!("unexpected lifecycle lag while draining the startup trace")
+        };
         if matches!(
-            item,
-            LifecycleItem::Event(shelterwood::LifecycleEvent {
+            event,
+            shelterwood::LifecycleEvent {
                 kind: LifecycleEventKind::ScopeState {
                     state: ScopeState::StartupFailed,
                 },
                 ..
-            })
+            }
         ) {
             startup_failed_edges += 1;
         }
@@ -662,26 +641,14 @@ async fn plain_restart_publishes_exited_old_before_started_new() {
     fail_first.release();
 
     loop {
-        let item = tokio::time::timeout(POLL_TIMEOUT, lifecycle.recv())
-            .await
-            .expect("restart lifecycle is bounded")
-            .expect("lifecycle stream remains open");
-        let LifecycleItem::Event(event) = item else {
-            panic!("small restart fixture must not lag");
-        };
+        let event = next_event(&mut lifecycle).await;
         match event.kind {
             LifecycleEventKind::Exited { incarnation, .. } if incarnation == first => break,
             _ => {}
         }
     }
     let second = loop {
-        let item = tokio::time::timeout(POLL_TIMEOUT, lifecycle.recv())
-            .await
-            .expect("replacement lifecycle is bounded")
-            .expect("lifecycle stream remains open");
-        let LifecycleItem::Event(event) = item else {
-            panic!("small restart fixture must not lag");
-        };
+        let event = next_event(&mut lifecycle).await;
         if let LifecycleEventKind::Started { incarnation, .. } = event.kind
             && incarnation.supersedes(first)
         {

--- a/crates/shelterwood/tests/mailbox.rs
+++ b/crates/shelterwood/tests/mailbox.rs
@@ -9,10 +9,12 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, advance_time, assert_eventually, assert_quiet, poll_once};
+use crate::common::{
+    GatedRecorder, MessageRecorder, ReleaseGate, advance_time, assert_eventually, assert_quiet,
+    poll_once,
+};
 use shelterwood::{
-    CallErrorKind, ExitResult, Mailbox, MailboxShutdown, PolicyError, RawActor, RawContext, RawDef,
-    Reply, ReplyError, SendErrorKind, Tree,
+    CallErrorKind, Mailbox, PolicyError, RawDef, Reply, ReplyError, SendErrorKind, Tree,
 };
 
 #[test]
@@ -53,15 +55,16 @@ impl Drop for CountedReplyDrop {
 }
 
 struct Recorder {
-    gate: Option<ReleaseGate>,
     values: Arc<Mutex<Vec<usize>>>,
     asks: Arc<AtomicUsize>,
     reply_mode: ReplyMode,
     held: Option<Reply<usize>>,
 }
 
-impl Recorder {
-    fn handle(&mut self, message: Message) {
+impl MessageRecorder for Recorder {
+    type Message = Message;
+
+    fn record(&mut self, message: Message) {
         match message {
             Message::Value(value) => self
                 .values
@@ -80,38 +83,22 @@ impl Recorder {
     }
 }
 
-impl RawActor for Recorder {
-    type Msg = Message;
-
-    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
-        if let Some(gate) = self.gate.take() {
-            gate.wait().await;
-        }
-        while let Some(message) = context.recv().await {
-            self.handle(message);
-        }
-        if context.mailbox_shutdown() == MailboxShutdown::Drain {
-            while let Some(message) = context.try_recv() {
-                self.handle(message);
-            }
-        }
-        Ok(())
-    }
-}
-
 fn recorder(
     gate: Option<ReleaseGate>,
     values: &Arc<Mutex<Vec<usize>>>,
     asks: &Arc<AtomicUsize>,
     reply_mode: ReplyMode,
-) -> Recorder {
-    Recorder {
+) -> GatedRecorder<Recorder> {
+    GatedRecorder::new(
         gate,
-        values: Arc::clone(values),
-        asks: Arc::clone(asks),
-        reply_mode,
-        held: None,
-    }
+        Recorder {
+            values: Arc::clone(values),
+            asks: Arc::clone(asks),
+            reply_mode,
+            held: None,
+        },
+    )
+    .drain_on_shutdown()
 }
 
 #[tokio::test(start_paused = true)]

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use crate::common::{
-    POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet, poll_once,
+    POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet, next_event, next_item, poll_once,
     waiting::{gate_released_manual_ready_task, task as waiting_task, tree as waiting_tree},
 };
 use shelterwood::{
@@ -20,20 +20,6 @@ use shelterwood::{
     RestartPolicy, Retention, ScopeFlavor, ScopeRef, ScopeState, StopReason, Strategy, SubtreeDef,
     SubtreeOnceDef, TaskDef, TaskOnceDef, TaskRef, TotalRestarts, Tree, WaitError,
 };
-
-async fn next_item(events: &mut LifecycleEvents) -> LifecycleItem {
-    tokio::time::timeout(Duration::from_secs(2), events.recv())
-        .await
-        .expect("lifecycle receive is bounded")
-        .expect("lifecycle stream remains open")
-}
-
-async fn next_event(events: &mut LifecycleEvents) -> LifecycleEvent {
-    match next_item(events).await {
-        LifecycleItem::Event(event) => event,
-        LifecycleItem::Lagged { dropped } => panic!("unexpected lag marker dropping {dropped}"),
-    }
-}
 
 fn event_watermark(scope: &ScopeRef, event: &LifecycleEvent) -> Option<LifecycleSeq> {
     let snapshot = scope.snapshot();

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -8,12 +8,13 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{POLL_TIMEOUT, PanicOnDrop, ReleaseGate, assert_eventually, assert_quiet};
+use crate::common::{
+    POLL_TIMEOUT, PanicOnDrop, ReleaseGate, assert_eventually, assert_quiet, next_event,
+};
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
-    Guard, Handler, LifecycleEventKind, LifecycleItem, Mailbox, MailboxShutdown, RawActor,
-    RawContext, RawOnceDef, Readiness, Shutdown, StartupError, StartupFailureCause, StopContext,
-    Tree,
+    Guard, Handler, LifecycleEventKind, Mailbox, MailboxShutdown, RawActor, RawContext, RawOnceDef,
+    Readiness, Shutdown, StartupError, StartupFailureCause, StopContext, Tree,
 };
 
 enum ZeroMessage {
@@ -1037,10 +1038,7 @@ async fn cancellation_destructor_panic_wakes_an_otherwise_idle_actor() {
 
     let exit = tokio::time::timeout(POLL_TIMEOUT, async {
         loop {
-            let item = events.recv().await.expect("lifecycle remains open");
-            let LifecycleItem::Event(event) = item else {
-                panic!("small fixture must not lag");
-            };
+            let event = next_event(&mut events).await;
             if let LifecycleEventKind::Exited { id, exit, .. } = event.kind
                 && id.as_str() == "idle-offload"
             {
@@ -1583,18 +1581,15 @@ async fn externally_stopped_recv_resumes_a_pending_offload_panic() {
         .await
         .expect("failed actor shuts down");
 
-    let mut panic_message = None;
-    while let Some(item) = events.recv().await {
-        let LifecycleItem::Event(event) = item else {
-            panic!("small fixture must not lag");
-        };
+    let panic_message = loop {
+        let event = next_event(&mut events).await;
         if let LifecycleEventKind::Exited { id, exit, .. } = event.kind
             && id.as_str() == "external-stop-recv-panic"
             && let ExitKind::Panicked { message } = exit.kind()
         {
-            panic_message = message.clone();
+            break message.clone();
         }
-    }
+    };
     assert_eq!(
         panic_message.as_deref(),
         Some("external-stop recv offload panic")
@@ -1818,18 +1813,15 @@ async fn queued_offload_panic_survives_hard_abort() {
         .await
         .expect("hard abort bounds shutdown");
 
-    let mut panic_message = None;
-    while let Some(item) = events.recv().await {
-        let LifecycleItem::Event(event) = item else {
-            panic!("small fixture must not lag");
-        };
+    let panic_message = loop {
+        let event = next_event(&mut events).await;
         if let LifecycleEventKind::Exited { id, exit, .. } = event.kind
             && id.as_str() == "panic"
             && let ExitKind::Panicked { message } = exit.kind()
         {
-            panic_message = message.clone();
+            break message.clone();
         }
-    }
+    };
     assert_eq!(panic_message.as_deref(), Some("owned offload panic"));
 }
 
@@ -1892,18 +1884,15 @@ async fn hard_abort_preserves_owned_offload_panic_over_handler_destructor() {
         .await
         .expect("the two panics remain contained");
 
-    let mut panic_message = None;
-    while let Some(item) = events.recv().await {
-        let LifecycleItem::Event(event) = item else {
-            panic!("small fixture must not lag");
-        };
+    let panic_message = loop {
+        let event = next_event(&mut events).await;
         if let LifecycleEventKind::Exited { id, exit, .. } = event.kind
             && id.as_str() == "handler-double-panic"
             && let ExitKind::Panicked { message } = exit.kind()
         {
-            panic_message = message.clone();
+            break message.clone();
         }
-    }
+    };
     assert_eq!(
         panic_message.as_deref(),
         Some("handler owned offload panic")

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -9,7 +9,8 @@ use std::{
 };
 
 use crate::common::{
-    POLL_TIMEOUT, PanicOnDrop, ReleaseGate, assert_eventually, assert_quiet, next_event,
+    POLL_TIMEOUT, PanicOnDrop, ReleaseGate, assert_eventually, assert_quiet, last_panic_message,
+    next_event,
 };
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
@@ -1581,15 +1582,7 @@ async fn externally_stopped_recv_resumes_a_pending_offload_panic() {
         .await
         .expect("failed actor shuts down");
 
-    let panic_message = loop {
-        let event = next_event(&mut events).await;
-        if let LifecycleEventKind::Exited { id, exit, .. } = event.kind
-            && id.as_str() == "external-stop-recv-panic"
-            && let ExitKind::Panicked { message } = exit.kind()
-        {
-            break message.clone();
-        }
-    };
+    let panic_message = last_panic_message(&mut events, "external-stop-recv-panic").await;
     assert_eq!(
         panic_message.as_deref(),
         Some("external-stop recv offload panic")
@@ -1813,15 +1806,7 @@ async fn queued_offload_panic_survives_hard_abort() {
         .await
         .expect("hard abort bounds shutdown");
 
-    let panic_message = loop {
-        let event = next_event(&mut events).await;
-        if let LifecycleEventKind::Exited { id, exit, .. } = event.kind
-            && id.as_str() == "panic"
-            && let ExitKind::Panicked { message } = exit.kind()
-        {
-            break message.clone();
-        }
-    };
+    let panic_message = last_panic_message(&mut events, "panic").await;
     assert_eq!(panic_message.as_deref(), Some("owned offload panic"));
 }
 
@@ -1884,15 +1869,7 @@ async fn hard_abort_preserves_owned_offload_panic_over_handler_destructor() {
         .await
         .expect("the two panics remain contained");
 
-    let panic_message = loop {
-        let event = next_event(&mut events).await;
-        if let LifecycleEventKind::Exited { id, exit, .. } = event.kind
-            && id.as_str() == "handler-double-panic"
-            && let ExitKind::Panicked { message } = exit.kind()
-        {
-            break message.clone();
-        }
-    };
+    let panic_message = last_panic_message(&mut events, "handler-double-panic").await;
     assert_eq!(
         panic_message.as_deref(),
         Some("handler owned offload panic")

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -8,7 +8,9 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, assert_eventually, assert_quiet, waiting::task as waiting_task};
+use crate::common::{
+    ReleaseGate, assert_eventually, assert_quiet, next_event, waiting::task as waiting_task,
+};
 use shelterwood::{
     DynamicTree, ExitError, ExitResult, Mailbox, MailboxShutdown, PolicyError, RawActor,
     RawContext, RawDef, RawOnceDef, Readiness, ReadinessDeadline, RemoveOutcome, ScopeDefaults,
@@ -430,17 +432,14 @@ async fn live_try_recv_resumes_a_retained_offload_panic() {
     system.wait_started().await.expect("manual readiness fires");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
 
-    let mut observed_exit = None;
-    while let Some(item) = events.recv().await {
-        let shelterwood::LifecycleItem::Event(event) = item else {
-            panic!("small fixture must not lag");
-        };
+    let observed_exit = loop {
+        let event = next_event(&mut events).await;
         if let shelterwood::LifecycleEventKind::Exited { id, exit, .. } = event.kind
             && id.as_str() == "try-recv-panic"
         {
-            observed_exit = Some(exit);
+            break Some(exit);
         }
-    }
+    };
     let exit = observed_exit.expect("panic exit is observable on the lifecycle stream");
     assert!(matches!(
         exit.kind(),
@@ -658,18 +657,15 @@ async fn hard_abort_offload_panic_with_panicking_raw_destructor_is_contained() {
         .await
         .expect("the two panics remain contained");
 
-    let mut panic_message = None;
-    while let Some(item) = events.recv().await {
-        let shelterwood::LifecycleItem::Event(event) = item else {
-            panic!("small fixture must not lag");
-        };
+    let panic_message = loop {
+        let event = next_event(&mut events).await;
         if let shelterwood::LifecycleEventKind::Exited { id, exit, .. } = event.kind
             && id.as_str() == "double-panic"
             && let shelterwood::ExitKind::Panicked { message } = exit.kind()
         {
-            panic_message = message.clone();
+            break message.clone();
         }
-    }
+    };
     assert_eq!(panic_message.as_deref(), Some("injected offload panic"));
 }
 

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use crate::common::{
-    ReleaseGate, assert_eventually, assert_quiet, next_event, waiting::task as waiting_task,
+    ReleaseGate, assert_eventually, assert_quiet, last_panic_message, waiting::task as waiting_task,
 };
 use shelterwood::{
     DynamicTree, ExitError, ExitResult, Mailbox, MailboxShutdown, PolicyError, RawActor,
@@ -432,20 +432,12 @@ async fn live_try_recv_resumes_a_retained_offload_panic() {
     system.wait_started().await.expect("manual readiness fires");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
 
-    let observed_exit = loop {
-        let event = next_event(&mut events).await;
-        if let shelterwood::LifecycleEventKind::Exited { id, exit, .. } = event.kind
-            && id.as_str() == "try-recv-panic"
-        {
-            break Some(exit);
-        }
-    };
-    let exit = observed_exit.expect("panic exit is observable on the lifecycle stream");
-    assert!(matches!(
-        exit.kind(),
-        shelterwood::ExitKind::Panicked { message }
-            if message.as_deref() == Some("try_recv retained offload panic")
-    ));
+    let panic_message = last_panic_message(&mut events, "try-recv-panic").await;
+    assert_eq!(
+        panic_message.as_deref(),
+        Some("try_recv retained offload panic"),
+        "the panic exit is observable on the lifecycle stream"
+    );
     assert!(panic_queued.load(Ordering::SeqCst));
 }
 
@@ -657,15 +649,7 @@ async fn hard_abort_offload_panic_with_panicking_raw_destructor_is_contained() {
         .await
         .expect("the two panics remain contained");
 
-    let panic_message = loop {
-        let event = next_event(&mut events).await;
-        if let shelterwood::LifecycleEventKind::Exited { id, exit, .. } = event.kind
-            && id.as_str() == "double-panic"
-            && let shelterwood::ExitKind::Panicked { message } = exit.kind()
-        {
-            break message.clone();
-        }
-    };
+    let panic_message = last_panic_message(&mut events, "double-panic").await;
     assert_eq!(panic_message.as_deref(), Some("injected offload panic"));
 }
 

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -12,8 +12,9 @@ use crate::common::{
     POLL_TIMEOUT, ReleaseGate, advance_time, assert_eventually, assert_quiet,
     policy::never,
     waiting::{
-        cancellation_signalled_waiting_task, gate_released_manual_ready_task,
-        signalled_waiting_task, start_signalled_waiting_task, task as waiting_task,
+        cancellation_signalled_waiting_task, construction_signalled_waiting_task,
+        gate_released_manual_ready_task, signalled_waiting_task, start_signalled_waiting_task,
+        task as waiting_task,
     },
 };
 use shelterwood::{
@@ -1284,7 +1285,7 @@ async fn immediate_raw_construction_panic_classifies_post_ready() {
     .expect("valid raw actor");
     tree.add_task(
         "sibling",
-        start_signalled_waiting_task(Arc::clone(&sibling_started)),
+        construction_signalled_waiting_task(Arc::clone(&sibling_started)),
     )
     .expect("valid sibling");
 

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -11,7 +11,10 @@ use std::{
 use crate::common::{
     POLL_TIMEOUT, ReleaseGate, advance_time, assert_eventually, assert_quiet,
     policy::never,
-    waiting::{gate_released_manual_ready_task, task as waiting_task},
+    waiting::{
+        cancellation_signalled_waiting_task, gate_released_manual_ready_task,
+        signalled_waiting_task, start_signalled_waiting_task, task as waiting_task,
+    },
 };
 use shelterwood::{
     Actor, ActorOnceDef, Backoff, Cancellation, ChildState, Context, DynamicTree, ExitError,
@@ -511,17 +514,7 @@ async fn ordered_terminal_pre_ready_exit_parks_the_root_and_marks_suffix_never_s
     let mut tree = Tree::new();
     tree.add_task(
         "prefix",
-        TaskDef::new({
-            let prefix_cancelled = Arc::clone(&prefix_cancelled);
-            move |context| {
-                let prefix_cancelled = Arc::clone(&prefix_cancelled);
-                async move {
-                    context.shutdown_token().cancelled().await;
-                    prefix_cancelled.store(true, Ordering::SeqCst);
-                    Ok(())
-                }
-            }
-        }),
+        cancellation_signalled_waiting_task(Arc::clone(&prefix_cancelled)),
     )
     .expect("valid prefix");
     tree.add_task(
@@ -578,23 +571,10 @@ async fn dynamic_startup_failure_keeps_other_initial_members_supervised() {
     .expect("valid failing task");
     tree.add_task(
         "sibling",
-        TaskDef::new({
-            let sibling_cancelled = Arc::clone(&sibling_cancelled);
-            let sibling_started = Arc::clone(&sibling_started);
-            move |context| {
-                let sibling_cancelled = Arc::clone(&sibling_cancelled);
-                let sibling_started = Arc::clone(&sibling_started);
-                async move {
-                    sibling_started.store(true, Ordering::SeqCst);
-                    context.shutdown_token().cancelled().await;
-                    sibling_cancelled.store(true, Ordering::SeqCst);
-                    Ok(())
-                }
-            }
-        })
-        .readiness(Readiness::Manual)
-        .expect("manual readiness")
-        .readiness_deadline(ReadinessDeadline::Unbounded),
+        signalled_waiting_task(Arc::clone(&sibling_started), Arc::clone(&sibling_cancelled))
+            .readiness(Readiness::Manual)
+            .expect("manual readiness")
+            .readiness_deadline(ReadinessDeadline::Unbounded),
     )
     .expect("valid sibling");
     let system = tree.spawn().expect("runtime is available");
@@ -822,20 +802,10 @@ async fn runtime_dynamic_additions_never_join_aggregate_readiness() {
     let runtime_task = scope
         .add_task(
             "runtime",
-            TaskDef::new({
-                let runtime_started = Arc::clone(&runtime_started);
-                move |context| {
-                    let runtime_started = Arc::clone(&runtime_started);
-                    async move {
-                        runtime_started.store(true, Ordering::SeqCst);
-                        context.shutdown_token().cancelled().await;
-                        Ok(())
-                    }
-                }
-            })
-            .readiness(Readiness::Manual)
-            .expect("manual readiness")
-            .readiness_deadline(ReadinessDeadline::Unbounded),
+            start_signalled_waiting_task(Arc::clone(&runtime_started))
+                .readiness(Readiness::Manual)
+                .expect("manual readiness")
+                .readiness_deadline(ReadinessDeadline::Unbounded),
         )
         .await
         .expect("runtime member is admitted");
@@ -875,20 +845,10 @@ async fn nested_dynamic_startup_failure_rolls_back_and_preserves_inner_cause() {
     nested
         .add_task(
             "inner-sibling",
-            TaskDef::new({
-                let sibling_cancelled = Arc::clone(&sibling_cancelled);
-                move |context| {
-                    let sibling_cancelled = Arc::clone(&sibling_cancelled);
-                    async move {
-                        context.shutdown_token().cancelled().await;
-                        sibling_cancelled.store(true, Ordering::SeqCst);
-                        Ok(())
-                    }
-                }
-            })
-            .readiness(Readiness::Manual)
-            .expect("manual readiness")
-            .readiness_deadline(ReadinessDeadline::Unbounded),
+            cancellation_signalled_waiting_task(Arc::clone(&sibling_cancelled))
+                .readiness(Readiness::Manual)
+                .expect("manual readiness")
+                .readiness_deadline(ReadinessDeadline::Unbounded),
         )
         .expect("valid sibling");
 
@@ -961,17 +921,7 @@ async fn nested_ordered_startup_failure_rolls_back_only_the_started_prefix() {
     nested
         .add_task(
             "prefix",
-            TaskDef::new({
-                let prefix_cancelled = Arc::clone(&prefix_cancelled);
-                move |context| {
-                    let prefix_cancelled = Arc::clone(&prefix_cancelled);
-                    async move {
-                        context.shutdown_token().cancelled().await;
-                        prefix_cancelled.store(true, Ordering::SeqCst);
-                        Ok(())
-                    }
-                }
-            }),
+            cancellation_signalled_waiting_task(Arc::clone(&prefix_cancelled)),
         )
         .expect("valid prefix");
     nested
@@ -1100,17 +1050,7 @@ async fn start_or_shutdown_preserves_startup_error_and_rolls_back_the_prefix() {
     let mut tree = Tree::new();
     tree.add_task(
         "prefix",
-        TaskDef::new({
-            let prefix_cancelled = Arc::clone(&prefix_cancelled);
-            move |context| {
-                let prefix_cancelled = Arc::clone(&prefix_cancelled);
-                async move {
-                    context.shutdown_token().cancelled().await;
-                    prefix_cancelled.store(true, Ordering::SeqCst);
-                    Ok(())
-                }
-            }
-        }),
+        cancellation_signalled_waiting_task(Arc::clone(&prefix_cancelled)),
     )
     .expect("valid prefix");
     tree.add_task(
@@ -1344,16 +1284,7 @@ async fn immediate_raw_construction_panic_classifies_post_ready() {
     .expect("valid raw actor");
     tree.add_task(
         "sibling",
-        TaskDef::new({
-            let sibling_started = Arc::clone(&sibling_started);
-            move |context| {
-                sibling_started.store(true, Ordering::SeqCst);
-                async move {
-                    context.shutdown_token().cancelled().await;
-                    Ok(())
-                }
-            }
-        }),
+        start_signalled_waiting_task(Arc::clone(&sibling_started)),
     )
     .expect("valid sibling");
 

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -10,8 +10,8 @@ use std::{
 };
 
 use crate::common::{
-    POLL_TIMEOUT, ReleaseGate, advance_time, assert_eventually, assert_quiet, poll_once,
-    poll_until, waiting::task as waiting_task,
+    ReleaseGate, advance_time, assert_eventually, assert_quiet, next_event, poll_once, poll_until,
+    startup_failed_child, waiting::task as waiting_task,
 };
 use shelterwood::{
     Actor, ActorOnceDef, Backoff, Cancellation, ChildState, Context, DefaultsInheritance,
@@ -109,16 +109,12 @@ async fn one_shot_subtree_lowering_failure_retains_structured_provenance() {
     root.add_subtree_once("nested", SubtreeOnceDef::new(nested))
         .expect("valid subtree edge");
     let system = root.spawn().expect("runtime is available");
-    let StartupError::StartupFailed(failure) = system
-        .wait_started()
-        .await
-        .expect_err("nested lowering fails")
-    else {
-        panic!("expected structured startup failure");
-    };
-    let StartupFailureCause::Child { id, exit, .. } = failure.cause else {
-        panic!("root failure must name its nested child");
-    };
+    let (id, exit) = startup_failed_child(
+        system
+            .wait_started()
+            .await
+            .expect_err("nested lowering fails"),
+    );
     assert_eq!(id.as_str(), "nested");
     let ExitKind::Failed(error) = exit.kind() else {
         panic!("nested lowering is a child failure");
@@ -156,16 +152,12 @@ async fn subtree_intensity_trip_retains_structured_provenance() {
     root.add_subtree_once("nested", SubtreeOnceDef::new(nested))
         .expect("valid subtree edge");
     let system = root.spawn().expect("runtime is available");
-    let StartupError::StartupFailed(failure) = system
-        .wait_started()
-        .await
-        .expect_err("nested budget trips during startup")
-    else {
-        panic!("expected structured startup failure");
-    };
-    let StartupFailureCause::Child { id, exit, .. } = failure.cause else {
-        panic!("root failure must name its nested child");
-    };
+    let (id, exit) = startup_failed_child(
+        system
+            .wait_started()
+            .await
+            .expect_err("nested budget trips during startup"),
+    );
     assert_eq!(id.as_str(), "nested");
     let ExitKind::Failed(error) = exit.kind() else {
         panic!("a tripped subtree is a child failure");
@@ -231,13 +223,7 @@ async fn over_budget_restart_is_charged_but_never_spawned() {
     let mut trace = Vec::new();
     let mut scheduled = 0usize;
     loop {
-        let item = tokio::time::timeout(POLL_TIMEOUT, events.recv())
-            .await
-            .expect("the next lifecycle event arrives promptly")
-            .expect("the lifecycle stream remains open through scope failure");
-        let LifecycleItem::Event(event) = item else {
-            panic!("the short restart trace cannot lag");
-        };
+        let event = next_event(&mut events).await;
         match event.kind {
             LifecycleEventKind::Exited { .. } => trace.push("exited"),
             LifecycleEventKind::RestartScheduled { attempt, .. } => {
@@ -783,12 +769,7 @@ async fn locally_requested_subtree_shutdown_reads_cancelled() {
         .wait_started()
         .await
         .expect_err("the nested self-shutdown aborts parent startup pre-ready");
-    let StartupError::StartupFailed(failure) = startup else {
-        panic!("unexpected startup error: {startup:?}");
-    };
-    let StartupFailureCause::Child { id, exit, .. } = &failure.cause else {
-        panic!("unexpected failure cause: {:?}", failure.cause);
-    };
+    let (id, exit) = startup_failed_child(startup);
     assert_eq!(id.as_str(), "nested");
     assert!(matches!(exit.kind(), ExitKind::Completed));
     assert_eq!(
@@ -818,12 +799,7 @@ async fn shutdown_latched_before_a_subtree_lowering_failure_reads_cancelled() {
         .wait_started()
         .await
         .expect_err("the nested stop aborts parent startup pre-ready");
-    let StartupError::StartupFailed(failure) = startup else {
-        panic!("unexpected startup error: {startup:?}");
-    };
-    let StartupFailureCause::Child { id, exit, .. } = &failure.cause else {
-        panic!("unexpected failure cause: {:?}", failure.cause);
-    };
+    let (id, exit) = startup_failed_child(startup);
     assert_eq!(id.as_str(), "nested");
     assert!(
         matches!(exit.kind(), ExitKind::Completed),

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -2,7 +2,7 @@ mod common;
 
 use std::time::Duration;
 
-use crate::common::LiveFlag;
+use crate::common::{LiveFlag, assert_eventually};
 use shelterwood::{
     BuildError, Cancellation, DynamicTree, Exit, ExitError, ExitKind, GracePhase, PolicyError,
     Readiness, ReadinessDeadline, RemoveOutcome, ReserveError, Shutdown, StopReason, TaskDef,
@@ -325,13 +325,7 @@ async fn dropping_the_owner_requests_cooperative_shutdown() {
     assert_eq!(exit.cancellation(), Cancellation::Observed);
     assert!(matches!(exit.kind(), ExitKind::Completed));
     assert_eq!(completion.wait().await, Ok(()));
-    tokio::time::timeout(Duration::from_secs(1), async {
-        while live.is_live() {
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("task future dropped");
+    assert_eventually!(|| !live.is_live(), "task future dropped").await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
Part of #282 and the #284 test-debt sequence.

## What changed

- Adds shared gated recorders, lifecycle receive helpers, and startup-child exit extraction.
- Reuses signalled waiting helpers across readiness, lifecycle, and dynamic tests.
- Unifies unexpected lifecycle-lag handling.
- Replaces the remaining polling-style task wait with `assert_eventually!`.

Net change: 114 lines removed across the affected integration fixtures.

Validation: 251 affected integration tests passed; the stacked branch passed full serial `just ci`, and the final combined #282 stack passes ordinary `./tools/dev just ci` with 674/674 tests.

Stack: based on the driver-fixture PR.