### PR TITLE
Adapt the hostile call-waker probe to the channel-based disposal recorder

### DIFF
--- a/crates/shelterwood-mailbox/src/futures.rs
+++ b/crates/shelterwood-mailbox/src/futures.rs
@@ -977,7 +977,7 @@ mod tests {
     unsafe fn drop_panicking_drop_waker(data: *const ()) {
         // SAFETY: drop consumes the reference represented by this raw waker.
         let probe = unsafe { Arc::<EveryWakerDropPanics>::from_raw(data.cast()) };
-        *probe.0.lock().expect("waker disposal recorder mutex") = Some(std::thread::current().id());
+        record_disposal(&probe.0);
         panic!("injected call waker drop panic");
     }
 
@@ -1082,7 +1082,7 @@ mod tests {
         let waker_thread = disposal_thread();
         let mut call = Box::pin(actor.call(
             {
-                let message_thread = Arc::clone(&message_thread);
+                let message_thread = message_thread.clone();
                 move |reply| CallMessage {
                     _reply: reply,
                     _payload: ThreadRecordingDrop(message_thread),
@@ -1090,7 +1090,7 @@ mod tests {
             },
             Duration::from_secs(1),
         ));
-        let hostile = panicking_drop_waker(Arc::clone(&waker_thread));
+        let hostile = panicking_drop_waker(waker_thread.clone());
         let mut context = Context::from_waker(&hostile);
         let deadline = crate::deadline::Deadline::after(
             crate::capability::tests::runtime().now(),


### PR DESCRIPTION
Fixes main, which is currently red.

PRs #296 and #297 both touch `crates/shelterwood-mailbox/src/futures.rs`'s `DisposalThread` fixture. #297 added the panicking-drop waker vtable and `call_acceptance_timeout_isolates_message_before_hostile_waker_drop` against the old `Arc<Mutex<Option<ThreadId>>>` newtype; #296 reworked `DisposalThread` into a struct that publishes through an mpsc channel (replacing a polled counter, to remove a flake).

Both were green individually — their merge refs were computed against different bases, so the combination was never compiled. The merge kept #296's struct and #297's call sites:

- `futures.rs:980` — `probe.0.lock()` → `record_disposal(&probe.0)`
- `futures.rs:1085,1093` — `Arc::clone(&recorder)` → `recorder.clone()` (the struct derives `Clone`)

No semantic change: `await_disposal` still blocks on the notification channel with `recv_timeout(...).expect("isolated disposal destroys the value")`, so the test still fails if the value is never isolated.

`just ci` passes locally: 692/692 tests, exit 0.