### PR TITLE
Order AfterInit readiness before init self-stop

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1256,7 +1256,9 @@ and `supervisor::…` names the pure reducer suite.
    override receives no such edge and the same pre-ready stop remains R7.
    (`integration::ordered_terminal_pre_ready_exit_parks_the_root_and_marks_suffix_never_started`,
    `integration::dynamic_startup_failure_keeps_other_initial_members_supervised`,
-   `integration::nested_dynamic_startup_failure_rolls_back_and_preserves_inner_cause`.)
+   `integration::nested_dynamic_startup_failure_rolls_back_and_preserves_inner_cause`,
+   `integration::after_init_stop_waits_for_success_then_advances_the_ordered_suffix`,
+   `integration::manual_stop_in_init_remains_a_terminal_pre_ready_failure`.)
 
 No rule above is flagged unverified: each has direct checked evidence. The
 remaining prose in this section specifies declaration defaults, user-facing
@@ -2397,7 +2399,14 @@ framework contract**. No other normative shutdown paragraph is unmapped.
   bound on its drain-plus-`on_stop` window (§5.2), so a wedged self-stop
   escalates — grace expiry, tidy beat, hard abort — exactly like a
   supervisor-initiated one. Self-stop changes who started the clock,
-  never which ladder runs.
+  never which ladder runs. One case defers the clock rather than
+  changing it: an effective `AfterInit` initializer publishes its
+  `stop()` only when it returns (R7, §6), so an initializer that
+  requests a stop and then never returns has not yet armed the ladder.
+  Intake is already frozen and the readiness deadline still bounds it,
+  but a `ReadinessDeadline::Unbounded` declaration leaves that wedge
+  bounded only by parent or scope shutdown. Declaring an unbounded
+  readiness deadline is what accepts that.
 - Shutdown requests are **level-triggered, not queued**: owner drop,
   `request_shutdown()` / `request_scope_shutdown()`, and parent
   escalation each set an idempotent per-scope latch (a token edge, like

--- a/SPEC.md
+++ b/SPEC.md
@@ -1249,7 +1249,11 @@ and `supervisor::…` names the pure reducer suite.
    position-dependent.** The exit funnel applies restart policy first. A
    terminal pre-ready failure emits `FailStartup`; an ordered suffix becomes
    `NeverStarted`, while a dynamic scope has no unstarted suffix. Root failure
-   parks in `StartupFailed`; nested failure begins ordinary rollback.
+   parks in `StartupFailed`; nested failure begins ordinary rollback. For an
+   effective `AfterInit` callback actor, a `stop()` requested during an
+   initializer that returns `Ok` becomes observable only after the automatic
+   readiness edge, so its clean exit is post-ready. An effective `Manual`
+   override receives no such edge and the same pre-ready stop remains R7.
    (`integration::ordered_terminal_pre_ready_exit_parks_the_root_and_marks_suffix_never_started`,
    `integration::dynamic_startup_failure_keeps_other_initial_members_supervised`,
    `integration::nested_dynamic_startup_failure_rolls_back_and_preserves_inner_cause`.)
@@ -1275,7 +1279,12 @@ enum Readiness { Immediate, AfterInit, Manual }   // mode only — the deadline 
 ```
 
 - `Actor` (blanket) children default to `AfterInit`: ready when `init`
-  returns `Ok`.
+  returns `Ok`. If that successful initializer requested `Context::stop()`,
+  intake freezes at the request but the blanket loop publishes the automatic
+  readiness edge before publishing the self-stop. This fixed latch order
+  preserves `AfterInit` under arbitrary scheduling of the readiness and
+  self-stop watcher tasks; it does not change an effective `Manual`
+  initializer's pre-ready stop.
 - Raw actor types declare via `RawActor::readiness()`; decorators propagate
   with a visible `R::readiness()`. The trait default is `Immediate`, so
   a decorator that omits propagation reports immediate readiness — an
@@ -1308,8 +1317,9 @@ enum Readiness { Immediate, AfterInit, Manual }   // mode only — the deadline 
   exactly **two** states: immediate, or gated with a resolved deadline.
   `AfterInit` is declaration-level sugar — the blanket loop reports
   readiness through the same public `mark_ready` mechanism after `init`
-  returns `Ok`; there is no third engine state and no framework-private
-  readiness path (§1 principles 2 and 5). Deadline expiry is a distinct
+  returns `Ok`, then publishes any self-stop deferred from that initializer;
+  there is no third engine state and no framework-private readiness path (§1
+  principles 2 and 5). Deadline expiry is a distinct
   startup-failure exit cause (§7) — one type, for tasks and actors alike,
   produced by one engine-side timeout (not re-implemented per child kind
   and reunited by downcast).
@@ -3702,7 +3712,7 @@ the same series during shutdown drain; **Stop** = `StopContext<'_, A>` in
 | `recv()` / `try_recv()` (the merged event source: mailbox, offload completions, fired timers, queued continuations, §5.2 priority; `recv` yields `None` on stop request, biased; `try_recv` ignores the stop token — the drain primitive for raw loops: under `Drain`, exhaust the frozen prefix via `try_recv` after `recv` yields `None`, §10's raw-loop obligation) | ✓ | — | — | — |
 | `mailbox_shutdown()` (the resolved §10 policy for this actor's mailbox — what a raw loop consults to honor `Drain` vs `Discard`) | ✓ | — | — | — |
 | `mark_ready()` (one-shot effect by construction; meaningful only under gated readiness, else a documented no-op — B.2's rule, uniformly; during drain always the no-op) | ✓ | ✓ | ✓ | — |
-| `stop()` (clean self-stop; `Err` outcome wins; idempotent — during drain the already-stopping no-op; arms the child's configured §10 ladder as the stop bound. Live/Drain: effective after the current callback. Raw: freezes intake at the call — drain the frozen prefix via `try_recv` after `recv` yields `None`; §1 principle 5's public primitive for the blanket loop's `stop()`) | ✓ | ✓ | ✓ | — |
+| `stop()` (clean self-stop; `Err` outcome wins; idempotent — during drain the already-stopping no-op; arms the child's configured §10 ladder as the stop bound. Live/Drain: effective after the current callback; in a successful effective-`AfterInit` initializer, after its automatic readiness edge. Raw: freezes intake at the call — drain the frozen prefix via `try_recv` after `recv` yields `None`; §1 principle 5's public primitive for the blanket loop's `stop()`) | ✓ | ✓ | ✓ | — |
 | `is_draining()` | — | ✓ | ✓ | — |
 | `continue_with(msg)` (next-message continuation; no mailbox capacity; anti-starvation per §5.2) | ✓ | ✓ | **R** | — |
 | Keyed timers: `set_timeout` / `set_interval` / `clear_timer` (§5.3) | ✓ | ✓ | **R** | — |

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -123,6 +123,7 @@ macro_rules! actor_context_forwarders {
 /// Which mailbox delivery stage owns the current callback.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum DeliveryStage {
+    Initializing,
     Live,
     DrainingFrozenPrefix,
 }
@@ -131,6 +132,7 @@ enum DeliveryStage {
 pub struct Context<'a, A: Actor> {
     raw: &'a mut RawContext<A::Msg>,
     stage: DeliveryStage,
+    owns_init_boundary: bool,
     actor: PhantomData<fn() -> A>,
 }
 
@@ -150,23 +152,48 @@ impl<'a, A: Actor> Context<'a, A> {
         Self {
             raw,
             stage,
+            owns_init_boundary: false,
             actor: PhantomData,
         }
+    }
+
+    fn new_initializing(raw: &'a mut RawContext<A::Msg>) -> Self {
+        Self {
+            raw,
+            stage: DeliveryStage::Initializing,
+            owns_init_boundary: true,
+            actor: PhantomData,
+        }
+    }
+
+    fn initialization_returned(&mut self) {
+        debug_assert_eq!(self.stage, DeliveryStage::Initializing);
+        self.owns_init_boundary = false;
     }
 
     actor_context_forwarders!(A);
 
     /// Releases this incarnation's readiness gate while live.
     pub fn mark_ready(&self) {
-        if self.stage == DeliveryStage::Live {
+        if self.stage != DeliveryStage::DrainingFrozenPrefix {
             self.raw.mark_ready();
         }
     }
 
     /// Requests a clean local stop after the current callback.
+    ///
+    /// During a successful initializer with effective [`Readiness::AfterInit`],
+    /// the automatic readiness edge is published before this request becomes
+    /// observable to the supervisor. This preserves `AfterInit`'s promise
+    /// that returning `Ok` establishes readiness. An explicit
+    /// [`Readiness::Manual`] override keeps ordinary pre-ready stop semantics.
     pub fn stop(&mut self) {
-        if self.stage == DeliveryStage::Live {
-            self.raw.stop();
+        match self.stage {
+            DeliveryStage::Initializing if self.raw.readiness() == Readiness::AfterInit => {
+                self.raw.defer_stop_until_after_init();
+            }
+            DeliveryStage::Initializing | DeliveryStage::Live => self.raw.stop(),
+            DeliveryStage::DrainingFrozenPrefix => {}
         }
     }
 
@@ -280,7 +307,22 @@ impl<'a, A: Actor> Context<'a, A> {
         Context {
             raw: &mut *self.raw,
             stage,
+            // The outermost handler context owns the initializer-return
+            // boundary. A decorator's projected context must not publish a
+            // deferred self-stop before the outer initializer also returns.
+            owns_init_boundary: false,
             actor: PhantomData,
+        }
+    }
+}
+
+impl<A: Actor> Drop for Context<'_, A> {
+    fn drop(&mut self) {
+        if self.owns_init_boundary {
+            // Cancellation and panic do not cross the successful-init
+            // ordering point. Preserve the requested stop for exit
+            // classification without manufacturing readiness.
+            self.raw.finish_callback_init(false);
         }
     }
 }
@@ -440,19 +482,22 @@ impl<A: Actor> RawActor for Handler<A> {
             panic!("handler actor initialization invoked more than once");
         };
         let initialized = {
-            let mut context = Context::<A>::new(raw, DeliveryStage::Live);
-            A::init(args, &mut context).await
+            let mut context = Context::<A>::new_initializing(raw);
+            let initialized = A::init(args, &mut context).await;
+            context.initialization_returned();
+            initialized
         };
         match initialized {
             Ok(actor) => self.state = HandlerState::Running(actor),
-            Err(error) => return fail_after_teardown(raw, error).await,
+            Err(error) => {
+                raw.finish_callback_init(false);
+                return fail_after_teardown(raw, error).await;
+            }
         }
         let HandlerState::Running(actor) = &mut self.state else {
             unreachable!("successful initialization installs the running actor")
         };
-        if raw.readiness() == Readiness::AfterInit {
-            raw.mark_ready();
-        }
+        raw.finish_callback_init(true);
 
         while let Some(message) = raw.recv().await {
             let handled = {

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -784,6 +784,7 @@ pub struct RawContext<M> {
     abort: CancellationToken,
     ready: CompletionGatedLatch,
     local_stop: Latch,
+    deferred_init_stop: bool,
     readiness: Readiness,
     mailbox_shutdown: MailboxShutdown,
     receiver: MailboxReceiver<M>,
@@ -816,6 +817,7 @@ impl<M: Send + 'static> RawContext<M> {
             abort: ParentCancellationToken::from_latch(run.abort).token(),
             ready: run.ready,
             local_stop: run.local_stop,
+            deferred_init_stop: false,
             readiness,
             mailbox_shutdown: run.mailbox_shutdown,
             receiver: MailboxReceiver::new(mailbox, run.incarnation),
@@ -911,8 +913,37 @@ impl<M: Send + 'static> RawContext<M> {
         self.local_stop.fire();
     }
 
+    /// Freezes a callback actor at an `AfterInit` initializer's stop request,
+    /// but holds supervisor publication until the initializer returns. The
+    /// blanket handler then fires automatic readiness and this stop in one
+    /// fixed order; projected decorator contexts share the same pending bit.
+    pub(crate) fn defer_stop_until_after_init(&mut self) {
+        if self.deferred_init_stop {
+            return;
+        }
+        // Record the request before cleanup so an unwind from cleanup still
+        // publishes it through the initializer context's Drop fallback.
+        self.deferred_init_stop = true;
+        self.receiver.freeze();
+        self.freeze_and_report();
+    }
+
+    /// Closes the callback initializer boundary. Consuming the pending bit
+    /// lets a successful effective `AfterInit` initializer use the ordinary
+    /// `mark_ready` path before its own stop is published. Parent shutdown
+    /// keeps the existing no-readiness rule.
+    pub(crate) fn finish_callback_init(&mut self, successful: bool) {
+        let deferred_stop = std::mem::take(&mut self.deferred_init_stop);
+        if successful && self.readiness == Readiness::AfterInit {
+            self.mark_ready();
+        }
+        if deferred_stop {
+            self.local_stop.fire();
+        }
+    }
+
     pub(crate) fn is_stopping(&self) -> bool {
-        self.local_stop.is_fired() || self.shutdown.is_cancelled()
+        self.deferred_init_stop || self.local_stop.is_fired() || self.shutdown.is_cancelled()
     }
 
     /// Queues an actor-local continuation ahead of external input.

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -18,10 +18,10 @@ use crate::common::{
     },
 };
 use shelterwood::{
-    Actor, ActorOnceDef, Backoff, Cancellation, ChildState, Context, DynamicTree, ExitError,
-    ExitKind, ExitResult, Jitter, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
-    ReadinessDeadline, RestartCondition, RestartPolicy, ScopeState, Shutdown, StartupError,
-    StartupFailureCause, SubtreeOnceDef, TaskDef, Tree,
+    Actor, ActorDef, ActorOnceDef, Backoff, Cancellation, ChildState, Context, DynamicTree,
+    ExitError, ExitKind, ExitResult, Jitter, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
+    ReadinessDeadline, RestartCondition, RestartPolicy, Retention, ScopeState, Shutdown,
+    StartupError, StartupFailureCause, SubtreeOnceDef, TaskDef, Tree,
 };
 
 struct ReadyThenStop;
@@ -37,6 +37,88 @@ impl RawActor for ReadyThenStop {
         context.mark_ready();
         context.stop();
         Ok(())
+    }
+}
+
+struct GatedStopInInit;
+
+impl Actor for GatedStopInInit {
+    type Msg = ();
+    type Args = (ReleaseGate, ReleaseGate);
+
+    async fn init(
+        (entered, release): Self::Args,
+        context: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        context.stop();
+        entered.release();
+        release.wait().await;
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): (), _: &mut Context<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+}
+
+struct RepeatingStopInInit;
+
+impl Actor for RepeatingStopInInit {
+    type Msg = ();
+    type Args = Arc<AtomicUsize>;
+
+    async fn init(starts: Self::Args, context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        starts.fetch_add(1, Ordering::SeqCst);
+        context.stop();
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): (), _: &mut Context<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+}
+
+struct FailAfterStopInInit;
+
+impl Actor for FailAfterStopInInit {
+    type Msg = ();
+    type Args = ();
+
+    async fn init((): (), context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        context.stop();
+        Err(ExitError::message("init failed after requesting stop"))
+    }
+
+    async fn handle(&mut self, (): (), _: &mut Context<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+}
+
+struct DelayedStopDecorator {
+    inner: GatedStopInInit,
+}
+
+impl Actor for DelayedStopDecorator {
+    type Msg = ();
+    type Args = ((ReleaseGate, ReleaseGate), ReleaseGate, ReleaseGate);
+
+    async fn init(
+        (inner_args, decorator_entered, release_decorator): Self::Args,
+        context: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        let inner = {
+            let mut inner_context = context.for_actor::<GatedStopInInit>();
+            GatedStopInInit::init(inner_args, &mut inner_context).await?
+        };
+        decorator_entered.release();
+        release_decorator.wait().await;
+        Ok(Self { inner })
+    }
+
+    async fn handle(&mut self, (): (), context: &mut Context<'_, Self>) -> ExitResult {
+        self.inner
+            .handle((), &mut context.for_actor::<GatedStopInInit>())
+            .await
     }
 }
 
@@ -122,6 +204,201 @@ async fn readiness_fired_before_clean_self_stop_counts_for_startup() {
         .await
         .expect("ready-before-stop completes startup");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+}
+
+#[tokio::test]
+async fn after_init_stop_waits_for_success_then_advances_the_ordered_suffix() {
+    let init_entered = ReleaseGate::default();
+    let release_init = ReleaseGate::default();
+    let decorator_entered = ReleaseGate::default();
+    let release_decorator = ReleaseGate::default();
+    let suffix_started = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.add_actor_once(
+        "stop-in-init",
+        ActorOnceDef::<DelayedStopDecorator>::new((
+            (init_entered.clone(), release_init.clone()),
+            decorator_entered.clone(),
+            release_decorator.clone(),
+        ))
+        .retention(Retention::Retain),
+    )
+    .expect("valid actor");
+    tree.add_task(
+        "suffix",
+        TaskDef::new({
+            let suffix_started = suffix_started.clone();
+            move |context| {
+                let suffix_started = suffix_started.clone();
+                async move {
+                    suffix_started.release();
+                    context.shutdown_token().cancelled().await;
+                    Ok(())
+                }
+            }
+        }),
+    )
+    .expect("valid suffix");
+
+    let system = tree.spawn().expect("runtime is available");
+    let scope = system.scope();
+    init_entered.wait().await;
+    assert_quiet(Duration::from_millis(20), || {
+        scope
+            .child("suffix")
+            .is_some_and(|child| !matches!(child.state, ChildState::Admitted))
+    })
+    .await;
+
+    release_init.release();
+    decorator_entered.wait().await;
+    assert_quiet(Duration::from_millis(20), || {
+        scope
+            .child("suffix")
+            .is_some_and(|child| !matches!(child.state, ChildState::Admitted))
+    })
+    .await;
+    release_decorator.release();
+    suffix_started.wait().await;
+    system
+        .wait_started()
+        .await
+        .expect("successful AfterInit initialization publishes readiness before self-stop");
+    let stopped = scope
+        .wait_for_child(
+            "stop-in-init",
+            |child| child.state.is_terminal(),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_or_else(|error| {
+            panic!(
+                "self-stopping actor terminalizes: {error:?}; snapshot: {:?}",
+                scope.snapshot()
+            )
+        });
+    let ChildState::Stopped { exit } = stopped.state else {
+        panic!("ready self-stop is not a startup abort: {stopped:?}");
+    };
+    assert!(matches!(exit.kind(), ExitKind::Completed));
+    assert_eq!(exit.cancellation(), Cancellation::Observed);
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("ordered suffix cooperates");
+}
+
+#[tokio::test]
+async fn manual_stop_in_init_remains_a_terminal_pre_ready_failure() {
+    let init_entered = ReleaseGate::default();
+    let release_init = ReleaseGate::default();
+    let suffix_started = Arc::new(AtomicBool::new(false));
+    let mut tree = Tree::new();
+    tree.add_actor_once(
+        "manual-stop-in-init",
+        ActorOnceDef::<GatedStopInInit>::new((init_entered.clone(), release_init.clone()))
+            .readiness(Readiness::Manual)
+            .readiness_deadline(ReadinessDeadline::Unbounded),
+    )
+    .expect("valid manually gated actor");
+    let suffix = tree
+        .add_task(
+            "suffix",
+            TaskDef::new({
+                let suffix_started = Arc::clone(&suffix_started);
+                move |_| {
+                    suffix_started.store(true, Ordering::SeqCst);
+                    async { Ok(()) }
+                }
+            }),
+        )
+        .expect("valid suffix");
+
+    let system = tree.spawn().expect("runtime is available");
+    init_entered.wait().await;
+    release_init.release();
+    let (id, exit) = crate::common::startup_failed_child(
+        system
+            .wait_started()
+            .await
+            .expect_err("manual pre-ready self-stop still aborts startup"),
+    );
+    assert_eq!(id.as_str(), "manual-stop-in-init");
+    assert!(matches!(exit.kind(), ExitKind::Completed));
+    assert_eq!(exit.cancellation(), Cancellation::Observed);
+    assert!(!suffix_started.load(Ordering::SeqCst));
+    assert!(matches!(suffix.wait().await.kind(), ExitKind::NeverStarted));
+    system
+        .shutdown(Duration::ZERO)
+        .await
+        .expect("failed tree has no straggler");
+}
+
+#[tokio::test]
+async fn after_init_stop_does_not_publish_readiness_when_init_fails() {
+    let suffix_started = Arc::new(AtomicBool::new(false));
+    let mut tree = Tree::new();
+    tree.add_actor_once(
+        "failed-stop-in-init",
+        ActorOnceDef::<FailAfterStopInInit>::new(()),
+    )
+    .expect("valid actor");
+    let suffix = tree
+        .add_task(
+            "suffix",
+            TaskDef::new({
+                let suffix_started = Arc::clone(&suffix_started);
+                move |_| {
+                    suffix_started.store(true, Ordering::SeqCst);
+                    async { Ok(()) }
+                }
+            }),
+        )
+        .expect("valid suffix");
+
+    let system = tree.spawn().expect("runtime is available");
+    let (id, exit) = crate::common::startup_failed_child(
+        system
+            .wait_started()
+            .await
+            .expect_err("only a successful AfterInit initializer becomes ready"),
+    );
+    assert_eq!(id.as_str(), "failed-stop-in-init");
+    assert!(matches!(exit.kind(), ExitKind::Failed(_)));
+    assert_eq!(exit.cancellation(), Cancellation::Observed);
+    assert!(!suffix_started.load(Ordering::SeqCst));
+    assert!(matches!(suffix.wait().await.kind(), ExitKind::NeverStarted));
+    system
+        .shutdown(Duration::ZERO)
+        .await
+        .expect("failed tree has no straggler");
+}
+
+#[tokio::test]
+async fn repeated_after_init_self_stops_are_post_ready_until_intensity_trips() {
+    let starts = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    tree.add_actor(
+        "restarting-stop-in-init",
+        ActorDef::<RepeatingStopInInit>::cloned(Arc::clone(&starts)).restart(RestartPolicy::new(
+            RestartCondition::Always,
+            Backoff::Immediate,
+        )),
+    )
+    .expect("valid restarting actor");
+
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("the first successful init establishes aggregate readiness");
+    let reason = system.wait().await;
+    assert!(
+        matches!(reason, shelterwood::StopReason::IntensityTripped(_)),
+        "the restart loop ends through intensity, not StartupFailed: {reason:?}"
+    );
+    assert!(starts.load(Ordering::SeqCst) > 1);
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/readiness.rs
+++ b/crates/shelterwood/tests/readiness.rs
@@ -94,6 +94,22 @@ impl Actor for FailAfterStopInInit {
     }
 }
 
+struct PanicAfterStopInInit;
+
+impl Actor for PanicAfterStopInInit {
+    type Msg = ();
+    type Args = ();
+
+    async fn init((): (), context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        context.stop();
+        panic!("init panicked after requesting stop");
+    }
+
+    async fn handle(&mut self, (): (), _: &mut Context<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+}
+
 struct DelayedStopDecorator {
     inner: GatedStopInInit,
 }
@@ -290,6 +306,43 @@ async fn after_init_stop_waits_for_success_then_advances_the_ordered_suffix() {
 }
 
 #[tokio::test]
+async fn immediate_stop_in_init_is_published_before_the_initializer_returns() {
+    let init_entered = ReleaseGate::default();
+    let release_init = ReleaseGate::default();
+    let mut tree = Tree::new();
+    tree.add_actor_once(
+        "immediate-stop-in-init",
+        ActorOnceDef::<GatedStopInInit>::new((init_entered.clone(), release_init.clone()))
+            .readiness(Readiness::Immediate),
+    )
+    .expect("valid immediate actor");
+
+    let system = tree.spawn().expect("runtime is available");
+    let scope = system.scope();
+    init_entered.wait().await;
+    system
+        .wait_started()
+        .await
+        .expect("immediate readiness does not wait for initialization");
+    scope
+        .wait_for_child(
+            "immediate-stop-in-init",
+            |child| matches!(child.state, ChildState::Stopping),
+            POLL_TIMEOUT,
+        )
+        .await
+        .unwrap_or_else(|error| {
+            panic!(
+                "an Immediate override publishes self-stop before init returns: {error:?}; snapshot: {:?}",
+                scope.snapshot()
+            )
+        });
+
+    release_init.release();
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+}
+
+#[tokio::test]
 async fn manual_stop_in_init_remains_a_terminal_pre_ready_failure() {
     let init_entered = ReleaseGate::default();
     let release_init = ReleaseGate::default();
@@ -316,7 +369,21 @@ async fn manual_stop_in_init_remains_a_terminal_pre_ready_failure() {
         .expect("valid suffix");
 
     let system = tree.spawn().expect("runtime is available");
+    let scope = system.scope();
     init_entered.wait().await;
+    scope
+        .wait_for_child(
+            "manual-stop-in-init",
+            |child| matches!(child.state, ChildState::Stopping),
+            POLL_TIMEOUT,
+        )
+        .await
+        .unwrap_or_else(|error| {
+            panic!(
+                "a Manual override publishes self-stop before init returns: {error:?}; snapshot: {:?}",
+                scope.snapshot()
+            )
+        });
     release_init.release();
     let (id, exit) = crate::common::startup_failed_child(
         system
@@ -329,6 +396,38 @@ async fn manual_stop_in_init_remains_a_terminal_pre_ready_failure() {
     assert_eq!(exit.cancellation(), Cancellation::Observed);
     assert!(!suffix_started.load(Ordering::SeqCst));
     assert!(matches!(suffix.wait().await.kind(), ExitKind::NeverStarted));
+    system
+        .shutdown(Duration::ZERO)
+        .await
+        .expect("failed tree has no straggler");
+}
+
+#[tokio::test]
+async fn after_init_stop_survives_init_panic_without_manufacturing_readiness() {
+    let mut tree = Tree::new();
+    tree.add_actor_once(
+        "panicked-stop-in-init",
+        ActorOnceDef::<PanicAfterStopInInit>::new(()),
+    )
+    .expect("valid actor");
+
+    let system = tree.spawn().expect("runtime is available");
+    let (id, exit) = crate::common::startup_failed_child(
+        system
+            .wait_started()
+            .await
+            .expect_err("an init panic remains a terminal pre-ready failure"),
+    );
+    assert_eq!(id.as_str(), "panicked-stop-in-init");
+    assert!(
+        matches!(exit.kind(), ExitKind::Panicked { message: Some(message) } if message.contains("init panicked after requesting stop")),
+        "the initializer panic remains authoritative: {exit:?}"
+    );
+    assert_eq!(
+        exit.cancellation(),
+        Cancellation::Observed,
+        "dropping the initializer context publishes its deferred stop"
+    );
     system
         .shutdown(Duration::ZERO)
         .await


### PR DESCRIPTION
Closes #352.

Tracking issue: #348.

## Semantic decision

An effective `AfterInit` callback actor whose initializer calls `Context::stop()` and then returns `Ok` is ready before its clean self-stop becomes observable to supervision. Returning `Ok` therefore keeps the `AfterInit` promise and the stop is post-ready for startup classification.

This ruling is intentionally narrow:

- intake and incarnation resources freeze at the `stop()` call;
- the pending stop counts as stopping for actor-side operations;
- after the outermost initializer returns successfully and installs actor state, the blanket handler uses the ordinary `mark_ready()` path and then fires `local_stop`, with no await between them;
- a `Manual` override preserves terminal pre-ready self-stop behavior;
- an initializer that returns `Err`, panics, or is cancelled publishes the pending stop without manufacturing readiness;
- projected decorator contexts share the pending request, while the outermost initializer owns the return boundary.

This also makes the existing `Context::stop()` wording (effective after the current callback) literal for an `AfterInit` initializer. A non-returning initializer does not arm its self-stop ladder until that callback ends; intake is already frozen, and readiness deadline, parent shutdown, and escalation remain available.

## Rejected alternatives

- **Fire readiness after `local_stop`.** Rejected as racy: the independently scheduled self-stop watcher may disarm the readiness gate before the late mark is processed.
- **Treat every `Completed + Observed` pre-ready exit as non-aborting.** Rejected because it changes unrelated `Manual` semantics and would require a second structural rule to advance an ordered cursor past a terminal-but-unready member.
- **Defer all initializer stops.** Rejected because `Manual` is explicitly how a declaration asks for pre-ready gating and failure.
- **Use a private readiness signal.** Rejected because SPEC §6 requires `AfterInit` sugar to flow through the same public `mark_ready` mechanism.

## Implementation

- add an explicit callback initialization stage and outer-boundary ownership to `Context`;
- freeze immediately but defer only `local_stop` publication for effective `AfterInit` initializers;
- close successful initialization with `mark_ready()` followed by the deferred stop;
- preserve stop publication on error, cancellation, and unwind through the context drop fallback;
- update SPEC §6/R7 and the public `Context::stop` rustdoc.

## Regression coverage

- successful stop-in-init through a projected decorator waits for the outer initializer and then advances an ordered suffix;
- the clean self-stop terminalizes as `Completed + Observed`, not `StartupAborted`;
- a `Manual` stop-in-init still aborts startup and leaves the ordered suffix `NeverStarted`;
- an `AfterInit` initializer that returns `Err` after requesting stop does not publish readiness;
- repeated successful stop-in-init incarnations are post-ready and end through restart intensity rather than `StartupFailed`.

## Validation

- `./tools/dev cargo test -p shelterwood --test readiness` — 30 passed
- `./tools/dev just ci` — passed (formatting, clippy, 770 nextest tests, doctests, rustdoc, API reachability, packaged-doc sync, external consumer, nixfmt)
