### PR TITLE
Shrink the dynamic route seam

### DIFF
--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -33,12 +33,10 @@ use shelterwood_core::{
 use shelterwood_mailbox::{ActorIdentity, MailboxControl, MailboxTermination};
 use shelterwood_runtime as runtime;
 
-use crate::{
-    observe::{
-        ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
-        LifecycleHub, LifecycleSeq, RetainedScopeSnapshot, ScopeSnapshot, SnapshotHub,
-        SnapshotPublication, SnapshotReceiver,
-    },
+use crate::observe::{
+    ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents, LifecycleHub,
+    LifecycleSeq, RetainedScopeSnapshot, ScopeSnapshot, SnapshotHub, SnapshotPublication,
+    SnapshotReceiver,
 };
 
 /// An exit copy retained by framework state.

--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -3,8 +3,8 @@
 //! These cells are the neutral synchronization and observation projection
 //! layer shared by public handles, mailboxes, actor/task contexts, and the
 //! mutable supervision driver. In particular, this module does not depend on
-//! mutable driver state. Its dynamic-route interface names declaration slots
-//! only as opaque capability payloads; their state remains owned elsewhere.
+//! mutable driver state. Its dynamic-route interface retains only the one
+//! close-admission hook needed by restart-stable scope transitions.
 
 use std::{
     any::Any,
@@ -31,10 +31,9 @@ use shelterwood_core::{
     policy::{ResolvedCommonOptions, ScopeFlavor},
 };
 use shelterwood_mailbox::{ActorIdentity, MailboxControl, MailboxTermination};
-use shelterwood_runtime::{self as runtime, Latch};
+use shelterwood_runtime as runtime;
 
 use crate::{
-    admission::{RemoveOutcome, ReserveError},
     observe::{
         ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind, LifecycleEvents,
         LifecycleHub, LifecycleSeq, RetainedScopeSnapshot, ScopeSnapshot, SnapshotHub,
@@ -842,66 +841,17 @@ impl ScopeRecord {
     }
 }
 
-/// Type-erased declaration slot carried by the restart-stable cell layer.
-///
-/// The route implementation chooses the concrete slot allocation. Erasing it
-/// here lets [`ScopeCell`] retain the route without depending on the plan
-/// layer that owns declaration state.
-pub type ErasedDynamicSlot = dyn Any + Send + Sync;
-
-/// Object-safe dynamic route retained by a restart-stable scope cell.
-pub type ErasedDynamicRoute = dyn DynamicRoute<Slot = ErasedDynamicSlot>;
-
-/// Cross-crate implementation seam for the façade's dynamic declaration
-/// route.
+/// Cross-crate close-admission hook retained by a restart-stable scope cell.
 ///
 /// # Implementation boundary
 ///
 /// This is not a user extension point. Only Shelterwood's façade implements
-/// and installs this trait. Its methods may run while the restart-stable tree
+/// and installs this trait. The callback runs while the restart-stable tree
 /// owns its observation gate, so a foreign implementation invalidates the
-/// framework's lock-rule guarantees.
-pub trait DynamicRoute: Send + Sync {
-    type Slot: ?Sized + Send + Sync;
-
-    fn reserve(
-        &self,
-        scope: &Arc<ScopeCell>,
-        id: ChildId,
-        child_scope: Option<ScopeFlavor>,
-        txn: &mut ObservationTxn<'_>,
-    ) -> Result<Arc<Self::Slot>, ReserveError>;
-
+/// framework's lock-rule guarantees. Requiring the transaction capability in
+/// the signature keeps that critical-section boundary explicit.
+pub trait DynamicRoute: Any + Send + Sync {
     fn close_admission(&self, txn: &mut ObservationTxn<'_>);
-
-    fn start_admission(
-        self: Arc<Self>,
-        slot: Arc<Self::Slot>,
-        fused_cancel: Option<Latch>,
-    ) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError>;
-
-    fn cancel_reservation(
-        &self,
-        scope: &Arc<ScopeCell>,
-        slot: &Self::Slot,
-        txn: &mut ObservationTxn<'_>,
-    );
-
-    fn signal_fused_cancel(
-        &self,
-        scope: &Arc<ScopeCell>,
-        slot: &Self::Slot,
-        latch: &Latch,
-        txn: &mut ObservationTxn<'_>,
-    );
-
-    fn remove(
-        &self,
-        scope: &Arc<ScopeCell>,
-        id: &ChildId,
-        exact: Option<Membership>,
-        txn: &mut ObservationTxn<'_>,
-    ) -> runtime::OneShotReceiver<RemoveOutcome>;
 }
 
 /// Shared critical section for one resident tree's observation projection.
@@ -1184,7 +1134,7 @@ pub struct ScopeCell {
     me: Weak<ScopeCell>,
     child_identity: Mutex<ScopeIdentity>,
     control: Mutex<ScopeControl>,
-    dynamic_route: Mutex<Option<Arc<ErasedDynamicRoute>>>,
+    dynamic_route: Mutex<Option<Arc<dyn DynamicRoute>>>,
     observation: ScopeObservation,
     #[cfg(any(test, feature = "test-util"))]
     ancestor_parent_reads: AtomicUsize,
@@ -2427,7 +2377,7 @@ impl ScopeCell {
         }
     }
 
-    pub fn set_dynamic_route(&self, route: Option<Arc<ErasedDynamicRoute>>) {
+    pub fn set_dynamic_route(&self, route: Option<Arc<dyn DynamicRoute>>) {
         self.with_observation_gate(|txn| {
             self.set_dynamic_route_locked(route, txn);
         });
@@ -2435,7 +2385,7 @@ impl ScopeCell {
 
     pub fn set_dynamic_route_locked(
         &self,
-        route: Option<Arc<ErasedDynamicRoute>>,
+        route: Option<Arc<dyn DynamicRoute>>,
         txn: &mut ObservationTxn<'_>,
     ) {
         let previous = std::mem::replace(
@@ -2449,7 +2399,7 @@ impl ScopeCell {
         txn.pulse(&self.member.record);
     }
 
-    pub fn dynamic_route_in(&self, _txn: &ObservationTxn<'_>) -> Option<Arc<ErasedDynamicRoute>> {
+    pub fn dynamic_route_in(&self, _txn: &ObservationTxn<'_>) -> Option<Arc<dyn DynamicRoute>> {
         self.dynamic_route
             .lock()
             .expect("scope dynamic-route mutex poisoned")
@@ -2457,7 +2407,7 @@ impl ScopeCell {
     }
 
     #[cfg(any(test, feature = "test-util"))]
-    pub fn dynamic_route(&self) -> Option<Arc<ErasedDynamicRoute>> {
+    pub fn dynamic_route(&self) -> Option<Arc<dyn DynamicRoute>> {
         self.with_observation_gate(|txn| self.dynamic_route_in(txn))
     }
 

--- a/crates/shelterwood-cells/src/lib.rs
+++ b/crates/shelterwood-cells/src/lib.rs
@@ -29,9 +29,9 @@ pub use admission::*;
 pub use cancellation::*;
 #[doc(hidden)]
 pub use cells::{
-    DynamicRoute, ErasedDynamicRoute, ErasedDynamicSlot, MemberCell, MemberStage, MemberTransition,
-    ObservationGate, ObservationTxn, ResidentProjection, RetainedExit, RetainedStopReason,
-    ScopeCell, ScopeControlEvent, StartupDisposition,
+    DynamicRoute, MemberCell, MemberStage, MemberTransition, ObservationGate, ObservationTxn,
+    ResidentProjection, RetainedExit, RetainedStopReason, ScopeCell, ScopeControlEvent,
+    StartupDisposition,
 };
 #[cfg(any(test, feature = "test-util"))]
 #[doc(hidden)]

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -1,6 +1,7 @@
 //! Dynamic membership control-plane transport and bookkeeping.
 
 use std::{
+    any::Any,
     collections::HashMap,
     sync::{Arc, Mutex, Weak},
 };
@@ -8,13 +9,8 @@ use std::{
 use crate::{
     ChildId, Membership, ScopeState,
     admission::{NotAdmittingCause, RemoveOutcome, ReserveError},
-    cells::{
-        DynamicRoute, ErasedDynamicRoute, ErasedDynamicSlot, MemberStage, ObservationTxn, ScopeCell,
-    },
-    plan::{
-        ChildConstruction, SlotCell, checked_id, concrete_dynamic_slot, concrete_dynamic_slot_ref,
-        erase_dynamic_slot, mint_reserved_slot,
-    },
+    cells::{DynamicRoute, MemberStage, ObservationTxn, ScopeCell},
+    plan::{ChildConstruction, SlotCell, checked_id, mint_reserved_slot},
     policy::ScopeFlavor,
     runtime::{self, Latch},
 };
@@ -203,7 +199,7 @@ impl DynamicState {
     }
 }
 
-pub(super) struct DynamicControl {
+pub(crate) struct DynamicControl {
     requests: runtime::UnboundedMpscSender<DriverEvent>,
     pub(super) state: Mutex<DynamicState>,
 }
@@ -232,6 +228,62 @@ impl DynamicControl {
                 _txn,
             );
         }
+    }
+
+    /// Recovers the façade-owned control from the restart-stable route slot.
+    ///
+    /// The lookup retains its transaction token: selecting the live
+    /// incarnation's control and acting on it are one observation-gated edge.
+    fn in_scope(scope: &ScopeCell, txn: &ObservationTxn<'_>) -> Option<Arc<DynamicControl>> {
+        let route: Arc<dyn Any + Send + Sync> = scope.dynamic_route_in(txn)?;
+        Some(Arc::downcast(route).expect("the façade installs only its concrete dynamic control"))
+    }
+
+    pub(super) fn reserve(
+        &self,
+        scope: &Arc<ScopeCell>,
+        id: ChildId,
+        child_scope: Option<ScopeFlavor>,
+        txn: &mut ObservationTxn<'_>,
+    ) -> Result<Arc<SlotCell>, ReserveError> {
+        reserve_dynamic_slot(self, scope, id, child_scope, txn)
+    }
+
+    pub(super) fn start_admission(
+        self: Arc<Self>,
+        slot: Arc<SlotCell>,
+        fused_cancel: Option<Latch>,
+    ) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError> {
+        start_dynamic_admission(self, slot, fused_cancel)
+    }
+
+    pub(super) fn cancel_reservation(
+        &self,
+        scope: &ScopeCell,
+        slot: &SlotCell,
+        txn: &mut ObservationTxn<'_>,
+    ) {
+        cancel_dynamic_reservation_impl(scope, self, slot, txn);
+    }
+
+    pub(super) fn signal_fused_cancel(
+        &self,
+        scope: &Arc<ScopeCell>,
+        slot: &SlotCell,
+        latch: &Latch,
+        txn: &mut ObservationTxn<'_>,
+    ) {
+        signal_fused_cancel_impl(self, scope, slot, latch, txn);
+    }
+
+    pub(super) fn remove(
+        &self,
+        scope: &Arc<ScopeCell>,
+        id: &ChildId,
+        exact: Option<Membership>,
+        txn: &mut ObservationTxn<'_>,
+    ) -> RemovalResponse {
+        remove_dynamic_impl(self, scope, id, exact, txn)
     }
 
     fn close_admission_in(&self, _txn: &mut ObservationTxn<'_>) {
@@ -277,7 +329,7 @@ fn take_terminal_reservation(
 pub(crate) struct DynamicReservation {
     pub(crate) scope: Arc<ScopeCell>,
     pub(crate) slot: Arc<SlotCell>,
-    pub(crate) control: Arc<ErasedDynamicRoute>,
+    pub(crate) control: Arc<DynamicControl>,
 }
 
 pub(crate) fn reserve_dynamic(
@@ -301,11 +353,9 @@ pub(super) fn reserve_dynamic_in(
     if matches!(scope.member.record().stage, MemberStage::Terminal(_)) {
         return Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal));
     }
-    let control = scope
-        .dynamic_route_in(txn)
-        .ok_or(ReserveError::NotAdmitting(
-            NotAdmittingCause::NoLiveIncarnation,
-        ))?;
+    let control = DynamicControl::in_scope(scope, txn).ok_or(ReserveError::NotAdmitting(
+        NotAdmittingCause::NoLiveIncarnation,
+    ))?;
     match scope.record().state {
         ScopeState::Starting | ScopeState::Running => {}
         ScopeState::Draining => {
@@ -320,7 +370,7 @@ pub(super) fn reserve_dynamic_in(
             ));
         }
     }
-    let slot = concrete_dynamic_slot(control.reserve(scope, id, child_scope, txn)?);
+    let slot = control.reserve(scope, id, child_scope, txn)?;
     Ok(DynamicReservation {
         scope: Arc::clone(scope),
         slot,
@@ -352,11 +402,11 @@ fn reserve_dynamic_slot(
 }
 
 pub(crate) fn start_admission(
-    control: Arc<ErasedDynamicRoute>,
+    control: Arc<DynamicControl>,
     slot: Arc<SlotCell>,
     fused_cancel: Option<Latch>,
 ) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError> {
-    control.start_admission(erase_dynamic_slot(slot), fused_cancel)
+    control.start_admission(slot, fused_cancel)
 }
 
 fn start_dynamic_admission(
@@ -406,7 +456,7 @@ pub(super) fn cancel_dynamic_reservation_parts(
 
 pub(crate) fn cancel_dynamic_reservation(
     scope: &Arc<ScopeCell>,
-    control: &ErasedDynamicRoute,
+    control: &DynamicControl,
     slot: &Arc<SlotCell>,
 ) {
     scope.with_observation_gate(|txn| control.cancel_reservation(scope, slot.as_ref(), txn));
@@ -426,7 +476,7 @@ fn cancel_dynamic_reservation_impl(
 
 pub(crate) fn signal_fused_cancel(
     scope: &Arc<ScopeCell>,
-    control: &ErasedDynamicRoute,
+    control: &DynamicControl,
     slot: &Arc<SlotCell>,
     latch: &Latch,
 ) {
@@ -477,7 +527,7 @@ pub(crate) fn remove_dynamic(
         ) {
             return completed_removal(RemoveOutcome::AlreadyAbsent);
         }
-        let Some(control) = scope.dynamic_route_in(txn) else {
+        let Some(control) = DynamicControl::in_scope(scope, txn) else {
             return completed_removal(RemoveOutcome::AlreadyAbsent);
         };
         control.remove(scope, id, exact, txn)
@@ -522,57 +572,8 @@ fn remove_dynamic_impl(
 }
 
 impl DynamicRoute for DynamicControl {
-    type Slot = ErasedDynamicSlot;
-
-    fn reserve(
-        &self,
-        scope: &Arc<ScopeCell>,
-        id: ChildId,
-        child_scope: Option<ScopeFlavor>,
-        txn: &mut ObservationTxn<'_>,
-    ) -> Result<Arc<Self::Slot>, ReserveError> {
-        reserve_dynamic_slot(self, scope, id, child_scope, txn).map(erase_dynamic_slot)
-    }
-
     fn close_admission(&self, txn: &mut ObservationTxn<'_>) {
         self.close_admission_in(txn);
-    }
-
-    fn start_admission(
-        self: Arc<Self>,
-        slot: Arc<Self::Slot>,
-        fused_cancel: Option<Latch>,
-    ) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError> {
-        start_dynamic_admission(self, concrete_dynamic_slot(slot), fused_cancel)
-    }
-
-    fn cancel_reservation(
-        &self,
-        scope: &Arc<ScopeCell>,
-        slot: &Self::Slot,
-        txn: &mut ObservationTxn<'_>,
-    ) {
-        cancel_dynamic_reservation_impl(scope, self, concrete_dynamic_slot_ref(slot), txn);
-    }
-
-    fn signal_fused_cancel(
-        &self,
-        scope: &Arc<ScopeCell>,
-        slot: &Self::Slot,
-        latch: &Latch,
-        txn: &mut ObservationTxn<'_>,
-    ) {
-        signal_fused_cancel_impl(self, scope, concrete_dynamic_slot_ref(slot), latch, txn);
-    }
-
-    fn remove(
-        &self,
-        scope: &Arc<ScopeCell>,
-        id: &ChildId,
-        exact: Option<Membership>,
-        txn: &mut ObservationTxn<'_>,
-    ) -> RemovalResponse {
-        remove_dynamic_impl(self, scope, id, exact, txn)
     }
 }
 

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -234,9 +234,19 @@ impl DynamicControl {
     ///
     /// The lookup retains its transaction token: selecting the live
     /// incarnation's control and acting on it are one observation-gated edge.
+    ///
+    /// A foreign route reads as no live incarnation rather than a panic. The
+    /// caller always holds the tree's outermost gate, so unwinding here would
+    /// poison it for every later operation instead of failing this one; both
+    /// call sites already have a graceful answer for `None`.
     fn in_scope(scope: &ScopeCell, txn: &ObservationTxn<'_>) -> Option<Arc<DynamicControl>> {
         let route: Arc<dyn Any + Send + Sync> = scope.dynamic_route_in(txn)?;
-        Some(Arc::downcast(route).expect("the façade installs only its concrete dynamic control"))
+        let control = Arc::downcast(route).ok();
+        debug_assert!(
+            control.is_some(),
+            "the façade installs only its concrete dynamic control"
+        );
+        control
     }
 
     pub(super) fn reserve(

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -363,11 +363,10 @@ fn dynamic_removal_waits_for_the_observation_gate_before_mutating_state() {
     let response = worker.join().expect("removal transition completes");
     drop(response);
 
-    let route = root
-        .dynamic_route()
-        .expect("the fixture exposes its dynamic route");
     assert!(matches!(
-        root.with_observation_gate(|txn| route.reserve(&root, child_id.clone(), None, txn)),
+        root.with_observation_gate(|txn| {
+            control.reserve(&root, child_id.clone(), None, txn)
+        }),
         Err(crate::ReserveError::RemovalInProgress(id)) if id == child_id
     ));
 }

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::{
     ChildId, DefaultsInheritance, Exit, Intensity, Readiness, ScopeDefaults,
     admission::ReserveError,
-    cells::{ErasedDynamicSlot, MemberCell, ObservationTxn, ScopeCell},
+    cells::{MemberCell, ObservationTxn, ScopeCell},
     definition::DefinitionSource,
     identity::ScopeIdentity,
     policy::{
@@ -76,25 +76,6 @@ pub(crate) struct SlotCell {
     pub(crate) member: Arc<MemberCell>,
     pub(crate) scope: Option<Arc<ScopeCell>>,
     definition: Mutex<DefinitionState>,
-}
-
-/// Erases a plan-owned slot without replacing its canonical `Arc` allocation.
-///
-/// Dynamic-route calls cross the lower cell layer through this representation;
-/// only the paired recovery helpers below consume values from that boundary.
-pub(crate) fn erase_dynamic_slot(slot: Arc<SlotCell>) -> Arc<ErasedDynamicSlot> {
-    slot
-}
-
-/// Recovers the plan-owned slot returned by the crate's dynamic route.
-pub(crate) fn concrete_dynamic_slot(slot: Arc<ErasedDynamicSlot>) -> Arc<SlotCell> {
-    Arc::downcast(slot).expect("the dynamic route must return its plan-owned slot type")
-}
-
-/// Borrows the plan-owned slot passed back to the crate's dynamic route.
-pub(crate) fn concrete_dynamic_slot_ref(slot: &ErasedDynamicSlot) -> &SlotCell {
-    slot.downcast_ref()
-        .expect("the dynamic route must receive its plan-owned slot type")
 }
 
 impl SlotCell {
@@ -630,7 +611,6 @@ mod tests {
 
     use super::{
         BuilderCore, ChildConstruction, ChildPlan, LowerError, ScopeConstruction, SlotCell,
-        concrete_dynamic_slot, concrete_dynamic_slot_ref, erase_dynamic_slot,
     };
 
     fn configured_task() -> TaskDef {
@@ -741,21 +721,6 @@ mod tests {
             root.snapshot().children.is_empty(),
             "plan teardown withdraws every published residency before root closure"
         );
-    }
-
-    #[test]
-    fn dynamic_slot_erasure_preserves_the_canonical_allocation() {
-        let declaration = BuilderCore::new(ScopeFlavor::Dynamic);
-        let slot = SlotCell::new(Arc::clone(&declaration.root.member), None);
-
-        let erased = erase_dynamic_slot(Arc::clone(&slot));
-        assert!(std::ptr::eq(
-            concrete_dynamic_slot_ref(erased.as_ref()),
-            slot.as_ref(),
-        ));
-
-        let restored = concrete_dynamic_slot(erased);
-        assert!(Arc::ptr_eq(&restored, &slot));
     }
 
     #[test]


### PR DESCRIPTION
Continues the #284 simplification stack. Closes #276.

`DynamicRoute` is now only the cells-side `close_admission(&mut ObservationTxn)` hook. Reservation, admission, cancellation, fused-cancel, and removal operations are inherent `DynamicControl` methods; reservations retain the concrete control.

The restart-stable `ScopeCell` still owns an `Arc<dyn DynamicRoute>`, but the facade recovers `DynamicControl` once. Slot values remain concrete end-to-end. The associated slot type, erased route/slot aliases, five per-call downcast helpers, and erasure-only test are deleted.

Validation: dynamic driver tests 20/20 and workspace all-target/all-feature check pass on the rebased stack; the original focused integration, gate-handoff, shutdown, and full-CI lanes were also green. The optional mailbox watcher allocation change remains deliberately separate.