### PR TITLE
Consolidate library test fixtures

### DIFF
--- a/crates/shelterwood-core/src/deadline.rs
+++ b/crates/shelterwood-core/src/deadline.rs
@@ -130,6 +130,8 @@ impl Deadline {
 mod tests {
     use std::time::{Duration, Instant};
 
+    use crate::test_support::latest_representable;
+
     use super::{Deadline, DeadlineBudget};
 
     #[test]
@@ -141,21 +143,6 @@ mod tests {
             expires.is_due(started_at),
             "the poll-once surfaces read their zero budget through this rule"
         );
-    }
-
-    fn latest_representable(started_at: Instant) -> Instant {
-        let mut low = Duration::ZERO;
-        let mut high = Duration::MAX;
-        assert!(started_at.checked_add(high).is_none());
-        while high - low > Duration::from_nanos(1) {
-            let mid = low + (high - low) / 2;
-            if started_at.checked_add(mid).is_some() {
-                low = mid;
-            } else {
-                high = mid;
-            }
-        }
-        started_at + low
     }
 
     #[test]

--- a/crates/shelterwood-core/src/lib.rs
+++ b/crates/shelterwood-core/src/lib.rs
@@ -14,6 +14,8 @@ pub mod identity;
 pub mod panic;
 pub mod policy;
 pub mod supervisor;
+#[cfg(any(test, feature = "test-util"))]
+pub mod test_support;
 
 pub use deadline::*;
 pub use engine::{MembershipStatus, ScopeState};

--- a/crates/shelterwood-core/src/test_support.rs
+++ b/crates/shelterwood-core/src/test_support.rs
@@ -1,0 +1,17 @@
+use std::time::{Duration, Instant};
+
+/// Returns the latest instant in the platform clock's representable range.
+pub fn latest_representable(started_at: Instant) -> Instant {
+    let mut low = Duration::ZERO;
+    let mut high = Duration::MAX;
+    assert!(started_at.checked_add(high).is_none());
+    while high - low > Duration::from_nanos(1) {
+        let mid = low + (high - low) / 2;
+        if started_at.checked_add(mid).is_some() {
+            low = mid;
+        } else {
+            high = mid;
+        }
+    }
+    started_at + low
+}

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -1437,8 +1437,8 @@ pub(super) mod tests {
 
     use crate::{
         ActorIdentity, ActorRef, ChildId, MailboxControl, MailboxReceiver, SendErrorKind,
-        identity::ScopeIdentity,
         policy::{ResolvedDefaults, ResolvedMailbox},
+        test_support::{mint_actor_incarnation, mint_actor_membership},
     };
 
     use super::MailboxCell;
@@ -1597,15 +1597,11 @@ pub(super) mod tests {
     }
 
     pub(crate) fn actor_for<M: Send + 'static>() -> (Arc<MailboxCell<M>>, ActorRef<M>) {
-        let mut identity = ScopeIdentity::new();
         let id = ChildId::from("actor");
+        let (membership, _) = mint_actor_membership();
         let member = Arc::new(TestIdentity {
             id: id.clone(),
-            membership: identity
-                .mint_membership(&id)
-                .expect("membership available")
-                .into_pair()
-                .0,
+            membership,
         });
         let mailbox = MailboxCell::new(id, crate::capability::tests::runtime());
         (
@@ -1627,12 +1623,7 @@ pub(super) mod tests {
     #[should_panic(expected = "mailbox must be configured before its first bind")]
     fn binding_before_configuration_trips_the_driver_contract() {
         let (mailbox, _) = actor();
-        let mut identity = ScopeIdentity::new();
-        let (_, mut incarnations) = identity
-            .mint_membership(&ChildId::from("actor"))
-            .expect("membership available")
-            .into_pair();
-        let incarnation = incarnations.mint().expect("incarnation available");
+        let incarnation = mint_actor_incarnation();
 
         MailboxControl::bind(&*mailbox, incarnation);
     }
@@ -1673,11 +1664,7 @@ pub(super) mod tests {
     fn rebinding_before_close_trips_the_driver_contract() {
         let (mailbox, _) = actor();
         MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox);
-        let mut identity = ScopeIdentity::new();
-        let (_, mut incarnations) = identity
-            .mint_membership(&ChildId::from("actor"))
-            .expect("membership available")
-            .into_pair();
+        let (_, mut incarnations) = mint_actor_membership();
         let first = incarnations.mint().expect("first incarnation available");
         let second = incarnations.mint().expect("second incarnation available");
 
@@ -1694,12 +1681,7 @@ pub(super) mod tests {
                 std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
             ),
         );
-        let mut identity = ScopeIdentity::new();
-        let (_, mut incarnations) = identity
-            .mint_membership(&ChildId::from("actor"))
-            .expect("membership available")
-            .into_pair();
-        let incarnation = incarnations.mint().expect("incarnation available");
+        let incarnation = mint_actor_incarnation();
         MailboxControl::bind(&*mailbox, incarnation);
 
         assert!(matches!(
@@ -1740,12 +1722,7 @@ pub(super) mod tests {
                 std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
             ),
         );
-        let mut identity = ScopeIdentity::new();
-        let (_, mut incarnations) = identity
-            .mint_membership(&ChildId::from("actor"))
-            .expect("membership available")
-            .into_pair();
-        let incarnation = incarnations.mint().expect("incarnation available");
+        let incarnation = mint_actor_incarnation();
         MailboxControl::bind(&*mailbox, incarnation);
         let receiver = MailboxReceiver::new(Arc::clone(&mailbox), incarnation);
 
@@ -1898,15 +1875,7 @@ pub(super) mod tests {
         park_with(&mut second, &second_panicking);
         park_with(&mut third, &counting);
         MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox);
-        let mut generations = {
-            let mut identity = ScopeIdentity::new();
-            let (_, generations) = identity
-                .mint_membership(&ChildId::from("actor"))
-                .expect("membership available")
-                .into_pair();
-            generations
-        };
-        let incarnation = generations.mint().expect("incarnation available");
+        let incarnation = mint_actor_incarnation();
 
         assert!(
             catch_unwind(AssertUnwindSafe(|| {
@@ -1956,15 +1925,7 @@ pub(super) mod tests {
         first.install_test_waker(Waker::from(Arc::new(BindOrderingWake(Arc::clone(&events)))));
         second.install_test_waker(Waker::from(Arc::new(BindOrderingWake(Arc::clone(&events)))));
 
-        let mut identity = ScopeIdentity::new();
-        let (_, mut incarnations) = identity
-            .mint_membership(&ChildId::from("actor"))
-            .expect("membership available")
-            .into_pair();
-        MailboxControl::bind(
-            &*mailbox,
-            incarnations.mint().expect("incarnation available"),
-        );
+        MailboxControl::bind(&*mailbox, mint_actor_incarnation());
 
         assert_eq!(
             *events.lock().expect("bind effect recorder mutex"),

--- a/crates/shelterwood-mailbox/src/futures.rs
+++ b/crates/shelterwood-mailbox/src/futures.rs
@@ -706,7 +706,7 @@ mod tests {
         time::Duration,
     };
 
-    use crate::{ChildId, MailboxControl, identity::ScopeIdentity};
+    use crate::{MailboxControl, test_support::mint_actor_incarnation};
 
     use super::{
         super::cell::tests::{actor, actor_for},
@@ -794,12 +794,7 @@ mod tests {
             &*mailbox,
             crate::policy::ResolvedDefaults::default().mailbox,
         );
-        let mut identity = ScopeIdentity::new();
-        let (_, mut incarnations) = identity
-            .mint_membership(&ChildId::from("actor"))
-            .expect("membership available")
-            .into_pair();
-        let incarnation = incarnations.mint().expect("incarnation available");
+        let incarnation = mint_actor_incarnation();
         MailboxControl::bind(&*mailbox, incarnation);
 
         let mut send = Box::pin(actor.send(1));

--- a/crates/shelterwood-mailbox/src/lib.rs
+++ b/crates/shelterwood-mailbox/src/lib.rs
@@ -26,6 +26,8 @@ mod deadline;
 mod errors;
 mod futures;
 mod reply;
+#[cfg(test)]
+mod test_support;
 
 #[doc(hidden)]
 pub use capability::{

--- a/crates/shelterwood-mailbox/src/test_support.rs
+++ b/crates/shelterwood-mailbox/src/test_support.rs
@@ -1,0 +1,13 @@
+use shelterwood_core::{ChildId, Incarnation, IncarnationCounter, Membership, ScopeIdentity};
+
+pub(crate) fn mint_actor_membership() -> (Membership, IncarnationCounter) {
+    ScopeIdentity::new()
+        .mint_membership(&ChildId::from("actor"))
+        .expect("membership available")
+        .into_pair()
+}
+
+pub(crate) fn mint_actor_incarnation() -> Incarnation {
+    let (_, mut incarnations) = mint_actor_membership();
+    incarnations.mint().expect("incarnation available")
+}

--- a/crates/shelterwood-runtime/Cargo.toml
+++ b/crates/shelterwood-runtime/Cargo.toml
@@ -23,4 +23,5 @@ shelterwood-mailbox.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
+shelterwood-core = { workspace = true, features = ["test-util"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }

--- a/crates/shelterwood-runtime/src/disposal.rs
+++ b/crates/shelterwood-runtime/src/disposal.rs
@@ -368,37 +368,26 @@ pub fn dispose_all<T: Send + 'static>(values: Vec<T>) -> Latch {
 mod tests {
     use std::{
         sync::{
-            Arc, Condvar, Mutex,
+            Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
             mpsc,
         },
         thread::{self, ThreadId},
-        time::{Duration, Instant},
+        time::Duration,
     };
 
     use super::{
         DisposalJob, DisposalPanic, FallbackDisposals, Isolated, dispose_detached,
         retain_fallback_disposal_with,
     };
-    use crate::spawn::{BlockingPoolJob, blocking_pool_accepted};
-
-    /// Name of the shared non-runtime disposal thread, asserted on to pin
-    /// *where* isolated destruction lands rather than merely where it does not.
-    const FALLBACK_THREAD: &str = "shelterwood-disposal";
-
-    /// Deadlock escape hatch for the hostile destructors below. A correct run
-    /// releases them in microseconds and never reaches this bound; a
-    /// regression that runs them inline reaches it and then fails the thread
-    /// assertions, so the suite reports a diagnosis instead of a hang.
-    const DESTRUCTOR_ESCAPE: Duration = Duration::from_secs(5);
-
-    /// The thread a user destructor ran on.
-    type DestructorThread = (ThreadId, Option<String>);
-
-    fn describe_current_thread() -> DestructorThread {
-        let current = thread::current();
-        (current.id(), current.name().map(str::to_owned))
-    }
+    use crate::{
+        spawn::BlockingPoolJob,
+        test_support::{
+            BlockingDrop, DESTRUCTOR_ESCAPE, DISPOSAL_THREAD as FALLBACK_THREAD, RecordingDrop,
+            assert_blocking_pool_outcomes, drop_gate, release,
+            submit_during_blocking_pool_shutdown,
+        },
+    };
 
     struct PanickingDrop(Arc<AtomicUsize>);
 
@@ -460,14 +449,6 @@ mod tests {
         assert_eq!(drops.load(Ordering::SeqCst), 1);
     }
 
-    struct ReportingDrop(mpsc::Sender<DestructorThread>);
-
-    impl Drop for ReportingDrop {
-        fn drop(&mut self) {
-            let _ = self.0.send(describe_current_thread());
-        }
-    }
-
     /// The teardown race `dispose_critical` cannot sample its way out of:
     /// Tokio may drop an accepted closure after acceptance was observed,
     /// leaving the submitter with the last still-pending reference. Dropping
@@ -477,7 +458,7 @@ mod tests {
     fn dropping_the_last_critical_job_reroutes_off_the_owning_thread() {
         let owning_thread = thread::current().id();
         let (destroyed, destroyed_rx) = mpsc::channel();
-        let job = DisposalJob::critical(ReportingDrop(destroyed), |_| {});
+        let job = DisposalJob::critical(RecordingDrop(destroyed), |_| {});
 
         drop(job);
 
@@ -498,60 +479,9 @@ mod tests {
     #[test]
     fn fallback_detection_distinguishes_blocking_spawn_outcomes() {
         let accepted = DisposalJob::new((), |_| {});
-        let accepted_worker = Arc::clone(&accepted);
-        assert!(
-            blocking_pool_accepted(&accepted),
-            "an accepted closure still owned by Tokio must stay on its blocking pool"
-        );
-        drop(accepted_worker);
-
         let rejected = DisposalJob::new((), |_| {});
-        let rejected_worker = Arc::clone(&rejected);
-        drop(rejected_worker);
-        assert!(
-            !blocking_pool_accepted(&rejected),
-            "a synchronously dropped closure must move to the fallback queue"
-        );
-
         let completed = DisposalJob::new((), |_| {});
-        let completed_worker = Arc::clone(&completed);
-        completed_worker.run();
-        drop(completed_worker);
-        assert!(
-            blocking_pool_accepted(&completed),
-            "an already-completed closure must not enqueue an empty job"
-        );
-    }
-
-    struct BlockingDrop {
-        entered: mpsc::Sender<DestructorThread>,
-        release: Arc<(Mutex<bool>, Condvar)>,
-        finished: mpsc::Sender<()>,
-    }
-
-    impl Drop for BlockingDrop {
-        fn drop(&mut self) {
-            let _ = self.entered.send(describe_current_thread());
-            let (released, wake) = &*self.release;
-            let mut released = released.lock().expect("release mutex available");
-            let deadline = Instant::now() + DESTRUCTOR_ESCAPE;
-            while !*released {
-                let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
-                    break;
-                };
-                released = wake
-                    .wait_timeout(released, remaining)
-                    .expect("release mutex available")
-                    .0;
-            }
-            let _ = self.finished.send(());
-        }
-    }
-
-    fn release(gate: &Arc<(Mutex<bool>, Condvar)>) {
-        let (released, wake) = &**gate;
-        *released.lock().expect("release mutex available") = true;
-        wake.notify_all();
+        assert_blocking_pool_outcomes(accepted, rejected, completed);
     }
 
     struct DisposeOnDrop {
@@ -574,46 +504,24 @@ mod tests {
 
     #[test]
     fn shut_down_blocking_pool_falls_back_off_the_teardown_thread() {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .max_blocking_threads(1)
-            .build()
-            .expect("test runtime");
-        let (worker_started, worker_started_rx) = mpsc::channel();
-        let (release_worker, release_worker_rx) = mpsc::channel();
-        drop(runtime.spawn_blocking(move || {
-            worker_started
-                .send(())
-                .expect("test observes the occupied blocking worker");
-            release_worker_rx
-                .recv()
-                .expect("test releases the occupied blocking worker");
-        }));
-        worker_started_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("the sole blocking worker starts");
-
         let (submitted, submitted_rx) = mpsc::channel();
         let (returned, returned_rx) = mpsc::channel();
         let (entered, entered_rx) = mpsc::channel();
         let (finished, finished_rx) = mpsc::channel();
-        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let gate = drop_gate();
         let trigger = DisposeOnDrop {
-            value: Some(BlockingDrop {
+            value: Some(BlockingDrop::with_completion(
                 entered,
-                release: Arc::clone(&gate),
+                Arc::clone(&gate),
                 finished,
-            }),
+            )),
             submitted,
             returned,
         };
         // With the only worker occupied, this outer task stays queued. After
         // shutdown begins, Tokio runs it while draining the worker queue; its
         // nested disposal submission is then synchronously rejected.
-        drop(runtime.spawn_blocking(move || drop(trigger)));
-        runtime.shutdown_background();
-        release_worker
-            .send(())
-            .expect("the blocking-pool teardown may proceed");
+        submit_during_blocking_pool_shutdown(move || drop(trigger));
 
         let teardown_thread = submitted_rx.recv_timeout(Duration::from_secs(1));
         let destructor_thread = entered_rx.recv_timeout(Duration::from_secs(1));
@@ -655,12 +563,12 @@ mod tests {
         let embedder_thread = thread::current().id();
         let (entered, entered_rx) = mpsc::channel();
         let (finished, finished_rx) = mpsc::channel();
-        let gate = Arc::new((Mutex::new(false), Condvar::new()));
-        let held = Isolated::new(BlockingDrop {
+        let gate = drop_gate();
+        let held = Isolated::new(BlockingDrop::with_completion(
             entered,
-            release: Arc::clone(&gate),
+            Arc::clone(&gate),
             finished,
-        });
+        ));
         runtime.spawn(async move {
             let _held = held;
             std::future::pending::<()>().await;

--- a/crates/shelterwood-runtime/src/lib.rs
+++ b/crates/shelterwood-runtime/src/lib.rs
@@ -9,6 +9,8 @@ mod disposal;
 mod mailbox;
 mod spawn;
 mod sync;
+#[cfg(test)]
+mod test_support;
 mod timer;
 
 pub use disposal::*;

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -563,56 +563,20 @@ mod tests {
     use std::{
         panic,
         sync::{
-            Arc, Condvar, Mutex,
+            Arc,
             atomic::{AtomicUsize, Ordering},
             mpsc,
         },
         task::{Context, Poll, Wake, Waker},
-        thread::{self, ThreadId},
-        time::{Duration, Instant},
+        thread,
+        time::Duration,
     };
 
     use super::BlockingPoolJob;
-
-    const WAIT: Duration = Duration::from_secs(5);
-
-    type ThreadDescription = (ThreadId, Option<String>);
-
-    fn describe_current_thread() -> ThreadDescription {
-        let current = thread::current();
-        (current.id(), current.name().map(str::to_owned))
-    }
-
-    struct BlockingDrop {
-        entered: mpsc::Sender<ThreadDescription>,
-        release: Arc<(Mutex<bool>, Condvar)>,
-    }
-
-    impl Drop for BlockingDrop {
-        fn drop(&mut self) {
-            let _ = self.entered.send(describe_current_thread());
-            let (released, wake) = &*self.release;
-            let mut released = released.lock().expect("release mutex available");
-            let deadline = Instant::now() + WAIT;
-            while !*released {
-                let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
-                    break;
-                };
-                released = wake
-                    .wait_timeout(released, remaining)
-                    .expect("release mutex available")
-                    .0;
-            }
-        }
-    }
-
-    struct RecordingDrop(mpsc::Sender<ThreadDescription>);
-
-    impl Drop for RecordingDrop {
-        fn drop(&mut self) {
-            let _ = self.0.send(describe_current_thread());
-        }
-    }
+    use crate::test_support::{
+        BlockingDrop, DESTRUCTOR_ESCAPE as WAIT, DISPOSAL_THREAD, RecordingDrop,
+        assert_blocking_pool_outcomes, drop_gate, release, submit_during_blocking_pool_shutdown,
+    };
 
     struct PanickingDrop(mpsc::Sender<()>);
 
@@ -634,12 +598,6 @@ mod tests {
             self.0.fetch_add(1, Ordering::SeqCst);
             panic!("hostile blocking-result waker");
         }
-    }
-
-    fn release(gate: &Arc<(Mutex<bool>, Condvar)>) {
-        let (released, wake) = &**gate;
-        *released.lock().expect("release mutex available") = true;
-        wake.notify_all();
     }
 
     #[tokio::test]
@@ -703,31 +661,11 @@ mod tests {
     fn fallback_detection_distinguishes_owned_pending_and_completed_jobs() {
         let (accepted_completion, _accepted_receiver) = super::oneshot();
         let accepted = super::BlockingJob::new(|| 1_u8, accepted_completion);
-        let accepted_worker = Arc::clone(&accepted);
-        assert!(
-            super::blocking_pool_accepted(&accepted),
-            "an accepted closure still owned by Tokio must stay on its blocking pool"
-        );
-        drop(accepted_worker);
-
         let (rejected_completion, _rejected_receiver) = super::oneshot();
         let rejected = super::BlockingJob::new(|| 2_u8, rejected_completion);
-        let rejected_worker = Arc::clone(&rejected);
-        drop(rejected_worker);
-        assert!(
-            !super::blocking_pool_accepted(&rejected),
-            "a synchronously dropped closure must move to the fallback thread"
-        );
-
         let (completed_completion, _completed_receiver) = super::oneshot();
         let completed = super::BlockingJob::new(|| 3_u8, completed_completion);
-        let completed_worker = Arc::clone(&completed);
-        completed_worker.run();
-        drop(completed_worker);
-        assert!(
-            super::blocking_pool_accepted(&completed),
-            "a fast completed closure must not enqueue an empty job"
-        );
+        assert_blocking_pool_outcomes(accepted, rejected, completed);
     }
 
     #[test]
@@ -804,7 +742,7 @@ mod tests {
         assert_ne!(destructor_thread, waiter_thread);
         assert_eq!(
             destructor_name.as_deref(),
-            Some("shelterwood-disposal"),
+            Some(DISPOSAL_THREAD),
             "an unclaimed result must not be destroyed on the awaiting task's thread"
         );
     }
@@ -857,7 +795,7 @@ mod tests {
         assert_ne!(destructor_thread, cancellation_thread);
         assert_eq!(
             destructor_name.as_deref(),
-            Some("shelterwood-disposal"),
+            Some(DISPOSAL_THREAD),
             "accepted cancellation must isolate closure destruction"
         );
     }
@@ -898,44 +836,23 @@ mod tests {
         assert_ne!(destructor_thread, submitting_thread);
         assert_eq!(
             destructor_name.as_deref(),
-            Some("shelterwood-disposal"),
+            Some(DISPOSAL_THREAD),
             "native fallback failure must retry through disposal isolation"
         );
     }
 
     #[test]
     fn shut_down_blocking_pool_runs_rejected_work_off_the_submitting_thread() {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .max_blocking_threads(1)
-            .build()
-            .expect("test runtime");
-        let (worker_started, worker_started_rx) = mpsc::channel();
-        let (release_worker, release_worker_rx) = mpsc::channel();
-        drop(runtime.spawn_blocking(move || {
-            worker_started
-                .send(())
-                .expect("test observes the occupied blocking worker");
-            release_worker_rx
-                .recv()
-                .expect("test releases the occupied blocking worker");
-        }));
-        worker_started_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("the sole blocking worker starts");
-
         let (future_tx, future_rx) = mpsc::channel();
         let (submitted, submitted_rx) = mpsc::channel();
         let (returned, returned_rx) = mpsc::channel();
         let (entered, entered_rx) = mpsc::channel();
-        let gate = Arc::new((Mutex::new(false), Condvar::new()));
-        let captured = BlockingDrop {
-            entered,
-            release: Arc::clone(&gate),
-        };
+        let gate = drop_gate();
+        let captured = BlockingDrop::new(entered, Arc::clone(&gate));
         // This outer task stays queued behind the occupied worker. Tokio runs
         // it while draining shutdown, so its nested blocking submission is
         // synchronously rejected even though `spawn_blocking` returns a handle.
-        drop(runtime.spawn_blocking(move || {
+        submit_during_blocking_pool_shutdown(move || {
             let submitting_thread = thread::current().id();
             let future = super::spawn_blocking_work(move || {
                 drop(captured);
@@ -948,11 +865,7 @@ mod tests {
                 .send(future)
                 .expect("test receives the blocking-work future");
             returned.send(()).expect("test observes submission return");
-        }));
-        runtime.shutdown_background();
-        release_worker
-            .send(())
-            .expect("the blocking-pool teardown may proceed");
+        });
 
         let submitting_thread = submitted_rx
             .recv_timeout(Duration::from_secs(1))

--- a/crates/shelterwood-runtime/src/test_support.rs
+++ b/crates/shelterwood-runtime/src/test_support.rs
@@ -1,0 +1,148 @@
+use std::{
+    sync::{Arc, Condvar, Mutex, mpsc},
+    thread::{self, ThreadId},
+    time::{Duration, Instant},
+};
+
+use crate::spawn::{BlockingPoolJob, blocking_pool_accepted};
+
+/// Deadlock escape hatch for hostile test destructors.
+pub(crate) const DESTRUCTOR_ESCAPE: Duration = Duration::from_secs(5);
+pub(crate) const DISPOSAL_THREAD: &str = "shelterwood-disposal";
+
+pub(crate) type ThreadDescription = (ThreadId, Option<String>);
+
+fn describe_current_thread() -> ThreadDescription {
+    let current = thread::current();
+    (current.id(), current.name().map(str::to_owned))
+}
+
+pub(crate) struct RecordingDrop(pub(crate) mpsc::Sender<ThreadDescription>);
+
+impl Drop for RecordingDrop {
+    fn drop(&mut self) {
+        let _ = self.0.send(describe_current_thread());
+    }
+}
+
+pub(crate) type DropGate = Arc<(Mutex<bool>, Condvar)>;
+
+pub(crate) fn drop_gate() -> DropGate {
+    Arc::new((Mutex::new(false), Condvar::new()))
+}
+
+pub(crate) struct BlockingDrop {
+    entered: mpsc::Sender<ThreadDescription>,
+    release: DropGate,
+    finished: Option<mpsc::Sender<()>>,
+}
+
+impl BlockingDrop {
+    pub(crate) fn new(entered: mpsc::Sender<ThreadDescription>, release: DropGate) -> Self {
+        Self {
+            entered,
+            release,
+            finished: None,
+        }
+    }
+
+    pub(crate) fn with_completion(
+        entered: mpsc::Sender<ThreadDescription>,
+        release: DropGate,
+        finished: mpsc::Sender<()>,
+    ) -> Self {
+        Self {
+            entered,
+            release,
+            finished: Some(finished),
+        }
+    }
+}
+
+impl Drop for BlockingDrop {
+    fn drop(&mut self) {
+        let _ = self.entered.send(describe_current_thread());
+        let (released, wake) = &*self.release;
+        let mut released = released.lock().expect("release mutex available");
+        let deadline = Instant::now() + DESTRUCTOR_ESCAPE;
+        while !*released {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                break;
+            };
+            released = wake
+                .wait_timeout(released, remaining)
+                .expect("release mutex available")
+                .0;
+        }
+        if let Some(finished) = &self.finished {
+            let _ = finished.send(());
+        }
+    }
+}
+
+pub(crate) fn release(gate: &DropGate) {
+    let (released, wake) = &**gate;
+    *released.lock().expect("release mutex available") = true;
+    wake.notify_all();
+}
+
+pub(crate) fn assert_blocking_pool_outcomes<
+    A: BlockingPoolJob,
+    R: BlockingPoolJob,
+    C: BlockingPoolJob,
+>(
+    accepted: Arc<A>,
+    rejected: Arc<R>,
+    completed: Arc<C>,
+) {
+    let accepted_worker = Arc::clone(&accepted);
+    assert!(
+        blocking_pool_accepted(&accepted),
+        "an accepted closure still owned by Tokio must stay on its blocking pool"
+    );
+    drop(accepted_worker);
+
+    let rejected_worker = Arc::clone(&rejected);
+    drop(rejected_worker);
+    assert!(
+        !blocking_pool_accepted(&rejected),
+        "a synchronously dropped closure must move to fallback"
+    );
+
+    let completed_worker = Arc::clone(&completed);
+    completed_worker.run();
+    drop(completed_worker);
+    assert!(
+        blocking_pool_accepted(&completed),
+        "an already-completed closure must not enqueue an empty job"
+    );
+}
+
+/// Submits `task` behind an occupied blocking worker, starts runtime teardown,
+/// then frees the worker so Tokio rejects nested blocking submissions in
+/// `task` synchronously.
+pub(crate) fn submit_during_blocking_pool_shutdown(task: impl FnOnce() + Send + 'static) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .max_blocking_threads(1)
+        .build()
+        .expect("test runtime");
+    let (worker_started, worker_started_rx) = mpsc::channel();
+    let (release_worker, release_worker_rx) = mpsc::channel();
+    drop(runtime.spawn_blocking(move || {
+        worker_started
+            .send(())
+            .expect("test observes the occupied blocking worker");
+        release_worker_rx
+            .recv()
+            .expect("test releases the occupied blocking worker");
+    }));
+    worker_started_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("the sole blocking worker starts");
+
+    drop(runtime.spawn_blocking(task));
+    runtime.shutdown_background();
+    release_worker
+        .send(())
+        .expect("the blocking-pool teardown may proceed");
+}

--- a/crates/shelterwood-runtime/src/timer.rs
+++ b/crates/shelterwood-runtime/src/timer.rs
@@ -126,22 +126,9 @@ mod tests {
         time::Duration,
     };
 
-    use super::{MAX_TIMER_SLICE, next_timer_deadline, timeout};
+    use shelterwood_core::test_support::latest_representable;
 
-    fn latest_representable(started_at: std::time::Instant) -> std::time::Instant {
-        let mut low = Duration::ZERO;
-        let mut high = Duration::MAX;
-        assert!(started_at.checked_add(high).is_none());
-        while high - low > Duration::from_nanos(1) {
-            let mid = low + (high - low) / 2;
-            if started_at.checked_add(mid).is_some() {
-                low = mid;
-            } else {
-                high = mid;
-            }
-        }
-        started_at + low
-    }
+    use super::{MAX_TIMER_SLICE, next_timer_deadline, timeout};
 
     #[tokio::test(start_paused = true)]
     async fn unarmable_absolute_deadline_stays_pending_without_substitution() {


### PR DESCRIPTION
Completes the fixture-deduplication work for #282. Closes #282.

## What changed

- Shares the latest representable deadline helper between core and runtime tests without adding a production dependency.
- Centralizes runtime destructor/thread, blocking-pool, and saturated-shutdown fixtures.
- Centralizes mailbox actor-membership and incarnation minting fixtures.
- Keeps every helper behind test/test-util boundaries.

Validation: core, runtime, and mailbox suites passed independently. After stacking all three #282 commits, `./tools/dev just ci` passed with 674/674 tests plus formatting, clippy, doctests, docs, API reachability, external consumer, and Nix formatting.

Stack: based on the integration-fixture PR.