### PR TITLE
Tighten mailbox transition discipline and regression coverage

### DIFF
--- a/crates/shelterwood-cells/src/cells/member.rs
+++ b/crates/shelterwood-cells/src/cells/member.rs
@@ -662,9 +662,7 @@ impl MemberCell {
         );
         if let Some(teardown) = teardown {
             txn.defer(move || {
-                if let Some(payload) = teardown.finish() {
-                    runtime::dispose_detached(payload);
-                }
+                runtime::dispose_detached(teardown.finish());
             });
         }
         // First terminalizer wins. A losing edge neither reclassifies startup

--- a/crates/shelterwood-mailbox/src/capability.rs
+++ b/crates/shelterwood-mailbox/src/capability.rs
@@ -227,15 +227,57 @@ pub(crate) mod tests {
         MailboxRuntime, MailboxSignal, MailboxSignalWatcher,
     };
 
-    struct AdapterRuntime;
+    type ErasedOneShot = (
+        Box<dyn ErasedOneShotSender>,
+        Pin<Box<dyn ErasedOneShotReceiver>>,
+    );
 
-    impl MailboxRuntime for AdapterRuntime {
+    type OneShotHook = dyn Fn() -> ErasedOneShot + Send + Sync;
+    type NowHook = dyn Fn() -> Instant + Send + Sync;
+
+    /// The one mailbox runtime used by this crate's tests. Optional hooks let
+    /// a focused test control one capability while every other method keeps
+    /// using the real runtime adapter primitives below.
+    pub(crate) struct TestRuntime {
+        oneshot: Option<Box<OneShotHook>>,
+        now: Option<Box<NowHook>>,
+    }
+
+    impl TestRuntime {
+        pub(crate) fn new() -> Self {
+            Self {
+                oneshot: None,
+                now: None,
+            }
+        }
+
+        pub(crate) fn with_oneshot(
+            mut self,
+            oneshot: impl Fn() -> ErasedOneShot + Send + Sync + 'static,
+        ) -> Self {
+            self.oneshot = Some(Box::new(oneshot));
+            self
+        }
+
+        pub(crate) fn with_now(
+            mut self,
+            now: impl Fn() -> Instant + Send + Sync + 'static,
+        ) -> Self {
+            self.now = Some(Box::new(now));
+            self
+        }
+    }
+
+    impl MailboxRuntime for TestRuntime {
         fn oneshot(
             &self,
         ) -> (
             Box<dyn ErasedOneShotSender>,
             Pin<Box<dyn ErasedOneShotReceiver>>,
         ) {
+            if let Some(oneshot) = &self.oneshot {
+                return oneshot();
+            }
             let (sender, receiver) = oneshot();
             (
                 Box::new(AdapterOneShotSender(sender)),
@@ -252,7 +294,7 @@ pub(crate) mod tests {
         }
 
         fn now(&self) -> Instant {
-            now()
+            self.now.as_ref().map_or_else(now, |now| now())
         }
 
         fn sleep_until(&self, deadline: Option<Instant>) -> BoxedSleep {
@@ -271,7 +313,13 @@ pub(crate) mod tests {
         }
     }
 
-    struct AdapterOneShotReceiver(OneShotReceiver<ErasedValue>);
+    pub(crate) struct AdapterOneShotReceiver(OneShotReceiver<ErasedValue>);
+
+    impl AdapterOneShotReceiver {
+        pub(crate) fn new(receiver: OneShotReceiver<ErasedValue>) -> Self {
+            Self(receiver)
+        }
+    }
 
     impl ErasedOneShotReceiver for AdapterOneShotReceiver {
         fn poll_receive(
@@ -323,6 +371,6 @@ pub(crate) mod tests {
     }
 
     pub(crate) fn runtime() -> Arc<dyn MailboxRuntime> {
-        Arc::new(AdapterRuntime)
+        Arc::new(TestRuntime::new())
     }
 }

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -2485,6 +2485,9 @@ pub(super) mod tests {
             first.poll(None, Waker::noop()),
             super::OperationPoll::Accepted(bound) if bound == incarnation
         ));
+        let closed = close(&mailbox, incarnation).expect("the bound incarnation closes");
+        let (_token, payload) = closed.into_parts();
+        drop(payload);
 
         let mut withdrawal = mailbox.withdraw(&second, super::WithdrawalDisposition::Inline);
         assert!(matches!(
@@ -2526,38 +2529,57 @@ pub(super) mod tests {
     }
 
     #[test]
-    fn repeated_withdrawal_panics_after_releasing_both_guards() {
+    fn withdrawal_invariant_panics_release_both_guards() {
         let (mailbox, _) = actor();
-        let operation = match mailbox.submit(1) {
+        let withdrawn = match mailbox.submit(1) {
             super::Submission::Parked(operation) => operation,
             super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
                 panic!("an unbound mailbox parks the send")
             }
         };
         mailbox
-            .withdraw(&operation, super::WithdrawalDisposition::Inline)
+            .withdraw(&withdrawn, super::WithdrawalDisposition::Inline)
             .finish();
 
-        assert!(
-            catch_unwind(AssertUnwindSafe(|| {
+        let missing_waiting = super::SendOperation::new(2_u8);
+        {
+            let mut state = missing_waiting.state.lock().expect("operation state");
+            state.outcome = super::OperationOutcome::Waiting {
+                message: None,
+                newest_observed: None,
+            };
+        }
+        let missing_terminal = super::SendOperation::new(3_u8);
+        {
+            let mut state = missing_terminal.state.lock().expect("operation state");
+            state.outcome = super::OperationOutcome::Terminated {
+                message: None,
+                final_incarnation: None,
+            };
+        }
+
+        for operation in [&withdrawn, &missing_waiting, &missing_terminal] {
+            assert!(
+                catch_unwind(AssertUnwindSafe(|| {
+                    mailbox
+                        .withdraw(operation, super::WithdrawalDisposition::Inline)
+                        .finish();
+                }))
+                .is_err()
+            );
+            drop(
+                operation
+                    .state
+                    .lock()
+                    .expect("withdrawal verdict panic releases the operation guard"),
+            );
+            drop(
                 mailbox
-                    .withdraw(&operation, super::WithdrawalDisposition::Inline)
-                    .finish();
-            }))
-            .is_err()
-        );
-        drop(
-            operation
-                .state
-                .lock()
-                .expect("repeated withdrawal panic releases the operation guard"),
-        );
-        drop(
-            mailbox
-                .state
-                .lock()
-                .expect("repeated withdrawal panic releases the mailbox guard"),
-        );
+                    .state
+                    .lock()
+                    .expect("withdrawal verdict panic releases the mailbox guard"),
+            );
+        }
     }
 
     #[test]

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -162,6 +162,10 @@ mod waker_slot {
     }
 
     impl WakerEffects {
+        pub(super) fn is_empty(&self) -> bool {
+            self.0.is_empty()
+        }
+
         fn push(&mut self, waker: Waker, action: WakerAction) {
             self.0.push(match action {
                 WakerAction::Wake => WakerEffect::Wake(waker),
@@ -294,31 +298,39 @@ impl<M> SendOperation<M> {
         let result = {
             let mut state = self.state.lock().expect("send operation mutex poisoned");
             match &mut state.outcome {
-                OperationOutcome::Accepted(incarnation) => OperationPoll::Accepted(*incarnation),
+                OperationOutcome::Accepted(incarnation) => {
+                    Ok(OperationPoll::Accepted(*incarnation))
+                }
                 OperationOutcome::Terminated {
                     message,
                     final_incarnation,
-                } => OperationPoll::Terminated {
-                    message: message
-                        .take()
-                        .expect("a terminal operation retains its message until observed"),
-                    final_incarnation: *final_incarnation,
-                },
+                } => message.take().map_or_else(
+                    || Err("a terminal operation retains its message until observed"),
+                    |message| {
+                        Ok(OperationPoll::Terminated {
+                            message,
+                            final_incarnation: *final_incarnation,
+                        })
+                    },
+                ),
                 OperationOutcome::Waiting { .. } => {
                     if let Some(replacement) = replacement {
                         state.waker.replace(replacement, &mut effects);
-                        OperationPoll::Pending
+                        Ok(OperationPoll::Pending)
                     } else if state.waker.will_wake(current) {
-                        OperationPoll::Pending
+                        Ok(OperationPoll::Pending)
                     } else {
-                        OperationPoll::NeedsWakerClone
+                        Ok(OperationPoll::NeedsWakerClone)
                     }
                 }
-                OperationOutcome::Withdrawn => panic!("a withdrawn send future was polled"),
+                OperationOutcome::Withdrawn => Err("a withdrawn send future was polled"),
             }
         };
         drop(effects);
-        result
+        match result {
+            Ok(result) => result,
+            Err(message) => panic!("{message}"),
+        }
     }
 
     #[cfg(test)]
@@ -350,6 +362,14 @@ impl<M> MailboxState<M> {
         }
     }
 
+    fn current_observation(&self) -> Option<Incarnation> {
+        match &self.binding {
+            MailboxBinding::Bound(bound) => Some(bound.incarnation()),
+            MailboxBinding::Frozen { incarnation, .. } => Some(*incarnation),
+            MailboxBinding::Unbound(_) | MailboxBinding::Terminal(_) => None,
+        }
+    }
+
     /// Replaces one binding only after its waiter identity domain is empty.
     ///
     /// The check is not an `assert!` because every caller holds the mailbox
@@ -359,7 +379,10 @@ impl<M> MailboxState<M> {
     /// `WaiterQueue` here. That drop would release the queue's
     /// `Arc<SendOperation<M>>`s under the mutex, so wherever one is the last
     /// owner a user message destructor would run in the critical section.
-    /// Declining costs a stalled transition, which is the lesser of the two.
+    /// At waiter-carrying call sites, declining also strands every parked
+    /// sender in the old binding. That fail-safe is still preferable to
+    /// destroying their operations and user messages under this mutex; every
+    /// production caller proves emptiness locally before reaching this seam.
     fn replace_binding(&mut self, replacement: MailboxBinding<M>) {
         let replaceable = match &self.binding {
             MailboxBinding::Unbound(waiters)
@@ -597,22 +620,20 @@ struct MailboxEffects<'a, 's, M: Send + 'static> {
 
 impl<'a, 's, M: Send + 'static> MailboxEffects<'a, 's, M> {
     fn new(cell: &'a MailboxCell<M>) -> Self {
-        Self {
-            cell,
-            external: None,
-            pulse: false,
-            displaced: Vec::new(),
-            isolate_displaced: false,
-            wakers: WakerEffects::default(),
-            returned: None,
-            accepted_sequence_exhausted: false,
-        }
+        Self::with_external(cell, None)
     }
 
     fn deferred(cell: &'a MailboxCell<M>, external: &'s mut dyn MailboxEffectSink) -> Self {
+        Self::with_external(cell, Some(external))
+    }
+
+    fn with_external(
+        cell: &'a MailboxCell<M>,
+        external: Option<&'s mut dyn MailboxEffectSink>,
+    ) -> Self {
         Self {
             cell,
-            external: Some(external),
+            external,
             pulse: false,
             displaced: Vec::new(),
             isolate_displaced: false,
@@ -633,6 +654,14 @@ impl<'a, 's, M: Send + 'static> MailboxEffects<'a, 's, M> {
 
 impl<M: Send + 'static> Drop for MailboxEffects<'_, '_, M> {
     fn drop(&mut self) {
+        if !self.pulse
+            && self.displaced.is_empty()
+            && self.wakers.is_empty()
+            && self.returned.is_none()
+            && !self.accepted_sequence_exhausted
+        {
+            return;
+        }
         let batch = MailboxEffectBatch {
             changed: Arc::clone(&self.cell.changed),
             runtime: Arc::clone(&self.cell.runtime),
@@ -881,16 +910,15 @@ impl<M: Send + 'static> MailboxTeardown<M> {
 }
 
 impl<M: Send + 'static> MailboxTermination for MailboxTeardown<M> {
-    fn finish(mut self: Box<Self>) -> Option<MailboxDisposal> {
+    fn finish(mut self: Box<Self>) -> MailboxDisposal {
         let panic = self.finish_framework();
         let payload = self
             .payload
             .take()
-            .map(|payload| Box::new(payload) as MailboxDisposal);
+            .map(|payload| Box::new(payload) as MailboxDisposal)
+            .expect("mailbox teardown retains its payload until finish");
         if let Some(panic) = panic {
-            if let Some(payload) = payload {
-                dispose(&self.runtime, payload);
-            }
+            self.runtime.dispose(payload);
             resume_panic(panic);
         }
         payload
@@ -987,17 +1015,11 @@ impl<M: Send + 'static> MailboxCell<M> {
                     }
                 }
             }
-            BindingStatus::Frozen(incarnation) => {
+            status @ (BindingStatus::Frozen(_) | BindingStatus::Unbound) => {
                 let operation = SendOperation::new(message);
-                operation.observe(incarnation);
-                if transaction.park(&operation) {
-                    SubmitTransition::Complete(Submission::Parked(operation))
-                } else {
-                    SubmitTransition::WaiterIdentityExhausted(operation)
+                if let BindingStatus::Frozen(incarnation) = status {
+                    operation.observe(incarnation);
                 }
-            }
-            BindingStatus::Unbound => {
-                let operation = SendOperation::new(message);
                 if transaction.park(&operation) {
                     SubmitTransition::Complete(Submission::Parked(operation))
                 } else {
@@ -1112,12 +1134,10 @@ impl<M: Send + 'static> MailboxCell<M> {
     }
 
     pub(super) fn current_observation(&self) -> Option<Incarnation> {
-        match self.state.lock().expect("mailbox mutex poisoned").status() {
-            BindingStatus::Bound(incarnation) | BindingStatus::Frozen(incarnation) => {
-                Some(incarnation)
-            }
-            BindingStatus::Unbound | BindingStatus::Terminal(_) => None,
-        }
+        self.state
+            .lock()
+            .expect("mailbox mutex poisoned")
+            .current_observation()
     }
 
     fn watcher(&self) -> Box<dyn MailboxSignalWatcher> {
@@ -1159,13 +1179,8 @@ impl<M: Send + 'static> MailboxCell<M> {
         // its guard, and only then can these effects run.
         let mut waker_effects = WakerEffects::default();
         let mut transaction = MailboxTxn::new(self);
-        let current_observation = match transaction.status() {
-            BindingStatus::Bound(incarnation) | BindingStatus::Frozen(incarnation) => {
-                Some(incarnation)
-            }
-            BindingStatus::Unbound | BindingStatus::Terminal(_) => None,
-        };
-        let (outcome, registration) = {
+        let current_observation = transaction.current_observation();
+        let transition = {
             let mut state = operation
                 .state
                 .lock()
@@ -1174,66 +1189,71 @@ impl<M: Send + 'static> MailboxCell<M> {
                 OperationOutcome::Waiting {
                     message,
                     newest_observed,
-                } => {
-                    // Mailbox terminality linearizes in the binding, while a
-                    // parked operation linearizes when its own outcome leaves
-                    // `Waiting`. A terminal teardown may therefore have
-                    // detached this waiter without discharging it yet; an
-                    // already-expired withdrawal legitimately wins that
-                    // operation-local race.
-                    let message = message
-                        .take()
-                        .expect("a waiting operation must retain its message");
-                    // The mailbox lock makes this one evidence snapshot: a
-                    // binding either precedes withdrawal and contributes its
-                    // incarnation, or follows the completed withdrawal. This
-                    // also covers an operation first submitted by an elapsed
-                    // (including zero-duration) deadline poll.
-                    let observed = (*newest_observed).or(current_observation);
-                    state.outcome = OperationOutcome::Withdrawn;
-                    state.waker.take(
-                        match disposition {
-                            WithdrawalDisposition::Inline => WakerAction::DropInline,
-                            WithdrawalDisposition::Isolated => {
-                                WakerAction::Dispose(Arc::clone(&self.runtime))
-                            }
-                        },
-                        &mut waker_effects,
-                    );
-                    (
-                        WithdrawalOutcome::Withdrawn { message, observed },
-                        state.registration.take(),
-                    )
-                }
+                } => match message.take() {
+                    Some(message) => {
+                        // Mailbox terminality linearizes in the binding, while a
+                        // parked operation linearizes when its own outcome leaves
+                        // `Waiting`. A terminal teardown may therefore have
+                        // detached this waiter without discharging it yet; an
+                        // already-expired withdrawal legitimately wins that
+                        // operation-local race.
+                        // The mailbox lock makes this one evidence snapshot: a
+                        // binding either precedes withdrawal and contributes its
+                        // incarnation, or follows the completed withdrawal. This
+                        // also covers an operation first submitted by an elapsed
+                        // (including zero-duration) deadline poll.
+                        let observed = (*newest_observed).or(current_observation);
+                        state.outcome = OperationOutcome::Withdrawn;
+                        state.waker.take(
+                            match disposition {
+                                WithdrawalDisposition::Inline => WakerAction::DropInline,
+                                WithdrawalDisposition::Isolated => {
+                                    WakerAction::Dispose(Arc::clone(&self.runtime))
+                                }
+                            },
+                            &mut waker_effects,
+                        );
+                        Ok((
+                            WithdrawalOutcome::Withdrawn { message, observed },
+                            state.registration.take(),
+                        ))
+                    }
+                    None => Err("a waiting operation must retain its message"),
+                },
                 OperationOutcome::Accepted(incarnation) => {
                     let incarnation = *incarnation;
                     // Acceptance took the waker in the same critical section
                     // that published this outcome, so no registration survives
                     // it for withdrawal to release.
                     debug_assert!(state.waker.is_empty());
-                    (
+                    Ok((
                         WithdrawalOutcome::Accepted(incarnation),
                         state.registration.take(),
-                    )
+                    ))
                 }
                 OperationOutcome::Terminated {
                     message,
                     final_incarnation,
-                } => {
-                    let message = message
-                        .take()
-                        .expect("a terminal operation must retain its message");
-                    let observed = *final_incarnation;
-                    // Termination likewise took the waker before publishing.
-                    debug_assert!(state.waker.is_empty());
-                    (
-                        WithdrawalOutcome::Terminated { message, observed },
-                        state.registration.take(),
-                    )
-                }
-                OperationOutcome::Withdrawn => {
-                    panic!("a send operation was withdrawn more than once")
-                }
+                } => match message.take() {
+                    Some(message) => {
+                        let observed = *final_incarnation;
+                        // Termination likewise took the waker before publishing.
+                        debug_assert!(state.waker.is_empty());
+                        Ok((
+                            WithdrawalOutcome::Terminated { message, observed },
+                            state.registration.take(),
+                        ))
+                    }
+                    None => Err("a terminal operation must retain its message"),
+                },
+                OperationOutcome::Withdrawn => Err("a send operation was withdrawn more than once"),
+            }
+        };
+        let (outcome, registration) = match transition {
+            Ok(transition) => transition,
+            Err(message) => {
+                transaction.finish(());
+                panic!("{message}");
             }
         };
         if let Some(registration) = registration {
@@ -1717,6 +1737,29 @@ pub(super) mod tests {
                 .upgrade()
                 .is_none_or(|mailbox| mailbox.state.try_lock().is_ok());
             let _ = dropped.send(unlocked);
+        }
+    }
+
+    struct LatestDisplacementMessage {
+        value: u8,
+        mailbox: Weak<MailboxCell<LatestDisplacementMessage>>,
+        displaced: Option<mpsc::Sender<(bool, Option<u8>)>>,
+    }
+
+    impl Drop for LatestDisplacementMessage {
+        fn drop(&mut self) {
+            let Some(displaced) = self.displaced.take() else {
+                return;
+            };
+            let observation = self.mailbox.upgrade().and_then(|mailbox| {
+                mailbox.state.try_lock().ok().map(|state| {
+                    (
+                        true,
+                        state.latest.as_ref().map(|latest| latest.message.value),
+                    )
+                })
+            });
+            let _ = displaced.send(observation.unwrap_or((false, None)));
         }
     }
 
@@ -2343,6 +2386,178 @@ pub(super) mod tests {
         );
         assert_eq!(receiver.try_recv(), Some(2));
         assert_eq!(receiver.try_recv(), None);
+    }
+
+    #[test]
+    fn stale_receivers_cannot_drain_a_rebound_or_frozen_mailbox() {
+        let (mailbox, actor) = actor();
+        let (first, second) = two_incarnations();
+        let token = configure(
+            &mailbox,
+            ResolvedMailbox::Queue(
+                std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
+            ),
+        );
+        bind(&mailbox, token, first);
+        let stale = MailboxReceiver::new(Arc::clone(&mailbox), first);
+
+        let closed = close(&mailbox, first).expect("the first incarnation closes");
+        let (token, payload) = closed.into_parts();
+        drop(payload);
+        bind(&mailbox, token, second);
+        actor.try_send(7).expect("the rebound mailbox accepts");
+        let through = stale.accepted_sequence();
+
+        assert_eq!(stale.try_recv(), None);
+        assert_eq!(stale.try_recv_live_through(through), None);
+        freeze(&mailbox, second);
+        assert_eq!(stale.try_recv(), None);
+        assert_eq!(stale.try_recv_live_through(through), None);
+
+        let current = MailboxReceiver::new(mailbox, second);
+        assert_eq!(
+            current.try_recv(),
+            Some(7),
+            "stale reads leave the payload intact"
+        );
+    }
+
+    #[test]
+    fn live_latest_displacement_drops_after_unlock_and_replacement_visibility() {
+        let (mailbox, actor): (
+            Arc<MailboxCell<LatestDisplacementMessage>>,
+            ActorRef<LatestDisplacementMessage>,
+        ) = actor_for();
+        let token = configure(&mailbox, ResolvedMailbox::Latest);
+        let incarnation = mint_actor_incarnation();
+        bind(&mailbox, token, incarnation);
+        let weak = Arc::downgrade(&mailbox);
+        let (displaced, observed) = mpsc::channel();
+
+        actor
+            .try_send(LatestDisplacementMessage {
+                value: 1,
+                mailbox: Weak::clone(&weak),
+                displaced: Some(displaced),
+            })
+            .expect("the first latest value accepts");
+        actor
+            .try_send(LatestDisplacementMessage {
+                value: 2,
+                mailbox: weak,
+                displaced: None,
+            })
+            .expect("the replacement latest value accepts");
+
+        assert_eq!(
+            observed
+                .recv_timeout(Duration::from_secs(5))
+                .expect("the displaced value reports its drop context"),
+            (true, Some(2)),
+            "displacement drops after unlock and after publishing the replacement"
+        );
+    }
+
+    #[test]
+    fn bind_observes_waiters_that_remain_parked_beyond_capacity() {
+        let (mailbox, _) = actor();
+        let token = configure(
+            &mailbox,
+            ResolvedMailbox::Queue(
+                std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
+            ),
+        );
+        let first = match mailbox.submit(1) {
+            super::Submission::Parked(operation) => operation,
+            super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+                panic!("an unbound mailbox parks the first send")
+            }
+        };
+        let second = match mailbox.submit(2) {
+            super::Submission::Parked(operation) => operation,
+            super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+                panic!("an unbound mailbox parks overflow sends")
+            }
+        };
+        let incarnation = mint_actor_incarnation();
+        bind(&mailbox, token, incarnation);
+        assert!(matches!(
+            first.poll(None, Waker::noop()),
+            super::OperationPoll::Accepted(bound) if bound == incarnation
+        ));
+
+        let mut withdrawal = mailbox.withdraw(&second, super::WithdrawalDisposition::Inline);
+        assert!(matches!(
+            withdrawal.take_outcome(),
+            super::WithdrawalOutcome::Withdrawn {
+                message: 2,
+                observed: Some(bound),
+            } if bound == incarnation
+        ));
+        withdrawal.finish();
+    }
+
+    #[test]
+    fn operation_invariant_panics_release_the_operation_guard() {
+        let withdrawn = super::SendOperation::new(1_u8);
+        withdrawn.state.lock().expect("operation state").outcome =
+            super::OperationOutcome::Withdrawn;
+        assert!(catch_unwind(AssertUnwindSafe(|| withdrawn.poll(None, Waker::noop()))).is_err());
+        drop(
+            withdrawn
+                .state
+                .lock()
+                .expect("withdrawn poll panic occurs after unlock"),
+        );
+
+        let missing = super::SendOperation::new(2_u8);
+        missing.state.lock().expect("operation state").outcome =
+            super::OperationOutcome::Terminated {
+                message: None,
+                final_incarnation: None,
+            };
+        assert!(catch_unwind(AssertUnwindSafe(|| missing.poll(None, Waker::noop()))).is_err());
+        drop(
+            missing
+                .state
+                .lock()
+                .expect("terminal verdict panic occurs after unlock"),
+        );
+    }
+
+    #[test]
+    fn repeated_withdrawal_panics_after_releasing_both_guards() {
+        let (mailbox, _) = actor();
+        let operation = match mailbox.submit(1) {
+            super::Submission::Parked(operation) => operation,
+            super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+                panic!("an unbound mailbox parks the send")
+            }
+        };
+        mailbox
+            .withdraw(&operation, super::WithdrawalDisposition::Inline)
+            .finish();
+
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                mailbox
+                    .withdraw(&operation, super::WithdrawalDisposition::Inline)
+                    .finish();
+            }))
+            .is_err()
+        );
+        drop(
+            operation
+                .state
+                .lock()
+                .expect("repeated withdrawal panic releases the operation guard"),
+        );
+        drop(
+            mailbox
+                .state
+                .lock()
+                .expect("repeated withdrawal panic releases the mailbox guard"),
+        );
     }
 
     #[test]

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -379,10 +379,17 @@ impl<M> MailboxState<M> {
     /// `WaiterQueue` here. That drop would release the queue's
     /// `Arc<SendOperation<M>>`s under the mutex, so wherever one is the last
     /// owner a user message destructor would run in the critical section.
-    /// At waiter-carrying call sites, declining also strands every parked
-    /// sender in the old binding. That fail-safe is still preferable to
-    /// destroying their operations and user messages under this mutex; every
-    /// production caller proves emptiness locally before reaching this seam.
+    ///
+    /// The guard covers the *old* binding only. `replacement` is taken by
+    /// value, so declining destroys it — and any operation it carries —
+    /// right here, still under the mutex. The decline is therefore a
+    /// last-resort diagnostic, not a safe fallback. At every waiter-carrying
+    /// call site it is unreachable by construction: `take_waiters` moves the
+    /// parked senders out of the old binding into the replacement first, so
+    /// the domain this check reads is already empty. The remaining callers
+    /// pass an `Available` or empty binding. Reaching the decline would mean
+    /// a terminal misuse in which either outcome destroys user values in the
+    /// critical section.
     fn replace_binding(&mut self, replacement: MailboxBinding<M>) {
         let replaceable = match &self.binding {
             MailboxBinding::Unbound(waiters)

--- a/crates/shelterwood-mailbox/src/futures.rs
+++ b/crates/shelterwood-mailbox/src/futures.rs
@@ -1353,7 +1353,11 @@ mod tests {
         let waker_thread = disposal_thread();
         let mut send =
             Box::pin(actor.send_timeout(ThreadRecordingDrop(message_thread.clone()), width));
-        let hostile = panicking_drop_waker(waker_thread.clone());
+        // Keep the caller-owned raw waker permanently inert: if an assertion
+        // below fails, dropping it during that unwind would create a second
+        // panic and abort the test process. Only its registered clone is the
+        // subject of this regression.
+        let hostile = ManuallyDrop::new(panicking_drop_waker(waker_thread.clone()));
         let mut context = Context::from_waker(&hostile);
         let deadline =
             crate::deadline::Deadline::after(crate::capability::tests::runtime().now(), width);
@@ -1374,11 +1378,6 @@ mod tests {
             )
         }))
         .expect_err("inline waker destruction surfaces its panic from the timeout poll");
-        // The caller-owned raw waker uses the same deliberately panicking
-        // vtable as its registered clone. Leak only this test-owned reference
-        // so the assertion observes the clone released by withdrawal.
-        std::mem::forget(hostile);
-
         assert_eq!(
             panic.downcast_ref::<&'static str>().copied(),
             Some("injected call waker drop panic")

--- a/crates/shelterwood-mailbox/src/futures.rs
+++ b/crates/shelterwood-mailbox/src/futures.rs
@@ -119,13 +119,7 @@ impl<M: Send + 'static> ActorRef<M> {
     pub fn send_timeout(&self, message: M, deadline: impl Into<DeadlineBudget>) -> SendTimeout<M> {
         let runtime = self.mailbox.runtime();
         SendTimeout {
-            deadlined: Deadlined::no_attempt(
-                TimedSend {
-                    send: self.send(message),
-                },
-                deadline,
-                runtime,
-            ),
+            deadlined: Deadlined::no_attempt(self.send(message), deadline, runtime),
         }
     }
 
@@ -401,11 +395,7 @@ impl<M: Send + 'static> Drop for SendFuture<M> {
 /// Cancellation-safe future returned by [`ActorRef::send_timeout`].
 #[must_use]
 pub struct SendTimeout<M: Send + 'static> {
-    deadlined: Deadlined<TimedSend<M>>,
-}
-
-struct TimedSend<M: Send + 'static> {
-    send: SendFuture<M>,
+    deadlined: Deadlined<SendFuture<M>>,
 }
 
 impl<M: Send + 'static> fmt::Debug for SendTimeout<M> {
@@ -449,15 +439,7 @@ fn withdraw_send_with<M: Send + 'static>(
     result
 }
 
-fn withdraw_send<M: Send + 'static>(send: &mut SendFuture<M>) -> Result<Incarnation, SendError<M>> {
-    // Unlike the cancellation path this is a normal return on the caller's own
-    // task, and the recovered message goes back to that same caller. No core
-    // lock is held, so the caller's waker destructor stays inline and its
-    // panic stays visible.
-    withdraw_send_with(send, WithdrawalDisposition::Inline)
-}
-
-impl<M: Send + 'static> DeadlineOperation for TimedSend<M> {
+impl<M: Send + 'static> DeadlineOperation for SendFuture<M> {
     type Output = Result<Incarnation, SendError<M>>;
 
     fn poll_deadlined(
@@ -466,13 +448,17 @@ impl<M: Send + 'static> DeadlineOperation for TimedSend<M> {
         _budget: crate::deadline::Deadline,
         phase: DeadlinePhase,
     ) -> Poll<Self::Output> {
-        if let Poll::Ready(result) = Pin::new(&mut self.send).poll(context) {
+        if let Poll::Ready(result) = Pin::new(&mut *self).poll(context) {
             return Poll::Ready(result);
         }
         if phase == DeadlinePhase::InitialAttempt {
             Poll::Pending
         } else {
-            Poll::Ready(withdraw_send(&mut self.send))
+            // Unlike cancellation this is a normal return on the caller's
+            // task. The recovered message goes back to that caller and the
+            // registered waker destructor stays inline, so its panic remains
+            // visible.
+            Poll::Ready(withdraw_send_with(self, WithdrawalDisposition::Inline))
         }
     }
 
@@ -480,7 +466,7 @@ impl<M: Send + 'static> DeadlineOperation for TimedSend<M> {
         // The send was never polled, so it was never submitted: withdrawal
         // recovers the message and reports the mailbox's current binding as
         // the newest incarnation observed during the attempt.
-        withdraw_send(&mut self.send)
+        withdraw_send_with(self, WithdrawalDisposition::Inline)
     }
 }
 
@@ -562,6 +548,22 @@ impl<M: Send + 'static, T: Send + 'static> CallOperation<M, T> {
             reply.close();
         }
     }
+
+    fn fail_send(
+        &mut self,
+        error: SendError<M>,
+        kind: CallErrorKind,
+    ) -> Poll<Result<Replied<T>, CallError>> {
+        self.close_reply();
+        // The call surface has no way to hand the recovered message back;
+        // route the discard through isolated disposal.
+        self.actor.mailbox.dispose(error.message);
+        Poll::Ready(Err(CallError {
+            actor_id: error.actor_id,
+            incarnation_observed: error.incarnation_observed,
+            kind,
+        }))
+    }
 }
 
 impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M, T> {
@@ -608,16 +610,7 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
                     self.send = None;
                 }
                 Poll::Ready(Err(error)) => {
-                    self.close_reply();
-                    // The call surface has no way to hand the recovered
-                    // message back; route the discard through isolated
-                    // disposal.
-                    self.actor.mailbox.dispose(error.message);
-                    return Poll::Ready(Err(CallError {
-                        actor_id: error.actor_id,
-                        incarnation_observed: error.incarnation_observed,
-                        kind: CallErrorKind::Terminated,
-                    }));
+                    return self.fail_send(error, CallErrorKind::Terminated);
                 }
                 Poll::Pending => {}
             }
@@ -652,21 +645,14 @@ impl<M: Send + 'static, T: Send + 'static> DeadlineOperation for CallOperation<M
                 self.poll_reply(context, incarnation, DeadlinePhase::TimeoutArbitration)
             }
             Err(error) => {
-                self.close_reply();
-                // The call surface has no way to hand the recovered message
-                // back; route the discard through isolated disposal.
-                self.actor.mailbox.dispose(error.message);
-                Poll::Ready(Err(CallError {
-                    actor_id: error.actor_id,
-                    incarnation_observed: error.incarnation_observed,
-                    kind: match error.kind {
-                        SendErrorKind::TimedOut => CallErrorKind::AcceptanceTimedOut,
-                        SendErrorKind::Terminated => CallErrorKind::Terminated,
-                        SendErrorKind::NotRunning | SendErrorKind::Full => {
-                            unreachable!("withdrawal returns only timed-out or terminal errors")
-                        }
-                    },
-                }))
+                let kind = match error.kind {
+                    SendErrorKind::TimedOut => CallErrorKind::AcceptanceTimedOut,
+                    SendErrorKind::Terminated => CallErrorKind::Terminated,
+                    SendErrorKind::NotRunning | SendErrorKind::Full => {
+                        unreachable!("withdrawal returns only timed-out or terminal errors")
+                    }
+                };
+                self.fail_send(error, kind)
             }
         }
     }
@@ -704,14 +690,13 @@ mod tests {
         },
         task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker},
         thread::ThreadId,
-        time::{Duration, Instant},
+        time::Duration,
     };
 
     use shelterwood_core::DeadlineBudget;
 
     use crate::{
-        BoxedSleep, CallErrorKind, ErasedOneShotReceiver, ErasedOneShotSender, Incarnation,
-        MailboxControl, MailboxEffectQueue, MailboxReceiver, MailboxRuntime, MailboxSignal, Reply,
+        CallErrorKind, Incarnation, MailboxControl, MailboxEffectQueue, MailboxReceiver, Reply,
         policy::ResolvedMailbox, test_support::mint_actor_incarnation,
     };
 
@@ -939,38 +924,6 @@ mod tests {
         assert_eq!(error.incarnation_observed, Some(incarnation));
     }
 
-    struct ControlledClockRuntime {
-        inner: Arc<dyn MailboxRuntime>,
-        now: Arc<Mutex<Instant>>,
-    }
-
-    impl MailboxRuntime for ControlledClockRuntime {
-        fn oneshot(
-            &self,
-        ) -> (
-            Box<dyn ErasedOneShotSender>,
-            Pin<Box<dyn ErasedOneShotReceiver>>,
-        ) {
-            self.inner.oneshot()
-        }
-
-        fn signal(&self) -> Arc<dyn MailboxSignal> {
-            self.inner.signal()
-        }
-
-        fn dispose(&self, value: Box<dyn Send + 'static>) {
-            self.inner.dispose(value);
-        }
-
-        fn now(&self) -> Instant {
-            *self.now.lock().expect("controlled clock mutex")
-        }
-
-        fn sleep_until(&self, deadline: Option<Instant>) -> BoxedSleep {
-            self.inner.sleep_until(deadline)
-        }
-    }
-
     struct ConstructionOverdueMessage {
         _reply: Reply<u8>,
         disposed: mpsc::Sender<ThreadId>,
@@ -986,10 +939,11 @@ mod tests {
     fn construction_that_consumes_the_budget_is_disposed_without_submission() {
         let start = crate::capability::tests::runtime().now();
         let clock = Arc::new(Mutex::new(start));
-        let runtime = Arc::new(ControlledClockRuntime {
-            inner: crate::capability::tests::runtime(),
-            now: Arc::clone(&clock),
-        });
+        let runtime_clock = Arc::clone(&clock);
+        let runtime = Arc::new(
+            crate::capability::tests::TestRuntime::new()
+                .with_now(move || *runtime_clock.lock().expect("controlled clock mutex")),
+        );
         let (mailbox, actor) = actor_for_with_runtime(runtime);
         let token = configure(
             &mailbox,
@@ -1386,6 +1340,55 @@ mod tests {
             "a hostile waker destructor cannot divert the message from isolated disposal"
         );
         assert_ne!(await_disposal(&waker_thread), here);
+    }
+
+    #[crate::runtime::test(start_paused = true)]
+    async fn send_timeout_releases_its_waker_inline_after_recovering_the_message() {
+        let (_, actor): (
+            Arc<MailboxCell<ThreadRecordingDrop>>,
+            ActorRef<ThreadRecordingDrop>,
+        ) = actor_for();
+        let width = Duration::from_secs(1);
+        let message_thread = disposal_thread();
+        let waker_thread = disposal_thread();
+        let mut send =
+            Box::pin(actor.send_timeout(ThreadRecordingDrop(message_thread.clone()), width));
+        let hostile = panicking_drop_waker(waker_thread.clone());
+        let mut context = Context::from_waker(&hostile);
+        let deadline =
+            crate::deadline::Deadline::after(crate::capability::tests::runtime().now(), width);
+
+        assert!(
+            send.deadlined
+                .operation
+                .poll_deadlined(&mut context, deadline, DeadlinePhase::InitialAttempt)
+                .is_pending()
+        );
+        crate::runtime::advance(width * 2).await;
+        let polling_thread = std::thread::current().id();
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            send.deadlined.operation.poll_deadlined(
+                &mut context,
+                deadline,
+                DeadlinePhase::TimeoutArbitration,
+            )
+        }))
+        .expect_err("inline waker destruction surfaces its panic from the timeout poll");
+        // The caller-owned raw waker uses the same deliberately panicking
+        // vtable as its registered clone. Leak only this test-owned reference
+        // so the assertion observes the clone released by withdrawal.
+        std::mem::forget(hostile);
+
+        assert_eq!(
+            panic.downcast_ref::<&'static str>().copied(),
+            Some("injected call waker drop panic")
+        );
+        assert_eq!(await_disposal(&waker_thread), polling_thread);
+        assert_eq!(
+            await_disposal(&message_thread),
+            polling_thread,
+            "the recovered message remains caller-owned when the waker drop unwinds"
+        );
     }
 
     #[test]

--- a/crates/shelterwood-mailbox/src/lib.rs
+++ b/crates/shelterwood-mailbox/src/lib.rs
@@ -178,6 +178,7 @@ impl Drop for MailboxEffectQueue {
 /// It is public solely because sibling implementation crates retain it through
 /// type erasure; it is not a user extension point.
 pub trait MailboxTermination: private::SealedMailboxTermination + Send {
+    #[must_use = "finishing hands back the unread payload for detached disposal"]
     fn finish(self: Box<Self>) -> MailboxDisposal;
 }
 

--- a/crates/shelterwood-mailbox/src/lib.rs
+++ b/crates/shelterwood-mailbox/src/lib.rs
@@ -178,7 +178,7 @@ impl Drop for MailboxEffectQueue {
 /// It is public solely because sibling implementation crates retain it through
 /// type erasure; it is not a user extension point.
 pub trait MailboxTermination: private::SealedMailboxTermination + Send {
-    fn finish(self: Box<Self>) -> Option<MailboxDisposal>;
+    fn finish(self: Box<Self>) -> MailboxDisposal;
 }
 
 /// Type-erased mailbox lifecycle surface owned by a member cell.

--- a/crates/shelterwood-mailbox/src/reply.rs
+++ b/crates/shelterwood-mailbox/src/reply.rs
@@ -154,19 +154,15 @@ impl<T: Send + 'static> DeadlineOperation for ReplyOperation<T> {
 mod tests {
     use std::{
         future::Future,
-        pin::Pin,
         sync::{
             Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
         },
         task::{Context, Poll, Wake, Waker},
-        time::{Duration, Instant},
+        time::Duration,
     };
 
-    use crate::{
-        BoxedSleep, ErasedOneShotClose, ErasedOneShotReceiver, ErasedOneShotSender, ErasedValue,
-        MailboxRuntime, MailboxSignal,
-    };
+    use crate::{ErasedOneShotSender, ErasedValue};
 
     use super::super::cell::tests::{actor, actor_for_with_runtime};
 
@@ -175,79 +171,6 @@ mod tests {
     impl ErasedOneShotSender for RejectingSender {
         fn send(self: Box<Self>, value: ErasedValue) -> Result<(), ErasedValue> {
             Err(value)
-        }
-    }
-
-    struct StagedReceiver(crate::runtime::OneShotReceiver<ErasedValue>);
-
-    impl ErasedOneShotReceiver for StagedReceiver {
-        fn poll_receive(
-            mut self: Pin<&mut Self>,
-            context: &mut Context<'_>,
-        ) -> Poll<Option<ErasedValue>> {
-            self.0.poll_receive(context)
-        }
-
-        fn close_and_poll_receive(
-            mut self: Pin<&mut Self>,
-            context: &mut Context<'_>,
-        ) -> ErasedOneShotClose {
-            match self.0.close_and_poll_receive(context) {
-                crate::runtime::OneShotClose::Value(value) => ErasedOneShotClose::Value(value),
-                crate::runtime::OneShotClose::SenderClosed => ErasedOneShotClose::SenderClosed,
-                crate::runtime::OneShotClose::Empty => ErasedOneShotClose::Empty,
-                crate::runtime::OneShotClose::Pending => ErasedOneShotClose::Pending,
-            }
-        }
-
-        fn close(mut self: Pin<&mut Self>) {
-            self.0.close();
-        }
-
-        fn close_and_take(mut self: Pin<&mut Self>) -> Option<ErasedValue> {
-            self.0.close_and_take()
-        }
-    }
-
-    struct StagedReplyRuntime {
-        inner: Arc<dyn MailboxRuntime>,
-        publisher: Mutex<Option<crate::runtime::OneShotSending<ErasedValue>>>,
-    }
-
-    impl MailboxRuntime for StagedReplyRuntime {
-        fn oneshot(
-            &self,
-        ) -> (
-            Box<dyn ErasedOneShotSender>,
-            Pin<Box<dyn ErasedOneShotReceiver>>,
-        ) {
-            let (publisher, receiver) = crate::runtime::oneshot_sending_for_test();
-            let displaced = self
-                .publisher
-                .lock()
-                .expect("staged reply publisher mutex")
-                .replace(publisher);
-            assert!(displaced.is_none(), "the test creates one reply channel");
-            (
-                Box::new(RejectingSender),
-                Box::pin(StagedReceiver(receiver)),
-            )
-        }
-
-        fn signal(&self) -> Arc<dyn MailboxSignal> {
-            self.inner.signal()
-        }
-
-        fn dispose(&self, value: Box<dyn Send + 'static>) {
-            self.inner.dispose(value);
-        }
-
-        fn now(&self) -> Instant {
-            self.inner.now()
-        }
-
-        fn sleep_until(&self, deadline: Option<Instant>) -> BoxedSleep {
-            self.inner.sleep_until(deadline)
         }
     }
 
@@ -302,10 +225,24 @@ mod tests {
 
     #[crate::runtime::test(start_paused = true)]
     async fn timeout_arbitration_waits_for_a_winning_send_to_publish() {
-        let runtime = Arc::new(StagedReplyRuntime {
-            inner: crate::capability::tests::runtime(),
-            publisher: Mutex::new(None),
-        });
+        let publisher = Arc::new(Mutex::new(None));
+        let staged_publisher = Arc::clone(&publisher);
+        let runtime = Arc::new(crate::capability::tests::TestRuntime::new().with_oneshot(
+            move || {
+                let (publisher, receiver) = crate::runtime::oneshot_sending_for_test();
+                let displaced = staged_publisher
+                    .lock()
+                    .expect("staged reply publisher mutex")
+                    .replace(publisher);
+                assert!(displaced.is_none(), "the test creates one reply channel");
+                (
+                    Box::new(RejectingSender),
+                    Box::pin(crate::capability::tests::AdapterOneShotReceiver::new(
+                        receiver,
+                    )),
+                )
+            },
+        ));
         let (_, actor) = actor_for_with_runtime::<()>(runtime.clone());
         let (reply, receiver) = actor.reply_channel::<u8>();
         let width = Duration::from_secs(1);
@@ -327,8 +264,7 @@ mod tests {
                 .is_pending(),
             "OneShotClose::Pending defers the timeout verdict"
         );
-        let publisher = runtime
-            .publisher
+        let publisher = publisher
             .lock()
             .expect("staged reply publisher mutex")
             .take()


### PR DESCRIPTION
## Summary

- pin mailbox incarnation isolation, latest-value displacement discipline, and bind-time waiter observation with mutation-sensitive tests
- consolidate mailbox test runtimes behind one hookable adapter and reuse the erased one-shot receiver
- move withdrawn and missing-terminal-message invariant panics past operation/mailbox guard release
- complete the mailbox residual cleanup batch: skip empty effect flushes, reduce duplicated transitions/initializers/observation logic, remove `TimedSend`, share call send-failure cleanup, and pin inline timeout-waker behavior
- remove the teardown double box and tighten sealed `MailboxTermination::finish` to return its mandatory disposal directly

## Design decisions

- Kept `replace_binding`'s release-mode fail-safe and corrected its contract to state that a declined waiter-carrying transition strands parked senders. A witness token would add transition choreography without eliminating the terminal-misuse case, so it would not actually make invalid replacement unconstructible.
- Tightened `MailboxTermination::finish` because the trait is sealed, `MailboxTeardown` is its only implementation, and every constructed teardown owns one payload.
- The hostile `send_timeout` test drives the private deadline operation after advancing paused time so the timer does not itself own the deliberately panicking raw waker; this isolates the inline withdrawal contract being tested.
- No checklist items were omitted.

## Adversarial review

The fresh review found and fixed three coverage defects in follow-up commit `602d133`:

- the bind-time `observe_all` regression had been shadowed by withdrawing while still bound; the test now closes before withdrawal and fails when `observe_all` is removed
- the inline-waker mutation could abort before cleanup; the fixture now owns the waker through `ManuallyDrop` from construction and fails normally under mutation
- guard-release coverage now includes both Waiting and Terminated missing-message invariant branches plus repeated withdrawal

## Validation

- `./tools/dev cargo test -p shelterwood-mailbox`
- `./tools/dev cargo test -p shelterwood-cells`
- `./tools/dev just ci` (772 tests plus formatting, clippy, docs, API reachability, packaged docs, and external-consumer checks)

Closes #333
Closes #338
Closes #339
Closes #344

Tracking: #348
