### PR TITLE
Make core state encodings structural

### DIFF
--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -27,7 +27,10 @@ use shelterwood_core::{
         ExitKind, StartupError, StartupFailure, StartupFailureCause, StopReason,
         stop_reason_precedence,
     },
-    identity::{AtomicPoisonedCounter, IncarnationCounter, MintedMembership, ScopeIdentity},
+    identity::{
+        AtomicPoisonedCounter, IncarnationCounter, MembershipReconciliation, MintedMembership,
+        ScopeIdentity,
+    },
     policy::{ResolvedCommonOptions, ScopeFlavor},
 };
 use shelterwood_mailbox::{ActorIdentity, MailboxControl, MailboxTermination};
@@ -1179,7 +1182,7 @@ impl ScopeCell {
         &self,
         id: &ChildId,
         provisional: Membership,
-    ) -> Option<Option<MintedMembership>> {
+    ) -> MembershipReconciliation {
         self.child_identity
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)

--- a/crates/shelterwood-core/src/identity.rs
+++ b/crates/shelterwood-core/src/identity.rs
@@ -306,6 +306,17 @@ pub struct MintedMembership {
     incarnation_counter: IncarnationCounter,
 }
 
+/// Result of reconciling a provisional membership with a stable scope.
+#[derive(Debug)]
+pub enum MembershipReconciliation {
+    /// The stable scope adopted the provisional lineage unchanged.
+    Adopted,
+    /// The stable scope already tracked the id and minted its successor.
+    Minted(MintedMembership),
+    /// The stable scope's membership generation was exhausted.
+    Exhausted,
+}
+
 impl MintedMembership {
     fn new(membership: Membership) -> Self {
         Self {
@@ -412,16 +423,18 @@ impl ScopeIdentity {
         &mut self,
         id: &ChildId,
         provisional: Membership,
-    ) -> Option<Option<MintedMembership>> {
+    ) -> MembershipReconciliation {
         match self.memberships.entry(id.clone()) {
             Entry::Occupied(mut entry) => {
-                let membership = entry.get_mut().mint().map(Membership)?;
-                Some(Some(MintedMembership::new(membership)))
+                let Some(membership) = entry.get_mut().mint().map(Membership) else {
+                    return MembershipReconciliation::Exhausted;
+                };
+                MembershipReconciliation::Minted(MintedMembership::new(membership))
             }
             Entry::Vacant(entry) => {
                 debug_assert_ne!(provisional.0.generation, Generation::POISON);
                 entry.insert(FenceCounter::from_fence(provisional.0));
-                Some(None)
+                MembershipReconciliation::Adopted
             }
         }
     }
@@ -449,7 +462,8 @@ mod tests {
     use crate::ChildId;
 
     use super::{
-        AtomicPoisonedCounter, Generation, IncarnationCounter, PoisonedCounter, ScopeIdentity,
+        AtomicPoisonedCounter, Generation, IncarnationCounter, MembershipReconciliation,
+        PoisonedCounter, ScopeIdentity,
     };
 
     #[test]
@@ -563,7 +577,7 @@ mod tests {
         let mut stable = ScopeIdentity::new();
         assert!(matches!(
             stable.adopt_or_mint_membership(&id, provisional),
-            Some(None)
+            MembershipReconciliation::Adopted
         ));
         let direct = stable
             .mint_membership(&id)
@@ -575,11 +589,12 @@ mod tests {
             .mint_membership(&id)
             .expect("rebuilt provisional membership available")
             .membership();
-        let reconciled = stable
-            .adopt_or_mint_membership(&id, rebuilt)
-            .expect("stable identity is not exhausted")
-            .expect("an occupied stable identity mints a successor")
-            .membership();
+        let MembershipReconciliation::Minted(reconciled) =
+            stable.adopt_or_mint_membership(&id, rebuilt)
+        else {
+            panic!("an occupied stable identity mints a successor")
+        };
+        let reconciled = reconciled.membership();
 
         assert!(direct.supersedes(provisional));
         assert!(reconciled.supersedes(direct));
@@ -610,17 +625,18 @@ mod tests {
         let mut stable = ScopeIdentity::new();
         assert!(matches!(
             stable.adopt_or_mint_membership(&id, first),
-            Some(None)
+            MembershipReconciliation::Adopted
         ));
         assert!(matches!(
             stable.adopt_or_mint_membership(&other_id, other),
-            Some(None)
+            MembershipReconciliation::Adopted
         ));
-        let successor = stable
-            .adopt_or_mint_membership(&id, rebuilt)
-            .expect("stable identity is not exhausted")
-            .expect("stable identity mints a rebuilt successor")
-            .membership();
+        let MembershipReconciliation::Minted(successor) =
+            stable.adopt_or_mint_membership(&id, rebuilt)
+        else {
+            panic!("stable identity mints a rebuilt successor")
+        };
+        let successor = successor.membership();
 
         assert!(successor.supersedes(first));
         assert!(!first.supersedes(successor));
@@ -692,8 +708,14 @@ mod tests {
             .expect("provisional membership available")
             .membership();
 
-        assert!(stable.adopt_or_mint_membership(&id, provisional).is_none());
-        assert!(stable.adopt_or_mint_membership(&id, provisional).is_none());
+        assert!(matches!(
+            stable.adopt_or_mint_membership(&id, provisional),
+            MembershipReconciliation::Exhausted
+        ));
+        assert!(matches!(
+            stable.adopt_or_mint_membership(&id, provisional),
+            MembershipReconciliation::Exhausted
+        ));
         assert!(
             stable.mint_membership(&ChildId::from("other")).is_some(),
             "exhaustion remains local to one child id"

--- a/crates/shelterwood-core/src/identity.rs
+++ b/crates/shelterwood-core/src/identity.rs
@@ -307,7 +307,12 @@ pub struct MintedMembership {
 }
 
 /// Result of reconciling a provisional membership with a stable scope.
+///
+/// Dropping a `Minted` outcome strands the slot on its provisional lineage
+/// while the stable scope has already issued the successor, so the
+/// reconciliation is never optional to consume.
 #[derive(Debug)]
+#[must_use]
 pub enum MembershipReconciliation {
     /// The stable scope adopted the provisional lineage unchanged.
     Adopted,

--- a/crates/shelterwood-core/src/policy.rs
+++ b/crates/shelterwood-core/src/policy.rs
@@ -843,21 +843,6 @@ pub enum ResolvedMailbox {
     Latest,
 }
 
-impl ResolvedMailbox {
-    fn resolve(
-        value: Option<Mailbox>,
-        inherited: Self,
-        inherited_queue_capacity: NonZeroUsize,
-    ) -> Self {
-        match value {
-            None => inherited,
-            Some(Mailbox::Queue(None)) => Self::Queue(inherited_queue_capacity),
-            Some(Mailbox::Queue(Some(capacity))) => Self::Queue(capacity),
-            Some(Mailbox::Latest) => Self::Latest,
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ResolvedReadinessDeadline {
     Bounded(NonZeroDuration),
@@ -909,6 +894,21 @@ impl ResolvedDefaults {
         match self.mailbox_kind {
             ResolvedMailboxKind::Queue => ResolvedMailbox::Queue(self.queue_capacity),
             ResolvedMailboxKind::Latest => ResolvedMailbox::Latest,
+        }
+    }
+
+    /// Resolves a child's mailbox override against these defaults.
+    ///
+    /// Kept on `ResolvedDefaults` for the same reason `overlay` resolves the
+    /// kind and the capacity together: an inherited `Queue` and the capacity
+    /// it inherits come from one value, so the contradictory pairing of
+    /// `Queue(a)` with a capacity `b != a` has no way to be written.
+    pub fn resolve_child_mailbox(&self, value: Option<Mailbox>) -> ResolvedMailbox {
+        match value {
+            None => self.mailbox(),
+            Some(Mailbox::Queue(None)) => ResolvedMailbox::Queue(self.queue_capacity),
+            Some(Mailbox::Queue(Some(capacity))) => ResolvedMailbox::Queue(capacity),
+            Some(Mailbox::Latest) => ResolvedMailbox::Latest,
         }
     }
 
@@ -970,11 +970,7 @@ pub fn resolve_common(
             resolve(options.restart, defaults.child_restart)
         },
         shutdown: resolve(options.shutdown, defaults.child_shutdown),
-        mailbox: ResolvedMailbox::resolve(
-            options.mailbox,
-            defaults.mailbox(),
-            defaults.queue_capacity,
-        ),
+        mailbox: defaults.resolve_child_mailbox(options.mailbox),
         mailbox_shutdown: resolve(options.mailbox_shutdown, defaults.mailbox_shutdown),
         readiness: resolve(options.readiness, default_readiness),
         readiness_deadline: ResolvedReadinessDeadline::resolve(

--- a/crates/shelterwood-core/src/policy.rs
+++ b/crates/shelterwood-core/src/policy.rs
@@ -824,11 +824,17 @@ pub struct CommonOptions {
 pub struct ResolvedDefaults {
     pub child_restart: RestartPolicy,
     pub child_shutdown: Shutdown,
-    pub mailbox: ResolvedMailbox,
+    mailbox_kind: ResolvedMailboxKind,
     /// Nearest resolved queue capacity, retained across defaults of other kinds.
-    pub queue_capacity: NonZeroUsize,
+    queue_capacity: NonZeroUsize,
     pub mailbox_shutdown: MailboxShutdown,
     readiness_deadline: ResolvedReadinessDeadline,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ResolvedMailboxKind {
+    Queue,
+    Latest,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -890,7 +896,7 @@ impl Default for ResolvedDefaults {
         Self {
             child_restart: RestartPolicy::default(),
             child_shutdown: Shutdown::default(),
-            mailbox: ResolvedMailbox::Queue(queue_capacity),
+            mailbox_kind: ResolvedMailboxKind::Queue,
             queue_capacity,
             mailbox_shutdown: MailboxShutdown::default(),
             readiness_deadline: ResolvedReadinessDeadline::Bounded(readiness_deadline),
@@ -899,15 +905,25 @@ impl Default for ResolvedDefaults {
 }
 
 impl ResolvedDefaults {
+    pub fn mailbox(&self) -> ResolvedMailbox {
+        match self.mailbox_kind {
+            ResolvedMailboxKind::Queue => ResolvedMailbox::Queue(self.queue_capacity),
+            ResolvedMailboxKind::Latest => ResolvedMailbox::Latest,
+        }
+    }
+
     pub fn overlay(&self, values: &ScopeDefaults) -> Self {
+        let (mailbox_kind, queue_capacity) = match values.mailbox {
+            None => (self.mailbox_kind, self.queue_capacity),
+            Some(Mailbox::Queue(None)) => (ResolvedMailboxKind::Queue, self.queue_capacity),
+            Some(Mailbox::Queue(Some(capacity))) => (ResolvedMailboxKind::Queue, capacity),
+            Some(Mailbox::Latest) => (ResolvedMailboxKind::Latest, self.queue_capacity),
+        };
         Self {
             child_restart: resolve(values.child_restart, self.child_restart),
             child_shutdown: resolve(values.child_shutdown, self.child_shutdown),
-            mailbox: ResolvedMailbox::resolve(values.mailbox, self.mailbox, self.queue_capacity),
-            queue_capacity: match values.mailbox {
-                Some(Mailbox::Queue(Some(capacity))) => capacity,
-                None | Some(Mailbox::Queue(None) | Mailbox::Latest) => self.queue_capacity,
-            },
+            mailbox_kind,
+            queue_capacity,
             mailbox_shutdown: resolve(values.mailbox_shutdown, self.mailbox_shutdown),
             readiness_deadline: ResolvedReadinessDeadline::resolve(
                 values.readiness_deadline,
@@ -956,7 +972,7 @@ pub fn resolve_common(
         shutdown: resolve(options.shutdown, defaults.child_shutdown),
         mailbox: ResolvedMailbox::resolve(
             options.mailbox,
-            defaults.mailbox,
+            defaults.mailbox(),
             defaults.queue_capacity,
         ),
         mailbox_shutdown: resolve(options.mailbox_shutdown, defaults.mailbox_shutdown),
@@ -1373,7 +1389,7 @@ mod tests {
             ..ScopeDefaults::default()
         });
         assert_eq!(
-            library_queue.mailbox,
+            library_queue.mailbox(),
             ResolvedMailbox::Queue(NonZeroUsize::new(64).expect("capacity is non-zero"))
         );
 
@@ -1385,14 +1401,14 @@ mod tests {
             mailbox: Some(Mailbox::latest()),
             ..ScopeDefaults::default()
         });
-        assert_eq!(latest.mailbox, ResolvedMailbox::Latest);
+        assert_eq!(latest.mailbox(), ResolvedMailbox::Latest);
 
         let deferred_queue = latest.overlay(&ScopeDefaults {
             mailbox: Some(Mailbox::queue_inherit()),
             ..ScopeDefaults::default()
         });
         assert_eq!(
-            deferred_queue.mailbox,
+            deferred_queue.mailbox(),
             ResolvedMailbox::Queue(NonZeroUsize::new(10).expect("capacity is non-zero"))
         );
         assert_eq!(deferred_queue.child_restart, latest.child_restart);
@@ -1403,7 +1419,7 @@ mod tests {
             ..ScopeDefaults::default()
         });
         assert_eq!(
-            reset_queue.mailbox,
+            reset_queue.mailbox(),
             ResolvedMailbox::Queue(NonZeroUsize::new(64).expect("capacity is non-zero"))
         );
     }
@@ -1438,7 +1454,7 @@ mod tests {
         );
         assert_eq!(child.restart, inherited.child_restart);
         assert_eq!(child.shutdown, inherited.child_shutdown);
-        assert_eq!(child.mailbox, inherited.mailbox);
+        assert_eq!(child.mailbox, inherited.mailbox());
         assert_eq!(child.mailbox_shutdown, inherited.mailbox_shutdown);
         assert_eq!(child.readiness, Readiness::Manual);
         assert_eq!(child.readiness_deadline, inherited.readiness_deadline);
@@ -1461,7 +1477,7 @@ mod tests {
         );
         assert_eq!(overridden.restart, RestartPolicy::default());
         assert_eq!(overridden.shutdown, Shutdown::default());
-        assert_eq!(overridden.mailbox, inherited.mailbox);
+        assert_eq!(overridden.mailbox, inherited.mailbox());
         assert_eq!(overridden.mailbox_shutdown, MailboxShutdown::Drain);
         assert_eq!(overridden.readiness, Readiness::Immediate);
         assert_eq!(

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -254,6 +254,7 @@ impl SupervisorState {
         self.children.get(&child).map(|record| record.state)
     }
 
+    /// Missing keys have already been reclaimed and fail closed as removing.
     pub fn membership_status(&self, child: ChildKey) -> MembershipStatus {
         self.child_state(child)
             .map_or(MembershipStatus::Removing, ChildState::membership_status)

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -1672,7 +1672,7 @@ pub(super) mod tests {
     #[should_panic(expected = "mailbox must close the prior incarnation before rebinding")]
     fn rebinding_before_close_trips_the_driver_contract() {
         let (mailbox, _) = actor();
-        MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox);
+        MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox());
         let mut identity = ScopeIdentity::new();
         let (_, mut incarnations) = identity
             .mint_membership(&ChildId::from("actor"))
@@ -1897,7 +1897,7 @@ pub(super) mod tests {
         park_with(&mut first, &first_panicking);
         park_with(&mut second, &second_panicking);
         park_with(&mut third, &counting);
-        MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox);
+        MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox());
         let mut generations = {
             let mut identity = ScopeIdentity::new();
             let (_, generations) = identity

--- a/crates/shelterwood-mailbox/src/futures.rs
+++ b/crates/shelterwood-mailbox/src/futures.rs
@@ -792,7 +792,7 @@ mod tests {
         let (mailbox, actor) = actor();
         MailboxControl::configure(
             &*mailbox,
-            crate::policy::ResolvedDefaults::default().mailbox,
+            crate::policy::ResolvedDefaults::default().mailbox(),
         );
         let mut identity = ScopeIdentity::new();
         let (_, mut incarnations) = identity

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -10,7 +10,7 @@ use crate::{
     admission::ReserveError,
     cells::{MemberCell, ObservationTxn, ScopeCell},
     definition::DefinitionSource,
-    identity::ScopeIdentity,
+    identity::{MembershipReconciliation, ScopeIdentity},
     policy::{
         ChildMode, CommonOptions, ResolvedCommonOptions, ResolvedDefaults, ScopeFlavor,
         resolve_common,
@@ -376,15 +376,16 @@ impl BuilderCore {
             // not this builder's throwaway root.
             self.adopting_root = Some(Arc::clone(&root));
             for slot in &self.slots {
-                let Some(rebased) =
-                    root.adopt_or_mint_membership(slot.member.id(), slot.member.membership())
-                else {
-                    let id = slot.member.id().clone();
-                    let disposal = self.begin_failed_disposal();
-                    return Err(LowerError::IdentityExhausted { id, disposal });
-                };
-                if let Some(identity) = rebased {
-                    slot.member.rebase_membership(identity);
+                match root.adopt_or_mint_membership(slot.member.id(), slot.member.membership()) {
+                    MembershipReconciliation::Adopted => {}
+                    MembershipReconciliation::Minted(identity) => {
+                        slot.member.rebase_membership(identity);
+                    }
+                    MembershipReconciliation::Exhausted => {
+                        let id = slot.member.id().clone();
+                        let disposal = self.begin_failed_disposal();
+                        return Err(LowerError::IdentityExhausted { id, disposal });
+                    }
                 }
             }
         }

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -2257,7 +2257,7 @@ mod tests {
         );
         let mailbox = MailboxCell::new(id.clone(), crate::runtime::mailbox_runtime());
         member.attach_mailbox(mailbox.clone());
-        MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox);
+        MailboxControl::configure(&*mailbox, ResolvedDefaults::default().mailbox());
         let incarnation = member
             .take_incarnation_counter()
             .mint()


### PR DESCRIPTION
Part of #278 in the #284 simplification stack.

- `ResolvedDefaults` now stores one mailbox kind plus its nearest capacity and derives `ResolvedMailbox`, eliminating contradictory parallel state.
- Membership reconciliation is the named three-way `Adopted | Minted | Exhausted` result throughout identity, cells, and lowering.
- Documents the fail-closed missing-membership status ruling.

Existing tests pin every reconciliation arm, capacity inheritance, and partial-adoption exhaustion. The complete core/mailbox/construction stack passes `./tools/dev just ci` with 676/676 tests and all documentation/API lanes.

Stack: based on #308.