### PR TITLE
Document that StopContext has no self-handle

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -598,8 +598,11 @@ trait Actor: Sized + Send + 'static {
   the normal supervision path, classified as a startup failure.
 - `on_stop` is best-effort teardown; it runs under the child's shutdown
   grace and its context is the narrowed `StopContext` (§5.4, Appendix B.1).
-  A panic in `on_stop` is classified `Panicked` by the fallback report
-  token, superseding the run's outcome (§7).
+  `StopContext` exposes no `myself()`: an `ActorRef` is a send handle, and
+  posting from `on_stop` is futile. Self-identity for teardown MUST be
+  captured from `Context::myself()` during the live phase and carried in
+  actor state [#324]. A panic in `on_stop` is classified `Panicked` by
+  the fallback report token, superseding the run's outcome (§7).
 
 ### 4.2 One-shot is primitive; restartable is proven
 
@@ -3705,7 +3708,13 @@ the same series during shutdown drain; **Stop** = `StopContext<'_, A>` in
 | Re-entry/mapping: `for_actor` (same-`Msg`, core); `project` *(II §17)* | — | ✓ | ✓ | `for_actor` only |
 
 `StopContext` withholds everything that queues future work for this
-incarnation — there is no one left to deliver to, so `myself()` is absent.
+incarnation. `myself()` is in that set: `ActorRef<M>` is the send surface
+(`send` / `call`, and `Eq`/`Hash` by slot identity), intake is already
+frozen, and no callback remains to receive posted work. Absence is the
+contract, not a documented-don't-post on a still-present accessor [#324].
+Scope-local `id()` and the `Incarnation` / `Membership` tokens are not
+substitutes for an `ActorRef` map key (B.8). Capture `Context::myself()`
+while live and carry it in actor state; `on_stop` exposes no self-handle.
 
 ### B.2 `TaskContext`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -599,10 +599,14 @@ trait Actor: Sized + Send + 'static {
 - `on_stop` is best-effort teardown; it runs under the child's shutdown
   grace and its context is the narrowed `StopContext` (§5.4, Appendix B.1).
   `StopContext` exposes no `myself()`: an `ActorRef` is a send handle, and
-  posting from `on_stop` is futile. Self-identity for teardown MUST be
-  captured from `Context::myself()` during the live phase and carried in
-  actor state [#324]. A panic in `on_stop` is classified `Panicked` by
-  the fallback report token, superseding the run's outcome (§7).
+  posting from `on_stop` is futile. Teardown that needs the handle itself
+  — a map keyed by `ActorRef`, or a send — MUST capture it from
+  `Context::myself()` during the live phase and carry it in actor state
+  [#324]. Teardown that needs only identity captures nothing: the stop
+  context still exposes `incarnation()`, and `Incarnation::membership()`
+  is a process-wide unique key (§3.2, Appendix B.1). A panic in `on_stop`
+  is classified `Panicked` by the fallback report token, superseding the
+  run's outcome (§7).
 
 ### 4.2 One-shot is primitive; restartable is proven
 
@@ -3712,9 +3716,15 @@ incarnation. `myself()` is in that set: `ActorRef<M>` is the send surface
 (`send` / `call`, and `Eq`/`Hash` by slot identity), intake is already
 frozen, and no callback remains to receive posted work. Absence is the
 contract, not a documented-don't-post on a still-present accessor [#324].
-Scope-local `id()` and the `Incarnation` / `Membership` tokens are not
-substitutes for an `ActorRef` map key (B.8). Capture `Context::myself()`
-while live and carry it in actor state; `on_stop` exposes no self-handle.
+Identity is not withheld with it. `incarnation()` remains, and
+`Incarnation::membership()` yields a process-wide unique `Copy` key —
+unlike scope-local `id()` — stable across restart and reborn on
+remove-and-re-add (§3.2, §3.4), so a `Membership`-keyed registry
+deregisters from `on_stop` with no capture at all; such a registry evicts
+by key equality, since the rebirth leaves `supersedes` incomparable
+across a re-add. Only an `ActorRef`-keyed map (B.8) or a teardown that
+must send needs `Context::myself()` captured while live and carried in
+actor state.
 
 ### B.2 `TaskContext`
 

--- a/crates/shelterwood/doctests/docs/shutdown-and-resources.md
+++ b/crates/shelterwood/doctests/docs/shutdown-and-resources.md
@@ -30,6 +30,18 @@ boundary. Durable correctness must already survive a crash. Size a resource
 owner's grace for drain plus close, or choose `Discard` when draining is less
 important than allowing the close its full budget.
 
+## Self-identity is captured while live
+
+`StopContext` has no `myself()`. `ActorRef` is a send handle, and posting to
+this incarnation from `on_stop` is futile: intake is already frozen and no
+callback remains to receive the work. `id()` is unique only within one scope,
+and `incarnation()` / `membership()` are not `ActorRef` map keys.
+
+If teardown needs this actor as a registry key, capture `context.myself()` in
+`init` or `handle` and keep it in actor state. Unregister that must also cover
+init failure, handler error or panic, or hard abort belongs in `Drop` or on a
+`Removed` lifecycle event — `on_stop` does not run on those paths.
+
 ## Teardown communication uses `try_send`
 
 Ordinary `send` waits through rebind windows. During teardown, that can park

--- a/crates/shelterwood/doctests/docs/shutdown-and-resources.md
+++ b/crates/shelterwood/doctests/docs/shutdown-and-resources.md
@@ -30,14 +30,21 @@ boundary. Durable correctness must already survive a crash. Size a resource
 owner's grace for drain plus close, or choose `Discard` when draining is less
 important than allowing the close its full budget.
 
-## Self-identity is captured while live
+## Self-identity in teardown
 
 `StopContext` has no `myself()`. `ActorRef` is a send handle, and posting to
 this incarnation from `on_stop` is futile: intake is already frozen and no
-callback remains to receive the work. `id()` is unique only within one scope,
-and `incarnation()` / `membership()` are not `ActorRef` map keys.
+callback remains to receive the work.
 
-If teardown needs this actor as a registry key, capture `context.myself()` in
+Identity survives the narrowing. `context.incarnation().membership()` is a
+process-wide unique `Copy + Eq + Hash` key — unlike `id()`, which is unique
+only within one scope — stable across restart and reborn on remove-and-re-add.
+A `Membership`-keyed registry therefore deregisters straight from `on_stop`
+with nothing captured; evict by key equality, because a re-added child is a
+different key rather than a superseding one.
+
+Capture is for teardown that needs the handle itself: a map keyed by
+`ActorRef`, or a notification to send. Take `context.myself()` in
 `init` or `handle` and keep it in actor state. Unregister that must also cover
 init failure, handler error or panic, or hard abort belongs in the `Drop` of
 whatever owns the registration, or on a `Removed` lifecycle event — `on_stop`

--- a/crates/shelterwood/doctests/docs/shutdown-and-resources.md
+++ b/crates/shelterwood/doctests/docs/shutdown-and-resources.md
@@ -39,8 +39,10 @@ and `incarnation()` / `membership()` are not `ActorRef` map keys.
 
 If teardown needs this actor as a registry key, capture `context.myself()` in
 `init` or `handle` and keep it in actor state. Unregister that must also cover
-init failure, handler error or panic, or hard abort belongs in `Drop` or on a
-`Removed` lifecycle event — `on_stop` does not run on those paths.
+init failure, handler error or panic, or hard abort belongs in the `Drop` of
+whatever owns the registration, or on a `Removed` lifecycle event — `on_stop`
+does not run on those paths. A failed `init` constructs no actor to drop, so a
+registration made there belongs to a guard among `init`'s own locals.
 
 ## Teardown communication uses `try_send`
 

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -33,6 +33,12 @@ pub trait Actor: Sized + Send + 'static {
     ) -> impl Future<Output = ExitResult> + Send;
 
     /// Performs best-effort cooperative teardown.
+    ///
+    /// Runs under the child's shutdown grace with a narrowed [`StopContext`].
+    /// Not called when `init` failed, when a handler returned `Err` or
+    /// panicked, or on hard abort. [`StopContext`] has no self-handle;
+    /// capture [`Context::myself`] during the live phase if teardown needs
+    /// this actor's slot identity.
     fn on_stop(&mut self, _context: &mut StopContext<'_, Self>) -> impl Future<Output = ()> + Send {
         async {}
     }
@@ -102,6 +108,9 @@ macro_rules! actor_context_forwarders {
         context_common_forwarders!();
 
         /// Returns a membership-addressed handle to this actor.
+        ///
+        /// Absent from [`StopContext`]. Capture it during [`Actor::init`] or
+        /// [`Actor::handle`] if [`Actor::on_stop`] needs the slot identity.
         #[must_use]
         pub fn myself(&self) -> ActorRef<$actor::Msg> {
             self.raw.myself()
@@ -275,6 +284,12 @@ impl<'a, A: Actor> Context<'a, A> {
 }
 
 /// Narrowed context supplied only to [`Actor::on_stop`].
+///
+/// Work that queues delivery to this incarnation is unrepresentable: no
+/// continuations, timers, offloads, or [`Context::myself`]. [`ActorRef`] is
+/// a send handle; posting from `on_stop` is futile, so there is no
+/// self-handle here. Capture [`Context::myself`] during [`Actor::init`] or
+/// [`Actor::handle`] if teardown needs the slot identity.
 pub struct StopContext<'a, A: Actor> {
     raw: &'a mut RawContext<A::Msg>,
     actor: PhantomData<fn() -> A>,

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -38,7 +38,8 @@ pub trait Actor: Sized + Send + 'static {
     /// Not called when `init` failed, when a handler returned `Err` or
     /// panicked, or on hard abort. [`StopContext`] has no self-handle;
     /// capture [`Context::myself`] during the live phase if teardown needs
-    /// this actor's slot identity.
+    /// the handle itself. Identity alone needs no capture — the stop
+    /// context still exposes [`StopContext::incarnation`].
     fn on_stop(&mut self, _context: &mut StopContext<'_, Self>) -> impl Future<Output = ()> + Send {
         async {}
     }
@@ -110,7 +111,8 @@ macro_rules! actor_context_forwarders {
         /// Returns a membership-addressed handle to this actor.
         ///
         /// Absent from [`StopContext`]. Capture it during [`Actor::init`] or
-        /// [`Actor::handle`] if [`Actor::on_stop`] needs the slot identity.
+        /// [`Actor::handle`] if [`Actor::on_stop`] needs the handle itself;
+        /// for identity alone the stop context keeps `incarnation()`.
         #[must_use]
         pub fn myself(&self) -> ActorRef<$actor::Msg> {
             self.raw.myself()
@@ -288,8 +290,63 @@ impl<'a, A: Actor> Context<'a, A> {
 /// Work that queues delivery to this incarnation is unrepresentable: no
 /// continuations, timers, offloads, or [`Context::myself`]. [`ActorRef`] is
 /// a send handle; posting from `on_stop` is futile, so there is no
-/// self-handle here. Capture [`Context::myself`] during [`Actor::init`] or
-/// [`Actor::handle`] if teardown needs the slot identity.
+/// self-handle here. The absence is structural — `myself` is forwarded only
+/// onto [`Context`] — and this fence is what keeps it so:
+///
+/// ```compile_fail,E0599
+/// use shelterwood::{Actor, Context, ExitError, ExitResult, StopContext};
+///
+/// struct Teardown;
+///
+/// impl Actor for Teardown {
+///     type Msg = ();
+///     type Args = ();
+///
+///     async fn init((): Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+///         Ok(Self)
+///     }
+///
+///     async fn handle(&mut self, (): Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+///         Ok(())
+///     }
+///
+///     async fn on_stop(&mut self, context: &mut StopContext<'_, Self>) {
+///         let _self_handle = context.myself();
+///     }
+/// }
+/// ```
+///
+/// A `compile_fail` fence passes for *any* compilation error, so the same
+/// actor compiles here with the one supported teardown identity in place of
+/// that call — which is what isolates the fence above to the missing method:
+///
+/// ```
+/// use shelterwood::{Actor, Context, ExitError, ExitResult, Membership, StopContext};
+///
+/// struct Teardown;
+///
+/// impl Actor for Teardown {
+///     type Msg = ();
+///     type Args = ();
+///
+///     async fn init((): Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+///         Ok(Self)
+///     }
+///
+///     async fn handle(&mut self, (): Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+///         Ok(())
+///     }
+///
+///     async fn on_stop(&mut self, context: &mut StopContext<'_, Self>) {
+///         // Process-wide unique, so it keys a registry no `ActorRef` needs
+///         // to have been captured for.
+///         let _key: Membership = context.incarnation().membership();
+///     }
+/// }
+/// ```
+///
+/// Capture [`Context::myself`] during [`Actor::init`] or [`Actor::handle`]
+/// only when teardown needs the handle itself.
 pub struct StopContext<'a, A: Actor> {
     raw: &'a mut RawContext<A::Msg>,
     actor: PhantomData<fn() -> A>,

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -837,8 +837,10 @@ impl<M: Send + 'static> RawContext<M> {
 
     /// Returns a membership-addressed handle to this actor.
     ///
-    /// The high-level [`crate::StopContext`] has no equivalent: capture this
-    /// handle before stop if teardown needs the slot identity.
+    /// Available for the whole raw incarnation, teardown included. The
+    /// high-level [`crate::StopContext`] withholds its equivalent, so
+    /// callback-actor authors capture [`crate::Context::myself`] while live
+    /// instead.
     #[must_use]
     pub fn myself(&self) -> ActorRef<M> {
         self.myself.clone()

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -836,6 +836,9 @@ impl<M: Send + 'static> RawContext<M> {
     }
 
     /// Returns a membership-addressed handle to this actor.
+    ///
+    /// The high-level [`crate::StopContext`] has no equivalent: capture this
+    /// handle before stop if teardown needs the slot identity.
     #[must_use]
     pub fn myself(&self) -> ActorRef<M> {
         self.myself.clone()

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -12,9 +12,9 @@ use crate::common::{
     POLL_TIMEOUT, ReleaseGate, assert_eventually, assert_quiet, waiting::task as waiting_task,
 };
 use shelterwood::{
-    Actor, ActorDef, ActorOnceDef, ActorRef, ChildId, ChildState, Context, DynamicTree, ExitError,
-    ExitKind, ExitResult, Handler, Mailbox, RawActor, RawContext, RawOnceDef, Readiness, Retention,
-    ScopeRef, SendErrorKind, StopContext, TaskDef, Tree,
+    Actor, ActorDef, ActorOnceDef, ActorRef, ChildState, Context, DynamicTree, ExitError, ExitKind,
+    ExitResult, Handler, Mailbox, RawActor, RawContext, RawOnceDef, Readiness, Retention, ScopeRef,
+    SendErrorKind, StopContext, TaskDef, Tree,
 };
 
 #[derive(Clone)]
@@ -532,8 +532,9 @@ enum ContextSurfaceMessage {
 struct ContextSurfaceActor {
     entered: ReleaseGate,
     release: ReleaseGate,
+    myself: ActorRef<ContextSurfaceMessage>,
     observed: Option<tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>>,
-    stopped: Option<tokio::sync::oneshot::Sender<(ChildId, ScopeRef)>>,
+    stopped: Option<tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>>,
 }
 
 impl Actor for ContextSurfaceActor {
@@ -542,16 +543,17 @@ impl Actor for ContextSurfaceActor {
         ReleaseGate,
         ReleaseGate,
         tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>,
-        tokio::sync::oneshot::Sender<(ChildId, ScopeRef)>,
+        tokio::sync::oneshot::Sender<(ActorRef<ContextSurfaceMessage>, ScopeRef)>,
     );
 
     async fn init(
         (entered, release, observed, stopped): Self::Args,
-        _: &mut Context<'_, Self>,
+        context: &mut Context<'_, Self>,
     ) -> Result<Self, ExitError> {
         Ok(Self {
             entered,
             release,
+            myself: context.myself(),
             observed: Some(observed),
             stopped: Some(stopped),
         })
@@ -585,16 +587,17 @@ impl Actor for ContextSurfaceActor {
     }
 
     async fn on_stop(&mut self, context: &mut StopContext<'_, Self>) {
-        let id = context.id().clone();
         let scope: ScopeRef = context.scope();
         self.stopped
             .take()
             .expect("stop-context observation is sent once")
-            .send((id, scope))
-            .expect("test still awaits typed stop-context identity");
+            .send((self.myself.clone(), scope))
+            .expect("test still awaits the live-phase self-handle");
     }
 }
 
+/// Live context preserves slot identity and self-send capacity. Stop context
+/// has no `myself()`; the handle reported from `on_stop` is captured in `init`.
 #[tokio::test]
 async fn typed_context_handles_preserve_identity_and_self_send_capacity() {
     let entered = ReleaseGate::default();
@@ -631,10 +634,10 @@ async fn typed_context_handles_preserve_identity_and_self_send_capacity() {
     assert_eq!(myself, actor);
     assert_eq!(scope, system.scope());
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
-    let (stopping_id, stopping_scope) = stop_observation
+    let (stopping_myself, stopping_scope) = stop_observation
         .await
-        .expect("actor reports stop-context identity");
-    assert_eq!(&stopping_id, actor.id());
+        .expect("actor reports the captured self-handle from stop");
+    assert_eq!(stopping_myself, actor);
     assert_eq!(stopping_scope, scope);
 }
 

--- a/docs/shutdown-and-resources.md
+++ b/docs/shutdown-and-resources.md
@@ -30,6 +30,18 @@ boundary. Durable correctness must already survive a crash. Size a resource
 owner's grace for drain plus close, or choose `Discard` when draining is less
 important than allowing the close its full budget.
 
+## Self-identity is captured while live
+
+`StopContext` has no `myself()`. `ActorRef` is a send handle, and posting to
+this incarnation from `on_stop` is futile: intake is already frozen and no
+callback remains to receive the work. `id()` is unique only within one scope,
+and `incarnation()` / `membership()` are not `ActorRef` map keys.
+
+If teardown needs this actor as a registry key, capture `context.myself()` in
+`init` or `handle` and keep it in actor state. Unregister that must also cover
+init failure, handler error or panic, or hard abort belongs in `Drop` or on a
+`Removed` lifecycle event — `on_stop` does not run on those paths.
+
 ## Teardown communication uses `try_send`
 
 Ordinary `send` waits through rebind windows. During teardown, that can park

--- a/docs/shutdown-and-resources.md
+++ b/docs/shutdown-and-resources.md
@@ -30,14 +30,21 @@ boundary. Durable correctness must already survive a crash. Size a resource
 owner's grace for drain plus close, or choose `Discard` when draining is less
 important than allowing the close its full budget.
 
-## Self-identity is captured while live
+## Self-identity in teardown
 
 `StopContext` has no `myself()`. `ActorRef` is a send handle, and posting to
 this incarnation from `on_stop` is futile: intake is already frozen and no
-callback remains to receive the work. `id()` is unique only within one scope,
-and `incarnation()` / `membership()` are not `ActorRef` map keys.
+callback remains to receive the work.
 
-If teardown needs this actor as a registry key, capture `context.myself()` in
+Identity survives the narrowing. `context.incarnation().membership()` is a
+process-wide unique `Copy + Eq + Hash` key — unlike `id()`, which is unique
+only within one scope — stable across restart and reborn on remove-and-re-add.
+A `Membership`-keyed registry therefore deregisters straight from `on_stop`
+with nothing captured; evict by key equality, because a re-added child is a
+different key rather than a superseding one.
+
+Capture is for teardown that needs the handle itself: a map keyed by
+`ActorRef`, or a notification to send. Take `context.myself()` in
 `init` or `handle` and keep it in actor state. Unregister that must also cover
 init failure, handler error or panic, or hard abort belongs in the `Drop` of
 whatever owns the registration, or on a `Removed` lifecycle event — `on_stop`

--- a/docs/shutdown-and-resources.md
+++ b/docs/shutdown-and-resources.md
@@ -39,8 +39,10 @@ and `incarnation()` / `membership()` are not `ActorRef` map keys.
 
 If teardown needs this actor as a registry key, capture `context.myself()` in
 `init` or `handle` and keep it in actor state. Unregister that must also cover
-init failure, handler error or panic, or hard abort belongs in `Drop` or on a
-`Removed` lifecycle event — `on_stop` does not run on those paths.
+init failure, handler error or panic, or hard abort belongs in the `Drop` of
+whatever owns the registration, or on a `Removed` lifecycle event — `on_stop`
+does not run on those paths. A failed `init` constructs no actor to drop, so a
+registration made there belongs to a guard among `init`'s own locals.
 
 ## Teardown communication uses `try_send`
 


### PR DESCRIPTION
Closes #324.

`StopContext::myself()` stays gone. `ActorRef` is a send surface; posting from `on_stop` is futile, and returning the handle would reopen the surface the type exists to close. Self-identity for teardown is captured from `Context::myself()` during the live phase and carried in actor state.

- SPEC §4.1 and Appendix B.1 record the omission as the contract, not a missing accessor.
- Rustdoc on `Actor::on_stop`, `Context::myself`, `StopContext`, and `RawContext::myself` makes that discoverable from the signatures.
- Shutdown guidance states the same capture rule, including that unregister covering panic/abort belongs in `Drop` or on `Removed`.
- The context-surface test now reports the handle captured in `init` from `on_stop`, instead of treating `ChildId` as stop-phase slot identity.

Validation: `./tools/dev just ci` (766/766 tests plus formatting, clippy, docs, reachability, packaged-docs, external consumer, and Nix formatting).