### PR TITLE
Make tidy-beat completion test deterministic

### DIFF
--- a/crates/shelterwood/tests/lifecycle.rs
+++ b/crates/shelterwood/tests/lifecycle.rs
@@ -754,7 +754,7 @@ async fn abort_policy_task_exits_aborted_without_grace() {
     assert_eq!(exit.cancellation(), Cancellation::Observed);
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn completion_during_the_tidy_beat_is_not_reclassified_as_abort() {
     let mut tree = Tree::new();
     let task = tree


### PR DESCRIPTION
## What changed

Run `completion_during_the_tidy_beat_is_not_reclassified_as_abort` with Tokio's clock paused.

## Why

The `Abort` policy deliberately uses a 1 ms tidy beat. The test's task waited for the abort token and then returned immediately, but on a CPU-constrained machine the task could be starved for longer than that wall-clock interval. In that case the task had not actually completed before the hard-abort deadline, so the observed `Aborted { WithinGrace }` verdict was correct even though the fixture expected `Completed`.

A paused clock preserves the production policy while making the test's intended ordering deterministic: runnable completion work is polled before virtual time advances to the tidy deadline.

## Impact

This removes a load-sensitive test failure without changing runtime shutdown behavior or the public API.

## Validation

- 1,000 targeted runs with the test pinned to four CPUs saturated by spinner processes
- `./tools/dev just ci`
  - 766 unit/integration tests
  - doctests
  - formatting and clippy
  - docs/API reachability
  - external-consumer checks
  - Nix formatting

Closes #330