### PR TITLE
Pin mailbox runtime and engine contracts

### DIFF
--- a/crates/shelterwood-core/src/engine.rs
+++ b/crates/shelterwood-core/src/engine.rs
@@ -1216,6 +1216,24 @@ mod tests {
     }
 
     #[test]
+    fn force_in_idle_arms_immediate_escalation_on_the_first_advance() {
+        let forced_at = Instant::now();
+        let mut ladder = StopLadder::new(
+            Shutdown::graceful(Duration::from_secs(30)).expect("test grace is non-zero"),
+        );
+
+        ladder.force(forced_at);
+        assert_eq!(ladder.deadline(), None, "an idle ladder is not armed yet");
+        assert_eq!(ladder.advance(forced_at), Some(StopAction::Cancel));
+        assert_eq!(ladder.deadline(), Some(forced_at));
+        assert_eq!(
+            ladder.advance(forced_at),
+            Some(StopAction::Escalate),
+            "force before the first advance skips the cooperative grace"
+        );
+    }
+
+    #[test]
     fn force_preserves_an_already_due_deadline() {
         let start = Instant::now();
         let grace = Duration::from_secs(30);
@@ -1284,6 +1302,33 @@ mod tests {
             Some(StopAction::HardAbort {
                 phase: GracePhase::WithinGrace
             })
+        );
+    }
+
+    #[test]
+    fn framework_abort_acknowledgement_is_ignored_before_the_abort_phase() {
+        let start = Instant::now();
+        let mut ladder = StopLadder::for_framework_driver(Shutdown::Abort);
+
+        ladder.acknowledge_framework_abort();
+        assert_eq!(ladder.advance(start), Some(StopAction::Cancel));
+        ladder.acknowledge_framework_abort();
+        assert_eq!(ladder.advance(start), Some(StopAction::Escalate));
+        ladder.acknowledge_framework_abort();
+        let tidy = ladder.deadline().expect("abort policy keeps a tidy beat");
+        assert_eq!(
+            ladder.advance(tidy),
+            Some(StopAction::AbortFramework {
+                phase: GracePhase::WithinGrace
+            })
+        );
+        let framework_tidy = ladder.deadline().expect("framework abort has a tidy beat");
+        assert_eq!(
+            ladder.advance(framework_tidy),
+            Some(StopAction::HardAbort {
+                phase: GracePhase::WithinGrace
+            }),
+            "acknowledgements before AbortingFramework must not suppress the hard-abort fallback"
         );
     }
 
@@ -1610,6 +1655,37 @@ mod tests {
             Some(ReadinessEffect::TimedOut { deadline })
         );
         assert!(!timed_out.needs_signal_watch());
+
+        let configured_deadline = deadline + Duration::from_secs(2);
+        let mut premature = ReadinessGate::new();
+        assert_eq!(
+            premature.step(ReadinessEvent::Configure {
+                readiness: crate::Readiness::Manual,
+                deadline: Some(configured_deadline),
+            }),
+            Some(ReadinessEffect::ArmDeadline {
+                deadline: configured_deadline
+            })
+        );
+        assert_eq!(
+            premature.step(ReadinessEvent::Deadline {
+                now: deadline,
+                signal_seen: false,
+            }),
+            None,
+            "a deadline event before the configured instant cannot time readiness out"
+        );
+        assert!(premature.needs_signal_watch());
+        assert_eq!(
+            premature.step(ReadinessEvent::Deadline {
+                now: configured_deadline,
+                signal_seen: false,
+            }),
+            Some(ReadinessEffect::TimedOut {
+                deadline: configured_deadline
+            }),
+            "the original deadline remains armed after a premature event"
+        );
 
         let mut immediate = ReadinessGate::new();
         assert_eq!(

--- a/crates/shelterwood-core/src/exit.rs
+++ b/crates/shelterwood-core/src/exit.rs
@@ -1149,7 +1149,22 @@ mod tests {
     }
 
     #[test]
-    fn stop_reason_precedence_is_an_explicit_exhaustive_table() {
+    fn stop_reason_precedence_is_severity_ascending() {
+        use super::StopPrecedence;
+
+        // `StopPrecedence` derives `Ord` from declaration order, and both
+        // consumers resolve competing verdicts with strictly-greater, so the
+        // order is the contract. Pin the two boundaries the doc calls out by
+        // name.
+        assert!(
+            StopPrecedence::StartupFailed < StopPrecedence::ShutdownRequested,
+            "a requested stop supersedes the structured failures"
+        );
+        assert!(
+            StopPrecedence::ShutdownRequested < StopPrecedence::NeverStarted,
+            "a membership that never started is the top element"
+        );
+
         let trip = IntensityTrip {
             max_restarts: 1,
             observed_restarts: 2,
@@ -1160,28 +1175,33 @@ mod tests {
                 id: ChildId::from("nested"),
             },
         };
-        let cases = [
-            (StopReason::Finished, super::StopPrecedence::Finished),
-            (
-                StopReason::IntensityTripped(trip),
-                super::StopPrecedence::IntensityTripped,
-            ),
-            (
-                StopReason::StartupFailed(startup),
-                super::StopPrecedence::StartupFailed,
-            ),
-            (
-                StopReason::ShutdownRequested,
-                super::StopPrecedence::ShutdownRequested,
-            ),
-            (
-                StopReason::NeverStarted,
-                super::StopPrecedence::NeverStarted,
-            ),
+        let ascending = [
+            StopReason::Finished,
+            StopReason::IntensityTripped(trip),
+            StopReason::StartupFailed(startup),
+            StopReason::ShutdownRequested,
+            StopReason::NeverStarted,
         ];
 
-        for (reason, expected) in cases {
-            assert_eq!(stop_reason_precedence(&reason), expected as u8);
+        for reason in &ascending {
+            // Exhaustive over `StopReason` without restating the mapping: a
+            // new variant does not compile until it is placed in the list
+            // above, which is what the ordering below then checks.
+            match reason {
+                StopReason::Finished
+                | StopReason::IntensityTripped(_)
+                | StopReason::StartupFailed(_)
+                | StopReason::ShutdownRequested
+                | StopReason::NeverStarted => {}
+            }
+        }
+        for pair in ascending.windows(2) {
+            assert!(
+                stop_reason_precedence(&pair[0]) < stop_reason_precedence(&pair[1]),
+                "{:?} must outrank {:?}",
+                pair[1],
+                pair[0]
+            );
         }
     }
 

--- a/crates/shelterwood-core/src/exit.rs
+++ b/crates/shelterwood-core/src/exit.rs
@@ -705,8 +705,8 @@ mod tests {
         Cancellation, ChildId, Exit, ExitError, ExitKind, GracePhase, IntensityTrip, JoinOutcome,
         RecordedOutcome, StartupError, StartupFailure, StartupFailureCause, StopReason,
         classify_disposal_panic, classify_exit, exit_kind_eq, prefer_earlier,
-        reconcile_recorded_outcomes, stop_reason_into_nested_result, stop_reason_root_exit,
-        structured_intensity_trip_error, structured_startup_failure_error,
+        reconcile_recorded_outcomes, stop_reason_into_nested_result, stop_reason_precedence,
+        stop_reason_root_exit, structured_intensity_trip_error, structured_startup_failure_error,
     };
 
     fn exit(kind: ExitKind, cancellation: Cancellation) -> Exit {
@@ -1146,6 +1146,43 @@ mod tests {
             never_started.as_error().to_string(),
             "nested scope never started"
         );
+    }
+
+    #[test]
+    fn stop_reason_precedence_is_an_explicit_exhaustive_table() {
+        let trip = IntensityTrip {
+            max_restarts: 1,
+            observed_restarts: 2,
+            within: Duration::from_secs(10),
+        };
+        let startup = StartupFailure {
+            cause: StartupFailureCause::IdentityExhausted {
+                id: ChildId::from("nested"),
+            },
+        };
+        let cases = [
+            (StopReason::Finished, super::StopPrecedence::Finished),
+            (
+                StopReason::IntensityTripped(trip),
+                super::StopPrecedence::IntensityTripped,
+            ),
+            (
+                StopReason::StartupFailed(startup),
+                super::StopPrecedence::StartupFailed,
+            ),
+            (
+                StopReason::ShutdownRequested,
+                super::StopPrecedence::ShutdownRequested,
+            ),
+            (
+                StopReason::NeverStarted,
+                super::StopPrecedence::NeverStarted,
+            ),
+        ];
+
+        for (reason, expected) in cases {
+            assert_eq!(stop_reason_precedence(&reason), expected as u8);
+        }
     }
 
     #[test]

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -1676,7 +1676,7 @@ pub(super) mod tests {
         pin::Pin,
         sync::{
             Arc, Mutex, Weak,
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
             mpsc,
         },
         task::{Context, Poll, Wake, Waker},
@@ -1776,7 +1776,8 @@ pub(super) mod tests {
     /// flush can be made to unwind on demand.
     struct PanickingPulseRuntime {
         inner: Arc<dyn crate::MailboxRuntime>,
-        armed: Arc<std::sync::atomic::AtomicBool>,
+        armed: Arc<AtomicBool>,
+        disposals: Arc<AtomicUsize>,
     }
 
     impl crate::MailboxRuntime for PanickingPulseRuntime {
@@ -1797,6 +1798,7 @@ pub(super) mod tests {
         }
 
         fn dispose(&self, value: Box<dyn Send + 'static>) {
+            self.disposals.fetch_add(1, Ordering::SeqCst);
             self.inner.dispose(value);
         }
 
@@ -1811,7 +1813,7 @@ pub(super) mod tests {
 
     struct PanickingPulseSignal {
         inner: Arc<dyn crate::MailboxSignal>,
-        armed: Arc<std::sync::atomic::AtomicBool>,
+        armed: Arc<AtomicBool>,
     }
 
     impl crate::MailboxSignal for PanickingPulseSignal {
@@ -1930,25 +1932,31 @@ pub(super) mod tests {
         }
     }
 
-    pub(crate) fn actor_for<M: Send + 'static>() -> (Arc<MailboxCell<M>>, ActorRef<M>) {
+    pub(crate) fn actor_for_with_runtime<M: Send + 'static>(
+        runtime: Arc<dyn crate::MailboxRuntime>,
+    ) -> (Arc<MailboxCell<M>>, ActorRef<M>) {
         let id = ChildId::from("actor");
         let (membership, _) = mint_actor_membership();
         let member = Arc::new(TestIdentity {
             id: id.clone(),
             membership,
         });
-        let mailbox = MailboxCell::new(id, crate::capability::tests::runtime());
+        let mailbox = MailboxCell::new(id, runtime);
         (
             Arc::clone(&mailbox),
             crate::actor_ref_from_parts(member, mailbox),
         )
     }
 
+    pub(crate) fn actor_for<M: Send + 'static>() -> (Arc<MailboxCell<M>>, ActorRef<M>) {
+        actor_for_with_runtime(crate::capability::tests::runtime())
+    }
+
     pub(crate) fn actor() -> (Arc<MailboxCell<u8>>, ActorRef<u8>) {
         actor_for()
     }
 
-    fn configure<M: Send + 'static>(
+    pub(crate) fn configure<M: Send + 'static>(
         mailbox: &MailboxCell<M>,
         policy: ResolvedMailbox,
     ) -> crate::MailboxBindToken {
@@ -1956,7 +1964,7 @@ pub(super) mod tests {
         MailboxControl::configure(mailbox, policy, &mut effects)
     }
 
-    fn bind<M: Send + 'static>(
+    pub(crate) fn bind<M: Send + 'static>(
         mailbox: &MailboxCell<M>,
         token: crate::MailboxBindToken,
         incarnation: Incarnation,
@@ -1965,7 +1973,7 @@ pub(super) mod tests {
         MailboxControl::bind(mailbox, token, incarnation, &mut effects);
     }
 
-    fn prepare_termination<M: Send + 'static>(
+    pub(crate) fn prepare_termination<M: Send + 'static>(
         mailbox: &MailboxCell<M>,
     ) -> Option<Box<dyn crate::MailboxTermination>> {
         let mut effects = crate::MailboxEffectQueue::default();
@@ -1975,6 +1983,307 @@ pub(super) mod tests {
     fn park_with(future: &mut std::pin::Pin<Box<crate::SendFuture<u8>>>, waker: &Waker) {
         let mut context = Context::from_waker(waker);
         assert!(future.as_mut().poll(&mut context).is_pending());
+    }
+
+    pub(crate) fn freeze<M: Send + 'static>(mailbox: &MailboxCell<M>, incarnation: Incarnation) {
+        let mut effects = crate::MailboxEffectQueue::default();
+        MailboxControl::freeze(mailbox, incarnation, &mut effects);
+    }
+
+    /// Closes in the driver's shape: the result stays live across the effect
+    /// flush, so a panicking waker cannot strand the unread payload.
+    pub(crate) fn close<M: Send + 'static>(
+        mailbox: &MailboxCell<M>,
+        incarnation: Incarnation,
+    ) -> Option<crate::MailboxClose> {
+        let mut effects = crate::MailboxEffectQueue::default();
+        MailboxControl::close(mailbox, incarnation, &mut effects)
+    }
+
+    fn two_incarnations() -> (Incarnation, Incarnation) {
+        let (_, mut incarnations) = mint_actor_membership();
+        (
+            incarnations.mint().expect("first incarnation available"),
+            incarnations.mint().expect("second incarnation available"),
+        )
+    }
+
+    struct TrackedMessage {
+        value: u8,
+        drops: Arc<AtomicUsize>,
+    }
+
+    impl Drop for TrackedMessage {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn freeze_and_close_preserve_waiters_payloads_and_incarnation_boundaries() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let (first, second) = two_incarnations();
+        let mailbox = MailboxCell::new(ChildId::from("actor"), crate::capability::tests::runtime());
+        let token = configure(
+            &mailbox,
+            ResolvedMailbox::Queue(
+                std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
+            ),
+        );
+
+        freeze(&mailbox, first);
+        assert!(close(&mailbox, first).is_none());
+        bind(&mailbox, token, first);
+        assert!(matches!(
+            mailbox.submit(TrackedMessage {
+                value: 1,
+                drops: Arc::clone(&drops),
+            }),
+            super::Submission::Accepted(bound) if bound == first
+        ));
+        let second_message = match mailbox.submit(TrackedMessage {
+            value: 2,
+            drops: Arc::clone(&drops),
+        }) {
+            super::Submission::Parked(operation) => operation,
+            super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+                panic!("the second message parks behind the full queue")
+            }
+        };
+
+        freeze(&mailbox, second);
+        assert!(close(&mailbox, second).is_none());
+        assert!(matches!(
+            &mailbox.state.lock().expect("mailbox mutex poisoned").binding,
+            super::MailboxBinding::Bound(super::BoundState::Full { incarnation, waiters })
+                if *incarnation == first && waiters.len() == 1
+        ));
+
+        freeze(&mailbox, first);
+        let third_message = match mailbox.submit(TrackedMessage {
+            value: 3,
+            drops: Arc::clone(&drops),
+        }) {
+            super::Submission::Parked(operation) => operation,
+            super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+                panic!("frozen intake parks new messages")
+            }
+        };
+        assert!(matches!(
+            &mailbox.state.lock().expect("mailbox mutex poisoned").binding,
+            super::MailboxBinding::Frozen { incarnation, waiters }
+                if *incarnation == first && waiters.len() == 2
+        ));
+
+        let closed =
+            close(&mailbox, first).expect("the matching close returns the unread queue payload");
+        assert!(matches!(
+            &mailbox.state.lock().expect("mailbox mutex poisoned").binding,
+            super::MailboxBinding::Unbound(waiters) if waiters.len() == 2
+        ));
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+        let (token, payload) = closed.into_parts();
+        drop(payload);
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            1,
+            "close transfers the unread payload instead of dropping it inline"
+        );
+
+        bind(&mailbox, token, second);
+        assert!(matches!(
+            second_message.poll(None, Waker::noop()),
+            super::OperationPoll::Accepted(bound) if bound == second
+        ));
+        assert!(matches!(
+            third_message.poll(None, Waker::noop()),
+            super::OperationPoll::NeedsWakerClone
+        ));
+        let receiver = MailboxReceiver::new(Arc::clone(&mailbox), second);
+        let message = receiver.try_recv().expect("the oldest waiter was promoted");
+        assert_eq!(message.value, 2);
+        drop(message);
+        assert!(matches!(
+            third_message.poll(None, Waker::noop()),
+            super::OperationPoll::Accepted(bound) if bound == second
+        ));
+        let message = receiver
+            .try_recv()
+            .expect("the remaining waiter was promoted");
+        assert_eq!(message.value, 3);
+        drop(message);
+        assert_eq!(drops.load(Ordering::SeqCst), 3);
+
+        freeze(&mailbox, first);
+        assert!(close(&mailbox, first).is_none());
+        drop(close(&mailbox, second));
+        let teardown = prepare_termination(&mailbox).expect("an unbound mailbox can terminalize");
+        drop(teardown.finish());
+        freeze(&mailbox, second);
+        assert!(close(&mailbox, second).is_none());
+
+        let latest_drops = Arc::new(AtomicUsize::new(0));
+        let latest = MailboxCell::new(ChildId::from("latest"), crate::capability::tests::runtime());
+        let latest_token = configure(&latest, ResolvedMailbox::Latest);
+        bind(&latest, latest_token, first);
+        assert!(matches!(
+            latest.submit(TrackedMessage {
+                value: 4,
+                drops: Arc::clone(&latest_drops),
+            }),
+            super::Submission::Accepted(bound) if bound == first
+        ));
+        freeze(&latest, first);
+        let closed = close(&latest, first).expect("close returns the frozen latest payload");
+        assert_eq!(latest_drops.load(Ordering::SeqCst), 0);
+        let (_token, payload) = closed.into_parts();
+        drop(payload);
+        assert_eq!(latest_drops.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn accepted_sequence_boundary_is_inclusive_and_live_only_refuses_frozen_input() {
+        let (mailbox, actor_ref) = actor();
+        let (incarnation, _) = two_incarnations();
+        let token = configure(
+            &mailbox,
+            ResolvedMailbox::Queue(
+                std::num::NonZeroUsize::new(4).expect("non-zero queue capacity"),
+            ),
+        );
+        bind(&mailbox, token, incarnation);
+        let receiver = MailboxReceiver::new(Arc::clone(&mailbox), incarnation);
+
+        assert!(matches!(actor_ref.try_send(1), Ok(bound) if bound == incarnation));
+        assert!(matches!(actor_ref.try_send(2), Ok(bound) if bound == incarnation));
+        let through = receiver.accepted_sequence();
+        assert!(matches!(actor_ref.try_send(3), Ok(bound) if bound == incarnation));
+        assert_eq!(receiver.try_recv_live_through(through), Some(1));
+        assert_eq!(
+            receiver.try_recv_live_through(through),
+            Some(2),
+            "the accepted-sequence boundary itself is included"
+        );
+        assert_eq!(receiver.try_recv_live_through(through), None);
+
+        receiver.freeze();
+        let frozen_through = receiver.accepted_sequence();
+        assert_eq!(receiver.try_recv_live_through(frozen_through), None);
+        assert_eq!(
+            receiver.try_recv(),
+            Some(3),
+            "IncludeFrozen drains the same payload LiveOnly refuses"
+        );
+
+        let (latest_mailbox, latest_actor) = actor();
+        let latest_token = configure(&latest_mailbox, ResolvedMailbox::Latest);
+        bind(&latest_mailbox, latest_token, incarnation);
+        let latest_receiver = MailboxReceiver::new(latest_mailbox, incarnation);
+        assert!(matches!(
+            latest_actor.try_send(4),
+            Ok(bound) if bound == incarnation
+        ));
+        let latest_through = latest_receiver.accepted_sequence();
+        assert_eq!(
+            latest_receiver.try_recv_live_through(latest_through),
+            Some(4),
+            "latest mailboxes also include the exact accepted-sequence boundary"
+        );
+        assert!(matches!(
+            latest_actor.try_send(5),
+            Ok(bound) if bound == incarnation
+        ));
+        assert_eq!(latest_receiver.try_recv_live_through(latest_through), None);
+        assert_eq!(latest_receiver.try_recv(), Some(5));
+    }
+
+    #[test]
+    fn termination_that_wins_before_withdrawal_reports_the_terminal_outcome() {
+        let (mailbox, _) = actor();
+        let (incarnation, _) = two_incarnations();
+        let token = configure(
+            &mailbox,
+            ResolvedMailbox::Queue(
+                std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
+            ),
+        );
+        bind(&mailbox, token, incarnation);
+        assert!(matches!(
+            mailbox.submit(1),
+            super::Submission::Accepted(bound) if bound == incarnation
+        ));
+        let operation = match mailbox.submit(2) {
+            super::Submission::Parked(operation) => operation,
+            super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+                panic!("the second message parks")
+            }
+        };
+
+        let teardown = prepare_termination(&mailbox).expect("the mailbox prepares termination");
+        let payload = teardown.finish();
+        let mut withdrawal = mailbox.withdraw(&operation, super::WithdrawalDisposition::Inline);
+        assert!(matches!(
+            withdrawal.take_outcome(),
+            super::WithdrawalOutcome::Terminated {
+                message: 2,
+                observed: Some(final_incarnation),
+            } if final_incarnation == incarnation
+        ));
+        withdrawal.finish();
+        drop(payload);
+    }
+
+    #[test]
+    fn termination_finish_completes_waiters_and_isolates_payload_after_signal_panic() {
+        let armed = Arc::new(AtomicBool::new(false));
+        let disposals = Arc::new(AtomicUsize::new(0));
+        let runtime = Arc::new(PanickingPulseRuntime {
+            inner: crate::capability::tests::runtime(),
+            armed: Arc::clone(&armed),
+            disposals: Arc::clone(&disposals),
+        });
+        let (mailbox, actor) = actor_for_with_runtime(runtime);
+        let (incarnation, _) = two_incarnations();
+        let token = configure(
+            &mailbox,
+            ResolvedMailbox::Queue(
+                std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
+            ),
+        );
+        bind(&mailbox, token, incarnation);
+        assert!(matches!(actor.try_send(1), Ok(bound) if bound == incarnation));
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let waker = Waker::from(Arc::new(CountWake(Arc::clone(&wakes))));
+        let mut second = Box::pin(actor.send(2));
+        let mut third = Box::pin(actor.send(3));
+        park_with(&mut second, &waker);
+        park_with(&mut third, &waker);
+
+        let teardown = prepare_termination(&mailbox).expect("the mailbox prepares termination");
+        armed.store(true, Ordering::SeqCst);
+        let panic = catch_unwind(AssertUnwindSafe(move || {
+            let _ = teardown.finish();
+        }))
+        .expect_err("the primary signal panic resumes after teardown");
+        assert_eq!(
+            panic.downcast_ref::<&'static str>().copied(),
+            Some("injected mailbox pulse panic")
+        );
+        assert_eq!(wakes.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            disposals.load(Ordering::SeqCst),
+            1,
+            "a panicking finish submits the unread payload for isolated disposal"
+        );
+        for send in [&mut second, &mut third] {
+            let Poll::Ready(Err(error)) =
+                send.as_mut().poll(&mut Context::from_waker(Waker::noop()))
+            else {
+                panic!("every waiter is terminal before the primary panic resumes")
+            };
+            assert_eq!(error.kind, SendErrorKind::Terminated);
+            assert_eq!(error.incarnation_observed, Some(incarnation));
+        }
     }
 
     #[cfg(debug_assertions)]
@@ -2632,10 +2941,11 @@ pub(super) mod tests {
 
     #[test]
     fn a_panicking_close_flush_isolates_the_unread_payload() {
-        let armed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let armed = Arc::new(AtomicBool::new(false));
         let runtime = Arc::new(PanickingPulseRuntime {
             inner: crate::capability::tests::runtime(),
             armed: Arc::clone(&armed),
+            disposals: Arc::new(AtomicUsize::new(0)),
         });
         let mailbox = MailboxCell::new(ChildId::from("actor"), runtime);
         let token = configure(&mailbox, ResolvedMailbox::Latest);

--- a/crates/shelterwood-mailbox/src/futures.rs
+++ b/crates/shelterwood-mailbox/src/futures.rs
@@ -696,6 +696,7 @@ mod tests {
     use std::{
         future::Future,
         mem::ManuallyDrop,
+        pin::Pin,
         sync::{
             Arc, Mutex, Weak,
             atomic::{AtomicUsize, Ordering},
@@ -703,18 +704,314 @@ mod tests {
         },
         task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker},
         thread::ThreadId,
-        time::Duration,
+        time::{Duration, Instant},
     };
 
-    use crate::{MailboxControl, MailboxEffectQueue, test_support::mint_actor_incarnation};
+    use shelterwood_core::DeadlineBudget;
+
+    use crate::{
+        BoxedSleep, CallErrorKind, ErasedOneShotReceiver, ErasedOneShotSender, Incarnation,
+        MailboxControl, MailboxEffectQueue, MailboxReceiver, MailboxRuntime, MailboxSignal, Reply,
+        policy::ResolvedMailbox, test_support::mint_actor_incarnation,
+    };
 
     use super::{
-        super::cell::tests::{actor, actor_for},
+        super::cell::tests::{
+            actor, actor_for, actor_for_with_runtime, bind, close, configure, prepare_termination,
+        },
         ActorRef, DeadlineOperation, DeadlinePhase, MailboxCell, SendFuture, SendFutureState,
         SendOperation,
     };
 
     const DISPOSAL_WAIT: Duration = Duration::from_secs(5);
+
+    struct CallRequest {
+        reply: Option<Reply<u8>>,
+    }
+
+    fn bound_call_actor(
+        capacity: usize,
+    ) -> (
+        Arc<MailboxCell<CallRequest>>,
+        ActorRef<CallRequest>,
+        Incarnation,
+        MailboxReceiver<CallRequest>,
+    ) {
+        let (mailbox, actor) = actor_for();
+        let token = configure(
+            &mailbox,
+            ResolvedMailbox::Queue(
+                std::num::NonZeroUsize::new(capacity).expect("non-zero queue capacity"),
+            ),
+        );
+        let incarnation = mint_actor_incarnation();
+        bind(&mailbox, token, incarnation);
+        let receiver = MailboxReceiver::new(Arc::clone(&mailbox), incarnation);
+        (mailbox, actor, incarnation, receiver)
+    }
+
+    fn poll_once<F: Future>(future: Pin<&mut F>) -> Poll<F::Output> {
+        future.poll(&mut Context::from_waker(Waker::noop()))
+    }
+
+    #[test]
+    fn zero_budget_call_never_constructs_or_submits_a_message() {
+        let (mailbox, actor): (Arc<MailboxCell<CallRequest>>, ActorRef<CallRequest>) = actor_for();
+        let token = configure(
+            &mailbox,
+            ResolvedMailbox::Queue(
+                std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
+            ),
+        );
+        let constructions = Arc::new(AtomicUsize::new(0));
+        let constructed = Arc::clone(&constructions);
+        let mut call = Box::pin(actor.call(
+            move |reply| {
+                constructed.fetch_add(1, Ordering::SeqCst);
+                CallRequest { reply: Some(reply) }
+            },
+            DeadlineBudget::ZERO,
+        ));
+
+        let Poll::Ready(Err(error)) = poll_once(call.as_mut()) else {
+            panic!("a zero-width call budget resolves on its first poll")
+        };
+        assert_eq!(error.kind, CallErrorKind::AcceptanceTimedOut);
+        assert_eq!(error.incarnation_observed, None);
+        assert_eq!(constructions.load(Ordering::SeqCst), 0);
+
+        let incarnation = mint_actor_incarnation();
+        bind(&mailbox, token, incarnation);
+        let receiver = MailboxReceiver::new(mailbox, incarnation);
+        assert!(receiver.try_recv().is_none(), "no request was submitted");
+    }
+
+    #[crate::runtime::test(start_paused = true)]
+    async fn call_acceptance_timeout_covers_unbound_and_full_mailboxes() {
+        let width = Duration::from_secs(1);
+
+        let (unbound_mailbox, unbound_actor): (
+            Arc<MailboxCell<CallRequest>>,
+            ActorRef<CallRequest>,
+        ) = actor_for();
+        let _token = configure(
+            &unbound_mailbox,
+            ResolvedMailbox::Queue(
+                std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
+            ),
+        );
+        let constructions = Arc::new(AtomicUsize::new(0));
+        let constructed = Arc::clone(&constructions);
+        let mut unbound = Box::pin(unbound_actor.call(
+            move |reply| {
+                constructed.fetch_add(1, Ordering::SeqCst);
+                CallRequest { reply: Some(reply) }
+            },
+            width,
+        ));
+        assert!(poll_once(unbound.as_mut()).is_pending());
+        assert_eq!(constructions.load(Ordering::SeqCst), 1);
+        crate::runtime::advance(width * 2).await;
+        let error = unbound
+            .await
+            .expect_err("an unbound call withdraws before acceptance");
+        assert_eq!(error.kind, CallErrorKind::AcceptanceTimedOut);
+        assert_eq!(error.incarnation_observed, None);
+
+        let (_mailbox, full_actor, incarnation, receiver) = bound_call_actor(1);
+        assert!(matches!(
+            full_actor.try_send(CallRequest { reply: None }),
+            Ok(bound) if bound == incarnation
+        ));
+        let mut full = Box::pin(full_actor.call(|reply| CallRequest { reply: Some(reply) }, width));
+        assert!(poll_once(full.as_mut()).is_pending());
+        crate::runtime::advance(width * 2).await;
+        let error = full
+            .await
+            .expect_err("a call parked behind a full queue withdraws");
+        assert_eq!(error.kind, CallErrorKind::AcceptanceTimedOut);
+        assert_eq!(error.incarnation_observed, Some(incarnation));
+        let filler = receiver.try_recv().expect("the filler remains queued");
+        assert!(filler.reply.is_none());
+        assert!(
+            receiver.try_recv().is_none(),
+            "the timed-out call was withdrawn"
+        );
+
+        let (_mailbox, frozen_actor, incarnation, receiver) = bound_call_actor(1);
+        receiver.freeze();
+        let mut frozen =
+            Box::pin(frozen_actor.call(|reply| CallRequest { reply: Some(reply) }, width));
+        assert!(poll_once(frozen.as_mut()).is_pending());
+        crate::runtime::advance(width * 2).await;
+        let error = frozen
+            .await
+            .expect_err("a call parks while its accepting incarnation is frozen");
+        assert_eq!(error.kind, CallErrorKind::AcceptanceTimedOut);
+        assert_eq!(error.incarnation_observed, Some(incarnation));
+        assert!(
+            receiver.try_recv().is_none(),
+            "the frozen call was withdrawn"
+        );
+    }
+
+    #[crate::runtime::test(start_paused = true)]
+    async fn accepted_call_reports_reply_drop_response_timeout_and_success() {
+        let width = Duration::from_secs(1);
+
+        let (_mailbox, actor, incarnation, receiver) = bound_call_actor(1);
+        let mut success = Box::pin(actor.call(|reply| CallRequest { reply: Some(reply) }, width));
+        assert!(poll_once(success.as_mut()).is_pending());
+        receiver
+            .try_recv()
+            .expect("the successful request was accepted")
+            .reply
+            .expect("a call message carries its reply")
+            .send(7);
+        let replied = success.await.expect("the reply is delivered");
+        assert_eq!(replied.value, 7);
+        assert_eq!(replied.incarnation, incarnation);
+
+        let (_mailbox, actor, incarnation, receiver) = bound_call_actor(1);
+        let mut dropped = Box::pin(actor.call(|reply| CallRequest { reply: Some(reply) }, width));
+        assert!(poll_once(dropped.as_mut()).is_pending());
+        drop(
+            receiver
+                .try_recv()
+                .expect("the dropped-reply request was accepted")
+                .reply,
+        );
+        let error = dropped.await.expect_err("the accepted reply was dropped");
+        assert_eq!(error.kind, CallErrorKind::ReplyDropped);
+        assert_eq!(error.incarnation_observed, Some(incarnation));
+
+        let (_mailbox, actor, incarnation, receiver) = bound_call_actor(1);
+        let mut timed_out = Box::pin(actor.call(|reply| CallRequest { reply: Some(reply) }, width));
+        assert!(poll_once(timed_out.as_mut()).is_pending());
+        let held_reply = receiver
+            .try_recv()
+            .expect("the response-timeout request was accepted")
+            .reply
+            .expect("a call message carries its reply");
+        crate::runtime::advance(width * 2).await;
+        let error = timed_out
+            .await
+            .expect_err("an accepted request can outlive its response budget");
+        assert_eq!(error.kind, CallErrorKind::ResponseTimedOut);
+        assert_eq!(error.incarnation_observed, Some(incarnation));
+        drop(held_reply);
+    }
+
+    #[test]
+    fn terminal_call_reports_the_last_incarnation_without_acceptance() {
+        let (mailbox, actor, incarnation, _receiver) = bound_call_actor(1);
+        drop(close(&mailbox, incarnation));
+        let teardown = prepare_termination(&mailbox).expect("the closed mailbox can terminalize");
+        drop(teardown.finish());
+
+        let mut call = Box::pin(actor.call(
+            |reply| CallRequest { reply: Some(reply) },
+            Duration::from_secs(1),
+        ));
+        let Poll::Ready(Err(error)) = poll_once(call.as_mut()) else {
+            panic!("a terminal mailbox rejects the constructed request immediately")
+        };
+        assert_eq!(error.kind, CallErrorKind::Terminated);
+        assert_eq!(error.incarnation_observed, Some(incarnation));
+    }
+
+    struct ControlledClockRuntime {
+        inner: Arc<dyn MailboxRuntime>,
+        now: Arc<Mutex<Instant>>,
+    }
+
+    impl MailboxRuntime for ControlledClockRuntime {
+        fn oneshot(
+            &self,
+        ) -> (
+            Box<dyn ErasedOneShotSender>,
+            Pin<Box<dyn ErasedOneShotReceiver>>,
+        ) {
+            self.inner.oneshot()
+        }
+
+        fn signal(&self) -> Arc<dyn MailboxSignal> {
+            self.inner.signal()
+        }
+
+        fn dispose(&self, value: Box<dyn Send + 'static>) {
+            self.inner.dispose(value);
+        }
+
+        fn now(&self) -> Instant {
+            *self.now.lock().expect("controlled clock mutex")
+        }
+
+        fn sleep_until(&self, deadline: Option<Instant>) -> BoxedSleep {
+            self.inner.sleep_until(deadline)
+        }
+    }
+
+    struct ConstructionOverdueMessage {
+        _reply: Reply<u8>,
+        disposed: mpsc::Sender<ThreadId>,
+    }
+
+    impl Drop for ConstructionOverdueMessage {
+        fn drop(&mut self) {
+            let _ = self.disposed.send(std::thread::current().id());
+        }
+    }
+
+    #[test]
+    fn construction_that_consumes_the_budget_is_disposed_without_submission() {
+        let start = crate::capability::tests::runtime().now();
+        let clock = Arc::new(Mutex::new(start));
+        let runtime = Arc::new(ControlledClockRuntime {
+            inner: crate::capability::tests::runtime(),
+            now: Arc::clone(&clock),
+        });
+        let (mailbox, actor) = actor_for_with_runtime(runtime);
+        let token = configure(
+            &mailbox,
+            ResolvedMailbox::Queue(
+                std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
+            ),
+        );
+        let (disposed, disposal) = mpsc::channel();
+        let constructions = Arc::new(AtomicUsize::new(0));
+        let constructed = Arc::clone(&constructions);
+        let mut call = Box::pin(actor.call(
+            move |reply| {
+                constructed.fetch_add(1, Ordering::SeqCst);
+                *clock.lock().expect("controlled clock mutex") = start + Duration::from_secs(2);
+                ConstructionOverdueMessage {
+                    _reply: reply,
+                    disposed,
+                }
+            },
+            Duration::from_secs(1),
+        ));
+
+        let Poll::Ready(Err(error)) = poll_once(call.as_mut()) else {
+            panic!("construction that overruns the captured budget times out immediately")
+        };
+        assert_eq!(error.kind, CallErrorKind::AcceptanceTimedOut);
+        assert_eq!(error.incarnation_observed, None);
+        assert_eq!(constructions.load(Ordering::SeqCst), 1);
+        let disposal_thread = disposal
+            .recv_timeout(DISPOSAL_WAIT)
+            .expect("the overdue constructed message reaches isolated disposal");
+        assert_ne!(disposal_thread, std::thread::current().id());
+
+        let incarnation = mint_actor_incarnation();
+        bind(&mailbox, token, incarnation);
+        let receiver = MailboxReceiver::new(mailbox, incarnation);
+        assert!(
+            receiver.try_recv().is_none(),
+            "the overdue request was never submitted"
+        );
+    }
 
     #[derive(Default)]
     struct WakerVtableCalls {

--- a/crates/shelterwood-mailbox/src/futures.rs
+++ b/crates/shelterwood-mailbox/src/futures.rs
@@ -838,11 +838,18 @@ mod tests {
             "the timed-out call was withdrawn"
         );
 
-        let (_mailbox, frozen_actor, incarnation, receiver) = bound_call_actor(1);
+        let (mailbox, frozen_actor, incarnation, receiver) = bound_call_actor(1);
         receiver.freeze();
         let mut frozen =
             Box::pin(frozen_actor.call(|reply| CallRequest { reply: Some(reply) }, width));
         assert!(poll_once(frozen.as_mut()).is_pending());
+        // A frozen submission parks as a waiter and never enters the queue,
+        // so `try_recv` reads `None` whether or not the withdrawal happened.
+        // The waiter list is the artifact the withdrawal actually unlinks.
+        assert!(
+            !frozen_waiters_empty(&mailbox),
+            "the frozen call parks as a waiter"
+        );
         crate::runtime::advance(width * 2).await;
         let error = frozen
             .await
@@ -850,9 +857,21 @@ mod tests {
         assert_eq!(error.kind, CallErrorKind::AcceptanceTimedOut);
         assert_eq!(error.incarnation_observed, Some(incarnation));
         assert!(
-            receiver.try_recv().is_none(),
+            frozen_waiters_empty(&mailbox),
             "the frozen call was withdrawn"
         );
+    }
+
+    /// Reports whether a frozen mailbox holds any parked waiter, read
+    /// through the state guard the way `MailboxState::waiters` intends.
+    fn frozen_waiters_empty(mailbox: &MailboxCell<CallRequest>) -> bool {
+        mailbox
+            .state
+            .lock()
+            .expect("mailbox mutex poisoned")
+            .waiters()
+            .expect("a frozen mailbox owns its parked waiters")
+            .is_empty()
     }
 
     #[crate::runtime::test(start_paused = true)]

--- a/crates/shelterwood-mailbox/src/reply.rs
+++ b/crates/shelterwood-mailbox/src/reply.rs
@@ -152,7 +152,112 @@ impl<T: Send + 'static> DeadlineOperation for ReplyOperation<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::cell::tests::actor;
+    use std::{
+        future::Future,
+        pin::Pin,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+        task::{Context, Poll, Wake, Waker},
+        time::{Duration, Instant},
+    };
+
+    use crate::{
+        BoxedSleep, ErasedOneShotClose, ErasedOneShotReceiver, ErasedOneShotSender, ErasedValue,
+        MailboxRuntime, MailboxSignal,
+    };
+
+    use super::super::cell::tests::{actor, actor_for_with_runtime};
+
+    struct RejectingSender;
+
+    impl ErasedOneShotSender for RejectingSender {
+        fn send(self: Box<Self>, value: ErasedValue) -> Result<(), ErasedValue> {
+            Err(value)
+        }
+    }
+
+    struct StagedReceiver(crate::runtime::OneShotReceiver<ErasedValue>);
+
+    impl ErasedOneShotReceiver for StagedReceiver {
+        fn poll_receive(
+            mut self: Pin<&mut Self>,
+            context: &mut Context<'_>,
+        ) -> Poll<Option<ErasedValue>> {
+            self.0.poll_receive(context)
+        }
+
+        fn close_and_poll_receive(
+            mut self: Pin<&mut Self>,
+            context: &mut Context<'_>,
+        ) -> ErasedOneShotClose {
+            match self.0.close_and_poll_receive(context) {
+                crate::runtime::OneShotClose::Value(value) => ErasedOneShotClose::Value(value),
+                crate::runtime::OneShotClose::SenderClosed => ErasedOneShotClose::SenderClosed,
+                crate::runtime::OneShotClose::Empty => ErasedOneShotClose::Empty,
+                crate::runtime::OneShotClose::Pending => ErasedOneShotClose::Pending,
+            }
+        }
+
+        fn close(mut self: Pin<&mut Self>) {
+            self.0.close();
+        }
+
+        fn close_and_take(mut self: Pin<&mut Self>) -> Option<ErasedValue> {
+            self.0.close_and_take()
+        }
+    }
+
+    struct StagedReplyRuntime {
+        inner: Arc<dyn MailboxRuntime>,
+        publisher: Mutex<Option<crate::runtime::OneShotSending<ErasedValue>>>,
+    }
+
+    impl MailboxRuntime for StagedReplyRuntime {
+        fn oneshot(
+            &self,
+        ) -> (
+            Box<dyn ErasedOneShotSender>,
+            Pin<Box<dyn ErasedOneShotReceiver>>,
+        ) {
+            let (publisher, receiver) = crate::runtime::oneshot_sending_for_test();
+            let displaced = self
+                .publisher
+                .lock()
+                .expect("staged reply publisher mutex")
+                .replace(publisher);
+            assert!(displaced.is_none(), "the test creates one reply channel");
+            (
+                Box::new(RejectingSender),
+                Box::pin(StagedReceiver(receiver)),
+            )
+        }
+
+        fn signal(&self) -> Arc<dyn MailboxSignal> {
+            self.inner.signal()
+        }
+
+        fn dispose(&self, value: Box<dyn Send + 'static>) {
+            self.inner.dispose(value);
+        }
+
+        fn now(&self) -> Instant {
+            self.inner.now()
+        }
+
+        fn sleep_until(&self, deadline: Option<Instant>) -> BoxedSleep {
+            self.inner.sleep_until(deadline)
+        }
+    }
+
+    struct CountWake(Arc<AtomicUsize>);
+
+    impl Wake for CountWake {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
 
     #[test]
     fn reply_debug_still_reports_the_derived_unanswered_state() {
@@ -193,5 +298,49 @@ mod tests {
         let (reply, receiver) = actor.reply_channel::<u8>();
         drop(receiver);
         reply.send(9);
+    }
+
+    #[crate::runtime::test(start_paused = true)]
+    async fn timeout_arbitration_waits_for_a_winning_send_to_publish() {
+        let runtime = Arc::new(StagedReplyRuntime {
+            inner: crate::capability::tests::runtime(),
+            publisher: Mutex::new(None),
+        });
+        let (_, actor) = actor_for_with_runtime::<()>(runtime.clone());
+        let (reply, receiver) = actor.reply_channel::<u8>();
+        let width = Duration::from_secs(1);
+        let mut receive = Box::pin(receiver.recv(width));
+        assert!(
+            receive
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+
+        crate::runtime::advance(width * 2).await;
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let waker = Waker::from(Arc::new(CountWake(Arc::clone(&wakes))));
+        assert!(
+            receive
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending(),
+            "OneShotClose::Pending defers the timeout verdict"
+        );
+        let publisher = runtime
+            .publisher
+            .lock()
+            .expect("staged reply publisher mutex")
+            .take()
+            .expect("reply channel installed its publisher");
+        publisher
+            .publish(Box::new(7_u8))
+            .unwrap_or_else(|_| panic!("the staged receiver remains live"));
+        assert_eq!(wakes.load(Ordering::SeqCst), 1);
+        assert!(matches!(
+            receive.as_mut().poll(&mut Context::from_waker(&waker)),
+            Poll::Ready(Ok(7))
+        ));
+        drop(reply);
     }
 }

--- a/crates/shelterwood-runtime/src/disposal.rs
+++ b/crates/shelterwood-runtime/src/disposal.rs
@@ -370,12 +370,12 @@ pub fn dispose_all<T: Send + 'static>(values: Vec<T>) -> Latch {
 mod tests {
     use std::{
         sync::{
-            Arc, Mutex,
+            Arc, Condvar, Mutex,
             atomic::{AtomicBool, AtomicUsize, Ordering},
             mpsc,
         },
         thread::{self, ThreadId},
-        time::Duration,
+        time::{Duration, Instant},
     };
 
     use super::{
@@ -530,6 +530,104 @@ mod tests {
         let rejected = DisposalJob::new((), |_| {});
         let completed = DisposalJob::new((), |_| {});
         assert_blocking_pool_outcomes(accepted, rejected, completed);
+    }
+
+    struct AggregateDrop {
+        id: u8,
+        dropped: mpsc::Sender<u8>,
+        gate: Option<Arc<(Mutex<bool>, Condvar)>>,
+        panic: bool,
+    }
+
+    impl Drop for AggregateDrop {
+        fn drop(&mut self) {
+            let _ = self.dropped.send(self.id);
+            if let Some(gate) = &self.gate {
+                let (released, wake) = &**gate;
+                let mut released = released.lock().expect("aggregate gate remains healthy");
+                let deadline = Instant::now() + DESTRUCTOR_ESCAPE;
+                while !*released {
+                    let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                        break;
+                    };
+                    released = wake
+                        .wait_timeout(released, remaining)
+                        .expect("aggregate gate remains healthy")
+                        .0;
+                }
+            }
+            assert!(!self.panic, "injected aggregate destructor panic");
+        }
+    }
+
+    #[test]
+    fn dispose_all_empty_fires_synchronously() {
+        let completion = super::dispose_all::<u8>(Vec::new());
+        assert!(completion.is_fired());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dispose_all_fires_only_after_every_value_finishes() {
+        let (dropped, dropped_rx) = mpsc::channel();
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let values = (0_u8..3)
+            .map(|id| AggregateDrop {
+                id,
+                dropped: dropped.clone(),
+                gate: (id == 2).then(|| Arc::clone(&gate)),
+                panic: false,
+            })
+            .collect();
+        let completion = super::dispose_all(values);
+
+        let mut observed = Vec::new();
+        for _ in 0..3 {
+            observed.push(
+                dropped_rx
+                    .recv_timeout(Duration::from_secs(1))
+                    .expect("every destructor starts"),
+            );
+        }
+        observed.sort_unstable();
+        assert_eq!(observed, [0, 1, 2]);
+        assert!(matches!(
+            crate::timeout(Duration::from_millis(100), completion.fired()).await,
+            crate::Timeout::Elapsed
+        ));
+        release(&gate);
+        assert!(matches!(
+            crate::timeout(Duration::from_secs(1), completion.fired()).await,
+            crate::Timeout::Completed(())
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dispose_all_contains_one_panic_and_completes_the_rest() {
+        let (dropped, dropped_rx) = mpsc::channel();
+        let values = (0_u8..3)
+            .map(|id| AggregateDrop {
+                id,
+                dropped: dropped.clone(),
+                gate: None,
+                panic: id == 1,
+            })
+            .collect();
+        let completion = super::dispose_all(values);
+
+        assert!(matches!(
+            crate::timeout(Duration::from_secs(1), completion.fired()).await,
+            crate::Timeout::Completed(())
+        ));
+        let mut observed = Vec::new();
+        for _ in 0..3 {
+            observed.push(
+                dropped_rx
+                    .recv_timeout(Duration::from_secs(1))
+                    .expect("one panicking destructor cannot suppress another"),
+            );
+        }
+        observed.sort_unstable();
+        assert_eq!(observed, [0, 1, 2]);
     }
 
     struct DisposeOnDrop {

--- a/crates/shelterwood-runtime/src/mailbox.rs
+++ b/crates/shelterwood-runtime/src/mailbox.rs
@@ -116,3 +116,179 @@ impl MailboxSignalWatcher for TokioSignalWatcher {
         Box::pin(self.0.changed())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+            mpsc,
+        },
+        task::{Context, Poll, Wake, Waker},
+        thread::ThreadId,
+        time::Duration,
+    };
+
+    use shelterwood_mailbox::{ErasedOneShotClose, ErasedOneShotReceiver, ErasedValue};
+
+    use super::{TokioOneShotReceiver, mailbox_runtime};
+
+    struct CountWake(Arc<AtomicUsize>);
+
+    impl Wake for CountWake {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct RecordDrop(mpsc::Sender<ThreadId>);
+
+    impl Drop for RecordDrop {
+        fn drop(&mut self) {
+            let _ = self.0.send(std::thread::current().id());
+        }
+    }
+
+    #[test]
+    fn adapter_oneshot_maps_value_sender_close_receiver_close_and_pending_send() {
+        let runtime = mailbox_runtime();
+        let mut context = Context::from_waker(Waker::noop());
+
+        let (sender, mut receiver) = runtime.oneshot();
+        sender
+            .send(Box::new(7_u8))
+            .unwrap_or_else(|_| panic!("the adapter receiver is live"));
+        let Poll::Ready(Some(value)) = receiver.as_mut().poll_receive(&mut context) else {
+            panic!("the adapter publishes the sent value")
+        };
+        assert_eq!(*value.downcast::<u8>().expect("value type is preserved"), 7);
+
+        let (sender, mut receiver) = runtime.oneshot();
+        drop(sender);
+        assert!(matches!(
+            receiver.as_mut().close_and_poll_receive(&mut context),
+            ErasedOneShotClose::SenderClosed
+        ));
+
+        let (sender, mut receiver) = runtime.oneshot();
+        assert!(matches!(
+            receiver.as_mut().close_and_poll_receive(&mut context),
+            ErasedOneShotClose::Empty
+        ));
+        assert!(sender.send(Box::new(8_u8)).is_err());
+
+        let (sender, mut receiver) = runtime.oneshot();
+        receiver.as_mut().close();
+        assert!(sender.send(Box::new(9_u8)).is_err());
+
+        let (sender, mut receiver) = runtime.oneshot();
+        sender
+            .send(Box::new(10_u8))
+            .unwrap_or_else(|_| panic!("the adapter receiver is live"));
+        let value = receiver
+            .as_mut()
+            .close_and_take()
+            .expect("close-and-take recovers an already published value");
+        assert_eq!(
+            *value.downcast::<u8>().expect("value type is preserved"),
+            10
+        );
+
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let waker = Waker::from(Arc::new(CountWake(Arc::clone(&wakes))));
+        let mut context = Context::from_waker(&waker);
+        let (sending, receiver) = crate::oneshot_sending_for_test::<ErasedValue>();
+        let mut receiver = Box::pin(TokioOneShotReceiver(receiver));
+        assert!(matches!(
+            ErasedOneShotReceiver::close_and_poll_receive(receiver.as_mut(), &mut context),
+            ErasedOneShotClose::Pending
+        ));
+        sending
+            .publish(Box::new(11_u8))
+            .unwrap_or_else(|_| panic!("the staged adapter receiver remains live"));
+        assert_eq!(wakes.load(Ordering::SeqCst), 1);
+        let ErasedOneShotClose::Value(value) =
+            ErasedOneShotReceiver::close_and_poll_receive(receiver.as_mut(), &mut context)
+        else {
+            panic!("the adapter returns the value after staged publication")
+        };
+        assert_eq!(
+            *value.downcast::<u8>().expect("value type is preserved"),
+            11
+        );
+    }
+
+    #[test]
+    fn adapter_signal_wakes_an_already_parked_watcher() {
+        let signal = mailbox_runtime().signal();
+        let mut watcher = signal.watcher();
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let waker = Waker::from(Arc::new(CountWake(Arc::clone(&wakes))));
+        let mut changed = watcher.changed();
+
+        assert!(
+            changed
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending()
+        );
+        signal.pulse();
+        assert_eq!(wakes.load(Ordering::SeqCst), 1);
+        assert!(
+            changed
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_ready()
+        );
+    }
+
+    #[test]
+    fn adapter_disposal_runs_on_an_isolated_thread() {
+        let caller = std::thread::current().id();
+        let (dropped, dropped_rx) = mpsc::channel();
+        mailbox_runtime().dispose(Box::new(RecordDrop(dropped)));
+
+        let destructor = dropped_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("adapter disposal destroys the value");
+        assert_ne!(destructor, caller);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn adapter_clock_and_sleep_follow_the_runtime_clock() {
+        let runtime = mailbox_runtime();
+        let now = runtime.now();
+        assert_eq!(now, crate::now());
+
+        let mut bounded = runtime.sleep_until(Some(now + Duration::from_secs(1)));
+        assert!(
+            bounded
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert!(
+            bounded
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_ready()
+        );
+
+        let mut absent = runtime.sleep_until(None);
+        assert!(
+            absent
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert!(
+            absent
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+    }
+}

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -667,6 +667,75 @@ mod tests {
         assert_eq!(control_receiver.try_recv(), Some(0));
     }
 
+    #[tokio::test]
+    async fn scope_wait_reports_parent_shutdown_directly() {
+        let (_sender, mut receiver) = super::unbounded_mpsc::<()>();
+        let wake = super::wait_scope(
+            super::ScopeWait {
+                signal: std::future::pending(),
+                parent_shutdown: std::future::ready(()),
+            },
+            &mut receiver,
+            None,
+            None,
+        )
+        .await;
+
+        assert!(matches!(wake, super::ScopeWake::ParentShutdown));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn scope_wait_reports_deadline_and_keeps_an_absent_deadline_pending() {
+        let (_sender, mut receiver) = super::unbounded_mpsc::<()>();
+        let deadline = crate::now() + Duration::from_secs(10);
+        let wake = super::wait_scope(
+            super::ScopeWait {
+                signal: std::future::pending(),
+                parent_shutdown: std::future::pending(),
+            },
+            &mut receiver,
+            None,
+            Some(deadline),
+        )
+        .await;
+        assert!(matches!(wake, super::ScopeWake::Deadline));
+
+        let (sender, mut receiver) = super::unbounded_mpsc();
+        let mut waiting = Box::pin(super::wait_scope(
+            super::ScopeWait {
+                signal: std::future::pending(),
+                parent_shutdown: std::future::pending(),
+            },
+            &mut receiver,
+            None,
+            None,
+        ));
+        assert!(
+            waiting
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        assert!(sender.send(7_u8).is_ok());
+        assert!(matches!(waiting.await, super::ScopeWake::Message(Some(7))));
+    }
+
+    #[tokio::test]
+    async fn select_two_covers_both_sides_and_biases_ready_ties_left() {
+        assert!(matches!(
+            super::select_two(std::future::ready(1_u8), std::future::pending::<u8>()).await,
+            super::Either::Left(1)
+        ));
+        assert!(matches!(
+            super::select_two(std::future::pending::<u8>(), std::future::ready(2_u8)).await,
+            super::Either::Right(2)
+        ));
+        assert!(matches!(
+            super::select_two(std::future::ready(3_u8), std::future::ready(4_u8)).await,
+            super::Either::Left(3)
+        ));
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn blocking_work_preserves_values_and_panics() {
         assert_eq!(super::spawn_blocking_work(|| 42_u8).await, 42);

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -684,6 +684,79 @@ mod tests {
         assert!(matches!(wake, super::ScopeWake::ParentShutdown));
     }
 
+    /// Each arm alone only pins its own `ScopeWake` mapping; the `biased;`
+    /// precedence is a property of ties. Walk the chain
+    /// `signal > parent_shutdown > message > control > deadline` with every
+    /// weaker arm simultaneously ready, so dropping `biased;` cannot pass.
+    #[tokio::test]
+    async fn scope_wait_resolves_simultaneous_arms_in_declaration_order() {
+        let elapsed = crate::now();
+        let (sender, mut receiver) = super::unbounded_mpsc();
+        let (control_sender, mut control_receiver) = super::unbounded_mpsc();
+        assert!(sender.send(1_u8).is_ok());
+        assert!(control_sender.send(2_u8).is_ok());
+
+        let wake = super::wait_scope(
+            super::ScopeWait {
+                signal: std::future::ready(()),
+                parent_shutdown: std::future::ready(()),
+            },
+            &mut receiver,
+            Some(&mut control_receiver),
+            Some(elapsed),
+        )
+        .await;
+        assert!(matches!(wake, super::ScopeWake::Signal));
+
+        let wake = super::wait_scope(
+            super::ScopeWait {
+                signal: std::future::pending(),
+                parent_shutdown: std::future::ready(()),
+            },
+            &mut receiver,
+            Some(&mut control_receiver),
+            Some(elapsed),
+        )
+        .await;
+        assert!(matches!(wake, super::ScopeWake::ParentShutdown));
+
+        let wake = super::wait_scope(
+            super::ScopeWait {
+                signal: std::future::pending(),
+                parent_shutdown: std::future::pending(),
+            },
+            &mut receiver,
+            Some(&mut control_receiver),
+            Some(elapsed),
+        )
+        .await;
+        assert!(matches!(wake, super::ScopeWake::Message(Some(1))));
+
+        let wake = super::wait_scope(
+            super::ScopeWait {
+                signal: std::future::pending(),
+                parent_shutdown: std::future::pending(),
+            },
+            &mut receiver,
+            Some(&mut control_receiver),
+            Some(elapsed),
+        )
+        .await;
+        assert!(matches!(wake, super::ScopeWake::ControlMessage(Some(2))));
+
+        let wake = super::wait_scope(
+            super::ScopeWait {
+                signal: std::future::pending(),
+                parent_shutdown: std::future::pending(),
+            },
+            &mut receiver,
+            Some(&mut control_receiver),
+            Some(elapsed),
+        )
+        .await;
+        assert!(matches!(wake, super::ScopeWake::Deadline));
+    }
+
     #[tokio::test(start_paused = true)]
     async fn scope_wait_reports_deadline_and_keeps_an_absent_deadline_pending() {
         let (_sender, mut receiver) = super::unbounded_mpsc::<()>();

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -402,6 +402,54 @@ pub fn oneshot<T>() -> (OneShotSender<T>, OneShotReceiver<T>) {
     )
 }
 
+/// Test-only publication half for staging the `ONESHOT_SENDING` window.
+#[cfg(any(test, feature = "test-util"))]
+#[doc(hidden)]
+pub struct OneShotSending<T> {
+    channel: Option<oneshot::Sender<T>>,
+    state: Arc<AtomicU8>,
+}
+
+/// Builds a one-shot whose send transition has won but whose value has not
+/// been published yet.
+#[cfg(any(test, feature = "test-util"))]
+#[doc(hidden)]
+pub fn oneshot_sending_for_test<T>() -> (OneShotSending<T>, OneShotReceiver<T>) {
+    let (channel, receiver) = oneshot::channel();
+    let state = Arc::new(AtomicU8::new(ONESHOT_SENDING));
+    (
+        OneShotSending {
+            channel: Some(channel),
+            state: Arc::clone(&state),
+        },
+        OneShotReceiver {
+            channel: receiver,
+            state,
+        },
+    )
+}
+
+#[cfg(any(test, feature = "test-util"))]
+impl<T> OneShotSending<T> {
+    /// Publishes the value and completes the staged send transition.
+    pub fn publish(mut self, value: T) -> Result<(), T> {
+        let channel = self
+            .channel
+            .take()
+            .expect("a staged one-shot send publishes at most once");
+        match channel.send(value) {
+            Ok(()) => {
+                self.state.store(ONESHOT_SENT, Ordering::Release);
+                Ok(())
+            }
+            Err(value) => {
+                self.state.store(ONESHOT_RECEIVER_CLOSED, Ordering::Release);
+                Err(value)
+            }
+        }
+    }
+}
+
 impl<T> OneShotSender<T> {
     pub fn send(mut self, value: T) -> Result<(), T> {
         if self
@@ -971,8 +1019,8 @@ mod tests {
     };
 
     use crate::{
-        CompletionGatedLatch, JoinOutcome, Latch, OneShotClose, Signal, Timeout, join, oneshot,
-        spawn, timeout, yield_now,
+        BroadcastReceive, CompletionGatedLatch, JoinOutcome, Latch, OneShotClose, Signal, Timeout,
+        broadcast, join, oneshot, oneshot_sending_for_test, spawn, timeout, yield_now,
     };
 
     struct CountWake(Arc<AtomicUsize>);
@@ -1039,6 +1087,87 @@ mod tests {
             OneShotClose::Empty
         ));
         assert_eq!(sender.send(1), Err(1));
+    }
+
+    #[test]
+    fn closing_oneshot_waits_for_a_send_that_won_before_publication() {
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let waker = Waker::from(Arc::new(CountWake(Arc::clone(&wakes))));
+        let mut context = Context::from_waker(&waker);
+        let (sending, mut receiver) = oneshot_sending_for_test();
+
+        assert!(matches!(
+            receiver.close_and_poll_receive(&mut context),
+            OneShotClose::Pending
+        ));
+        sending.publish(7_u8).expect("the staged receiver is live");
+        assert_eq!(wakes.load(Ordering::SeqCst), 1);
+        assert!(matches!(
+            receiver.close_and_poll_receive(&mut context),
+            OneShotClose::Value(7)
+        ));
+    }
+
+    #[test]
+    fn broadcast_wrapper_maps_items_empty_close_and_exact_lag() {
+        let (sender, mut receiver) = broadcast(2);
+        assert!(matches!(receiver.try_receive(), BroadcastReceive::Empty));
+        assert_eq!(sender.send(0_u8), Ok(1));
+        assert!(matches!(receiver.try_receive(), BroadcastReceive::Item(0)));
+
+        for value in 1_u8..=5 {
+            assert_eq!(sender.send(value), Ok(1));
+        }
+        assert!(matches!(
+            receiver.try_receive(),
+            BroadcastReceive::Lagged(3)
+        ));
+        assert!(matches!(receiver.try_receive(), BroadcastReceive::Item(4)));
+        assert!(matches!(receiver.try_receive(), BroadcastReceive::Item(5)));
+        assert!(matches!(receiver.try_receive(), BroadcastReceive::Empty));
+        drop(sender);
+        assert!(matches!(receiver.try_receive(), BroadcastReceive::Closed));
+    }
+
+    #[test]
+    fn signal_pulse_wakes_a_parked_watcher_and_advances_generations() {
+        let signal = Signal::default();
+        let mut watcher = signal.watcher();
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let waker = Waker::from(Arc::new(CountWake(Arc::clone(&wakes))));
+
+        let mut first = Box::pin(watcher.changed());
+        assert!(
+            first
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending()
+        );
+        signal.pulse();
+        assert_eq!(wakes.load(Ordering::SeqCst), 1);
+        assert!(
+            first
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_ready()
+        );
+        drop(first);
+
+        let mut second = Box::pin(watcher.changed());
+        assert!(
+            second
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending()
+        );
+        signal.pulse();
+        assert_eq!(wakes.load(Ordering::SeqCst), 2);
+        assert!(
+            second
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_ready()
+        );
     }
 
     #[test]

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -437,15 +437,26 @@ impl<T> OneShotSending<T> {
             .channel
             .take()
             .expect("a staged one-shot send publishes at most once");
-        match channel.send(value) {
-            Ok(()) => {
-                self.state.store(ONESHOT_SENT, Ordering::Release);
-                Ok(())
-            }
-            Err(value) => {
-                self.state.store(ONESHOT_RECEIVER_CLOSED, Ordering::Release);
-                Err(value)
-            }
+        publish_oneshot(channel, &self.state, value)
+    }
+}
+
+/// Publishes into a one-shot channel whose `ONESHOT_SENDING` window the
+/// caller already owns, then closes that window with the outcome.
+///
+/// `OneShotSender::send` and the staged `OneShotSending::publish` differ only
+/// in how they enter the window — `send` wins it with a CAS from
+/// `ONESHOT_OPEN`, the test half is constructed inside it — so they share the
+/// tail rather than restating it.
+fn publish_oneshot<T>(channel: oneshot::Sender<T>, state: &AtomicU8, value: T) -> Result<(), T> {
+    match channel.send(value) {
+        Ok(()) => {
+            state.store(ONESHOT_SENT, Ordering::Release);
+            Ok(())
+        }
+        Err(value) => {
+            state.store(ONESHOT_RECEIVER_CLOSED, Ordering::Release);
+            Err(value)
         }
     }
 }
@@ -468,16 +479,7 @@ impl<T> OneShotSender<T> {
             .channel
             .take()
             .expect("a live one-shot sender retains its channel");
-        match sender.send(value) {
-            Ok(()) => {
-                self.state.store(ONESHOT_SENT, Ordering::Release);
-                Ok(())
-            }
-            Err(value) => {
-                self.state.store(ONESHOT_RECEIVER_CLOSED, Ordering::Release);
-                Err(value)
-            }
-        }
+        publish_oneshot(sender, &self.state, value)
     }
 
     pub fn is_closed(&self) -> bool {


### PR DESCRIPTION
Part of #283 and the #284 behavioral-pinning sequence.

Adds direct, mutation-checked coverage for:

- mailbox freeze/close, accepted-sequence boundaries, termination/withdrawal, and the complete call-future state matrix;
- runtime disposal aggregation/isolation, wait/select semantics, broadcast/signal behavior, and every mailbox-adapter operation;
- idle hard-force, framework-abort acknowledgement, premature readiness deadlines, and exact stop precedence.

The only non-test seam is a hidden test-util staged one-shot helper needed to deterministically reach `ONESHOT_SENDING`. Hostile multi-waker coverage remains in #265–#267 as the tracker assigns.

Mutation checks killed early completion, boundary exclusivity, frozen-live-read, idle-force, abort phase, readiness, precedence, pending-reply, and overdue-submission mutants.

Validation: core 80/80, runtime 47/47, mailbox 38/38, and `./tools/dev just ci` passed with 700/700 tests plus all formatting, documentation, API, external-consumer, and Nix lanes.

Stack: based on #296 / issue #281.