### PR TITLE
Simplify retained lifecycle events

### DIFF
--- a/crates/shelterwood-cells/src/observe.rs
+++ b/crates/shelterwood-cells/src/observe.rs
@@ -87,12 +87,24 @@ struct RetainedLifecycleEvent {
 
 impl RetainedLifecycleEvent {
     fn new(event: LifecycleEvent) -> Self {
+        // Exhaustive with no wildcard arm on purpose: `LifecycleEventKind` is
+        // non-exhaustive for downstream crates but not here, so a new variant
+        // fails to compile until its retention is declared. A variant that
+        // carries an `Exit` and slipped through with no guard would let ring
+        // eviction drop a user error under the observation gate.
         let mut guards = Vec::new();
-        if let LifecycleEventKind::Exited { exit, .. } = &event.kind {
-            RetainedExit::retain_exit(&mut guards, exit);
-        }
-        if let LifecycleEventKind::ScopeState { state } = &event.kind {
-            RetainedExit::retain_scope_state(&mut guards, state);
+        match &event.kind {
+            LifecycleEventKind::Exited { exit, .. } => {
+                RetainedExit::retain_exit(&mut guards, exit);
+            }
+            LifecycleEventKind::ScopeState { state } => {
+                RetainedExit::retain_scope_state(&mut guards, state);
+            }
+            LifecycleEventKind::Added { .. }
+            | LifecycleEventKind::Started { .. }
+            | LifecycleEventKind::Ready { .. }
+            | LifecycleEventKind::RestartScheduled { .. }
+            | LifecycleEventKind::Removed { .. } => {}
         }
         Self {
             event,
@@ -102,10 +114,18 @@ impl RetainedLifecycleEvent {
 
     fn into_public(self) -> LifecycleEvent {
         let Self { event, guards } = self;
-        // A broadcast receive owns a clone of the retained wrapper. Moving the
-        // public event out first leaves its raw exits protected while this
-        // cloned guard allocation is released as refcount traffic.
-        drop(guards);
+        // The public event owns a raw clone corresponding to every guard, so
+        // retiring these copies inline is provably refcount-only. Unwrapping
+        // the guard allocation first matters: a broadcast receive is often the
+        // last owner, and letting the arc drop the guards would route a live
+        // user error through isolated disposal for nothing.
+        let guards = match Arc::try_unwrap(guards) {
+            Ok(guards) => guards,
+            Err(shared) => shared.as_ref().clone(),
+        };
+        for guard in guards {
+            drop(guard.into_exit());
+        }
         event
     }
 }

--- a/crates/shelterwood-cells/src/observe.rs
+++ b/crates/shelterwood-cells/src/observe.rs
@@ -76,200 +76,37 @@ pub struct LifecycleEvent {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct RetainedLifecycleEvent {
-    scope_path: Vec<ChildId>,
-    scope: Membership,
-    seq: LifecycleSeq,
-    kind: RetainedLifecycleEventKind,
+    // Keep the public event before its guards. Ring eviction therefore drops
+    // every raw exit projection while a retained copy still protects its user
+    // error, and only the guards' later drop submits destruction to isolated
+    // disposal. This is the same field-order argument as
+    // `RetainedScopeSnapshot` and `RetainedStopReason`.
+    event: LifecycleEvent,
+    guards: Arc<Vec<RetainedExit>>,
 }
 
 impl RetainedLifecycleEvent {
     fn new(event: LifecycleEvent) -> Self {
+        let mut guards = Vec::new();
+        if let LifecycleEventKind::Exited { exit, .. } = &event.kind {
+            RetainedExit::retain_exit(&mut guards, exit);
+        }
+        if let LifecycleEventKind::ScopeState { state } = &event.kind {
+            RetainedExit::retain_scope_state(&mut guards, state);
+        }
         Self {
-            scope_path: event.scope_path,
-            scope: event.scope,
-            seq: event.seq,
-            kind: RetainedLifecycleEventKind::new(event.kind),
+            event,
+            guards: Arc::new(guards),
         }
     }
 
     fn into_public(self) -> LifecycleEvent {
-        LifecycleEvent {
-            scope_path: self.scope_path,
-            scope: self.scope,
-            seq: self.seq,
-            kind: self.kind.into_public(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum RetainedLifecycleEventKind {
-    Added {
-        id: ChildId,
-        membership: Membership,
-    },
-    Started {
-        id: ChildId,
-        membership: Membership,
-        incarnation: Incarnation,
-    },
-    Ready {
-        id: ChildId,
-        membership: Membership,
-        incarnation: Incarnation,
-    },
-    Exited {
-        id: ChildId,
-        membership: Membership,
-        incarnation: Incarnation,
-        exit: RetainedExit,
-    },
-    RestartScheduled {
-        id: ChildId,
-        membership: Membership,
-        attempt: RestartAttempt,
-        delay: Duration,
-    },
-    Removed {
-        id: ChildId,
-        membership: Membership,
-        last_incarnation: Option<Incarnation>,
-    },
-    ScopeState {
-        state: ScopeState,
-        retained_exits: Vec<RetainedExit>,
-    },
-}
-
-impl RetainedLifecycleEventKind {
-    fn new(kind: LifecycleEventKind) -> Self {
-        match kind {
-            LifecycleEventKind::Added { id, membership } => Self::Added { id, membership },
-            LifecycleEventKind::Started {
-                id,
-                membership,
-                incarnation,
-            } => Self::Started {
-                id,
-                membership,
-                incarnation,
-            },
-            LifecycleEventKind::Ready {
-                id,
-                membership,
-                incarnation,
-            } => Self::Ready {
-                id,
-                membership,
-                incarnation,
-            },
-            LifecycleEventKind::Exited {
-                id,
-                membership,
-                incarnation,
-                exit,
-            } => Self::Exited {
-                id,
-                membership,
-                incarnation,
-                exit: RetainedExit::new(exit),
-            },
-            LifecycleEventKind::RestartScheduled {
-                id,
-                membership,
-                attempt,
-                delay,
-            } => Self::RestartScheduled {
-                id,
-                membership,
-                attempt,
-                delay,
-            },
-            LifecycleEventKind::Removed {
-                id,
-                membership,
-                last_incarnation,
-            } => Self::Removed {
-                id,
-                membership,
-                last_incarnation,
-            },
-            LifecycleEventKind::ScopeState { state } => {
-                let mut retained_exits = Vec::new();
-                RetainedExit::retain_scope_state(&mut retained_exits, &state);
-                Self::ScopeState {
-                    state,
-                    retained_exits,
-                }
-            }
-        }
-    }
-
-    fn into_public(self) -> LifecycleEventKind {
-        match self {
-            Self::Added { id, membership } => LifecycleEventKind::Added { id, membership },
-            Self::Started {
-                id,
-                membership,
-                incarnation,
-            } => LifecycleEventKind::Started {
-                id,
-                membership,
-                incarnation,
-            },
-            Self::Ready {
-                id,
-                membership,
-                incarnation,
-            } => LifecycleEventKind::Ready {
-                id,
-                membership,
-                incarnation,
-            },
-            Self::Exited {
-                id,
-                membership,
-                incarnation,
-                exit,
-            } => LifecycleEventKind::Exited {
-                id,
-                membership,
-                incarnation,
-                exit: exit.into_exit(),
-            },
-            Self::RestartScheduled {
-                id,
-                membership,
-                attempt,
-                delay,
-            } => LifecycleEventKind::RestartScheduled {
-                id,
-                membership,
-                attempt,
-                delay,
-            },
-            Self::Removed {
-                id,
-                membership,
-                last_incarnation,
-            } => LifecycleEventKind::Removed {
-                id,
-                membership,
-                last_incarnation,
-            },
-            Self::ScopeState {
-                state,
-                retained_exits,
-            } => {
-                // The public state now owns the raw copies. Converting the
-                // guards back to ordinary exits preserves caller-controlled
-                // last-drop timing at this read boundary.
-                for exit in retained_exits {
-                    drop(exit.into_exit());
-                }
-                LifecycleEventKind::ScopeState { state }
-            }
-        }
+        let Self { event, guards } = self;
+        // A broadcast receive owns a clone of the retained wrapper. Moving the
+        // public event out first leaves its raw exits protected while this
+        // cloned guard allocation is released as refcount traffic.
+        drop(guards);
+        event
     }
 }
 


### PR DESCRIPTION
Continues the #284 simplification stack. Closes #275.

`RetainedLifecycleEvent` now owns the public `LifecycleEvent` directly, followed by one shared guard vector. Construction retains exits only for `Exited` and recursively for `ScopeState`; all seven mirrored retained variants and both exhaustive conversion matches are gone.

The public event field is deliberately declared before its guards so ring eviction drops the raw projection while retained guards still protect user error payloads. Delivery moves the event out and releases the cloned guard arc after leaving the ring.

Validation: both hostile lifecycle-ring eviction regressions, all cells observation tests, formatting, and full `just ci` passed on the original branch; the tracker-ordered rebased branch passes the focused eviction suite 2/2.