### PR TITLE
Deduplicate raw cells and driver transitions

### DIFF
--- a/crates/shelterwood-cells/src/cells.rs
+++ b/crates/shelterwood-cells/src/cells.rs
@@ -564,9 +564,18 @@ impl MemberCell {
     }
 
     fn with_observation_txn<R>(&self, operation: impl FnOnce(&mut ObservationTxn<'_>) -> R) -> R {
+        self.with_observation_txn_probed(|| {}, operation)
+    }
+
+    fn with_observation_txn_probed<R>(
+        &self,
+        mut report_capture: impl FnMut(),
+        operation: impl FnOnce(&mut ObservationTxn<'_>) -> R,
+    ) -> R {
         let mut operation = Some(operation);
         loop {
             let gate = self.current_observation_gate();
+            report_capture();
             let guard = gate.lock();
             if gate.shares_gate(&self.current_observation_gate()) {
                 let mut txn = ObservationTxn::new(guard);
@@ -608,14 +617,38 @@ impl MemberCell {
     }
 
     fn adopt_observation_gate(&self, gate: &ObservationGate, _txn: &mut ObservationTxn<'_>) {
+        self.adopt_observation_gate_with(
+            gate,
+            || {},
+            |previous| {
+                self.install_observation_gate_locked(previous, gate);
+            },
+        );
+    }
+
+    fn adopt_observation_gate_with(
+        &self,
+        gate: &ObservationGate,
+        mut report_capture: impl FnMut(),
+        install: impl FnOnce(&ObservationGate),
+    ) {
+        let mut install = Some(install);
         loop {
             let current = self.current_observation_gate();
             if current.shares_gate(gate) {
                 return;
             }
+            report_capture();
+            // An operation that passed the pointer check may finish its
+            // complete edge before handoff. One that merely captured this
+            // obsolete gate retries after acquiring it and observing the
+            // replacement.
             let current_guard = current.lock();
             if current.shares_gate(&self.current_observation_gate()) {
-                self.install_observation_gate_locked(&current, gate);
+                let install = install
+                    .take()
+                    .expect("observation gate adoption installs exactly once");
+                install(&current);
                 drop(current_guard);
                 return;
             }
@@ -1398,32 +1431,21 @@ impl ScopeCell {
             gate.shares_gate(&parent.current_observation_gate()),
             "observation gates are adopted only in the parent-to-child direction"
         );
-        loop {
-            let current = self.current_observation_gate();
-            if current.shares_gate(gate) {
-                return;
-            }
-            debug_assert!(
-                self.dynamic_route_in(txn).is_none(),
-                "a scope with a live dynamic route is never re-homed"
-            );
-
-            #[cfg(any(test, feature = "test-util"))]
-            self.report_gate_capture(GateCapture::Adoption);
-
-            // An operation that passed `with_observation_gate`'s pointer
-            // check may finish its complete edge before handoff. An operation
-            // that merely captured this obsolete gate retries after acquiring
-            // it and observing the replacement.
-            let current_guard = current.lock();
-            if current.shares_gate(&self.current_observation_gate()) {
-                self.member.install_observation_gate_locked(&current, gate);
-                self.adopt_descendant_observation_gates_locked(&current, gate, txn);
-                drop(current_guard);
-                return;
-            }
-            drop(current_guard);
-        }
+        self.member.adopt_observation_gate_with(
+            gate,
+            || {
+                #[cfg(any(test, feature = "test-util"))]
+                self.report_gate_capture(GateCapture::Adoption);
+            },
+            |current| {
+                debug_assert!(
+                    self.dynamic_route_in(txn).is_none(),
+                    "a scope with a live dynamic route is never re-homed"
+                );
+                self.member.install_observation_gate_locked(current, gate);
+                self.adopt_descendant_observation_gates_locked(current, gate, txn);
+            },
+        );
     }
 
     pub fn adopt_child_observation_gate(
@@ -1474,23 +1496,13 @@ impl ScopeCell {
         &self,
         operation: impl FnOnce(&mut ObservationTxn<'_>) -> R,
     ) -> R {
-        let mut operation = Some(operation);
-        loop {
-            let gate = self.current_observation_gate();
-            #[cfg(any(test, feature = "test-util"))]
-            self.report_gate_capture(GateCapture::Observation);
-            let guard = gate.lock();
-            if gate.shares_gate(&self.current_observation_gate()) {
-                let operation = operation
-                    .take()
-                    .expect("observation operation runs exactly once");
-                let mut txn = ObservationTxn::new(guard);
-                let result = operation(&mut txn);
-                drop(txn);
-                return result;
-            }
-            drop(guard);
-        }
+        self.member.with_observation_txn_probed(
+            || {
+                #[cfg(any(test, feature = "test-util"))]
+                self.report_gate_capture(GateCapture::Observation);
+            },
+            operation,
+        )
     }
 
     pub fn set_state(&self, state: ScopeState) {

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -1263,17 +1263,15 @@ impl ScopeRuntime {
         member.set_terminal_disposal_pending(false);
         if self.supervisor.membership_status(key) == MembershipStatus::Removing {
             self.flush_supervisor_effects();
-        } else if terminal.startup == StartupDisposition::Aborted
+            return;
+        }
+        if terminal.startup == StartupDisposition::Aborted
             && !self.supervisor.lifecycle().is_draining()
         {
             self.fail_startup(key, exit);
-            if self.children[key].options.retention == crate::Retention::Remove {
-                self.prune_terminal(key);
-            }
-        } else {
-            if self.children[key].options.retention == crate::Retention::Remove {
-                self.prune_terminal(key);
-            }
+        }
+        if self.children[key].options.retention == crate::Retention::Remove {
+            self.prune_terminal(key);
         }
     }
 }

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -6,26 +6,22 @@ pub(super) struct RemovalRequest {
 }
 
 impl ScopeRuntime {
-    pub(super) fn with_dynamic_entry<R>(
-        &self,
-        key: ChildKey,
-        inspect: impl FnOnce(&DynamicEntry) -> R,
-    ) -> Option<R> {
-        let child = self.children.get(key)?;
-        let control = self.dynamic.as_ref()?;
-        let state = control.state.lock().expect("dynamic-state mutex poisoned");
-        state
-            .entry(child.slot.member.id())
-            .filter(|entry| entry.slot.member.membership() == child.slot.member.membership())
-            .filter(|entry| entry.matches_key(key))
-            .map(inspect)
-    }
-
     pub(super) fn removal_latched(&self, key: ChildKey) -> bool {
-        self.supervisor.membership_status(key) == MembershipStatus::Removing
-            || self
-                .with_dynamic_entry(key, DynamicEntry::removal_latched)
-                .unwrap_or(false)
+        if self.supervisor.membership_status(key) == MembershipStatus::Removing {
+            return true;
+        }
+        let Some(child) = self.children.get(key) else {
+            return false;
+        };
+        let Some(control) = &self.dynamic else {
+            return false;
+        };
+        let state = control.state.lock().expect("dynamic-state mutex poisoned");
+        state.entry(child.slot.member.id()).is_some_and(|entry| {
+            entry.slot.member.membership() == child.slot.member.membership()
+                && entry.matches_key(key)
+                && entry.removal_latched()
+        })
     }
 
     pub(super) fn handle_removal(&mut self, removal: RemovalRequest) {
@@ -113,10 +109,10 @@ impl ScopeRuntime {
         }
         // The entry's release completes any in-flight removal response; it
         // must follow the Removed edge so a woken remover never sees the
-        // child resident. A removal that latches between this path's
-        // `dynamic_membership_is_removing` check and the gate above lands its
-        // response here rather than in `finalize_removal`, so it takes the
-        // same starting-phase retention.
+        // child resident. A removal that latches between a terminal route's
+        // membership-status check and the gate above lands its response here
+        // rather than in `finalize_removal`, so it takes the same
+        // starting-phase retention.
         if let Some(entry) = removed {
             self.release_removed_entry(entry);
         }

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -539,6 +539,12 @@ enum IntervalRearm<M> {
     Interval(M),
 }
 
+#[derive(Clone, Copy)]
+struct TimerLocation {
+    hash: KeyHash,
+    index: usize,
+}
+
 /// Type-aware keyed timer lookup paired with an independently ordered
 /// deadline index.
 ///
@@ -634,32 +640,20 @@ impl<M> TimerStore<M> {
     where
         K: Eq + 'static,
     {
-        let (entry, empty) = {
-            let bucket = self.keyed.get_mut(&hash)?;
-            #[cfg(test)]
-            let mut probes = 0;
-            let index = bucket.iter().position(|entry| {
-                #[cfg(test)]
-                {
-                    probes += 1;
-                }
-                entry.key.downcast_ref::<K>() == Some(key)
-            })?;
+        #[cfg(test)]
+        let mut probes = 0;
+        let location = self.locate(hash, |entry| {
             #[cfg(test)]
             {
-                self.lookup_probes = self.lookup_probes.saturating_add(probes);
+                probes += 1;
             }
-            let entry = bucket.swap_remove(index);
-            (entry, bucket.is_empty())
-        };
-        if empty {
-            self.keyed.remove(&hash);
+            entry.key.downcast_ref::<K>() == Some(key)
+        })?;
+        #[cfg(test)]
+        {
+            self.lookup_probes = self.lookup_probes.saturating_add(probes);
         }
-        self.armings.remove(&entry.arming_order);
-        if let Some(deadline) = entry.deadline {
-            self.deadlines.remove(&(deadline, entry.arming_order));
-        }
-        Some(entry)
+        Some(self.unlink(location))
     }
 
     fn remove<K>(&mut self, key: &K) -> bool
@@ -703,39 +697,68 @@ impl<M> TimerStore<M> {
         self.disposal.dispose(message);
     }
 
-    fn remove_arming(&mut self, arming_order: ArmingOrder) -> Option<TimerEntry<M>> {
-        let hash = self.armings.remove(&arming_order)?;
+    fn locate(
+        &self,
+        hash: KeyHash,
+        mut predicate: impl FnMut(&TimerEntry<M>) -> bool,
+    ) -> Option<TimerLocation> {
+        let index = self.keyed.get(&hash)?.iter().position(&mut predicate)?;
+        Some(TimerLocation { hash, index })
+    }
+
+    fn unlink(&mut self, location: TimerLocation) -> TimerEntry<M> {
+        let arming_order = self
+            .keyed
+            .get(&location.hash)
+            .and_then(|bucket| bucket.get(location.index))
+            .expect("a timer location must reference a timer")
+            .arming_order;
+        let indexed_hash = self
+            .armings
+            .get(&arming_order)
+            .expect("a timer must have an arming index");
+        assert_eq!(
+            *indexed_hash, location.hash,
+            "a timer's key and arming indexes must agree"
+        );
         let (entry, empty) = {
             let bucket = self
                 .keyed
-                .get_mut(&hash)
-                .expect("an arming index must reference a key bucket");
-            let index = bucket
-                .iter()
-                .position(|entry| entry.arming_order == arming_order)
-                .expect("an arming index must reference a timer");
-            let entry = bucket.swap_remove(index);
+                .get_mut(&location.hash)
+                .expect("a timer location must reference a key bucket");
+            let entry = bucket.swap_remove(location.index);
             (entry, bucket.is_empty())
         };
         if empty {
-            self.keyed.remove(&hash);
+            self.keyed.remove(&location.hash);
         }
+        self.armings.remove(&entry.arming_order);
         if let Some(deadline) = entry.deadline {
-            self.deadlines.remove(&(deadline, arming_order));
+            self.deadlines.remove(&(deadline, entry.arming_order));
         }
-        Some(entry)
+        entry
+    }
+
+    fn remove_arming(&mut self, arming_order: ArmingOrder) -> Option<TimerEntry<M>> {
+        let hash = *self.armings.get(&arming_order)?;
+        let location = self
+            .locate(hash, |entry| entry.arming_order == arming_order)
+            .expect("an arming index must reference a timer");
+        Some(self.unlink(location))
     }
 
     fn entry_mut(&mut self, arming_order: ArmingOrder) -> Option<&mut TimerEntry<M>> {
         let hash = *self.armings.get(&arming_order)?;
-        let entry = self
-            .keyed
-            .get_mut(&hash)
-            .expect("an arming index must reference a key bucket")
-            .iter_mut()
-            .find(|entry| entry.arming_order == arming_order)
+        let location = self
+            .locate(hash, |entry| entry.arming_order == arming_order)
             .expect("an arming index must reference a timer");
-        Some(entry)
+        Some(
+            self.keyed
+                .get_mut(&location.hash)
+                .expect("a timer location must reference a key bucket")
+                .get_mut(location.index)
+                .expect("a timer location must reference a timer"),
+        )
     }
 
     fn take_due(&mut self, now: Instant) -> VecDeque<ArmingOrder> {
@@ -1636,6 +1659,18 @@ impl<M: Send + 'static> RawContext<M> {
         Ok(guard)
     }
 
+    fn pop_continuation(&mut self, batch: &mut ReadyBatch, allow_lead: bool) -> Option<M> {
+        if (!allow_lead || !self.resources.continuation_needs_external)
+            && batch.continuation_is_eligible()
+            && let Some(message) = self.resources.continuations.pop_front()
+        {
+            batch.record_continuation_delivery();
+            self.resources.continuation_needs_external = true;
+            return Some(message);
+        }
+        None
+    }
+
     /// Selects one live-incarnation input without awaiting.
     ///
     /// Every selection runs through one bounded arbitration batch. Steady
@@ -1678,12 +1713,7 @@ impl<M: Send + 'static> RawContext<M> {
                 .ready_batch
                 .take()
                 .expect("ready selection always owns an arbitration batch");
-            if !self.resources.continuation_needs_external
-                && batch.continuation_is_eligible()
-                && let Some(message) = self.resources.continuations.pop_front()
-            {
-                batch.record_continuation_delivery();
-                self.resources.continuation_needs_external = true;
+            if let Some(message) = self.pop_continuation(&mut batch, true) {
                 self.resources.ready_batch = Some(batch);
                 return Some(message);
             }
@@ -1733,11 +1763,7 @@ impl<M: Send + 'static> RawContext<M> {
                 continue;
             }
 
-            if batch.continuation_is_eligible()
-                && let Some(message) = self.resources.continuations.pop_front()
-            {
-                batch.record_continuation_delivery();
-                self.resources.continuation_needs_external = true;
+            if let Some(message) = self.pop_continuation(&mut batch, false) {
                 self.resources.ready_batch = Some(batch);
                 return Some(message);
             }
@@ -3050,7 +3076,7 @@ mod timer_store_tests {
         panic::{AssertUnwindSafe, catch_unwind},
         sync::{
             Arc,
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
         },
         time::{Duration, Instant},
     };
@@ -3087,6 +3113,29 @@ mod timer_store_tests {
         fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
             self.hashes.fetch_add(1, Ordering::SeqCst);
             std::hash::Hash::hash(&self.value, state);
+        }
+    }
+
+    struct PanickingEqKey {
+        value: u8,
+        panic_on_eq: Arc<AtomicBool>,
+    }
+
+    impl PartialEq for PanickingEqKey {
+        fn eq(&self, other: &Self) -> bool {
+            assert!(
+                !self.panic_on_eq.load(Ordering::SeqCst),
+                "timer key equality panic"
+            );
+            self.value == other.value
+        }
+    }
+
+    impl Eq for PanickingEqKey {}
+
+    impl std::hash::Hash for PanickingEqKey {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            self.value.hash(state);
         }
     }
 
@@ -3274,6 +3323,52 @@ mod timer_store_tests {
             "replacement"
         );
         assert!(timers.is_empty());
+    }
+
+    #[test]
+    fn equality_panic_leaves_timer_indexes_and_probe_count_coherent() {
+        let panic_on_eq = Arc::new(AtomicBool::new(false));
+        let start = Instant::now();
+        let deadline = start + Duration::from_secs(1);
+        let mut timers = TimerStore::default();
+        timers.replace(
+            PanickingEqKey {
+                value: 7,
+                panic_on_eq: Arc::clone(&panic_on_eq),
+            },
+            Some(deadline),
+            order(1),
+            TimerMessage::Once("message"),
+            None,
+        );
+        let query = PanickingEqKey {
+            value: 7,
+            panic_on_eq: Arc::clone(&panic_on_eq),
+        };
+
+        panic_on_eq.store(true, Ordering::SeqCst);
+        let panic = catch_unwind(AssertUnwindSafe(|| timers.take(&query)))
+            .err()
+            .expect("user equality panic escapes the timer lookup");
+        assert_eq!(
+            panic.downcast_ref::<&'static str>().copied(),
+            Some("timer key equality panic")
+        );
+        assert_eq!(timers.lookup_probes, 0, "a panicked scan is not committed");
+        assert_eq!(
+            timers.armings.get(&order(1)),
+            Some(&timers.hash_key(&query))
+        );
+        assert_eq!(timers.next_deadline(), Some(deadline));
+
+        panic_on_eq.store(false, Ordering::SeqCst);
+        assert_eq!(
+            once(timers.take(&query).expect("the timer remains linked")),
+            "message"
+        );
+        assert_eq!(timers.lookup_probes, 1);
+        assert!(timers.is_empty());
+        assert!(timers.deadlines.is_empty());
     }
 
     #[test]

--- a/crates/shelterwood/src/raw.rs
+++ b/crates/shelterwood/src/raw.rs
@@ -707,20 +707,6 @@ impl<M> TimerStore<M> {
     }
 
     fn unlink(&mut self, location: TimerLocation) -> TimerEntry<M> {
-        let arming_order = self
-            .keyed
-            .get(&location.hash)
-            .and_then(|bucket| bucket.get(location.index))
-            .expect("a timer location must reference a timer")
-            .arming_order;
-        let indexed_hash = self
-            .armings
-            .get(&arming_order)
-            .expect("a timer must have an arming index");
-        assert_eq!(
-            *indexed_hash, location.hash,
-            "a timer's key and arming indexes must agree"
-        );
         let (entry, empty) = {
             let bucket = self
                 .keyed
@@ -729,6 +715,17 @@ impl<M> TimerStore<M> {
             let entry = bucket.swap_remove(location.index);
             (entry, bucket.is_empty())
         };
+        // `replace` writes the key bucket and the arming index in one window
+        // that cannot panic between them — the user `Hash`/`Eq` callbacks run
+        // strictly before it — and an entry never migrates buckets except
+        // through this method. Their agreement is therefore structural, so
+        // check it where a broken invariant is cheap to see rather than
+        // paying two extra map lookups on every removal.
+        debug_assert_eq!(
+            self.armings.get(&entry.arming_order),
+            Some(&location.hash),
+            "a timer's key and arming indexes must agree"
+        );
         if empty {
             self.keyed.remove(&location.hash);
         }
@@ -739,19 +736,31 @@ impl<M> TimerStore<M> {
         entry
     }
 
-    fn remove_arming(&mut self, arming_order: ArmingOrder) -> Option<TimerEntry<M>> {
+    /// Resolves an arming index to its key-bucket location.
+    ///
+    /// `None` means the arming order is unknown, which is an ordinary miss.
+    /// A known arming order whose bucket or entry is absent is index
+    /// corruption; the two shapes panic distinctly so a failure names which
+    /// half of the pair went missing.
+    fn locate_arming(&self, arming_order: ArmingOrder) -> Option<TimerLocation> {
         let hash = *self.armings.get(&arming_order)?;
-        let location = self
-            .locate(hash, |entry| entry.arming_order == arming_order)
+        let index = self
+            .keyed
+            .get(&hash)
+            .expect("an arming index must reference a key bucket")
+            .iter()
+            .position(|entry| entry.arming_order == arming_order)
             .expect("an arming index must reference a timer");
+        Some(TimerLocation { hash, index })
+    }
+
+    fn remove_arming(&mut self, arming_order: ArmingOrder) -> Option<TimerEntry<M>> {
+        let location = self.locate_arming(arming_order)?;
         Some(self.unlink(location))
     }
 
     fn entry_mut(&mut self, arming_order: ArmingOrder) -> Option<&mut TimerEntry<M>> {
-        let hash = *self.armings.get(&arming_order)?;
-        let location = self
-            .locate(hash, |entry| entry.arming_order == arming_order)
-            .expect("an arming index must reference a timer");
+        let location = self.locate_arming(arming_order)?;
         Some(
             self.keyed
                 .get_mut(&location.hash)
@@ -1659,8 +1668,8 @@ impl<M: Send + 'static> RawContext<M> {
         Ok(guard)
     }
 
-    fn pop_continuation(&mut self, batch: &mut ReadyBatch, allow_lead: bool) -> Option<M> {
-        if (!allow_lead || !self.resources.continuation_needs_external)
+    fn pop_continuation(&mut self, batch: &mut ReadyBatch, is_lead_slot: bool) -> Option<M> {
+        if (!is_lead_slot || !self.resources.continuation_needs_external)
             && batch.continuation_is_eligible()
             && let Some(message) = self.resources.continuations.pop_front()
         {

--- a/crates/shelterwood/src/tree/builders.rs
+++ b/crates/shelterwood/src/tree/builders.rs
@@ -3,7 +3,6 @@ use std::{fmt, sync::Arc};
 use crate::{
     ActorDef, ActorOnceDef, ActorRef, ChildId, Intensity, ScopeDefaults,
     admission::ReserveError,
-    mailbox::MailboxCell,
     plan::{BuilderCore, LowerError, SlotCell},
     policy::{ResolvedDefaults, ScopeFlavor},
     raw::{RawDef, RawOnceDef},
@@ -14,7 +13,9 @@ use crate::{
 
 use super::{
     ActorSlot, Subtree, SubtreeDef, SubtreeOnceDef, SubtreeSlot, System, TaskSlot,
-    slots::{ActorSlotCore, StaticSlotEndpoint, SubtreeSlotCore, TaskSlotCore},
+    slots::{
+        ActorSlotCore, StaticSlotEndpoint, SubtreeSlotCore, TaskSlotCore, attach_actor_mailbox,
+    },
     system::sealed,
 };
 
@@ -46,8 +47,7 @@ pub(super) fn dispose_rejected<D: Send + 'static>(
 }
 
 fn attach_actor_slot<M: Send + 'static>(slot: Arc<SlotCell>) -> ActorSlot<M> {
-    let mailbox = MailboxCell::new(slot.member.id().clone(), crate::runtime::mailbox_runtime());
-    slot.member.attach_mailbox(mailbox.clone());
+    let mailbox = attach_actor_mailbox(&slot);
     ActorSlot {
         core: ActorSlotCore::new(StaticSlotEndpoint(slot), mailbox),
     }

--- a/crates/shelterwood/src/tree/dynamic_api.rs
+++ b/crates/shelterwood/src/tree/dynamic_api.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use crate::{
     ActorDef, ActorOnceDef, ActorRef, ChildId,
     admission::ReserveError,
-    mailbox::MailboxCell,
     raw::{RawDef, RawOnceDef},
     scope::{DynamicScopeRef, ScopeRef},
     task::{OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
@@ -15,6 +14,7 @@ use super::{
     builders::dispose_rejected,
     slots::{
         ActorSlotCore, AdmissionOwnership, DynamicSlotEndpoint, SubtreeSlotCore, TaskSlotCore,
+        attach_actor_mailbox,
     },
     system::sealed,
 };
@@ -66,11 +66,7 @@ impl DynamicScopeRef {
         ownership: AdmissionOwnership,
     ) -> Result<DynamicActorSlot<M>, ReserveError> {
         crate::driver::reserve_dynamic(&self.0.cell, id.into(), None).map(|reservation| {
-            let mailbox = MailboxCell::new(
-                reservation.slot.member.id().clone(),
-                crate::runtime::mailbox_runtime(),
-            );
-            reservation.slot.member.attach_mailbox(mailbox.clone());
+            let mailbox = attach_actor_mailbox(&reservation.slot);
             DynamicActorSlot {
                 core: ActorSlotCore::new(DynamicSlotEndpoint::new(reservation, ownership), mailbox),
             }

--- a/crates/shelterwood/src/tree/slots.rs
+++ b/crates/shelterwood/src/tree/slots.rs
@@ -96,6 +96,12 @@ pub(super) struct ActorSlotCore<E, M> {
     mailbox: Arc<MailboxCell<M>>,
 }
 
+pub(super) fn attach_actor_mailbox<M: Send + 'static>(slot: &SlotCell) -> Arc<MailboxCell<M>> {
+    let mailbox = MailboxCell::new(slot.member.id().clone(), crate::runtime::mailbox_runtime());
+    slot.member.attach_mailbox(mailbox.clone());
+    mailbox
+}
+
 macro_rules! impl_actor_core_definition {
     ($method:ident, $definition:ident) => {
         pub(super) fn $method<R>(self, definition: $definition<R>) -> E::Output<ActorRef<M>>


### PR DESCRIPTION
Starts the #279 cleanup after the #278 structural stack.

- Centralizes timer bucket lookup/unlink with panic-coherent pre-mutation validation.
- Centralizes continuation delivery with the explicit lead gate.
- Unifies observation and adoption retry loops through member-level primitives.
- Hoists construction-disposal pruning after the required removing flush.
- Inlines the single dynamic-entry inspection helper and fixes its stale race comment.
- Shares static/dynamic actor mailbox attachment.

New timer equality-panic coverage proves index coherence and lookup-probe accounting remain intact. `DrainStarted` work is deliberately absent because #306 fully subsumes it.

Validation: focused timer, observation, continuation, construction, and dynamic suites passed. On the full simplification stack, `./tools/dev just ci` hit the known unrelated parallel arrived-disposal race once; the exact test passed immediately and serial full CI passed all 677 tests plus every formatting/docs/API/external-consumer lane.

Stack: based on #309 and also logically depends on #310 before merge. The raw/cells split drafts follow this PR and will be rebased over the final ReadyBatch shape.