### PR TITLE
Address core findings from the full review

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2243,7 +2243,8 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
 5. **S5 — completion is derived and level-triggered.** `all_children_joined`
    is derived from child states. `Settle` emits `Finished` once iff the
    lifecycle’s flavor-specific finish predicate accepts that derived value.
-   (`supervisor::derived_completion_property_matches_the_child_states`,
+   (`engine::scope_lifecycle_owns_first_failure_drain_status_and_finish_policy`,
+   `supervisor::derived_completion_property_matches_the_child_states`,
    `supervisor::exhaustive_reachable_states_preserve_the_reducer_invariants`.)
 6. **S6 — shutdown requests are sampled latches.** Scope shutdown and removal
    are synchronous, idempotent latches sampled into reducer events at step
@@ -2646,13 +2647,13 @@ or lifetime paragraph is unmapped.
   was requested concurrently elsewhere);
   `wait_started()` resolves once at startup and cannot observe a
   later trip, so `wait()` is the post-startup observation point. Natural
-  completion is pinned exactly: an **ordered** scope *finishes* when it
-  has at least one membership and every membership is terminal (a
-  retained terminal child counts — §8's retention is observability, not
-  liveness); a root parked in `StartupFailed` is exempt — it never
-  finishes (the park rule above). The finishing test runs **at each membership's
-  terminalization, strictly before retention-based pruning** removes it
-  (§8's remove-on-terminal default), and its result is latched — so
+  completion is pinned exactly: once aggregate startup has completed, an
+  **ordered** scope *finishes* when it has at least one membership and every
+  membership is terminal (a retained terminal child counts — §8's retention
+  is observability, not liveness); a root parked in `StartupFailed` is exempt —
+  it never finishes (the park rule above). The finishing test runs **at each
+  membership's terminalization, strictly before retention-based pruning**
+  removes it (§8's remove-on-terminal default), and its result is latched — so
   pruning the final one-shot membership can never turn a finished
   workload into an idling empty scope, and pruning order is otherwise
   unobservable. The scope then publishes `Stopped { reason: Finished }` and, when

--- a/crates/shelterwood-core/src/engine.rs
+++ b/crates/shelterwood-core/src/engine.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::{
-    Exit, GracePhase, Intensity, IntensityTrip, JitterSample, Readiness, RestartAttempt,
+    Exit, ExitKind, GracePhase, Intensity, IntensityTrip, JitterSample, Readiness, RestartAttempt,
     RestartCount, RestartPolicy, Shutdown, TotalRestarts,
     deadline::Deadline,
     exit::{StopReason, stop_reason_precedence},
@@ -251,6 +251,10 @@ pub fn dispatch_exit(
     scope: ScopeMode,
     membership: MembershipStatus,
 ) -> ExitDispatch {
+    debug_assert!(
+        !matches!(exit.kind(), ExitKind::NeverStarted),
+        "NeverStarted is a membership outcome outside incarnation dispatch"
+    );
     if scope == ScopeMode::Draining || membership == MembershipStatus::Removing {
         return ExitDispatch::Terminal;
     }
@@ -285,7 +289,8 @@ struct IntensityCharge {
 }
 
 impl IntensityTrip {
-    fn new(policy: Intensity, charge: IntensityCharge) -> Self {
+    fn new(charge: IntensityCharge) -> Self {
+        let policy = charge.policy;
         debug_assert_eq!(charge.tripped, charge.in_window > policy.max_restarts());
         Self {
             max_restarts: policy.max_restarts(),
@@ -401,9 +406,7 @@ impl RestartDecision {
     }
 
     pub fn intensity_trip(&self) -> Option<IntensityTrip> {
-        self.charge
-            .tripped
-            .then(|| IntensityTrip::new(self.charge.policy, self.charge))
+        self.charge.tripped.then(|| IntensityTrip::new(self.charge))
     }
 }
 
@@ -910,7 +913,7 @@ impl ScopeLifecycle {
         if let Some(reason) = self.draining_reason() {
             return children.all_terminal.then(|| reason.clone());
         }
-        (!self.startup_failed()
+        (self.startup_complete()
             && flavor == ScopeFlavor::Ordered
             && children.has_children
             && children.all_terminal)
@@ -1378,7 +1381,6 @@ mod tests {
                 },
                 true,
             ),
-            (ExitKind::NeverStarted, true),
         ];
         let policies = [
             (RestartCondition::Never, false, false),
@@ -1389,10 +1391,8 @@ mod tests {
         for cancellation in [Cancellation::NotObserved, Cancellation::Observed] {
             for (kind, failure) in &cases {
                 // Built through the per-kind constructors rather than a generic
-                // `Exit::new`, which no longer exists. `NeverStarted` pairs only
-                // with `NotObserved`: SPEC declares that pair the sole
-                // unconstructible combination, so the matrix covers the eleven
-                // reachable ones.
+                // `Exit::new`, which no longer exists. `NeverStarted` is a
+                // membership fact outside dispatch's incarnation-exit domain.
                 let exit = match kind {
                     ExitKind::Completed => Exit::completed(cancellation),
                     ExitKind::Failed(error) => Exit::failed(error.clone(), cancellation),
@@ -1401,10 +1401,7 @@ mod tests {
                         Exit::readiness_timed_out(*deadline, cancellation)
                     }
                     ExitKind::Aborted { phase } => Exit::aborted(*phase, cancellation),
-                    ExitKind::NeverStarted => match cancellation {
-                        Cancellation::NotObserved => Exit::never_started(),
-                        Cancellation::Observed => continue,
-                    },
+                    ExitKind::NeverStarted => unreachable!("the cases exclude membership exits"),
                 };
                 assert_eq!(exit.is_failure(), *failure);
                 for (condition, restart_completed, restart_failure) in policies {
@@ -1443,6 +1440,19 @@ mod tests {
         }
     }
 
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "NeverStarted is a membership outcome outside incarnation dispatch")]
+    fn funnel_dispatch_rejects_the_membership_level_never_started_outcome() {
+        let exit = Exit::never_started();
+        let _ = dispatch_exit(
+            &exit,
+            RestartPolicy::default(),
+            ScopeMode::Running,
+            MembershipStatus::Active,
+        );
+    }
+
     #[test]
     fn intensity_window_is_strict_and_tripping_charge_is_counted() {
         let start = Instant::now();
@@ -1453,7 +1463,7 @@ mod tests {
         assert!(trip.tripped);
         assert_eq!(trip.in_window, 2);
         assert_eq!(trip.total_restarts, TotalRestarts::ZERO.bump().bump());
-        let trip_payload = crate::IntensityTrip::new(policy, trip);
+        let trip_payload = crate::IntensityTrip::new(trip);
         assert_eq!(trip_payload.max_restarts, policy.max_restarts());
         assert_eq!(trip_payload.observed_restarts, trip.in_window);
         assert_eq!(trip_payload.within, policy.within());
@@ -1519,7 +1529,7 @@ mod tests {
         assert!(decision.charge.tripped);
         assert_eq!(
             decision.intensity_trip(),
-            Some(crate::IntensityTrip::new(intensity_policy, decision.charge))
+            Some(crate::IntensityTrip::new(decision.charge))
         );
     }
 
@@ -1714,6 +1724,19 @@ mod tests {
 
     #[test]
     fn scope_lifecycle_owns_first_failure_drain_status_and_finish_policy() {
+        let starting = ScopeLifecycle::starting();
+        assert_eq!(
+            starting.finish_if_ready(
+                ScopeFlavor::Ordered,
+                ChildCompletionState {
+                    has_children: true,
+                    all_terminal: true,
+                },
+            ),
+            None,
+            "natural completion waits for aggregate startup to complete"
+        );
+
         let mut lifecycle = ScopeLifecycle::starting();
         assert_eq!(lifecycle.fail_startup(), Some(ScopeState::StartupFailed));
         assert_eq!(

--- a/crates/shelterwood-core/src/exit.rs
+++ b/crates/shelterwood-core/src/exit.rs
@@ -161,24 +161,22 @@ impl ExitError {
     }
 }
 
-/// Mints the framework-authenticated intensity-trip payload.
-///
-/// This and its startup-failure twin are the entire authentication boundary
-/// for [`ExitError::intensity_trip`] and [`ExitError::startup_failure`]: the
-/// wrapped inner variants are unreachable any other way, so a value that
-/// arrived through the blanket user conversion can never answer `Some`. The
-/// split published this crate, which means the boundary is now a convention
-/// rather than a privacy rule — hidden from documentation so it does not read
-/// as supported API.
-#[doc(hidden)]
+/// Mints the framework-authenticated intensity-trip payload. Privacy is the
+/// authentication boundary: only this module's stop-reason conversion paths
+/// can construct the wrapped variant, so blanket user conversion can never
+/// make [`ExitError::intensity_trip`] answer `Some`.
 fn structured_intensity_trip_error(value: IntensityTrip) -> ExitError {
     ExitError(Arc::new(ExitErrorInner::IntensityTrip(
         StructuredIntensityTrip(value),
     )))
 }
 
-/// Mints the framework-authenticated startup-failure payload; see
-/// [`structured_intensity_trip_error`] for the boundary this participates in.
+/// Mints the framework-authenticated startup-failure payload.
+///
+/// The sibling-crate driver needs this edge, so unlike the private intensity
+/// constructor its authentication boundary is conventional: the supported
+/// facade neither exposes this function nor permits callers to mint the
+/// wrapped variant through blanket user conversion.
 #[doc(hidden)]
 pub fn structured_startup_failure_error(value: StartupFailure) -> ExitError {
     ExitError(Arc::new(ExitErrorInner::StartupFailure(

--- a/crates/shelterwood-core/src/panic.rs
+++ b/crates/shelterwood-core/src/panic.rs
@@ -136,7 +136,15 @@ mod tests {
 
     use super::{
         PanicAccumulator, PanicPayload, UnwindPanics, discard_panic, resume_preferred_panic,
+        resume_preferred_panic_outside_unwind,
     };
+
+    fn panic_message(payload: &PanicPayload) -> Option<&str> {
+        payload
+            .downcast_ref::<&'static str>()
+            .copied()
+            .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+    }
 
     struct RecursivelyPanickingPayload;
 
@@ -193,6 +201,44 @@ mod tests {
         assert_eq!(payload.downcast_ref::<&str>(), Some(&"outer panic"));
         assert_eq!(primary_drops.load(Ordering::SeqCst), 1);
         assert_eq!(cleanup_drops.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn primary_panic_takes_precedence_over_cleanup_outside_an_unwind() {
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            resume_preferred_panic(UnwindPanics {
+                primary: Some(Box::new("primary panic")),
+                cleanup: Some(Box::new("cleanup panic")),
+            });
+        }))
+        .expect_err("the primary panic is resumed");
+        assert_eq!(panic_message(&payload), Some("primary panic"));
+    }
+
+    #[test]
+    fn outside_unwind_resumption_preserves_primary_and_cleanup_precedence() {
+        let primary = catch_unwind(AssertUnwindSafe(|| {
+            resume_preferred_panic_outside_unwind(UnwindPanics {
+                primary: Some(Box::new("primary panic")),
+                cleanup: Some(Box::new("cleanup panic")),
+            });
+        }))
+        .expect_err("the primary panic is resumed");
+        assert_eq!(panic_message(&primary), Some("primary panic"));
+
+        let cleanup = catch_unwind(AssertUnwindSafe(|| {
+            resume_preferred_panic_outside_unwind(UnwindPanics {
+                primary: None,
+                cleanup: Some(Box::new("cleanup panic")),
+            });
+        }))
+        .expect_err("cleanup stands in when there is no primary panic");
+        assert_eq!(panic_message(&cleanup), Some("cleanup panic"));
+
+        resume_preferred_panic_outside_unwind(UnwindPanics {
+            primary: None,
+            cleanup: None,
+        });
     }
 
     struct TaggedPanic {

--- a/crates/shelterwood-core/src/policy.rs
+++ b/crates/shelterwood-core/src/policy.rs
@@ -1421,6 +1421,76 @@ mod tests {
     }
 
     #[test]
+    fn child_mailbox_overrides_cover_every_kind_and_capacity_source() {
+        let queue_capacity = NonZeroUsize::new(10).expect("capacity is non-zero");
+        let explicit_capacity = NonZeroUsize::new(3).expect("capacity is non-zero");
+        let defaults = ResolvedDefaults::default()
+            .overlay(&ScopeDefaults {
+                mailbox: Some(Mailbox::Queue(Some(queue_capacity))),
+                ..ScopeDefaults::default()
+            })
+            .overlay(&ScopeDefaults {
+                mailbox: Some(Mailbox::Latest),
+                ..ScopeDefaults::default()
+            });
+
+        assert_eq!(
+            defaults.resolve_child_mailbox(None),
+            ResolvedMailbox::Latest
+        );
+        assert_eq!(
+            defaults.resolve_child_mailbox(Some(Mailbox::Queue(None))),
+            ResolvedMailbox::Queue(queue_capacity),
+            "queue inheritance retains the last queue capacity across a Latest default"
+        );
+        assert_eq!(
+            defaults.resolve_child_mailbox(Some(Mailbox::Queue(Some(explicit_capacity)))),
+            ResolvedMailbox::Queue(explicit_capacity)
+        );
+        assert_eq!(
+            defaults.resolve_child_mailbox(Some(Mailbox::Latest)),
+            ResolvedMailbox::Latest
+        );
+    }
+
+    #[test]
+    fn one_shot_resolution_forces_never_restart_and_defaults_to_removal() {
+        let explicit_restart = RestartPolicy::new(RestartCondition::Always, Backoff::Immediate);
+        let defaults = ResolvedDefaults::default();
+        let resolved = resolve_common(
+            &CommonOptions {
+                restart: Some(explicit_restart),
+                ..CommonOptions::default()
+            },
+            &defaults,
+            ChildMode::OneShot,
+            Readiness::Immediate,
+        );
+        assert_eq!(
+            resolved.restart,
+            RestartPolicy::new(RestartCondition::Never, Backoff::Immediate),
+            "one-shot mode overrides even an explicit restart policy"
+        );
+        assert_eq!(resolved.retention, Retention::Remove);
+
+        let retained = resolve_common(
+            &CommonOptions {
+                restart: Some(explicit_restart),
+                retention: Some(Retention::Retain),
+                ..CommonOptions::default()
+            },
+            &defaults,
+            ChildMode::OneShot,
+            Readiness::Immediate,
+        );
+        assert_eq!(
+            retained.restart,
+            RestartPolicy::new(RestartCondition::Never, Backoff::Immediate)
+        );
+        assert_eq!(retained.retention, Retention::Retain);
+    }
+
+    #[test]
     fn default_overlay_and_child_resolution_share_inheritance_rules() {
         let inherited = ResolvedDefaults::default().overlay(&ScopeDefaults {
             child_restart: Some(RestartPolicy::new(

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -689,11 +689,6 @@ impl SupervisorState {
         assert_eq!(self.children.len(), self.child_keys.len());
         for (&key, child) in &self.children {
             assert_eq!(self.child_keys.get(&child.membership), Some(&key));
-            // A start effect is only ever derived from `startable`, so a
-            // spawnable record must be one `Event::Spawned` away from
-            // executing. This is the emission/acceptance agreement that keeps
-            // level-triggered settlement terminating.
-            assert!(!child.startable() || !child.state.joined());
         }
         // The ordered cursors are flavor-owned state; a dynamic scope that
         // grew one would silently acquire a second stop sequencer.

--- a/crates/shelterwood-core/src/supervisor/tests/exploration.rs
+++ b/crates/shelterwood-core/src/supervisor/tests/exploration.rs
@@ -707,8 +707,9 @@ fn check_s5_derived_level_triggered_completion(transition: &Transition<'_>) {
         assert!(
             transition.after.lifecycle().is_draining()
                 || (transition.after.flavor() == ScopeFlavor::Ordered
+                    && transition.after.lifecycle().startup_complete()
                     && !transition.after.is_empty()),
-            "only a draining scope, or a non-empty ordered one, finishes"
+            "only a draining scope, or a running non-empty ordered one, finishes"
         );
     }
     // And its liveness half: settlement is level-triggered, so a drained scope


### PR DESCRIPTION
## Summary

- require ordered natural completion to wait until aggregate startup has completed, and pin the `Starting` edge in both the lifecycle unit test and reducer exploration
- cover every child mailbox override plus the one-shot restart/retention resolution branches
- complete the core residual cleanup: collapse the intensity-trip constructor input, remove the vacuous supervisor assertion, add local panic-precedence pins, correct structured-error boundary docs, and make `NeverStarted`'s dispatch exclusion assert-loud

## Design decisions

### #335: `Starting` does not naturally finish

I ruled that an ordered scope must not report `Finished` until aggregate startup has completed. The production driver currently makes the suspicious state structurally difficult to reach: it admits the entire initial plan before the first settle, `Settle` runs startup progression before finish progression, and a terminal pre-ready exit leaves `Starting` through startup failure. However, accepting natural completion directly from `Starting` would still contradict the readiness barrier and would make a future driver refactor able to publish `Stopped { reason: Finished }` without ever publishing `Running`.

The predicate now requires `startup_complete()`, SPEC section 11 states that ordering explicitly, and the exhaustive reducer property rejects a non-draining `Finished` edge unless the lifecycle has completed startup.

### #346: `NeverStarted` is outside dispatch's domain

I chose the assert-loud hygiene option from the issue comment. `dispatch_exit` now has the same `debug_assert!` domain guard as the stop-reason twin, and its matrix tests only the ten constructible incarnation-exit/cancellation combinations. A direct debug assertion test pins the boundary. No defensive terminal arm was added because that would silently accept an invalid membership-level input.

No checklist items were omitted.

## Validation

- `./tools/dev cargo test -p shelterwood-core` (89 unit tests and 9 doc tests passed)
- `./tools/dev just ci` (format, clippy, 771 nextest tests, doc tests/docs, API reachability, packaged docs, external consumer, and Nix formatting passed)

Closes #335
Closes #336
Closes #346

Tracking: #348
