### PR TITLE
Contain raw teardown panics and freeze drain boundaries

### DIFF
--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -702,15 +702,24 @@ impl<M> RawResources<M> {
         }
         self.accepting = false;
         let dropped_continuations = self.continuations.len();
-        // Cancellation catches each future's destructor independently, so a
-        // failure cannot prevent later offloads from being cancelled/signalled.
+        // Treat the whole freeze as one cleanup transaction. Cancellation
+        // contains each latch wake, future disposal and task abort
+        // independently, while this outer accumulator keeps one failure from
+        // skipping later offloads or any of the collection drains.
+        let mut panics = PanicAccumulator::default();
         for offload in &mut self.offloads {
-            offload.cancel();
+            panics.record(offload.cancel());
         }
-        self.continuations.clear();
-        self.timers.clear();
-        self.ready_batch = None;
-        self.events.clear();
+        panics.run(|| self.continuations.clear());
+        panics.run(|| self.timers.clear());
+        panics.run(|| self.ready_batch = None);
+        panics.run(|| self.events.clear());
+        if let Some(payload) = panics.take() {
+            // The owned raw-incarnation epilogue drains this slot after the
+            // freeze and before joining, so publication is delayed until all
+            // synchronous cleanup has completed without losing the diagnostic.
+            self.disposal.panic.record(payload);
+        }
         dropped_continuations
     }
 
@@ -1129,6 +1138,10 @@ impl<M: Send + 'static> RawContext<M> {
     /// resuming the loop.
     pub fn try_recv(&mut self) -> Option<M> {
         if self.is_stopping() {
+            // Establish the receive boundary locally just as `recv` does. Do
+            // not rely on the driver's mailbox-freeze ordering relative to
+            // the shutdown latch this call observes.
+            self.receiver.freeze();
             self.freeze_and_report();
             self.resources.resume_pending_panic();
             self.receiver.try_recv()
@@ -2067,6 +2080,73 @@ mod tests {
                 .expect_err("recv's local freeze closes the acceptance boundary")
                 .kind,
             crate::SendErrorKind::NotRunning
+        );
+    }
+
+    #[test]
+    fn try_recv_freezes_its_mailbox_when_it_observes_shutdown() {
+        let (mut context, actor, shutdown) = bound_raw_context_for::<u8>();
+        actor
+            .try_send(1)
+            .expect("the live mailbox accepts before shutdown");
+        shutdown.fire();
+
+        assert_eq!(
+            context.try_recv(),
+            Some(1),
+            "drain mode still reads the prefix accepted before the local freeze"
+        );
+        assert_eq!(
+            actor
+                .try_send(2)
+                .expect_err("try_recv's local freeze closes the acceptance boundary")
+                .kind,
+            crate::SendErrorKind::NotRunning
+        );
+    }
+
+    #[test]
+    fn cancelled_queued_event_is_disposed_without_materializing_its_message() {
+        let (mut context, _actor, _shutdown) = bound_raw_context_for::<u8>();
+        let cancellation = Latch::default();
+        cancellation.fire();
+        let drops = Arc::new(AtomicUsize::new(0));
+        let invoked = Arc::new(AtomicUsize::new(0));
+        let event_payload = PanickingDrop(Arc::clone(&drops));
+        let invoked_by_event = Arc::clone(&invoked);
+        context.resources.events.push(QueuedEvent {
+            cancellation,
+            make_message: Box::new(move || {
+                invoked_by_event.fetch_add(1, Ordering::SeqCst);
+                drop(event_payload);
+                7
+            }),
+        });
+
+        assert_eq!(
+            context.try_recv(),
+            None,
+            "a completion cancelled after queueing does not deliver a message"
+        );
+        assert_eq!(
+            invoked.load(Ordering::SeqCst),
+            0,
+            "the cancelled completion never runs its message builder"
+        );
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            1,
+            "the queued completion is disposed at materialization time"
+        );
+        let payload = context
+            .resources
+            .disposal
+            .panic
+            .take()
+            .expect("the hostile event destructor is retained by raw disposal");
+        assert_eq!(
+            panic_message(&payload),
+            Some("contained raw payload destructor panic")
         );
     }
 

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -922,6 +922,13 @@ impl<M: Send + 'static> RawContext<M> {
     /// frozen mailbox. Idempotent. This is the primitive the blanket handler
     /// loop's `Context::stop` is built on (§1 principle 5); the child's
     /// configured §10 ladder bounds the stop.
+    ///
+    /// A cleanup failure raised while freezing — a hostile waker woken by
+    /// offload cancellation, or a released destructor — is retained as this
+    /// incarnation's exit rather than raised here, so this call returns
+    /// normally and the caller's loop keeps running. The payload surfaces
+    /// from the next [`recv`](Self::recv)/[`try_recv`](Self::try_recv) or
+    /// from the epilogue.
     pub fn stop(&mut self) {
         self.receiver.freeze();
         self.freeze_and_report();
@@ -1073,9 +1080,12 @@ impl<M: Send + 'static> RawContext<M> {
     /// reported: an offload-work panic, and — because the stop branches
     /// freeze first — a destructor panic from the queued continuations,
     /// armed timers, queued offload completions and offload futures that the
-    /// freeze releases. Retention is the guarantee, not a join: a payload
-    /// recorded after this check is still the incarnation's exit, but is
-    /// classified by the epilogue and cannot suppress `on_stop`.
+    /// freeze releases, a waker panic from the `Guard::finished()` waiters
+    /// and cancellation latches that cancelling those offloads wakes, and a
+    /// panic raised by aborting an offload task. Retention is the guarantee,
+    /// not a join: a payload recorded after this check is still the
+    /// incarnation's exit, but is classified by the epilogue and cannot
+    /// suppress `on_stop`.
     ///
     /// A panic in an offload's continuation closure — the `FnOnce` that
     /// builds the message from the offload result, not a
@@ -1130,9 +1140,12 @@ impl<M: Send + 'static> RawContext<M> {
     /// [`continue_with`](Self::continue_with) continuation, which is a plain
     /// stored message) surfaces directly from this call. During drain it
     /// freezes first, then resumes any incarnation-owned disposal panic
-    /// retained by that point — an offload-work panic, or a destructor panic
+    /// retained by that point — an offload-work panic, a destructor panic
     /// from the continuations, timers, queued completions and offload futures
-    /// the freeze releases — before reading the frozen accepted mailbox
+    /// the freeze releases, a waker panic from the `Guard::finished()`
+    /// waiters and cancellation latches that cancelling those offloads wakes,
+    /// or a panic raised by aborting an offload task — before reading the
+    /// frozen accepted mailbox
     /// prefix. Retention is the guarantee, not a join: a payload recorded
     /// after the check is still the incarnation's exit, but is classified by
     /// the epilogue and cannot suppress `on_stop`.

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -707,18 +707,26 @@ impl<M> RawResources<M> {
         // independently, while this outer accumulator keeps one failure from
         // skipping later offloads or any of the collection drains.
         let mut panics = PanicAccumulator::default();
+        // An already-retained offload failure happened before this freeze and
+        // therefore precedes every synchronous cleanup failure below.
+        panics.record(self.disposal.panic.take());
         for offload in &mut self.offloads {
-            panics.record(offload.cancel());
+            panics.record(offload.cancel(&self.disposal.panic));
+            panics.record(self.disposal.panic.take());
         }
         panics.run(|| self.continuations.clear());
+        panics.record(self.disposal.panic.take());
         panics.run(|| self.timers.clear());
+        panics.record(self.disposal.panic.take());
         panics.run(|| self.ready_batch = None);
+        panics.record(self.disposal.panic.take());
         panics.run(|| self.events.clear());
+        panics.record(self.disposal.panic.take());
         if let Some(payload) = panics.take() {
             // The owned raw-incarnation epilogue drains this slot after the
             // freeze and before joining, so publication is delayed until all
             // synchronous cleanup has completed without losing the diagnostic.
-            self.disposal.panic.record(payload);
+            self.disposal.panic.restore_first(payload);
         }
         dropped_continuations
     }
@@ -1550,7 +1558,7 @@ mod tests {
             Arc, Barrier,
             atomic::{AtomicUsize, Ordering},
         },
-        task::{Context, Poll, Waker},
+        task::{Context, Poll, Wake, Waker},
         thread,
         time::Duration,
     };
@@ -1699,6 +1707,18 @@ mod tests {
     }
 
     struct PanickingDrop(Arc<AtomicUsize>);
+
+    struct PanickingWake(&'static str);
+
+    impl Wake for PanickingWake {
+        fn wake(self: Arc<Self>) {
+            panic!("{}", self.0);
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            panic!("{}", self.0);
+        }
+    }
 
     impl Drop for PanickingDrop {
         fn drop(&mut self) {
@@ -2346,6 +2366,108 @@ mod tests {
             drops.load(Ordering::SeqCst),
             2,
             "repeat cancellation is inert"
+        );
+    }
+
+    #[test]
+    fn freeze_preserves_an_offload_wake_panic_ahead_of_later_collection_disposal() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut resources = RawResources::<PanickingDrop>::default();
+        resources
+            .continuations
+            .push_back(PanickingDrop(Arc::clone(&drops)));
+
+        let finished = Latch::default();
+        let mut waiter = Box::pin(finished.fired());
+        let hostile = Waker::from(Arc::new(PanickingWake("first finished wake panic")));
+        assert!(
+            waiter
+                .as_mut()
+                .poll(&mut Context::from_waker(&hostile))
+                .is_pending()
+        );
+        resources.offloads.push(OffloadResource {
+            cancellation: Latch::default(),
+            finished: finished.clone(),
+            state: None,
+            task: None,
+        });
+
+        assert_eq!(resources.freeze(), 1);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        let payload = resources
+            .disposal
+            .panic
+            .take()
+            .expect("the first cleanup failure is retained");
+        assert_eq!(panic_message(&payload), Some("first finished wake panic"));
+    }
+
+    #[test]
+    fn freeze_preserves_future_disposal_ahead_of_its_later_finished_wake() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut resources = RawResources::<()>::default();
+        let finished = Latch::default();
+        let mut waiter = Box::pin(finished.fired());
+        let hostile = Waker::from(Arc::new(PanickingWake("later finished wake panic")));
+        assert!(
+            waiter
+                .as_mut()
+                .poll(&mut Context::from_waker(&hostile))
+                .is_pending()
+        );
+        let state = SharedOffloadState::new(
+            Box::pin(BlockingPollDrop {
+                entered: Arc::new(Barrier::new(1)),
+                release: Arc::new(Barrier::new(1)),
+                drops: Arc::clone(&drops),
+                panic_on_drop: true,
+            }),
+            resources.disposal.clone(),
+            finished.clone(),
+        );
+        resources.offloads.push(OffloadResource {
+            cancellation: Latch::default(),
+            finished: finished.clone(),
+            state: Some(state),
+            task: None,
+        });
+
+        assert_eq!(resources.freeze(), 0);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        let payload = resources
+            .disposal
+            .panic
+            .take()
+            .expect("the first cleanup failure is retained");
+        assert_eq!(
+            panic_message(&payload),
+            Some("unit offload destructor panic")
+        );
+    }
+
+    #[test]
+    fn repeated_freeze_preserves_the_first_failure_without_repeating_disposal() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut resources = RawResources::<PanickingDrop>::default();
+        resources
+            .continuations
+            .push_back(PanickingDrop(Arc::clone(&drops)));
+
+        assert_eq!(resources.freeze(), 1);
+        assert_eq!(resources.freeze(), 0, "the freeze transition is one-shot");
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+        let payload = catch_unwind(AssertUnwindSafe(|| drop(resources)))
+            .expect_err("drop resumes the failure retained by the first freeze");
+        assert_eq!(
+            panic_message(&payload),
+            Some("contained raw payload destructor panic")
+        );
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            1,
+            "drop does not re-run already completed disposal"
         );
     }
 

--- a/crates/shelterwood/src/raw/disposal.rs
+++ b/crates/shelterwood/src/raw/disposal.rs
@@ -89,6 +89,21 @@ impl PanicSlot {
             .expect("offload panic mutex poisoned")
             .take()
     }
+
+    /// Restores a payload already established to precede anything that can
+    /// have reached this slot in the meantime.
+    ///
+    /// Raw-resource freeze temporarily folds slot-retained disposal failures
+    /// into its cleanup-wide accumulator. An offload task may publish another
+    /// failure before that transaction installs its winner, so ordinary
+    /// first-wins [`Self::record`] would invert the observed cleanup order.
+    pub(super) fn restore_first(&self, payload: PanicPayload) {
+        let displaced = {
+            let mut pending = self.payload.lock().expect("offload panic mutex poisoned");
+            pending.replace(payload)
+        };
+        discard_panic(displaced);
+    }
 }
 
 /// The one cleanup route for values owned by a raw incarnation.

--- a/crates/shelterwood/src/raw/offload.rs
+++ b/crates/shelterwood/src/raw/offload.rs
@@ -10,7 +10,7 @@ use std::{
 
 use crate::runtime::{ActorWork, Latch, PanicAccumulator, PanicPayload, catch_panic};
 
-use super::disposal::RawDisposal;
+use super::disposal::{PanicSlot, RawDisposal};
 
 type OffloadFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 type SharedWork = Arc<SharedOffloadState>;
@@ -263,13 +263,19 @@ pub(super) struct OffloadResource {
 }
 
 impl OffloadResource {
-    pub(super) fn cancel(&mut self) -> Option<PanicPayload> {
+    pub(super) fn cancel(&mut self, retained: &PanicSlot) -> Option<PanicPayload> {
         let mut panics = PanicAccumulator::default();
         panics.run(|| {
             self.cancellation.fire();
         });
+        panics.record(retained.take());
         if let Some(state) = &self.state {
-            panics.run(|| state.cancel());
+            // `state.cancel` disposes the future before firing `finished`.
+            // Pull that contained destructor failure into the accumulator
+            // before recording a later wake panic escaping the call.
+            let state_panic = catch_panic(|| state.cancel()).err();
+            panics.record(retained.take());
+            panics.record(state_panic);
         }
         if let Some(task) = &self.task {
             // These are complementary: `state.cancel()` synchronously
@@ -278,10 +284,12 @@ impl OffloadResource {
             // requests cancellation of the runtime task driving that poll.
             // Neither substitutes for the other.
             panics.run(|| task.abort());
+            panics.record(retained.take());
         }
         panics.run(|| {
             self.finished.fire();
         });
+        panics.record(retained.take());
         panics.take()
     }
 }

--- a/crates/shelterwood/src/raw/offload.rs
+++ b/crates/shelterwood/src/raw/offload.rs
@@ -8,7 +8,7 @@ use std::{
     task::{Context as TaskPollContext, Poll},
 };
 
-use crate::runtime::{ActorWork, Latch, PanicPayload, catch_panic};
+use crate::runtime::{ActorWork, Latch, PanicAccumulator, PanicPayload, catch_panic};
 
 use super::disposal::RawDisposal;
 
@@ -263,10 +263,13 @@ pub(super) struct OffloadResource {
 }
 
 impl OffloadResource {
-    pub(super) fn cancel(&mut self) {
-        self.cancellation.fire();
+    pub(super) fn cancel(&mut self) -> Option<PanicPayload> {
+        let mut panics = PanicAccumulator::default();
+        panics.run(|| {
+            self.cancellation.fire();
+        });
         if let Some(state) = &self.state {
-            state.cancel();
+            panics.run(|| state.cancel());
         }
         if let Some(task) = &self.task {
             // These are complementary: `state.cancel()` synchronously
@@ -274,8 +277,11 @@ impl OffloadResource {
             // in-progress poll to dispose on return, while abort independently
             // requests cancellation of the runtime task driving that poll.
             // Neither substitutes for the other.
-            task.abort();
+            panics.run(|| task.abort());
         }
-        self.finished.fire();
+        panics.run(|| {
+            self.finished.fire();
+        });
+        panics.take()
     }
 }

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -1,10 +1,12 @@
 mod common;
 
 use std::{
+    future::Future,
     sync::{
         Arc, Condvar, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
+    task::{Context as TaskContext, Wake, Waker},
     time::Duration,
 };
 
@@ -1283,6 +1285,109 @@ async fn polled_cancellation_destructor_panic_does_not_poison_offload_state() {
 #[tokio::test]
 async fn cancellation_destructor_panic_does_not_mask_actor_panic() {
     assert_cancellation_drop_panic(CancellationDropMode::Actor, "primary actor panic").await;
+}
+
+struct HostileFinishedWake;
+
+impl Wake for HostileFinishedWake {
+    fn wake(self: Arc<Self>) {
+        panic!("hostile offload finished wake");
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        panic!("hostile offload finished wake");
+    }
+}
+
+struct HostileFinishedActor {
+    later_drops: Arc<AtomicUsize>,
+}
+
+impl Actor for HostileFinishedActor {
+    type Msg = ();
+    type Args = Arc<AtomicUsize>;
+
+    async fn init(later_drops: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self { later_drops })
+    }
+
+    async fn handle(&mut self, (): (), context: &mut Context<'_, Self>) -> ExitResult {
+        let first = context
+            .offload_scoped(std::future::pending::<()>(), |_| (), Duration::MAX)
+            .expect("first offload accepted");
+        let second = context
+            .offload_scoped(
+                PendingDropFuture {
+                    drops: Arc::clone(&self.later_drops),
+                    panic_on_drop: false,
+                    polled: None,
+                    dropped: None,
+                },
+                |_| (),
+                Duration::MAX,
+            )
+            .expect("second offload accepted");
+
+        let mut finished = Box::pin(first.finished());
+        let hostile = Waker::from(Arc::new(HostileFinishedWake));
+        assert!(
+            finished
+                .as_mut()
+                .poll(&mut TaskContext::from_waker(&hostile))
+                .is_pending(),
+            "the hostile waker is registered before the freeze"
+        );
+        // Keep the waiter registered without polling it again. Its wake is
+        // the supported `Guard::finished` path that must not cut cleanup short.
+        std::mem::forget(finished);
+        first.detach();
+        second.detach();
+        context.stop();
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn hostile_finished_waker_cannot_strand_later_offload_or_exit_publication() {
+    let later_drops = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "hostile-finished",
+            ActorOnceDef::<HostileFinishedActor>::new(Arc::clone(&later_drops)),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    let mut events = system.scope().subscribe_lifecycle();
+
+    actor.send(()).await.expect("actor is live");
+    let exit = tokio::time::timeout(POLL_TIMEOUT, async {
+        loop {
+            let event = next_event(&mut events).await;
+            if let LifecycleEventKind::Exited { id, exit, .. } = event.kind
+                && id.as_str() == "hostile-finished"
+            {
+                break exit;
+            }
+        }
+    })
+    .await
+    .expect("the incarnation publishes its exit without parent shutdown");
+
+    let ExitKind::Panicked { message } = exit.kind() else {
+        panic!("expected hostile-waker panic exit, got {:?}", exit.kind());
+    };
+    assert_eq!(message.as_deref(), Some("hostile offload finished wake"));
+    assert_eq!(
+        later_drops.load(Ordering::SeqCst),
+        1,
+        "the later offload is cancelled and disposed before exit publication"
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed actor scope shuts down");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- contain every offload-cancellation effect independently and accumulate failures across the entire raw-resource freeze
- retain the first freeze failure in the incarnation disposal slot only after all later offloads and raw collections have been cleaned up
- make `try_recv` establish its own mailbox freeze boundary before draining
- add deterministic coverage for a cancelled queued completion with a hostile captured destructor
- add an end-to-end hostile `Guard::finished()` waker regression proving a later offload is cancelled and the incarnation publishes its exit without parent shutdown

Closes #350.
Closes #342.

## Design decisions and omissions

- `OffloadResource::cancel` returns its first accumulated panic payload to its owner. `RawResources::freeze` owns the cleanup-wide accumulator and therefore controls when that payload becomes observable.
- The completed freeze records its first direct cleanup panic into the existing `PanicSlot` rather than pulsing `RawDisposal`. The actor is already synchronously entering its owned epilogue, which immediately drains the slot before joining; another wake is unnecessary and would introduce a new hostile-waker surface during teardown.
- Existing `PanicSlot` first-wins behavior preserves an earlier offload/destructor diagnostic ahead of a later wake failure.
- `try_recv` freezes the receiver before resources. The mailbox operation is idempotent and matches `recv`'s local containment boundary without depending on driver/latch ordering.
- The hostile-waker regression intentionally forgets one polled `Guard::finished()` future so its waker remains registered until teardown; this models the supported abandoned-waiter path deterministically and leaks only that bounded test fixture allocation.
- No disposal routing was changed for cancelled offload work: as noted in #350, `SharedOffloadFuture` already routes those futures through `RawDisposal`; the defect was stalled cleanup and joining, not missed disposal.

## Validation

- `./tools/dev cargo test -p shelterwood raw::context::tests --lib`
- `./tools/dev cargo test -p shelterwood --test offloads hostile_finished_waker_cannot_strand_later_offload_or_exit_publication -- --exact --nocapture`
- `./tools/dev cargo test -p shelterwood --test offloads`
- `./tools/dev just ci`
