### PR TITLE
Delete dead code and accidental configurability

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -840,8 +840,8 @@ runs under either mutex. The one carve-out is a framework invariant break
 the payload still under the guard, and they poison the mutex regardless, so the
 transition is abandoned rather than completed.
 The registered-waker slot exposes no operation that returns or replaces a
-`Waker` without an effects sink, making the #202 failure shape structurally
-unrepresentable rather than a call-site convention. Cancellation returns one
+`Waker` without an effects sink, making an under-lock caller-code drop
+structurally unrepresentable rather than a call-site convention. Cancellation returns one
 withdrawal outcome plus its post-unlock effects object, never a tuple carrying
 a raw waker across the boundary.
 
@@ -1083,8 +1083,8 @@ zero-cost reborrow of the same underlying context — no boxing, no
 mapping layer (Part II §17's `project` is the paying, boxed cousin; the
 `Msg`-equality bound is what makes the free identity possible). The
 returned context therefore *is* the outer actor's: same incarnation and
-identity (`id()`, `incarnation()`, `myself()`), same mailbox and shared
-resources, same incarnation-owned timer table (§5.3's heterogeneous keys
+identity (`id()`, `incarnation()`), same mailbox and shared resources, same
+incarnation-owned timer table (§5.3's heterogeneous keys
 keep an inner actor's keys collision-free by type), and every operation
 through it — sends, timers, offloads, `stop()` — attributes to the one
 outer actor (one mailbox, one identity, one lifecycle: §17's attribution
@@ -1289,7 +1289,7 @@ enum Readiness { Immediate, AfterInit, Manual }   // mode only — the deadline 
   exception: their readiness is structural (below), so the subtree veneer
   carries no mode override — only the deadline.
 - The deadline is not part of the mode: it lives on the shared options
-  record (§8) as `ReadinessDeadline: Inherit | Bounded(Duration) |
+  record (§8) as `ReadinessDeadline: Inherit | Bounded(NonZeroDuration) |
   Unbounded`, defaulting to `Inherit` — resolution is declaration → scope
   default → library default (Appendix A). Unbounded gating exists only via
   the explicit `Unbounded` value; no `None` does double duty as both
@@ -2680,7 +2680,7 @@ or lifetime paragraph is unmapped.
   cells terminalize exactly as a dropped unspawned tree's do (§3.2),
   and the incarnation exits `Failed` carrying the structured
   startup-failure payload with a **lowering cause** naming the
-  undefined slots' child-id paths — the same data
+  undefined slots' child ids relative to that subtree root — the same data
   `BuildError::UnfilledReservations` carries, reached through B.5's
   `startup_failure()` accessor (§7 provenance, non-forgeable). The
   scope publishes `Stopped { reason: StartupFailed }` (B.6) and exits
@@ -2965,7 +2965,7 @@ integration toolkit for the driver shell and the end-to-end invariants.
    Provoke each verdict (readiness expiry, grace-expiry abort, cancelled
    completion) and match the typed variant — never a stringly `Failed`.
    Enforce the mechanism structurally: core classification consumes typed
-   `RecordedOutcome` and `JoinVerdict` values and contains no `Any` or
+   `RecordedOutcome` and `JoinOutcome` values and contains no `Any` or
    downcast path; the runtime adapter converts its join result before core
    sees it, while user error erasure stays at the façade boundary. The former
    grep-level exit-path check is retired with the crate split because the
@@ -3664,7 +3664,8 @@ the same series during shutdown drain; **Stop** = `StopContext<'_, A>` in
 
 | Operation | Raw | Live | Drain | Stop |
 |---|---|---|---|---|
-| `id()`, `incarnation()`, `myself()`, `scope()`, `shutdown_token()` | ✓ | ✓ | ✓ | ✓ |
+| `id()`, `incarnation()`, `scope()`, `shutdown_token()` | ✓ | ✓ | ✓ | ✓ |
+| `myself()` | ✓ | ✓ | ✓ | — |
 | `request_scope_shutdown()` (fire-and-forget; awaiting your own scope's shutdown deadlocks — documented) | ✓ | ✓ | ✓ | ✓ |
 | `run_blocking(f)` | ✓ | ✓ | ✓ | ✓ |
 | `recv()` / `try_recv()` (the merged event source: mailbox, offload completions, fired timers, queued continuations, §5.2 priority; `recv` yields `None` on stop request, biased; `try_recv` ignores the stop token — the drain primitive for raw loops: under `Drain`, exhaust the frozen prefix via `try_recv` after `recv` yields `None`, §10's raw-loop obligation) | ✓ | — | — | — |
@@ -3680,8 +3681,7 @@ the same series during shutdown drain; **Stop** = `StopContext<'_, A>` in
 | Re-entry/mapping: `for_actor` (same-`Msg`, core); `project` *(II §17)* | — | ✓ | ✓ | `for_actor` only |
 
 `StopContext` withholds everything that queues future work for this
-incarnation — there is no one left to deliver to; `myself()` is present but
-documented "do not post work to yourself."
+incarnation — there is no one left to deliver to, so `myself()` is absent.
 
 ### B.2 `TaskContext`
 
@@ -4135,8 +4135,8 @@ and their defines cannot fail (§8).
 
 `BuildError` (spawn-time, §11) is enumerated and exhaustive pre-release:
 `NoRuntime` (no ambient async runtime reachable through the private façade
-over `shelterwood-runtime`) and `UnfilledReservations` (the child-id paths of
-every undefined reserved slot, §8). Nothing else lives there by design:
+over `shelterwood-runtime`) and `UnfilledReservations` (the child ids of every
+undefined reserved slot at that root, §8). Nothing else lives there by design:
 everything decidable earlier fails at declaration (§9.3's eager validation),
 and everything later is the child's ordinary supervision story — spawn is not
 a third validation point. `BuildError` is spawn-only because spawn

--- a/SPEC.md
+++ b/SPEC.md
@@ -260,8 +260,9 @@ Scope flavors:
 - **Ordered** — declared membership fixed at build time; sequential,
   readiness-gated startup in declaration order; reverse-order teardown.
 - **Dynamic** — runtime membership; concurrent start/stop; per-child
-  fate-sharing only (strategy is structurally `OneForOne`; the strategy knob
-  does not exist on dynamic scopes [#371]).
+  fate-sharing only (strategy is structurally `OneForOne`, and a dynamic
+  scope carries no strategy at all — not in its builder, its config, or its
+  snapshot [#371]; §9.1).
 
 **Child ids.** Every child has an id: a non-empty UTF-8 string, unique among
 the **resident** memberships of its containing scope — live *or*
@@ -2021,7 +2022,14 @@ single largest block of deferred engine complexity, and §10's mode-based
 exit funnel is designed so they land without restructuring. The `Strategy`
 type is non-exhaustive from day one, is a property of **ordered** scopes
 only (§2), and does not exist on dynamic scope builders, configs, or
-snapshots.
+snapshots. While `OneForOne` is the sole variant, ordered builders carry no
+strategy setter either: a knob whose only value is its default selects
+nothing, and offering it would pin a call shape no caller can vary. The
+setter is deferred until a second `Strategy` variant lands with Part II §19;
+until then the type is reachable only where it is *read* — `ScopeSnapshot`
+reports `Some(OneForOne)` for an ordered scope and `None` for a dynamic one
+(B.6). Adding the setter back is an additive change, and the type staying
+non-exhaustive is what keeps it one.
 
 ### 9.2 Restart policy and intensity [#371]
 
@@ -2502,8 +2510,9 @@ or lifetime paragraph is unmapped.
 - **Builder operation inventory** (content-normative; Appendix B's
   naming latitude applies). One constructor per flavor — `Tree` for an
   ordered root, `DynamicTree` for a dynamic one. Per-scope
-  configuration setters: `strategy` (ordered only, §9.1), `intensity`
-  (§9.2), `defaults(ScopeDefaults)` (§9.3). Membership declaration:
+  configuration setters: `intensity` (§9.2), `defaults(ScopeDefaults)`
+  (§9.3) — there is no strategy setter on either flavor, per §9.1.
+  Membership declaration:
   the eight `add_*` entry points and the `reserve_*` slot family (§8) —
   on an ordered builder, declaration order is start order (§2); nested
   scopes declare through `add_subtree` / `add_subtree_once`, whose

--- a/crates/shelterwood-cells/src/admission.rs
+++ b/crates/shelterwood-cells/src/admission.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use crate::identity::ChildId;
+use shelterwood_core::ChildId;
 
 /// A child reservation or dynamic admission error.
 #[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]

--- a/crates/shelterwood-cells/src/cancellation.rs
+++ b/crates/shelterwood-cells/src/cancellation.rs
@@ -1,6 +1,6 @@
 //! Read-only cancellation capabilities shared by supervised children and work.
 
-use crate::runtime::{self, Latch};
+use shelterwood_runtime::{self as runtime, Latch};
 
 /// A library-owned cancellation token.
 #[derive(Clone, Debug)]
@@ -69,11 +69,11 @@ impl ParentCancellationToken {
 mod tests {
     use std::time::Duration;
 
-    use crate::runtime::{self, JoinOutcome, Latch, Timeout};
+    use shelterwood_runtime::{self as runtime, JoinOutcome, Latch, Timeout};
 
     use super::ParentCancellationToken;
 
-    #[crate::runtime::test]
+    #[shelterwood_runtime::test]
     async fn local_cancellation_cancels_only_the_derived_token() {
         let primary = Latch::default();
         let local = Latch::default();
@@ -90,7 +90,7 @@ mod tests {
         assert!(!primary.is_fired());
     }
 
-    #[crate::runtime::test]
+    #[shelterwood_runtime::test]
     async fn supervisor_cancellation_cancels_the_derived_token() {
         let primary = Latch::default();
         let local = Latch::default();
@@ -107,7 +107,7 @@ mod tests {
         assert!(!local.is_fired());
     }
 
-    #[crate::runtime::test(flavor = "multi_thread", worker_threads = 4)]
+    #[shelterwood_runtime::test(flavor = "multi_thread", worker_threads = 4)]
     async fn simultaneous_supervisor_and_local_cancellation_wake_the_operation() {
         for _ in 0..128 {
             let primary = Latch::default();

--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -20,23 +20,26 @@ use std::{
 #[cfg(any(test, feature = "test-util"))]
 use std::sync::atomic::AtomicUsize;
 
-use crate::{
+use shelterwood_core::{
     ChildId, Exit, Incarnation, Intensity, Membership, RestartCount, Strategy, TotalRestarts,
-    admission::{RemoveOutcome, ReserveError},
     engine::{Epoch, MembershipStatus, RequestTarget, ScopeEpochs, ScopeState},
     exit::{
         ExitKind, StartupError, StartupFailure, StartupFailureCause, StopReason,
         stop_reason_precedence,
     },
     identity::{AtomicPoisonedCounter, IncarnationCounter, MintedMembership, ScopeIdentity},
-    mailbox::{ActorIdentity, MailboxControl, MailboxTermination},
+    policy::{ResolvedCommonOptions, ScopeFlavor},
+};
+use shelterwood_mailbox::{ActorIdentity, MailboxControl, MailboxTermination};
+use shelterwood_runtime::{self as runtime, Latch};
+
+use crate::{
+    admission::{RemoveOutcome, ReserveError},
     observe::{
         ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
-        LifecycleHub, LifecycleSeq, RetainedScopeSnapshot, ScopeKind, ScopeSnapshot, SnapshotHub,
+        LifecycleHub, LifecycleSeq, RetainedScopeSnapshot, ScopeSnapshot, SnapshotHub,
         SnapshotPublication, SnapshotReceiver,
     },
-    policy::{ResolvedCommonOptions, ScopeFlavor},
-    runtime::{self, Latch},
 };
 
 /// An exit copy retained by framework state.
@@ -59,14 +62,6 @@ impl RetainedExit {
 
     pub fn into_exit(mut self) -> Exit {
         self.0.take().expect("retained exit was already taken")
-    }
-
-    pub fn kind(&self) -> &ExitKind {
-        self.as_exit().kind()
-    }
-
-    pub fn cancellation(&self) -> crate::exit::Cancellation {
-        self.as_exit().cancellation()
     }
 
     pub(crate) fn retain_scope_state(exits: &mut Vec<Self>, state: &ScopeState) {
@@ -573,7 +568,7 @@ impl MemberCell {
         loop {
             let gate = self.current_observation_gate();
             let guard = gate.lock();
-            if gate.same_gate(&self.current_observation_gate()) {
+            if gate.shares_gate(&self.current_observation_gate()) {
                 let mut txn = ObservationTxn::new(guard);
                 return operation
                     .take()
@@ -602,11 +597,11 @@ impl MemberCell {
             .observation_gate
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if installed.same_gate(previous) {
+        if installed.shares_gate(previous) {
             *installed = gate.clone();
         } else {
             assert!(
-                installed.same_gate(gate),
+                installed.shares_gate(gate),
                 "a resident member must share its tree observation gate"
             );
         }
@@ -615,11 +610,11 @@ impl MemberCell {
     fn adopt_observation_gate(&self, gate: &ObservationGate, _txn: &mut ObservationTxn<'_>) {
         loop {
             let current = self.current_observation_gate();
-            if current.same_gate(gate) {
+            if current.shares_gate(gate) {
                 return;
             }
             let current_guard = current.lock();
-            if current.same_gate(&self.current_observation_gate()) {
+            if current.shares_gate(&self.current_observation_gate()) {
                 self.install_observation_gate_locked(&current, gate);
                 drop(current_guard);
                 return;
@@ -919,8 +914,13 @@ impl ObservationGate {
         Self(Arc::new(Mutex::new(())))
     }
 
-    pub fn same_gate(&self, other: &Self) -> bool {
+    fn shares_gate(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.0, &other.0)
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn same_gate(&self, other: &Self) -> bool {
+        self.shares_gate(other)
     }
 
     pub fn lock(&self) -> MutexGuard<'_, ()> {
@@ -1111,7 +1111,6 @@ impl Drop for ResidentChild {
 
 #[derive(Clone, Copy, Debug, Default)]
 struct ObservationConfig {
-    strategy: Strategy,
     intensity: Intensity,
 }
 
@@ -1421,12 +1420,12 @@ impl ScopeCell {
         // Re-homing the parent would first have to acquire that same gate, so
         // rereading its installed pointer here cannot race a parent handoff.
         debug_assert!(
-            gate.same_gate(&parent.current_observation_gate()),
+            gate.shares_gate(&parent.current_observation_gate()),
             "observation gates are adopted only in the parent-to-child direction"
         );
         loop {
             let current = self.current_observation_gate();
-            if current.same_gate(gate) {
+            if current.shares_gate(gate) {
                 return;
             }
             debug_assert!(
@@ -1442,7 +1441,7 @@ impl ScopeCell {
             // that merely captured this obsolete gate retries after acquiring
             // it and observing the replacement.
             let current_guard = current.lock();
-            if current.same_gate(&self.current_observation_gate()) {
+            if current.shares_gate(&self.current_observation_gate()) {
                 self.member.install_observation_gate_locked(&current, gate);
                 self.adopt_descendant_observation_gates_locked(&current, gate, txn);
                 drop(current_guard);
@@ -1506,7 +1505,7 @@ impl ScopeCell {
             #[cfg(any(test, feature = "test-util"))]
             self.report_gate_capture(GateCapture::Observation);
             let guard = gate.lock();
-            if gate.same_gate(&self.current_observation_gate()) {
+            if gate.shares_gate(&self.current_observation_gate()) {
                 let operation = operation
                     .take()
                     .expect("observation operation runs exactly once");
@@ -1560,7 +1559,7 @@ impl ScopeCell {
             for member in terminal_disposals {
                 debug_assert!(
                     self.current_observation_gate()
-                        .same_gate(&member.current_observation_gate()),
+                        .shares_gate(&member.current_observation_gate()),
                     "a drain entry may mark only a resident member on its observation gate"
                 );
                 member.set_terminal_disposal_pending(true);
@@ -1595,16 +1594,14 @@ impl ScopeCell {
         self.emit_locked(txn, LifecycleEventKind::ScopeState { state });
     }
 
-    pub fn set_observation_config(&self, strategy: Strategy, intensity: Intensity) {
+    pub fn set_observation_config(&self, intensity: Intensity) {
         self.with_observation_gate(|wakes| {
             *self
                 .observation
                 .config
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner) = ObservationConfig {
-                strategy,
-                intensity,
-            };
+                .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                ObservationConfig { intensity };
             self.publish_snapshot_chain_locked(wakes);
         });
     }
@@ -1821,11 +1818,8 @@ impl ScopeCell {
         }
         let snapshot = Arc::new(ScopeSnapshot {
             state: record.state,
-            kind: match self.flavor {
-                ScopeFlavor::Ordered => ScopeKind::Ordered,
-                ScopeFlavor::Dynamic => ScopeKind::Dynamic,
-            },
-            strategy: (self.flavor == ScopeFlavor::Ordered).then_some(config.strategy),
+            kind: self.flavor,
+            strategy: (self.flavor == ScopeFlavor::Ordered).then_some(Strategy::default()),
             intensity: config.intensity,
             total_restarts: record.total_restarts,
             lifecycle_seq: LifecycleSeq::new(
@@ -2590,14 +2584,11 @@ mod tests {
     };
 
     use shelterwood_core::{
-        Cancellation, Exit, ExitError, ExitKind, ScopeState, StartupFailure, StartupFailureCause,
-        StopReason,
+        Cancellation, ChildId, Exit, ExitError, ExitKind, ScopeState, StartupFailure,
+        StartupFailureCause, StopReason, identity::ScopeIdentity, policy::ScopeFlavor,
     };
 
-    use crate::{
-        ChildId, MemberCell, RetainedExit, RetainedStopReason, ScopeCell, StartupDisposition,
-        identity::ScopeIdentity, policy::ScopeFlavor,
-    };
+    use crate::{MemberCell, RetainedExit, RetainedStopReason, ScopeCell, StartupDisposition};
 
     struct ThreadProbe(mpsc::SyncSender<std::thread::ThreadId>);
 

--- a/crates/shelterwood-cells/src/lib.rs
+++ b/crates/shelterwood-cells/src/lib.rs
@@ -28,34 +28,12 @@ mod observe;
 pub use admission::*;
 pub use cancellation::*;
 #[doc(hidden)]
-pub use cells::*;
-pub use observe::*;
-
-pub(crate) use shelterwood_core::{
-    ChildId, Exit, Incarnation, Intensity, Membership, RestartAttempt, RestartCount, RestartPolicy,
-    Retention, Strategy, TotalRestarts,
+pub use cells::{
+    DynamicRoute, ErasedDynamicRoute, ErasedDynamicSlot, MemberCell, MemberStage, MemberTransition,
+    ObservationGate, ObservationTxn, ResidentProjection, RetainedExit, RetainedStopReason,
+    ScopeCell, ScopeControlEvent, StartupDisposition,
 };
-
-mod engine {
-    pub(crate) use shelterwood_core::engine::*;
-}
-
-mod exit {
-    pub(crate) use shelterwood_core::exit::*;
-}
-
-mod identity {
-    pub(crate) use shelterwood_core::identity::*;
-}
-
-mod mailbox {
-    pub(crate) use shelterwood_mailbox::*;
-}
-
-mod policy {
-    pub(crate) use shelterwood_core::policy::*;
-}
-
-mod runtime {
-    pub(crate) use shelterwood_runtime::*;
-}
+#[cfg(any(test, feature = "test-util"))]
+#[doc(hidden)]
+pub use cells::{GateCapture, RuntimeStorage};
+pub use observe::*;

--- a/crates/shelterwood-cells/src/observe.rs
+++ b/crates/shelterwood-cells/src/observe.rs
@@ -6,13 +6,16 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{
+use shelterwood_core::{
     ChildId, Exit, Incarnation, Intensity, Membership, RestartAttempt, RestartCount, RestartPolicy,
     Retention, Strategy, TotalRestarts,
-    cells::RetainedExit,
     engine::{MembershipStatus, ScopeState},
-    runtime,
+    identity::PoisonedCounter,
+    policy::ScopeFlavor,
 };
+use shelterwood_runtime as runtime;
+
+use crate::cells::RetainedExit;
 
 /// Number of lifecycle events retained independently for each subscriber.
 pub const LIFECYCLE_EVENT_CAPACITY: usize = 128;
@@ -372,15 +375,6 @@ impl ChildState {
     }
 }
 
-/// Static flavor of a scope snapshot.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum ScopeKind {
-    /// Fixed, readiness-ordered membership.
-    Ordered,
-    /// Runtime-dynamic membership.
-    Dynamic,
-}
-
 /// Recursive current-state projection for one child membership.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ChildSnapshot {
@@ -417,7 +411,7 @@ pub struct ScopeSnapshot {
     /// Current scope state.
     pub state: ScopeState,
     /// Ordered or dynamic scope flavor.
-    pub kind: ScopeKind,
+    pub kind: ScopeFlavor,
     /// Fate-sharing strategy for ordered scopes; `None` for dynamic scopes.
     pub strategy: Option<Strategy>,
     /// Scope-wide restart budget.
@@ -604,7 +598,7 @@ pub(crate) struct SnapshotHub {
 #[derive(Clone, Debug)]
 struct SnapshotHubState {
     snapshot: RetainedScopeSnapshot,
-    generation: crate::identity::PoisonedCounter,
+    generation: PoisonedCounter,
     closed: bool,
 }
 
@@ -767,7 +761,7 @@ impl SnapshotHub {
             initialized = true;
             runtime::watch(SnapshotHubState {
                 snapshot: initial.clone(),
-                generation: crate::identity::PoisonedCounter::new(),
+                generation: PoisonedCounter::new(),
                 closed: false,
             })
             .0
@@ -858,7 +852,7 @@ impl SnapshotHub {
                 snapshot: final_snapshot
                     .take()
                     .expect("final snapshot is built exactly once")(),
-                generation: crate::identity::PoisonedCounter::new(),
+                generation: PoisonedCounter::new(),
                 closed: true,
             })
             .0
@@ -1123,13 +1117,15 @@ mod tests {
         },
     };
 
-    use crate::{
-        Intensity,
-        identity::ScopeIdentity,
-        observe::{
-            LifecycleEvent, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, ScopeKind,
-            ScopeSnapshot,
-        },
+    use shelterwood_core::{
+        ChildId, Intensity, TotalRestarts,
+        identity::{PoisonedCounter, ScopeIdentity},
+        policy::ScopeFlavor,
+    };
+    use shelterwood_runtime as runtime;
+
+    use crate::observe::{
+        LifecycleEvent, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, ScopeSnapshot,
     };
     use shelterwood_core::{ScopeState, StopReason};
 
@@ -1141,10 +1137,10 @@ mod tests {
         RetainedScopeSnapshot::new(
             Arc::new(ScopeSnapshot {
                 state,
-                kind: ScopeKind::Dynamic,
+                kind: ScopeFlavor::Dynamic,
                 strategy: None,
                 intensity: Intensity::default(),
-                total_restarts: crate::TotalRestarts::ZERO,
+                total_restarts: TotalRestarts::ZERO,
                 lifecycle_seq: LifecycleSeq::new(0),
                 children: Arc::from([]),
             }),
@@ -1187,7 +1183,7 @@ mod tests {
 
         let sender = hub.sender.get().expect("subscription initializes the hub");
         sender.modify_silently(|state| {
-            state.generation = crate::identity::PoisonedCounter::near_exhaustion();
+            state.generation = PoisonedCounter::near_exhaustion();
         });
 
         let mut txn = crate::cells::ObservationTxn::detached();
@@ -1307,7 +1303,7 @@ mod tests {
         ));
     }
 
-    #[crate::runtime::test]
+    #[shelterwood_runtime::test]
     async fn snapshot_publication_before_close_is_drained() {
         let hub = SnapshotHub::default();
         let mut txn = crate::cells::ObservationTxn::detached();
@@ -1374,7 +1370,7 @@ mod tests {
         assert!(after_close.changed().await.is_err());
     }
 
-    #[crate::runtime::test]
+    #[shelterwood_runtime::test]
     async fn receiverless_snapshot_close_installs_the_terminal_state() {
         let hub = SnapshotHub::default();
         let mut txn = crate::cells::ObservationTxn::detached();
@@ -1397,7 +1393,7 @@ mod tests {
         assert!(receiver.changed().await.is_err());
     }
 
-    #[crate::runtime::test]
+    #[shelterwood_runtime::test]
     async fn initialized_receiverless_snapshot_close_refreshes_the_terminal_state() {
         let hub = SnapshotHub::default();
         let mut txn = crate::cells::ObservationTxn::detached();
@@ -1425,7 +1421,7 @@ mod tests {
         assert!(receiver.changed().await.is_err());
     }
 
-    #[crate::runtime::test]
+    #[shelterwood_runtime::test]
     async fn snapshot_close_installs_the_terminal_state_even_with_live_receivers() {
         // A close site may terminalize without publishing a `Stopped`
         // projection first; the retained value is what every later subscriber
@@ -1459,25 +1455,25 @@ mod tests {
         assert!(later.changed().await.is_err());
     }
 
-    #[crate::runtime::test]
+    #[shelterwood_runtime::test]
     async fn lifecycle_close_wakes_parked_receivers() {
         let hub = Arc::new(LifecycleHub::default());
         let mut events = hub.subscribe();
-        let waiter = crate::runtime::spawn(async move { events.recv().await });
-        crate::runtime::yield_now().await;
+        let waiter = runtime::spawn(async move { events.recv().await });
+        runtime::yield_now().await;
 
         let mut txn = crate::cells::ObservationTxn::detached();
         hub.close(&mut txn);
         drop(txn);
 
-        assert_eq!(crate::runtime::join_resuming(waiter).await, None);
+        assert_eq!(runtime::join_resuming(waiter).await, None);
     }
 
     #[test]
     fn lifecycle_publication_after_close_appends_nothing() {
         let mut identity = ScopeIdentity::new();
         let membership = identity
-            .mint_membership(&crate::ChildId::from("scope"))
+            .mint_membership(&ChildId::from("scope"))
             .expect("membership available")
             .membership();
         let hub = LifecycleHub::default();
@@ -1508,7 +1504,7 @@ mod tests {
     fn a_retained_event_after_explicit_lag_remains_subject_to_later_overflow() {
         let mut identity = ScopeIdentity::new();
         let membership = identity
-            .mint_membership(&crate::ChildId::from("scope"))
+            .mint_membership(&ChildId::from("scope"))
             .expect("membership available")
             .membership();
         let event = |seq| LifecycleEvent {
@@ -1550,7 +1546,7 @@ mod tests {
     fn lifecycle_close_drains_the_queued_prefix_and_rejects_late_publication() {
         let mut identity = ScopeIdentity::new();
         let membership = identity
-            .mint_membership(&crate::ChildId::from("scope"))
+            .mint_membership(&ChildId::from("scope"))
             .expect("membership available")
             .membership();
         let event = |seq| LifecycleEvent {

--- a/crates/shelterwood-core/src/engine.rs
+++ b/crates/shelterwood-core/src/engine.rs
@@ -362,7 +362,10 @@ impl Default for RestartState {
     }
 }
 
-/// Complete restart verdict consumed verbatim by the scope driver.
+/// Complete restart verdict consumed verbatim by the cross-crate scope driver.
+///
+/// Its public visibility is required by [`schedule_restart`]'s sibling-crate
+/// return edge; the supported façade neither names nor exports this type.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RestartDecision {
     attempt: RestartAttempt,
@@ -731,31 +734,6 @@ struct ScopeDrain {
     startup: StartupPhase,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct DrainEffect {
-    startup_pending: bool,
-    /// Always [`ScopeState::Draining`] by construction; carried so the driver
-    /// publishes exactly the state the machine returned.
-    state: ScopeState,
-}
-
-impl DrainEffect {
-    pub fn startup_pending(&self) -> bool {
-        self.startup_pending
-    }
-
-    pub fn state(&self) -> ScopeState {
-        self.state.clone()
-    }
-}
-
-/// The child state relevant to deciding whether a scope can finish.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ChildCompletionState {
-    pub has_children: bool,
-    pub all_terminal: bool,
-}
-
 /// Authoritative lifecycle and finish policy for one scope incarnation.
 ///
 /// `ScopeRecord` is only this machine's observation projection; epoch-tagged
@@ -817,7 +795,7 @@ impl ScopeLifecycle {
                     StartupPhase::Complete => 1,
                     StartupPhase::Failed => 2,
                 },
-                stop_reason_precedence(reason) as u8,
+                stop_reason_precedence(reason),
             ),
         }
     }
@@ -886,7 +864,7 @@ impl ScopeLifecycle {
     /// resolve competing reasons in opposite directions. The returned effect
     /// exists only for the initial transition: upgrades change the eventual
     /// verdict without repeating teardown side effects.
-    pub fn begin_drain(&mut self, reason: StopReason) -> Option<DrainEffect> {
+    pub fn begin_drain(&mut self, reason: StopReason) -> Option<(bool, ScopeState)> {
         debug_assert!(
             !matches!(reason, StopReason::NeverStarted),
             "NeverStarted is not a live-incarnation drain reason"
@@ -905,24 +883,19 @@ impl ScopeLifecycle {
         };
         let startup_pending = startup == StartupPhase::Pending;
         self.state = ScopeLifecycleState::Draining(ScopeDrain { reason, startup });
-        Some(DrainEffect {
-            startup_pending,
-            state: self.state(),
-        })
+        Some((startup_pending, self.state()))
     }
 
     pub fn finish_if_ready(
         &self,
         flavor: ScopeFlavor,
-        children: ChildCompletionState,
+        has_children: bool,
+        all_terminal: bool,
     ) -> Option<StopReason> {
         if let Some(reason) = self.draining_reason() {
-            return children.all_terminal.then(|| reason.clone());
+            return all_terminal.then(|| reason.clone());
         }
-        (!self.startup_failed()
-            && flavor == ScopeFlavor::Ordered
-            && children.has_children
-            && children.all_terminal)
+        (!self.startup_failed() && flavor == ScopeFlavor::Ordered && has_children && all_terminal)
             .then_some(StopReason::Finished)
     }
 }
@@ -1084,11 +1057,10 @@ mod tests {
     };
 
     use super::{
-        ArbitrationClass, ChildCompletionState, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch,
-        IncarnationRun, IntensityState, MembershipStatus, ReadinessEffect, ReadinessEvent,
-        ReadinessGate, RequestTarget, RestartState, ScopeEpochs, ScopeLifecycle, ScopeMode,
-        ScopeState, StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart,
-        tidy_abort_beat,
+        ArbitrationClass, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch, IncarnationRun,
+        IntensityState, MembershipStatus, ReadinessEffect, ReadinessEvent, ReadinessGate,
+        RequestTarget, RestartState, ScopeEpochs, ScopeLifecycle, ScopeMode, ScopeState,
+        StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart, tidy_abort_beat,
     };
 
     #[test]
@@ -1610,51 +1582,27 @@ mod tests {
             "simultaneous initial failures publish one transition"
         );
         assert_eq!(
-            lifecycle.finish_if_ready(
-                ScopeFlavor::Ordered,
-                ChildCompletionState {
-                    has_children: true,
-                    all_terminal: true,
-                },
-            ),
+            lifecycle.finish_if_ready(ScopeFlavor::Ordered, true, true),
             None
         );
         let drain = lifecycle
             .begin_drain(crate::exit::StopReason::ShutdownRequested)
             .expect("a failed startup can begin draining");
-        assert!(!drain.startup_pending);
-        assert_eq!(drain.state, ScopeState::Draining);
+        assert!(!drain.0);
+        assert_eq!(drain.1, ScopeState::Draining);
         assert_eq!(
-            lifecycle.finish_if_ready(
-                ScopeFlavor::Dynamic,
-                ChildCompletionState {
-                    has_children: true,
-                    all_terminal: true,
-                },
-            ),
+            lifecycle.finish_if_ready(ScopeFlavor::Dynamic, true, true),
             Some(crate::exit::StopReason::ShutdownRequested)
         );
 
         let mut running = ScopeLifecycle::starting();
         assert_eq!(running.complete_startup(), Some(ScopeState::Running));
         assert_eq!(
-            running.finish_if_ready(
-                ScopeFlavor::Ordered,
-                ChildCompletionState {
-                    has_children: false,
-                    all_terminal: true,
-                },
-            ),
+            running.finish_if_ready(ScopeFlavor::Ordered, false, true),
             None
         );
         assert_eq!(
-            running.finish_if_ready(
-                ScopeFlavor::Ordered,
-                ChildCompletionState {
-                    has_children: true,
-                    all_terminal: true,
-                },
-            ),
+            running.finish_if_ready(ScopeFlavor::Ordered, true, true),
             Some(crate::exit::StopReason::Finished)
         );
 
@@ -1662,8 +1610,8 @@ mod tests {
         let drain = starting
             .begin_drain(crate::exit::StopReason::ShutdownRequested)
             .expect("starting can begin draining");
-        assert!(drain.startup_pending);
-        assert_eq!(drain.state, ScopeState::Draining);
+        assert!(drain.0);
+        assert_eq!(drain.1, ScopeState::Draining);
     }
 
     #[test]

--- a/crates/shelterwood-core/src/engine.rs
+++ b/crates/shelterwood-core/src/engine.rs
@@ -734,6 +734,20 @@ struct ScopeDrain {
     startup: StartupPhase,
 }
 
+/// The child state relevant to deciding whether a scope can finish.
+///
+/// The two fields are both booleans and answer different questions, so a
+/// positional pair would transpose silently at the one call site
+/// (`SupervisorState::settle`) and quietly change the finish predicate.
+/// Naming them is what makes that transposition a compile error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ChildCompletionState {
+    /// Whether the scope holds any child registration at all.
+    pub(crate) has_children: bool,
+    /// Whether every child registration has reached the joined terminal.
+    pub(crate) all_terminal: bool,
+}
+
 /// Authoritative lifecycle and finish policy for one scope incarnation.
 ///
 /// `ScopeRecord` is only this machine's observation projection; epoch-tagged
@@ -886,16 +900,18 @@ impl ScopeLifecycle {
         Some((startup_pending, self.state()))
     }
 
-    pub fn finish_if_ready(
+    pub(crate) fn finish_if_ready(
         &self,
         flavor: ScopeFlavor,
-        has_children: bool,
-        all_terminal: bool,
+        children: ChildCompletionState,
     ) -> Option<StopReason> {
         if let Some(reason) = self.draining_reason() {
-            return all_terminal.then(|| reason.clone());
+            return children.all_terminal.then(|| reason.clone());
         }
-        (!self.startup_failed() && flavor == ScopeFlavor::Ordered && has_children && all_terminal)
+        (!self.startup_failed()
+            && flavor == ScopeFlavor::Ordered
+            && children.has_children
+            && children.all_terminal)
             .then_some(StopReason::Finished)
     }
 }
@@ -1057,10 +1073,11 @@ mod tests {
     };
 
     use super::{
-        ArbitrationClass, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch, IncarnationRun,
-        IntensityState, MembershipStatus, ReadinessEffect, ReadinessEvent, ReadinessGate,
-        RequestTarget, RestartState, ScopeEpochs, ScopeLifecycle, ScopeMode, ScopeState,
-        StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart, tidy_abort_beat,
+        ArbitrationClass, ChildCompletionState, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch,
+        IncarnationRun, IntensityState, MembershipStatus, ReadinessEffect, ReadinessEvent,
+        ReadinessGate, RequestTarget, RestartState, ScopeEpochs, ScopeLifecycle, ScopeMode,
+        ScopeState, StopAction, StopLadder, arbitrate, dispatch_exit, schedule_restart,
+        tidy_abort_beat,
     };
 
     #[test]
@@ -1582,36 +1599,60 @@ mod tests {
             "simultaneous initial failures publish one transition"
         );
         assert_eq!(
-            lifecycle.finish_if_ready(ScopeFlavor::Ordered, true, true),
+            lifecycle.finish_if_ready(
+                ScopeFlavor::Ordered,
+                ChildCompletionState {
+                    has_children: true,
+                    all_terminal: true,
+                },
+            ),
             None
         );
-        let drain = lifecycle
+        let (startup_pending, state) = lifecycle
             .begin_drain(crate::exit::StopReason::ShutdownRequested)
             .expect("a failed startup can begin draining");
-        assert!(!drain.0);
-        assert_eq!(drain.1, ScopeState::Draining);
+        assert!(!startup_pending);
+        assert_eq!(state, ScopeState::Draining);
         assert_eq!(
-            lifecycle.finish_if_ready(ScopeFlavor::Dynamic, true, true),
+            lifecycle.finish_if_ready(
+                ScopeFlavor::Dynamic,
+                ChildCompletionState {
+                    has_children: true,
+                    all_terminal: true,
+                },
+            ),
             Some(crate::exit::StopReason::ShutdownRequested)
         );
 
         let mut running = ScopeLifecycle::starting();
         assert_eq!(running.complete_startup(), Some(ScopeState::Running));
         assert_eq!(
-            running.finish_if_ready(ScopeFlavor::Ordered, false, true),
+            running.finish_if_ready(
+                ScopeFlavor::Ordered,
+                ChildCompletionState {
+                    has_children: false,
+                    all_terminal: true,
+                },
+            ),
             None
         );
         assert_eq!(
-            running.finish_if_ready(ScopeFlavor::Ordered, true, true),
+            running.finish_if_ready(
+                ScopeFlavor::Ordered,
+                ChildCompletionState {
+                    has_children: true,
+                    all_terminal: true,
+                },
+            ),
             Some(crate::exit::StopReason::Finished)
         );
 
         let mut starting = ScopeLifecycle::starting();
-        let drain = starting
+        let (startup_pending, state) = starting
             .begin_drain(crate::exit::StopReason::ShutdownRequested)
             .expect("starting can begin draining");
-        assert!(drain.0);
-        assert_eq!(drain.1, ScopeState::Draining);
+        assert!(startup_pending);
+        assert_eq!(state, ScopeState::Draining);
     }
 
     #[test]

--- a/crates/shelterwood-core/src/exit.rs
+++ b/crates/shelterwood-core/src/exit.rs
@@ -54,14 +54,14 @@ pub fn stop_reason_root_exit(reason: &StopReason) -> Exit {
     }
 }
 
-pub fn stop_reason_precedence(reason: &StopReason) -> StopPrecedence {
-    match reason {
+pub fn stop_reason_precedence(reason: &StopReason) -> u8 {
+    (match reason {
         StopReason::Finished => StopPrecedence::Finished,
         StopReason::IntensityTripped(_) => StopPrecedence::IntensityTripped,
         StopReason::StartupFailed(_) => StopPrecedence::StartupFailed,
         StopReason::ShutdownRequested => StopPrecedence::ShutdownRequested,
         StopReason::NeverStarted => StopPrecedence::NeverStarted,
-    }
+    }) as u8
 }
 
 /// Total precedence order over stop reasons: the single lattice that resolves
@@ -85,7 +85,7 @@ pub fn stop_reason_precedence(reason: &StopReason) -> StopPrecedence {
 /// without ever spawning, the scope-state projection must agree with the
 /// membership exit, in either arrival order.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub enum StopPrecedence {
+enum StopPrecedence {
     Finished,
     IntensityTripped,
     StartupFailed,
@@ -171,7 +171,7 @@ impl ExitError {
 /// rather than a privacy rule — hidden from documentation so it does not read
 /// as supported API.
 #[doc(hidden)]
-pub fn structured_intensity_trip_error(value: IntensityTrip) -> ExitError {
+fn structured_intensity_trip_error(value: IntensityTrip) -> ExitError {
     ExitError(Arc::new(ExitErrorInner::IntensityTrip(
         StructuredIntensityTrip(value),
     )))
@@ -354,8 +354,8 @@ pub enum StartupFailureCause {
     },
     /// A produced subtree contained undefined reservations.
     Lowering {
-        /// Undefined child-id paths relative to the subtree root.
-        undefined: Vec<Vec<ChildId>>,
+        /// Undefined child ids relative to the subtree root.
+        undefined: Vec<ChildId>,
     },
     /// The stable scope could mint no identity for a declared child.
     IdentityExhausted {
@@ -506,7 +506,7 @@ pub enum ExitKind {
 }
 
 /// Runtime-neutral result of joining one supervised operation.
-pub enum JoinVerdict<T> {
+pub enum JoinOutcome<T> {
     Ok { value: T },
     Panic { message: Option<String> },
     Cancelled,
@@ -581,15 +581,15 @@ pub fn reconcile_recorded_outcomes(
 /// [`GracePhase::WithinGrace`].
 pub fn classify_exit(
     recorded: Option<RecordedOutcome>,
-    join: JoinVerdict<()>,
+    join: JoinOutcome<()>,
     hard_abort_phase: Option<GracePhase>,
     cancellation: Cancellation,
 ) -> Exit {
     let recorded_kind = recorded.map(RecordedOutcome::into_kind);
     let join_kind = match join {
-        JoinVerdict::Ok { .. } => None,
-        JoinVerdict::Panic { message } => Some(ExitKind::Panicked { message }),
-        JoinVerdict::Cancelled => Some(ExitKind::Aborted {
+        JoinOutcome::Ok { .. } => None,
+        JoinOutcome::Panic { message } => Some(ExitKind::Panicked { message }),
+        JoinOutcome::Cancelled => Some(ExitKind::Aborted {
             phase: hard_abort_phase.unwrap_or(GracePhase::WithinGrace),
         }),
     };
@@ -670,11 +670,11 @@ mod tests {
     use crate::identity::ScopeIdentity;
 
     use super::{
-        Cancellation, ChildId, Exit, ExitError, ExitKind, GracePhase, IntensityTrip,
-        JoinVerdict as JoinOutcome, RecordedOutcome, StartupError, StartupFailure,
-        StartupFailureCause, StopReason, classify_disposal_panic, classify_exit, exit_kind_eq,
-        prefer_earlier, reconcile_recorded_outcomes, stop_reason_into_nested_result,
-        stop_reason_root_exit, structured_intensity_trip_error, structured_startup_failure_error,
+        Cancellation, ChildId, Exit, ExitError, ExitKind, GracePhase, IntensityTrip, JoinOutcome,
+        RecordedOutcome, StartupError, StartupFailure, StartupFailureCause, StopReason,
+        classify_disposal_panic, classify_exit, exit_kind_eq, prefer_earlier,
+        reconcile_recorded_outcomes, stop_reason_into_nested_result, stop_reason_root_exit,
+        structured_intensity_trip_error, structured_startup_failure_error,
     };
 
     #[test]

--- a/crates/shelterwood-core/src/policy.rs
+++ b/crates/shelterwood-core/src/policy.rs
@@ -91,18 +91,18 @@ pub enum ChildMode {
 }
 
 /// The default bounded FIFO mailbox capacity.
-pub const DEFAULT_MAILBOX_CAPACITY: usize = 64;
+const DEFAULT_MAILBOX_CAPACITY: usize = 64;
 /// The default child shutdown grace.
-pub const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 /// The default gated-readiness deadline.
-pub const DEFAULT_READINESS_DEADLINE: Duration = Duration::from_secs(30);
+const DEFAULT_READINESS_DEADLINE: Duration = Duration::from_secs(30);
 
 /// A duration statically known to be non-zero.
 ///
 /// Policy variants use this sealed value when zero would otherwise create a
 /// second semantic branch: [`Shutdown::Graceful`] (whose zero grace would
 /// duplicate `Abort` with different recorded provenance) and
-/// [`BoundedReadinessDeadline`]. Construct it with [`NonZeroDuration::new`];
+/// [`ReadinessDeadline::Bounded`]. Construct it with [`NonZeroDuration::new`];
 /// the private representation prevents zero-valued literals:
 ///
 /// ```compile_fail,E0423
@@ -600,44 +600,15 @@ pub enum ReadinessDeadline {
     #[default]
     Inherit,
     /// Apply a non-zero bound.
-    Bounded(BoundedReadinessDeadline),
+    Bounded(NonZeroDuration),
     /// Wait without a deadline.
     Unbounded,
-}
-
-/// Validated non-zero payload of a bounded [`ReadinessDeadline`].
-///
-/// Values are created by [`ReadinessDeadline::bounded`]. The invariant is
-/// carried by [`NonZeroDuration`] rather than re-checked here, so the policy
-/// surface has one non-zero-duration type. `E0423` records the privacy failure
-/// this proof depends on:
-///
-/// ```compile_fail,E0423
-/// use std::time::Duration;
-/// use shelterwood_core::policy::{
-///     BoundedReadinessDeadline, NonZeroDuration, ReadinessDeadline,
-/// };
-///
-/// let duration = NonZeroDuration::new(Duration::from_secs(1)).unwrap();
-/// let _ = ReadinessDeadline::Bounded(BoundedReadinessDeadline(duration));
-/// ```
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct BoundedReadinessDeadline(NonZeroDuration);
-
-impl BoundedReadinessDeadline {
-    /// Returns the non-zero deadline duration.
-    #[must_use]
-    pub const fn duration(self) -> Duration {
-        self.0.get()
-    }
 }
 
 impl ReadinessDeadline {
     /// Constructs a validated bounded deadline.
     pub fn bounded(duration: Duration) -> Result<Self, PolicyError> {
-        Ok(Self::Bounded(BoundedReadinessDeadline(
-            NonZeroDuration::new(duration)?,
-        )))
+        Ok(Self::Bounded(NonZeroDuration::new(duration)?))
     }
 }
 
@@ -881,7 +852,7 @@ impl ResolvedMailbox {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ResolvedReadinessDeadline {
-    Bounded(BoundedReadinessDeadline),
+    Bounded(NonZeroDuration),
     Unbounded,
 }
 
@@ -896,7 +867,7 @@ impl ResolvedReadinessDeadline {
 
     fn duration(self) -> Option<Duration> {
         match self {
-            Self::Bounded(duration) => Some(duration.duration()),
+            Self::Bounded(duration) => Some(duration.get()),
             Self::Unbounded => None,
         }
     }

--- a/crates/shelterwood-core/src/policy.rs
+++ b/crates/shelterwood-core/src/policy.rs
@@ -5,9 +5,11 @@ use std::{fmt, num::NonZeroUsize, time::Duration};
 use crate::Exit;
 
 /// Whether a scope has fixed ordered membership or runtime-dynamic membership.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum ScopeFlavor {
+    /// Fixed, readiness-ordered membership.
     Ordered,
+    /// Runtime-dynamic membership.
     Dynamic,
 }
 

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -12,7 +12,7 @@ use std::{
 
 use crate::{
     Membership, MembershipStatus, PoisonedCounter, ScopeFlavor, ScopeState, StopReason,
-    engine::{ChildCompletionState, ScopeLifecycle},
+    engine::ScopeLifecycle,
 };
 
 /// A never-reused child registration.
@@ -28,7 +28,7 @@ impl ChildKey {
 
 /// The incarnation-level portion of one authoritative child state.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum IncarnationState {
+enum IncarnationState {
     /// No incarnation has been started yet.
     Unstarted,
     /// The current incarnation is executing.
@@ -51,7 +51,7 @@ pub enum IncarnationState {
 /// synchronous control-plane latch is sampled into [`Event::RemovalLatched`];
 /// after that transition, this enum is the reducer's sole authority.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum ChildState {
+enum ChildState {
     /// Ordinary resident membership.
     Resident(IncarnationState),
     /// Planned removal won while the child was in the enclosed state.
@@ -76,21 +76,6 @@ impl ChildState {
         match self {
             Self::Resident(state) | Self::Removing(state) => Self::Removing(state),
         }
-    }
-
-    /// Whether the membership-terminal edge has been published.
-    ///
-    /// Identical to [`Self::joined`] *by construction*, not by accident: this
-    /// model routes every terminal through `Disposing`, and the shell
-    /// publishes the terminal stage only once retained-definition disposal has
-    /// joined. The state that separated them before the consolidation — a
-    /// published terminal with disposal still outstanding — is unrepresentable
-    /// here, so the old `!is_terminal() || is_disposing()` incompleteness test
-    /// collapses to `!joined()`. Both names are kept because the completion
-    /// trichotomy is the vocabulary the shutdown surface is stated in; see
-    /// `ScopeCell::settled` for the scope-level counterparts.
-    pub fn membership_terminal(self) -> bool {
-        self.incarnation() == IncarnationState::Joined
     }
 
     /// Whether the current incarnation has stopped executing.
@@ -303,7 +288,7 @@ impl SupervisorState {
         self.children.get(&child).map(|record| record.membership)
     }
 
-    pub fn child_state(&self, child: ChildKey) -> Option<ChildState> {
+    fn child_state(&self, child: ChildKey) -> Option<ChildState> {
         self.children.get(&child).map(|record| record.state)
     }
 
@@ -333,11 +318,6 @@ impl SupervisorState {
     pub fn is_disposing(&self, child: ChildKey) -> bool {
         self.child_state(child)
             .is_some_and(|state| state.incarnation() == IncarnationState::Disposing)
-    }
-
-    pub fn membership_terminal(&self, child: ChildKey) -> bool {
-        self.child_state(child)
-            .is_some_and(ChildState::membership_terminal)
     }
 
     pub fn incarnation_complete(&self, child: ChildKey) -> bool {
@@ -390,8 +370,7 @@ impl SupervisorState {
         next: IncarnationState,
     ) -> bool {
         if let Some(record) = self.children.get_mut(&child) {
-            if record.state.membership_terminal() || !expected.contains(&record.state.incarnation())
-            {
+            if record.state.joined() || !expected.contains(&record.state.incarnation()) {
                 return false;
             }
             record.state = record.state.with_incarnation(next);
@@ -509,12 +488,12 @@ impl SupervisorState {
     }
 
     fn begin_drain(&mut self, reason: StopReason, effects: &mut impl EffectSink) {
-        let Some(effect) = self.lifecycle.begin_drain(reason) else {
+        let Some((startup_pending, state)) = self.lifecycle.begin_drain(reason) else {
             return;
         };
         effects.push(Effect::DrainStarted {
-            state: effect.state(),
-            startup_pending: effect.startup_pending(),
+            state,
+            startup_pending,
         });
         match self.flavor {
             ScopeFlavor::Ordered => {
@@ -561,10 +540,8 @@ impl SupervisorState {
         }
         let reason = self.lifecycle.finish_if_ready(
             self.flavor,
-            ChildCompletionState {
-                has_children: !self.children.is_empty(),
-                all_terminal: self.all_children_joined(),
-            },
+            !self.children.is_empty(),
+            self.all_children_joined(),
         );
         if let Some(reason) = reason {
             self.finish_emitted = true;
@@ -602,7 +579,7 @@ impl SupervisorState {
                     return;
                 };
                 if record.state.membership_status() == MembershipStatus::Removing
-                    || record.state.membership_terminal()
+                    || record.state.joined()
                     || !matches!(
                         record.state.incarnation(),
                         IncarnationState::Active | IncarnationState::Stopping
@@ -749,7 +726,7 @@ impl SupervisorState {
             // spawnable record must be one `Event::Spawned` away from
             // executing. This is the emission/acceptance agreement that keeps
             // level-triggered settlement terminating.
-            assert!(!child.startable() || !child.state.membership_terminal());
+            assert!(!child.startable() || !child.state.joined());
         }
         // The ordered cursors are flavor-owned state; a dynamic scope that
         // grew one would silently acquire a second stop sequencer.

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -12,7 +12,7 @@ use std::{
 
 use crate::{
     Membership, MembershipStatus, PoisonedCounter, ScopeFlavor, ScopeState, StopReason,
-    engine::ScopeLifecycle,
+    engine::{ChildCompletionState, ScopeLifecycle},
 };
 
 /// A never-reused child registration.
@@ -540,8 +540,10 @@ impl SupervisorState {
         }
         let reason = self.lifecycle.finish_if_ready(
             self.flavor,
-            !self.children.is_empty(),
-            self.all_children_joined(),
+            ChildCompletionState {
+                has_children: !self.children.is_empty(),
+                all_terminal: self.all_children_joined(),
+            },
         );
         if let Some(reason) = reason {
             self.finish_emitted = true;

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -4,6 +4,7 @@ use std::{
     num::NonZeroUsize,
     ops::{Deref, DerefMut},
     sync::{Arc, Mutex, MutexGuard, atomic::Ordering},
+    time::Instant,
 };
 
 use crate::{
@@ -102,9 +103,9 @@ mod waker_slot {
     /// The only storage surface for a caller-owned waker.
     ///
     /// Its value is private even from the parent mailbox module, and every
-    /// mutating operation requires an effects sink. The old #202 spelling --
-    /// replacing or taking an `Option<Waker>` and accidentally dropping it
-    /// beside a guard -- therefore does not type-check.
+    /// mutating operation requires an effects sink, so replacing or taking an
+    /// `Option<Waker>` and accidentally dropping it beside a guard does not
+    /// type-check.
     #[derive(Default)]
     pub(super) struct WakerSlot(Option<Waker>);
 
@@ -556,10 +557,9 @@ impl<M: Send + 'static> Drop for MailboxEffects<'_, M> {
         if self.pulse {
             panics.run(|| self.cell.changed.pulse());
         }
-        // Binding a latest-value mailbox historically handed displaced
-        // payloads to isolated disposal before accepted senders were woken.
-        // Preserve that observable ownership edge: a woken sender may run
-        // immediately and must not race ahead of disposal submission.
+        // Submit displaced latest-value payloads to isolated disposal before
+        // waking accepted senders: a woken sender may run immediately and must
+        // not race ahead of disposal submission.
         if self.isolate_displaced && !self.displaced.is_empty() {
             let displaced = std::mem::take(&mut self.displaced);
             panics.run(|| {
@@ -928,6 +928,14 @@ impl<M: Send + 'static> MailboxCell<M> {
 impl<M> MailboxCell<M> {
     pub(super) fn runtime(&self) -> Arc<dyn MailboxRuntime> {
         Arc::clone(&self.runtime)
+    }
+
+    pub(super) fn now(&self) -> Instant {
+        self.runtime.now()
+    }
+
+    pub(super) fn dispose<T: Send + 'static>(&self, value: T) {
+        dispose_value(self.runtime.as_ref(), value);
     }
 }
 
@@ -1404,6 +1412,10 @@ impl<M: Send + 'static> MailboxReceiver<M> {
         self.mailbox.freeze(self.incarnation);
     }
 
+    /// Waits for mailbox activity in the façade's merged raw-actor event loop.
+    ///
+    /// This remains public only as the cross-crate receiver seam used by
+    /// `RawContext`; it is not reachable from Shelterwood's supported API.
     pub async fn changed(&mut self) {
         self.watcher.changed().await;
     }

--- a/crates/shelterwood-mailbox/src/futures.rs
+++ b/crates/shelterwood-mailbox/src/futures.rs
@@ -10,8 +10,7 @@ use std::{
 use shelterwood_core::DeadlineBudget;
 
 use crate::{
-    ActorIdentity, ChildId, Incarnation, MailboxRuntime, Membership,
-    capability::{DisposingReceiver, dispose},
+    ActorIdentity, ChildId, Incarnation, MailboxRuntime, Membership, capability::DisposingReceiver,
 };
 
 use super::{
@@ -163,12 +162,10 @@ impl<M: Send + 'static> ActorRef<M> {
             deadlined: Deadlined::no_attempt(
                 CallOperation {
                     actor: self.clone(),
-                    runtime: Arc::clone(&runtime),
                     make_msg: Some(Box::new(make_msg)),
                     send: None,
                     reply: None,
                     accepted: None,
-                    dispose_constructor: dispose::<MessageConstructor<M, T>>,
                 },
                 deadline,
                 runtime,
@@ -214,18 +211,10 @@ impl<M> Hash for ActorRef<M> {
 
 /// Cancellation-safe future returned by [`ActorRef::send`].
 #[must_use]
-pub struct SendFuture<M> {
+pub struct SendFuture<M: Send + 'static> {
     mailbox: Arc<MailboxCell<M>>,
-    runtime: Arc<dyn MailboxRuntime>,
     state: SendFutureState<M>,
-    // Captured where `M: Send + 'static` holds so the unbounded `Drop` impl
-    // can route a withdrawn message through isolated disposal.
-    dispose: fn(&Arc<dyn MailboxRuntime>, M),
-    withdraw_operation: WithdrawOperation<M>,
 }
-
-type WithdrawOperation<M> =
-    fn(&MailboxCell<M>, &Arc<SendOperation<M>>, WithdrawalDisposition) -> Withdrawal<M>;
 
 enum SendFutureState<M> {
     Immediate(Option<M>),
@@ -239,17 +228,13 @@ enum SendFutureState<M> {
 
 // No field is structurally pinned. In particular, the immediate message may
 // move when first poll hands it to the mailbox.
-impl<M> Unpin for SendFuture<M> {}
+impl<M: Send + 'static> Unpin for SendFuture<M> {}
 
 impl<M: Send + 'static> SendFuture<M> {
     fn new(mailbox: Arc<MailboxCell<M>>, message: M) -> Self {
-        let runtime = mailbox.runtime();
         Self {
             mailbox,
-            runtime,
             state: SendFutureState::Immediate(Some(message)),
-            dispose: dispose::<M>,
-            withdraw_operation: MailboxCell::withdraw,
         }
     }
 
@@ -273,7 +258,7 @@ impl<M: Send + 'static> SendFuture<M> {
     }
 }
 
-impl<M> fmt::Debug for SendFuture<M> {
+impl<M: Send + 'static> fmt::Debug for SendFuture<M> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("SendFuture")
@@ -370,7 +355,7 @@ impl<M: Send + 'static> Future for SendFuture<M> {
     }
 }
 
-impl<M> Drop for SendFuture<M> {
+impl<M: Send + 'static> Drop for SendFuture<M> {
     fn drop(&mut self) {
         // Cancellation recovers the unaccepted message with no caller left to
         // hand it to. Destroying it inline would run a possibly blocking or
@@ -379,19 +364,17 @@ impl<M> Drop for SendFuture<M> {
         match std::mem::replace(&mut self.state, SendFutureState::Done) {
             SendFutureState::Immediate(mut message) => {
                 if let Some(message) = message.take() {
-                    (self.dispose)(&self.runtime, message);
+                    self.mailbox.dispose(message);
                 }
             }
             SendFutureState::Parked(operation) => {
-                let mut withdrawal = (self.withdraw_operation)(
-                    &self.mailbox,
-                    &operation,
-                    WithdrawalDisposition::Isolated,
-                );
+                let mut withdrawal = self
+                    .mailbox
+                    .withdraw(&operation, WithdrawalDisposition::Isolated);
                 match withdrawal.take_outcome() {
                     WithdrawalOutcome::Withdrawn { message, .. }
                     | WithdrawalOutcome::Terminated { message, .. } => {
-                        (self.dispose)(&self.runtime, message);
+                        self.mailbox.dispose(message);
                     }
                     WithdrawalOutcome::Accepted(_) => {}
                 }
@@ -411,15 +394,15 @@ impl<M> Drop for SendFuture<M> {
 
 /// Cancellation-safe future returned by [`ActorRef::send_timeout`].
 #[must_use]
-pub struct SendTimeout<M> {
+pub struct SendTimeout<M: Send + 'static> {
     deadlined: Deadlined<TimedSend<M>>,
 }
 
-struct TimedSend<M> {
+struct TimedSend<M: Send + 'static> {
     send: SendFuture<M>,
 }
 
-impl<M> fmt::Debug for SendTimeout<M> {
+impl<M: Send + 'static> fmt::Debug for SendTimeout<M> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("SendTimeout")
@@ -491,38 +474,33 @@ impl<M: Send + 'static> Future for SendTimeout<M> {
 
 /// Cancellation-safe future returned by [`ActorRef::call`].
 #[must_use]
-pub struct CallFuture<M, T> {
+pub struct CallFuture<M: Send + 'static, T: Send + 'static> {
     deadlined: Deadlined<CallOperation<M, T>>,
 }
 
 type MessageConstructor<M, T> = Box<dyn FnOnce(Reply<T>) -> M + Send + 'static>;
 
-struct CallOperation<M, T> {
+struct CallOperation<M: Send + 'static, T: Send + 'static> {
     actor: ActorRef<M>,
-    runtime: Arc<dyn MailboxRuntime>,
     make_msg: Option<MessageConstructor<M, T>>,
     send: Option<SendFuture<M>>,
     reply: Option<DisposingReceiver<T>>,
     accepted: Option<Incarnation>,
-    // Captured where `M: Send + 'static` holds so the unbounded `Drop` impl
-    // can route an unused constructor and its captures through isolated
-    // disposal.
-    dispose_constructor: fn(&Arc<dyn MailboxRuntime>, MessageConstructor<M, T>),
 }
 
-impl<M, T> Drop for CallOperation<M, T> {
+impl<M: Send + 'static, T: Send + 'static> Drop for CallOperation<M, T> {
     fn drop(&mut self) {
         if let Some(make_msg) = self.make_msg.take() {
             // An unstarted or short-circuited call discards its constructor
             // without ever building a message. Destroying the captures inline
             // would run possibly blocking or panicking user destructors in
             // this drop glue, so route them through isolated disposal.
-            (self.dispose_constructor)(&self.runtime, make_msg);
+            self.actor.mailbox.dispose(make_msg);
         }
     }
 }
 
-impl<M, T> fmt::Debug for CallFuture<M, T> {
+impl<M: Send + 'static, T: Send + 'static> fmt::Debug for CallFuture<M, T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("CallFuture")
@@ -532,7 +510,7 @@ impl<M, T> fmt::Debug for CallFuture<M, T> {
     }
 }
 
-impl<M, T: Send + 'static> CallOperation<M, T> {
+impl<M: Send + 'static, T: Send + 'static> CallOperation<M, T> {
     fn poll_reply(
         &mut self,
         context: &mut Context<'_>,
@@ -576,9 +554,6 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
         phase: DeadlinePhase,
     ) -> Poll<Self::Output> {
         if self.make_msg.is_some() {
-            if phase == DeadlinePhase::TimeoutArbitration {
-                return Poll::Ready(self.short_circuit());
-            }
             // Capture the one overall budget before invoking user code. A
             // slow message constructor consumes acceptance/response time. The
             // shared scaffold captured `budget` before this callback runs.
@@ -591,11 +566,11 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
             // at the exact deadline win. Construction is different: no send
             // existed before it completed, so do not start one after the
             // captured budget is strictly in the past.
-            if budget.is_overdue(self.runtime.now()) {
+            if budget.is_overdue(self.actor.mailbox.now()) {
                 // Construction completed, but timeout cleanup owns the
                 // unsubmitted message. Keep its potentially blocking or
                 // panicking destructor off the caller task.
-                dispose(&self.runtime, message);
+                self.actor.mailbox.dispose(message);
                 return Poll::Ready(self.short_circuit());
             }
             self.reply = Some(receiver.receiver);
@@ -617,7 +592,7 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
                     // The call surface has no way to hand the recovered
                     // message back; route the discard through isolated
                     // disposal.
-                    dispose(&self.runtime, error.message);
+                    self.actor.mailbox.dispose(error.message);
                     return Poll::Ready(Err(CallError {
                         actor_id: error.actor_id,
                         incarnation_observed: error.incarnation_observed,
@@ -656,7 +631,7 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
                 self.close_reply();
                 // The call surface has no way to hand the recovered message
                 // back; route the discard through isolated disposal.
-                dispose(&self.runtime, error.message);
+                self.actor.mailbox.dispose(error.message);
                 Poll::Ready(Err(CallError {
                     actor_id: error.actor_id,
                     incarnation_observed: error.incarnation_observed,

--- a/crates/shelterwood-mailbox/src/lib.rs
+++ b/crates/shelterwood-mailbox/src/lib.rs
@@ -15,7 +15,7 @@
 //! foreign implementations may be called from framework critical sections and
 //! therefore invalidate the framework's lock-rule guarantees.
 
-use std::{fmt, sync::Arc};
+use std::fmt;
 
 use shelterwood_core::policy::ResolvedMailbox;
 pub use shelterwood_core::{ChildId, Incarnation, Membership};
@@ -117,16 +117,6 @@ pub trait MailboxControl: private::SealedMailboxControl + fmt::Debug + Send + Sy
 pub trait ActorIdentity: Send + Sync {
     fn id(&self) -> &ChildId;
     fn membership(&self) -> Membership;
-}
-
-impl<T: ActorIdentity + ?Sized> ActorIdentity for Arc<T> {
-    fn id(&self) -> &ChildId {
-        (**self).id()
-    }
-
-    fn membership(&self) -> Membership {
-        (**self).membership()
-    }
 }
 
 /// The Tokio adapter, reachable only as a dev-dependency.

--- a/crates/shelterwood-runtime/src/lib.rs
+++ b/crates/shelterwood-runtime/src/lib.rs
@@ -16,7 +16,7 @@ pub use mailbox::*;
 // Unwind handling is plain `std::panic`, so it lives in the runtime-neutral
 // core. Re-exported here because the adapter's own modules and the façade
 // reach it as a runtime facility.
-pub use shelterwood_core::{exit::JoinVerdict as JoinOutcome, panic::*};
+pub use shelterwood_core::{exit::JoinOutcome, panic::*};
 pub use spawn::*;
 pub use sync::*;
 pub use timer::*;

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -8,7 +8,7 @@ use std::{
 
 use tokio::{sync::mpsc, task};
 
-use shelterwood_core::exit::JoinVerdict as JoinOutcome;
+use shelterwood_core::exit::JoinOutcome;
 
 use super::{
     DisposingReceiver, OneShotReceiver, OneShotSender, PanicPayload, catch_panic, discard_panic,
@@ -99,34 +99,38 @@ impl DedicatedRuntime {
 
 pub struct ActorWork {
     handle: Option<JoinHandle<()>>,
-    abort: AbortHandle,
 }
 
 impl ActorWork {
     pub fn abort(&self) {
-        self.abort.abort();
+        self.handle
+            .as_ref()
+            .expect("actor work retains its join handle until join")
+            .inner
+            .abort();
     }
 
     pub async fn join(mut self) -> JoinOutcome<()> {
-        let Some(handle) = self.handle.take() else {
-            return JoinOutcome::Cancelled;
-        };
+        let handle = self
+            .handle
+            .take()
+            .expect("actor work retains its join handle until join");
         join(handle).await
     }
 }
 
 impl Drop for ActorWork {
     fn drop(&mut self) {
-        self.abort.abort();
+        if let Some(handle) = &self.handle {
+            handle.inner.abort();
+        }
     }
 }
 
 pub fn spawn_actor_work(future: impl Future<Output = ()> + Send + 'static) -> ActorWork {
     let handle = spawn(future);
-    let abort = handle.abort_handle();
     ActorWork {
         handle: Some(handle),
-        abort,
     }
 }
 

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -103,11 +103,18 @@ pub struct ActorWork {
 
 impl ActorWork {
     pub fn abort(&self) {
-        self.handle
-            .as_ref()
-            .expect("actor work retains its join handle until join")
-            .inner
-            .abort();
+        // A handle is taken only by `join`, which consumes the work, so the
+        // slot is populated on every reachable call. Assert rather than
+        // panic: this shares its shape with the locked callers of
+        // `OneShotSender::is_closed`, and aborting nothing is the harmless
+        // reading of an already-joined handle.
+        debug_assert!(
+            self.handle.is_some(),
+            "actor work retains its join handle until join"
+        );
+        if let Some(handle) = &self.handle {
+            handle.inner.abort();
+        }
     }
 
     pub async fn join(mut self) -> JoinOutcome<()> {

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -306,7 +306,10 @@ impl<T> OneShotSender<T> {
     }
 
     pub fn is_closed(&self) -> bool {
-        self.channel.as_ref().is_none_or(oneshot::Sender::is_closed)
+        self.channel
+            .as_ref()
+            .expect("an observable one-shot sender retains its channel")
+            .is_closed()
     }
 }
 

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -306,10 +306,16 @@ impl<T> OneShotSender<T> {
     }
 
     pub fn is_closed(&self) -> bool {
-        self.channel
-            .as_ref()
-            .expect("an observable one-shot sender retains its channel")
-            .is_closed()
+        // Observed under the observation gate and the dynamic-state mutex
+        // (`RemovalResponses::subscribe`), so the missing-channel verdict
+        // cannot be raised as a panic without poisoning both for every later
+        // caller. The total form reports the taken channel as closed, which
+        // is what a sender past `send` is.
+        debug_assert!(
+            self.channel.is_some(),
+            "an observable one-shot sender retains its channel"
+        );
+        self.channel.as_ref().is_none_or(oneshot::Sender::is_closed)
     }
 }
 

--- a/crates/shelterwood-runtime/src/timer.rs
+++ b/crates/shelterwood-runtime/src/timer.rs
@@ -1,8 +1,9 @@
-use std::{future::Future, pin::Pin, time::Duration};
+use std::{future::Future, time::Duration};
 
 use tokio::time;
 
 use shelterwood_core::deadline::Deadline;
+pub use shelterwood_mailbox::BoxedSleep;
 
 /// Advances a paused test clock, keeping timer control in this module.
 #[cfg(any(test, feature = "test-util"))]
@@ -37,19 +38,8 @@ fn next_timer_deadline(
     )
 }
 
-pub type BoxedSleep = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
-
-pub fn deadline(duration: Duration) -> Deadline {
+fn deadline(duration: Duration) -> Deadline {
     Deadline::after(now(), duration)
-}
-
-pub fn sleep_deadline(deadline: Deadline) -> BoxedSleep {
-    Box::pin(async move {
-        match deadline.instant() {
-            Some(deadline) => sleep_until_std(deadline).await,
-            None => std::future::pending().await,
-        }
-    })
 }
 
 pub fn sleep_until(deadline: std::time::Instant) -> BoxedSleep {
@@ -88,7 +78,7 @@ where
     // deadline addition overflows outright; a representable deadline flush
     // against the clock limit would still panic at arming. Route the
     // budget through Deadline so an unarmable timeout never elapses,
-    // matching sleep_deadline's overflow semantics.
+    // matching the runtime's absolute-deadline overflow semantics.
     let Some(deadline) = deadline(duration).instant() else {
         return Timeout::Completed(future.await);
     };

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -38,8 +38,8 @@ pub trait Actor: Sized + Send + 'static {
     }
 }
 
-macro_rules! actor_context_forwarders {
-    ($actor:ident) => {
+macro_rules! context_common_forwarders {
+    () => {
         /// Returns this actor's child id.
         #[must_use]
         pub fn id(&self) -> &ChildId {
@@ -50,15 +50,6 @@ macro_rules! actor_context_forwarders {
         #[must_use]
         pub fn incarnation(&self) -> Incarnation {
             self.raw.incarnation()
-        }
-
-        /// Returns a membership-addressed handle to this actor.
-        ///
-        /// During [`Actor::on_stop`], do not post work to this handle: no
-        /// callback remains to receive it.
-        #[must_use]
-        pub fn myself(&self) -> ActorRef<$actor::Msg> {
-            self.raw.myself()
         }
 
         /// Returns this actor's supervising scope.
@@ -102,6 +93,18 @@ macro_rules! actor_context_forwarders {
             T: Send + 'static,
         {
             self.raw.run_blocking(operation)
+        }
+    };
+}
+
+macro_rules! actor_context_forwarders {
+    ($actor:ident) => {
+        context_common_forwarders!();
+
+        /// Returns a membership-addressed handle to this actor.
+        #[must_use]
+        pub fn myself(&self) -> ActorRef<$actor::Msg> {
+            self.raw.myself()
         }
     };
 }
@@ -295,7 +298,7 @@ impl<'a, A: Actor> StopContext<'a, A> {
         }
     }
 
-    actor_context_forwarders!(A);
+    context_common_forwarders!();
 
     /// Re-enters a same-message actor with the same narrowed stop context.
     pub fn for_actor<B: Actor<Msg = A::Msg>>(&mut self) -> StopContext<'_, B> {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -256,37 +256,21 @@ impl<T> Default for ChildResources<T> {
     }
 }
 
-trait ChildKeyArg {
-    fn child_key(self) -> ChildKey;
-}
-
-impl ChildKeyArg for ChildKey {
-    fn child_key(self) -> ChildKey {
-        self
-    }
-}
-
-impl ChildKeyArg for &ChildKey {
-    fn child_key(self) -> ChildKey {
-        *self
-    }
-}
-
 impl<T> ChildResources<T> {
     fn insert(&mut self, key: ChildKey, child: T) -> Option<T> {
         self.0.insert(key, child)
     }
 
-    fn get(&self, key: impl ChildKeyArg) -> Option<&T> {
-        self.0.get(&key.child_key())
+    fn get(&self, key: ChildKey) -> Option<&T> {
+        self.0.get(&key)
     }
 
-    fn get_mut(&mut self, key: impl ChildKeyArg) -> Option<&mut T> {
-        self.0.get_mut(&key.child_key())
+    fn get_mut(&mut self, key: ChildKey) -> Option<&mut T> {
+        self.0.get_mut(&key)
     }
 
-    fn remove(&mut self, key: impl ChildKeyArg) -> Option<T> {
-        self.0.remove(&key.child_key())
+    fn remove(&mut self, key: ChildKey) -> Option<T> {
+        self.0.remove(&key)
     }
 
     fn iter(&self) -> impl Iterator<Item = (ChildKey, &T)> {
@@ -320,22 +304,8 @@ impl<T> Index<ChildKey> for ChildResources<T> {
     }
 }
 
-impl<T> Index<&ChildKey> for ChildResources<T> {
-    type Output = T;
-
-    fn index(&self, key: &ChildKey) -> &Self::Output {
-        self.get(key).expect("live child resource key")
-    }
-}
-
 impl<T> IndexMut<ChildKey> for ChildResources<T> {
     fn index_mut(&mut self, key: ChildKey) -> &mut Self::Output {
-        self.get_mut(key).expect("live child resource key")
-    }
-}
-
-impl<T> IndexMut<&ChildKey> for ChildResources<T> {
-    fn index_mut(&mut self, key: &ChildKey) -> &mut Self::Output {
         self.get_mut(key).expect("live child resource key")
     }
 }

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -116,16 +116,6 @@ impl DynamicEntry {
         matches!(self.state, DynamicMembershipState::Removing { .. })
     }
 
-    fn removal_requested(&self) -> bool {
-        match &self.state {
-            DynamicMembershipState::Resident { fused_cancel, .. } => {
-                fused_cancel.as_ref().is_some_and(Latch::is_fired)
-            }
-            DynamicMembershipState::Removing { .. } => true,
-            DynamicMembershipState::Reserved => false,
-        }
-    }
-
     pub(super) fn key(&self) -> Option<ChildKey> {
         match self.state {
             DynamicMembershipState::Reserved => None,
@@ -347,7 +337,7 @@ fn reserve_dynamic_slot(
         return Err(ReserveError::NotAdmitting(NotAdmittingCause::Draining));
     }
     if let Some(existing) = state.entry(&id) {
-        if existing.removal_requested() {
+        if existing.removal_latched() {
             return Err(ReserveError::RemovalInProgress(id));
         }
         return Err(ReserveError::DuplicateId(id));

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -549,7 +549,7 @@ impl ScopeRuntime {
         // already-joined boundary directly, so normalize them through the
         // same reducer predecessor instead of allowing `Terminalized` to
         // skip arbitrary incarnation states.
-        if !self.supervisor.is_disposing(key) && !self.supervisor.membership_terminal(key) {
+        if !self.supervisor.is_disposing(key) && !self.supervisor.joined(key) {
             self.reduce(SupervisorEvent::DisposalStarted { child: key });
         }
         let changed = self
@@ -586,7 +586,7 @@ impl ScopeRuntime {
         };
         if self.supervisor.lifecycle().is_draining()
             || child.active.is_some()
-            || self.supervisor.membership_terminal(key)
+            || self.supervisor.joined(key)
             || self.supervisor.is_disposing(key)
         {
             return;
@@ -711,7 +711,7 @@ impl ScopeRuntime {
         let Some(child) = self.children.get(key) else {
             return;
         };
-        if self.supervisor.membership_terminal(key) || self.supervisor.is_disposing(key) {
+        if self.supervisor.joined(key) || self.supervisor.is_disposing(key) {
             return;
         }
         if child
@@ -1045,7 +1045,7 @@ impl ScopeRuntime {
     ) {
         if !self.supervisor.contains(key)
             || self.supervisor.is_disposing(key)
-            || self.supervisor.membership_terminal(key)
+            || self.supervisor.joined(key)
         {
             return;
         }
@@ -1149,11 +1149,11 @@ impl ScopeRuntime {
             && !self.supervisor.lifecycle().is_draining()
         {
             self.fail_startup(key, exit);
-            if self.children[&key].options.retention == crate::Retention::Remove {
+            if self.children[key].options.retention == crate::Retention::Remove {
                 self.prune_terminal(key);
             }
         } else {
-            if self.children[&key].options.retention == crate::Retention::Remove {
+            if self.children[key].options.retention == crate::Retention::Remove {
                 self.prune_terminal(key);
             }
         }

--- a/crates/shelterwood/src/driver/events.rs
+++ b/crates/shelterwood/src/driver/events.rs
@@ -255,10 +255,7 @@ impl ScopeRuntime {
         let Some(child) = self.children.get_mut(key) else {
             return;
         };
-        if !target_is_pending
-            || self.supervisor.membership_terminal(key)
-            || self.supervisor.is_disposing(key)
-        {
+        if !target_is_pending || self.supervisor.joined(key) || self.supervisor.is_disposing(key) {
             child.restart_shutdown_pending = None;
             return;
         }
@@ -267,9 +264,8 @@ impl ScopeRuntime {
             return;
         }
         if !self.supervisor.spawned_once(key) {
-            // Only a member in the restart gap may be expedited. The wake-start
-            // scan this path replaced required `MemberStage::Restarting`; with
-            // no active incarnation and the terminal/disposing cases excluded
+            // Only a member in the restart gap may be expedited. With no active
+            // incarnation and the terminal/disposing cases excluded
             // above, `spawned_once` is that stage bit — false means the member
             // is still `Admitted` and has never run. Expediting it would let a
             // shutdown request against the first (pending) incarnation start an

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -41,7 +41,7 @@ impl ScopeRuntime {
         let Some(control) = &self.dynamic else {
             return;
         };
-        let member = Arc::clone(&self.children[&key].slot.member);
+        let member = Arc::clone(&self.children[key].slot.member);
         let id = member.id().clone();
         let root = Arc::clone(&self.root);
         let entry = root.with_observation_gate(|txn| {
@@ -87,7 +87,7 @@ impl ScopeRuntime {
     }
 
     pub(super) fn prune_terminal(&mut self, key: ChildKey) {
-        let member = Arc::clone(&self.children[&key].slot.member);
+        let member = Arc::clone(&self.children[key].slot.member);
         let root = Arc::clone(&self.root);
         let removed = root.with_observation_gate(|txn| {
             let mut state = self

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -100,7 +100,7 @@ impl ScopeRuntime {
                 }
                 _ => continue,
             };
-            if self.supervisor.membership_terminal(key)
+            if self.supervisor.joined(key)
                 || self.supervisor.is_disposing(key)
                 || self
                     .children

--- a/crates/shelterwood/src/driver/startup.rs
+++ b/crates/shelterwood/src/driver/startup.rs
@@ -137,7 +137,7 @@ impl ScopeRuntime {
             for later in later_children {
                 if !self.supervisor.spawned_once(later)
                     && !self.supervisor.is_disposing(later)
-                    && !self.supervisor.membership_terminal(later)
+                    && !self.supervisor.joined(later)
                 {
                     self.begin_terminal_disposal(
                         later,

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -965,7 +965,7 @@ fn receiverless_config_state_is_atomic_under_concurrent_snapshots() {
     let scope = isolated_scope("scope", ScopeFlavor::Ordered);
     let first = Intensity::new(1, Duration::from_secs(1)).expect("valid first intensity");
     let second = Intensity::new(2, Duration::from_secs(2)).expect("valid second intensity");
-    scope.set_observation_config(Default::default(), first);
+    scope.set_observation_config(first);
 
     let start = Arc::new(Barrier::new(2));
     let (first_update, first_update_seen) = std::sync::mpsc::sync_channel(0);
@@ -976,7 +976,7 @@ fn receiverless_config_state_is_atomic_under_concurrent_snapshots() {
         writer_start.wait();
         for update in 0..UPDATES {
             let intensity = if update % 2 == 0 { second } else { first };
-            writer_scope.set_observation_config(Default::default(), intensity);
+            writer_scope.set_observation_config(intensity);
             if update == 0 {
                 first_update
                     .send(())
@@ -1153,7 +1153,7 @@ fn plain_parent_state_preserves_nested_snapshot_propagation() {
     let snapshots = root.subscribe_snapshots();
     let intensity = Intensity::new(7, Duration::from_secs(11)).expect("valid intensity");
 
-    nested.set_observation_config(Default::default(), intensity);
+    nested.set_observation_config(intensity);
 
     assert_eq!(
         snapshots

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -40,14 +40,14 @@ pub use mailbox::{
 };
 pub use observe::{
     ChildSnapshot, ChildState, LIFECYCLE_EVENT_CAPACITY, LifecycleEvent, LifecycleEventKind,
-    LifecycleEvents, LifecycleItem, LifecycleSeq, LifecycleTryRecvError, ScopeKind, ScopeSnapshot,
+    LifecycleEvents, LifecycleItem, LifecycleSeq, LifecycleTryRecvError, ScopeSnapshot,
     SnapshotClosed, SnapshotReceiver, WaitError,
 };
 pub use policy::{
-    Backoff, BackoffFactor, BoundedReadinessDeadline, DefaultsInheritance, ExponentialBackoff,
-    FixedBackoff, Intensity, Jitter, JitterSample, Mailbox, MailboxShutdown, NonZeroDuration,
-    PolicyError, Readiness, ReadinessDeadline, RestartAttempt, RestartCondition, RestartCount,
-    RestartPolicy, Retention, ScopeDefaults, Shutdown, Strategy, TotalRestarts,
+    Backoff, BackoffFactor, DefaultsInheritance, ExponentialBackoff, FixedBackoff, Intensity,
+    Jitter, JitterSample, Mailbox, MailboxShutdown, NonZeroDuration, PolicyError, Readiness,
+    ReadinessDeadline, RestartAttempt, RestartCondition, RestartCount, RestartPolicy, Retention,
+    ScopeDefaults, ScopeFlavor, Shutdown, Strategy, TotalRestarts,
 };
 pub use raw::{
     Blocking, DeadlineElapsed, Guard, RawActor, RawContext, RawDef, RawOnceDef, Rejected,

--- a/crates/shelterwood/src/observe.rs
+++ b/crates/shelterwood/src/observe.rs
@@ -1,5 +1,5 @@
 pub use shelterwood_cells::{
     ChildSnapshot, ChildState, LIFECYCLE_EVENT_CAPACITY, LifecycleEvent, LifecycleEventKind,
-    LifecycleEvents, LifecycleItem, LifecycleSeq, LifecycleTryRecvError, ScopeKind, ScopeSnapshot,
+    LifecycleEvents, LifecycleItem, LifecycleSeq, LifecycleTryRecvError, ScopeSnapshot,
     SnapshotClosed, SnapshotReceiver, WaitError,
 };

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crate::{
-    ChildId, DefaultsInheritance, Exit, Intensity, Readiness, ScopeDefaults, Strategy,
+    ChildId, DefaultsInheritance, Exit, Intensity, Readiness, ScopeDefaults,
     admission::ReserveError,
     cells::{ErasedDynamicSlot, MemberCell, ObservationTxn, ScopeCell},
     definition::DefinitionSource,
@@ -22,7 +22,6 @@ use crate::{
 
 #[derive(Clone, Debug, Default)]
 struct ScopeConfig {
-    strategy: Strategy,
     intensity: Intensity,
     defaults: ScopeDefaults,
 }
@@ -217,9 +216,20 @@ impl SlotCell {
         &self,
         defaults: &ResolvedDefaults,
     ) -> Option<(Isolated<ChildConstruction>, ResolvedCommonOptions)> {
-        self.resolve_and_take_defined_with(defaults, || {})
+        let mut state = self.definition.lock().expect("definition mutex poisoned");
+        let DefinitionState::Defined(definition) = &*state else {
+            return None;
+        };
+        let resolved = self.resolve_defined_policy(definition, defaults);
+        let DefinitionState::Defined(definition) =
+            std::mem::replace(&mut *state, DefinitionState::Lowered)
+        else {
+            unreachable!("the definition lock keeps resolution and claim atomic")
+        };
+        Some((definition, resolved))
     }
 
+    #[cfg(test)]
     fn resolve_and_take_defined_with(
         &self,
         defaults: &ResolvedDefaults,
@@ -264,7 +274,11 @@ impl SlotCell {
                 Readiness::Immediate,
             ),
             ChildConstruction::Scope(definition) => {
-                (&definition.options, definition.mode(), Readiness::Manual)
+                let options = CommonOptions {
+                    readiness: None,
+                    ..definition.options.clone()
+                };
+                return resolve_common(&options, defaults, definition.mode(), Readiness::Manual);
             }
         };
         resolve_common(options, defaults, mode, default_readiness)
@@ -286,10 +300,6 @@ pub(crate) struct BuilderCore {
 }
 
 impl BuilderCore {
-    pub(crate) fn set_strategy(&mut self, strategy: Strategy) {
-        self.config.strategy = strategy;
-    }
-
     pub(crate) fn set_intensity(&mut self, intensity: Intensity) {
         self.config.intensity = intensity;
     }
@@ -356,7 +366,7 @@ impl BuilderCore {
             .slots
             .iter()
             .filter(|slot| slot.is_undefined())
-            .map(|slot| vec![slot.member.id().clone()])
+            .map(|slot| slot.member.id().clone())
             .collect();
         if !undefined.is_empty() {
             let disposal = self.begin_failed_disposal();
@@ -384,7 +394,7 @@ impl BuilderCore {
                 }
             }
         }
-        root.set_observation_config(self.config.strategy, self.config.intensity);
+        root.set_observation_config(self.config.intensity);
         let mut children = Vec::with_capacity(self.slots.len());
         debug_assert_eq!(
             self.slots.len(),
@@ -530,7 +540,7 @@ impl ChildPlan {
 #[derive(Debug)]
 pub(crate) enum LowerError {
     Undefined {
-        paths: Vec<Vec<ChildId>>,
+        paths: Vec<ChildId>,
         disposal: Latch,
     },
     IdentityExhausted {
@@ -713,7 +723,9 @@ mod tests {
             Readiness::Manual
         );
 
-        // A declared override wins over every per-kind default.
+        // Task and raw declarations expose readiness overrides. Scope
+        // readiness is structural even if an internal fixture forges the
+        // otherwise-unreachable common-options field.
         assert_eq!(
             resolved_readiness(ChildConstruction::Task(
                 TaskDef::new(|_| async { Ok(()) })
@@ -737,7 +749,7 @@ mod tests {
                 readiness: Some(Readiness::Immediate),
                 ..CommonOptions::default()
             })),
-            Readiness::Immediate
+            Readiness::Manual
         );
         assert_eq!(
             resolved_readiness(raw_construction(CommonOptions {

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -216,20 +216,18 @@ impl SlotCell {
         &self,
         defaults: &ResolvedDefaults,
     ) -> Option<(Isolated<ChildConstruction>, ResolvedCommonOptions)> {
-        let mut state = self.definition.lock().expect("definition mutex poisoned");
-        let DefinitionState::Defined(definition) = &*state else {
-            return None;
-        };
-        let resolved = self.resolve_defined_policy(definition, defaults);
-        let DefinitionState::Defined(definition) =
-            std::mem::replace(&mut *state, DefinitionState::Lowered)
-        else {
-            unreachable!("the definition lock keeps resolution and claim atomic")
-        };
-        Some((definition, resolved))
+        self.resolve_and_take_defined_with(defaults, || {})
     }
 
-    #[cfg(test)]
+    /// The body of [`Self::resolve_and_take_defined`], with a seam between
+    /// resolution and claim.
+    ///
+    /// Production always passes an empty closure; the sole consumer of a
+    /// non-empty one is
+    /// `dynamic_policy_resolution_and_definition_claim_are_atomic`, which
+    /// releases a competing remover through it. Delegating rather than
+    /// duplicating is what keeps that test pinned to the shipped path: an
+    /// unlock injected here fails it.
     fn resolve_and_take_defined_with(
         &self,
         defaults: &ResolvedDefaults,

--- a/crates/shelterwood/src/tree/builders.rs
+++ b/crates/shelterwood/src/tree/builders.rs
@@ -1,7 +1,7 @@
 use std::{fmt, sync::Arc};
 
 use crate::{
-    ActorDef, ActorOnceDef, ActorRef, ChildId, Intensity, ScopeDefaults, Strategy,
+    ActorDef, ActorOnceDef, ActorRef, ChildId, Intensity, ScopeDefaults,
     admission::ReserveError,
     mailbox::MailboxCell,
     plan::{BuilderCore, LowerError, SlotCell},
@@ -27,8 +27,8 @@ pub enum BuildError {
     /// One or more reserved slots were left undefined.
     #[error("tree contains undefined reserved slots")]
     UnfilledReservations {
-        /// Child-id paths of every undefined reservation.
-        paths: Vec<Vec<ChildId>>,
+        /// Child ids of every undefined reservation.
+        paths: Vec<ChildId>,
     },
 }
 /// Routes a definition rejected before admission through isolated disposal.
@@ -238,12 +238,6 @@ impl Tree {
         Self {
             core: BuilderCore::new(ScopeFlavor::Ordered),
         }
-    }
-
-    /// Sets the ordered scope's fate-sharing strategy.
-    pub fn strategy(&mut self, strategy: Strategy) -> &mut Self {
-        self.core.set_strategy(strategy);
-        self
     }
 
     /// Lowers and starts this tree synchronously.

--- a/crates/shelterwood/src/tree/slots.rs
+++ b/crates/shelterwood/src/tree/slots.rs
@@ -283,6 +283,7 @@ impl TaskSlot {
     }
 
     /// Defines a one-shot task and consumes the slot.
+    #[must_use = "the returned task and completion handles must be retained"]
     pub fn define_once<T: Send + 'static>(
         self,
         definition: TaskOnceDef<T>,

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -12,9 +12,9 @@ use crate::common::{
     POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet, waiting::task as waiting_task,
 };
 use shelterwood::{
-    Actor, ActorDef, ActorOnceDef, ActorRef, ChildState, Context, DynamicTree, ExitError, ExitKind,
-    ExitResult, Handler, Mailbox, RawActor, RawContext, RawOnceDef, Readiness, Retention, ScopeRef,
-    SendErrorKind, StopContext, TaskDef, Tree,
+    Actor, ActorDef, ActorOnceDef, ActorRef, ChildId, ChildState, Context, DynamicTree, ExitError,
+    ExitKind, ExitResult, Handler, Mailbox, RawActor, RawContext, RawOnceDef, Readiness, Retention,
+    ScopeRef, SendErrorKind, StopContext, TaskDef, Tree,
 };
 
 #[derive(Clone)]
@@ -533,7 +533,7 @@ struct ContextSurfaceActor {
     entered: ReleaseGate,
     release: ReleaseGate,
     observed: Option<tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>>,
-    stopped: Option<tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>>,
+    stopped: Option<tokio::sync::oneshot::Sender<(ChildId, ScopeRef)>>,
 }
 
 impl Actor for ContextSurfaceActor {
@@ -542,7 +542,7 @@ impl Actor for ContextSurfaceActor {
         ReleaseGate,
         ReleaseGate,
         tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>,
-        tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>,
+        tokio::sync::oneshot::Sender<(ChildId, ScopeRef)>,
     );
 
     async fn init(
@@ -585,13 +585,13 @@ impl Actor for ContextSurfaceActor {
     }
 
     async fn on_stop(&mut self, context: &mut StopContext<'_, Self>) {
-        let myself: ActorRef<ContextSurfaceMessage> = context.myself();
+        let id = context.id().clone();
         let scope: ScopeRef = context.scope();
         self.stopped
             .take()
             .expect("stop-context observation is sent once")
-            .send((myself, scope))
-            .expect("test still awaits typed stop-context handles");
+            .send((id, scope))
+            .expect("test still awaits typed stop-context identity");
     }
 }
 
@@ -631,10 +631,10 @@ async fn typed_context_handles_preserve_identity_and_self_send_capacity() {
     assert_eq!(myself, actor);
     assert_eq!(scope, system.scope());
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
-    let (stopping_myself, stopping_scope) = stop_observation
+    let (stopping_id, stopping_scope) = stop_observation
         .await
-        .expect("actor reports stop-context handles");
-    assert_eq!(stopping_myself, actor);
+        .expect("actor reports stop-context identity");
+    assert_eq!(&stopping_id, actor.id());
     assert_eq!(stopping_scope, scope);
 }
 

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -9,7 +9,7 @@ use shelterwood::{
     NonZeroDuration, OneShotTaskRef, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
     ReadinessDeadline, Removal, Reply, ReplyReceive, ReplyReceiver, ReserveError, RestartAttempt,
     RestartCount, RestartPolicy, Retention, ScopeDefaults, ScopeRef, SendError, SendFuture,
-    SendTimeout, Shutdown, SnapshotClosed, SnapshotReceiver, StopContext, Strategy, SubtreeDef,
+    SendTimeout, Shutdown, SnapshotClosed, SnapshotReceiver, StopContext, SubtreeDef,
     SubtreeOnceDef, SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, TotalRestarts,
     Tree, WaitError,
 };
@@ -295,7 +295,6 @@ impl RawActor for OpaqueRaw {
 #[test]
 fn ordered_and_dynamic_builders_expose_the_parallel_typed_surface() {
     let mut ordered = Tree::new();
-    let _: &mut Tree = ordered.strategy(Strategy::default());
     let _: &mut Tree = ordered.intensity(Intensity::default());
     let _: &mut Tree = ordered.defaults(ScopeDefaults::default());
     let _: Result<ActorSlot<Cell<()>>, ReserveError> = ordered.reserve_actor("ordered-actor-slot");

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -17,7 +17,7 @@ use shelterwood::{
     Backoff, ChildState, DynamicScopeRef, DynamicTree, Intensity, Jitter, LIFECYCLE_EVENT_CAPACITY,
     LifecycleEvent, LifecycleEventKind, LifecycleEvents, LifecycleItem, LifecycleSeq,
     LifecycleTryRecvError, MembershipStatus, RemoveOutcome, RestartCondition, RestartCount,
-    RestartPolicy, Retention, ScopeKind, ScopeRef, ScopeState, StopReason, Strategy, SubtreeDef,
+    RestartPolicy, Retention, ScopeFlavor, ScopeRef, ScopeState, StopReason, Strategy, SubtreeDef,
     SubtreeOnceDef, TaskDef, TaskOnceDef, TaskRef, TotalRestarts, Tree, WaitError,
 };
 
@@ -1281,7 +1281,6 @@ async fn end_to_end_snapshot_projects_kinds_policies_membership_status_and_stopp
         Backoff::fixed(Duration::from_secs(5), Jitter::None).expect("valid backoff"),
     );
     let mut nested = Tree::new();
-    nested.strategy(Strategy::OneForOne);
     nested.intensity(Intensity::new(3, Duration::from_secs(45)).expect("valid intensity"));
     nested
         .add_task(
@@ -1346,7 +1345,7 @@ async fn end_to_end_snapshot_projects_kinds_policies_membership_status_and_stopp
 
     let running = scope.as_scope().snapshot();
     assert_eq!(running.state, ScopeState::Running);
-    assert_eq!(running.kind, ScopeKind::Dynamic);
+    assert_eq!(running.kind, ScopeFlavor::Dynamic);
     assert_eq!(
         running.strategy, None,
         "dynamic scopes have no fate-sharing strategy"
@@ -1383,7 +1382,7 @@ async fn end_to_end_snapshot_projects_kinds_policies_membership_status_and_stopp
     let recursive = nested_row.nested.as_ref().expect("nested scope is live");
     assert_eq!(nested_row.scope_seq, Some(recursive.lifecycle_seq));
     assert_eq!(recursive.state, ScopeState::Running);
-    assert_eq!(recursive.kind, ScopeKind::Ordered);
+    assert_eq!(recursive.kind, ScopeFlavor::Ordered);
     assert_eq!(recursive.strategy, Some(Strategy::OneForOne));
     assert_eq!(
         recursive.intensity,

--- a/crates/shelterwood/tests/policy_validation.rs
+++ b/crates/shelterwood/tests/policy_validation.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use shelterwood::{
-    Backoff, BackoffFactor, BoundedReadinessDeadline, ExponentialBackoff, FixedBackoff, Intensity,
-    Jitter, Mailbox, PolicyError, ReadinessDeadline,
+    Backoff, BackoffFactor, ExponentialBackoff, FixedBackoff, Intensity, Jitter, Mailbox,
+    NonZeroDuration, PolicyError, ReadinessDeadline,
 };
 
 #[test]
@@ -102,9 +102,9 @@ fn sealed_payloads_expose_only_constructor_validated_values() {
     else {
         panic!("bounded constructor returned another variant");
     };
-    let bounded: BoundedReadinessDeadline = bounded;
-    assert_eq!(bounded.duration(), deadline);
-    assert!(!bounded.duration().is_zero());
+    let bounded: NonZeroDuration = bounded;
+    assert_eq!(bounded.get(), deadline);
+    assert!(!bounded.get().is_zero());
 
     let intensity =
         Intensity::new(3, Duration::from_secs(30)).expect("the intensity window is non-zero");

--- a/crates/shelterwood/tests/subtrees.rs
+++ b/crates/shelterwood/tests/subtrees.rs
@@ -129,7 +129,7 @@ async fn one_shot_subtree_lowering_failure_retains_structured_provenance() {
     assert!(matches!(
         nested.cause,
         StartupFailureCause::Lowering { ref undefined }
-            if undefined.len() == 1 && undefined[0][0].as_str() == "missing"
+            if undefined.len() == 1 && undefined[0].as_str() == "missing"
     ));
     system
         .shutdown(Duration::from_secs(1))

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -74,7 +74,7 @@ fn declaration_errors_are_eager_and_root_lowering_is_the_only_other_build_error(
         assert!(matches!(
             tree.spawn(),
             Err(BuildError::UnfilledReservations { ref paths })
-                if paths.len() == 1 && paths[0][0].as_str() == "duplicate"
+                if paths.len() == 1 && paths[0].as_str() == "duplicate"
         ));
         assert!(matches!(task.wait().await.kind(), ExitKind::NeverStarted));
     });


### PR DESCRIPTION
Starts the #284 simplification sequence. Closes #277.

This audits every issue checkbox and either deletes the named seam or records the one real cross-crate reason it remains.

Highlights:

- Removes dead timer, retained-exit, tree strategy, scope readiness, identity, child-key, actor-work, timeout-arbitration, and context-forwarding paths.
- Flattens undefined-child paths and replaces the bounded readiness wrapper with `NonZeroDuration`.
- Deletes future disposal/withdraw function pointers using structural `Send + 'static` bounds.
- Tightens lower-crate visibility/reexports and unifies duplicate state aliases.
- Adds `#[must_use]` to one-shot task definition.

Two explicit ownership decisions: `EffectSink` is completed by the following #274 PR, and the two still-public cross-crate names have documented live consumers.

Validation: focused crate/API suites and `./tools/dev just ci` passed (674/674 tests plus formatting, clippy, docs, reachability, external consumer, and Nix formatting).

Merge order: review after the #281–#283 behavioral pins; this draft is based on current main to keep the deletion diff readable.