### PR TITLE
Contain waiter notification and separate shutdown edges

### DIFF
--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -1324,6 +1324,28 @@ mod tests {
         }
     }
 
+    #[test]
+    fn a_panicking_watch_closure_leaves_the_channel_usable() {
+        let (sender, mut receiver) = super::watch(0u8);
+        let panicked = catch_unwind(AssertUnwindSafe(|| {
+            sender.modify_silently(|value| {
+                *value = 1;
+                panic!("injected watch mutation panic");
+            });
+        }));
+        assert!(panicked.is_err());
+
+        // The guard is poisoned; every later reader must still see the
+        // surviving framework state rather than inheriting the panic.
+        assert_eq!(sender.read_cloned(), 1);
+        assert_eq!(sender.read_with(|value| *value), 1);
+        assert_eq!(receiver.borrow_cloned(), 1);
+        assert_eq!(receiver.borrow_and_update_cloned(), 1);
+        sender.modify_silently(|value| *value = 2);
+        sender.pulse();
+        assert_eq!(receiver.borrow_cloned(), 2);
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn all_pre_fire_waiters_wake() {
         const WAITERS: usize = 32;

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -1,15 +1,108 @@
 use std::{
     fmt,
+    future::Future,
     pin::Pin,
     sync::{
-        Arc,
-        atomic::{AtomicBool, AtomicU8, Ordering},
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering},
     },
+    task::{Context, Poll, Waker},
 };
 
-use tokio::sync::{Notify, broadcast, oneshot, watch};
+use tokio::sync::{broadcast, oneshot};
 
-use super::dispose_detached;
+use super::{PanicAccumulator, dispose_detached};
+
+/// A caller-waker registry whose lock protects only inert storage changes.
+///
+/// Registration clones happen before entering the registry. Removal and
+/// draining only move wakers out; their vtables run after unlock, one behind
+/// each accumulator boundary. The opaque identity is retained by its waiter,
+/// so its `Arc` traffic under the lock cannot destroy even framework data.
+#[derive(Default)]
+struct WaiterRegistry {
+    waiters: Mutex<Vec<RegisteredWaker>>,
+}
+
+struct RegisteredWaker {
+    identity: Arc<()>,
+    waker: Waker,
+}
+
+impl WaiterRegistry {
+    fn register(&self, identity: &Arc<()>, waker: Waker) -> Option<RegisteredWaker> {
+        let mut waiters = self
+            .waiters
+            .lock()
+            .expect("waiter registry lock is never held across caller code");
+        if let Some(index) = waiters
+            .iter()
+            .position(|waiter| Arc::ptr_eq(&waiter.identity, identity))
+        {
+            Some(std::mem::replace(
+                &mut waiters[index],
+                RegisteredWaker {
+                    identity: Arc::clone(identity),
+                    waker,
+                },
+            ))
+        } else {
+            waiters.push(RegisteredWaker {
+                identity: Arc::clone(identity),
+                waker,
+            });
+            None
+        }
+    }
+
+    fn remove(&self, identity: &Arc<()>) -> Option<RegisteredWaker> {
+        let mut waiters = self
+            .waiters
+            .lock()
+            .expect("waiter registry lock is never held across caller code");
+        waiters
+            .iter()
+            .position(|waiter| Arc::ptr_eq(&waiter.identity, identity))
+            .map(|index| waiters.swap_remove(index))
+    }
+
+    fn wake_all(&self) {
+        let waiters = {
+            let mut waiters = self
+                .waiters
+                .lock()
+                .expect("waiter registry lock is never held across caller code");
+            std::mem::take(&mut *waiters)
+        };
+        let mut panics = PanicAccumulator::default();
+        for RegisteredWaker { waker, .. } in waiters {
+            panics.run(|| waker.wake());
+        }
+    }
+
+    fn drop_registered(waiters: impl IntoIterator<Item = Option<RegisteredWaker>>) {
+        let mut panics = PanicAccumulator::default();
+        for waiter in waiters.into_iter().flatten() {
+            panics.run(|| drop(waiter));
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.waiters
+            .lock()
+            .expect("waiter registry lock is never held across caller code")
+            .len()
+    }
+}
+
+impl fmt::Debug for WaiterRegistry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WaiterRegistry")
+            .field("waiters", &self.len())
+            .finish()
+    }
+}
 
 #[derive(Debug)]
 pub struct Signal {
@@ -56,14 +149,13 @@ impl SignalWatcher {
         self.inner.changed().await;
     }
 }
-/// A one-shot, multi-waiter signal backed by Tokio's waiter queue.
+/// A one-shot, multi-waiter signal backed by a contained waiter registry.
 ///
 /// The atomic provides a linearizable, idempotent transition and retains the
-/// fired state for future waiters. [`Notify`] wakes the waiters that already
-/// exist and removes cancelled waits from its intrusive queue. Creating the
-/// notification before rechecking the atomic is essential: Tokio guarantees
-/// that such a notification observes a subsequent `notify_waiters`, even when
-/// it has not been polled yet.
+/// fired state for future waiters. A wait registers before rechecking that
+/// state, so it either observes the transition or is present in the registry
+/// drained by the publisher. Each drained waker runs independently after the
+/// registry lock is released.
 ///
 /// This deliberately does not use `tokio_util::sync::CancellationToken`.
 /// Shelterwood also uses latches for readiness and completion, needs `fire` to
@@ -80,7 +172,7 @@ pub struct Latch {
 #[derive(Debug, Default)]
 struct LatchState {
     fired: AtomicBool,
-    notify: Notify,
+    waiters: WaiterRegistry,
 }
 
 impl Latch {
@@ -98,11 +190,9 @@ impl Latch {
     /// Splitting the transition from the wake lets an observation-gate
     /// transaction linearize the fire inside its critical section while
     /// deferring the waker-visible [`Self::notify`] until after the gate is
-    /// released. Deferral cannot strand a waiter: [`Self::fired`] rechecks
-    /// `is_fired` after creating its notification, so a waiter either
-    /// observes the committed transition directly or holds a notification
-    /// created before the deferred `notify_waiters`, which Tokio guarantees
-    /// to be observed even when it has not been polled yet.
+    /// released. Deferral cannot strand a waiter: [`Self::fired`] registers
+    /// before rechecking `is_fired`, so a waiter either observes the committed
+    /// transition directly or is present for the deferred drain.
     pub fn fire_silently(&self) -> bool {
         self.state
             .fired
@@ -116,24 +206,60 @@ impl Latch {
     /// won `fire_silently` inside an observation-gate transaction defer this
     /// wake past the gate release.
     pub fn notify(&self) {
-        self.state.notify.notify_waiters();
+        self.state.waiters.wake_all();
     }
 
     pub fn is_fired(&self) -> bool {
         self.state.fired.load(Ordering::Acquire)
     }
 
-    pub async fn fired(&self) {
-        if self.is_fired() {
-            return;
+    pub fn fired(&self) -> LatchWait<'_> {
+        LatchWait {
+            latch: self,
+            identity: Arc::new(()),
+        }
+    }
+}
+
+/// Future returned by [`Latch::fired`].
+pub struct LatchWait<'a> {
+    latch: &'a Latch,
+    identity: Arc<()>,
+}
+
+impl Future for LatchWait<'_> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        if this.latch.is_fired() {
+            let registered = this.latch.state.waiters.remove(&this.identity);
+            WaiterRegistry::drop_registered([registered]);
+            return Poll::Ready(());
         }
 
-        let notified = self.state.notify.notified();
-        if self.is_fired() {
-            return;
+        // Caller code runs before the registry lock is acquired.
+        let waker = context.waker().clone();
+        let displaced = this.latch.state.waiters.register(&this.identity, waker);
+        let fired = this.latch.is_fired();
+        let registered = fired
+            .then(|| this.latch.state.waiters.remove(&this.identity))
+            .flatten();
+        // Finish the register/recheck protocol before a hostile displaced
+        // waker destructor is allowed to resume its panic.
+        WaiterRegistry::drop_registered([displaced, registered]);
+        if fired {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
         }
-        notified.await;
-        debug_assert!(self.is_fired());
+    }
+}
+
+impl Drop for LatchWait<'_> {
+    fn drop(&mut self) {
+        let registered = self.latch.state.waiters.remove(&self.identity);
+        WaiterRegistry::drop_registered([registered]);
     }
 }
 
@@ -460,40 +586,95 @@ impl<T> Drop for DisposingReceiver<T> {
     }
 }
 
+/// Shared state for the framework's conflating watch channel.
+///
+/// The value lock never contains wakers. Versions and endpoint counts are
+/// atomic so waiter registration can use the same register/recheck protocol
+/// as [`Latch`] without nesting locks.
+struct WatchShared<T> {
+    value: Mutex<T>,
+    version: AtomicU64,
+    senders: AtomicUsize,
+    receivers: AtomicUsize,
+    waiters: WaiterRegistry,
+}
+
 /// Publishing half of a runtime-backed conflating state channel.
-pub struct WatchSender<T>(watch::Sender<T>);
+pub struct WatchSender<T> {
+    shared: Arc<WatchShared<T>>,
+}
 
 /// Observing half of a runtime-backed conflating state channel.
-pub struct WatchReceiver<T>(watch::Receiver<T>);
+pub struct WatchReceiver<T> {
+    shared: Arc<WatchShared<T>>,
+    seen: u64,
+}
+
+fn retain_endpoint(counter: &AtomicUsize, endpoint: &str) {
+    counter
+        .try_update(Ordering::Relaxed, Ordering::Relaxed, |count| {
+            count.checked_add(1)
+        })
+        .unwrap_or_else(|_| panic!("{endpoint} count exhausted"));
+}
 
 impl<T> Clone for WatchSender<T> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        retain_endpoint(&self.shared.senders, "watch sender");
+        Self {
+            shared: Arc::clone(&self.shared),
+        }
+    }
+}
+
+impl<T> Drop for WatchSender<T> {
+    fn drop(&mut self) {
+        let previous = self.shared.senders.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "a watch sender is released at most once");
+        if previous == 1 {
+            self.shared.waiters.wake_all();
+        }
     }
 }
 
 pub fn watch<T>(initial: T) -> (WatchSender<T>, WatchReceiver<T>) {
-    let (sender, receiver) = watch::channel(initial);
-    (WatchSender(sender), WatchReceiver(receiver))
+    let shared = Arc::new(WatchShared {
+        value: Mutex::new(initial),
+        version: AtomicU64::new(0),
+        senders: AtomicUsize::new(1),
+        receivers: AtomicUsize::new(1),
+        waiters: WaiterRegistry::default(),
+    });
+    (
+        WatchSender {
+            shared: Arc::clone(&shared),
+        },
+        WatchReceiver { shared, seen: 0 },
+    )
 }
 
 impl<T> WatchSender<T> {
     /// Whether both senders address the same watch channel.
     #[must_use]
     pub fn same_channel(&self, other: &Self) -> bool {
-        self.0.same_channel(&other.0)
+        Arc::ptr_eq(&self.shared, &other.shared)
     }
 
     pub fn watcher(&self) -> WatchReceiver<T> {
-        WatchReceiver(self.0.subscribe())
+        retain_endpoint(&self.shared.receivers, "watch receiver");
+        WatchReceiver {
+            shared: Arc::clone(&self.shared),
+            seen: self.shared.version.load(Ordering::Acquire),
+        }
     }
 
     pub fn receiver_count(&self) -> usize {
-        self.0.receiver_count()
+        self.shared.receivers.load(Ordering::Acquire)
     }
 
     pub fn pulse(&self) {
-        self.0.send_modify(|_| {});
+        self.shared.version.fetch_add(1, Ordering::AcqRel);
+        self.shared.waiters.wake_all();
     }
 
     /// Mutates the retained value without advancing the watch version.
@@ -502,31 +683,140 @@ impl<T> WatchSender<T> {
     /// synchronous state transition before receivers are notified. The caller
     /// must follow a successful logical mutation with [`Self::pulse`].
     pub fn modify_silently(&self, update: impl FnOnce(&mut T)) {
-        let notified = self.0.send_if_modified(|value| {
-            update(value);
-            false
-        });
-        debug_assert!(!notified);
+        let mut value = self
+            .shared
+            .value
+            .lock()
+            .expect("framework watch mutation does not panic");
+        update(&mut value);
     }
 
     /// Reads a projection of the retained value without cloning it.
     ///
-    /// `project` runs under the watch's read guard, so it must stay cheap and
+    /// `project` runs under the watch's value guard, so it must stay cheap and
     /// must not touch the same channel.
     pub fn read_with<R>(&self, project: impl FnOnce(&T) -> R) -> R {
-        project(&self.0.borrow())
+        let value = self
+            .shared
+            .value
+            .lock()
+            .expect("framework watch mutation does not panic");
+        project(&value)
     }
 }
 
 impl<T: Clone> WatchSender<T> {
     pub fn read_cloned(&self) -> T {
-        self.0.borrow().clone()
+        self.shared
+            .value
+            .lock()
+            .expect("framework watch mutation does not panic")
+            .clone()
     }
 }
 
 impl<T> Clone for WatchReceiver<T> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        retain_endpoint(&self.shared.receivers, "watch receiver");
+        Self {
+            shared: Arc::clone(&self.shared),
+            seen: self.seen,
+        }
+    }
+}
+
+impl<T> Drop for WatchReceiver<T> {
+    fn drop(&mut self) {
+        let previous = self.shared.receivers.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "a watch receiver is released at most once");
+    }
+}
+
+enum WatchWaitOutcome {
+    Changed,
+    Closed,
+}
+
+struct WatchWait<'a, T> {
+    receiver: &'a mut WatchReceiver<T>,
+    identity: Arc<()>,
+}
+
+impl<T> WatchWait<'_, T> {
+    fn poll(&mut self, context: &mut Context<'_>) -> Poll<WatchWaitOutcome> {
+        let version = self.receiver.shared.version.load(Ordering::Acquire);
+        if version != self.receiver.seen {
+            self.receiver.seen = version;
+            let registered = self.receiver.shared.waiters.remove(&self.identity);
+            WaiterRegistry::drop_registered([registered]);
+            return Poll::Ready(WatchWaitOutcome::Changed);
+        }
+        if self.receiver.shared.senders.load(Ordering::Acquire) == 0 {
+            let registered = self.receiver.shared.waiters.remove(&self.identity);
+            WaiterRegistry::drop_registered([registered]);
+            return Poll::Ready(WatchWaitOutcome::Closed);
+        }
+
+        // Caller code runs before the registry lock is acquired.
+        let waker = context.waker().clone();
+        let displaced = self.receiver.shared.waiters.register(&self.identity, waker);
+        let version = self.receiver.shared.version.load(Ordering::Acquire);
+        let outcome = if version != self.receiver.seen {
+            self.receiver.seen = version;
+            Some(WatchWaitOutcome::Changed)
+        } else if self.receiver.shared.senders.load(Ordering::Acquire) == 0 {
+            Some(WatchWaitOutcome::Closed)
+        } else {
+            None
+        };
+        let registered = outcome
+            .is_some()
+            .then(|| self.receiver.shared.waiters.remove(&self.identity))
+            .flatten();
+        // Complete the publication recheck before a hostile displaced waker
+        // destructor is allowed to resume its panic.
+        WaiterRegistry::drop_registered([displaced, registered]);
+        outcome.map_or(Poll::Pending, Poll::Ready)
+    }
+}
+
+impl<T> Drop for WatchWait<'_, T> {
+    fn drop(&mut self) {
+        let registered = self.receiver.shared.waiters.remove(&self.identity);
+        WaiterRegistry::drop_registered([registered]);
+    }
+}
+
+/// Future returned by [`WatchReceiver::changed`].
+pub struct WatchChanged<'a, T> {
+    wait: WatchWait<'a, T>,
+}
+
+impl<T> Future for WatchChanged<'_, T> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.get_mut().wait.poll(context) {
+            Poll::Ready(WatchWaitOutcome::Changed) => Poll::Ready(()),
+            Poll::Ready(WatchWaitOutcome::Closed) | Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Future returned by [`WatchReceiver::changed_or_closed`].
+pub struct WatchChangedOrClosed<'a, T> {
+    wait: WatchWait<'a, T>,
+}
+
+impl<T> Future for WatchChangedOrClosed<'_, T> {
+    type Output = bool;
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.get_mut().wait.poll(context) {
+            Poll::Ready(WatchWaitOutcome::Changed) => Poll::Ready(true),
+            Poll::Ready(WatchWaitOutcome::Closed) => Poll::Ready(false),
+            Poll::Pending => Poll::Pending,
+        }
     }
 }
 
@@ -536,42 +826,62 @@ impl<T> WatchReceiver<T> {
     /// Callers that need to observe publisher closure must use
     /// [`Self::changed_or_closed`] instead. Parking here prevents a loop that
     /// intentionally ignores closure from becoming permanently always-ready.
-    pub async fn changed(&mut self) {
-        if self.0.changed().await.is_err() {
-            std::future::pending().await
+    pub fn changed(&mut self) -> WatchChanged<'_, T> {
+        WatchChanged {
+            wait: WatchWait {
+                receiver: self,
+                identity: Arc::new(()),
+            },
         }
     }
 
-    pub async fn changed_or_closed(&mut self) -> bool {
-        self.0.changed().await.is_ok()
+    pub fn changed_or_closed(&mut self) -> WatchChangedOrClosed<'_, T> {
+        WatchChangedOrClosed {
+            wait: WatchWait {
+                receiver: self,
+                identity: Arc::new(()),
+            },
+        }
     }
 }
 
 impl<T: Clone> WatchReceiver<T> {
     pub fn borrow_cloned(&self) -> T {
-        self.0.borrow().clone()
+        self.shared
+            .value
+            .lock()
+            .expect("framework watch mutation does not panic")
+            .clone()
     }
 
     pub fn borrow_and_update_cloned(&mut self) -> T {
-        self.0.borrow_and_update().clone()
+        let value = self
+            .shared
+            .value
+            .lock()
+            .expect("framework watch mutation does not panic");
+        // Sampling the version before cloning may produce a harmless extra
+        // wake if a pulse races this read, but cannot mark an unseen value as
+        // observed. Publication writes the value before advancing the version.
+        self.seen = self.shared.version.load(Ordering::Acquire);
+        value.clone()
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for WatchSender<T> {
+impl<T> fmt::Debug for WatchSender<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("WatchSender")
-            .field("value", &*self.0.borrow())
-            .field("receivers", &self.0.receiver_count())
-            .finish()
+            .field("receivers", &self.receiver_count())
+            .finish_non_exhaustive()
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for WatchReceiver<T> {
+impl<T> fmt::Debug for WatchReceiver<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("WatchReceiver")
-            .field("value", &*self.0.borrow())
+            .field("seen", &self.seen)
             .finish_non_exhaustive()
     }
 }
@@ -651,6 +961,7 @@ impl<T> fmt::Debug for BroadcastReceiver<T> {
 mod tests {
     use std::{
         future::Future,
+        panic::{AssertUnwindSafe, catch_unwind},
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -670,6 +981,30 @@ mod tests {
         fn wake(self: Arc<Self>) {
             self.0.fetch_add(1, Ordering::SeqCst);
         }
+    }
+
+    struct CountPanicWake {
+        wakes: Arc<AtomicUsize>,
+        message: &'static str,
+    }
+
+    impl Wake for CountPanicWake {
+        fn wake(self: Arc<Self>) {
+            self.wakes.fetch_add(1, Ordering::SeqCst);
+            std::panic::panic_any(self.message);
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.wakes.fetch_add(1, Ordering::SeqCst);
+            std::panic::panic_any(self.message);
+        }
+    }
+
+    fn assert_panic_message(payload: &(dyn std::any::Any + Send), expected: &'static str) {
+        assert_eq!(
+            payload.downcast_ref::<&'static str>().copied(),
+            Some(expected)
+        );
     }
 
     #[test]
@@ -789,6 +1124,137 @@ mod tests {
                 .as_mut()
                 .poll(&mut Context::from_waker(&waker))
                 .is_ready()
+        );
+    }
+
+    #[test]
+    fn hostile_latch_waiter_cannot_strand_a_well_behaved_waiter() {
+        const PANIC: &str = "injected latch waker panic";
+
+        let latch = Latch::default();
+        let hostile_wakes = Arc::new(AtomicUsize::new(0));
+        let ordinary_wakes = Arc::new(AtomicUsize::new(0));
+        let hostile = Waker::from(Arc::new(CountPanicWake {
+            wakes: Arc::clone(&hostile_wakes),
+            message: PANIC,
+        }));
+        let ordinary = Waker::from(Arc::new(CountWake(Arc::clone(&ordinary_wakes))));
+        let mut hostile_wait = Box::pin(latch.fired());
+        let mut ordinary_wait = Box::pin(latch.fired());
+        assert!(
+            hostile_wait
+                .as_mut()
+                .poll(&mut Context::from_waker(&hostile))
+                .is_pending()
+        );
+        assert!(
+            ordinary_wait
+                .as_mut()
+                .poll(&mut Context::from_waker(&ordinary))
+                .is_pending()
+        );
+
+        let result = catch_unwind(AssertUnwindSafe(|| latch.fire()));
+
+        let payload = result.expect_err("the hostile latch wake still surfaces");
+        assert_panic_message(&*payload, PANIC);
+        assert!(latch.is_fired());
+        assert_eq!(hostile_wakes.load(Ordering::SeqCst), 1);
+        assert_eq!(ordinary_wakes.load(Ordering::SeqCst), 1);
+        assert!(
+            ordinary_wait
+                .as_mut()
+                .poll(&mut Context::from_waker(&ordinary))
+                .is_ready()
+        );
+    }
+
+    #[test]
+    fn hostile_watch_waiter_cannot_strand_a_well_behaved_pulse_waiter() {
+        const PANIC: &str = "injected watch pulse waker panic";
+
+        let (sender, mut hostile_receiver) = super::watch(0_u8);
+        let mut ordinary_receiver = sender.watcher();
+        let hostile_wakes = Arc::new(AtomicUsize::new(0));
+        let ordinary_wakes = Arc::new(AtomicUsize::new(0));
+        let hostile = Waker::from(Arc::new(CountPanicWake {
+            wakes: Arc::clone(&hostile_wakes),
+            message: PANIC,
+        }));
+        let ordinary = Waker::from(Arc::new(CountWake(Arc::clone(&ordinary_wakes))));
+        let mut hostile_wait = Box::pin(hostile_receiver.changed_or_closed());
+        let mut ordinary_wait = Box::pin(ordinary_receiver.changed_or_closed());
+        assert!(
+            hostile_wait
+                .as_mut()
+                .poll(&mut Context::from_waker(&hostile))
+                .is_pending()
+        );
+        assert!(
+            ordinary_wait
+                .as_mut()
+                .poll(&mut Context::from_waker(&ordinary))
+                .is_pending()
+        );
+        sender.modify_silently(|value| *value = 1);
+
+        let result = catch_unwind(AssertUnwindSafe(|| sender.pulse()));
+
+        let payload = result.expect_err("the hostile watch pulse still surfaces");
+        assert_panic_message(&*payload, PANIC);
+        assert_eq!(hostile_wakes.load(Ordering::SeqCst), 1);
+        assert_eq!(ordinary_wakes.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            ordinary_wait
+                .as_mut()
+                .poll(&mut Context::from_waker(&ordinary)),
+            Poll::Ready(true)
+        );
+        drop(hostile_wait);
+        drop(ordinary_wait);
+        assert_eq!(hostile_receiver.borrow_and_update_cloned(), 1);
+        assert_eq!(ordinary_receiver.borrow_and_update_cloned(), 1);
+    }
+
+    #[test]
+    fn hostile_watch_waiter_cannot_strand_a_well_behaved_close_waiter() {
+        const PANIC: &str = "injected watch close waker panic";
+
+        let (sender, mut hostile_receiver) = super::watch(());
+        let mut ordinary_receiver = sender.watcher();
+        let hostile_wakes = Arc::new(AtomicUsize::new(0));
+        let ordinary_wakes = Arc::new(AtomicUsize::new(0));
+        let hostile = Waker::from(Arc::new(CountPanicWake {
+            wakes: Arc::clone(&hostile_wakes),
+            message: PANIC,
+        }));
+        let ordinary = Waker::from(Arc::new(CountWake(Arc::clone(&ordinary_wakes))));
+        let mut hostile_wait = Box::pin(hostile_receiver.changed_or_closed());
+        let mut ordinary_wait = Box::pin(ordinary_receiver.changed_or_closed());
+        assert!(
+            hostile_wait
+                .as_mut()
+                .poll(&mut Context::from_waker(&hostile))
+                .is_pending()
+        );
+        assert!(
+            ordinary_wait
+                .as_mut()
+                .poll(&mut Context::from_waker(&ordinary))
+                .is_pending()
+        );
+
+        let result = catch_unwind(AssertUnwindSafe(|| drop(sender)));
+
+        let payload = result.expect_err("the hostile watch close still surfaces");
+        assert_panic_message(&*payload, PANIC);
+        assert_eq!(hostile_wakes.load(Ordering::SeqCst), 1);
+        assert_eq!(ordinary_wakes.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            ordinary_wait
+                .as_mut()
+                .poll(&mut Context::from_waker(&ordinary)),
+            Poll::Ready(false)
         );
     }
 

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -3,7 +3,7 @@ use std::{
     future::Future,
     pin::Pin,
     sync::{
-        Arc, Mutex,
+        Arc, Mutex, MutexGuard, PoisonError,
         atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering},
     },
     task::{Context, Poll, Waker},
@@ -222,6 +222,7 @@ impl Latch {
 }
 
 /// Future returned by [`Latch::fired`].
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct LatchWait<'a> {
     latch: &'a Latch,
     identity: Arc<()>,
@@ -599,6 +600,23 @@ struct WatchShared<T> {
     waiters: WaiterRegistry,
 }
 
+impl<T> WatchShared<T> {
+    /// Acquires the retained value, tolerating poisoning.
+    ///
+    /// `modify_silently` and `read_with` run a caller closure under this
+    /// guard, and those closures do real work: a lifecycle publication sends
+    /// on a broadcast channel here, and a snapshot installation evaluates a
+    /// `debug_assert!` and mints a generation. A panic in any of them would
+    /// otherwise wedge every later read, publication, subscription and
+    /// terminal wait on the channel. The guarded data is plain framework
+    /// state with no invariant spanning the closure, so the surviving value
+    /// stays usable; this matches `ObservationGate::lock`, which tolerates
+    /// poisoning for the same reason.
+    fn value(&self) -> MutexGuard<'_, T> {
+        self.value.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
 /// Publishing half of a runtime-backed conflating state channel.
 pub struct WatchSender<T> {
     shared: Arc<WatchShared<T>>,
@@ -683,11 +701,7 @@ impl<T> WatchSender<T> {
     /// synchronous state transition before receivers are notified. The caller
     /// must follow a successful logical mutation with [`Self::pulse`].
     pub fn modify_silently(&self, update: impl FnOnce(&mut T)) {
-        let mut value = self
-            .shared
-            .value
-            .lock()
-            .expect("framework watch mutation does not panic");
+        let mut value = self.shared.value();
         update(&mut value);
     }
 
@@ -696,22 +710,14 @@ impl<T> WatchSender<T> {
     /// `project` runs under the watch's value guard, so it must stay cheap and
     /// must not touch the same channel.
     pub fn read_with<R>(&self, project: impl FnOnce(&T) -> R) -> R {
-        let value = self
-            .shared
-            .value
-            .lock()
-            .expect("framework watch mutation does not panic");
+        let value = self.shared.value();
         project(&value)
     }
 }
 
 impl<T: Clone> WatchSender<T> {
     pub fn read_cloned(&self) -> T {
-        self.shared
-            .value
-            .lock()
-            .expect("framework watch mutation does not panic")
-            .clone()
+        self.shared.value().clone()
     }
 }
 
@@ -788,6 +794,7 @@ impl<T> Drop for WatchWait<'_, T> {
 }
 
 /// Future returned by [`WatchReceiver::changed`].
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct WatchChanged<'a, T> {
     wait: WatchWait<'a, T>,
 }
@@ -804,6 +811,7 @@ impl<T> Future for WatchChanged<'_, T> {
 }
 
 /// Future returned by [`WatchReceiver::changed_or_closed`].
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct WatchChangedOrClosed<'a, T> {
     wait: WatchWait<'a, T>,
 }
@@ -847,19 +855,11 @@ impl<T> WatchReceiver<T> {
 
 impl<T: Clone> WatchReceiver<T> {
     pub fn borrow_cloned(&self) -> T {
-        self.shared
-            .value
-            .lock()
-            .expect("framework watch mutation does not panic")
-            .clone()
+        self.shared.value().clone()
     }
 
     pub fn borrow_and_update_cloned(&mut self) -> T {
-        let value = self
-            .shared
-            .value
-            .lock()
-            .expect("framework watch mutation does not panic");
+        let value = self.shared.value();
         // Sampling the version before cloning may produce a harmless extra
         // wake if a pulse races this read, but cannot mark an unseen value as
         // observed. Publication writes the value before advancing the version.

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -18,7 +18,7 @@ mod storage;
 
 use storage::Obligation;
 
-use child::ChildRuntime;
+use child::{ChildRuntime, fire_shutdown_edges};
 #[cfg(test)]
 use child::{ChildTerminality, discharge_child_terminality, report_slot};
 use events::{
@@ -167,13 +167,14 @@ fn monitor_root_driver(
 }
 
 struct AncestorCommandLatches {
-    shutdown: Latch,
+    framework_shutdown: Latch,
     abort: Latch,
     abort_ack: Latch,
 }
 
 struct NestedScopeLatches {
     parent_ready: CompletionGatedLatch,
+    child_shutdown: Latch,
     ancestor: AncestorCommandLatches,
 }
 
@@ -365,7 +366,7 @@ impl Drop for ScopeRuntime {
                     }
                 }
                 panics.run(|| {
-                    active.shutdown.fire();
+                    fire_shutdown_edges(&active.shutdown, active.framework_shutdown.as_ref());
                 });
                 panics.run(|| {
                     active.abort.fire();
@@ -819,15 +820,19 @@ async fn run_nested_tree_with_epoch(
             // The ancestor *abort* latch needs no separate arm: it is the
             // framework-abort edge, fired only by `StopAction::AbortFramework`,
             // and the stop ladder unconditionally passes through
-            // `StopAction::Cancel` — which fires this same ancestor shutdown
+            // `StopAction::Cancel` — which fires this same framework shutdown
             // latch — before it can reach that phase.
-            if scope.has_stop_request(epoch.epoch()) || latches.ancestor.shutdown.is_fired() {
+            let self_shutdown = scope.has_stop_request(epoch.epoch());
+            if self_shutdown || latches.ancestor.framework_shutdown.is_fired() {
                 // Mirror the loop's `Pending::Shutdown` arm: firing the
-                // ancestor shutdown latch is what makes this scope's exit read
+                // child-facing shutdown latch is what makes this scope's exit read
                 // `Cancellation::Observed` at its parent, as a requested stop
-                // must (§11). The latch is level-triggered, so re-firing an
-                // ancestor-driven stop is a no-op.
-                latches.ancestor.shutdown.fire();
+                // must (§11). An ancestor-driven stop already fired that latch
+                // independently; do not couple its framework observer back to
+                // user-installable cancellation waiters.
+                if self_shutdown {
+                    latches.child_shutdown.fire();
+                }
                 epoch.lifecycle.begin_drain(StopReason::ShutdownRequested);
             }
             // Both drain effects are deliberately discarded: this path
@@ -1014,7 +1019,7 @@ async fn run_scope_incarnation(
             && scope
                 .role
                 .ancestor()
-                .is_some_and(|latches| latches.shutdown.is_fired())
+                .is_some_and(|latches| latches.framework_shutdown.is_fired())
         {
             scope.ancestor_shutdown_seen = true;
             pending.push(Pending::AncestorShutdown.classified());
@@ -1052,7 +1057,7 @@ async fn run_scope_incarnation(
                 .role
                 .ancestor()
                 .filter(|_| !scope.ancestor_shutdown_seen)
-                .map(|latches| latches.shutdown.clone());
+                .map(|latches| latches.framework_shutdown.clone());
             let ancestor_abort = scope
                 .role
                 .ancestor()
@@ -1115,8 +1120,8 @@ async fn run_scope_incarnation(
         for (_, event) in pending.drain(..) {
             match event {
                 Pending::Shutdown => {
-                    if let Some(latches) = scope.role.ancestor() {
-                        latches.shutdown.fire();
+                    if let ScopeRole::Nested(nested) = &scope.role {
+                        nested.child_shutdown.fire();
                         scope.ancestor_shutdown_seen = true;
                     }
                     scope.begin_drain(StopReason::ShutdownRequested);

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -102,6 +102,7 @@ pub(super) struct ActiveChild {
     pub(super) readiness: ReadinessGate,
     pub(super) readiness_deadline: Option<DeadlineHandle>,
     pub(super) ready_signal: CompletionGatedLatch,
+    pub(super) framework_shutdown: Option<Latch>,
     pub(super) framework_abort: Option<Latch>,
     pub(super) framework_abort_ack: Option<Latch>,
     pub(super) stop_deadline: Option<DeadlineHandle>,
@@ -308,8 +309,10 @@ struct SpawnDispatch {
 /// Latches have deliberately separate ownership:
 ///
 /// - `shutdown`/`abort` are the child-facing cooperative ladder;
-/// - `framework_abort`/`framework_abort_ack` bound a nested scope driver's
-///   recursive drain before its task is aborted;
+/// - `framework_shutdown` is the nested scope driver's private observation
+///   edge, separate from user-installable shutdown-token waiters;
+/// - `framework_abort`/`framework_abort_ack` bound that driver's recursive
+///   drain before its task is aborted;
 /// - `ready` also carries the completion edge that makes readiness and
 ///   self-stop watcher tasks finite.
 struct SpawnLatches {
@@ -317,6 +320,7 @@ struct SpawnLatches {
     abort: Latch,
     ready: CompletionGatedLatch,
     local_stop: Latch,
+    framework_shutdown: Option<Latch>,
     framework_abort: Option<Latch>,
     framework_abort_ack: Option<Latch>,
 }
@@ -328,6 +332,7 @@ impl SpawnLatches {
             abort: Latch::default(),
             ready: CompletionGatedLatch::default(),
             local_stop: Latch::default(),
+            framework_shutdown: scope_child.then(Latch::default),
             framework_abort: scope_child.then(Latch::default),
             framework_abort_ack: scope_child.then(Latch::default),
         }
@@ -344,8 +349,12 @@ impl SpawnLatches {
     fn nested_scope(&self) -> NestedScopeLatches {
         NestedScopeLatches {
             parent_ready: self.ready.clone(),
+            child_shutdown: self.shutdown.clone(),
             ancestor: AncestorCommandLatches {
-                shutdown: self.shutdown.clone(),
+                framework_shutdown: self
+                    .framework_shutdown
+                    .clone()
+                    .expect("scope incarnations own a framework-shutdown latch"),
                 abort: self
                     .framework_abort
                     .clone()
@@ -357,6 +366,18 @@ impl SpawnLatches {
             },
         }
     }
+}
+
+pub(super) fn fire_shutdown_edges(shutdown: &Latch, framework_shutdown: Option<&Latch>) {
+    let mut panics = runtime::PanicAccumulator::default();
+    if let Some(framework_shutdown) = framework_shutdown {
+        panics.run(|| {
+            framework_shutdown.fire();
+        });
+    }
+    panics.run(|| {
+        shutdown.fire();
+    });
 }
 
 struct ChildTaskLaunch {
@@ -662,7 +683,9 @@ impl ScopeRuntime {
         // - ready and local_stop flow from application code back to helpers;
         // - ready's completion edge terminates those helpers when the child
         //   exits first and orders late retained readiness capabilities;
-        // - framework_abort/ack join nested-scope escalation before exit.
+        // - framework_shutdown keeps the nested driver observer separate from
+        //   user waiters, while framework_abort/ack joins escalation before
+        //   exit.
         // Each edge is level-triggered, so helper startup cannot lose a pulse.
         let scope_child = matches!(child.construction.get_mut(), ChildConstruction::Scope(_));
         let latches = SpawnLatches::new(scope_child);
@@ -735,6 +758,7 @@ impl ScopeRuntime {
             readiness,
             readiness_deadline: None,
             ready_signal: latches.ready,
+            framework_shutdown: latches.framework_shutdown,
             framework_abort: latches.framework_abort,
             framework_abort_ack: latches.framework_abort_ack,
             stop_deadline: None,
@@ -839,7 +863,11 @@ impl ScopeRuntime {
         while let Some(action) = ladder.advance(now) {
             match action {
                 StopAction::Cancel => {
-                    active.shutdown.fire();
+                    // Publish the framework-only edge independently so a
+                    // hostile user cancellation waiter cannot strand the
+                    // nested scope driver. The latch implementation itself
+                    // finishes every waiter before this call resumes a panic.
+                    fire_shutdown_edges(&active.shutdown, active.framework_shutdown.as_ref());
                 }
                 StopAction::Escalate => {
                     active.abort.fire();
@@ -1199,5 +1227,102 @@ impl ScopeRuntime {
                 self.prune_terminal(key);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod latch_topology_tests {
+    use std::{
+        future::Future,
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        task::{Context, Wake, Waker},
+    };
+
+    use super::{SpawnLatches, fire_shutdown_edges};
+
+    struct PanicWake(&'static str);
+
+    impl Wake for PanicWake {
+        fn wake(self: Arc<Self>) {
+            std::panic::panic_any(self.0);
+        }
+    }
+
+    struct CountWake(Arc<AtomicUsize>);
+
+    impl Wake for CountWake {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn nested_scope_shutdown_observer_is_not_a_user_cancellation_waiter() {
+        let latches = SpawnLatches::new(true);
+        let nested = latches.nested_scope();
+
+        assert!(latches.shutdown.fire());
+        assert!(latches.shutdown.is_fired());
+        assert!(
+            !nested.ancestor.framework_shutdown.is_fired(),
+            "firing the user cancellation edge cannot fire the framework observer"
+        );
+
+        let latches = SpawnLatches::new(true);
+        let nested = latches.nested_scope();
+        assert!(nested.ancestor.framework_shutdown.fire());
+        assert!(nested.ancestor.framework_shutdown.is_fired());
+        assert!(
+            !latches.shutdown.is_fired(),
+            "firing the framework observer cannot publish user cancellation"
+        );
+    }
+
+    #[test]
+    fn non_scope_children_do_not_allocate_framework_shutdown_observers() {
+        let latches = SpawnLatches::new(false);
+
+        assert!(latches.framework_shutdown.is_none());
+        assert!(latches.framework_abort.is_none());
+        assert!(latches.framework_abort_ack.is_none());
+    }
+
+    #[test]
+    fn hostile_user_shutdown_waiter_cannot_strand_the_framework_observer() {
+        const PANIC: &str = "injected user cancellation waker panic";
+
+        let latches = SpawnLatches::new(true);
+        let nested = latches.nested_scope();
+        let mut user_wait = Box::pin(latches.shutdown.fired());
+        let mut framework_wait = Box::pin(nested.ancestor.framework_shutdown.fired());
+        let hostile = Waker::from(Arc::new(PanicWake(PANIC)));
+        let framework_wakes = Arc::new(AtomicUsize::new(0));
+        let framework = Waker::from(Arc::new(CountWake(Arc::clone(&framework_wakes))));
+        assert!(
+            user_wait
+                .as_mut()
+                .poll(&mut Context::from_waker(&hostile))
+                .is_pending()
+        );
+        assert!(
+            framework_wait
+                .as_mut()
+                .poll(&mut Context::from_waker(&framework))
+                .is_pending()
+        );
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            fire_shutdown_edges(&latches.shutdown, Some(&nested.ancestor.framework_shutdown));
+        }));
+
+        let payload = result.expect_err("the hostile user wake still surfaces");
+        assert_eq!(payload.downcast_ref::<&'static str>().copied(), Some(PANIC));
+        assert!(latches.shutdown.is_fired());
+        assert!(nested.ancestor.framework_shutdown.is_fired());
+        assert_eq!(framework_wakes.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -370,14 +370,19 @@ impl SpawnLatches {
 
 pub(super) fn fire_shutdown_edges(shutdown: &Latch, framework_shutdown: Option<&Latch>) {
     let mut panics = runtime::PanicAccumulator::default();
+    // Commit the child-facing cancellation evidence before waking the nested
+    // driver. That observer may finish on another worker and have completion
+    // sample this bit as soon as its wake runs. User waiters remain last so a
+    // hostile one cannot strand framework progress.
+    let notify_shutdown = shutdown.fire_silently();
     if let Some(framework_shutdown) = framework_shutdown {
         panics.run(|| {
             framework_shutdown.fire();
         });
     }
-    panics.run(|| {
-        shutdown.fire();
-    });
+    if notify_shutdown {
+        panics.run(|| shutdown.notify());
+    }
 }
 
 struct ChildTaskLaunch {
@@ -1237,7 +1242,7 @@ mod latch_topology_tests {
         panic::{AssertUnwindSafe, catch_unwind},
         sync::{
             Arc,
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
         },
         task::{Context, Wake, Waker},
     };
@@ -1257,6 +1262,18 @@ mod latch_topology_tests {
     impl Wake for CountWake {
         fn wake(self: Arc<Self>) {
             self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct ObserveShutdownWake {
+        shutdown: crate::runtime::Latch,
+        observed: Arc<AtomicBool>,
+    }
+
+    impl Wake for ObserveShutdownWake {
+        fn wake(self: Arc<Self>) {
+            self.observed
+                .store(self.shutdown.is_fired(), Ordering::SeqCst);
         }
     }
 
@@ -1324,5 +1341,30 @@ mod latch_topology_tests {
         assert!(latches.shutdown.is_fired());
         assert!(nested.ancestor.framework_shutdown.is_fired());
         assert_eq!(framework_wakes.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn framework_shutdown_wake_observes_child_cancellation_already_committed() {
+        let latches = SpawnLatches::new(true);
+        let nested = latches.nested_scope();
+        let observed = Arc::new(AtomicBool::new(false));
+        let mut framework_wait = Box::pin(nested.ancestor.framework_shutdown.fired());
+        let framework = Waker::from(Arc::new(ObserveShutdownWake {
+            shutdown: latches.shutdown.clone(),
+            observed: Arc::clone(&observed),
+        }));
+        assert!(
+            framework_wait
+                .as_mut()
+                .poll(&mut Context::from_waker(&framework))
+                .is_pending()
+        );
+
+        fire_shutdown_edges(&latches.shutdown, Some(&nested.ancestor.framework_shutdown));
+
+        assert!(
+            observed.load(Ordering::SeqCst),
+            "the nested driver cannot run before child cancellation is visible"
+        );
     }
 }

--- a/crates/shelterwood/src/driver/events.rs
+++ b/crates/shelterwood/src/driver/events.rs
@@ -218,10 +218,9 @@ impl ScopeRuntime {
         self.supervisor.lifecycle().is_draining()
             || self.supervisor.hard_forced()
             || self.root.has_stop_request(self.epoch)
-            || self
-                .role
-                .ancestor()
-                .is_some_and(|latches| latches.shutdown.is_fired() || latches.abort.is_fired())
+            || self.role.ancestor().is_some_and(|latches| {
+                latches.framework_shutdown.is_fired() || latches.abort.is_fired()
+            })
             || self.removal_latched(key)
     }
 

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -95,8 +95,9 @@ async fn task_aborted_scope_driver_resolves_startup() {
         plan,
         ScopeRole::Nested(NestedScopeLatches {
             parent_ready: CompletionGatedLatch::default(),
+            child_shutdown: Latch::default(),
             ancestor: AncestorCommandLatches {
-                shutdown: Latch::default(),
+                framework_shutdown: Latch::default(),
                 abort: Latch::default(),
                 abort_ack: Latch::default(),
             },
@@ -267,8 +268,9 @@ async fn scope_plan_conversion_panic_terminalizes_every_child() {
         plan,
         ScopeRole::Nested(NestedScopeLatches {
             parent_ready: CompletionGatedLatch::default(),
+            child_shutdown: Latch::default(),
             ancestor: AncestorCommandLatches {
-                shutdown: Latch::default(),
+                framework_shutdown: Latch::default(),
                 abort: Latch::default(),
                 abort_ack: Latch::default(),
             },
@@ -355,8 +357,9 @@ async fn conversion_unwind_evicts_never_started_child_identities() {
         plan,
         ScopeRole::Nested(NestedScopeLatches {
             parent_ready: CompletionGatedLatch::default(),
+            child_shutdown: Latch::default(),
             ancestor: AncestorCommandLatches {
-                shutdown: Latch::default(),
+                framework_shutdown: Latch::default(),
                 abort: Latch::default(),
                 abort_ack: Latch::default(),
             },

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -418,8 +418,9 @@ async fn nested_membership_exhaustion_is_structured_and_fail_closed() {
         crate::policy::ResolvedDefaults::default(),
         NestedScopeLatches {
             parent_ready: ready.clone(),
+            child_shutdown: Latch::default(),
             ancestor: AncestorCommandLatches {
-                shutdown: Latch::default(),
+                framework_shutdown: Latch::default(),
                 abort: Latch::default(),
                 abort_ack: Latch::default(),
             },
@@ -481,6 +482,7 @@ async fn assert_pre_loop_stop_upgrades_a_nested_lowering_failure(source: PreLoop
         .expect("provisional declaration succeeds");
     let epoch = ScopeEpochGuard::begin(&scope).expect("the first nested epoch is available");
     let ancestor_shutdown = Latch::default();
+    let child_shutdown = Latch::default();
     match source {
         PreLoopStopSource::ScopeShutdown => {
             let target = scope
@@ -491,6 +493,9 @@ async fn assert_pre_loop_stop_upgrades_a_nested_lowering_failure(source: PreLoop
         PreLoopStopSource::ScopeForce => scope.force_shutdown(epoch.epoch()),
         PreLoopStopSource::AncestorShutdown => {
             ancestor_shutdown.fire();
+            // Parent cancellation publishes the user-facing edge separately
+            // from the nested driver's framework-only observation edge.
+            child_shutdown.fire();
         }
     }
     let ready = CompletionGatedLatch::default();
@@ -500,8 +505,9 @@ async fn assert_pre_loop_stop_upgrades_a_nested_lowering_failure(source: PreLoop
         crate::policy::ResolvedDefaults::default(),
         NestedScopeLatches {
             parent_ready: ready.clone(),
+            child_shutdown: child_shutdown.clone(),
             ancestor: AncestorCommandLatches {
-                shutdown: ancestor_shutdown.clone(),
+                framework_shutdown: ancestor_shutdown.clone(),
                 abort: Latch::default(),
                 abort_ack: Latch::default(),
             },
@@ -512,8 +518,8 @@ async fn assert_pre_loop_stop_upgrades_a_nested_lowering_failure(source: PreLoop
 
     assert!(result.is_ok());
     assert!(
-        ancestor_shutdown.is_fired(),
-        "the upgraded verdict fires the latch that reports the exit as cancelled"
+        child_shutdown.is_fired(),
+        "the upgraded verdict fires the user-facing latch that classifies the exit as cancelled"
     );
     assert!(matches!(
         scope.record().startup,

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -492,10 +492,13 @@ async fn assert_pre_loop_stop_upgrades_a_nested_lowering_failure(source: PreLoop
         }
         PreLoopStopSource::ScopeForce => scope.force_shutdown(epoch.epoch()),
         PreLoopStopSource::AncestorShutdown => {
-            ancestor_shutdown.fire();
             // Parent cancellation publishes the user-facing edge separately
-            // from the nested driver's framework-only observation edge.
-            child_shutdown.fire();
+            // from the nested driver's framework-only observation edge. The
+            // fixture deliberately withholds that separate parent-published
+            // edge so the post-call assertion observes only what this path
+            // fires: the ancestor arm must not couple its framework observer
+            // back to user-installable cancellation waiters.
+            ancestor_shutdown.fire();
         }
     }
     let ready = CompletionGatedLatch::default();
@@ -517,10 +520,16 @@ async fn assert_pre_loop_stop_upgrades_a_nested_lowering_failure(source: PreLoop
     .await;
 
     assert!(result.is_ok());
-    assert!(
-        child_shutdown.is_fired(),
-        "the upgraded verdict fires the user-facing latch that classifies the exit as cancelled"
-    );
+    match source {
+        PreLoopStopSource::ScopeShutdown | PreLoopStopSource::ScopeForce => assert!(
+            child_shutdown.is_fired(),
+            "a self-requested stop fires the user-facing latch that classifies the exit as cancelled"
+        ),
+        PreLoopStopSource::AncestorShutdown => assert!(
+            !child_shutdown.is_fired(),
+            "an ancestor-driven stop leaves the user-facing latch to the parent that published it"
+        ),
+    }
     assert!(matches!(
         scope.record().startup,
         Some(Err(StartupError::ShutdownRequested))

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -848,8 +848,9 @@ async fn panicking_nested_factory_releases_its_pre_driver_epoch() {
             crate::policy::ResolvedDefaults::default(),
             NestedScopeLatches {
                 parent_ready: CompletionGatedLatch::default(),
+                child_shutdown: Latch::default(),
                 ancestor: AncestorCommandLatches {
-                    shutdown: Latch::default(),
+                    framework_shutdown: Latch::default(),
                     abort: Latch::default(),
                     abort_ack: Latch::default(),
                 },


### PR DESCRIPTION
Completes the #284 hostile-waker stack. Closes #265.

## What changed

- Replaces Tokio bulk notification in the affected latch/watch paths with a framework-owned waiter registry.
- Clones wakers before locking, moves only inert registry state under lock, and wakes/drops every waiter after unlock under individual panic containment.
- Preserves register-then-recheck lost-wake protection, level-triggered latch behavior, watch conflation/versioning/cloning/closure semantics, and final unseen values.
- Gives nested scopes a framework-only shutdown edge distinct from the user-facing cancellation latch; parent cancellation and teardown publish both independently.

Regressions combine hostile and ordinary latch/watch waiters, cover pulse and closure, pin latch identity separation, prove a hostile user cancellation waiter cannot strand the nested driver, and prove non-scope children allocate no extra latch. Assertions remain outside `catch_unwind`.

Validation: runtime sync 14/14, cells 24/24, driver 138/138, facade suites, and `./tools/dev just ci` passed with 687/687 tests plus all formatting, clippy, documentation, API, external-consumer, and Nix lanes.

Stack: based on #298 / issue #266; no loom work is included because #152 remains the dedicated future target.