### PR TITLE
Address façade review findings

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1667,6 +1667,15 @@ terminates the process by contract.
   `Drop` — is a genuine double panic and aborts the process; that is
   Rust's contract, documented alongside §11's `panic = "unwind"`
   precondition, not something the runner can contain.
+- **Declaration-hook isolation.** The static and dynamic `add_*` entry points
+  isolate the supplied definition before invoking the caller's
+  `Into<ChildId>` conversion, and raw-definition erasure keeps the definition
+  isolated while invoking `RawActor::readiness`. A panic from either eager
+  hook therefore cannot unwind through and destroy that definition on the
+  caller's thread. This is a narrow ownership guarantee, not an extension of
+  the runner boundary: other locals in the user's synchronous declaration
+  call remain subject to Rust's ordinary unwinding and double-panic contract,
+  as do user values that the framework never accepted or wrapped.
 
 ## 8. Child specification and options [#368]
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1216,7 +1216,7 @@ and `supervisor::…` names the pure reducer suite.
    before the removal response resolves. (`supervisor::sampled_removal_suppresses_start_effects_until_commit`,
    `supervisor::exhaustive_reachable_states_preserve_the_reducer_invariants`,
    `integration::queued_removal_suppresses_replayed_self_stop_readiness`,
-   `integration::startup_removal_response_follows_aggregate_recomputation`.)
+   `integration::startup_removal_response_follows_recomputation_and_drop_discharges_it`.)
 4. **R4 — ordered start is one accepted edge at a time.** `Settle` emits
    `StartChild` only for the current initial cursor, and advances the cursor
    only past a spawned-and-ready member or a reclaimed key, reaching every
@@ -1458,7 +1458,7 @@ One classification, produced at one point, used by every consumer.
 3. **E3 — cancellation is orthogonal sampled state.** The exit records
    `Observed` iff the incarnation cancellation latch had fired when the
    outcome was recorded. Restart eligibility never inspects this field.
-   (`engine::funnel_dispatch_depends_on_mode_and_membership_state`,
+   (`engine::funnel_dispatch_covers_every_policy_exit_and_suppression_combination`,
    `integration::locally_requested_subtree_shutdown_reads_cancelled`.)
 4. **E4 — one authoritative membership/incarnation state.** Incarnation
    phases advance only through `Unstarted → Active → Stopping? → Complete →
@@ -1470,7 +1470,7 @@ One classification, produced at one point, used by every consumer.
 5. **E5 — restart suppression is state-derived.** Exits schedule restart only
    while the scope is running and the membership is resident. Draining or
    `Removing` records schedule nothing and charge no intensity.
-   (`engine::funnel_dispatch_depends_on_mode_and_membership_state`,
+   (`engine::funnel_dispatch_covers_every_policy_exit_and_suppression_combination`,
    `integration::same_batch_removal_suppresses_pending_restart_shutdown`.)
 6. **E6 — publication fences replacement.** A replacement spawn follows the
    predecessor’s terminal publication; stale incarnation evidence cannot

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -157,6 +157,10 @@ impl<'a, A: Actor> Context<'a, A> {
     actor_context_forwarders!(A);
 
     /// Releases this incarnation's readiness gate while live.
+    ///
+    /// During frozen-prefix drain the incarnation is already stopping, so
+    /// readiness can no longer change the startup outcome and this call is a
+    /// deliberate no-op.
     pub fn mark_ready(&self) {
         if self.stage == DeliveryStage::Live {
             self.raw.mark_ready();
@@ -164,6 +168,10 @@ impl<'a, A: Actor> Context<'a, A> {
     }
 
     /// Requests a clean local stop after the current callback.
+    ///
+    /// During frozen-prefix drain the incarnation is already stopping, so
+    /// this call deliberately does not inject a second local-stop edge and
+    /// returns silently.
     pub fn stop(&mut self) {
         if self.stage == DeliveryStage::Live {
             self.raw.stop();

--- a/crates/shelterwood/src/definition.rs
+++ b/crates/shelterwood/src/definition.rs
@@ -1,5 +1,7 @@
 //! Shared private machinery for declaration definitions.
 
+use crate::policy::ChildMode;
+
 /// Repeatable or consuming definition payload state.
 ///
 /// The explicit `Spent` state lets consumers move a one-shot payload without
@@ -14,6 +16,14 @@ pub(crate) enum DefinitionSource<R, O> {
 impl<R, O> DefinitionSource<R, O> {
     pub(crate) fn is_one_shot(&self) -> bool {
         matches!(self, Self::OneShot(_) | Self::Spent)
+    }
+
+    pub(crate) fn mode(&self) -> ChildMode {
+        if self.is_one_shot() {
+            ChildMode::OneShot
+        } else {
+            ChildMode::Restartable
+        }
     }
 
     pub(crate) fn restartable(&self) -> Option<&R> {
@@ -139,6 +149,8 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
     };
 
+    use crate::policy::ChildMode;
+
     use super::DefinitionSource;
 
     #[test]
@@ -146,6 +158,7 @@ mod tests {
         let mut source = DefinitionSource::<_, ()>::Restartable(String::from("factory"));
 
         assert!(!source.is_one_shot());
+        assert_eq!(source.mode(), ChildMode::Restartable);
         assert_eq!(source.restartable().map(String::as_str), Some("factory"));
         assert_eq!(source.take_one_shot(), None);
         assert_eq!(source.restartable().map(String::as_str), Some("factory"));
@@ -156,10 +169,12 @@ mod tests {
         let mut source = DefinitionSource::<(), _>::OneShot(String::from("body"));
 
         assert!(source.is_one_shot());
+        assert_eq!(source.mode(), ChildMode::OneShot);
         assert_eq!(source.take_one_shot().as_deref(), Some("body"));
         assert!(source.is_one_shot());
         assert!(source.take_one_shot().is_none());
         assert!(matches!(source, DefinitionSource::Spent));
+        assert_eq!(source.mode(), ChildMode::OneShot);
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -38,13 +38,10 @@ use crate::{
     },
     deadline::Deadline,
     engine::{
-        ArbitrationClass, ChildKey, DeadlineHandle, DeadlineQueue, Effect as SupervisorEffect,
-        Epoch, Event as SupervisorEvent, ExitDispatch, IncarnationRun, IntensityState,
-        MembershipStatus, ReadinessEffect, ReadinessEvent, ReadinessGate, RestartState,
-        ScopeLifecycle, ScopeMode, StopAction, StopLadder, SupervisorState,
-        admit as supervisor_admit, arbitrate, begin_drain as supervisor_begin_drain, dispatch_exit,
-        fail_startup as supervisor_fail_startup, force as supervisor_force, schedule_restart,
-        step as supervisor_step,
+        ArbitrationClass, DeadlineHandle, DeadlineQueue, Epoch, ExitDispatch, IncarnationRun,
+        IntensityState, MembershipStatus, ReadinessEffect, ReadinessEvent, ReadinessGate,
+        RestartState, ScopeLifecycle, ScopeMode, StopAction, StopLadder, arbitrate, dispatch_exit,
+        schedule_restart,
     },
     exit::{
         RecordedOutcome, StartupError, StopReason, classify_disposal_panic, classify_exit,
@@ -61,6 +58,11 @@ use crate::{
     raw::{CatchUnwindFuture, RawRunContext, RawSpawn},
     runtime::{self, CompletionGatedLatch, Latch},
     task::{TaskContext, TaskContextLatches, TaskFactory},
+};
+use shelterwood_core::supervisor::{
+    ChildKey, Effect as SupervisorEffect, Event as SupervisorEvent, SupervisorState,
+    admit as supervisor_admit, begin_drain as supervisor_begin_drain,
+    fail_startup as supervisor_fail_startup, force as supervisor_force, step as supervisor_step,
 };
 
 use admission_control::{
@@ -345,6 +347,11 @@ struct ScopeCompletion {
     root_exit: Option<RetainedExit>,
 }
 
+/// Runs the synchronous fail-closed scope epilogue.
+///
+/// `pending_startup_removals` can reach this path only when a resumed
+/// user-code panic unwinds the driver: no await point exists between retaining
+/// one of those completions and the orderly batch epilogue that publishes it.
 impl Drop for ScopeRuntime {
     fn drop(&mut self) {
         let mut panics = runtime::PanicAccumulator::default();
@@ -416,6 +423,7 @@ impl Drop for ScopeRuntime {
         // Residency owns the matching Removed edges. Clearing the set after
         // terminality discharges them all before the scope's final event.
         panics.run(|| self.root.clear_residents());
+        panics.run(|| self.publish_startup_removals());
         // Dynamic entries own removal completions. Keep them armed until the
         // corresponding members are terminal and no longer resident.
         panics.run(|| drop(dynamic_entries.take()));

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -271,9 +271,22 @@ impl DynamicControl {
         scope: &Arc<ScopeCell>,
         id: ChildId,
         child_scope: Option<ScopeFlavor>,
-        txn: &mut ObservationTxn<'_>,
+        _txn: &mut ObservationTxn<'_>,
     ) -> Result<Arc<SlotCell>, ReserveError> {
-        reserve_dynamic_slot(self, scope, id, child_scope, txn)
+        let mut state = self.state.lock().expect("dynamic-state mutex poisoned");
+        if !state.accepting {
+            return Err(ReserveError::NotAdmitting(NotAdmittingCause::Draining));
+        }
+        if let Some(existing) = state.entry(&id) {
+            if existing.removal_latched() {
+                return Err(ReserveError::RemovalInProgress(id));
+            }
+            return Err(ReserveError::DuplicateId(id));
+        }
+        let slot = mint_reserved_slot(scope, &id, child_scope)?;
+        scope.adopt_child_observation_gate(&slot.member, slot.scope.as_deref(), _txn);
+        state.insert(id, DynamicEntry::reserved(Arc::clone(&slot)), _txn);
+        Ok(slot)
     }
 
     pub(super) fn start_admission(
@@ -281,7 +294,22 @@ impl DynamicControl {
         slot: Arc<SlotCell>,
         fused_cancel: Option<Latch>,
     ) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError> {
-        start_dynamic_admission(self, slot, fused_cancel)
+        if !runtime::is_available() {
+            return Err(ReserveError::NoRuntime);
+        }
+        let (sender, response) = runtime::oneshot();
+        let request = AdmissionRequest {
+            control: Arc::downgrade(&self),
+            slot,
+            fused_cancel,
+            response: Obligation::new(sender, |sender| {
+                let _ = sender.send(Err(LOST_ADMISSION_RESPONSE_ERROR));
+            }),
+        };
+        // Queue synchronously so dropping a split-admission future immediately
+        // after its first poll cannot cancel the admitted request.
+        queue_driver_event(&self, DriverEvent::Admission(request));
+        Ok(response)
     }
 
     pub(super) fn cancel_reservation(
@@ -290,7 +318,10 @@ impl DynamicControl {
         slot: &SlotCell,
         txn: &mut ObservationTxn<'_>,
     ) {
-        cancel_dynamic_reservation_impl(scope, self, slot, txn);
+        let (definition, removed) = cancel_dynamic_reservation_parts(scope, self, slot, txn);
+        // The entry's drop completes its removal response; it must follow the
+        // member's terminal publication and isolated definition disposal.
+        txn.defer(move || dispose_definition_then(definition, move || drop(removed)));
     }
 
     pub(super) fn signal_fused_cancel(
@@ -300,7 +331,27 @@ impl DynamicControl {
         latch: &Latch,
         txn: &mut ObservationTxn<'_>,
     ) {
-        signal_fused_cancel_impl(self, scope, slot, latch, txn);
+        // The fire linearizes inside the transaction so a racing `remove` sees a
+        // decided latch, but the waker-visible wake must not run under the gate.
+        if !latch.fire_silently() {
+            return;
+        }
+        let latch = latch.clone();
+        txn.defer(move || latch.notify());
+        // The authoritative state transition owns request publication, so a
+        // racing explicit removal cannot queue the same membership again.
+        let removal = {
+            let mut state = self.state.lock().expect("dynamic-state mutex poisoned");
+            state
+                .entry_mut(slot.member.id())
+                .filter(|entry| entry.slot.member.membership() == slot.member.membership())
+                .and_then(|entry| entry.mark_removing(txn))
+                .map(|key| RemovalRequest { key })
+        };
+        if let Some(removal) = removal {
+            scope.set_child_removing_locked(&slot.member, txn);
+            defer_driver_event(txn, self, DriverEvent::Removal(removal));
+        }
     }
 
     pub(super) fn remove(
@@ -310,7 +361,34 @@ impl DynamicControl {
         exact: Option<Membership>,
         txn: &mut ObservationTxn<'_>,
     ) -> RemovalResponse {
-        remove_dynamic_impl(self, scope, id, exact, txn)
+        let mut state = self.state.lock().expect("dynamic-state mutex poisoned");
+        let Some(entry) = state.entry_mut(id) else {
+            return completed_removal(RemoveOutcome::AlreadyAbsent);
+        };
+        if exact.is_some_and(|membership| membership != entry.slot.member.membership()) {
+            return completed_removal(RemoveOutcome::AlreadyAbsent);
+        }
+        let response = entry.removal.payload_mut().subscribe();
+        if entry.is_reserved() {
+            let entry = state.remove(id, txn).expect("entry was just resolved");
+            drop(state);
+            let definition = take_terminal_reservation(scope, &entry.slot, txn);
+            txn.defer(move || dispose_definition_then(definition, move || drop(entry)));
+            return response;
+        }
+        // Terminal residents still have a driver registration. Route them
+        // through the normal removal path, like live residents, so that
+        // registration is reclaimed before the removal response completes.
+        let member = Arc::clone(&entry.slot.member);
+        let removal = entry.mark_removing(txn).map(|key| RemovalRequest { key });
+        drop(state);
+        if let Some(removal) = removal {
+            // Projection first, then the deferred request: the same order the
+            // fused source commits in.
+            scope.set_child_removing_locked(&member, txn);
+            defer_driver_event(txn, self, DriverEvent::Removal(removal));
+        }
+        response
     }
 
     fn close_admission_in(&self, _txn: &mut ObservationTxn<'_>) {
@@ -405,58 +483,12 @@ pub(super) fn reserve_dynamic_in(
     })
 }
 
-fn reserve_dynamic_slot(
-    control: &DynamicControl,
-    scope: &Arc<ScopeCell>,
-    id: ChildId,
-    child_scope: Option<ScopeFlavor>,
-    _txn: &mut ObservationTxn<'_>,
-) -> Result<Arc<SlotCell>, ReserveError> {
-    let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-    if !state.accepting {
-        return Err(ReserveError::NotAdmitting(NotAdmittingCause::Draining));
-    }
-    if let Some(existing) = state.entry(&id) {
-        if existing.removal_latched() {
-            return Err(ReserveError::RemovalInProgress(id));
-        }
-        return Err(ReserveError::DuplicateId(id));
-    }
-    let slot = mint_reserved_slot(scope, &id, child_scope)?;
-    scope.adopt_child_observation_gate(&slot.member, slot.scope.as_deref(), _txn);
-    state.insert(id, DynamicEntry::reserved(Arc::clone(&slot)), _txn);
-    Ok(slot)
-}
-
 pub(crate) fn start_admission(
     control: Arc<DynamicControl>,
     slot: Arc<SlotCell>,
     fused_cancel: Option<Latch>,
 ) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError> {
     control.start_admission(slot, fused_cancel)
-}
-
-fn start_dynamic_admission(
-    control: Arc<DynamicControl>,
-    slot: Arc<SlotCell>,
-    fused_cancel: Option<Latch>,
-) -> Result<runtime::OneShotReceiver<Result<(), ReserveError>>, ReserveError> {
-    if !runtime::is_available() {
-        return Err(ReserveError::NoRuntime);
-    }
-    let (sender, response) = runtime::oneshot();
-    let request = AdmissionRequest {
-        control: Arc::downgrade(&control),
-        slot,
-        fused_cancel,
-        response: Obligation::new(sender, |sender| {
-            let _ = sender.send(Err(LOST_ADMISSION_RESPONSE_ERROR));
-        }),
-    };
-    // Queue synchronously so dropping a split-admission future immediately
-    // after its first poll cannot cancel the admitted request.
-    queue_driver_event(&control, DriverEvent::Admission(request));
-    Ok(response)
 }
 
 pub(super) fn cancel_dynamic_reservation_parts(
@@ -489,18 +521,6 @@ pub(crate) fn cancel_dynamic_reservation(
     scope.with_observation_gate(|txn| control.cancel_reservation(scope, slot.as_ref(), txn));
 }
 
-fn cancel_dynamic_reservation_impl(
-    scope: &ScopeCell,
-    control: &DynamicControl,
-    slot: &SlotCell,
-    txn: &mut ObservationTxn<'_>,
-) {
-    let (definition, removed) = cancel_dynamic_reservation_parts(scope, control, slot, txn);
-    // The entry's drop completes its removal response; it must follow the
-    // member's terminal publication and isolated definition disposal.
-    txn.defer(move || dispose_definition_then(definition, move || drop(removed)));
-}
-
 pub(crate) fn signal_fused_cancel(
     scope: &Arc<ScopeCell>,
     control: &DynamicControl,
@@ -510,36 +530,6 @@ pub(crate) fn signal_fused_cancel(
     scope.with_observation_gate(|txn| {
         control.signal_fused_cancel(scope, slot.as_ref(), latch, txn);
     });
-}
-
-fn signal_fused_cancel_impl(
-    control: &DynamicControl,
-    scope: &Arc<ScopeCell>,
-    slot: &SlotCell,
-    latch: &Latch,
-    txn: &mut ObservationTxn<'_>,
-) {
-    // The fire linearizes inside the transaction so a racing `remove` sees a
-    // decided latch, but the waker-visible wake must not run under the gate.
-    if !latch.fire_silently() {
-        return;
-    }
-    let latch = latch.clone();
-    txn.defer(move || latch.notify());
-    // The authoritative state transition owns request publication, so a
-    // racing explicit removal cannot queue the same membership again.
-    let removal = {
-        let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-        state
-            .entry_mut(slot.member.id())
-            .filter(|entry| entry.slot.member.membership() == slot.member.membership())
-            .and_then(|entry| entry.mark_removing(txn))
-            .map(|key| RemovalRequest { key })
-    };
-    if let Some(removal) = removal {
-        scope.set_child_removing_locked(&slot.member, txn);
-        defer_driver_event(txn, control, DriverEvent::Removal(removal));
-    }
 }
 
 pub(crate) fn remove_dynamic(
@@ -559,43 +549,6 @@ pub(crate) fn remove_dynamic(
         };
         control.remove(scope, id, exact, txn)
     })
-}
-
-fn remove_dynamic_impl(
-    control: &DynamicControl,
-    scope: &Arc<ScopeCell>,
-    id: &ChildId,
-    exact: Option<Membership>,
-    txn: &mut ObservationTxn<'_>,
-) -> RemovalResponse {
-    let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-    let Some(entry) = state.entry_mut(id) else {
-        return completed_removal(RemoveOutcome::AlreadyAbsent);
-    };
-    if exact.is_some_and(|membership| membership != entry.slot.member.membership()) {
-        return completed_removal(RemoveOutcome::AlreadyAbsent);
-    }
-    let response = entry.removal.payload_mut().subscribe();
-    if entry.is_reserved() {
-        let entry = state.remove(id, txn).expect("entry was just resolved");
-        drop(state);
-        let definition = take_terminal_reservation(scope, &entry.slot, txn);
-        txn.defer(move || dispose_definition_then(definition, move || drop(entry)));
-        return response;
-    }
-    // Terminal residents still have a driver registration. Route them
-    // through the normal removal path, like live residents, so that
-    // registration is reclaimed before the removal response completes.
-    let member = Arc::clone(&entry.slot.member);
-    let removal = entry.mark_removing(txn).map(|key| RemovalRequest { key });
-    drop(state);
-    if let Some(removal) = removal {
-        // Projection first, then the deferred request: the same order the
-        // fused source commits in.
-        scope.set_child_removing_locked(&member, txn);
-        defer_driver_event(txn, control, DriverEvent::Removal(removal));
-    }
-    response
 }
 
 impl DynamicRoute for DynamicControl {

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -690,6 +690,7 @@ impl ScopeRuntime {
         {
             return;
         }
+        let startup = self.terminal_startup_disposition(key);
         let child = self
             .children
             .get_mut(key)
@@ -704,14 +705,6 @@ impl ScopeRuntime {
                 .record()
                 .last_exit
                 .unwrap_or_else(Exit::never_started);
-            let startup = if self.supervisor.is_initial(key)
-                && !self.supervisor.lifecycle().startup_complete()
-                && !self.supervisor.initial_ready(key)
-            {
-                StartupDisposition::Aborted
-            } else {
-                StartupDisposition::NotAborted
-            };
             // Exhaustion is a terminal outcome, not an exceptional cleanup
             // path. Join retained-definition disposal before terminality,
             // retention, removal completion, or ordered-scope progression.
@@ -1049,6 +1042,7 @@ impl ScopeRuntime {
         // `construction_is_suppressed` still gates the restart deadline arm,
         // where every suppression source has a guaranteed follow-up event.
         let membership_status = self.dispatch_membership_status(key);
+        let startup = self.terminal_startup_disposition(key);
         let child = self
             .children
             .get_mut(key)
@@ -1061,18 +1055,6 @@ impl ScopeRuntime {
         };
         match dispatch_exit(&exit, child.options.restart, mode, membership_status) {
             ExitDispatch::Terminal => {
-                // §6's startup abort is a startup-sequence property: the
-                // membership failed before its *initial* readiness edge. A
-                // later incarnation stopped pre-ready (e.g. during drain)
-                // does not rewind it.
-                let startup = if self.supervisor.is_initial(key)
-                    && !self.supervisor.lifecycle().startup_complete()
-                    && !self.supervisor.initial_ready(key)
-                {
-                    StartupDisposition::Aborted
-                } else {
-                    StartupDisposition::NotAborted
-                };
                 self.begin_terminal_disposal(key, exit, Some(incarnation), startup);
             }
             ExitDispatch::ScheduleRestart => {
@@ -1150,6 +1132,20 @@ impl ScopeRuntime {
             // intensity or fail startup, and the execution-time suppression
             // re-check then observes that drain.
             self.restart_shutdown_retries.push((key, target));
+        }
+    }
+
+    fn terminal_startup_disposition(&self, key: ChildKey) -> StartupDisposition {
+        // §6's startup abort is a startup-sequence property: the membership
+        // failed before its *initial* readiness edge. A later incarnation
+        // stopped pre-ready (for example during drain) does not rewind it.
+        if self.supervisor.is_initial(key)
+            && !self.supervisor.lifecycle().startup_complete()
+            && !self.supervisor.initial_ready(key)
+        {
+            StartupDisposition::Aborted
+        } else {
+            StartupDisposition::NotAborted
         }
     }
 

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -785,10 +785,11 @@ async fn ordered_startup_advances_past_a_reclaimed_cursor() {
 }
 
 /// A removal response is an observation boundary, not merely a wake. Keep it
-/// pending after membership commit until the batch epilogue has recomputed
-/// startup over the shrunken declared set.
+/// pending after membership commit until startup has been recomputed over the
+/// shrunken declared set, and make the synchronous driver epilogue explicitly
+/// discharge the retained completion if unwind bypasses the batch epilogue.
 #[crate::runtime::test]
-async fn startup_removal_response_follows_aggregate_recomputation() {
+async fn startup_removal_response_follows_recomputation_and_drop_discharges_it() {
     let mut tree = DynamicTree::new();
     tree.add_task(
         "gate",
@@ -837,7 +838,12 @@ async fn startup_removal_response_follows_aggregate_recomputation() {
     scope.progress_startup();
     assert!(scope.supervisor.lifecycle().startup_complete());
     assert_eq!(root.record().startup, Some(Ok(())));
-    scope.publish_startup_removals();
+    assert_eq!(
+        removal.try_receive(),
+        None,
+        "the fixture retains the completion until the explicit drop epilogue"
+    );
+    drop(scope);
     assert_eq!(removal.try_receive(), Some(RemoveOutcome::Removed));
 }
 

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -20,7 +20,7 @@ pub(super) use crate::{
     SendErrorKind, StartupError, StartupFailure, StartupFailureCause, StopReason, SubtreeDef,
     SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
     cells::LIFECYCLE_EVENT_CAPACITY,
-    engine::{ChildKey, Epoch, Event as SupervisorEvent, ScopeLifecycle, StopLadder, arbitrate},
+    engine::{Epoch, ScopeLifecycle, StopLadder, arbitrate},
     exit::RecordedOutcome,
     identity::{IncarnationCounter, ScopeIdentity},
     mailbox::{MailboxCell, actor_ref_from_parts},
@@ -28,6 +28,7 @@ pub(super) use crate::{
     policy::ResolvedDefaults,
     runtime::{CompletionGatedLatch, DedicatedRuntime, Latch},
 };
+pub(super) use shelterwood_core::supervisor::{ChildKey, Event as SupervisorEvent};
 
 pub(super) struct ObservedExit {
     pub(super) child: ChildKey,

--- a/crates/shelterwood/src/engine.rs
+++ b/crates/shelterwood/src/engine.rs
@@ -1,2 +1,1 @@
 pub use shelterwood_core::engine::*;
-pub(crate) use shelterwood_core::supervisor::*;

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -11,10 +11,7 @@ use crate::{
     cells::{MemberCell, ObservationTxn, ScopeCell},
     definition::DefinitionSource,
     identity::{MembershipReconciliation, ScopeIdentity},
-    policy::{
-        ChildMode, CommonOptions, ResolvedCommonOptions, ResolvedDefaults, ScopeFlavor,
-        resolve_common,
-    },
+    policy::{CommonOptions, ResolvedCommonOptions, ResolvedDefaults, ScopeFlavor, resolve_common},
     raw::RawConstruction,
     runtime::{self, Isolated, Latch},
     task::TaskConstruction,
@@ -55,7 +52,7 @@ pub(crate) fn resolve_fixture_options(member: &MemberCell) {
     let options = resolve_common(
         &CommonOptions::default(),
         &ResolvedDefaults::default(),
-        ChildMode::Restartable,
+        crate::policy::ChildMode::Restartable,
         Readiness::Immediate,
     );
     member.set_options(options);
@@ -109,13 +106,6 @@ impl SlotCell {
             rejected.is_none(),
             "a child slot was defined more than once"
         );
-    }
-
-    pub(crate) fn is_undefined(&self) -> bool {
-        matches!(
-            *self.definition.lock().expect("definition mutex poisoned"),
-            DefinitionState::Undefined
-        )
     }
 
     fn take_definition(
@@ -192,6 +182,7 @@ impl SlotCell {
         definition
     }
 
+    #[cfg(test)]
     pub(crate) fn resolve_policy(
         &self,
         defaults: &ResolvedDefaults,
@@ -201,6 +192,20 @@ impl SlotCell {
             return None;
         };
         Some(self.resolve_defined_policy(definition, defaults))
+    }
+
+    fn resolve_policy_for_lowering(
+        &self,
+        defaults: &ResolvedDefaults,
+    ) -> Result<Option<ResolvedCommonOptions>, DefinitionAlreadyLowered> {
+        let state = self.definition.lock().expect("definition mutex poisoned");
+        match &*state {
+            DefinitionState::Undefined => Ok(None),
+            DefinitionState::Defined(definition) => {
+                Ok(Some(self.resolve_defined_policy(definition, defaults)))
+            }
+            DefinitionState::Lowered => Err(DefinitionAlreadyLowered),
+        }
     }
 
     /// Resolves policy and claims the matching construction under one
@@ -253,12 +258,12 @@ impl SlotCell {
             // nameable, so it arrives here as the kind default.
             ChildConstruction::Raw(definition) => (
                 definition.options(),
-                definition.mode(),
+                definition.source.mode(),
                 definition.readiness(),
             ),
             ChildConstruction::Task(definition) => (
                 definition.options(),
-                definition.mode(),
+                definition.source.mode(),
                 Readiness::Immediate,
             ),
             ChildConstruction::Scope(definition) => {
@@ -266,7 +271,12 @@ impl SlotCell {
                     readiness: None,
                     ..definition.options.clone()
                 };
-                return resolve_common(&options, defaults, definition.mode(), Readiness::Manual);
+                return resolve_common(
+                    &options,
+                    defaults,
+                    definition.source.mode(),
+                    Readiness::Manual,
+                );
             }
         };
         resolve_common(options, defaults, mode, default_readiness)
@@ -350,11 +360,24 @@ impl BuilderCore {
         root_override: Option<Arc<ScopeCell>>,
     ) -> Result<ScopePlan, LowerError> {
         let root = root_override.unwrap_or_else(|| Arc::clone(&self.root));
-        let undefined: Vec<_> = self
+        let defaults = inherited.overlay(&self.config.defaults);
+        // Resolve and classify each definition under one definition-lock pass.
+        // Resolution is pure, so evaluating defined siblings before reporting
+        // an undefined slot cannot publish or consume anything.
+        let resolved: Vec<Result<ResolvedCommonOptions, ChildId>> = self
             .slots
             .iter()
-            .filter(|slot| slot.is_undefined())
-            .map(|slot| slot.member.id().clone())
+            .map(|slot| match slot.resolve_policy_for_lowering(&defaults) {
+                Ok(Some(options)) => Ok(options),
+                Ok(None) => Err(slot.member.id().clone()),
+                Err(DefinitionAlreadyLowered) => {
+                    panic!("a tree must be lowered at most once")
+                }
+            })
+            .collect();
+        let undefined: Vec<_> = resolved
+            .iter()
+            .filter_map(|result| result.as_ref().err().cloned())
             .collect();
         if !undefined.is_empty() {
             let disposal = self.begin_failed_disposal();
@@ -363,7 +386,6 @@ impl BuilderCore {
                 disposal,
             });
         }
-        let (defaults, resolved) = self.resolve_policies(&inherited);
         if !Arc::ptr_eq(&root, &self.root) {
             // From the first adoption on, a failed or unwound lowering must
             // evict the terminalized slots from the override's identity map,
@@ -385,13 +407,11 @@ impl BuilderCore {
         }
         root.set_observation_config(self.config.intensity);
         let mut children = Vec::with_capacity(self.slots.len());
-        debug_assert_eq!(
-            self.slots.len(),
-            resolved.len(),
-            "policy resolution is one entry per slot, in slot order"
-        );
-        for (slot, resolved) in self.slots.iter().zip(resolved) {
-            let resolved = resolved.expect("defined slot must have resolved options");
+        for (slot, resolved) in self
+            .slots
+            .iter()
+            .zip(resolved.into_iter().filter_map(Result::ok))
+        {
             let definition = slot
                 .take_definition()
                 .expect("a tree must be lowered at most once")
@@ -410,21 +430,6 @@ impl BuilderCore {
             children,
             terminality: Some(ScopePlanTerminality),
         })
-    }
-
-    fn resolve_policies(
-        &self,
-        inherited: &ResolvedDefaults,
-    ) -> (ResolvedDefaults, Vec<Option<ResolvedCommonOptions>>) {
-        let defaults = inherited.overlay(&self.config.defaults);
-        // One entry per slot, in slot order. An undefined slot resolves to
-        // `None` rather than being skipped, so this vector can never shift a
-        // later child onto another child's options.
-        let mut resolved = Vec::with_capacity(self.slots.len());
-        for slot in &self.slots {
-            resolved.push(slot.resolve_policy(&defaults));
-        }
-        (defaults, resolved)
     }
 
     fn terminalize(&self) {
@@ -553,14 +558,6 @@ pub(crate) struct ScopeConstruction {
 pub(crate) type ScopeFactory = Arc<dyn Fn() -> BuilderCore + Send + Sync + 'static>;
 
 impl ScopeConstruction {
-    pub(crate) fn mode(&self) -> ChildMode {
-        if self.source.is_one_shot() {
-            ChildMode::OneShot
-        } else {
-            ChildMode::Restartable
-        }
-    }
-
     pub(crate) fn restartable(&self) -> Option<&ScopeFactory> {
         self.source.restartable()
     }
@@ -642,6 +639,22 @@ mod tests {
             slots.push(slot);
         }
         (builder, slots)
+    }
+
+    #[test]
+    #[should_panic(expected = "a tree must be lowered at most once")]
+    fn fused_lowering_keeps_lowered_distinct_from_undefined() {
+        let mut builder = BuilderCore::new(ScopeFlavor::Ordered);
+        let slot = builder
+            .reserve("claimed", None)
+            .expect("reservation succeeds");
+        slot.define(ChildConstruction::Task(configured_task()));
+        let _claimed = slot
+            .take_definition()
+            .expect("slot has not been lowered")
+            .expect("slot is defined");
+
+        let _ = builder.lower(ResolvedDefaults::default(), None);
     }
 
     #[test]

--- a/crates/shelterwood/src/raw/definition.rs
+++ b/crates/shelterwood/src/raw/definition.rs
@@ -9,10 +9,11 @@ use crate::{
     cells::MemberCell,
     definition::DefinitionSource,
     mailbox::{MailboxCell, MailboxControl, MailboxEffectQueue, actor_ref_from_parts},
-    policy::{ChildMode, CommonOptions},
+    policy::CommonOptions,
     runtime::{
-        CompletionGatedLatch, Latch, PanicAccumulator, PanicPayload, UnwindPanics, catch_panic,
-        keep_first_panic, resume_preferred_panic, resume_preferred_panic_outside_unwind,
+        CompletionGatedLatch, Isolated, Latch, PanicAccumulator, PanicPayload, UnwindPanics,
+        catch_panic, keep_first_panic, resume_preferred_panic,
+        resume_preferred_panic_outside_unwind,
     },
     scope::ScopeRef,
 };
@@ -86,9 +87,18 @@ impl<R: RawActor> RawDef<R> {
         retention,
     );
 
-    pub(crate) fn erase(self, mailbox: Arc<MailboxCell<R::Msg>>) -> RawConstruction {
-        let factory = self.factory;
-        let readiness = self.options.readiness.unwrap_or_else(R::readiness);
+    pub(crate) fn erase(
+        mut definition: Isolated<Self>,
+        mailbox: Arc<MailboxCell<R::Msg>>,
+    ) -> RawConstruction {
+        let readiness = definition
+            .get()
+            .options
+            .readiness
+            .unwrap_or_else(R::readiness);
+        let Self { factory, options } = definition
+            .take()
+            .expect("isolated raw definition is available");
         RawConstruction {
             source: DefinitionSource::Restartable(Arc::new(move || {
                 let actor = factory();
@@ -97,7 +107,7 @@ impl<R: RawActor> RawDef<R> {
                     mailbox: Arc::clone(&mailbox),
                 })
             })),
-            options: self.options,
+            options,
             readiness,
         }
     }
@@ -137,14 +147,21 @@ impl<R: RawActor> RawOnceDef<R> {
         retention,
     );
 
-    pub(crate) fn erase(self, mailbox: Arc<MailboxCell<R::Msg>>) -> RawConstruction {
-        let readiness = self.options.readiness.unwrap_or_else(R::readiness);
+    pub(crate) fn erase(
+        mut definition: Isolated<Self>,
+        mailbox: Arc<MailboxCell<R::Msg>>,
+    ) -> RawConstruction {
+        let readiness = definition
+            .get()
+            .options
+            .readiness
+            .unwrap_or_else(R::readiness);
+        let Self { actor, options } = definition
+            .take()
+            .expect("isolated raw definition is available");
         RawConstruction {
-            source: DefinitionSource::OneShot(Box::new(RawInstance {
-                actor: self.actor,
-                mailbox,
-            })),
-            options: self.options,
+            source: DefinitionSource::OneShot(Box::new(RawInstance { actor, mailbox })),
+            options,
             readiness,
         }
     }
@@ -153,7 +170,7 @@ impl<R: RawActor> RawOnceDef<R> {
 type RawFuture = Pin<Box<dyn Future<Output = ExitResult> + Send + 'static>>;
 type RawFactory = Arc<dyn Fn() -> Box<dyn ErasedRawInstance> + Send + Sync + 'static>;
 
-trait ErasedRawInstance: Send {
+pub(crate) trait ErasedRawInstance: Send {
     fn run(self: Box<Self>, context: RawRunContext, readiness: Readiness) -> RawFuture;
 }
 
@@ -280,7 +297,7 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
 }
 
 pub(crate) struct RawConstruction {
-    source: DefinitionSource<RawFactory, Box<dyn ErasedRawInstance>>,
+    pub(crate) source: DefinitionSource<RawFactory, Box<dyn ErasedRawInstance>>,
     options: CommonOptions,
     readiness: Readiness,
 }
@@ -292,14 +309,6 @@ impl RawConstruction {
 
     pub(crate) fn readiness(&self) -> Readiness {
         self.readiness
-    }
-
-    pub(crate) fn mode(&self) -> ChildMode {
-        if self.source.is_one_shot() {
-            ChildMode::OneShot
-        } else {
-            ChildMode::Restartable
-        }
     }
 
     pub(crate) fn one_shot(&self) -> bool {

--- a/crates/shelterwood/src/scope.rs
+++ b/crates/shelterwood/src/scope.rs
@@ -72,6 +72,30 @@ impl ScopeRef {
     pub fn request_shutdown(&self) {
         let _ = self.cell.request_shutdown();
     }
+
+    /// Requests shutdown and waits for this scope's incarnation to finish its
+    /// scope epilogue.
+    ///
+    /// `timeout` bounds cooperative teardown, not this call's return: it arms
+    /// when the targeted incarnation enters its drain and, once expired,
+    /// escalates and reports stragglers while the wait continues to
+    /// completion. Membership terminality published by an ancestor's teardown
+    /// does not resolve the call while that incarnation is still running its
+    /// epilogue.
+    ///
+    /// A scheduled scope driver joins its children before completing. If an
+    /// ancestor hard-aborts a framework driver at the tidy-abort backstop, its
+    /// synchronous drop epilogue can only *request* abort for active children,
+    /// so cancellation and user-future destruction below that boundary may
+    /// finish after this call returns.
+    /// A zero budget still requests cooperative cancellation, then skips its
+    /// wait and enters the ordinary escalation tail immediately.
+    pub async fn shutdown_and_wait(
+        &self,
+        timeout: impl Into<DeadlineBudget>,
+    ) -> Result<(), crate::ShutdownTimeout> {
+        crate::driver::shutdown_scope(Arc::clone(&self.cell), timeout.into()).await
+    }
 }
 
 impl ScopeRef {

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -14,7 +14,7 @@ use crate::{
     cancellation::{CancellationToken, ParentCancellationToken},
     cells::MemberCell,
     definition::DefinitionSource,
-    policy::{ChildMode, CommonOptions},
+    policy::CommonOptions,
     runtime::{self, CompletionGatedLatch, Latch},
 };
 
@@ -196,21 +196,13 @@ impl<T: Send + 'static> TaskOnceDef<T> {
 type OnceTaskFactory = Box<dyn FnOnce(TaskContext) -> TaskFuture + Send + 'static>;
 
 pub(crate) struct TaskConstruction {
-    source: DefinitionSource<TaskFactory, OnceTaskFactory>,
+    pub(crate) source: DefinitionSource<TaskFactory, OnceTaskFactory>,
     options: CommonOptions,
 }
 
 impl TaskConstruction {
     pub(crate) fn options(&self) -> &CommonOptions {
         &self.options
-    }
-
-    pub(crate) fn mode(&self) -> ChildMode {
-        if self.source.is_one_shot() {
-            ChildMode::OneShot
-        } else {
-            ChildMode::Restartable
-        }
     }
 
     pub(crate) fn restartable(&self) -> Option<&TaskFactory> {

--- a/crates/shelterwood/src/tree/builders.rs
+++ b/crates/shelterwood/src/tree/builders.rs
@@ -34,15 +34,18 @@ pub enum BuildError {
 }
 /// Routes a definition rejected before admission through isolated disposal.
 ///
-/// A failed reservation returns before framework state owns the supplied
-/// definition, so dropping it inline would run a possibly blocking or
-/// panicking user destructor on the caller instead of producing an ordinary
-/// [`ReserveError`].
+/// Builder and dynamic-add entry points wrap the definition before evaluating
+/// the caller's `Into<ChildId>` hook or raw readiness metadata. A failed
+/// reservation therefore arrives here already isolated, and dropping the
+/// wrapper cannot run a possibly blocking or panicking user destructor on the
+/// caller instead of producing an ordinary [`ReserveError`]. This guarantee
+/// covers the supplied definition only; Rust's ordinary unwind rules still
+/// govern every other caller-owned local.
 pub(super) fn dispose_rejected<D: Send + 'static>(
-    definition: D,
+    definition: runtime::Isolated<D>,
     error: ReserveError,
 ) -> ReserveError {
-    runtime::dispose_detached(definition);
+    drop(definition);
     error
 }
 
@@ -90,8 +93,11 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: ActorDef<A>,
         ) -> Result<ActorRef<A::Msg>, ReserveError> {
+            let mut definition = runtime::Isolated::new(definition);
             match self.reserve_actor(id) {
-                Ok(slot) => Ok(slot.define(definition)),
+                Ok(slot) => Ok(slot.define(
+                    definition.take().expect("isolated definition is available"),
+                )),
                 Err(error) => Err(dispose_rejected(definition, error)),
             }
         }
@@ -103,8 +109,11 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: ActorOnceDef<A>,
         ) -> Result<ActorRef<A::Msg>, ReserveError> {
+            let mut definition = runtime::Isolated::new(definition);
             match self.reserve_actor(id) {
-                Ok(slot) => Ok(slot.define_once(definition)),
+                Ok(slot) => Ok(slot.define_once(
+                    definition.take().expect("isolated definition is available"),
+                )),
                 Err(error) => Err(dispose_rejected(definition, error)),
             }
         }
@@ -116,8 +125,11 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: RawDef<R>,
         ) -> Result<ActorRef<R::Msg>, ReserveError> {
+            let mut definition = runtime::Isolated::new(definition);
             match self.reserve_actor(id) {
-                Ok(slot) => Ok(slot.define_raw(definition)),
+                Ok(slot) => Ok(slot.define_raw(
+                    definition.take().expect("isolated definition is available"),
+                )),
                 Err(error) => Err(dispose_rejected(definition, error)),
             }
         }
@@ -129,8 +141,11 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: RawOnceDef<R>,
         ) -> Result<ActorRef<R::Msg>, ReserveError> {
+            let mut definition = runtime::Isolated::new(definition);
             match self.reserve_actor(id) {
-                Ok(slot) => Ok(slot.define_once_raw(definition)),
+                Ok(slot) => Ok(slot.define_once_raw(
+                    definition.take().expect("isolated definition is available"),
+                )),
                 Err(error) => Err(dispose_rejected(definition, error)),
             }
         }
@@ -150,8 +165,11 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: TaskDef,
         ) -> Result<TaskRef, ReserveError> {
+            let mut definition = runtime::Isolated::new(definition);
             match self.reserve_task(id) {
-                Ok(slot) => Ok(slot.define(definition)),
+                Ok(slot) => Ok(slot.define(
+                    definition.take().expect("isolated definition is available"),
+                )),
                 Err(error) => Err(dispose_rejected(definition, error)),
             }
         }
@@ -163,8 +181,11 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: TaskOnceDef<T>,
         ) -> Result<(TaskRef, OneShotTaskRef<T>), ReserveError> {
+            let mut definition = runtime::Isolated::new(definition);
             match self.reserve_task(id) {
-                Ok(slot) => Ok(slot.define_once(definition)),
+                Ok(slot) => Ok(slot.define_once(
+                    definition.take().expect("isolated definition is available"),
+                )),
                 Err(error) => Err(dispose_rejected(definition, error)),
             }
         }
@@ -189,8 +210,11 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: SubtreeDef<T>,
         ) -> Result<T::Ref, ReserveError> {
+            let mut definition = runtime::Isolated::new(definition);
             match self.reserve_subtree::<T>(id) {
-                Ok(slot) => Ok(slot.define(definition)),
+                Ok(slot) => Ok(slot.define(
+                    definition.take().expect("isolated definition is available"),
+                )),
                 Err(error) => Err(dispose_rejected(definition, error)),
             }
         }
@@ -202,8 +226,11 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: SubtreeOnceDef<T>,
         ) -> Result<T::Ref, ReserveError> {
+            let mut definition = runtime::Isolated::new(definition);
             match self.reserve_subtree::<T>(id) {
-                Ok(slot) => Ok(slot.define_once(definition)),
+                Ok(slot) => Ok(slot.define_once(
+                    definition.take().expect("isolated definition is available"),
+                )),
                 Err(error) => Err(dispose_rejected(definition, error)),
             }
         }

--- a/crates/shelterwood/src/tree/dynamic_api.rs
+++ b/crates/shelterwood/src/tree/dynamic_api.rs
@@ -1,9 +1,8 @@
-use std::sync::Arc;
-
 use crate::{
     ActorDef, ActorOnceDef, ActorRef, ChildId,
     admission::ReserveError,
     raw::{RawDef, RawOnceDef},
+    runtime,
     scope::{DynamicScopeRef, ScopeRef},
     task::{OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
 };
@@ -19,43 +18,21 @@ use super::{
     system::sealed,
 };
 
-impl ScopeRef {
-    /// Requests shutdown and waits for this scope's incarnation to finish its
-    /// scope epilogue.
-    ///
-    /// `timeout` bounds cooperative teardown, not this call's return: it arms
-    /// when the targeted incarnation enters its drain and, once expired,
-    /// escalates and reports stragglers while the wait continues to
-    /// completion. Membership terminality published by an ancestor's teardown
-    /// does not resolve the call while that incarnation is still running its
-    /// epilogue.
-    ///
-    /// A scheduled scope driver joins its children before completing. If an
-    /// ancestor hard-aborts a framework driver at the tidy-abort backstop, its
-    /// synchronous drop epilogue can only *request* abort for active children,
-    /// so cancellation and user-future destruction below that boundary may
-    /// finish after this call returns.
-    /// A zero budget still requests cooperative cancellation, then skips its
-    /// wait and enters the ordinary escalation tail immediately.
-    pub async fn shutdown_and_wait(
-        &self,
-        timeout: impl Into<crate::DeadlineBudget>,
-    ) -> Result<(), crate::ShutdownTimeout> {
-        crate::driver::shutdown_scope(Arc::clone(&self.cell), timeout.into()).await
-    }
-}
-
 impl DynamicScopeRef {
     fn define_or_reject<D, S, H>(
         definition: D,
-        slot: Result<S, ReserveError>,
+        reserve: impl FnOnce() -> Result<S, ReserveError>,
         define: impl FnOnce(S, D) -> Admission<H>,
     ) -> Admission<H>
     where
         D: Send + 'static,
     {
-        match slot {
-            Ok(slot) => define(slot, definition),
+        let mut definition = runtime::Isolated::new(definition);
+        match reserve() {
+            Ok(slot) => define(
+                slot,
+                definition.take().expect("isolated definition is available"),
+            ),
             Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
     }
@@ -114,7 +91,7 @@ impl DynamicScopeRef {
     ) -> Admission<ActorRef<A::Msg>> {
         Self::define_or_reject(
             definition,
-            self.reserve_actor_with(id, AdmissionOwnership::Fused),
+            || self.reserve_actor_with(id, AdmissionOwnership::Fused),
             |slot, definition| slot.core.define_raw(definition.into_raw()),
         )
     }
@@ -127,7 +104,7 @@ impl DynamicScopeRef {
     ) -> Admission<ActorRef<A::Msg>> {
         Self::define_or_reject(
             definition,
-            self.reserve_actor_with(id, AdmissionOwnership::Fused),
+            || self.reserve_actor_with(id, AdmissionOwnership::Fused),
             |slot, definition| slot.core.define_once_raw(definition.into_raw()),
         )
     }
@@ -140,7 +117,7 @@ impl DynamicScopeRef {
     ) -> Admission<ActorRef<R::Msg>> {
         Self::define_or_reject(
             definition,
-            self.reserve_actor_with(id, AdmissionOwnership::Fused),
+            || self.reserve_actor_with(id, AdmissionOwnership::Fused),
             |slot, definition| slot.core.define_raw(definition),
         )
     }
@@ -153,7 +130,7 @@ impl DynamicScopeRef {
     ) -> Admission<ActorRef<R::Msg>> {
         Self::define_or_reject(
             definition,
-            self.reserve_actor_with(id, AdmissionOwnership::Fused),
+            || self.reserve_actor_with(id, AdmissionOwnership::Fused),
             |slot, definition| slot.core.define_once_raw(definition),
         )
     }
@@ -169,7 +146,7 @@ impl DynamicScopeRef {
     pub fn add_task(&self, id: impl Into<ChildId>, definition: TaskDef) -> Admission<TaskRef> {
         Self::define_or_reject(
             definition,
-            self.reserve_task_with(id, AdmissionOwnership::Fused),
+            || self.reserve_task_with(id, AdmissionOwnership::Fused),
             |slot, definition| slot.core.define(definition),
         )
     }
@@ -182,7 +159,7 @@ impl DynamicScopeRef {
     ) -> Admission<(TaskRef, OneShotTaskRef<T>)> {
         Self::define_or_reject(
             definition,
-            self.reserve_task_with(id, AdmissionOwnership::Fused),
+            || self.reserve_task_with(id, AdmissionOwnership::Fused),
             |slot, definition| slot.core.define_once(definition),
         )
     }
@@ -205,7 +182,7 @@ impl DynamicScopeRef {
     ) -> Admission<T::Ref> {
         Self::define_or_reject(
             definition,
-            self.reserve_subtree_with::<T>(id, AdmissionOwnership::Fused),
+            || self.reserve_subtree_with::<T>(id, AdmissionOwnership::Fused),
             |slot, definition| slot.core.define(definition),
         )
     }
@@ -218,7 +195,7 @@ impl DynamicScopeRef {
     ) -> Admission<T::Ref> {
         Self::define_or_reject(
             definition,
-            self.reserve_subtree_with::<T>(id, AdmissionOwnership::Fused),
+            || self.reserve_subtree_with::<T>(id, AdmissionOwnership::Fused),
             |slot, definition| slot.core.define_once(definition),
         )
     }

--- a/crates/shelterwood/src/tree/slots.rs
+++ b/crates/shelterwood/src/tree/slots.rs
@@ -110,7 +110,13 @@ macro_rules! impl_actor_core_definition {
         {
             let actor = self.actor_ref();
             let Self { endpoint, mailbox } = self;
-            endpoint.define(actor, ChildConstruction::Raw(definition.erase(mailbox)))
+            endpoint.define(
+                actor,
+                ChildConstruction::Raw($definition::erase(
+                    runtime::Isolated::new(definition),
+                    mailbox,
+                )),
+            )
         }
     };
 }

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -455,6 +455,32 @@ impl Actor for OffloadThenFailActor {
     }
 }
 
+struct OffloadThenFailInitActor;
+
+impl Actor for OffloadThenFailInitActor {
+    type Msg = ();
+    type Args = Arc<Mutex<Vec<&'static str>>>;
+
+    async fn init(log: Self::Args, context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        let guard = TeardownDropLog { log };
+        context
+            .offload(
+                async move {
+                    let _guard = guard;
+                    std::future::pending::<()>().await;
+                },
+                |_| (),
+                Duration::MAX,
+            )
+            .expect("live init offload accepted");
+        Err(ExitError::message("injected init failure"))
+    }
+
+    async fn handle(&mut self, (): Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+        unreachable!("failed initialization never enters the handler loop")
+    }
+}
+
 /// `Handler` is the advertised raw-decorator composition point, so the raw
 /// incarnation boundary is not necessarily its immediate caller: a callback
 /// error must freeze and join incarnation-owned work inside `Handler::run`,
@@ -488,6 +514,38 @@ async fn handler_error_joins_offloads_before_returning_to_a_raw_decorator() {
         .shutdown(Duration::from_secs(1))
         .await
         .expect("tree shuts down");
+}
+
+/// The init-error call site must use the same teardown funnel as handler
+/// errors: outstanding work is destroyed before a raw decorator resumes and
+/// before startup exposes the exit.
+#[tokio::test]
+async fn init_error_joins_live_offloads_before_the_exit_is_observed() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut tree = Tree::new();
+    tree.add_raw_once(
+        "init-error",
+        RawOnceDef::new(ResumeProbeDecorator {
+            inner: Handler::<OffloadThenFailInitActor>::new(Arc::clone(&log)),
+            log: Arc::clone(&log),
+        }),
+    )
+    .expect("valid decorated actor");
+    let system = tree.spawn().expect("runtime is available");
+
+    system
+        .wait_started()
+        .await
+        .expect_err("the init error prevents startup");
+    assert_eq!(
+        *log.lock().expect("teardown log mutex poisoned"),
+        ["offload-destroyed", "decorator-resumed"],
+        "startup cannot expose the init error before its offload is destroyed"
+    );
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed-startup tree shuts down");
 }
 
 #[tokio::test(start_paused = true)]

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -3,6 +3,7 @@ mod common;
 use std::{
     future::{Future, poll_fn},
     marker::PhantomData,
+    panic::{AssertUnwindSafe, catch_unwind},
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -17,10 +18,10 @@ use crate::common::{
     next_event, policy::never, poll_once,
 };
 use shelterwood::{
-    Backoff, CallErrorKind, Cancellation, ChildState, DynamicTree, ExitError, ExitKind, ExitResult,
-    Jitter, LifecycleEventKind, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
-    ReadinessDeadline, RemoveOutcome, Reply, ReserveError, RestartCondition, RestartPolicy,
-    ScopeState, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
+    Backoff, CallErrorKind, Cancellation, ChildId, ChildState, DynamicTree, ExitError, ExitKind,
+    ExitResult, Jitter, LifecycleEventKind, Mailbox, RawActor, RawContext, RawDef, RawOnceDef,
+    Readiness, ReadinessDeadline, RemoveOutcome, Reply, ReserveError, RestartCondition,
+    RestartPolicy, ScopeState, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
 };
 
 struct DropProbe {
@@ -1177,6 +1178,108 @@ impl RawActor for HostileCapture {
     async fn run(&mut self, _context: &mut RawContext<Self::Msg>) -> ExitResult {
         Ok(())
     }
+}
+
+struct PanickingDefinitionId;
+
+impl From<PanickingDefinitionId> for ChildId {
+    fn from(_: PanickingDefinitionId) -> Self {
+        panic!("injected child-id conversion panic")
+    }
+}
+
+struct HostileReadinessCapture {
+    _probe: DropProbe,
+}
+
+impl RawActor for HostileReadinessCapture {
+    type Msg = ();
+
+    fn readiness() -> Readiness {
+        panic!("injected raw-readiness panic")
+    }
+
+    async fn run(&mut self, _context: &mut RawContext<Self::Msg>) -> ExitResult {
+        unreachable!("readiness metadata prevents admission")
+    }
+}
+
+fn hostile_task_definition(
+    dropped: tokio::sync::mpsc::UnboundedSender<ThreadId>,
+    panic: &'static str,
+) -> TaskDef {
+    TaskDef::new({
+        let capture = DropProbe::panicking(dropped, panic);
+        move |_| {
+            let _ = &capture;
+            async { Ok(()) }
+        }
+    })
+}
+
+#[tokio::test]
+async fn add_id_conversion_panics_keep_static_and_dynamic_definitions_isolated() {
+    let (static_dropped, mut static_drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let static_result = catch_unwind(AssertUnwindSafe(|| {
+        let _ = tree.add_task(
+            PanickingDefinitionId,
+            hostile_task_definition(static_dropped, "static id-hook definition destructor"),
+        );
+    }));
+    assert!(
+        static_result.is_err(),
+        "the id conversion panic still surfaces"
+    );
+    assert_disposed_off_current(
+        &mut static_drops,
+        "the static definition survives the id-hook unwind and is disposed off-thread",
+    )
+    .await;
+
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+    let (dynamic_dropped, mut dynamic_drops) = tokio::sync::mpsc::unbounded_channel();
+    let dynamic_result = catch_unwind(AssertUnwindSafe(|| {
+        drop(scope.add_task(
+            PanickingDefinitionId,
+            hostile_task_definition(dynamic_dropped, "dynamic id-hook definition destructor"),
+        ));
+    }));
+    assert!(
+        dynamic_result.is_err(),
+        "the dynamic id conversion panic still surfaces"
+    );
+    assert_disposed_off_current(
+        &mut dynamic_drops,
+        "the dynamic definition survives the id-hook unwind and is disposed off-thread",
+    )
+    .await;
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root shuts down");
+}
+
+#[tokio::test]
+async fn raw_readiness_panic_keeps_the_definition_destructor_isolated() {
+    let (dropped, mut drops) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let _ = tree.add_raw_once(
+            "readiness-panic",
+            RawOnceDef::new(HostileReadinessCapture {
+                _probe: DropProbe::panicking(dropped, "readiness-hook definition destructor"),
+            }),
+        );
+    }));
+    assert!(result.is_err(), "the readiness panic still surfaces");
+    assert_disposed_off_current(
+        &mut drops,
+        "the raw definition survives the readiness-hook unwind and is disposed off-thread",
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -24,6 +24,21 @@ enum Message {
     Offload,
 }
 
+const CONTINUATION_RECOVERED: usize = 1 << 0;
+const TIMEOUT_RECOVERED: usize = 1 << 1;
+const INTERVAL_RECOVERED: usize = 1 << 2;
+const CLEAR_REJECTED: usize = 1 << 3;
+const OFFLOAD_RECOVERED: usize = 1 << 4;
+const SCOPED_OFFLOAD_RECOVERED: usize = 1 << 5;
+const SILENT_DRAIN_CONTROL_RETURNED: usize = 1 << 6;
+const ALL_DRAIN_REJECTIONS_OBSERVED: usize = CONTINUATION_RECOVERED
+    | TIMEOUT_RECOVERED
+    | INTERVAL_RECOVERED
+    | CLEAR_REJECTED
+    | OFFLOAD_RECOVERED
+    | SCOPED_OFFLOAD_RECOVERED
+    | SILENT_DRAIN_CONTROL_RETURNED;
+
 /// Publishes a handler's `is_draining()` observations for judgement in the
 /// test body.
 ///
@@ -64,6 +79,7 @@ struct Args {
     drain_entered: Arc<AtomicBool>,
     allow_drain: ReleaseGate,
     deferred_ran: Arc<AtomicBool>,
+    rejections: Arc<AtomicUsize>,
     log: Arc<Mutex<Vec<u8>>>,
 }
 
@@ -90,29 +106,37 @@ impl Actor for DrainActor {
                 self.0.value_draining.record(context.is_draining());
                 self.0.log.lock().expect("log mutex poisoned").push(value);
                 if !self.0.drain_entered.swap(true, Ordering::SeqCst) {
-                    let continuation = context
+                    let mut observed = 0;
+                    if context
                         .continue_with(Message::Deferred)
-                        .expect_err("drain rejects continuations");
-                    assert!(matches!(continuation.into_inner(), Message::Deferred));
+                        .is_err_and(|rejected| matches!(rejected.into_inner(), Message::Deferred))
+                    {
+                        observed |= CONTINUATION_RECOVERED;
+                    }
 
-                    let timer = context
+                    if context
                         .set_timeout("timer", Message::Timer, Duration::ZERO)
-                        .expect_err("drain rejects timers");
-                    assert!(matches!(timer.into_inner().1, Message::Timer));
+                        .is_err_and(|rejected| matches!(rejected.into_inner().1, Message::Timer))
+                    {
+                        observed |= TIMEOUT_RECOVERED;
+                    }
 
-                    let interval = context
+                    if context
                         .set_interval("interval", Message::Timer, Duration::from_secs(1))
-                        .expect_err("drain rejects intervals");
-                    let (interval_key, interval_message) = interval.into_inner();
-                    assert_eq!(interval_key, "interval");
-                    assert!(matches!(interval_message, Message::Timer));
+                        .is_err_and(|rejected| {
+                            let (key, message) = rejected.into_inner();
+                            key == "interval" && matches!(message, Message::Timer)
+                        })
+                    {
+                        observed |= INTERVAL_RECOVERED;
+                    }
 
-                    context
-                        .clear_timer(&"timer")
-                        .expect_err("drain rejects timer retraction");
+                    if context.clear_timer(&"timer").is_err() {
+                        observed |= CLEAR_REJECTED;
+                    }
 
                     let ran = Arc::clone(&self.0.deferred_ran);
-                    let offload = context
+                    if context
                         .offload(
                             async move {
                                 ran.store(true, Ordering::SeqCst);
@@ -120,11 +144,17 @@ impl Actor for DrainActor {
                             |_| Message::Offload,
                             Duration::from_secs(1),
                         )
-                        .expect_err("drain rejects offloads");
-                    drop(offload);
+                        .is_err_and(|rejected| {
+                            let (work, continuation) = rejected.into_inner();
+                            drop(work);
+                            matches!(continuation(Ok(())), Message::Offload)
+                        })
+                    {
+                        observed |= OFFLOAD_RECOVERED;
+                    }
 
                     let scoped_ran = Arc::clone(&self.0.deferred_ran);
-                    let scoped = context
+                    if context
                         .offload_scoped(
                             async move {
                                 scoped_ran.store(true, Ordering::SeqCst);
@@ -132,13 +162,26 @@ impl Actor for DrainActor {
                             |_| Message::Offload,
                             Duration::from_secs(1),
                         )
-                        .expect_err("drain rejects scoped offloads");
-                    // The rejected payload is recovered whole: the work
-                    // future is discarded without running and the
-                    // continuation still produces its message.
-                    let (scoped_work, scoped_continuation) = scoped.into_inner();
-                    drop(scoped_work);
-                    assert!(matches!(scoped_continuation(Ok(())), Message::Offload));
+                        .is_err_and(|rejected| {
+                            // The rejected payload is recovered whole: the
+                            // work future is discarded without running and the
+                            // continuation still produces its message.
+                            let (work, continuation) = rejected.into_inner();
+                            drop(work);
+                            matches!(continuation(Ok(())), Message::Offload)
+                        })
+                    {
+                        observed |= SCOPED_OFFLOAD_RECOVERED;
+                    }
+
+                    // These unit-returning controls deliberately stay silent
+                    // during frozen-prefix drain. Calling them here and then
+                    // completing the exact prefix pins that they neither
+                    // reject by panicking nor perturb drain progression.
+                    context.mark_ready();
+                    context.stop();
+                    observed |= SILENT_DRAIN_CONTROL_RETURNED;
+                    self.0.rejections.store(observed, Ordering::SeqCst);
 
                     self.0.allow_drain.wait().await;
                 }
@@ -159,6 +202,7 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
     let drain_entered = Arc::new(AtomicBool::new(false));
     let allow_drain = ReleaseGate::default();
     let deferred_ran = Arc::new(AtomicBool::new(false));
+    let rejections = Arc::new(AtomicUsize::new(0));
     let log = Arc::new(Mutex::new(Vec::new()));
 
     let mut tree = Tree::new();
@@ -173,6 +217,7 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
                 drain_entered: Arc::clone(&drain_entered),
                 allow_drain: allow_drain.clone(),
                 deferred_ran: Arc::clone(&deferred_ran),
+                rejections: Arc::clone(&rejections),
                 log: Arc::clone(&log),
             })
             .mailbox(mailbox),
@@ -235,6 +280,11 @@ async fn assert_drain_fixture(mailbox: Mailbox, expected: &[u8]) {
         "every drained delivery observes the draining phase",
     );
     assert!(!deferred_ran.load(Ordering::SeqCst));
+    assert_eq!(
+        rejections.load(Ordering::SeqCst),
+        ALL_DRAIN_REJECTIONS_OBSERVED,
+        "every rejected operation returns its original payload for body-side judgement"
+    );
 }
 
 #[tokio::test(start_paused = true)]

--- a/crates/shelterwood/tests/one_shot_resource_ownership.rs
+++ b/crates/shelterwood/tests/one_shot_resource_ownership.rs
@@ -78,8 +78,8 @@ async fn one_shot_raw_resource_drops_once_on_normal_exit() {
     count.assert_once();
 }
 
-#[test]
-fn one_shot_raw_resource_drops_once_on_readiness_definition_panic() {
+#[tokio::test(flavor = "current_thread")]
+async fn one_shot_raw_resource_drops_once_on_readiness_definition_panic() {
     let count = ConsumeCount::default();
     let mut tree = Tree::new();
     let result = catch_unwind(AssertUnwindSafe(|| {
@@ -91,6 +91,7 @@ fn one_shot_raw_resource_drops_once_on_readiness_definition_panic() {
         );
     }));
     assert!(result.is_err());
+    assert_eventually!(|| count.get() == 1).await;
     count.assert_once();
 }
 
@@ -111,6 +112,7 @@ async fn dynamic_one_shot_raw_resource_drops_once_on_readiness_definition_panic(
     }));
 
     assert!(result.is_err());
+    assert_eventually!(|| count.get() == 1).await;
     count.assert_once();
     drop(
         scope

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -18,7 +18,8 @@ use shelterwood::{
 };
 
 struct FactoryTaskActor {
-    factory_task: String,
+    factory_task: tokio::task::Id,
+    observations: Arc<Mutex<Vec<(tokio::task::Id, tokio::task::Id)>>>,
 }
 
 struct InertRaw;
@@ -35,23 +36,39 @@ impl RawActor for FactoryTaskActor {
     type Msg = ();
 
     async fn run(&mut self, _context: &mut RawContext<Self::Msg>) -> ExitResult {
-        assert_eq!(self.factory_task, format!("{:?}", tokio::task::id()));
+        self.observations
+            .lock()
+            .expect("task observation mutex poisoned")
+            .push((self.factory_task, tokio::task::id()));
         Ok(())
     }
 }
 
 #[tokio::test]
 async fn restartable_raw_factory_runs_inside_the_incarnation_task() {
+    let observations = Arc::new(Mutex::new(Vec::new()));
     let mut tree = Tree::new();
     tree.add_raw(
         "factory-task",
-        RawDef::factory(|| FactoryTaskActor {
-            factory_task: format!("{:?}", tokio::task::id()),
+        RawDef::factory({
+            let observations = Arc::clone(&observations);
+            move || FactoryTaskActor {
+                factory_task: tokio::task::id(),
+                observations: Arc::clone(&observations),
+            }
         }),
     )
     .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    let observed = observations
+        .lock()
+        .expect("task observation mutex poisoned");
+    assert_eq!(observed.len(), 1, "the one incarnation publishes one pair");
+    assert_eq!(
+        observed[0].0, observed[0].1,
+        "the factory and raw run execute in the same Tokio task"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- collapse dynamic admission control from three forwarding layers to the public façade entry points plus concrete `DynamicControl` methods
- complete the façade cleanup batch: centralize definition mode, centralize startup-abort classification, move `shutdown_and_wait`, document/test drain-stage silent controls, fuse lowering's undefined/policy pass, explicitly discharge startup removals on driver Drop, and import the supervisor reducer honestly
- move raw/drain test verdicts into the test body and add the missing init-error/live-offload teardown regression
- isolate supplied definitions across eager `Into<ChildId>` and `RawActor::readiness` hooks, with SPEC wording and hostile-panic regressions

Closes #337
Closes #343
Closes #347
Closes #351

## Decisions and boundaries

- `Context::stop` and `Context::mark_ready` remain unit-returning, deliberately silent no-ops during frozen-prefix drain. Changing them to `Result` would be a public API break for behavior that is already semantically inert; docs and drain-body assertions now pin that choice.
- Static lowering now resolves and classifies every slot in one pass into `Vec<Result<ResolvedCommonOptions, ChildId>>`, then claims definitions only after undefined validation and identity adoption. A dedicated state-aware resolver preserves `Lowered` as the existing panic rather than misreporting it as `Undefined`.
- `pending_startup_removals` is explicitly discharged by the synchronous Drop epilogue after residency cleanup. The field can reach Drop only through a resumed user-code panic because the retain-to-orderly-publish path contains no await.
- Declaration-hook isolation is intentionally narrow: it protects the supplied definition while the framework invokes the eager id/readiness hook. It does not extend the supervised runner boundary to arbitrary locals in a user's synchronous call; SPEC §7 and the `dispose_rejected` docs say so explicitly.
- No #353 declaration-matrix design was implemented. The eight nominal `add_*` entry points and all three reserve families remain intact. This PR only makes the existing internal `DefinitionSource::mode` the shared mode authority and widens the erased raw source seam crate-privately; there is no public declaration-surface change for the follow-on ruling.

## Validation

- `./tools/dev just ci`
  - rustfmt and clippy with warnings denied
  - 770/770 nextest tests
  - doctests and rustdoc warnings
  - public runtime reachability checks
  - packaged docs and external consumer checks
  - Nix formatting check
- targeted façade library and `actor`, `raw`, `drain`, `disposal`, and `one_shot_resource_ownership` test targets

