### PR TITLE
Harden cells observation transactions

### DIFF
--- a/crates/shelterwood-cells/src/cells/gate.rs
+++ b/crates/shelterwood-cells/src/cells/gate.rs
@@ -122,6 +122,11 @@ impl<'a> ObservationTxn<'a> {
         // "T1 unlocks, T2 stages and installs a newer cut, T1 installs its
         // stale one", leaving every ungated borrow behind the tree until some
         // later publication corrected it. SPEC §12 promises this ordering.
+        // This install segment must remain panic-free apart from unreachable
+        // invariant assertions. A panic raised here runs from `Drop`, escapes
+        // before the post-unlock accumulator, and would strand later snapshot
+        // installations plus every queued effect; the current path invokes no
+        // user code and defers generation exhaustion into `effects`.
         for publication in self.snapshots.drain(..) {
             publication.install(&mut self.effects);
         }

--- a/crates/shelterwood-cells/src/cells/member.rs
+++ b/crates/shelterwood-cells/src/cells/member.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use shelterwood_core::{
-    ChildId, Exit, Incarnation, Membership, RestartCount,
+    ChildId, Exit, ExitKind, Incarnation, Membership, RestartCount,
     engine::MembershipStatus,
     identity::{IncarnationCounter, MintedMembership},
     policy::ResolvedCommonOptions,
@@ -27,6 +27,20 @@ pub enum MemberStage {
     Restarting,
     Stopping,
     Terminal(Exit),
+}
+
+impl MemberStage {
+    fn tag(&self) -> &'static str {
+        match self {
+            Self::Reserved => "Reserved",
+            Self::Admitted => "Admitted",
+            Self::Starting => "Starting",
+            Self::Running => "Running",
+            Self::Restarting => "Restarting",
+            Self::Stopping => "Stopping",
+            Self::Terminal(_) => "Terminal",
+        }
+    }
 }
 
 /// One non-terminal member-record transition owned by the cell layer.
@@ -105,16 +119,16 @@ impl MemberRecord {
             MemberTransition::Admitted => {
                 debug_assert!(
                     matches!(self.stage, MemberStage::Reserved),
-                    "admission must consume a fresh reservation, not {:?}",
-                    self.stage
+                    "admission must consume a fresh reservation, not {}",
+                    self.stage.tag()
                 );
                 self.stage = MemberStage::Admitted;
             }
             MemberTransition::Starting { incarnation } => {
                 debug_assert!(
                     matches!(self.stage, MemberStage::Admitted | MemberStage::Restarting),
-                    "a spawn must start an admitted or restarting member, not {:?}",
-                    self.stage
+                    "a spawn must start an admitted or restarting member, not {}",
+                    self.stage.tag()
                 );
                 self.stage = MemberStage::Starting;
                 self.incarnation = Some(incarnation);
@@ -125,16 +139,16 @@ impl MemberRecord {
                 debug_assert!(
                     matches!(self.stage, MemberStage::Starting | MemberStage::Reserved),
                     "readiness must promote a starting member (or the root scope's own \
-                     never-admitted reservation), not {:?}",
-                    self.stage
+                     never-admitted reservation), not {}",
+                    self.stage.tag()
                 );
                 self.stage = MemberStage::Running;
             }
             MemberTransition::Stopping => {
                 debug_assert!(
                     matches!(self.stage, MemberStage::Starting | MemberStage::Running),
-                    "a stop ladder must begin on a starting or running member, not {:?}",
-                    self.stage
+                    "a stop ladder must begin on a starting or running member, not {}",
+                    self.stage.tag()
                 );
                 self.stage = MemberStage::Stopping;
             }
@@ -148,8 +162,8 @@ impl MemberRecord {
                         self.stage,
                         MemberStage::Starting | MemberStage::Running | MemberStage::Stopping
                     ),
-                    "a restart must be scheduled from an active incarnation's exit, not {:?}",
-                    self.stage
+                    "a restart must be scheduled from an active incarnation's exit, not {}",
+                    self.stage.tag()
                 );
                 self.stage = MemberStage::Restarting;
                 self.incarnation = None;
@@ -216,12 +230,26 @@ impl fmt::Debug for MemberMailbox {
                 control,
                 exit,
                 teardown,
-            } => formatter
-                .debug_struct("Terminal")
-                .field("control", control)
-                .field("exit", exit)
-                .field("teardown_pending", &teardown.is_some())
-                .finish(),
+            } => {
+                // Formatting `ExitKind::Failed` would invoke the user's error
+                // formatter while `MemberCell::mailbox` is held by the
+                // derived `MemberCell` Debug implementation. A static tag is
+                // the only mailbox diagnostic needed here.
+                let exit = match exit.as_exit().kind() {
+                    ExitKind::Completed => "Completed",
+                    ExitKind::Failed(_) => "Failed",
+                    ExitKind::Panicked { .. } => "Panicked",
+                    ExitKind::ReadinessTimedOut { .. } => "ReadinessTimedOut",
+                    ExitKind::Aborted { .. } => "Aborted",
+                    ExitKind::NeverStarted => "NeverStarted",
+                };
+                formatter
+                    .debug_struct("Terminal")
+                    .field("control", control)
+                    .field("exit", &exit)
+                    .field("teardown_pending", &teardown.is_some())
+                    .finish()
+            }
         }
     }
 }
@@ -319,7 +347,7 @@ impl MemberCell {
         };
     }
 
-    /// Reads the drain-entry terminal-disposal marker.
+    /// Reports terminality or drain-entry terminal-disposal intent.
     ///
     /// `Acquire` pairs with the `Release` store in
     /// [`Self::set_terminal_disposal_pending`]. Two separate edges make a
@@ -329,7 +357,11 @@ impl MemberCell {
     /// [`ScopeCell::resident_projections`] takes `observation.current_children`
     /// — a different mutex from the gate `publish_drain` holds.
     ///
-    /// * A load that observes the *clear* synchronizes with the store the
+    /// This method owns the marker-before-record order so a caller cannot
+    /// accidentally recreate the trailing gap by reversing two independent
+    /// reads.
+    ///
+    /// * A marker load that observes the *clear* synchronizes with the store the
     ///   driver issues after `terminalize_child` published
     ///   `MemberStage::Terminal`, so the sampler's following record read is
     ///   ordered after that publication. It cannot pair a stale nonterminal
@@ -342,8 +374,9 @@ impl MemberCell {
     ///   write/read pair supplies happens-before, and coherence then forbids
     ///   this load from returning a value preceding `true` in the marker's
     ///   modification order.
-    pub fn terminal_disposal_pending(&self) -> bool {
+    pub fn terminal_or_disposal_pending(&self) -> bool {
         self.terminal_disposal_pending.load(Ordering::Acquire)
+            || matches!(self.record().stage, MemberStage::Terminal(_))
     }
 
     /// Installs or clears the drain-entry terminal-disposal marker.
@@ -353,7 +386,7 @@ impl MemberCell {
     /// `MemberStage::Terminal` to any sampler whose `Acquire` load reads it;
     /// the setting store is made visible by the `Draining` record write that
     /// `publish_drain` performs afterwards. See
-    /// [`Self::terminal_disposal_pending`] for the full argument.
+    /// [`Self::terminal_or_disposal_pending`] for the full argument.
     pub fn set_terminal_disposal_pending(&self, pending: bool) {
         self.terminal_disposal_pending
             .store(pending, Ordering::Release);
@@ -763,6 +796,24 @@ mod tests {
                 .is_pending(),
             "a losing terminalizer publishes no second record edge"
         );
+    }
+
+    #[test]
+    fn terminal_sample_accepts_pending_disposal_or_a_terminal_record() {
+        let scope = isolated_scope("root", ScopeFlavor::Ordered);
+        let member = &scope.member;
+        assert!(!member.terminal_or_disposal_pending());
+
+        member.set_terminal_disposal_pending(true);
+        assert!(member.terminal_or_disposal_pending());
+
+        member.set_terminal_disposal_pending(false);
+        assert!(!member.terminal_or_disposal_pending());
+        member.terminalize(
+            Exit::completed(Cancellation::NotObserved),
+            StartupDisposition::Unchanged,
+        );
+        assert!(member.terminal_or_disposal_pending());
     }
 
     #[test]

--- a/crates/shelterwood-cells/src/cells/retained.rs
+++ b/crates/shelterwood-cells/src/cells/retained.rs
@@ -214,6 +214,37 @@ mod tests {
     }
 
     #[test]
+    fn retained_exit_install_replaces_and_isolates_a_changed_last_owned_set() {
+        let retiring_thread = std::thread::current().id();
+        let (dropped, observed) = mpsc::sync_channel(1);
+        let mut guards = Arc::new(vec![RetainedExit::new(Exit::failed(
+            ExitError::from(ThreadProbe(dropped)),
+            Cancellation::NotObserved,
+        ))]);
+        let original = Arc::downgrade(&guards);
+
+        RetainedExit::install(
+            &mut guards,
+            vec![RetainedExit::new(Exit::completed(
+                Cancellation::NotObserved,
+            ))],
+        );
+
+        assert!(
+            original.upgrade().is_none(),
+            "a changed guard set replaces the shared allocation"
+        );
+        assert!(matches!(guards[0].as_exit().kind(), ExitKind::Completed));
+        assert_ne!(
+            observed
+                .recv_timeout(TEST_WAIT)
+                .expect("the displaced last-owned failure is disposed"),
+            retiring_thread,
+            "replacement must isolate the displaced failed payload"
+        );
+    }
+
+    #[test]
     fn retained_failed_exit_disposes_off_the_retiring_thread() {
         let retiring_thread = std::thread::current().id();
         let (dropped, observed) = mpsc::sync_channel(1);

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -53,65 +53,13 @@ impl ResidentProjection {
     }
 }
 
-struct ResidencyCompletion {
-    parent: Weak<ScopeCell>,
-    projection: ResidentProjection,
-}
-
 struct ResidentChild {
     projection: ResidentProjection,
-    removal: Option<ResidencyCompletion>,
 }
 
 impl ResidentChild {
-    fn new(parent: &Arc<ScopeCell>, projection: ResidentProjection) -> Self {
-        Self {
-            removal: Some(ResidencyCompletion {
-                parent: Arc::downgrade(parent),
-                projection: projection.clone(),
-            }),
-            projection,
-        }
-    }
-
-    fn disarm_removal(&mut self) -> ResidencyCompletion {
-        self.removal
-            .take()
-            .expect("a resident completes removal exactly once")
-    }
-
-    fn publish_removal(completion: ResidencyCompletion, txn: &mut ObservationTxn<'_>) {
-        if let Some(parent) = completion.parent.upgrade() {
-            parent.emit_locked(
-                txn,
-                LifecycleEventKind::Removed {
-                    id: completion.projection.member.id().clone(),
-                    membership: completion.projection.member.membership(),
-                    last_incarnation: completion.projection.member.record().last_incarnation,
-                },
-            );
-        }
-        // The projection can carry the last member/mailbox owner. Retire it
-        // only after the resident-tree observation gate is released.
-        txn.defer(move || drop(completion));
-    }
-
-    fn complete_removal(mut self, txn: &mut ObservationTxn<'_>) {
-        let completion = self.disarm_removal();
-        Self::publish_removal(completion, txn);
-        txn.defer(move || drop(self));
-    }
-}
-
-impl Drop for ResidentChild {
-    fn drop(&mut self) {
-        let Some(completion) = self.removal.take() else {
-            return;
-        };
-        let Some(parent) = completion.parent.upgrade() else {
-            return;
-        };
-        parent.with_observation_gate(|txn| Self::publish_removal(completion, txn));
+    fn new(projection: ResidentProjection) -> Self {
+        Self { projection }
     }
 }
 
@@ -127,6 +75,28 @@ struct ScopeControl {
 struct ScopeRequest {
     epoch: Epoch,
     consumed: bool,
+}
+
+#[derive(Clone, Copy)]
+enum ScopeRequestSlot {
+    Shutdown,
+    Force,
+}
+
+impl ScopeRequestSlot {
+    fn get(self, control: &ScopeControl) -> Option<&ScopeRequest> {
+        match self {
+            Self::Shutdown => control.shutdown.as_ref(),
+            Self::Force => control.force.as_ref(),
+        }
+    }
+
+    fn get_mut(self, control: &mut ScopeControl) -> Option<&mut ScopeRequest> {
+        match self {
+            Self::Shutdown => control.shutdown.as_mut(),
+            Self::Force => control.force.as_mut(),
+        }
+    }
 }
 
 /// One fact published by a scope control-plane transaction for its driver.
@@ -158,11 +128,9 @@ pub enum ScopeControlEvent {
 struct ScopeObservation {
     config: Mutex<ObservationConfig>,
     record: runtime::WatchSender<ScopeRecord>,
-    // `ResidentChild::drop` emits `Removed` by taking the observation gate
-    // itself, so dropping a resident anywhere the gate is already held
-    // self-deadlocks. In-gate removal paths must consume the resident through
-    // `complete_removal(txn)`. Dropping a resident while holding this mutex
-    // likewise self-deadlocks, so removal moves it into outer storage first.
+    // Removal paths move residents into transaction effects before emitting
+    // their `Removed` edges. A projection can be the last member/mailbox
+    // owner, so neither this mutex nor the observation gate may retire one.
     current_children: Mutex<Vec<ResidentChild>>,
     parent: Mutex<Option<Weak<ScopeCell>>>,
     lifecycle_seq: AtomicPoisonedCounter,
@@ -495,13 +463,13 @@ impl ScopeCell {
     }
 
     pub fn set_state(&self, state: ScopeState) {
-        self.with_observation_gate(|txn| self.set_state_locked(state, txn));
+        self.with_observation_gate(|txn| self.set_state_locked(state, &[], txn));
     }
 
     pub fn set_state_and_startup(&self, state: ScopeState, startup: Result<(), StartupError>) {
         self.with_observation_gate(|txn| {
             self.set_startup_locked(startup, txn);
-            self.set_state_locked(state, txn);
+            self.set_state_locked(state, &[], txn);
         });
     }
 
@@ -520,34 +488,31 @@ impl ScopeCell {
     ) {
         debug_assert!(matches!(state, ScopeState::Draining));
         self.with_observation_gate(|txn| {
-            // Statement order is load-bearing: every marker must be stored
-            // *before* `set_state_locked` writes `Draining` into the scope
-            // record. A zero-budget sampler reads that record first, so the
-            // `Draining` read is the release edge that makes the markers
-            // visible to it. Publishing the state first reopens #270: the
-            // driver writes `Draining` with no marker yet stored, a sampler on
-            // another worker reads `Draining`, then reads `false` for a child
-            // this very step is disposing, then reads that child's still
-            // nonterminal record, and reports a spurious
-            // `Err(ShutdownTimeout)`. No test holds this order — moving the
-            // loop below `set_state_locked` leaves the suite green — so this
-            // comment is the only guard.
-            for member in terminal_disposals {
-                debug_assert!(
-                    self.current_observation_gate()
-                        .shares_gate(&member.current_observation_gate()),
-                    "a drain entry may mark only a resident member on its observation gate"
-                );
-                member.set_terminal_disposal_pending(true);
-            }
             if let Some(startup) = startup {
                 self.set_startup_locked(startup, txn);
             }
-            self.set_state_locked(state, txn);
+            self.set_state_locked(state, terminal_disposals, txn);
         });
     }
 
-    fn set_state_locked(&self, state: ScopeState, txn: &mut ObservationTxn<'_>) {
+    fn set_state_locked(
+        &self,
+        state: ScopeState,
+        terminal_disposals: &[Arc<MemberCell>],
+        txn: &mut ObservationTxn<'_>,
+    ) {
+        // The marker slice is part of the state-writer signature so the #270
+        // regression guard cannot be reordered at a caller. Every marker is
+        // stored before the `Draining` record write whose release edge makes
+        // it visible to zero-budget shutdown samplers on other workers.
+        for member in terminal_disposals {
+            debug_assert!(
+                self.current_observation_gate()
+                    .shares_gate(&member.current_observation_gate()),
+                "a drain entry may mark only a resident member on its observation gate"
+            );
+            member.set_terminal_disposal_pending(true);
+        }
         let mut transient_retained = Vec::new();
         RetainedExit::retain_scope_state(&mut transient_retained, &state);
         if matches!(state, ScopeState::Draining | ScopeState::StartupFailed)
@@ -729,7 +694,16 @@ impl ScopeCell {
             return false;
         };
         debug_assert_eq!(resident.projection.member.membership(), membership);
-        resident.complete_removal(txn);
+        let event = LifecycleEventKind::Removed {
+            id: resident.projection.member.id().clone(),
+            membership,
+            last_incarnation: resident.projection.member.record().last_incarnation,
+        };
+        // The projection can carry the last member/mailbox owner. Put it in
+        // the transaction before the fallible publication path so unwind also
+        // retires it only after the observation gate is released.
+        txn.defer(move || drop(resident));
+        self.emit_locked(txn, event);
         true
     }
 
@@ -770,7 +744,7 @@ impl ScopeCell {
         // Tuple field order is intentional: a rejected raw startup result is
         // released while its retained guards still exist, then those guards
         // transfer failed destruction to isolated disposal.
-        drop(incoming);
+        txn.defer(move || drop(incoming));
         if published {
             txn.pulse(&self.member.record);
             txn.pulse(&self.observation.record);
@@ -995,25 +969,7 @@ impl ScopeCell {
     }
 
     pub fn take_shutdown_request(&self, epoch: Epoch) -> bool {
-        let pending = self
-            .control
-            .lock()
-            .expect("scope control mutex poisoned")
-            .shutdown
-            .is_some_and(|request| request.epoch == epoch && !request.consumed);
-        if !pending {
-            return false;
-        }
-        self.with_observation_gate(|_txn| {
-            let mut control = self.control.lock().expect("scope control mutex poisoned");
-            match control.shutdown.as_mut() {
-                Some(request) if request.epoch == epoch && !request.consumed => {
-                    request.consumed = true;
-                    true
-                }
-                _ => false,
-            }
-        })
+        self.take_request(ScopeRequestSlot::Shutdown, epoch)
     }
 
     pub fn force_shutdown(&self, epoch: Epoch) {
@@ -1031,18 +987,19 @@ impl ScopeCell {
     }
 
     pub fn take_force_request(&self, epoch: Epoch) -> bool {
-        let pending = self
-            .control
-            .lock()
-            .expect("scope control mutex poisoned")
-            .force
+        self.take_request(ScopeRequestSlot::Force, epoch)
+    }
+
+    fn take_request(&self, slot: ScopeRequestSlot, epoch: Epoch) -> bool {
+        let pending = slot
+            .get(&self.control.lock().expect("scope control mutex poisoned"))
             .is_some_and(|request| request.epoch == epoch && !request.consumed);
         if !pending {
             return false;
         }
         self.with_observation_gate(|_txn| {
             let mut control = self.control.lock().expect("scope control mutex poisoned");
-            match control.force.as_mut() {
+            match slot.get_mut(&mut control) {
                 Some(request) if request.epoch == epoch && !request.consumed => {
                     request.consumed = true;
                     true
@@ -1124,8 +1081,7 @@ impl ScopeCell {
         child
             .member
             .transition_locked(txn, MemberTransition::Admitted);
-        self.current_children()
-            .push(ResidentChild::new(self, child));
+        self.current_children().push(ResidentChild::new(child));
         self.emit_locked(txn, LifecycleEventKind::Added { id, membership });
     }
 
@@ -1134,20 +1090,24 @@ impl ScopeCell {
     }
 
     pub fn clear_residents_locked(&self, wakes: &mut ObservationTxn<'_>) {
-        let mut residents = {
+        let residents = {
             let mut children = self.current_children();
             std::mem::take(&mut *children)
         };
-        // Disarm every drop fallback before publishing any edge. If an emit
-        // unwinds, the untouched suffix no longer re-enters the non-reentrant
-        // observation gate from ResidentChild::drop.
-        let completions = residents
-            .iter_mut()
-            .map(ResidentChild::disarm_removal)
+        let removals = residents
+            .iter()
+            .map(|resident| LifecycleEventKind::Removed {
+                id: resident.projection.member.id().clone(),
+                membership: resident.projection.member.membership(),
+                last_incarnation: resident.projection.member.record().last_incarnation,
+            })
             .collect::<Vec<_>>();
+        // Schedule the whole displaced set before emitting any edge. This
+        // both preserves last-owner disposal and makes an unwind retire the
+        // untouched suffix after unlock.
         wakes.defer(move || drop(residents));
-        for completion in completions {
-            ResidentChild::publish_removal(completion, wakes);
+        for removal in removals {
+            self.emit_locked(wakes, removal);
         }
     }
 
@@ -1292,8 +1252,10 @@ impl ScopeCell {
         } else {
             // Release the rejected raw projection before its guards. This is
             // the same field order used by retained framework state.
-            drop(state);
-            drop(transient_retained);
+            wakes.defer(move || {
+                drop(state);
+                drop(transient_retained);
+            });
         }
     }
 
@@ -1450,6 +1412,18 @@ mod tests {
             &leaf_scope.parent().expect("leaf parent is installed"),
             &nested
         ));
+    }
+
+    #[test]
+    fn drain_publication_installs_terminal_disposal_intent_with_the_state() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let child = child_member(&root, "child");
+        root.set_admitted_children(vec![ResidentProjection::new(Arc::clone(&child), None)]);
+
+        root.publish_drain(ScopeState::Draining, None, &[Arc::clone(&child)]);
+
+        assert!(matches!(root.record().state, ScopeState::Draining));
+        assert!(child.terminal_or_disposal_pending());
     }
 
     #[test]

--- a/crates/shelterwood-cells/src/cells/scope/projection.rs
+++ b/crates/shelterwood-cells/src/cells/scope/projection.rs
@@ -97,8 +97,8 @@ impl ScopeCell {
     }
 
     pub fn subscribe_lifecycle(&self) -> LifecycleEvents {
-        self.with_observation_gate(|_txn| {
-            let events = self.observation.lifecycle.subscribe();
+        self.with_observation_gate(|txn| {
+            let events = self.observation.lifecycle.subscribe(txn);
             debug_assert!(
                 !self.observation.closed.load(Ordering::Acquire)
                     || self.observation.lifecycle.is_closed(),

--- a/crates/shelterwood-cells/src/observe.rs
+++ b/crates/shelterwood-cells/src/observe.rs
@@ -470,9 +470,8 @@ impl SnapshotReceiver {
     /// Waits for and returns a newer snapshot.
     pub async fn changed(&mut self) -> Result<Arc<ScopeSnapshot>, SnapshotClosed> {
         loop {
-            let state = self.inner.borrow_cloned();
+            let state = self.inner.borrow_and_update_cloned();
             if state.generation.current() != self.seen_generation {
-                let state = self.inner.borrow_and_update_cloned();
                 self.seen_generation = state.generation.current();
                 return Ok(state.snapshot.public());
             }
@@ -888,10 +887,6 @@ impl fmt::Debug for LifecycleEvents {
 }
 
 pub(crate) struct LifecycleHub {
-    channels: LifecycleChannels,
-}
-
-struct LifecycleChannels {
     events: runtime::BroadcastSender<RetainedLifecycleEvent>,
     signal: runtime::WatchSender<LifecycleSignal>,
 }
@@ -909,25 +904,27 @@ impl Default for LifecycleHub {
     fn default() -> Self {
         let (events, _) = runtime::broadcast(LIFECYCLE_EVENT_CAPACITY);
         let (signal, _) = runtime::watch(LifecycleSignal::default());
-        Self {
-            channels: LifecycleChannels { events, signal },
-        }
+        Self { events, signal }
     }
 }
 
 impl LifecycleHub {
-    pub(crate) fn subscribe(&self) -> LifecycleEvents {
-        let signal = self.channels.signal.watcher();
+    /// Subscribes while the containing scope's observation gate is held.
+    ///
+    /// Requiring the transaction makes the signal snapshot and broadcast
+    /// subscription atomic with publication by construction.
+    pub(crate) fn subscribe(&self, _txn: &mut crate::cells::ObservationTxn<'_>) -> LifecycleEvents {
+        let signal = self.signal.watcher();
         let seen_explicit_lag = signal.borrow_cloned().explicit_lag;
         LifecycleEvents {
-            events: self.channels.events.subscribe(),
+            events: self.events.subscribe(),
             signal,
             seen_explicit_lag,
         }
     }
 
     pub(crate) fn is_closed(&self) -> bool {
-        self.channels.signal.read_with(|signal| signal.closed)
+        self.signal.read_with(|signal| signal.closed)
     }
 
     /// Publishes while the containing scope's observation gate is held.
@@ -939,26 +936,36 @@ impl LifecycleHub {
         let event = event.into();
         let mut published = false;
         let mut undelivered = None;
-        self.channels.signal.modify_silently(|signal| {
+        self.signal.modify_silently(|signal| {
             if signal.closed {
                 undelivered = Some(event);
                 return;
             }
-            undelivered = self.channels.events.send(event).err();
+            // Keep insertion under the gate. Deferring `send` would let two
+            // transactions flush out of `seq` order, invert a child's `Added`
+            // edge against events from inside it, and expose closure before
+            // the final event from the closing transaction. Tokio's send does
+            // not invoke a user callback here: Shelterwood never awaits the
+            // broadcast receiver, so its waiter list is empty. A full ring can
+            // evict a retained event in this call, whose last guard may submit
+            // critical disposal under both locks. That submission is
+            // refcount/framework work only and is the accepted trade because
+            // drop glue inside the send has no transaction sink to reach.
+            undelivered = self.events.send(event).err();
             published = true;
         });
         if let Some(undelivered) = undelivered {
-            drop(undelivered);
+            txn.defer(move || drop(undelivered));
         }
         if published {
-            txn.pulse(&self.channels.signal);
+            txn.pulse(&self.signal);
         }
     }
 
     /// Publishes an explicit lag marker under the observation gate.
     pub(crate) fn publish_lagged(&self, txn: &mut crate::cells::ObservationTxn<'_>, dropped: u64) {
         let mut published = false;
-        self.channels.signal.modify_silently(|signal| {
+        self.signal.modify_silently(|signal| {
             if signal.closed {
                 return;
             }
@@ -966,21 +973,21 @@ impl LifecycleHub {
             published = true;
         });
         if published {
-            txn.pulse(&self.channels.signal);
+            txn.pulse(&self.signal);
         }
     }
 
     /// Closes while the containing scope's observation gate is held.
     pub(crate) fn close(&self, txn: &mut crate::cells::ObservationTxn<'_>) {
         let mut modified = false;
-        self.channels.signal.modify_silently(|signal| {
+        self.signal.modify_silently(|signal| {
             if !signal.closed {
                 signal.closed = true;
                 modified = true;
             }
         });
         if modified {
-            txn.pulse(&self.channels.signal);
+            txn.pulse(&self.signal);
         }
     }
 }
@@ -989,11 +996,8 @@ impl fmt::Debug for LifecycleHub {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("LifecycleHub")
-            .field("receivers", &self.channels.events.receiver_count())
-            .field(
-                "closed",
-                &self.channels.signal.read_with(|signal| signal.closed),
-            )
+            .field("receivers", &self.events.receiver_count())
+            .field("closed", &self.signal.read_with(|signal| signal.closed))
             .finish()
     }
 }
@@ -1363,7 +1367,9 @@ mod tests {
     #[shelterwood_runtime::test]
     async fn lifecycle_close_wakes_parked_receivers() {
         let hub = Arc::new(LifecycleHub::default());
-        let mut events = hub.subscribe();
+        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut events = hub.subscribe(&mut txn);
+        drop(txn);
         let waiter = runtime::spawn(async move { events.recv().await });
         runtime::yield_now().await;
 
@@ -1382,8 +1388,8 @@ mod tests {
             .expect("membership available")
             .membership();
         let hub = LifecycleHub::default();
-        let mut events = hub.subscribe();
         let mut txn = crate::cells::ObservationTxn::detached();
+        let mut events = hub.subscribe(&mut txn);
         hub.close(&mut txn);
 
         hub.publish(
@@ -1421,9 +1427,8 @@ mod tests {
             },
         };
         let hub = LifecycleHub::default();
-        let mut events = hub.subscribe();
-
         let mut txn = crate::cells::ObservationTxn::detached();
+        let mut events = hub.subscribe(&mut txn);
         hub.publish_lagged(&mut txn, 1);
         hub.publish(&mut txn, event(1));
         drop(txn);
@@ -1463,9 +1468,8 @@ mod tests {
             },
         };
         let hub = LifecycleHub::default();
-        let mut events = hub.subscribe();
-
         let mut txn = crate::cells::ObservationTxn::detached();
+        let mut events = hub.subscribe(&mut txn);
         hub.publish_lagged(&mut txn, 2);
         hub.publish(&mut txn, event(1));
         hub.close(&mut txn);
@@ -1476,8 +1480,11 @@ mod tests {
         assert_eq!(events.try_recv(), Ok(LifecycleItem::Lagged { dropped: 2 }));
         assert_eq!(events.try_recv(), Ok(LifecycleItem::Event(event(1))));
         assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Closed));
+        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut after_close = hub.subscribe(&mut txn);
+        drop(txn);
         assert_eq!(
-            hub.subscribe().try_recv(),
+            after_close.try_recv(),
             Err(LifecycleTryRecvError::Closed),
             "post-close subscribers start at the drained terminal edge"
         );

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -3,19 +3,10 @@ use super::*;
 fn collect_stragglers(scope: &ScopeCell, prefix: &[ChildId], out: &mut Vec<ShutdownStraggler>) {
     let children = scope.resident_projections();
     for child in children {
-        // Read the release/acquire marker before the terminal projection. If
-        // terminal publication has already cleared it, that acquire orders
-        // the following record read after publication; if cleanup is still
-        // pending, the marker itself excludes the child. Reading the record
-        // first could pair a stale nonterminal projection with the later
-        // cleared marker and recreate a narrow trailing gap.
-        //
-        // Argued, not pinned: the window is too narrow to provoke
-        // deterministically, and reverting to record-first leaves the suite
-        // green.
-        if child.member.terminal_disposal_pending()
-            || matches!(child.member.record().stage, MemberStage::Terminal(_))
-        {
+        // The cell owns the load ordering: the release/acquire marker is read
+        // before the terminal projection, so a caller cannot pair a stale
+        // nonterminal record with a later cleared marker.
+        if child.member.terminal_or_disposal_pending() {
             continue;
         }
         let mut path = prefix.to_vec();


### PR DESCRIPTION
## Summary

- make drain-entry marker-before-record publication and straggler marker-before-record sampling structural
- remove the unreachable `ResidentChild` armed-drop fallback while preserving post-unlock last-owner retirement
- defer rejected retained values through `ObservationTxn` when an effects sink is available
- tighten lifecycle subscription, simplify observation state, and add focused retained-exit/order tests
- make member diagnostics avoid formatting user errors under framework locks and document snapshot-install unwind requirements

## Design decisions

- `ScopeCell::set_state_locked` now accepts the terminal-disposal slice and stores every marker before touching the scope record. This keeps the #270 ordering inside the writer rather than behind a test-only timing seam.
- `MemberCell::terminal_or_disposal_pending` owns the inverse sampling order. The shutdown driver can no longer independently reverse the marker and record reads.
- lifecycle broadcast `send` deliberately remains under the observation gate. Deferring it would permit transaction flush order to diverge from lifecycle `seq`, invert `Added` against descendant events, and expose closure before the final event. Undelivered values are deferred; in-ring eviction remains inline and its refcount/disposal tradeoff is documented at the send site.
- resident removal schedules the displaced projection in transaction effects before emitting `Removed`, including on unwind. There is no armed `Drop` fallback or gate reacquisition.
- no checklist items are omitted.

## Validation

- `./tools/dev cargo check --workspace --all-targets --all-features`
- `./tools/dev cargo test -p shelterwood-cells --all-features`
- `./tools/dev cargo test -p shelterwood --all-features shutdown`
- `./tools/dev just ci` (769 tests; formatting, clippy, docs, API reachability, and external consumer all green)

Closes #332
Closes #334
Closes #340
Closes #345
