### PR TITLE
Make construction states structural

### DIFF
--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -325,19 +325,20 @@ pub struct Handler<A: Actor> {
 }
 
 enum HandlerState<A: Actor> {
-    // The inner Option is the one-run sentinel while initialization owns the
-    // arguments and after any path that returns without constructing an
-    // actor. Unlike the former parallel Options, the enum makes the handler's
-    // phase structural.
-    Uninit(Option<A::Args>),
+    Uninit(A::Args),
     Running(A),
+    // The one-run sentinel. Initialization moves the arguments out and leaves
+    // `Spent` behind, so every path that returns without constructing an
+    // actor is already observably spent and a second run has exactly one
+    // panic site to reach.
+    Spent,
 }
 
 impl<A: Actor> Handler<A> {
     /// Wraps owned args using the callback-actor default `AfterInit` readiness.
     pub fn new(args: A::Args) -> Self {
         Self {
-            state: HandlerState::Uninit(Some(args)),
+            state: HandlerState::Uninit(args),
         }
     }
 }
@@ -362,12 +363,10 @@ impl<A: Actor> RawActor for Handler<A> {
     /// returns, and it must not observe still-live incarnation resources;
     /// every error exit therefore freezes and joins them here first.
     async fn run(&mut self, raw: &mut RawContext<Self::Msg>) -> ExitResult {
-        let HandlerState::Uninit(args) = &mut self.state else {
+        let HandlerState::Uninit(args) = std::mem::replace(&mut self.state, HandlerState::Spent)
+        else {
             panic!("handler actor initialization invoked more than once");
         };
-        let args = args
-            .take()
-            .expect("handler actor initialization invoked more than once");
         let initialized = {
             let mut context = Context::<A>::new(raw, DeliveryStage::Live);
             A::init(args, &mut context).await

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -315,17 +315,29 @@ impl<'a, A: Actor> StopContext<'a, A> {
 /// actors. It also encapsulates the callback loop's error-path resource
 /// teardown, so decorators need no framework-internal teardown operations.
 /// Its declared readiness is read before [`RawActor::run`] is polled.
+///
+/// Like every [`RawActor`], one `Handler` value owns exactly one call to
+/// [`RawActor::run`]. The call consumes its `Uninit` state even when
+/// initialization returns an error or its future is cancelled; a second call
+/// is a contract violation and panics.
 pub struct Handler<A: Actor> {
-    args: Option<A::Args>,
-    actor: Option<A>,
+    state: HandlerState<A>,
+}
+
+enum HandlerState<A: Actor> {
+    // The inner Option is the one-run sentinel while initialization owns the
+    // arguments and after any path that returns without constructing an
+    // actor. Unlike the former parallel Options, the enum makes the handler's
+    // phase structural.
+    Uninit(Option<A::Args>),
+    Running(A),
 }
 
 impl<A: Actor> Handler<A> {
     /// Wraps owned args using the callback-actor default `AfterInit` readiness.
     pub fn new(args: A::Args) -> Self {
         Self {
-            args: Some(args),
-            actor: None,
+            state: HandlerState::Uninit(Some(args)),
         }
     }
 }
@@ -350,17 +362,22 @@ impl<A: Actor> RawActor for Handler<A> {
     /// returns, and it must not observe still-live incarnation resources;
     /// every error exit therefore freezes and joins them here first.
     async fn run(&mut self, raw: &mut RawContext<Self::Msg>) -> ExitResult {
-        let args = self
-            .args
+        let HandlerState::Uninit(args) = &mut self.state else {
+            panic!("handler actor initialization invoked more than once");
+        };
+        let args = args
             .take()
             .expect("handler actor initialization invoked more than once");
         let initialized = {
             let mut context = Context::<A>::new(raw, DeliveryStage::Live);
             A::init(args, &mut context).await
         };
-        let actor = match initialized {
-            Ok(actor) => self.actor.insert(actor),
+        match initialized {
+            Ok(actor) => self.state = HandlerState::Running(actor),
             Err(error) => return fail_after_teardown(raw, error).await,
+        }
+        let HandlerState::Running(actor) = &mut self.state else {
+            unreachable!("successful initialization installs the running actor")
         };
         if raw.readiness() == Readiness::AfterInit {
             raw.mark_ready();

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -439,20 +439,36 @@ fn dispatch_child_construction(
                 construction_spent,
             }
         }
-        ChildConstruction::Task(definition) => SpawnDispatch {
-            body: PendingSpawnBody::restartable(SpawnBody::TaskRestartable {
-                factory: Arc::clone(&definition.factory),
-                context: TaskContext::new(id, incarnation, latches.task_context()),
-            }),
-            construction_spent: false,
-        },
-        ChildConstruction::TaskOnce(definition) => SpawnDispatch {
-            body: PendingSpawnBody::one_shot(SpawnBody::TaskOnce {
-                body: definition.take_body(),
-                context: TaskContext::new(id, incarnation, latches.task_context()),
-            }),
-            construction_spent: true,
-        },
+        ChildConstruction::Task(definition) => {
+            let context = TaskContext::new(id, incarnation, latches.task_context());
+            let (body, construction_spent) = if let Some(factory) = definition.restartable() {
+                (
+                    SpawnBody::TaskRestartable {
+                        factory: Arc::clone(factory),
+                        context,
+                    },
+                    false,
+                )
+            } else {
+                (
+                    SpawnBody::TaskOnce {
+                        body: definition
+                            .take_one_shot()
+                            .expect("one-shot task construction invoked more than once"),
+                        context,
+                    },
+                    true,
+                )
+            };
+            SpawnDispatch {
+                body: if construction_spent {
+                    PendingSpawnBody::one_shot(body)
+                } else {
+                    PendingSpawnBody::restartable(body)
+                },
+                construction_spent,
+            }
+        }
         ChildConstruction::Scope(definition) => {
             let inherited = match definition.defaults {
                 DefaultsInheritance::Inherit => defaults.clone(),

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -516,6 +516,30 @@ fn dispatch_child_construction(
     }
 }
 
+/// Test-only entry point to the construction dispatch, which the driver
+/// otherwise reaches only through `spawn_child`. `spawn_child` releases a
+/// spent construction before it can be dispatched again, so this is the one
+/// way to exercise the one-shot invariant panics directly.
+#[cfg(test)]
+pub(super) fn dispatch_child_construction_for_test(
+    child: &mut ChildRuntime,
+    root: &Arc<ScopeCell>,
+    defaults: &ResolvedDefaults,
+    incarnation: Incarnation,
+) {
+    let latches = SpawnLatches::new(matches!(
+        child.construction.get_mut(),
+        ChildConstruction::Scope(_)
+    ));
+    drop(dispatch_child_construction(
+        child,
+        root,
+        defaults,
+        incarnation,
+        &latches,
+    ));
+}
+
 fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
     let ChildTaskLaunch {
         events,

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -391,7 +391,9 @@ async fn conversion_unwind_evicts_never_started_child_identities() {
         let slot = rebuild
             .reserve(id, None)
             .expect("re-added id is reservable");
-        slot.define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
+        slot.define(ChildConstruction::Task(
+            TaskDef::new(|_| future::pending()).erase(),
+        ));
     }
     let replacement = rebuild
         .lower(ResolvedDefaults::default(), Some(Arc::clone(&root)))

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -495,3 +495,42 @@ async fn initial_added_wake_observes_the_keyed_dynamic_route() {
         crate::runtime::JoinOutcome::Cancelled
     ));
 }
+
+// `spawn_child` releases a spent one-shot construction before it could be
+// dispatched a second time, so the invariant panic is only reachable through
+// the dispatch helper directly.
+#[crate::runtime::test]
+#[should_panic(expected = "one-shot task construction invoked more than once")]
+async fn dispatching_a_spent_one_shot_task_construction_panics() {
+    let mut tree = Tree::new();
+    let (_task, _claim) = tree
+        .add_task_once(
+            "worker",
+            TaskOnceDef::new(|_| async { Ok::<_, ExitError>(()) }),
+        )
+        .expect("valid one-shot task");
+    let mut plan = tree.lower_for_test();
+    let root = Arc::clone(&plan.root);
+    let _epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.set_admitted_children(
+        plan.children
+            .iter()
+            .map(|child| resident_projection(&child.slot))
+            .collect(),
+    );
+    let defaults = plan.defaults.clone();
+    let mut child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);
+    plan.finish_transfer();
+    let incarnation = child
+        .incarnations
+        .mint()
+        .expect("the first incarnation mints");
+
+    dispatch_child_construction_for_test(&mut child, &root, &defaults, incarnation);
+    // The child never started, so discharge terminality before the panic
+    // rather than leaving the obligation to run its fallback under the unwind.
+    child.complete_terminality();
+    dispatch_child_construction_for_test(&mut child, &root, &defaults, incarnation);
+}

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -91,14 +91,16 @@ async fn latched_removal_suppresses_a_queued_start_effect() {
         &mut scope,
         &control,
         "worker",
-        ChildConstruction::Task(TaskDef::new({
-            let starts = Arc::clone(&starts);
-            move |_| {
-                starts.fetch_add(1, Ordering::SeqCst);
-                future::pending()
-            }
-        })
-        .erase()),
+        ChildConstruction::Task(
+            TaskDef::new({
+                let starts = Arc::clone(&starts);
+                move |_| {
+                    starts.fetch_add(1, Ordering::SeqCst);
+                    future::pending()
+                }
+            })
+            .erase(),
+        ),
         |_| {},
         DynamicFixtureState::Resident,
     );
@@ -640,11 +642,9 @@ async fn a_dropped_admission_request_publishes_the_fail_closed_response() {
     let root = Arc::clone(&scope.root);
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
-    reservation
-        .slot
-        .define(ChildConstruction::Task(
-            TaskDef::new(|_| future::pending()).erase(),
-        ));
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new(|_| future::pending()).erase(),
+    ));
     let (mut response, request) =
         begin_admission(&reservation, &mut dynamic_event_receiver, None).await;
 

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -97,7 +97,8 @@ async fn latched_removal_suppresses_a_queued_start_effect() {
                 starts.fetch_add(1, Ordering::SeqCst);
                 future::pending()
             }
-        })),
+        })
+        .erase()),
         |_| {},
         DynamicFixtureState::Resident,
     );
@@ -360,7 +361,7 @@ async fn final_removal_holds_the_id_until_removed_publication_commits() {
         &mut scope,
         &control,
         "worker",
-        ChildConstruction::Task(TaskDef::new(|_| future::pending())),
+        ChildConstruction::Task(TaskDef::new(|_| future::pending()).erase()),
         |_| {},
         DynamicFixtureState::Resident,
     );
@@ -427,7 +428,7 @@ async fn removal_tolerates_synchronous_reclaim_from_the_stop_funnel() {
         &mut scope,
         &control,
         "worker",
-        ChildConstruction::Task(TaskDef::new(|_| future::pending())),
+        ChildConstruction::Task(TaskDef::new(|_| future::pending()).erase()),
         |child| {
             // Model the latent restart-gap shape: there is no active
             // incarnation and no retained construction, so a hard-force stop
@@ -577,9 +578,9 @@ async fn admission_conversion_panic_does_not_poison_dynamic_cleanup() {
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
     let member = Arc::clone(&reservation.slot.member);
-    reservation
-        .slot
-        .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new(|_| future::pending()).erase(),
+    ));
     let (response, request) = begin_admission(&reservation, &mut event_receiver, None).await;
 
     assert!(
@@ -641,7 +642,9 @@ async fn a_dropped_admission_request_publishes_the_fail_closed_response() {
         .expect("running dynamic scope reserves the child");
     reservation
         .slot
-        .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
+        .define(ChildConstruction::Task(
+            TaskDef::new(|_| future::pending()).erase(),
+        ));
     let (mut response, request) =
         begin_admission(&reservation, &mut dynamic_event_receiver, None).await;
 
@@ -670,9 +673,9 @@ async fn annulment_before_admission_owns_never_started_terminality() {
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
     let member = Arc::clone(&reservation.slot.member);
-    reservation
-        .slot
-        .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new(|_| future::pending()).erase(),
+    ));
     let (response, request) =
         begin_admission(&reservation, &mut dynamic_event_receiver, None).await;
 
@@ -734,9 +737,8 @@ async fn annulment_after_promotion_is_inert_and_supervision_owns_the_exit() {
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
     let member = Arc::clone(&reservation.slot.member);
-    reservation
-        .slot
-        .define(ChildConstruction::Task(TaskDef::new({
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new({
             let started = started.clone();
             move |context| {
                 let started = started.clone();
@@ -746,7 +748,9 @@ async fn annulment_after_promotion_is_inert_and_supervision_owns_the_exit() {
                     Ok(())
                 }
             }
-        })));
+        })
+        .erase(),
+    ));
     let (mut response, request) =
         begin_admission(&reservation, &mut dynamic_event_receiver, None).await;
     scope.handle_admission(request);
@@ -838,9 +842,9 @@ async fn annulment_racing_admission_resolves_to_one_terminalization_owner() {
         let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
             .expect("running dynamic scope reserves the child");
         let member = Arc::clone(&reservation.slot.member);
-        reservation
-            .slot
-            .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
+        reservation.slot.define(ChildConstruction::Task(
+            TaskDef::new(|_| future::pending()).erase(),
+        ));
         let (response, request) =
             begin_admission(&reservation, &mut dynamic_event_receiver, None).await;
 
@@ -940,9 +944,9 @@ async fn fused_cancellation_overtaking_admission_rejects_before_conversion() {
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
     let member = Arc::clone(&reservation.slot.member);
-    reservation
-        .slot
-        .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new(|_| future::pending()).erase(),
+    ));
     let fused_cancel = Latch::default();
     let (response, request) = begin_admission(
         &reservation,
@@ -1007,9 +1011,9 @@ async fn fused_cancellation_during_conversion_is_rejected_by_the_under_lock_rech
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
     let member = Arc::clone(&reservation.slot.member);
-    reservation
-        .slot
-        .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new(|_| future::pending()).erase(),
+    ));
     let fused_cancel = Latch::default();
     let (response, request) = begin_admission(
         &reservation,
@@ -1101,9 +1105,8 @@ async fn exercise_coalesced_removal(source: RemovalSource) {
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
     let member = Arc::clone(&reservation.slot.member);
-    reservation
-        .slot
-        .define(ChildConstruction::Task(TaskDef::new({
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new({
             let started = started.clone();
             move |context| {
                 let started = started.clone();
@@ -1113,7 +1116,9 @@ async fn exercise_coalesced_removal(source: RemovalSource) {
                     Ok(())
                 }
             }
-        })));
+        })
+        .erase(),
+    ));
     let fused_cancel = Latch::default();
     let (mut admission_response, request) = begin_admission(
         &reservation,
@@ -1294,9 +1299,8 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
     let member = Arc::clone(&reservation.slot.member);
-    reservation
-        .slot
-        .define(ChildConstruction::Task(TaskDef::new({
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new({
             let release_failure = release_failure.clone();
             let starts = Arc::clone(&starts);
             move |_| {
@@ -1311,7 +1315,9 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
                     }
                 }
             }
-        })));
+        })
+        .erase(),
+    ));
     let mut admission = Box::pin(make_admission(reservation));
     assert!(
         admission

--- a/crates/shelterwood/src/driver/tests/events.rs
+++ b/crates/shelterwood/src/driver/tests/events.rs
@@ -180,9 +180,8 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
     let starts = Arc::new(AtomicUsize::new(0));
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
-    reservation
-        .slot
-        .define(ChildConstruction::Task(TaskDef::new({
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new({
             let starts = Arc::clone(&starts);
             move |_| {
                 let invocation = starts.fetch_add(1, Ordering::SeqCst) + 1;
@@ -194,7 +193,9 @@ async fn restart_deadline_gate_suppresses_a_fused_cancel_landing_after_schedulin
                     }
                 }
             }
-        })));
+        })
+        .erase(),
+    ));
     let fused_cancel = Latch::default();
     let (mut response, request) = begin_admission(
         &reservation,

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -38,9 +38,9 @@ async fn reserve_error_identity_exhausted_maps_the_child_key_domain() {
     let (mut scope, _events, mut dynamic_events, _control) = running_dynamic_fixture();
     let reservation = reserve_dynamic(&scope.root, ChildId::from("worker"), None)
         .expect("the membership domain still has capacity");
-    reservation
-        .slot
-        .define(ChildConstruction::Task(TaskDef::new(|_| future::pending())));
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new(|_| future::pending()).erase(),
+    ));
     let (response, request) = begin_admission(&reservation, &mut dynamic_events, None).await;
     scope.supervisor.exhaust_child_keys_for_test();
     scope.handle_admission(request);

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -18,7 +18,7 @@ pub(super) use crate::{
     Mailbox, MembershipStatus, RawOnceDef, Readiness, ReadinessDeadline, RemoveOutcome,
     ReserveError, RestartCondition, RestartCount, RestartPolicy, Retention, ScopeRef, ScopeState,
     SendErrorKind, StartupError, StartupFailure, StartupFailureCause, StopReason, SubtreeDef,
-    SubtreeOnceDef, TaskDef, Tree,
+    SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
     cells::LIFECYCLE_EVENT_CAPACITY,
     engine::{ChildKey, Epoch, Event as SupervisorEvent, ScopeLifecycle, StopLadder, arbitrate},
     exit::RecordedOutcome,
@@ -132,9 +132,10 @@ pub(super) use super::super::{
     MemberStage, MemberTransition, NestedScopeLatches, Pending, RemovalRequest, RemovalResponses,
     ResidentProjection, RuntimeStorage, ScopeCell, ScopeControlEvent, ScopeEpochGuard, ScopeFlavor,
     ScopeRole, ScopeRuntime, ScopeRuntimeTestWiring, StartupDisposition,
-    cancel_dynamic_reservation, discharge_child_terminality, events::collect_driver_events,
-    monitor_root_driver, report_slot, reserve_dynamic, resident_projection, restart_shutdown_work,
-    run_nested_factory, run_nested_tree, run_scope, run_scope_incarnation, storage::Obligation,
+    cancel_dynamic_reservation, child::dispatch_child_construction_for_test,
+    discharge_child_terminality, events::collect_driver_events, monitor_root_driver, report_slot,
+    reserve_dynamic, resident_projection, restart_shutdown_work, run_nested_factory,
+    run_nested_tree, run_scope, run_scope_incarnation, storage::Obligation,
 };
 
 pub(super) async fn begin_admission(

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     raw::RawConstruction,
     runtime::{self, Isolated, Latch},
-    task::{OnceTask, TaskDef},
+    task::TaskConstruction,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -28,8 +28,7 @@ struct ScopeConfig {
 
 pub(crate) enum ChildConstruction {
     Raw(RawConstruction),
-    Task(TaskDef),
-    TaskOnce(OnceTask),
+    Task(TaskConstruction),
     Scope(Box<ScopeConstruction>),
 }
 
@@ -258,13 +257,8 @@ impl SlotCell {
                 definition.readiness(),
             ),
             ChildConstruction::Task(definition) => (
-                &definition.options,
-                ChildMode::Restartable,
-                Readiness::Immediate,
-            ),
-            ChildConstruction::TaskOnce(definition) => (
-                &definition.options,
-                ChildMode::OneShot,
+                definition.options(),
+                definition.mode(),
                 Readiness::Immediate,
             ),
             ChildConstruction::Scope(definition) => {
@@ -607,14 +601,14 @@ mod tests {
         policy::{CommonOptions, ResolvedDefaults, ScopeFlavor},
         raw::RawConstruction,
         runtime::{self, Timeout},
-        task::TaskDef,
+        task::{TaskConstruction, TaskDef},
     };
 
     use super::{
         BuilderCore, ChildConstruction, ChildPlan, LowerError, ScopeConstruction, SlotCell,
     };
 
-    fn configured_task() -> TaskDef {
+    fn configured_task() -> TaskConstruction {
         TaskDef::new(|_| async { Ok(()) })
             .restart(RestartPolicy::new(
                 RestartCondition::Always,
@@ -624,6 +618,7 @@ mod tests {
             .readiness(Readiness::Manual)
             .expect("manual task readiness is valid")
             .retention(Retention::Remove)
+            .erase()
     }
 
     struct PanicWake(&'static str);
@@ -790,12 +785,14 @@ mod tests {
         // definition carries the mode already resolved from its actor type's
         // metadata at erasure.
         assert_eq!(
-            resolved_readiness(ChildConstruction::Task(TaskDef::new(|_| async { Ok(()) }))),
+            resolved_readiness(ChildConstruction::Task(
+                TaskDef::new(|_| async { Ok(()) }).erase()
+            )),
             Readiness::Immediate
         );
         let (completion, _claim) = runtime::oneshot();
         assert_eq!(
-            resolved_readiness(ChildConstruction::TaskOnce(
+            resolved_readiness(ChildConstruction::Task(
                 TaskOnceDef::new(|_| async { Ok::<_, ExitError>(()) }).erase(completion)
             )),
             Readiness::Immediate
@@ -817,12 +814,13 @@ mod tests {
                 TaskDef::new(|_| async { Ok(()) })
                     .readiness(Readiness::Manual)
                     .expect("manual task readiness is valid")
+                    .erase()
             )),
             Readiness::Manual
         );
         let (completion, _claim) = runtime::oneshot();
         assert_eq!(
-            resolved_readiness(ChildConstruction::TaskOnce(
+            resolved_readiness(ChildConstruction::Task(
                 TaskOnceDef::new(|_| async { Ok::<_, ExitError>(()) })
                     .readiness(Readiness::Manual)
                     .expect("manual task readiness is valid")
@@ -966,7 +964,7 @@ mod tests {
         let slot = declaration
             .reserve("one-shot", None)
             .expect("reservation succeeds");
-        slot.define(ChildConstruction::TaskOnce(construction));
+        slot.define(ChildConstruction::Task(construction));
         let defaults = ResolvedDefaults::default();
         let options = slot
             .resolve_policy(&defaults)

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -3002,6 +3002,45 @@ mod tests {
             Some("contained raw payload destructor panic")
         );
     }
+
+    /// A callback actor whose initialization always fails, so `Handler::run`
+    /// takes the error path that returns without installing an actor.
+    struct RefusingInit;
+
+    impl crate::Actor for RefusingInit {
+        type Msg = u8;
+        type Args = ();
+
+        async fn init(
+            _args: Self::Args,
+            _context: &mut crate::Context<'_, Self>,
+        ) -> Result<Self, crate::ExitError> {
+            Err(crate::ExitError::message("initialization refused"))
+        }
+
+        async fn handle(
+            &mut self,
+            _message: Self::Msg,
+            _context: &mut crate::Context<'_, Self>,
+        ) -> crate::ExitResult {
+            Ok(())
+        }
+    }
+
+    // The handler lives in `crate::actor`, but its one-run contract is only
+    // observable against a live raw incarnation, which this module's fixture
+    // owns. A failed initialization spends the handler exactly as a
+    // successful one does.
+    #[crate::runtime::test]
+    #[should_panic(expected = "handler actor initialization invoked more than once")]
+    async fn handler_initialization_runs_at_most_once() {
+        let (mut context, _myself) = bound_raw_context();
+        let mut handler = crate::actor::Handler::<RefusingInit>::new(());
+        crate::RawActor::run(&mut handler, &mut context)
+            .await
+            .expect_err("initialization failure exits the incarnation");
+        let _ = crate::RawActor::run(&mut handler, &mut context).await;
+    }
 }
 
 #[cfg(test)]

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -13,7 +13,8 @@ use crate::{
     ReadinessDeadline, RestartPolicy, Retention, Shutdown,
     cancellation::{CancellationToken, ParentCancellationToken},
     cells::MemberCell,
-    policy::CommonOptions,
+    definition::DefinitionSource,
+    policy::{ChildMode, CommonOptions},
     runtime::{self, CompletionGatedLatch, Latch},
 };
 
@@ -122,6 +123,13 @@ impl TaskDef {
         task_readiness_deadline,
         retention,
     );
+
+    pub(crate) fn erase(self) -> TaskConstruction {
+        TaskConstruction {
+            source: DefinitionSource::Restartable(self.factory),
+            options: self.options,
+        }
+    }
 }
 
 type OnceTaskFuture<T> = Pin<Box<dyn Future<Output = Result<T, ExitError>> + Send + 'static>>;
@@ -159,10 +167,10 @@ impl<T: Send + 'static> TaskOnceDef<T> {
 
     common_options_setters!(shutdown, task_readiness, task_readiness_deadline, retention,);
 
-    pub(crate) fn erase(self, completion: runtime::OneShotSender<T>) -> OnceTask {
+    pub(crate) fn erase(self, completion: runtime::OneShotSender<T>) -> TaskConstruction {
         let body = self.body;
-        OnceTask {
-            body: Some(Box::new(move |context| {
+        TaskConstruction {
+            source: DefinitionSource::OneShot(Box::new(move |context| {
                 Box::pin(async move {
                     match body(context).await {
                         Ok(value) => {
@@ -185,18 +193,32 @@ impl<T: Send + 'static> TaskOnceDef<T> {
     }
 }
 
-pub(crate) struct OnceTask {
-    body: Option<OnceTaskFactory>,
-    pub(crate) options: CommonOptions,
-}
-
 type OnceTaskFactory = Box<dyn FnOnce(TaskContext) -> TaskFuture + Send + 'static>;
 
-impl OnceTask {
-    pub(crate) fn take_body(&mut self) -> OnceTaskFactory {
-        self.body
-            .take()
-            .expect("one-shot task construction invoked more than once")
+pub(crate) struct TaskConstruction {
+    source: DefinitionSource<TaskFactory, OnceTaskFactory>,
+    options: CommonOptions,
+}
+
+impl TaskConstruction {
+    pub(crate) fn options(&self) -> &CommonOptions {
+        &self.options
+    }
+
+    pub(crate) fn mode(&self) -> ChildMode {
+        if self.source.is_one_shot() {
+            ChildMode::OneShot
+        } else {
+            ChildMode::Restartable
+        }
+    }
+
+    pub(crate) fn restartable(&self) -> Option<&TaskFactory> {
+        self.source.restartable()
+    }
+
+    pub(crate) fn take_one_shot(&mut self) -> Option<OnceTaskFactory> {
+        self.source.take_one_shot()
     }
 }
 
@@ -408,7 +430,7 @@ mod tests {
         })
         .erase(completion);
 
-        let body = task.take_body();
+        let body = task.take_one_shot();
         assert_eq!(drops.load(Ordering::SeqCst), 0);
         drop(task);
         assert_eq!(drops.load(Ordering::SeqCst), 0);
@@ -417,13 +439,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "one-shot task construction invoked more than once")]
-    fn taking_one_shot_body_twice_preserves_the_invariant_panic() {
+    fn taking_one_shot_body_spends_the_definition_source() {
         let (completion, _claim) = runtime::oneshot::<()>();
         let mut task = TaskOnceDef::new(|_| async { Ok::<_, ExitError>(()) }).erase(completion);
 
-        drop(task.take_body());
-        drop(task.take_body());
+        assert!(task.take_one_shot().is_some());
+        assert!(task.take_one_shot().is_none());
     }
 
     fn one_shot_claim<T: Send + 'static>() -> (

--- a/crates/shelterwood/src/tree/slots.rs
+++ b/crates/shelterwood/src/tree/slots.rs
@@ -141,7 +141,7 @@ impl<E: SlotEndpoint> TaskSlotCore<E> {
     pub(super) fn define(self, definition: TaskDef) -> E::Output<TaskRef> {
         let task = self.task_ref();
         self.endpoint
-            .define(task, ChildConstruction::Task(definition))
+            .define(task, ChildConstruction::Task(definition.erase()))
     }
 
     pub(super) fn define_once<T: Send + 'static>(
@@ -153,7 +153,7 @@ impl<E: SlotEndpoint> TaskSlotCore<E> {
         let claim = OneShotTaskRef::new(receiver, task.clone());
         self.endpoint.define(
             (task, claim),
-            ChildConstruction::TaskOnce(definition.erase(completion)),
+            ChildConstruction::Task(definition.erase(completion)),
         )
     }
 }


### PR DESCRIPTION
Part of #278 in the #284 simplification stack.

- Merges `ChildConstruction::Task` and `TaskOnce` into one task construction backed by `DefinitionSource`.
- Deletes `OnceTask` and its mirrored optional body; one-shot extraction transitions structurally to `Spent`.
- Replaces parallel handler argument/actor options with `HandlerState::Uninit | Running` and documents the one-run contract.

The inner `Option<Args>` remains only as the consumed sentinel needed while async initialization owns the arguments; the invalid independent args-vs-actor combinations are gone. The optional `SpawnBody` reshaping was deliberately skipped.

Validation: actor/tasks/ownership, driver, shutdown, plan, and full-CI suites passed; the combined structural stack passes `./tools/dev just ci` with 676/676 tests.

Stack: based on the mailbox-encoding PR. The ReadyBatch phase PR completes #278 separately atop its required #268 panic-coherence base.