### PR TITLE
Close residual public surface holes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,7 @@ shelterwood-core = { path = "crates/shelterwood-core", version = "0.1.0" }
 shelterwood-mailbox = { path = "crates/shelterwood-mailbox", version = "0.1.0" }
 shelterwood-runtime = { path = "crates/shelterwood-runtime", version = "0.1.0" }
 thiserror = "2.0.19"
-tokio = { version = "1.53.1", features = ["macros", "rt", "sync", "time"] }
+# Blocking-pool rejection ownership is verified against this exact Tokio
+# release. Any upgrade must re-audit and re-run the adapter regressions.
+tokio = { version = "=1.53.1", features = ["macros", "rt", "sync", "time"] }
 tracing = "0.1.44"

--- a/SPEC.md
+++ b/SPEC.md
@@ -3112,6 +3112,18 @@ integration toolkit for the driver shell and the end-to-end invariants.
     hidden items rather than taught to descend into hidden methods on
     exported types; the façade-absence probe in
     `tools/check-external-consumer.sh` is what enforces this boundary.
+    `SnapshotReceiver::borrow_latest_and_closed` is the explicit benign
+    exception: the downstream façade needs this lower-crate bridge, its
+    signature contains only supported observation data, and it grants no
+    construction or installation capability. It therefore remains callable
+    on the façade-public receiver but is hidden from generated documentation;
+    the JSON walk deliberately does not gain a second hidden-item graph for
+    it. `MailboxCell::new` is likewise a hidden cross-crate constructor, but
+    the façade exports neither `MailboxCell` nor the `MailboxRuntime`
+    capability required to call it, so direct lower-crate construction remains
+    outside the supported boundary. The driver event lane's public adapter
+    types are opaque wrappers rather than Tokio aliases, and the lifecycle
+    ring capacity is an internal implementation choice rather than façade API.
 14. **Event-woken observers see consistent-or-newer snapshots.** Subscribe
    to lifecycle events; *synchronously inside the event arm*, read the
    snapshot and assert it already reflects the event — at both ends of the
@@ -3948,6 +3960,12 @@ pre-release, which does make the payload values themselves constructible by
 an application; that is deliberate and costs nothing, because authentication
 lives in the provenance structure rather than in the payload's privacy.
 Adding a cause or field must update every façade match.
+Construction is one named constructor per kind: `completed`, `failed`,
+`panicked`, `readiness_timed_out`, and `aborted` take the kind payload plus
+the orthogonal cancellation observation; `never_started` fixes cancellation
+to `NotObserved`. There is no public constructor that accepts an arbitrary
+`ExitKind`, so applications cannot construct the semantically impossible
+`NeverStarted`/`Observed` pair. The external-consumer probe pins that absence.
 Scope-level shutdown-timeout errors carry the affected children as
 structured data: child-id paths plus membership tokens (§7) — never
 bare ids, which sibling scopes may reuse (§2).

--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -2631,8 +2631,7 @@ mod tests {
     };
 
     use shelterwood_core::{
-        Cancellation, Exit, ExitError, ExitKind, ScopeState, StartupFailure, StartupFailureCause,
-        StopReason,
+        Cancellation, Exit, ExitError, ScopeState, StartupFailure, StartupFailureCause, StopReason,
     };
 
     use crate::{
@@ -2719,8 +2718,8 @@ mod tests {
     fn retained_failed_exit_disposes_off_the_retiring_thread() {
         let retiring_thread = std::thread::current().id();
         let (dropped, observed) = mpsc::sync_channel(1);
-        let retained = RetainedExit::new(Exit::new(
-            ExitKind::Failed(ExitError::from(ThreadProbe(dropped))),
+        let retained = RetainedExit::new(Exit::failed(
+            ExitError::from(ThreadProbe(dropped)),
             Cancellation::NotObserved,
         ));
 
@@ -2747,14 +2746,14 @@ mod tests {
                 .expect("membership is available"),
         );
         member.terminalize(
-            Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+            Exit::completed(Cancellation::NotObserved),
             StartupDisposition::Unchanged,
         );
         let (dropped, observed) = mpsc::sync_channel(1);
 
         member.terminalize(
-            Exit::new(
-                ExitKind::Failed(ExitError::from(ThreadProbe(dropped))),
+            Exit::failed(
+                ExitError::from(ThreadProbe(dropped)),
                 Cancellation::NotObserved,
             ),
             StartupDisposition::Unchanged,
@@ -2835,8 +2834,8 @@ mod tests {
     fn retained_exit_conversion_preserves_the_callers_drop_thread() {
         let caller = std::thread::current().id();
         let (dropped, observed) = mpsc::sync_channel(1);
-        let retained = RetainedExit::new(Exit::new(
-            ExitKind::Failed(ExitError::from(ThreadProbe(dropped))),
+        let retained = RetainedExit::new(Exit::failed(
+            ExitError::from(ThreadProbe(dropped)),
             Cancellation::NotObserved,
         ));
 
@@ -2867,8 +2866,8 @@ mod tests {
             cause: StartupFailureCause::Child {
                 id,
                 membership: member.membership(),
-                exit: Exit::new(
-                    ExitKind::Failed(ExitError::from(ThreadProbe(dropped))),
+                exit: Exit::failed(
+                    ExitError::from(ThreadProbe(dropped)),
                     Cancellation::NotObserved,
                 ),
             },
@@ -2898,8 +2897,8 @@ mod tests {
                 .expect("membership is available"),
         );
         member.terminalize(
-            Exit::new(
-                ExitKind::Failed(ExitError::from(ThreadProbe(dropped))),
+            Exit::failed(
+                ExitError::from(ThreadProbe(dropped)),
                 Cancellation::NotObserved,
             ),
             StartupDisposition::Unchanged,
@@ -3061,8 +3060,8 @@ mod tests {
             id,
             membership,
             incarnation: incarnations.mint().expect("incarnation available"),
-            exit: Exit::new(
-                ExitKind::Failed(ExitError::from(GateDropError { gate, dropped })),
+            exit: Exit::failed(
+                ExitError::from(GateDropError { gate, dropped }),
                 Cancellation::NotObserved,
             ),
         });

--- a/crates/shelterwood-cells/src/observe.rs
+++ b/crates/shelterwood-cells/src/observe.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 
 /// Number of lifecycle events retained independently for each subscriber.
+#[doc(hidden)]
 pub const LIFECYCLE_EVENT_CAPACITY: usize = 128;
 
 // Tokio rounds broadcast capacity up to a power of two. `try_recv` compares
@@ -572,6 +573,12 @@ impl SnapshotReceiver {
     }
 
     /// Borrows the newest snapshot and terminal flag from one retained state.
+    // This method bridges the lower cell crate to the downstream façade's
+    // `ScopeRef` implementation. It remains callable on the façade-public
+    // receiver, but its signature is entirely supported façade data and grants
+    // no construction or implementation capability. Hiding it from generated
+    // docs is the explicit boundary ruling; the rustdoc-JSON walk deliberately
+    // does not grow a second hidden-item graph for this benign bridge.
     #[must_use]
     #[doc(hidden)]
     pub fn borrow_latest_and_closed(&self) -> (Arc<ScopeSnapshot>, bool) {

--- a/crates/shelterwood-core/src/engine.rs
+++ b/crates/shelterwood-core/src/engine.rs
@@ -1079,8 +1079,8 @@ mod tests {
     };
 
     use crate::{
-        Cancellation, Exit, ExitKind, GracePhase, Intensity, JitterSample, RestartAttempt,
-        RestartCondition, RestartCount, RestartPolicy, Shutdown, TotalRestarts,
+        Cancellation, Exit, GracePhase, Intensity, JitterSample, RestartAttempt, RestartCondition,
+        RestartCount, RestartPolicy, Shutdown, TotalRestarts,
         identity::PoisonedCounter,
         policy::{Backoff, ScopeFlavor},
     };
@@ -1323,10 +1323,7 @@ mod tests {
 
     #[test]
     fn funnel_dispatch_depends_on_mode_and_membership_state() {
-        let failure = Exit::new(
-            ExitKind::Failed(crate::ExitError::message("boom")),
-            Cancellation::NotObserved,
-        );
+        let failure = Exit::failed(crate::ExitError::message("boom"), Cancellation::NotObserved);
         let restart = RestartPolicy::new(RestartCondition::OnFailure, Backoff::Immediate);
         assert_eq!(
             dispatch_exit(
@@ -1346,7 +1343,7 @@ mod tests {
             ),
             ExitDispatch::Terminal
         );
-        let success = Exit::new(ExitKind::Completed, Cancellation::NotObserved);
+        let success = Exit::completed(Cancellation::NotObserved);
         assert_eq!(
             dispatch_exit(
                 &success,

--- a/crates/shelterwood-core/src/exit.rs
+++ b/crates/shelterwood-core/src/exit.rs
@@ -40,14 +40,14 @@ pub fn stop_reason_into_nested_result(reason: StopReason) -> ExitResult {
 
 pub fn stop_reason_root_exit(reason: &StopReason) -> Exit {
     match reason {
-        StopReason::Finished => Exit::new(ExitKind::Completed, Cancellation::NotObserved),
-        StopReason::ShutdownRequested => Exit::new(ExitKind::Completed, Cancellation::Observed),
-        StopReason::IntensityTripped(trip) => Exit::new(
-            ExitKind::Failed(structured_intensity_trip_error(trip.clone())),
+        StopReason::Finished => Exit::completed(Cancellation::NotObserved),
+        StopReason::ShutdownRequested => Exit::completed(Cancellation::Observed),
+        StopReason::IntensityTripped(trip) => Exit::failed(
+            structured_intensity_trip_error(trip.clone()),
             Cancellation::NotObserved,
         ),
-        StopReason::StartupFailed(failure) => Exit::new(
-            ExitKind::Failed(structured_startup_failure_error(failure.clone())),
+        StopReason::StartupFailed(failure) => Exit::failed(
+            structured_startup_failure_error(failure.clone()),
             Cancellation::NotObserved,
         ),
         StopReason::NeverStarted => Exit::never_started(),
@@ -416,10 +416,38 @@ pub struct Exit {
 }
 
 impl Exit {
-    /// Creates an exit from its kind and cancellation observation.
-    #[must_use]
-    pub const fn new(kind: ExitKind, cancellation: Cancellation) -> Self {
+    const fn from_kind(kind: ExitKind, cancellation: Cancellation) -> Self {
         Self { kind, cancellation }
+    }
+
+    /// Constructs a successfully completed incarnation exit.
+    #[must_use]
+    pub const fn completed(cancellation: Cancellation) -> Self {
+        Self::from_kind(ExitKind::Completed, cancellation)
+    }
+
+    /// Constructs an application-failure exit.
+    #[must_use]
+    pub const fn failed(error: ExitError, cancellation: Cancellation) -> Self {
+        Self::from_kind(ExitKind::Failed(error), cancellation)
+    }
+
+    /// Constructs an exit for a panic in user code or destruction.
+    #[must_use]
+    pub const fn panicked(message: Option<String>, cancellation: Cancellation) -> Self {
+        Self::from_kind(ExitKind::Panicked { message }, cancellation)
+    }
+
+    /// Constructs an exit for an expired readiness deadline.
+    #[must_use]
+    pub const fn readiness_timed_out(deadline: Instant, cancellation: Cancellation) -> Self {
+        Self::from_kind(ExitKind::ReadinessTimedOut { deadline }, cancellation)
+    }
+
+    /// Constructs an exit for an incarnation future destroyed by the framework.
+    #[must_use]
+    pub const fn aborted(phase: GracePhase, cancellation: Cancellation) -> Self {
+        Self::from_kind(ExitKind::Aborted { phase }, cancellation)
     }
 
     /// Returns the exit kind.
@@ -441,9 +469,13 @@ impl Exit {
     }
 
     /// Constructs the membership-level never-started exit.
+    ///
+    /// A membership with no incarnation cannot have observed an incarnation's
+    /// cancellation token, so this constructor fixes cancellation to
+    /// [`Cancellation::NotObserved`].
     #[must_use]
     pub const fn never_started() -> Self {
-        Self::new(ExitKind::NeverStarted, Cancellation::NotObserved)
+        Self::from_kind(ExitKind::NeverStarted, Cancellation::NotObserved)
     }
 }
 
@@ -602,7 +634,7 @@ pub fn classify_exit(
             phase: GracePhase::WithinGrace,
         },
     };
-    Exit::new(kind, cancellation)
+    Exit::from_kind(kind, cancellation)
 }
 
 /// Adds a destructor panic to an already-classified exit without erasing an
@@ -610,7 +642,7 @@ pub fn classify_exit(
 pub fn classify_disposal_panic(exit: Exit, message: Option<String>) -> Exit {
     let Exit { kind, cancellation } = exit;
     let kind = prefer_earlier(kind, ExitKind::Panicked { message });
-    Exit::new(kind, cancellation)
+    Exit::from_kind(kind, cancellation)
 }
 
 /// Diagnostic precedence shared by provisional and final exit evidence.
@@ -677,6 +709,22 @@ mod tests {
         stop_reason_root_exit, structured_intensity_trip_error, structured_startup_failure_error,
     };
 
+    fn exit(kind: ExitKind, cancellation: Cancellation) -> Exit {
+        match kind {
+            ExitKind::Completed => Exit::completed(cancellation),
+            ExitKind::Failed(error) => Exit::failed(error, cancellation),
+            ExitKind::Panicked { message } => Exit::panicked(message, cancellation),
+            ExitKind::ReadinessTimedOut { deadline } => {
+                Exit::readiness_timed_out(deadline, cancellation)
+            }
+            ExitKind::Aborted { phase } => Exit::aborted(phase, cancellation),
+            ExitKind::NeverStarted => {
+                assert_eq!(cancellation, Cancellation::NotObserved);
+                Exit::never_started()
+            }
+        }
+    }
+
     #[test]
     fn child_startup_failure_display_summarizes_every_exit_kind() {
         let mut identity = ScopeIdentity::new();
@@ -734,7 +782,7 @@ mod tests {
                 cause: StartupFailureCause::Child {
                     id: id.clone(),
                     membership,
-                    exit: Exit::new(kind, Cancellation::NotObserved),
+                    exit: exit(kind, Cancellation::NotObserved),
                 },
             };
 
@@ -844,7 +892,7 @@ mod tests {
                 JoinOutcome::Ok { value: () },
                 None,
                 Cancellation::NotObserved,
-                Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+                Exit::completed(Cancellation::NotObserved),
             ),
             (
                 "cancellation overrides recorded completion",
@@ -852,7 +900,7 @@ mod tests {
                 JoinOutcome::Cancelled,
                 Some(GracePhase::AfterGrace),
                 Cancellation::Observed,
-                Exit::new(
+                exit(
                     ExitKind::Aborted {
                         phase: GracePhase::AfterGrace,
                     },
@@ -865,7 +913,7 @@ mod tests {
                 JoinOutcome::Ok { value: () },
                 None,
                 Cancellation::NotObserved,
-                Exit::new(ExitKind::Failed(failure.clone()), Cancellation::NotObserved),
+                Exit::failed(failure.clone(), Cancellation::NotObserved),
             ),
             (
                 "late cancellation preserves recorded failure",
@@ -873,7 +921,7 @@ mod tests {
                 JoinOutcome::Cancelled,
                 Some(GracePhase::AfterGrace),
                 Cancellation::Observed,
-                Exit::new(ExitKind::Failed(failure.clone()), Cancellation::Observed),
+                Exit::failed(failure.clone(), Cancellation::Observed),
             ),
             (
                 "join panic overrides recorded failure",
@@ -883,7 +931,7 @@ mod tests {
                 },
                 None,
                 Cancellation::NotObserved,
-                Exit::new(
+                exit(
                     ExitKind::Panicked {
                         message: Some("drop panic".to_owned()),
                     },
@@ -896,7 +944,7 @@ mod tests {
                 JoinOutcome::Cancelled,
                 Some(GracePhase::AfterGrace),
                 Cancellation::Observed,
-                Exit::new(
+                exit(
                     ExitKind::ReadinessTimedOut { deadline },
                     Cancellation::Observed,
                 ),
@@ -909,7 +957,7 @@ mod tests {
                 },
                 None,
                 Cancellation::NotObserved,
-                Exit::new(
+                exit(
                     ExitKind::Panicked {
                         message: Some("drop panic".to_owned()),
                     },
@@ -926,7 +974,7 @@ mod tests {
                 },
                 None,
                 Cancellation::Observed,
-                Exit::new(
+                exit(
                     ExitKind::Panicked {
                         message: Some("callback panic".to_owned()),
                     },
@@ -939,7 +987,7 @@ mod tests {
                 JoinOutcome::Cancelled,
                 Some(GracePhase::AfterGrace),
                 Cancellation::Observed,
-                Exit::new(
+                exit(
                     ExitKind::Aborted {
                         phase: GracePhase::WithinGrace,
                     },
@@ -952,7 +1000,7 @@ mod tests {
                 JoinOutcome::Cancelled,
                 None,
                 Cancellation::Observed,
-                Exit::new(
+                exit(
                     ExitKind::Aborted {
                         phase: GracePhase::WithinGrace,
                     },
@@ -965,7 +1013,7 @@ mod tests {
                 JoinOutcome::Ok { value: () },
                 Some(GracePhase::AfterGrace),
                 Cancellation::Observed,
-                Exit::new(ExitKind::Completed, Cancellation::Observed),
+                Exit::completed(Cancellation::Observed),
             ),
             (
                 "join cancellation supplies a missing outcome",
@@ -973,7 +1021,7 @@ mod tests {
                 JoinOutcome::Cancelled,
                 Some(GracePhase::AfterGrace),
                 Cancellation::Observed,
-                Exit::new(
+                exit(
                     ExitKind::Aborted {
                         phase: GracePhase::AfterGrace,
                     },
@@ -986,7 +1034,7 @@ mod tests {
                 JoinOutcome::Ok { value: () },
                 None,
                 Cancellation::NotObserved,
-                Exit::new(
+                exit(
                     ExitKind::Aborted {
                         phase: GracePhase::WithinGrace,
                     },
@@ -1007,12 +1055,12 @@ mod tests {
     #[test]
     fn disposal_panic_uses_exit_precedence_and_preserves_cancellation() {
         let classified = classify_disposal_panic(
-            Exit::new(ExitKind::Completed, Cancellation::Observed),
+            Exit::completed(Cancellation::Observed),
             Some("destructor".to_owned()),
         );
         assert_eq!(
             classified,
-            Exit::new(
+            exit(
                 ExitKind::Panicked {
                     message: Some("destructor".to_owned())
                 },
@@ -1027,10 +1075,10 @@ mod tests {
         ] {
             assert_eq!(
                 classify_disposal_panic(
-                    Exit::new(weaker, Cancellation::NotObserved),
+                    exit(weaker, Cancellation::NotObserved),
                     Some("destructor".to_owned()),
                 ),
-                Exit::new(
+                exit(
                     ExitKind::Panicked {
                         message: Some("destructor".to_owned())
                     },
@@ -1039,7 +1087,7 @@ mod tests {
             );
         }
 
-        let earlier = Exit::new(
+        let earlier = exit(
             ExitKind::Panicked {
                 message: Some("task".to_owned()),
             },
@@ -1057,7 +1105,7 @@ mod tests {
         assert!(stop_reason_into_nested_result(StopReason::ShutdownRequested).is_ok());
         assert_eq!(
             stop_reason_root_exit(&StopReason::ShutdownRequested),
-            Exit::new(ExitKind::Completed, Cancellation::Observed)
+            Exit::completed(Cancellation::Observed)
         );
         assert_eq!(
             stop_reason_root_exit(&StopReason::NeverStarted),
@@ -1103,30 +1151,21 @@ mod tests {
     #[test]
     fn failed_exit_equality_is_shared_provenance_not_content() {
         let error = ExitError::message("boom");
-        let exit = Exit::new(ExitKind::Failed(error.clone()), Cancellation::NotObserved);
+        let exit = Exit::failed(error.clone(), Cancellation::NotObserved);
 
         // Clones of one error — including framework-published copies —
         // compare equal.
         assert_eq!(exit, exit.clone());
-        assert_eq!(
-            exit,
-            Exit::new(ExitKind::Failed(error.clone()), Cancellation::NotObserved)
-        );
+        assert_eq!(exit, Exit::failed(error.clone(), Cancellation::NotObserved));
 
         // Independently created errors with identical content do not.
         assert_ne!(
             exit,
-            Exit::new(
-                ExitKind::Failed(ExitError::message("boom")),
-                Cancellation::NotObserved
-            )
+            Exit::failed(ExitError::message("boom"), Cancellation::NotObserved)
         );
 
         // Cancellation remains structural even with shared provenance.
-        assert_ne!(
-            exit,
-            Exit::new(ExitKind::Failed(error), Cancellation::Observed)
-        );
+        assert_ne!(exit, Exit::failed(error, Cancellation::Observed));
     }
 
     #[test]
@@ -1142,13 +1181,13 @@ mod tests {
                 "application failure survives forced abort",
                 Some(RecordedOutcome::returned(Err(failure.clone()))),
                 Some(RecordedOutcome::aborted(GracePhase::AfterGrace)),
-                Exit::new(ExitKind::Failed(failure), Cancellation::Observed),
+                Exit::failed(failure, Cancellation::Observed),
             ),
             (
                 "forced readiness timeout overrides completion",
                 Some(RecordedOutcome::returned(Ok(()))),
                 Some(RecordedOutcome::readiness_timed_out(deadline)),
-                Exit::new(
+                exit(
                     ExitKind::ReadinessTimedOut { deadline },
                     Cancellation::Observed,
                 ),
@@ -1157,7 +1196,7 @@ mod tests {
                 "earlier abort evidence wins a tie",
                 Some(RecordedOutcome::aborted(GracePhase::WithinGrace)),
                 Some(RecordedOutcome::aborted(GracePhase::AfterGrace)),
-                Exit::new(
+                exit(
                     ExitKind::Aborted {
                         phase: GracePhase::WithinGrace,
                     },

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -893,6 +893,11 @@ impl<M> fmt::Debug for MailboxCell<M> {
 }
 
 impl<M: Send + 'static> MailboxCell<M> {
+    // This constructor bridges the lower mailbox crate to the downstream
+    // façade and therefore cannot be crate-private. Direct construction is
+    // outside the supported API; the façade does not export either this type
+    // or the `MailboxRuntime` capability in its signature.
+    #[doc(hidden)]
     pub fn new(actor_id: ChildId, runtime: Arc<dyn MailboxRuntime>) -> Arc<Self> {
         let changed = runtime.signal();
         Arc::new(Self {

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -491,18 +491,6 @@ pub fn unbounded_mpsc<T>() -> (UnboundedMpscSender<T>, UnboundedMpscReceiver<T>)
     (UnboundedMpscSender(sender), UnboundedMpscReceiver(receiver))
 }
 
-pub fn unbounded_mpsc_send<T>(sender: &UnboundedMpscSender<T>, value: T) -> Result<(), T> {
-    sender.send(value)
-}
-
-pub fn unbounded_mpsc_try_recv<T>(receiver: &mut UnboundedMpscReceiver<T>) -> Option<T> {
-    receiver.try_recv()
-}
-
-pub fn unbounded_mpsc_is_empty<T>(receiver: &UnboundedMpscReceiver<T>) -> bool {
-    receiver.is_empty()
-}
-
 pub enum ScopeWake<T> {
     Signal,
     ParentShutdown,
@@ -691,9 +679,9 @@ mod tests {
         let (sender, mut receiver) = super::unbounded_mpsc();
         let (control_sender, mut control_receiver) = super::unbounded_mpsc();
         for value in 0..128 {
-            assert!(super::unbounded_mpsc_send(&control_sender, value).is_ok());
+            assert!(control_sender.send(value).is_ok());
         }
-        assert!(super::unbounded_mpsc_send(&sender, 999).is_ok());
+        assert!(sender.send(999).is_ok());
 
         let wake = super::wait_scope(
             super::ScopeWait {
@@ -707,10 +695,7 @@ mod tests {
         .await;
 
         assert!(matches!(wake, super::ScopeWake::Message(Some(999))));
-        assert_eq!(
-            super::unbounded_mpsc_try_recv(&mut control_receiver),
-            Some(0)
-        );
+        assert_eq!(control_receiver.try_recv(), Some(0));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -327,11 +327,13 @@ pub(crate) fn submit_blocking_job<J: BlockingPoolJob>(job: &Arc<J>) -> bool {
 /// the reference count — rerouting the latter would place already-empty jobs
 /// behind live ones.
 ///
-/// This pins Tokio's `spawn_task` shutdown path: a rejected closure is
-/// destroyed synchronously, before `spawn_blocking` returns. A future Tokio
-/// that deferred that drop would leave the count at two and degrade fail-safe
-/// to the old inline behavior rather than misroute a live closure. The
-/// end-to-end regressions in this crate pin the behavior we rely on.
+/// This pins Tokio 1.53.1's `spawn_task` shutdown path: a rejected closure is
+/// destroyed synchronously, before `spawn_blocking` returns. The workspace
+/// pins that exact release so an upgrade requires an explicit re-audit. A
+/// future Tokio that deferred that drop would leave the count at two and
+/// degrade fail-safe to the old inline behavior rather than misroute a live
+/// closure. The end-to-end regressions in this crate pin the behavior we rely
+/// on.
 pub(crate) fn blocking_pool_accepted<J: BlockingPoolJob>(job: &Arc<J>) -> bool {
     Arc::strong_count(job) > 1 || !job.is_pending()
 }
@@ -385,7 +387,8 @@ where
     }
 }
 
-pub fn spawn_blocking<F, T>(operation: F) -> JoinHandle<T>
+#[cfg(any(test, feature = "test-util"))]
+fn spawn_blocking<F, T>(operation: F) -> JoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
@@ -447,19 +450,53 @@ pub async fn yield_now() {
     task::yield_now().await;
 }
 
-pub type UnboundedMpscSender<T> = mpsc::UnboundedSender<T>;
-pub type UnboundedMpscReceiver<T> = mpsc::UnboundedReceiver<T>;
+/// Runtime-neutral publishing half of an unbounded driver event lane.
+pub struct UnboundedMpscSender<T>(mpsc::UnboundedSender<T>);
+
+impl<T> Clone for UnboundedMpscSender<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> UnboundedMpscSender<T> {
+    /// Sends one value, returning it when the receive lane is closed.
+    pub fn send(&self, value: T) -> Result<(), T> {
+        self.0.send(value).map_err(|error| error.0)
+    }
+}
+
+/// Runtime-neutral receiving half of an unbounded driver event lane.
+pub struct UnboundedMpscReceiver<T>(mpsc::UnboundedReceiver<T>);
+
+impl<T> UnboundedMpscReceiver<T> {
+    /// Waits for the next value, or returns `None` when every sender is gone.
+    pub async fn recv(&mut self) -> Option<T> {
+        self.0.recv().await
+    }
+
+    /// Receives one immediately available value.
+    pub fn try_recv(&mut self) -> Option<T> {
+        self.0.try_recv().ok()
+    }
+
+    /// Reports whether the receive lane currently contains no values.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
 
 pub fn unbounded_mpsc<T>() -> (UnboundedMpscSender<T>, UnboundedMpscReceiver<T>) {
-    mpsc::unbounded_channel()
+    let (sender, receiver) = mpsc::unbounded_channel();
+    (UnboundedMpscSender(sender), UnboundedMpscReceiver(receiver))
 }
 
 pub fn unbounded_mpsc_send<T>(sender: &UnboundedMpscSender<T>, value: T) -> Result<(), T> {
-    sender.send(value).map_err(|error| error.0)
+    sender.send(value)
 }
 
 pub fn unbounded_mpsc_try_recv<T>(receiver: &mut UnboundedMpscReceiver<T>) -> Option<T> {
-    receiver.try_recv().ok()
+    receiver.try_recv()
 }
 
 pub fn unbounded_mpsc_is_empty<T>(receiver: &UnboundedMpscReceiver<T>) -> bool {
@@ -670,7 +707,10 @@ mod tests {
         .await;
 
         assert!(matches!(wake, super::ScopeWake::Message(Some(999))));
-        assert_eq!(control_receiver.try_recv(), Ok(0));
+        assert_eq!(
+            super::unbounded_mpsc_try_recv(&mut control_receiver),
+            Some(0)
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -467,8 +467,7 @@ impl ScopeRuntime {
     /// blocking pool stays detached and its unknowable result cannot delay
     /// the kill path.
     fn drain_arrived_disposal_events(&mut self) {
-        while let Some(event) = runtime::unbounded_mpsc_try_recv(&mut self.disposal_event_receiver)
-        {
+        while let Some(event) = self.disposal_event_receiver.try_recv() {
             // The lane has one producer, which sends exactly one variant.
             // Assert rather than let a pattern-matching loop condition drop
             // an unexpected event and silently abandon the rest of the
@@ -1116,7 +1115,10 @@ async fn run_scope_incarnation(
                     // A closed receiver would otherwise make this select arm
                     // permanently ready and spin, so diagnose any future
                     // ownership change where it is first observable.
-                    debug_assert!(false, "a driver event lane outlives its receive loop");
+                    debug_assert!(
+                        false,
+                        "a driver event lane closed before its receive loop exited"
+                    );
                 }
                 runtime::ScopeWake::Deadline => {
                     // A producer becoming ready at the same instant owns the

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1109,10 +1109,15 @@ async fn run_scope_incarnation(
             )
             .await
             {
-                runtime::ScopeWake::Signal
-                | runtime::ScopeWake::ParentShutdown
-                | runtime::ScopeWake::Message(None)
-                | runtime::ScopeWake::ControlMessage(None) => {}
+                runtime::ScopeWake::Signal | runtime::ScopeWake::ParentShutdown => {}
+                runtime::ScopeWake::Message(None) | runtime::ScopeWake::ControlMessage(None) => {
+                    // Every lane sender is retained by the scope runtime or
+                    // one of its registered children until this loop exits.
+                    // A closed receiver would otherwise make this select arm
+                    // permanently ready and spin, so diagnose any future
+                    // ownership change where it is first observable.
+                    debug_assert!(false, "a driver event lane outlives its receive loop");
+                }
                 runtime::ScopeWake::Deadline => {
                     // A producer becoming ready at the same instant owns the
                     // tie over its deadline. Give tasks woken by that clock

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -586,13 +586,13 @@ impl DynamicRoute for DynamicControl {
 fn queue_driver_event(control: &DynamicControl, event: DriverEvent) {
     // Synchronous and runtime-independent: admission detaches at its first
     // poll, and removal may be signalled from a foreign thread.
-    let _ = runtime::unbounded_mpsc_send(&control.requests, event);
+    let _ = control.requests.send(event);
 }
 
 fn defer_driver_event(txn: &mut ObservationTxn<'_>, control: &DynamicControl, event: DriverEvent) {
     let requests = control.requests.clone();
     txn.defer(move || {
-        let _ = runtime::unbounded_mpsc_send(&requests, event);
+        let _ = requests.send(event);
     });
 }
 

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -490,17 +490,14 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
         // ownership and immediate post-join availability without ever
         // blocking this runtime worker.
         let report = report_claim.receive();
-        let _ = runtime::unbounded_mpsc_send(
-            &exit_sender,
-            DriverEvent::Child(ChildEvent::Exited {
-                child: key,
-                incarnation,
-                recorded: report.outcome,
-                join,
-                cancellation: report.cancellation,
-                readiness_signal_seen: report.readiness_signal_seen,
-            }),
-        );
+        let _ = exit_sender.send(DriverEvent::Child(ChildEvent::Exited {
+            child: key,
+            incarnation,
+            recorded: report.outcome,
+            join,
+            cancellation: report.cancellation,
+            readiness_signal_seen: report.readiness_signal_seen,
+        }));
     });
 
     let completion = ready.clone();
@@ -512,13 +509,10 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
                 runtime::select_two(ready.fired(), ready_completion.completed()).await,
                 runtime::Either::Left(())
             ) {
-                let _ = runtime::unbounded_mpsc_send(
-                    &ready_sender,
-                    DriverEvent::Child(ChildEvent::Ready {
-                        child: key,
-                        incarnation,
-                    }),
-                );
+                let _ = ready_sender.send(DriverEvent::Child(ChildEvent::Ready {
+                    child: key,
+                    incarnation,
+                }));
             }
         });
     }
@@ -528,13 +522,10 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
             runtime::select_two(local_stop.fired(), completion.completed()).await,
             runtime::Either::Left(())
         ) {
-            let _ = runtime::unbounded_mpsc_send(
-                &events,
-                DriverEvent::Child(ChildEvent::SelfStop {
-                    child: key,
-                    incarnation,
-                }),
-            );
+            let _ = events.send(DriverEvent::Child(ChildEvent::SelfStop {
+                child: key,
+                incarnation,
+            }));
         }
     });
 
@@ -1100,11 +1091,12 @@ impl ScopeRuntime {
         let sender = self.disposal_events.clone();
         let signal = self.root.signal().clone();
         runtime::dispose_then(construction, move |panic| {
-            if runtime::unbounded_mpsc_send(
-                &sender,
-                DriverEvent::Child(ChildEvent::ConstructionDisposed { child: key, panic }),
-            )
-            .is_ok()
+            if sender
+                .send(DriverEvent::Child(ChildEvent::ConstructionDisposed {
+                    child: key,
+                    panic,
+                }))
+                .is_ok()
             {
                 signal.pulse();
             }

--- a/crates/shelterwood/src/driver/events.rs
+++ b/crates/shelterwood/src/driver/events.rs
@@ -167,7 +167,7 @@ pub(super) fn collect_driver_events(
     pending: &mut Vec<(ArbitrationClass, Pending)>,
 ) -> bool {
     for _ in 0..limit {
-        let Some(event) = runtime::unbounded_mpsc_try_recv(receiver) else {
+        let Some(event) = receiver.try_recv() else {
             return false;
         };
         pending.push(Pending::from(event).classified());
@@ -176,7 +176,7 @@ pub(super) fn collect_driver_events(
     // lane. Probe once more so a lane that drained right at the limit skips
     // the full-batch yield; a probed event joins this batch rather than
     // being deferred a wake.
-    let Some(event) = runtime::unbounded_mpsc_try_recv(receiver) else {
+    let Some(event) = receiver.try_recv() else {
         return false;
     };
     pending.push(Pending::from(event).classified());

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -143,7 +143,7 @@ async fn latched_removal_suppresses_a_queued_start_effect() {
         "a latch that wins before effect execution suppresses user construction"
     );
     assert!(matches!(
-        crate::runtime::unbounded_mpsc_try_recv(&mut dynamic_events),
+        dynamic_events.try_recv(),
         Some(DriverEvent::Removal(RemovalRequest { key: queued })) if queued == key
     ));
 }
@@ -999,7 +999,7 @@ async fn fused_cancellation_overtaking_admission_rejects_before_conversion() {
     );
     assert!(fused_cancel.is_fired());
     assert!(
-        crate::runtime::unbounded_mpsc_try_recv(&mut dynamic_event_receiver).is_none(),
+        dynamic_event_receiver.try_recv().is_none(),
         "a reserved membership cannot emit a key-addressed Removal"
     );
 
@@ -1107,7 +1107,7 @@ async fn fused_cancellation_during_conversion_is_rejected_by_the_under_lock_rech
         "the under-lock rejection admits no resident"
     );
     assert!(
-        crate::runtime::unbounded_mpsc_try_recv(&mut dynamic_event_receiver).is_none(),
+        dynamic_event_receiver.try_recv().is_none(),
         "a reservation-time cancellation emits no key-addressed Removal"
     );
     assert!(
@@ -1211,7 +1211,7 @@ async fn exercise_coalesced_removal(source: RemovalSource) {
     assert_eq!(removal.key, key);
     if source == RemovalSource::FusedAndExplicit {
         assert!(
-            crate::runtime::unbounded_mpsc_try_recv(&mut dynamic_event_receiver).is_none(),
+            dynamic_event_receiver.try_recv().is_none(),
             "the state transition coalesces fused and explicit removal sources"
         );
     }
@@ -1394,13 +1394,12 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
     .await;
     let key = exit.child;
     assert!(
-        crate::runtime::unbounded_mpsc_send(
-            &scope.events,
-            DriverEvent::Removal(RemovalRequest {
+        scope
+            .events
+            .send(DriverEvent::Removal(RemovalRequest {
                 key: ChildKey::fixture(u64::MAX - 1),
-            }),
-        )
-        .is_ok(),
+            }))
+            .is_ok(),
         "the open lane queues a predecessor edge ahead of the fused removal"
     );
     drop(admission);

--- a/crates/shelterwood/src/driver/tests/events.rs
+++ b/crates/shelterwood/src/driver/tests/events.rs
@@ -151,7 +151,7 @@ fn every_event_lane_is_capped_and_a_saturated_lane_forces_a_yield() {
         "disposal completions trail both lifecycle lanes so they stay batch-tail events"
     );
     assert!(
-        crate::runtime::unbounded_mpsc_try_recv(&mut disposal_receiver).is_some(),
+        disposal_receiver.try_recv().is_some(),
         "the disposal suffix remains for a later scheduler turn"
     );
 }

--- a/crates/shelterwood/src/driver/tests/events.rs
+++ b/crates/shelterwood/src/driver/tests/events.rs
@@ -38,15 +38,21 @@ async fn blocking_primary_wake_recollects_control_removal_before_arbitration() {
     );
     let publisher = crate::runtime::spawn(async move {
         crate::runtime::yield_now().await;
-        control
-            .send(DriverEvent::Removal(RemovalRequest { key }))
-            .expect("the control lane remains open");
-        primary
-            .send(DriverEvent::Child(ChildEvent::Ready {
-                child: key,
-                incarnation,
-            }))
-            .expect("the primary lane remains open");
+        assert!(
+            control
+                .send(DriverEvent::Removal(RemovalRequest { key }))
+                .is_ok(),
+            "the control lane remains open"
+        );
+        assert!(
+            primary
+                .send(DriverEvent::Child(ChildEvent::Ready {
+                    child: key,
+                    incarnation,
+                }))
+                .is_ok(),
+            "the primary lane remains open"
+        );
     });
     let wake = wait.await;
     assert!(matches!(
@@ -93,16 +99,19 @@ fn every_event_lane_is_capped_and_a_saturated_lane_forces_a_yield() {
     let (primary, mut primary_receiver) = crate::runtime::unbounded_mpsc();
     let (control, mut control_receiver) = crate::runtime::unbounded_mpsc();
     let (disposal, mut disposal_receiver) = crate::runtime::unbounded_mpsc();
-    primary
-        .send(disposed(primary_key))
-        .expect("the primary lane remains open");
-    control
-        .send(disposed(control_key))
-        .expect("the control lane remains open");
+    assert!(
+        primary.send(disposed(primary_key)).is_ok(),
+        "the primary lane remains open"
+    );
+    assert!(
+        control.send(disposed(control_key)).is_ok(),
+        "the control lane remains open"
+    );
     for _ in 0..limit * 2 {
-        disposal
-            .send(disposed(disposal_key))
-            .expect("the disposal lane remains open");
+        assert!(
+            disposal.send(disposed(disposal_key)).is_ok(),
+            "the disposal lane remains open"
+        );
     }
 
     let mut pending = Vec::new();

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -24,7 +24,7 @@ fn member_transitions_own_their_complete_record_projection() {
     member.transition(MemberTransition::Stopping);
     assert_eq!(member.record().stage, MemberStage::Stopping);
 
-    let exit = Exit::new(ExitKind::Completed, Cancellation::NotObserved);
+    let exit = Exit::completed(Cancellation::NotObserved);
     let restart_count = RestartCount::ZERO.bump();
     let restart_at = crate::runtime::now();
     member.transition(MemberTransition::RestartScheduled {
@@ -51,7 +51,7 @@ fn member_transitions_own_their_complete_record_projection() {
     assert_eq!(record.restart_at, None);
     assert_eq!(
         record.last_exit,
-        Some(Exit::new(ExitKind::Completed, Cancellation::NotObserved))
+        Some(Exit::completed(Cancellation::NotObserved))
     );
     assert_eq!(record.restart_count, restart_count);
 }
@@ -62,8 +62,8 @@ fn incarnation_mint_exhaustion_has_no_terminal_side_effects() {
     let id = ChildId::from("worker");
     let membership = identity.mint_membership(&id).expect("membership available");
     let member = MemberCell::new(id, membership);
-    let previous = Exit::new(
-        ExitKind::Failed(ExitError::message("last completed incarnation")),
+    let previous = Exit::failed(
+        ExitError::message("last completed incarnation"),
         Cancellation::NotObserved,
     );
     // Walk the record along the production path so the transition-source
@@ -128,8 +128,8 @@ async fn incarnation_exhaustion_uses_post_disposal_retention_routing() {
         .incarnations
         .mint()
         .expect("the last usable incarnation mints");
-    let previous = Exit::new(
-        ExitKind::Failed(ExitError::message("last completed incarnation")),
+    let previous = Exit::failed(
+        ExitError::message("last completed incarnation"),
         Cancellation::NotObserved,
     );
     root.transition_child(
@@ -173,7 +173,7 @@ async fn incarnation_exhaustion_uses_post_disposal_retention_routing() {
     };
     assert!(matches!(
         event_receiver.try_recv(),
-        Ok(DriverEvent::Child(ChildEvent::Ready { .. }))
+        Some(DriverEvent::Child(ChildEvent::Ready { .. }))
     ));
     scope.handle_construction_disposed(child, panic);
 
@@ -566,7 +566,7 @@ async fn scope_incarnation_exhaustion_closes_nested_observation() {
     member.update(|record| {
         record.stage = MemberStage::Restarting;
         record.last_incarnation = Some(first);
-        record.last_exit = Some(Exit::new(ExitKind::Completed, Cancellation::NotObserved));
+        record.last_exit = Some(Exit::completed(Cancellation::NotObserved));
     });
     scope.set_state(ScopeState::Stopped {
         reason: StopReason::Finished,
@@ -588,7 +588,7 @@ async fn scope_incarnation_exhaustion_closes_nested_observation() {
     assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Empty));
     assert!(parent.terminalize_child(
         &member,
-        Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+        Exit::completed(Cancellation::NotObserved),
         None,
         StartupDisposition::NotAborted,
     ));

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -144,14 +144,13 @@ async fn incarnation_exhaustion_uses_post_disposal_retention_routing() {
     );
 
     assert!(
-        crate::runtime::unbounded_mpsc_send(
-            &scope.events,
-            DriverEvent::Child(ChildEvent::Ready {
+        scope
+            .events
+            .send(DriverEvent::Child(ChildEvent::Ready {
                 child: key,
                 incarnation: first,
-            }),
-        )
-        .is_ok(),
+            }))
+            .is_ok(),
         "the driver lane remains open"
     );
 

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -259,7 +259,7 @@ async fn terminal_scope_waits_for_its_live_incarnation_to_stop() {
 
     assert!(parent.terminalize_child(
         &nested.member,
-        Exit::aborted(GracePhase::WithinGrace, Cancellation::Observed,),
+        Exit::aborted(GracePhase::WithinGrace, Cancellation::Observed),
         Some(incarnation),
         StartupDisposition::NotAborted,
     ));
@@ -350,7 +350,7 @@ async fn terminal_scope_in_drain_waits_for_its_live_incarnation_to_stop() {
 
     assert!(parent.terminalize_child(
         &nested.member,
-        Exit::aborted(GracePhase::WithinGrace, Cancellation::Observed,),
+        Exit::aborted(GracePhase::WithinGrace, Cancellation::Observed),
         Some(incarnation),
         StartupDisposition::NotAborted,
     ));
@@ -414,7 +414,7 @@ impl AbortedNestedDriverFixture {
     fn terminalize_from_parent(&self) {
         assert!(self.parent.terminalize_child(
             &self.nested.member,
-            Exit::aborted(GracePhase::WithinGrace, Cancellation::Observed,),
+            Exit::aborted(GracePhase::WithinGrace, Cancellation::Observed),
             Some(self.incarnation),
             StartupDisposition::NotAborted,
         ));

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -259,12 +259,7 @@ async fn terminal_scope_waits_for_its_live_incarnation_to_stop() {
 
     assert!(parent.terminalize_child(
         &nested.member,
-        Exit::new(
-            ExitKind::Aborted {
-                phase: GracePhase::WithinGrace,
-            },
-            Cancellation::Observed,
-        ),
+        Exit::aborted(GracePhase::WithinGrace, Cancellation::Observed,),
         Some(incarnation),
         StartupDisposition::NotAborted,
     ));
@@ -355,12 +350,7 @@ async fn terminal_scope_in_drain_waits_for_its_live_incarnation_to_stop() {
 
     assert!(parent.terminalize_child(
         &nested.member,
-        Exit::new(
-            ExitKind::Aborted {
-                phase: GracePhase::WithinGrace,
-            },
-            Cancellation::Observed,
-        ),
+        Exit::aborted(GracePhase::WithinGrace, Cancellation::Observed,),
         Some(incarnation),
         StartupDisposition::NotAborted,
     ));
@@ -424,12 +414,7 @@ impl AbortedNestedDriverFixture {
     fn terminalize_from_parent(&self) {
         assert!(self.parent.terminalize_child(
             &self.nested.member,
-            Exit::new(
-                ExitKind::Aborted {
-                    phase: GracePhase::WithinGrace,
-                },
-                Cancellation::Observed,
-            ),
+            Exit::aborted(GracePhase::WithinGrace, Cancellation::Observed,),
             Some(self.incarnation),
             StartupDisposition::NotAborted,
         ));
@@ -592,7 +577,7 @@ async fn wait_for_child_reloads_after_its_predicate_closes_the_snapshot_stream()
                     closing_scope.finish_root_incarnation(
                         epoch,
                         StopReason::Finished,
-                        Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+                        Exit::completed(Cancellation::NotObserved),
                     );
                 }
                 false
@@ -624,7 +609,7 @@ async fn terminality_fallback_preserves_restart_window_scope_reason() {
         record.stage = MemberStage::Restarting;
         record.incarnation = None;
         record.last_incarnation = Some(last_incarnation);
-        record.last_exit = Some(Exit::new(ExitKind::Completed, Cancellation::NotObserved));
+        record.last_exit = Some(Exit::completed(Cancellation::NotObserved));
     });
     nested.set_state(ScopeState::Stopped {
         reason: StopReason::Finished,
@@ -922,12 +907,7 @@ fn a_declined_epoch_still_publishes_its_owned_terminal_exit() {
     scope.finish_root_incarnation(
         epoch,
         StopReason::ShutdownRequested,
-        Exit::new(
-            ExitKind::Aborted {
-                phase: GracePhase::WithinGrace,
-            },
-            Cancellation::Observed,
-        ),
+        Exit::aborted(GracePhase::WithinGrace, Cancellation::Observed),
     );
     assert!(matches!(
         scope.member.record().stage,
@@ -1374,7 +1354,7 @@ fn gate_handoff_rejects_a_scope_with_an_unadmitted_dynamic_reservation() {
 fn a_losing_terminal_exit_payload_is_destroyed_outside_the_gate() {
     let scope = isolated_scope("scope", ScopeFlavor::Ordered);
     scope.member.terminalize(
-        Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+        Exit::completed(Cancellation::NotObserved),
         StartupDisposition::Unchanged,
     );
 
@@ -1401,7 +1381,7 @@ fn a_losing_supervised_terminal_exit_is_a_complete_noop_outside_the_gate() {
     resolve_fixture_options(&member);
     root.admit_child(ResidentProjection::new(Arc::clone(&member), None));
     member.terminalize(
-        Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+        Exit::completed(Cancellation::NotObserved),
         StartupDisposition::NotAborted,
     );
     let winning_record = member.record();
@@ -1488,7 +1468,7 @@ fn a_superseded_restart_exit_payload_is_destroyed_outside_the_gate() {
         incarnation: second,
     });
     member.transition(MemberTransition::RestartScheduled {
-        exit: Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+        exit: Exit::completed(Cancellation::NotObserved),
         restart_count: RestartCount::ZERO.bump().bump(),
         restart_at: None,
     });
@@ -1517,7 +1497,7 @@ fn a_restart_exit_payload_superseded_by_terminalization_outlives_the_gate() {
     );
 
     member.terminalize(
-        Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+        Exit::completed(Cancellation::NotObserved),
         StartupDisposition::Unchanged,
     );
     assert!(

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -84,7 +84,7 @@ async fn scope_with_arrived_factory_disposal_panic() -> (ScopeRuntime, ChildKey,
     assert!(scope.children[key].pending_terminal.is_some());
 
     let arrived = crate::runtime::timeout(DRIVER_PROGRESS_WAIT, async {
-        while crate::runtime::unbounded_mpsc_is_empty(&scope.disposal_event_receiver) {
+        while scope.disposal_event_receiver.is_empty() {
             crate::runtime::yield_now().await;
         }
     })

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -1093,7 +1093,7 @@ async fn queued_removal_suppresses_replayed_self_stop_readiness() {
         })
         .classified(),
     ];
-    while let Some(event) = crate::runtime::unbounded_mpsc_try_recv(&mut control_event_receiver) {
+    while let Some(event) = control_event_receiver.try_recv() {
         pending.push(Pending::from(event).classified());
     }
     arbitrate(&mut pending);

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -14,11 +14,12 @@ pub(super) use std::{
 
 pub(super) use crate::{
     ActorRef, Backoff, Cancellation, ChildId, ChildState, DynamicTree, Exit, ExitError, ExitKind,
-    GracePhase, Incarnation, Intensity, LIFECYCLE_EVENT_CAPACITY, LifecycleEventKind,
-    LifecycleItem, LifecycleTryRecvError, Mailbox, MembershipStatus, RawOnceDef, Readiness,
-    ReadinessDeadline, RemoveOutcome, ReserveError, RestartCondition, RestartCount, RestartPolicy,
-    Retention, ScopeRef, ScopeState, SendErrorKind, StartupError, StartupFailure,
-    StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
+    GracePhase, Incarnation, Intensity, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError,
+    Mailbox, MembershipStatus, RawOnceDef, Readiness, ReadinessDeadline, RemoveOutcome,
+    ReserveError, RestartCondition, RestartCount, RestartPolicy, Retention, ScopeRef, ScopeState,
+    SendErrorKind, StartupError, StartupFailure, StartupFailureCause, StopReason, SubtreeDef,
+    SubtreeOnceDef, TaskDef, Tree,
+    cells::LIFECYCLE_EVENT_CAPACITY,
     engine::{
         ChildKey, Effect as SupervisorEffect, Epoch, Event as SupervisorEvent, ScopeLifecycle,
         StopLadder, SupervisorState, arbitrate, step as supervisor_step,
@@ -414,12 +415,12 @@ pub(super) struct GateProbeError {
 /// Builds a failed exit whose payload reports where it was destroyed.
 pub(super) fn gate_probe_exit(scope: &Arc<ScopeCell>) -> (Exit, Arc<Mutex<Option<bool>>>) {
     let held_at_drop = Arc::new(Mutex::new(None));
-    let exit = Exit::new(
-        ExitKind::Failed(ExitError::from(GateProbeError {
+    let exit = Exit::failed(
+        ExitError::from(GateProbeError {
             gate: scope.observation_gate(),
             retiring_thread: std::thread::current().id(),
             held_at_drop: Arc::clone(&held_at_drop),
-        })),
+        }),
         Cancellation::NotObserved,
     );
     (exit, held_at_drop)

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -842,7 +842,7 @@ fn mailbox_wake_observes_terminal_record_and_reentrant_terminality_is_idempotent
     let first_exit = Exit::never_started();
     let probe = Arc::new(ObserveMemberOnMailboxWake {
         member: Arc::clone(&member),
-        competing_exit: Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+        competing_exit: Exit::completed(Cancellation::NotObserved),
         observed: Mutex::new(None),
     });
     let waker = Waker::from(Arc::clone(&probe));
@@ -883,7 +883,7 @@ fn attach_during_terminal_publication_finishes_record_before_mailbox_wake() {
     member.stage_terminal_before_mailbox(first_exit.clone());
     let probe = Arc::new(ObserveMemberOnMailboxWake {
         member: Arc::clone(&member),
-        competing_exit: Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+        competing_exit: Exit::completed(Cancellation::NotObserved),
         observed: Mutex::new(None),
     });
     let waker = Waker::from(Arc::clone(&probe));
@@ -921,7 +921,7 @@ fn concurrent_terminalizers_return_after_one_consistent_record_is_visible() {
     let start = Arc::new(Barrier::new(3));
     let workers = [
         Exit::never_started(),
-        Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+        Exit::completed(Cancellation::NotObserved),
     ]
     .into_iter()
     .map(|exit| {
@@ -954,7 +954,7 @@ fn a_losing_terminalizer_does_not_reclassify_or_republish_startup() {
         id.clone(),
         identity.mint_membership(&id).expect("membership available"),
     );
-    let winner = Exit::new(ExitKind::Completed, Cancellation::NotObserved);
+    let winner = Exit::completed(Cancellation::NotObserved);
     member.terminalize(winner, StartupDisposition::NotAborted);
     let winning_record = member.record();
 
@@ -968,10 +968,7 @@ fn a_losing_terminalizer_does_not_reclassify_or_republish_startup() {
         "the watcher starts at the winning terminal publication"
     );
 
-    member.terminalize(
-        Exit::new(ExitKind::NeverStarted, Cancellation::NotObserved),
-        StartupDisposition::Aborted,
-    );
+    member.terminalize(Exit::never_started(), StartupDisposition::Aborted);
 
     assert_eq!(
         member.record(),

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -39,9 +39,9 @@ pub use mailbox::{
     ReplyReceiver, SendError, SendErrorKind, SendFuture, SendTimeout,
 };
 pub use observe::{
-    ChildSnapshot, ChildState, LIFECYCLE_EVENT_CAPACITY, LifecycleEvent, LifecycleEventKind,
-    LifecycleEvents, LifecycleItem, LifecycleSeq, LifecycleTryRecvError, ScopeKind, ScopeSnapshot,
-    SnapshotClosed, SnapshotReceiver, WaitError,
+    ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents, LifecycleItem,
+    LifecycleSeq, LifecycleTryRecvError, ScopeKind, ScopeSnapshot, SnapshotClosed,
+    SnapshotReceiver, WaitError,
 };
 pub use policy::{
     Backoff, BackoffFactor, BoundedReadinessDeadline, DefaultsInheritance, ExponentialBackoff,

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -1,5 +1,5 @@
 pub use shelterwood_cells::{
-    ChildSnapshot, ChildState, LIFECYCLE_EVENT_CAPACITY, LifecycleEvent, LifecycleEventKind,
-    LifecycleEvents, LifecycleItem, LifecycleSeq, LifecycleTryRecvError, ScopeKind, ScopeSnapshot,
-    SnapshotClosed, SnapshotReceiver, WaitError,
+    ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents, LifecycleItem,
+    LifecycleSeq, LifecycleTryRecvError, ScopeKind, ScopeSnapshot, SnapshotClosed,
+    SnapshotReceiver, WaitError,
 };

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -322,7 +322,7 @@ mod tests {
     };
 
     use crate::{
-        Cancellation, ChildId, Exit, ExitError, ExitKind, GracePhase,
+        Cancellation, ChildId, Exit, ExitError, GracePhase,
         cells::MemberCell,
         identity::ScopeIdentity,
         runtime::{self, CompletionGatedLatch, Latch},
@@ -449,7 +449,7 @@ mod tests {
 
         assert!(matches!(waiting.as_mut().poll(&mut context), Poll::Pending));
         member.terminalize(
-            Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+            Exit::completed(Cancellation::NotObserved),
             crate::cells::StartupDisposition::Unchanged,
         );
         assert_eq!(waiting.await, Ok(42));
@@ -461,12 +461,7 @@ mod tests {
         sender.send(42_u8).expect("claim remains open");
         let mut waiting = Box::pin(claim.wait());
         let mut context = Context::from_waker(Waker::noop());
-        let exit = Exit::new(
-            ExitKind::Aborted {
-                phase: GracePhase::WithinGrace,
-            },
-            Cancellation::Observed,
-        );
+        let exit = Exit::aborted(GracePhase::WithinGrace, Cancellation::Observed);
 
         assert!(matches!(waiting.as_mut().poll(&mut context), Poll::Pending));
         member.terminalize(exit.clone(), crate::cells::StartupDisposition::Unchanged);
@@ -479,7 +474,7 @@ mod tests {
         let (sender, claim, member) = one_shot_claim::<u8>();
         drop(sender);
         member.terminalize(
-            Exit::new(ExitKind::Completed, Cancellation::NotObserved),
+            Exit::completed(Cancellation::NotObserved),
             crate::cells::StartupDisposition::Unchanged,
         );
 

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -14,12 +14,17 @@ use crate::common::{
     waiting::{gate_released_manual_ready_task, task as waiting_task, tree as waiting_tree},
 };
 use shelterwood::{
-    Backoff, ChildState, DynamicScopeRef, DynamicTree, Intensity, Jitter, LIFECYCLE_EVENT_CAPACITY,
-    LifecycleEvent, LifecycleEventKind, LifecycleEvents, LifecycleItem, LifecycleSeq,
-    LifecycleTryRecvError, MembershipStatus, RemoveOutcome, RestartCondition, RestartCount,
-    RestartPolicy, Retention, ScopeKind, ScopeRef, ScopeState, StopReason, Strategy, SubtreeDef,
-    SubtreeOnceDef, TaskDef, TaskOnceDef, TaskRef, TotalRestarts, Tree, WaitError,
+    Backoff, ChildState, DynamicScopeRef, DynamicTree, Intensity, Jitter, LifecycleEvent,
+    LifecycleEventKind, LifecycleEvents, LifecycleItem, LifecycleSeq, LifecycleTryRecvError,
+    MembershipStatus, RemoveOutcome, RestartCondition, RestartCount, RestartPolicy, Retention,
+    ScopeKind, ScopeRef, ScopeState, StopReason, Strategy, SubtreeDef, SubtreeOnceDef, TaskDef,
+    TaskOnceDef, TaskRef, TotalRestarts, Tree, WaitError,
 };
+
+// The ring width is an implementation choice, not façade API. This black-box
+// overflow regression deliberately pins the current behavior without asking
+// applications to compile against that tuning constant.
+const LIFECYCLE_EVENT_CAPACITY: usize = 128;
 
 async fn next_item(events: &mut LifecycleEvents) -> LifecycleItem {
     tokio::time::timeout(Duration::from_secs(2), events.recv())

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -23,26 +23,19 @@ fn task_families_reject_after_init_readiness_eagerly() {
 }
 
 #[test]
-fn public_exit_constructor_preserves_evidence_and_classifies_failures() {
-    let completed = Exit::new(ExitKind::Completed, Cancellation::Observed);
+fn public_exit_constructors_preserve_evidence_and_classify_failures() {
+    let completed = Exit::completed(Cancellation::Observed);
     assert_eq!(completed.cancellation(), Cancellation::Observed);
     assert!(matches!(completed.kind(), ExitKind::Completed));
     assert!(!completed.is_failure());
 
-    for kind in [
-        ExitKind::Failed(ExitError::message("failed")),
-        ExitKind::Panicked {
-            message: Some("panicked".to_owned()),
-        },
-        ExitKind::ReadinessTimedOut {
-            deadline: std::time::Instant::now(),
-        },
-        ExitKind::Aborted {
-            phase: GracePhase::AfterGrace,
-        },
-        ExitKind::NeverStarted,
+    for exit in [
+        Exit::failed(ExitError::message("failed"), Cancellation::NotObserved),
+        Exit::panicked(Some("panicked".to_owned()), Cancellation::NotObserved),
+        Exit::readiness_timed_out(std::time::Instant::now(), Cancellation::NotObserved),
+        Exit::aborted(GracePhase::AfterGrace, Cancellation::NotObserved),
+        Exit::never_started(),
     ] {
-        let exit = Exit::new(kind, Cancellation::NotObserved);
         assert_eq!(exit.cancellation(), Cancellation::NotObserved);
         assert!(exit.is_failure(), "non-completed exit: {:?}", exit.kind());
     }

--- a/tools/check-external-consumer.sh
+++ b/tools/check-external-consumer.sh
@@ -8,6 +8,16 @@ trap 'rm -f "$diagnostics"' EXIT
 
 cargo check --locked --manifest-path "$manifest"
 
+if cargo check --locked --manifest-path "$manifest" --features exit-new >"$diagnostics" 2>&1; then
+    echo "external consumers can construct an Exit from an arbitrary ExitKind" >&2
+    exit 1
+fi
+if ! grep -Fq 'no associated function or constant named `new` found for struct `Exit`' "$diagnostics"; then
+    cat "$diagnostics" >&2
+    echo "Exit::new probe failed for an unexpected reason" >&2
+    exit 1
+fi
+
 if cargo check --locked --manifest-path "$manifest" --features from-latch >"$diagnostics" 2>&1; then
     echo "external consumers can call CancellationToken::from_latch" >&2
     exit 1
@@ -15,6 +25,16 @@ fi
 if ! grep -Fq 'associated function `from_latch` is private' "$diagnostics"; then
     cat "$diagnostics" >&2
     echo "from_latch probe failed for an unexpected reason" >&2
+    exit 1
+fi
+
+if cargo check --locked --manifest-path "$manifest" --features lifecycle-capacity >"$diagnostics" 2>&1; then
+    echo "the supported façade exports its lifecycle buffer capacity" >&2
+    exit 1
+fi
+if ! grep -Fq 'no `LIFECYCLE_EVENT_CAPACITY` in the root' "$diagnostics"; then
+    cat "$diagnostics" >&2
+    echo "lifecycle-capacity probe failed for an unexpected reason" >&2
     exit 1
 fi
 

--- a/tools/external-consumer/Cargo.toml
+++ b/tools/external-consumer/Cargo.toml
@@ -7,8 +7,10 @@ publish = false
 [workspace]
 
 [features]
+exit-new = []
 from-latch = []
 installable-seams = []
+lifecycle-capacity = []
 sealed-mailbox-seams = ["dep:shelterwood-core", "dep:shelterwood-mailbox"]
 private-seal-module = ["dep:shelterwood-mailbox"]
 

--- a/tools/external-consumer/src/main.rs
+++ b/tools/external-consumer/src/main.rs
@@ -1,5 +1,11 @@
 use shelterwood::CancellationToken;
 
+#[cfg(feature = "exit-new")]
+use shelterwood::{Cancellation, Exit, ExitKind};
+
+#[cfg(feature = "lifecycle-capacity")]
+use shelterwood::LIFECYCLE_EVENT_CAPACITY;
+
 fn accepts_supported_token(_: &CancellationToken) {}
 
 #[cfg(feature = "installable-seams")]
@@ -59,6 +65,12 @@ use shelterwood_mailbox::private::SealedMailboxTermination;
 fn main() {
     let _ = accepts_supported_token;
 
+    #[cfg(feature = "exit-new")]
+    let _ = Exit::new(ExitKind::Completed, Cancellation::NotObserved);
+
     #[cfg(feature = "from-latch")]
     let _ = CancellationToken::from_latch(todo!());
+
+    #[cfg(feature = "lifecycle-capacity")]
+    let _ = LIFECYCLE_EVENT_CAPACITY;
 }


### PR DESCRIPTION
Continues the #284 hardening stack. Closes #273.

## What changed

- Replaces the open `Exit::new(ExitKind, Cancellation)` constructor with per-kind constructors; `NeverStarted` can now only be `NotObserved`.
- Restricts the raw runtime blocking-spawn wrapper to test/test-util use.
- Exact-pins Tokio to `=1.53.1`.
- Removes lifecycle capacity from the facade, replaces Tokio MPSC aliases with opaque adapters, and records the closed-lane sender-lifetime invariant.
- Documents the hidden lower-crate mailbox constructor boundary and the deliberately retained snapshot bridge.
- Extends the external-consumer negative fences for the retired API.

Validation: the rebased #269 → #272 → #273 stack passes `./tools/dev just ci` with 687/687 tests, formatting, clippy, doctests, docs, API reachability, packaged docs, external consumer, and Nix formatting.

Stack: based on #300 / issue #272 to avoid duplicating constructor migrations in its new regressions.