### PR TITLE
Make arrived disposal-panic teardown tests deterministic

### DIFF
--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -74,13 +74,28 @@ async fn scope_with_arrived_factory_disposal_panic() -> (ScopeRuntime, ChildKey,
     );
     assert!(scope.children[key].pending_terminal.is_some());
 
-    let arrived = crate::runtime::timeout(DRIVER_PROGRESS_WAIT, async {
-        while scope.disposal_event_receiver.is_empty() {
-            crate::runtime::yield_now().await;
-        }
-    })
+    let (disposed_child, panic) = recv_construction_disposed(
+        &mut scope.disposal_event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "the retained factory disposal panic to arrive",
+    )
     .await;
-    assert!(matches!(arrived, crate::runtime::Timeout::Completed(())));
+    assert_eq!(disposed_child, key);
+    let panic = panic.expect("the retained factory disposal panics");
+    assert_eq!(
+        panic.message.as_deref(),
+        Some(ARRIVED_FACTORY_DISPOSAL_PANIC)
+    );
+    assert!(
+        scope
+            .disposal_events
+            .send(DriverEvent::Child(ChildEvent::ConstructionDisposed {
+                child: disposed_child,
+                panic: Some(panic),
+            }))
+            .is_ok(),
+        "the validated disposal completion returns to the live lane"
+    );
     (scope, key, member)
 }
 

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -87,6 +87,13 @@ async fn scope_with_arrived_factory_disposal_panic() -> (ScopeRuntime, ChildKey,
         Some(ARRIVED_FACTORY_DISPOSAL_PANIC)
     );
     assert!(
+        scope.disposal_event_receiver.is_empty(),
+        "a terminal disposes its retained construction exactly once"
+    );
+    // Replay the validated completion, pulse included, so runtime teardown,
+    // batch collection and the hard-force fallback still meet it exactly as
+    // `handle_terminal_disposal` leaves it.
+    assert!(
         scope
             .disposal_events
             .send(DriverEvent::Child(ChildEvent::ConstructionDisposed {
@@ -96,6 +103,7 @@ async fn scope_with_arrived_factory_disposal_panic() -> (ScopeRuntime, ChildKey,
             .is_ok(),
         "the validated disposal completion returns to the live lane"
     );
+    scope.root.signal().pulse();
     (scope, key, member)
 }
 


### PR DESCRIPTION
## Summary

- replace the fixture's untyped disposal-lane `is_empty` polling with an exact `ConstructionDisposed` receive
- verify that the completion belongs to the expected child and carries the expected factory-drop panic
- pin that the terminal reports exactly one construction disposal, then replay the validated completion — pulse included — so runtime teardown, batch collection and hard force still exercise the production arrived-event paths

## Why

The reported tests depended on a timing observation: any non-empty disposal lane was treated as proof that the intended factory-disposal panic had arrived. It is not. `SpawnBody::TaskRestartable` holds `Arc::clone(factory)`, so the spawned task and the retained `ChildConstruction` co-own the factory; if the aborted task has not released its clone by the time `handle_terminal_disposal` runs, the retained drop is a non-last refcount decrement, `ConstructionDisposed` still arrives, and it carries `panic: None`. The old fixture accepted that and failed later, at the teardown assertion, while the real panic surfaced on an unrelated worker thread.

The post-join synchronization that landed through #298 removes that ownership race — #325 was filed 92 seconds before #298 merged, so both reports were against trees without it. This change does not alter any test outcome; it makes the arrival boundary exact so a recurrence names itself at the fixture instead of at teardown.

Closes #325.

## Validation

- affected three disposal-panic shutdown tests
- mutation check: with the `recv_child_exit` join deleted, the new assertion fires 117/200 runs (2 CPUs under load) at `the retained factory disposal panics`; with the join restored, 0/200
- `main` unmodified: 250 consecutive full `-p shelterwood` runs on 2 CPUs under load, 0 failures — the flake mode is already gone, this is the guard
- 100 consecutive full `cargo nextest run -p shelterwood` passes after the change (53,600 tests)
- `./tools/dev just ci`
- `./tools/dev just ci-nix`
