### PR TITLE
Make mailbox states structural

### DIFF
--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -55,11 +55,20 @@ impl<M> BoundState<M> {
     }
 }
 
-/// Which mailbox binding states may yield accepted messages.
+/// The structurally valid receive domains.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ReceiveMode {
-    LiveOnly,
-    IncludeFrozen,
+    Drain,
+    LiveThrough(AcceptedSequence),
+}
+
+impl ReceiveMode {
+    fn accepts(self, sequence: AcceptedSequence) -> bool {
+        match self {
+            Self::Drain => true,
+            Self::LiveThrough(limit) => sequence <= limit,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -336,6 +345,27 @@ impl<M> MailboxState<M> {
         }
     }
 
+    /// Replaces one binding only after its waiter identity domain is empty.
+    ///
+    /// This check remains a debug assertion because every caller holds the
+    /// mailbox mutex. A violated framework invariant must not poison the lock
+    /// in release builds, and the old binding stays installed if debug
+    /// diagnosis fires.
+    fn replace_binding(&mut self, replacement: MailboxBinding<M>) {
+        let replaceable = match &self.binding {
+            MailboxBinding::Unbound(waiters)
+            | MailboxBinding::Frozen { waiters, .. }
+            | MailboxBinding::Bound(BoundState::Full { waiters, .. }) => waiters.is_empty(),
+            MailboxBinding::Bound(BoundState::Available(_)) => true,
+            MailboxBinding::Terminal(_) => false,
+        };
+        debug_assert!(
+            replaceable,
+            "mailbox binding replacement requires an empty waiter queue"
+        );
+        self.binding = replacement;
+    }
+
     fn park(&mut self, operation: &Arc<SendOperation<M>>) {
         match &mut self.binding {
             MailboxBinding::Unbound(waiters)
@@ -351,10 +381,10 @@ impl<M> MailboxState<M> {
                 let incarnation = *incarnation;
                 let mut waiters = WaiterQueue::default();
                 waiters.park(operation);
-                self.binding = MailboxBinding::Bound(BoundState::Full {
+                self.replace_binding(MailboxBinding::Bound(BoundState::Full {
                     incarnation,
                     waiters,
-                });
+                }));
             }
             MailboxBinding::Terminal(_) => {
                 unreachable!("terminal submissions return their payload directly")
@@ -402,7 +432,7 @@ impl<M> MailboxState<M> {
             MailboxBinding::Bound(BoundState::Available(_)) | MailboxBinding::Terminal(_) => None,
         };
         if let Some(incarnation) = available {
-            self.binding = MailboxBinding::Bound(BoundState::Available(incarnation));
+            self.replace_binding(MailboxBinding::Bound(BoundState::Available(incarnation)));
         }
         removed
     }
@@ -438,9 +468,11 @@ impl WaiterId {
 /// FIFO registrations with direct removal by a send operation.
 ///
 /// Monotonic keys are insertion order, so the first map entry is the oldest
-/// waiter. Keys are never reused within one queue instance; a queue is only
-/// replaced when it is empty or by the absorbing Terminal state, so no
-/// registration outlives its queue and stale cancellation ids remain harmless.
+/// waiter. Keys are never reused within one queue instance;
+/// `MailboxState::replace_binding` permits replacing a queue only after it is
+/// empty, so no registration outlives its queue and stale cancellation ids
+/// remain harmless. Terminalization detaches the live queue before replacing
+/// the binding and discharges those registrations after unlocking.
 /// `u64::MAX` is a poison key and is never minted; exhaustion remains poisoned
 /// instead of wrapping back into the live id domain.
 pub(super) struct WaiterQueue<M> {
@@ -864,18 +896,11 @@ impl<M: Send + 'static> MailboxCell<M> {
         transaction.finish(result)
     }
 
-    fn receive(
-        &self,
-        incarnation: Incarnation,
-        mode: ReceiveMode,
-        accepted_through: Option<AcceptedSequence>,
-    ) -> Option<M> {
+    fn receive(&self, incarnation: Incarnation, mode: ReceiveMode) -> Option<M> {
         let mut transaction = MailboxTxn::new(self);
         let eligible = match transaction.status() {
             BindingStatus::Bound(current) => current == incarnation,
-            BindingStatus::Frozen(current) => {
-                mode == ReceiveMode::IncludeFrozen && current == incarnation
-            }
+            BindingStatus::Frozen(current) => mode == ReceiveMode::Drain && current == incarnation,
             BindingStatus::Unbound | BindingStatus::Terminal(_) => false,
         };
         if !eligible {
@@ -883,15 +908,17 @@ impl<M: Send + 'static> MailboxCell<M> {
         }
         let envelope = match transaction.kind {
             Some(MailboxKind::Queue(_)) => {
-                let eligible = transaction.queue.front().is_some_and(|item| {
-                    accepted_through.is_none_or(|limit| item.accepted_sequence <= limit)
-                });
+                let eligible = transaction
+                    .queue
+                    .front()
+                    .is_some_and(|item| mode.accepts(item.accepted_sequence));
                 eligible.then(|| transaction.queue.pop_front()).flatten()
             }
             Some(MailboxKind::Latest) => {
-                let eligible = transaction.latest.as_ref().is_some_and(|item| {
-                    accepted_through.is_none_or(|limit| item.accepted_sequence <= limit)
-                });
+                let eligible = transaction
+                    .latest
+                    .as_ref()
+                    .is_some_and(|item| mode.accepts(item.accepted_sequence));
                 eligible.then(|| transaction.latest.take()).flatten()
             }
             None => None,
@@ -1103,16 +1130,16 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             );
         }
         if waiters.is_empty() {
-            transaction.binding = MailboxBinding::Bound(BoundState::Available(incarnation));
+            transaction.replace_binding(MailboxBinding::Bound(BoundState::Available(incarnation)));
         } else {
             let MailboxKind::Queue(capacity) = kind else {
                 unreachable!("a latest mailbox finishes all waiting submissions")
             };
             debug_assert_eq!(transaction.queue.len(), capacity.get());
-            transaction.binding = MailboxBinding::Bound(BoundState::Full {
+            transaction.replace_binding(MailboxBinding::Bound(BoundState::Full {
                 incarnation,
                 waiters,
-            });
+            }));
         }
         transaction.effects.pulse();
         transaction.effects.isolate_displaced();
@@ -1125,10 +1152,10 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             return transaction.finish(());
         }
         let waiters = transaction.take_waiters();
-        transaction.binding = MailboxBinding::Frozen {
+        transaction.replace_binding(MailboxBinding::Frozen {
             incarnation,
             waiters,
-        };
+        });
         transaction.effects.pulse();
         transaction.finish(())
     }
@@ -1143,7 +1170,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             return transaction.finish(None);
         }
         let waiters = transaction.take_waiters();
-        transaction.binding = MailboxBinding::Unbound(waiters);
+        transaction.replace_binding(MailboxBinding::Unbound(waiters));
         let queue = std::mem::take(&mut transaction.queue);
         let latest = transaction.latest.take();
         transaction.effects.pulse();
@@ -1166,7 +1193,7 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         // detached waiter is decided separately by its `Waiting ->` outcome
         // transition, so an already-expired withdrawal may beat the deferred
         // discharge even after this mailbox-wide transition.
-        transaction.binding = MailboxBinding::Terminal(final_incarnation);
+        transaction.replace_binding(MailboxBinding::Terminal(final_incarnation));
         let queue = std::mem::take(&mut transaction.queue);
         let latest = transaction.latest.take();
         let termination = Termination {
@@ -1290,7 +1317,7 @@ fn promote_waiters<M: Send + 'static>(
         effects,
     );
     if waiters.is_empty() {
-        state.binding = MailboxBinding::Bound(BoundState::Available(incarnation));
+        state.replace_binding(MailboxBinding::Bound(BoundState::Available(incarnation)));
     }
 }
 
@@ -1392,15 +1419,13 @@ impl<M: Send + 'static> MailboxReceiver<M> {
     }
 
     pub fn try_recv(&self) -> Option<M> {
-        self.mailbox
-            .receive(self.incarnation, ReceiveMode::IncludeFrozen, None)
+        self.mailbox.receive(self.incarnation, ReceiveMode::Drain)
     }
 
     pub fn try_recv_live_through(&self, accepted_sequence: AcceptedSequence) -> Option<M> {
         self.mailbox.receive(
             self.incarnation,
-            ReceiveMode::LiveOnly,
-            Some(accepted_sequence),
+            ReceiveMode::LiveThrough(accepted_sequence),
         )
     }
 
@@ -1621,6 +1646,69 @@ pub(super) mod tests {
     fn park_with(future: &mut std::pin::Pin<Box<crate::SendFuture<u8>>>, waker: &Waker) {
         let mut context = Context::from_waker(waker);
         assert!(future.as_mut().poll(&mut context).is_pending());
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn binding_replacement_rejects_a_live_waiter_identity_domain() {
+        let operation = super::SendOperation::new(1_u8);
+        let mut waiters = super::WaiterQueue::default();
+        waiters.park(&operation);
+        let mut state = super::MailboxState {
+            kind: None,
+            binding: super::MailboxBinding::Unbound(waiters),
+            last_bound: None,
+            queue: std::collections::VecDeque::new(),
+            latest: None,
+        };
+
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                state
+                    .replace_binding(super::MailboxBinding::Unbound(super::WaiterQueue::default()));
+            }))
+            .is_err(),
+            "a live waiter queue cannot be replaced"
+        );
+        assert!(matches!(
+            &state.binding,
+            super::MailboxBinding::Unbound(waiters) if waiters.len() == 1
+        ));
+    }
+
+    #[test]
+    fn receive_modes_pin_live_cutoffs_and_frozen_drain() {
+        let (mailbox, actor) = actor();
+        MailboxControl::configure(
+            &*mailbox,
+            ResolvedMailbox::Queue(
+                std::num::NonZeroUsize::new(2).expect("non-zero queue capacity"),
+            ),
+        );
+        let mut identity = ScopeIdentity::new();
+        let (_, mut incarnations) = identity
+            .mint_membership(&ChildId::from("actor"))
+            .expect("membership available")
+            .into_pair();
+        let incarnation = incarnations.mint().expect("incarnation available");
+        MailboxControl::bind(&*mailbox, incarnation);
+        let receiver = MailboxReceiver::new(Arc::clone(&mailbox), incarnation);
+
+        actor.try_send(1).expect("first message accepts");
+        let through_first = receiver.accepted_sequence();
+        actor.try_send(2).expect("second message accepts");
+        assert_eq!(receiver.try_recv_live_through(through_first), Some(1));
+        assert_eq!(receiver.try_recv_live_through(through_first), None);
+
+        let through_all = receiver.accepted_sequence();
+        receiver.freeze();
+        assert_eq!(
+            receiver.try_recv_live_through(through_all),
+            None,
+            "live reception never enters a frozen mailbox"
+        );
+        assert_eq!(receiver.try_recv(), Some(2));
+        assert_eq!(receiver.try_recv(), None);
     }
 
     #[test]

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -347,10 +347,14 @@ impl<M> MailboxState<M> {
 
     /// Replaces one binding only after its waiter identity domain is empty.
     ///
-    /// This check remains a debug assertion because every caller holds the
-    /// mailbox mutex. A violated framework invariant must not poison the lock
-    /// in release builds, and the old binding stays installed if debug
-    /// diagnosis fires.
+    /// The check is not an `assert!` because every caller holds the mailbox
+    /// mutex and a violated framework invariant must not poison it. Both
+    /// builds therefore keep the old binding: debug diagnoses first, and
+    /// release declines the replacement rather than dropping a live
+    /// `WaiterQueue` here. That drop would release the queue's
+    /// `Arc<SendOperation<M>>`s under the mutex, so wherever one is the last
+    /// owner a user message destructor would run in the critical section.
+    /// Declining costs a stalled transition, which is the lesser of the two.
     fn replace_binding(&mut self, replacement: MailboxBinding<M>) {
         let replaceable = match &self.binding {
             MailboxBinding::Unbound(waiters)
@@ -363,6 +367,9 @@ impl<M> MailboxState<M> {
             replaceable,
             "mailbox binding replacement requires an empty waiter queue"
         );
+        if !replaceable {
+            return;
+        }
         self.binding = replacement;
     }
 


### PR DESCRIPTION
Part of #278 in the #284 simplification stack.

- Replaces `(ReceiveMode, Option<AcceptedSequence>)` with exactly `Drain | LiveThrough(sequence)`.
- Centralizes all live binding replacement through one invariant-checking helper.
- Adds direct cutoff/frozen-mode and live-waiter-domain regressions.

The debug assertion is deliberate under the project lock rule: it inspects only framework state at the point where releasing the mailbox mutex is structurally impossible.

Validation: mailbox 30/30, raw integration/lib suites, and full CI passed on the original branch; the combined #278 stack passes full CI with 676/676 tests.

Stack: based on the core-encoding PR.