### PR TITLE
Separate supervisor results from command effects

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -220,8 +220,10 @@ normative so that "pure" is not misread into pessimization:
 - `step` MAY take `&mut State` — pure means no I/O, clocks, randomness, or
   awaits; it does not mean persistent data structures or defensive clones.
 - Effects MAY flow through a caller-owned buffer
-  (`step(&mut state, event, &mut Vec<Effect>)`) rather than a returned `Vec`;
-  tests and production can reuse that buffer, so hot steps allocate nothing.
+  (`step(&mut state, event, &mut Vec<Effect>)`) rather than a returned `Vec`,
+  which a caller MAY reuse across steps. Reuse is a permission, not a
+  guarantee: a caller that drains the buffer by moving out of it gives the
+  allocation back on every flush.
 - The actor loop's next-action decision is a small `Copy` enum, not a
   boxed plan.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -219,9 +219,9 @@ normative so that "pure" is not misread into pessimization:
 
 - `step` MAY take `&mut State` — pure means no I/O, clocks, randomness, or
   awaits; it does not mean persistent data structures or defensive clones.
-- Effects MAY flow through a sink (`step(&mut state, event, &mut impl
-  EffectSink)`) rather than a returned `Vec` — tests pass a `Vec`,
-  production passes an inline executor; hot steps allocate nothing.
+- Effects MAY flow through a caller-owned buffer
+  (`step(&mut state, event, &mut Vec<Effect>)`) rather than a returned `Vec`;
+  tests and production can reuse that buffer, so hot steps allocate nothing.
 - The actor loop's next-action decision is a small `Copy` enum, not a
   boxed plan.
 

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -137,10 +137,6 @@ impl ChildRecord {
 /// One input to the structural reducer.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Event {
-    Admit {
-        membership: Membership,
-        initial: bool,
-    },
     Spawned {
         child: ChildKey,
     },
@@ -522,12 +518,6 @@ impl SupervisorState {
 
     fn apply(&mut self, event: Event, effects: &mut Vec<Effect>) {
         match event {
-            Event::Admit {
-                membership,
-                initial,
-            } => {
-                let _ = self.admit(membership, initial);
-            }
             Event::Spawned { child } => {
                 if let Some(record) = self.children.get_mut(&child)
                     && matches!(record.state, ChildState::Resident(_))
@@ -731,6 +721,11 @@ pub fn fail_startup(state: &mut SupervisorState) -> Option<ScopeState> {
 }
 
 /// Begins a drain and returns the transition its owner must publish.
+///
+/// The tuple is `(startup_pending, state)`: `startup_pending` reports whether
+/// startup was still in flight when the drain opened, so the owner knows a
+/// startup result accompanies this publication. `None` means no transition —
+/// a drain was already in progress and only its reason may have been upgraded.
 pub fn begin_drain(
     state: &mut SupervisorState,
     reason: StopReason,
@@ -740,6 +735,10 @@ pub fn begin_drain(
 }
 
 /// Hard-forces all incomplete children and returns a newly entered drain.
+///
+/// The tuple is `(startup_pending, state)`, exactly as `begin_drain` returns
+/// it; `None` means the force landed on an already-draining scope and there is
+/// no new transition to publish.
 pub fn force(state: &mut SupervisorState, effects: &mut Vec<Effect>) -> Option<(bool, ScopeState)> {
     state.force(effects)
 }
@@ -1190,14 +1189,6 @@ mod tests {
         let child = admit(&mut state, membership, false);
         let mut effects = Vec::new();
         assert_eq!(super::admit(&mut state, membership, false), None);
-        step(
-            &mut state,
-            Event::Admit {
-                membership,
-                initial: false,
-            },
-            &mut effects,
-        );
         assert!(effects.is_empty());
         assert_eq!(state.len(), 1);
 

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -2,8 +2,8 @@
 //!
 //! Runtime adapters sample latches and clocks before constructing an
 //! [`Event`]. The reducer owns membership, startup, and ordered-stop state and
-//! emits commands through an [`EffectSink`]; it never runs user code, reads a
-//! clock, samples randomness, or performs I/O.
+//! appends commands to a caller-owned effect vector; it never runs user code,
+//! reads a clock, samples randomness, or performs I/O.
 
 use std::{
     collections::{BTreeMap, HashMap},
@@ -140,7 +140,6 @@ pub enum Event {
     Admit {
         membership: Membership,
         initial: bool,
-        start_immediately: bool,
     },
     Spawned {
         child: ChildKey,
@@ -188,45 +187,12 @@ pub enum Event {
 /// A command for the runtime shell or observation projection.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Effect {
-    Admitted {
-        child: ChildKey,
-    },
-    StartChild {
-        child: ChildKey,
-    },
-    StopChild {
-        child: ChildKey,
-    },
-    ForceChild {
-        child: ChildKey,
-    },
-    FinalizeRemoval {
-        child: ChildKey,
-    },
-    StartupCompleted {
-        state: ScopeState,
-    },
-    StartupFailed {
-        state: ScopeState,
-    },
-    DrainStarted {
-        state: ScopeState,
-        startup_pending: bool,
-    },
-    Finished {
-        reason: StopReason,
-    },
-}
-
-/// Destination for effects emitted synchronously by [`step`].
-pub trait EffectSink {
-    fn push(&mut self, effect: Effect);
-}
-
-impl EffectSink for Vec<Effect> {
-    fn push(&mut self, effect: Effect) {
-        Vec::push(self, effect);
-    }
+    StartChild { child: ChildKey },
+    StopChild { child: ChildKey },
+    ForceChild { child: ChildKey },
+    FinalizeRemoval { child: ChildKey },
+    StartupCompleted { state: ScopeState },
+    Finished { reason: StopReason },
 }
 
 /// Authoritative structural state for one scope incarnation.
@@ -385,19 +351,11 @@ impl SupervisorState {
         Some(record.state.incarnation())
     }
 
-    fn admit(
-        &mut self,
-        membership: Membership,
-        initial: bool,
-        start_immediately: bool,
-        effects: &mut impl EffectSink,
-    ) {
+    fn admit(&mut self, membership: Membership, initial: bool) -> Option<ChildKey> {
         if self.child_keys.contains_key(&membership) {
-            return;
+            return None;
         }
-        let Some(raw) = self.keys.mint() else {
-            return;
-        };
+        let raw = self.keys.mint()?;
         let child = ChildKey(raw);
         let replaced = self.children.insert(
             child,
@@ -421,13 +379,10 @@ impl SupervisorState {
         if initial && self.flavor == ScopeFlavor::Ordered && self.next_ordered_start.is_none() {
             self.next_ordered_start = Some(child);
         }
-        effects.push(Effect::Admitted { child });
-        if start_immediately && !self.lifecycle.is_draining() && !self.lifecycle.startup_failed() {
-            effects.push(Effect::StartChild { child });
-        }
+        Some(child)
     }
 
-    fn settle_startup(&mut self, effects: &mut impl EffectSink) {
+    fn settle_startup(&mut self, effects: &mut Vec<Effect>) {
         if !self.lifecycle.is_starting() {
             return;
         }
@@ -487,14 +442,16 @@ impl SupervisorState {
         }
     }
 
-    fn begin_drain(&mut self, reason: StopReason, effects: &mut impl EffectSink) {
-        let Some((startup_pending, state)) = self.lifecycle.begin_drain(reason) else {
-            return;
-        };
-        effects.push(Effect::DrainStarted {
-            state,
-            startup_pending,
-        });
+    fn fail_startup(&mut self) -> Option<ScopeState> {
+        self.lifecycle.fail_startup()
+    }
+
+    fn begin_drain(
+        &mut self,
+        reason: StopReason,
+        effects: &mut Vec<Effect>,
+    ) -> Option<(bool, ScopeState)> {
+        let effect = self.lifecycle.begin_drain(reason)?;
         match self.flavor {
             ScopeFlavor::Ordered => {
                 self.ordered_stop_cursor = self.children.keys().next_back().copied();
@@ -507,9 +464,21 @@ impl SupervisorState {
                 }
             }
         }
+        Some(effect)
     }
 
-    fn settle_ordered_stop(&mut self, effects: &mut impl EffectSink) {
+    fn force(&mut self, effects: &mut Vec<Effect>) -> Option<(bool, ScopeState)> {
+        self.hard_forced = true;
+        let drain = self.begin_drain(StopReason::ShutdownRequested, effects);
+        for child in self.children.keys().copied() {
+            if !self.children[&child].state.joined() {
+                effects.push(Effect::ForceChild { child });
+            }
+        }
+        drain
+    }
+
+    fn settle_ordered_stop(&mut self, effects: &mut Vec<Effect>) {
         if self.flavor != ScopeFlavor::Ordered || !self.lifecycle.is_draining() {
             return;
         }
@@ -534,7 +503,7 @@ impl SupervisorState {
         }
     }
 
-    fn settle_finish(&mut self, effects: &mut impl EffectSink) {
+    fn settle_finish(&mut self, effects: &mut Vec<Effect>) {
         if self.finish_emitted {
             return;
         }
@@ -551,13 +520,14 @@ impl SupervisorState {
         }
     }
 
-    fn apply(&mut self, event: Event, effects: &mut impl EffectSink) {
+    fn apply(&mut self, event: Event, effects: &mut Vec<Effect>) {
         match event {
             Event::Admit {
                 membership,
                 initial,
-                start_immediately,
-            } => self.admit(membership, initial, start_immediately, effects),
+            } => {
+                let _ = self.admit(membership, initial);
+            }
             Event::Spawned { child } => {
                 if let Some(record) = self.children.get_mut(&child)
                     && matches!(record.state, ChildState::Resident(_))
@@ -672,19 +642,13 @@ impl SupervisorState {
                 debug_assert_eq!(removed, Some(child));
             }
             Event::FailStartup => {
-                if let Some(state) = self.lifecycle.fail_startup() {
-                    effects.push(Effect::StartupFailed { state });
-                }
+                let _ = self.fail_startup();
             }
-            Event::BeginDrain { reason } => self.begin_drain(reason, effects),
+            Event::BeginDrain { reason } => {
+                let _ = self.begin_drain(reason, effects);
+            }
             Event::Force => {
-                self.hard_forced = true;
-                self.begin_drain(StopReason::ShutdownRequested, effects);
-                for child in self.children.keys().copied() {
-                    if !self.children[&child].state.joined() {
-                        effects.push(Effect::ForceChild { child });
-                    }
-                }
+                let _ = self.force(effects);
             }
             Event::Settle => {
                 self.settle_startup(effects);
@@ -745,8 +709,39 @@ impl SupervisorState {
 }
 
 /// Applies one total transition to [`SupervisorState`].
-pub fn step(state: &mut SupervisorState, event: Event, effects: &mut impl EffectSink) {
+pub fn step(state: &mut SupervisorState, event: Event, effects: &mut Vec<Effect>) {
     state.apply(event, effects);
+}
+
+/// Admits one membership and returns its never-reused registration key.
+///
+/// Admission policy lives in the runtime facade. This structural operation
+/// rejects only a duplicate live membership or an exhausted key domain.
+pub fn admit(
+    state: &mut SupervisorState,
+    membership: Membership,
+    initial: bool,
+) -> Option<ChildKey> {
+    state.admit(membership, initial)
+}
+
+/// Records the first startup failure and returns the state its owner must publish.
+pub fn fail_startup(state: &mut SupervisorState) -> Option<ScopeState> {
+    state.fail_startup()
+}
+
+/// Begins a drain and returns the transition its owner must publish.
+pub fn begin_drain(
+    state: &mut SupervisorState,
+    reason: StopReason,
+    effects: &mut Vec<Effect>,
+) -> Option<(bool, ScopeState)> {
+    state.begin_drain(reason, effects)
+}
+
+/// Hard-forces all incomplete children and returns a newly entered drain.
+pub fn force(state: &mut SupervisorState, effects: &mut Vec<Effect>) -> Option<(bool, ScopeState)> {
+    state.force(effects)
 }
 
 #[cfg(test)]
@@ -771,20 +766,7 @@ mod tests {
     }
 
     fn admit(state: &mut SupervisorState, membership: Membership, initial: bool) -> ChildKey {
-        let mut effects = Vec::new();
-        step(
-            state,
-            Event::Admit {
-                membership,
-                initial,
-                start_immediately: false,
-            },
-            &mut effects,
-        );
-        let [Effect::Admitted { child }] = effects.as_slice() else {
-            panic!("admission emits exactly one key")
-        };
-        *child
+        super::admit(state, membership, initial).expect("fixture admission mints one key")
     }
 
     #[test]
@@ -1077,15 +1059,15 @@ mod tests {
         }
 
         let mut effects = Vec::new();
-        step(
-            &mut state,
-            Event::BeginDrain {
-                reason: StopReason::ShutdownRequested,
-            },
-            &mut effects,
+        let (startup_pending, drain_state) =
+            super::begin_drain(&mut state, StopReason::ShutdownRequested, &mut effects)
+                .expect("the first drain returns its publication result");
+        assert_eq!(drain_state, ScopeState::Draining);
+        assert!(!startup_pending);
+        assert!(
+            effects.is_empty(),
+            "an ordered drain exposes its first stop through settlement"
         );
-        assert!(matches!(effects.as_slice(), [Effect::DrainStarted { .. }]));
-        effects.clear();
 
         for &expected in keys.iter().rev() {
             step(&mut state, Event::Settle, &mut effects);
@@ -1124,6 +1106,53 @@ mod tests {
     }
 
     #[test]
+    fn transition_owner_results_are_separate_from_commands() {
+        let members = memberships(2);
+
+        let mut failed = SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::starting());
+        assert_eq!(
+            super::fail_startup(&mut failed),
+            Some(ScopeState::StartupFailed)
+        );
+        assert_eq!(
+            super::fail_startup(&mut failed),
+            None,
+            "only the winning startup failure publishes the transition"
+        );
+
+        let mut draining = SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::starting());
+        let child = admit(&mut draining, members[0], true);
+        let mut effects = Vec::new();
+        let (startup_pending, drain_state) =
+            super::begin_drain(&mut draining, StopReason::ShutdownRequested, &mut effects)
+                .expect("the first drain returns its publication result");
+        assert_eq!(drain_state, ScopeState::Draining);
+        assert!(startup_pending);
+        assert_eq!(effects, [Effect::StopChild { child }]);
+        effects.clear();
+        assert!(
+            super::begin_drain(&mut draining, StopReason::ShutdownRequested, &mut effects,)
+                .is_none(),
+            "a drain upgrade does not republish its entry result"
+        );
+        assert!(effects.is_empty());
+
+        let mut forced = SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::running());
+        let child = admit(&mut forced, members[1], false);
+        let (startup_pending, drain_state) = super::force(&mut forced, &mut effects)
+            .expect("forcing a live scope returns its initial drain");
+        assert_eq!(drain_state, ScopeState::Draining);
+        assert!(!startup_pending);
+        assert_eq!(
+            effects,
+            [Effect::StopChild { child }, Effect::ForceChild { child }]
+        );
+        effects.clear();
+        assert!(super::force(&mut forced, &mut effects).is_none());
+        assert_eq!(effects, [Effect::ForceChild { child }]);
+    }
+
+    #[test]
     fn registration_keys_are_monotonic_and_exhaustion_is_fail_closed() {
         let members = memberships(4);
         let mut state = SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::running());
@@ -1145,29 +1174,10 @@ mod tests {
         state.keys = PoisonedCounter::near_exhaustion();
         let last = admit(&mut state, members[2], false);
         assert_eq!(last, ChildKey(u64::MAX - 1));
-        let mut effects = Vec::new();
-        step(
-            &mut state,
-            Event::Admit {
-                membership: members[3],
-                initial: false,
-                start_immediately: false,
-            },
-            &mut effects,
-        );
-        assert!(effects.is_empty());
+        assert_eq!(super::admit(&mut state, members[3], false), None);
         assert_eq!(state.key_for(members[3]), None);
-        step(
-            &mut state,
-            Event::Admit {
-                membership: members[3],
-                initial: false,
-                start_immediately: false,
-            },
-            &mut effects,
-        );
         assert!(
-            effects.is_empty(),
+            super::admit(&mut state, members[3], false).is_none(),
             "poisoned exhaustion remains fail closed"
         );
         state.check_invariants();
@@ -1179,12 +1189,12 @@ mod tests {
         let mut state = SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::running());
         let child = admit(&mut state, membership, false);
         let mut effects = Vec::new();
+        assert_eq!(super::admit(&mut state, membership, false), None);
         step(
             &mut state,
             Event::Admit {
                 membership,
                 initial: false,
-                start_immediately: true,
             },
             &mut effects,
         );

--- a/crates/shelterwood-core/src/supervisor/tests/exploration.rs
+++ b/crates/shelterwood-core/src/supervisor/tests/exploration.rs
@@ -388,11 +388,7 @@ fn check_r5_effects_are_acknowledgeable(transition: &Transition<'_>) {
                     "removal is finalized only once disposal has joined"
                 );
             }
-            Effect::Admitted { .. }
-            | Effect::StartupCompleted { .. }
-            | Effect::StartupFailed { .. }
-            | Effect::DrainStarted { .. }
-            | Effect::Finished { .. } => {}
+            Effect::StartupCompleted { .. } | Effect::Finished { .. } => {}
         }
     }
 }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -41,8 +41,10 @@ use crate::{
         ArbitrationClass, ChildKey, DeadlineHandle, DeadlineQueue, Effect as SupervisorEffect,
         Epoch, Event as SupervisorEvent, ExitDispatch, IncarnationRun, IntensityState,
         MembershipStatus, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState,
-        ScopeLifecycle, ScopeMode, StopAction, StopLadder, SupervisorState, arbitrate,
-        dispatch_exit, schedule_restart, step as supervisor_step,
+        ScopeLifecycle, ScopeMode, StopAction, StopLadder, SupervisorState,
+        admit as supervisor_admit, arbitrate, begin_drain as supervisor_begin_drain, dispatch_exit,
+        fail_startup as supervisor_fail_startup, force as supervisor_force, schedule_restart,
+        step as supervisor_step,
     },
     exit::{
         RecordedOutcome, StartupError, StopReason, classify_disposal_panic, classify_exit,
@@ -469,9 +471,6 @@ impl ScopeRuntime {
             let effects = std::mem::take(&mut self.supervisor_effects);
             for effect in effects {
                 match effect {
-                    SupervisorEffect::Admitted { .. } => {
-                        unreachable!("admission consumes its key synchronously")
-                    }
                     SupervisorEffect::StartChild { child } => self.spawn_child(child),
                     SupervisorEffect::StopChild { child } => self.begin_stop_child(child, None),
                     SupervisorEffect::ForceChild { child } => self.force_child(child),
@@ -481,10 +480,6 @@ impl ScopeRuntime {
                     }
                     SupervisorEffect::Finished { reason } => {
                         self.finished.get_or_insert(reason);
-                    }
-                    SupervisorEffect::StartupFailed { .. }
-                    | SupervisorEffect::DrainStarted { .. } => {
-                        unreachable!("the transition owner publishes its contextual result")
                     }
                 }
             }
@@ -510,18 +505,9 @@ impl ScopeRuntime {
         initial: bool,
     ) -> Result<ChildKey, Box<ChildRuntime>> {
         let membership = child.slot.member.membership();
-        let before = self.supervisor_effects.len();
-        self.reduce(SupervisorEvent::Admit {
-            membership,
-            initial,
-            start_immediately: false,
-        });
-        let key = match self.supervisor_effects.get(before) {
-            Some(SupervisorEffect::Admitted { child }) => *child,
-            None => return Err(Box::new(child)),
-            Some(effect) => unreachable!("admission emitted {effect:?} before its key"),
+        let Some(key) = supervisor_admit(&mut self.supervisor, membership, initial) else {
+            return Err(Box::new(child));
         };
-        self.supervisor_effects.remove(before);
         let replaced = self.children.insert(key, child);
         debug_assert!(
             replaced.is_none(),
@@ -906,22 +892,12 @@ async fn run_scope_incarnation(
     // child's obligation before fallible setup. Thus a panic at any point has
     // exactly one terminality owner for every child.
     let mut supervisor = SupervisorState::new(root.flavor, epoch.lifecycle());
-    let mut supervisor_effects = Vec::new();
     let mut children = ChildResources::default();
     plan.children.reverse();
     while let Some(child) = plan.children.pop() {
         let child = ChildRuntime::from_plan(child, &root);
         let membership = child.slot.member.membership();
-        supervisor_step(
-            &mut supervisor,
-            SupervisorEvent::Admit {
-                membership,
-                initial: true,
-                start_immediately: false,
-            },
-            &mut supervisor_effects,
-        );
-        let Some(SupervisorEffect::Admitted { child: key }) = supervisor_effects.pop() else {
+        let Some(key) = supervisor_admit(&mut supervisor, membership, true) else {
             unreachable!("a fresh child-key domain accommodates an in-memory child collection")
         };
         let replaced = children.insert(key, child);
@@ -939,7 +915,7 @@ async fn run_scope_incarnation(
         intensity: IntensityState::default(),
         children,
         supervisor,
-        supervisor_effects,
+        supervisor_effects: Vec::new(),
         restart_shutdown_retries: Vec::new(),
         events,
         disposal_events,

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -149,20 +149,10 @@ impl ScopeRuntime {
         // retired.
         RetainedExit::retain_stop_reason(&mut self.retained_exits, &reason);
         let before = self.supervisor_effects.len();
-        self.reduce(SupervisorEvent::BeginDrain { reason });
-        let Some(position) = self.supervisor_effects[before..]
-            .iter()
-            .position(|effect| matches!(effect, SupervisorEffect::DrainStarted { .. }))
-            .map(|position| before + position)
+        let Some((startup_pending, state)) =
+            supervisor_begin_drain(&mut self.supervisor, reason, &mut self.supervisor_effects)
         else {
             return;
-        };
-        let SupervisorEffect::DrainStarted {
-            state,
-            startup_pending,
-        } = self.supervisor_effects.remove(position)
-        else {
-            unreachable!()
         };
         debug_assert!(startup.is_some() || !startup_pending);
         // Ordered drain exposes its first stop only through `Settle`; derive
@@ -180,24 +170,14 @@ impl ScopeRuntime {
 
     pub(super) fn force_all(&mut self) {
         let before = self.supervisor_effects.len();
-        self.reduce(SupervisorEvent::Force);
-        if let Some(position) = self.supervisor_effects[before..]
-            .iter()
-            .position(|effect| matches!(effect, SupervisorEffect::DrainStarted { .. }))
-            .map(|position| before + position)
+        if let Some((startup_pending, state)) =
+            supervisor_force(&mut self.supervisor, &mut self.supervisor_effects)
         {
-            let SupervisorEffect::DrainStarted {
-                state,
-                startup_pending,
-            } = self.supervisor_effects.remove(position)
-            else {
-                unreachable!()
-            };
             // No pre-`Settle` here, unlike `begin_drain_transition`.
-            // `SupervisorEvent::Force` already pushes `ForceChild` for every
-            // non-joined child, a strict superset of the single `StopChild` an
-            // ordered scope's `Settle` could add, so settling early cannot
-            // contribute a member this selection would otherwise miss.
+            // `supervisor_force` already pushes `ForceChild` for every non-joined
+            // child, a strict superset of the single `StopChild` an ordered
+            // scope's `Settle` could add, so settling early cannot contribute a
+            // member this selection would otherwise miss.
             let terminal_disposals =
                 self.drain_entry_terminal_disposals(&self.supervisor_effects[before..]);
             self.root.publish_drain(

--- a/crates/shelterwood/src/driver/startup.rs
+++ b/crates/shelterwood/src/driver/startup.rs
@@ -124,14 +124,9 @@ impl ScopeRuntime {
                 exit,
             },
         };
-        let before = self.supervisor_effects.len();
-        self.reduce(SupervisorEvent::FailStartup);
-        let Some(SupervisorEffect::StartupFailed { state }) =
-            self.supervisor_effects.get(before).cloned()
-        else {
+        let Some(state) = supervisor_fail_startup(&mut self.supervisor) else {
             return;
         };
-        self.supervisor_effects.remove(before);
         if self.root.flavor == ScopeFlavor::Ordered {
             let later_children: Vec<_> = self.supervisor.keys_after(key).collect();
             for later in later_children {

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -20,8 +20,8 @@ pub(super) use crate::{
     Retention, ScopeRef, ScopeState, SendErrorKind, StartupError, StartupFailure,
     StartupFailureCause, StopReason, SubtreeDef, SubtreeOnceDef, TaskDef, Tree,
     engine::{
-        ChildKey, Effect as SupervisorEffect, Epoch, Event as SupervisorEvent, ScopeLifecycle,
-        StopLadder, SupervisorState, arbitrate, step as supervisor_step,
+        ChildKey, Epoch, Event as SupervisorEvent, ScopeLifecycle, StopLadder, SupervisorState,
+        admit as supervisor_admit, arbitrate,
     },
     exit::RecordedOutcome,
     identity::{IncarnationCounter, ScopeIdentity},
@@ -238,19 +238,10 @@ impl ScopeRuntimeBuilder {
 
     pub(super) fn build(self) -> ScopeRuntime {
         let mut supervisor = SupervisorState::new(self.root.flavor, self.lifecycle);
-        let mut supervisor_effects = Vec::new();
         let mut children = ChildResources::default();
         for (expected, child) in self.children.into_iter() {
-            supervisor_step(
-                &mut supervisor,
-                SupervisorEvent::Admit {
-                    membership: child.slot.member.membership(),
-                    initial: true,
-                    start_immediately: false,
-                },
-                &mut supervisor_effects,
-            );
-            let Some(SupervisorEffect::Admitted { child: actual }) = supervisor_effects.pop()
+            let Some(actual) =
+                supervisor_admit(&mut supervisor, child.slot.member.membership(), true)
             else {
                 panic!("fixture admission produces one key")
             };
@@ -269,7 +260,7 @@ impl ScopeRuntimeBuilder {
             restart_shutdown_retries: Vec::new(),
             children,
             supervisor,
-            supervisor_effects,
+            supervisor_effects: Vec::new(),
             events: self.events,
             disposal_events: self.disposal_events,
             disposal_event_receiver: self.disposal_event_receiver,


### PR DESCRIPTION
Continues the #284 simplification stack. Closes #274 and completes #277's `EffectSink` item.

## What changed

- Makes `Vec<Effect>` a pure command stream by deleting `Admitted`, `StartupFailed`, and `DrainStarted`.
- Adds typed admission, startup-failure, drain, and force entry points shared with the total `Event` reducer.
- Deletes `Event::Admit::start_immediately` and every driver-side result scan/pop/remove/unreachable arm.
- Returns drain metadata directly as the structural tuple retained by #277, without resurrecting its deleted wrapper type.
- Updates the stale `EffectSink` specification text.

The exhaustive event alphabet and transition graph are unchanged: 48,669 states and 1,314,063 transitions.

Validation: focused supervisor and driver suites passed; the rebased #277 → #274 stack passes `./tools/dev just ci` with 675/675 tests and all documentation/API/external-consumer checks.

This also subsumes #279's proposed `DrainStarted` extraction helper.