### PR TITLE
Unify private definition dispatch

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1780,8 +1780,15 @@ API-shape rules:
 - The spec surface for one kind names operations identically across kinds —
   the one-shot operation is the `_once` twin, never a differently-named
   `spawn_once`.
-- Adding a new child kind or mode extends the shared record, not a
-  hand-maintained matrix.
+- Adding a new child kind or mode extends the shared record and the private
+  declaration dispatch, not duplicated reserve/add/define choreography. The
+  dispatch is deliberately sealed inside the façade: its associated handle
+  set and slot kind let the implementation share that choreography, but the
+  eight public add entry points and the nominal slot methods above it remain
+  concrete. Making the dispatch public would admit an oversized extension
+  surface and turn per-kind parameter errors into generic trait-bound errors;
+  collapsing the reserve methods would also be false because actor mailbox
+  type and subtree flavor are fixed before a definition exists.
 
 **Slots — the reserve-before-define surface.** §3.2's cell machinery has
 one public face, uniform across the three kinds and both scope flavors.

--- a/crates/shelterwood/src/tree/builders.rs
+++ b/crates/shelterwood/src/tree/builders.rs
@@ -3,7 +3,7 @@ use std::{fmt, sync::Arc};
 use crate::{
     ActorDef, ActorOnceDef, ActorRef, ChildId, Intensity, ScopeDefaults,
     admission::ReserveError,
-    plan::{BuilderCore, LowerError, SlotCell},
+    plan::{BuilderCore, LowerError},
     policy::{ResolvedDefaults, ScopeFlavor},
     raw::{RawDef, RawOnceDef},
     runtime,
@@ -13,10 +13,7 @@ use crate::{
 
 use super::{
     ActorSlot, Subtree, SubtreeDef, SubtreeOnceDef, SubtreeSlot, System, TaskSlot,
-    slots::{
-        ActorSlotCore, StaticSlotEndpoint, SubtreeSlotCore, TaskSlotCore, attach_actor_mailbox,
-    },
-    system::sealed,
+    slots::{ActorKind, Definition, SubtreeKind, TaskKind, reserve_static},
 };
 
 /// A root lowering error.
@@ -49,10 +46,15 @@ pub(super) fn dispose_rejected<D: Send + 'static>(
     error
 }
 
-fn attach_actor_slot<M: Send + 'static>(slot: Arc<SlotCell>) -> ActorSlot<M> {
-    let mailbox = attach_actor_mailbox(&slot);
-    ActorSlot {
-        core: ActorSlotCore::new(StaticSlotEndpoint(slot), mailbox),
+fn add_definition<D: Definition>(
+    core: &mut BuilderCore,
+    id: impl Into<ChildId>,
+    definition: D,
+) -> Result<D::Handles, ReserveError> {
+    let mut definition = runtime::Isolated::new(definition);
+    match reserve_static::<D::Kind>(core, id) {
+        Ok(slot) => Ok(slot.define(definition.take().expect("isolated definition is available"))),
+        Err(error) => Err(dispose_rejected(definition, error)),
     }
 }
 
@@ -83,7 +85,7 @@ macro_rules! impl_common_builder_surface {
             &mut self,
             id: impl Into<ChildId>,
         ) -> Result<ActorSlot<M>, ReserveError> {
-            self.core.reserve(id, None).map(attach_actor_slot)
+            reserve_static::<ActorKind<M>>(&mut self.core, id).map(|core| ActorSlot { core })
         }
 
         /// Adds a restartable callback-oriented actor.
@@ -93,13 +95,7 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: ActorDef<A>,
         ) -> Result<ActorRef<A::Msg>, ReserveError> {
-            let mut definition = runtime::Isolated::new(definition);
-            match self.reserve_actor(id) {
-                Ok(slot) => Ok(slot.define(
-                    definition.take().expect("isolated definition is available"),
-                )),
-                Err(error) => Err(dispose_rejected(definition, error)),
-            }
+            add_definition(&mut self.core, id, definition)
         }
 
         /// Adds a consuming one-shot callback-oriented actor.
@@ -109,13 +105,7 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: ActorOnceDef<A>,
         ) -> Result<ActorRef<A::Msg>, ReserveError> {
-            let mut definition = runtime::Isolated::new(definition);
-            match self.reserve_actor(id) {
-                Ok(slot) => Ok(slot.define_once(
-                    definition.take().expect("isolated definition is available"),
-                )),
-                Err(error) => Err(dispose_rejected(definition, error)),
-            }
+            add_definition(&mut self.core, id, definition)
         }
 
         /// Adds a restartable raw actor.
@@ -125,13 +115,7 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: RawDef<R>,
         ) -> Result<ActorRef<R::Msg>, ReserveError> {
-            let mut definition = runtime::Isolated::new(definition);
-            match self.reserve_actor(id) {
-                Ok(slot) => Ok(slot.define_raw(
-                    definition.take().expect("isolated definition is available"),
-                )),
-                Err(error) => Err(dispose_rejected(definition, error)),
-            }
+            add_definition(&mut self.core, id, definition)
         }
 
         /// Adds a consuming one-shot raw actor.
@@ -141,21 +125,13 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: RawOnceDef<R>,
         ) -> Result<ActorRef<R::Msg>, ReserveError> {
-            let mut definition = runtime::Isolated::new(definition);
-            match self.reserve_actor(id) {
-                Ok(slot) => Ok(slot.define_once_raw(
-                    definition.take().expect("isolated definition is available"),
-                )),
-                Err(error) => Err(dispose_rejected(definition, error)),
-            }
+            add_definition(&mut self.core, id, definition)
         }
 
         /// Reserves a task membership and returns its pre-spawn handle slot.
         #[doc = $member_note]
         pub fn reserve_task(&mut self, id: impl Into<ChildId>) -> Result<TaskSlot, ReserveError> {
-            self.core.reserve(id, None).map(|slot| TaskSlot {
-                core: TaskSlotCore::new(StaticSlotEndpoint(slot)),
-            })
+            reserve_static::<TaskKind>(&mut self.core, id).map(|core| TaskSlot { core })
         }
 
         /// Adds a restartable task.
@@ -165,13 +141,7 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: TaskDef,
         ) -> Result<TaskRef, ReserveError> {
-            let mut definition = runtime::Isolated::new(definition);
-            match self.reserve_task(id) {
-                Ok(slot) => Ok(slot.define(
-                    definition.take().expect("isolated definition is available"),
-                )),
-                Err(error) => Err(dispose_rejected(definition, error)),
-            }
+            add_definition(&mut self.core, id, definition)
         }
 
         /// Adds a consuming one-shot task and its typed completion claim.
@@ -181,13 +151,7 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: TaskOnceDef<T>,
         ) -> Result<(TaskRef, OneShotTaskRef<T>), ReserveError> {
-            let mut definition = runtime::Isolated::new(definition);
-            match self.reserve_task(id) {
-                Ok(slot) => Ok(slot.define_once(
-                    definition.take().expect("isolated definition is available"),
-                )),
-                Err(error) => Err(dispose_rejected(definition, error)),
-            }
+            add_definition(&mut self.core, id, definition)
         }
 
         /// Reserves a typed subtree membership.
@@ -196,11 +160,7 @@ macro_rules! impl_common_builder_surface {
             &mut self,
             id: impl Into<ChildId>,
         ) -> Result<SubtreeSlot<T>, ReserveError> {
-            self.core
-                .reserve(id, Some(<T as sealed::Sealed>::FLAVOR))
-                .map(|slot| SubtreeSlot {
-                    core: SubtreeSlotCore::new(StaticSlotEndpoint(slot)),
-                })
+            reserve_static::<SubtreeKind<T>>(&mut self.core, id).map(|core| SubtreeSlot { core })
         }
 
         /// Adds a restartable subtree.
@@ -210,13 +170,7 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: SubtreeDef<T>,
         ) -> Result<T::Ref, ReserveError> {
-            let mut definition = runtime::Isolated::new(definition);
-            match self.reserve_subtree::<T>(id) {
-                Ok(slot) => Ok(slot.define(
-                    definition.take().expect("isolated definition is available"),
-                )),
-                Err(error) => Err(dispose_rejected(definition, error)),
-            }
+            add_definition(&mut self.core, id, definition)
         }
 
         /// Adds a consuming one-shot subtree.
@@ -226,13 +180,7 @@ macro_rules! impl_common_builder_surface {
             id: impl Into<ChildId>,
             definition: SubtreeOnceDef<T>,
         ) -> Result<T::Ref, ReserveError> {
-            let mut definition = runtime::Isolated::new(definition);
-            match self.reserve_subtree::<T>(id) {
-                Ok(slot) => Ok(slot.define_once(
-                    definition.take().expect("isolated definition is available"),
-                )),
-                Err(error) => Err(dispose_rejected(definition, error)),
-            }
+            add_definition(&mut self.core, id, definition)
         }
     };
 }

--- a/crates/shelterwood/src/tree/dynamic_api.rs
+++ b/crates/shelterwood/src/tree/dynamic_api.rs
@@ -11,66 +11,20 @@ use super::{
     Admission, DynamicActorSlot, DynamicSubtreeSlot, DynamicTaskSlot, Removal, Subtree, SubtreeDef,
     SubtreeOnceDef,
     builders::dispose_rejected,
-    slots::{
-        ActorSlotCore, AdmissionOwnership, DynamicSlotEndpoint, SubtreeSlotCore, TaskSlotCore,
-        attach_actor_mailbox,
-    },
-    system::sealed,
+    slots::{ActorKind, AdmissionOwnership, Definition, SubtreeKind, TaskKind, reserve_dynamic},
 };
 
 impl DynamicScopeRef {
-    fn define_or_reject<D, S, H>(
+    fn add_definition<D: Definition>(
+        &self,
+        id: impl Into<ChildId>,
         definition: D,
-        reserve: impl FnOnce() -> Result<S, ReserveError>,
-        define: impl FnOnce(S, D) -> Admission<H>,
-    ) -> Admission<H>
-    where
-        D: Send + 'static,
-    {
+    ) -> Admission<D::Handles> {
         let mut definition = runtime::Isolated::new(definition);
-        match reserve() {
-            Ok(slot) => define(
-                slot,
-                definition.take().expect("isolated definition is available"),
-            ),
+        match reserve_dynamic::<D::Kind>(self, id, AdmissionOwnership::Fused) {
+            Ok(slot) => slot.define(definition.take().expect("isolated definition is available")),
             Err(error) => Admission::error(dispose_rejected(definition, error)),
         }
-    }
-
-    fn reserve_actor_with<M: Send + 'static>(
-        &self,
-        id: impl Into<ChildId>,
-        ownership: AdmissionOwnership,
-    ) -> Result<DynamicActorSlot<M>, ReserveError> {
-        crate::driver::reserve_dynamic(&self.0.cell, id.into(), None).map(|reservation| {
-            let mailbox = attach_actor_mailbox(&reservation.slot);
-            DynamicActorSlot {
-                core: ActorSlotCore::new(DynamicSlotEndpoint::new(reservation, ownership), mailbox),
-            }
-        })
-    }
-
-    fn reserve_task_with(
-        &self,
-        id: impl Into<ChildId>,
-        ownership: AdmissionOwnership,
-    ) -> Result<DynamicTaskSlot, ReserveError> {
-        crate::driver::reserve_dynamic(&self.0.cell, id.into(), None).map(|reservation| {
-            DynamicTaskSlot {
-                core: TaskSlotCore::new(DynamicSlotEndpoint::new(reservation, ownership)),
-            }
-        })
-    }
-
-    fn reserve_subtree_with<T: Subtree>(
-        &self,
-        id: impl Into<ChildId>,
-        ownership: AdmissionOwnership,
-    ) -> Result<DynamicSubtreeSlot<T>, ReserveError> {
-        crate::driver::reserve_dynamic(&self.0.cell, id.into(), Some(<T as sealed::Sealed>::FLAVOR))
-            .map(|reservation| DynamicSubtreeSlot {
-                core: SubtreeSlotCore::new(DynamicSlotEndpoint::new(reservation, ownership)),
-            })
     }
 
     /// Reserves an actor id synchronously and exposes its exact handle.
@@ -80,7 +34,8 @@ impl DynamicScopeRef {
         &self,
         id: impl Into<ChildId>,
     ) -> Result<DynamicActorSlot<M>, ReserveError> {
-        self.reserve_actor_with(id, AdmissionOwnership::Split)
+        reserve_dynamic::<ActorKind<M>>(self, id, AdmissionOwnership::Split)
+            .map(|core| DynamicActorSlot { core })
     }
 
     /// Adds a restartable callback-oriented actor, resolving at admission.
@@ -89,11 +44,7 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: ActorDef<A>,
     ) -> Admission<ActorRef<A::Msg>> {
-        Self::define_or_reject(
-            definition,
-            || self.reserve_actor_with(id, AdmissionOwnership::Fused),
-            |slot, definition| slot.core.define_raw(definition.into_raw()),
-        )
+        self.add_definition(id, definition)
     }
 
     /// Adds a consuming one-shot callback-oriented actor, resolving at admission.
@@ -102,11 +53,7 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: ActorOnceDef<A>,
     ) -> Admission<ActorRef<A::Msg>> {
-        Self::define_or_reject(
-            definition,
-            || self.reserve_actor_with(id, AdmissionOwnership::Fused),
-            |slot, definition| slot.core.define_once_raw(definition.into_raw()),
-        )
+        self.add_definition(id, definition)
     }
 
     /// Adds a restartable raw actor, resolving at admission.
@@ -115,11 +62,7 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: RawDef<R>,
     ) -> Admission<ActorRef<R::Msg>> {
-        Self::define_or_reject(
-            definition,
-            || self.reserve_actor_with(id, AdmissionOwnership::Fused),
-            |slot, definition| slot.core.define_raw(definition),
-        )
+        self.add_definition(id, definition)
     }
 
     /// Adds a consuming one-shot raw actor, resolving at admission.
@@ -128,27 +71,20 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: RawOnceDef<R>,
     ) -> Admission<ActorRef<R::Msg>> {
-        Self::define_or_reject(
-            definition,
-            || self.reserve_actor_with(id, AdmissionOwnership::Fused),
-            |slot, definition| slot.core.define_once_raw(definition),
-        )
+        self.add_definition(id, definition)
     }
 
     /// Reserves a task id synchronously and exposes its exact handle.
     ///
     /// Returns [`ReserveError::NoRuntime`] outside an ambient Tokio runtime.
     pub fn reserve_task(&self, id: impl Into<ChildId>) -> Result<DynamicTaskSlot, ReserveError> {
-        self.reserve_task_with(id, AdmissionOwnership::Split)
+        reserve_dynamic::<TaskKind>(self, id, AdmissionOwnership::Split)
+            .map(|core| DynamicTaskSlot { core })
     }
 
     /// Adds a restartable task, resolving at admission rather than startup.
     pub fn add_task(&self, id: impl Into<ChildId>, definition: TaskDef) -> Admission<TaskRef> {
-        Self::define_or_reject(
-            definition,
-            || self.reserve_task_with(id, AdmissionOwnership::Fused),
-            |slot, definition| slot.core.define(definition),
-        )
+        self.add_definition(id, definition)
     }
 
     /// Adds a consuming one-shot task, resolving at admission.
@@ -157,11 +93,7 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: TaskOnceDef<T>,
     ) -> Admission<(TaskRef, OneShotTaskRef<T>)> {
-        Self::define_or_reject(
-            definition,
-            || self.reserve_task_with(id, AdmissionOwnership::Fused),
-            |slot, definition| slot.core.define_once(definition),
-        )
+        self.add_definition(id, definition)
     }
 
     /// Reserves a typed subtree id synchronously.
@@ -171,7 +103,8 @@ impl DynamicScopeRef {
         &self,
         id: impl Into<ChildId>,
     ) -> Result<DynamicSubtreeSlot<T>, ReserveError> {
-        self.reserve_subtree_with(id, AdmissionOwnership::Split)
+        reserve_dynamic::<SubtreeKind<T>>(self, id, AdmissionOwnership::Split)
+            .map(|core| DynamicSubtreeSlot { core })
     }
 
     /// Adds a restartable subtree, resolving at admission.
@@ -180,11 +113,7 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: SubtreeDef<T>,
     ) -> Admission<T::Ref> {
-        Self::define_or_reject(
-            definition,
-            || self.reserve_subtree_with::<T>(id, AdmissionOwnership::Fused),
-            |slot, definition| slot.core.define(definition),
-        )
+        self.add_definition(id, definition)
     }
 
     /// Adds a consuming one-shot subtree, resolving at admission.
@@ -193,11 +122,7 @@ impl DynamicScopeRef {
         id: impl Into<ChildId>,
         definition: SubtreeOnceDef<T>,
     ) -> Admission<T::Ref> {
-        Self::define_or_reject(
-            definition,
-            || self.reserve_subtree_with::<T>(id, AdmissionOwnership::Fused),
-            |slot, definition| slot.core.define_once(definition),
-        )
+        self.add_definition(id, definition)
     }
 
     /// Latches id-based removal synchronously; the returned future only

--- a/crates/shelterwood/src/tree/slots.rs
+++ b/crates/shelterwood/src/tree/slots.rs
@@ -153,7 +153,8 @@ impl<E: SlotEndpoint, K: SlotKind> SlotCore<E, K> {
     where
         D: Definition<Kind = K>,
     {
-        definition.define(self)
+        let (handles, construction) = definition.lower(&self);
+        self.endpoint.define(handles, construction)
     }
 }
 
@@ -177,13 +178,19 @@ pub(super) fn reserve_dynamic<K: SlotKind>(
 /// Sealed semantic lowering for each nominal public definition type.
 ///
 /// `Kind` chooses the reservation shape; `Handles` pins the return type. The
-/// eight public add methods remain concrete wrappers, so this trait cannot
-/// enlarge the accepted public surface or weaken inference.
+/// borrowed slot lets each implementation construct its typed handles without
+/// gaining authority to bind or admit the endpoint; [`SlotCore::define`] owns
+/// that single final transition. The eight public add methods remain concrete
+/// wrappers, so this trait cannot enlarge the accepted public surface or
+/// weaken inference.
 pub(super) trait Definition: Send + 'static + Sized {
     type Kind: SlotKind;
     type Handles;
 
-    fn define<E: SlotEndpoint>(self, slot: SlotCore<E, Self::Kind>) -> E::Output<Self::Handles>;
+    fn lower<E: SlotEndpoint>(
+        self,
+        slot: &SlotCore<E, Self::Kind>,
+    ) -> (Self::Handles, ChildConstruction);
 }
 
 impl<E: SlotEndpoint, M: Send + 'static> SlotCore<E, ActorKind<M>> {
@@ -201,20 +208,16 @@ macro_rules! impl_raw_definition {
             type Kind = ActorKind<R::Msg>;
             type Handles = ActorRef<R::Msg>;
 
-            fn define<E: SlotEndpoint>(
+            fn lower<E: SlotEndpoint>(
                 self,
-                slot: SlotCore<E, Self::Kind>,
-            ) -> E::Output<Self::Handles> {
+                slot: &SlotCore<E, Self::Kind>,
+            ) -> (Self::Handles, ChildConstruction) {
                 let actor = slot.actor_ref();
-                let SlotCore {
-                    endpoint,
-                    kind: ActorKind { mailbox },
-                } = slot;
-                endpoint.define(
+                (
                     actor,
                     ChildConstruction::Raw($definition::erase(
                         runtime::Isolated::new(self),
-                        mailbox,
+                        Arc::clone(&slot.kind.mailbox),
                     )),
                 )
             }
@@ -229,8 +232,11 @@ impl<A: crate::Actor> Definition for ActorDef<A> {
     type Kind = ActorKind<A::Msg>;
     type Handles = ActorRef<A::Msg>;
 
-    fn define<E: SlotEndpoint>(self, slot: SlotCore<E, Self::Kind>) -> E::Output<Self::Handles> {
-        slot.define(self.into_raw())
+    fn lower<E: SlotEndpoint>(
+        self,
+        slot: &SlotCore<E, Self::Kind>,
+    ) -> (Self::Handles, ChildConstruction) {
+        self.into_raw().lower(slot)
     }
 }
 
@@ -238,8 +244,11 @@ impl<A: crate::Actor> Definition for ActorOnceDef<A> {
     type Kind = ActorKind<A::Msg>;
     type Handles = ActorRef<A::Msg>;
 
-    fn define<E: SlotEndpoint>(self, slot: SlotCore<E, Self::Kind>) -> E::Output<Self::Handles> {
-        slot.define(self.into_raw())
+    fn lower<E: SlotEndpoint>(
+        self,
+        slot: &SlotCore<E, Self::Kind>,
+    ) -> (Self::Handles, ChildConstruction) {
+        self.into_raw().lower(slot)
     }
 }
 
@@ -253,10 +262,12 @@ impl Definition for TaskDef {
     type Kind = TaskKind;
     type Handles = TaskRef;
 
-    fn define<E: SlotEndpoint>(self, slot: SlotCore<E, Self::Kind>) -> E::Output<Self::Handles> {
+    fn lower<E: SlotEndpoint>(
+        self,
+        slot: &SlotCore<E, Self::Kind>,
+    ) -> (Self::Handles, ChildConstruction) {
         let task = slot.task_ref();
-        slot.endpoint
-            .define(task, ChildConstruction::Task(self.erase()))
+        (task, ChildConstruction::Task(self.erase()))
     }
 }
 
@@ -264,11 +275,14 @@ impl<T: Send + 'static> Definition for TaskOnceDef<T> {
     type Kind = TaskKind;
     type Handles = (TaskRef, OneShotTaskRef<T>);
 
-    fn define<E: SlotEndpoint>(self, slot: SlotCore<E, Self::Kind>) -> E::Output<Self::Handles> {
+    fn lower<E: SlotEndpoint>(
+        self,
+        slot: &SlotCore<E, Self::Kind>,
+    ) -> (Self::Handles, ChildConstruction) {
         let task = slot.task_ref();
         let (completion, receiver) = runtime::oneshot();
         let claim = OneShotTaskRef::new(receiver, task.clone());
-        slot.endpoint.define(
+        (
             (task, claim),
             ChildConstruction::Task(self.erase(completion)),
         )
@@ -295,13 +309,12 @@ macro_rules! impl_subtree_definition {
             type Kind = SubtreeKind<T>;
             type Handles = T::Ref;
 
-            fn define<E: SlotEndpoint>(
+            fn lower<E: SlotEndpoint>(
                 self,
-                slot: SlotCore<E, Self::Kind>,
-            ) -> E::Output<Self::Handles> {
+                slot: &SlotCore<E, Self::Kind>,
+            ) -> (Self::Handles, ChildConstruction) {
                 let scope = slot.scope_ref();
-                slot.endpoint
-                    .define(scope, ChildConstruction::Scope(Box::new(self.erase())))
+                (scope, ChildConstruction::Scope(Box::new(self.erase())))
             }
         }
     };

--- a/crates/shelterwood/src/tree/slots.rs
+++ b/crates/shelterwood/src/tree/slots.rs
@@ -1,13 +1,15 @@
 use std::{fmt, marker::PhantomData, sync::Arc};
 
 use crate::{
-    ActorDef, ActorOnceDef, ActorRef,
+    ActorDef, ActorOnceDef, ActorRef, ChildId,
+    admission::ReserveError,
     driver::DynamicReservation,
     mailbox::{MailboxCell, actor_ref_from_parts},
-    plan::{ChildConstruction, SlotCell},
+    plan::{BuilderCore, ChildConstruction, SlotCell},
+    policy::ScopeFlavor,
     raw::{RawDef, RawOnceDef},
     runtime,
-    scope::ScopeRef,
+    scope::{DynamicScopeRef, ScopeRef},
     task::{OneShotTaskRef, TaskDef, TaskOnceDef, TaskRef},
 };
 
@@ -91,110 +93,189 @@ impl Drop for DynamicSlotEndpoint {
     }
 }
 
-pub(super) struct ActorSlotCore<E, M> {
-    pub(super) endpoint: E,
+/// Private declaration-kind dispatch shared by reservation and definition.
+///
+/// The public API stays nominal: callers never name this trait or its marker
+/// types. It exists so adding a definition mode supplies only its semantic
+/// lowering instead of copying the reserve/attach/admit choreography.
+pub(super) trait SlotKind: Sized {
+    const SCOPE_FLAVOR: Option<ScopeFlavor>;
+
+    fn attach(slot: &SlotCell) -> Self;
+}
+
+pub(super) struct ActorKind<M> {
     mailbox: Arc<MailboxCell<M>>,
 }
 
-pub(super) fn attach_actor_mailbox<M: Send + 'static>(slot: &SlotCell) -> Arc<MailboxCell<M>> {
-    let mailbox = MailboxCell::new(slot.member.id().clone(), crate::runtime::mailbox_runtime());
-    slot.member.attach_mailbox(mailbox.clone());
-    mailbox
+impl<M: Send + 'static> SlotKind for ActorKind<M> {
+    const SCOPE_FLAVOR: Option<ScopeFlavor> = None;
+
+    fn attach(slot: &SlotCell) -> Self {
+        let mailbox = MailboxCell::new(slot.member.id().clone(), crate::runtime::mailbox_runtime());
+        slot.member.attach_mailbox(mailbox.clone());
+        Self { mailbox }
+    }
 }
 
-macro_rules! impl_actor_core_definition {
-    ($method:ident, $definition:ident) => {
-        pub(super) fn $method<R>(self, definition: $definition<R>) -> E::Output<ActorRef<M>>
-        where
-            R: crate::RawActor<Msg = M>,
-        {
-            let actor = self.actor_ref();
-            let Self { endpoint, mailbox } = self;
-            endpoint.define(
-                actor,
-                ChildConstruction::Raw($definition::erase(
-                    runtime::Isolated::new(definition),
-                    mailbox,
-                )),
-            )
-        }
-    };
+pub(super) struct TaskKind;
+
+impl SlotKind for TaskKind {
+    const SCOPE_FLAVOR: Option<ScopeFlavor> = None;
+
+    fn attach(_slot: &SlotCell) -> Self {
+        Self
+    }
 }
 
-impl<E: SlotEndpoint, M: Send + 'static> ActorSlotCore<E, M> {
-    pub(super) fn new(endpoint: E, mailbox: Arc<MailboxCell<M>>) -> Self {
-        Self { endpoint, mailbox }
+pub(super) struct SubtreeKind<T: Subtree>(PhantomData<fn() -> T>);
+
+impl<T: Subtree> SlotKind for SubtreeKind<T> {
+    const SCOPE_FLAVOR: Option<ScopeFlavor> = Some(<T as sealed::Sealed>::FLAVOR);
+
+    fn attach(_slot: &SlotCell) -> Self {
+        Self(PhantomData)
+    }
+}
+
+pub(super) struct SlotCore<E, K> {
+    pub(super) endpoint: E,
+    kind: K,
+}
+
+impl<E: SlotEndpoint, K: SlotKind> SlotCore<E, K> {
+    fn new(endpoint: E) -> Self {
+        let kind = K::attach(endpoint.slot());
+        Self { endpoint, kind }
     }
 
+    pub(super) fn define<D>(self, definition: D) -> E::Output<D::Handles>
+    where
+        D: Definition<Kind = K>,
+    {
+        definition.define(self)
+    }
+}
+
+pub(super) fn reserve_static<K: SlotKind>(
+    core: &mut BuilderCore,
+    id: impl Into<ChildId>,
+) -> Result<SlotCore<StaticSlotEndpoint, K>, ReserveError> {
+    core.reserve(id, K::SCOPE_FLAVOR)
+        .map(|slot| SlotCore::new(StaticSlotEndpoint(slot)))
+}
+
+pub(super) fn reserve_dynamic<K: SlotKind>(
+    scope: &DynamicScopeRef,
+    id: impl Into<ChildId>,
+    ownership: AdmissionOwnership,
+) -> Result<SlotCore<DynamicSlotEndpoint, K>, ReserveError> {
+    crate::driver::reserve_dynamic(&scope.0.cell, id.into(), K::SCOPE_FLAVOR)
+        .map(|reservation| SlotCore::new(DynamicSlotEndpoint::new(reservation, ownership)))
+}
+
+/// Sealed semantic lowering for each nominal public definition type.
+///
+/// `Kind` chooses the reservation shape; `Handles` pins the return type. The
+/// eight public add methods remain concrete wrappers, so this trait cannot
+/// enlarge the accepted public surface or weaken inference.
+pub(super) trait Definition: Send + 'static + Sized {
+    type Kind: SlotKind;
+    type Handles;
+
+    fn define<E: SlotEndpoint>(self, slot: SlotCore<E, Self::Kind>) -> E::Output<Self::Handles>;
+}
+
+impl<E: SlotEndpoint, M: Send + 'static> SlotCore<E, ActorKind<M>> {
     fn actor_ref(&self) -> ActorRef<M> {
         actor_ref_from_parts(
             Arc::clone(&self.endpoint.slot().member),
-            Arc::clone(&self.mailbox),
-        )
-    }
-
-    impl_actor_core_definition!(define_raw, RawDef);
-    impl_actor_core_definition!(define_once_raw, RawOnceDef);
-}
-
-pub(super) struct TaskSlotCore<E> {
-    pub(super) endpoint: E,
-}
-
-impl<E: SlotEndpoint> TaskSlotCore<E> {
-    pub(super) fn new(endpoint: E) -> Self {
-        Self { endpoint }
-    }
-
-    fn task_ref(&self) -> TaskRef {
-        TaskRef::new(Arc::clone(&self.endpoint.slot().member))
-    }
-
-    pub(super) fn define(self, definition: TaskDef) -> E::Output<TaskRef> {
-        let task = self.task_ref();
-        self.endpoint
-            .define(task, ChildConstruction::Task(definition.erase()))
-    }
-
-    pub(super) fn define_once<T: Send + 'static>(
-        self,
-        definition: TaskOnceDef<T>,
-    ) -> E::Output<(TaskRef, OneShotTaskRef<T>)> {
-        let task = self.task_ref();
-        let (completion, receiver) = runtime::oneshot();
-        let claim = OneShotTaskRef::new(receiver, task.clone());
-        self.endpoint.define(
-            (task, claim),
-            ChildConstruction::Task(definition.erase(completion)),
+            Arc::clone(&self.kind.mailbox),
         )
     }
 }
 
-pub(super) struct SubtreeSlotCore<E, T: Subtree> {
-    pub(super) endpoint: E,
-    marker: PhantomData<fn() -> T>,
-}
+macro_rules! impl_raw_definition {
+    ($definition:ident) => {
+        impl<R: crate::RawActor> Definition for $definition<R> {
+            type Kind = ActorKind<R::Msg>;
+            type Handles = ActorRef<R::Msg>;
 
-macro_rules! impl_subtree_core_definition {
-    ($method:ident, $definition:ident) => {
-        pub(super) fn $method(self, definition: $definition<T>) -> E::Output<T::Ref> {
-            let scope = self.scope_ref();
-            self.endpoint.define(
-                scope,
-                ChildConstruction::Scope(Box::new(definition.erase())),
-            )
+            fn define<E: SlotEndpoint>(
+                self,
+                slot: SlotCore<E, Self::Kind>,
+            ) -> E::Output<Self::Handles> {
+                let actor = slot.actor_ref();
+                let SlotCore {
+                    endpoint,
+                    kind: ActorKind { mailbox },
+                } = slot;
+                endpoint.define(
+                    actor,
+                    ChildConstruction::Raw($definition::erase(
+                        runtime::Isolated::new(self),
+                        mailbox,
+                    )),
+                )
+            }
         }
     };
 }
 
-impl<E: SlotEndpoint, T: Subtree> SubtreeSlotCore<E, T> {
-    pub(super) fn new(endpoint: E) -> Self {
-        Self {
-            endpoint,
-            marker: PhantomData,
-        }
-    }
+impl_raw_definition!(RawDef);
+impl_raw_definition!(RawOnceDef);
 
+impl<A: crate::Actor> Definition for ActorDef<A> {
+    type Kind = ActorKind<A::Msg>;
+    type Handles = ActorRef<A::Msg>;
+
+    fn define<E: SlotEndpoint>(self, slot: SlotCore<E, Self::Kind>) -> E::Output<Self::Handles> {
+        slot.define(self.into_raw())
+    }
+}
+
+impl<A: crate::Actor> Definition for ActorOnceDef<A> {
+    type Kind = ActorKind<A::Msg>;
+    type Handles = ActorRef<A::Msg>;
+
+    fn define<E: SlotEndpoint>(self, slot: SlotCore<E, Self::Kind>) -> E::Output<Self::Handles> {
+        slot.define(self.into_raw())
+    }
+}
+
+impl<E: SlotEndpoint> SlotCore<E, TaskKind> {
+    fn task_ref(&self) -> TaskRef {
+        TaskRef::new(Arc::clone(&self.endpoint.slot().member))
+    }
+}
+
+impl Definition for TaskDef {
+    type Kind = TaskKind;
+    type Handles = TaskRef;
+
+    fn define<E: SlotEndpoint>(self, slot: SlotCore<E, Self::Kind>) -> E::Output<Self::Handles> {
+        let task = slot.task_ref();
+        slot.endpoint
+            .define(task, ChildConstruction::Task(self.erase()))
+    }
+}
+
+impl<T: Send + 'static> Definition for TaskOnceDef<T> {
+    type Kind = TaskKind;
+    type Handles = (TaskRef, OneShotTaskRef<T>);
+
+    fn define<E: SlotEndpoint>(self, slot: SlotCore<E, Self::Kind>) -> E::Output<Self::Handles> {
+        let task = slot.task_ref();
+        let (completion, receiver) = runtime::oneshot();
+        let claim = OneShotTaskRef::new(receiver, task.clone());
+        slot.endpoint.define(
+            (task, claim),
+            ChildConstruction::Task(self.erase(completion)),
+        )
+    }
+}
+
+impl<E: SlotEndpoint, T: Subtree> SlotCore<E, SubtreeKind<T>> {
     fn scope_ref(&self) -> T::Ref {
         <T as sealed::Sealed>::make_ref(ScopeRef {
             cell: Arc::clone(
@@ -206,10 +287,28 @@ impl<E: SlotEndpoint, T: Subtree> SubtreeSlotCore<E, T> {
             ),
         })
     }
-
-    impl_subtree_core_definition!(define, SubtreeDef);
-    impl_subtree_core_definition!(define_once, SubtreeOnceDef);
 }
+
+macro_rules! impl_subtree_definition {
+    ($definition:ident) => {
+        impl<T: Subtree> Definition for $definition<T> {
+            type Kind = SubtreeKind<T>;
+            type Handles = T::Ref;
+
+            fn define<E: SlotEndpoint>(
+                self,
+                slot: SlotCore<E, Self::Kind>,
+            ) -> E::Output<Self::Handles> {
+                let scope = slot.scope_ref();
+                slot.endpoint
+                    .define(scope, ChildConstruction::Scope(Box::new(self.erase())))
+            }
+        }
+    };
+}
+
+impl_subtree_definition!(SubtreeDef);
+impl_subtree_definition!(SubtreeOnceDef);
 
 macro_rules! impl_slot_debug {
     ($slot:ident $(<$generic:ident $(: $bound:path)?>)?, $label:literal) => {
@@ -225,7 +324,7 @@ macro_rules! impl_slot_debug {
 }
 /// An owned pre-spawn actor slot with a stable mailbox binding.
 pub struct ActorSlot<M> {
-    pub(super) core: ActorSlotCore<StaticSlotEndpoint, M>,
+    pub(super) core: SlotCore<StaticSlotEndpoint, ActorKind<M>>,
 }
 
 impl_slot_debug!(ActorSlot<M>, "ActorSlot");
@@ -243,7 +342,7 @@ impl<M: Send + 'static> ActorSlot<M> {
     where
         A: crate::Actor<Msg = M>,
     {
-        self.define_raw(definition.into_raw())
+        self.core.define(definition)
     }
 
     /// Defines a consuming one-shot callback-oriented actor and consumes the slot.
@@ -252,7 +351,7 @@ impl<M: Send + 'static> ActorSlot<M> {
     where
         A: crate::Actor<Msg = M>,
     {
-        self.define_once_raw(definition.into_raw())
+        self.core.define(definition)
     }
 
     /// Defines a restartable raw actor and consumes the slot.
@@ -261,7 +360,7 @@ impl<M: Send + 'static> ActorSlot<M> {
     where
         R: crate::RawActor<Msg = M>,
     {
-        self.core.define_raw(definition)
+        self.core.define(definition)
     }
 
     /// Defines a consuming one-shot raw actor and consumes the slot.
@@ -270,13 +369,13 @@ impl<M: Send + 'static> ActorSlot<M> {
     where
         R: crate::RawActor<Msg = M>,
     {
-        self.core.define_once_raw(definition)
+        self.core.define(definition)
     }
 }
 
 /// An owned pre-spawn task slot.
 pub struct TaskSlot {
-    pub(super) core: TaskSlotCore<StaticSlotEndpoint>,
+    pub(super) core: SlotCore<StaticSlotEndpoint, TaskKind>,
 }
 
 impl_slot_debug!(TaskSlot, "TaskSlot");
@@ -300,12 +399,12 @@ impl TaskSlot {
         self,
         definition: TaskOnceDef<T>,
     ) -> (TaskRef, OneShotTaskRef<T>) {
-        self.core.define_once(definition)
+        self.core.define(definition)
     }
 }
 /// A split dynamic actor reservation with a stable mailbox binding.
 pub struct DynamicActorSlot<M> {
-    pub(super) core: ActorSlotCore<DynamicSlotEndpoint, M>,
+    pub(super) core: SlotCore<DynamicSlotEndpoint, ActorKind<M>>,
 }
 
 impl_slot_debug!(DynamicActorSlot<M>, "DynamicActorSlot");
@@ -322,7 +421,7 @@ impl<M: Send + 'static> DynamicActorSlot<M> {
     where
         A: crate::Actor<Msg = M>,
     {
-        self.define_raw(definition.into_raw())
+        self.core.define(definition)
     }
 
     /// Defines a one-shot callback-oriented actor; dropping after first poll detaches.
@@ -330,7 +429,7 @@ impl<M: Send + 'static> DynamicActorSlot<M> {
     where
         A: crate::Actor<Msg = M>,
     {
-        self.define_once_raw(definition.into_raw())
+        self.core.define(definition)
     }
 
     /// Defines a restartable raw actor; dropping after first poll detaches.
@@ -338,7 +437,7 @@ impl<M: Send + 'static> DynamicActorSlot<M> {
     where
         R: crate::RawActor<Msg = M>,
     {
-        self.core.define_raw(definition)
+        self.core.define(definition)
     }
 
     /// Defines a one-shot raw actor; dropping after first poll detaches.
@@ -346,13 +445,13 @@ impl<M: Send + 'static> DynamicActorSlot<M> {
     where
         R: crate::RawActor<Msg = M>,
     {
-        self.core.define_once_raw(definition)
+        self.core.define(definition)
     }
 }
 
 /// A split dynamic task reservation.
 pub struct DynamicTaskSlot {
-    pub(super) core: TaskSlotCore<DynamicSlotEndpoint>,
+    pub(super) core: SlotCore<DynamicSlotEndpoint, TaskKind>,
 }
 
 impl_slot_debug!(DynamicTaskSlot, "DynamicTaskSlot");
@@ -374,13 +473,13 @@ impl DynamicTaskSlot {
         self,
         definition: TaskOnceDef<T>,
     ) -> Admission<(TaskRef, OneShotTaskRef<T>)> {
-        self.core.define_once(definition)
+        self.core.define(definition)
     }
 }
 
 /// A split dynamic subtree reservation.
 pub struct DynamicSubtreeSlot<T: Subtree> {
-    pub(super) core: SubtreeSlotCore<DynamicSlotEndpoint, T>,
+    pub(super) core: SlotCore<DynamicSlotEndpoint, SubtreeKind<T>>,
 }
 
 impl_slot_debug!(DynamicSubtreeSlot<T: Subtree>, "DynamicSubtreeSlot");
@@ -399,12 +498,12 @@ impl<T: Subtree> DynamicSubtreeSlot<T> {
 
     /// Defines a one-shot subtree; dropping after first poll detaches.
     pub fn define_once(self, definition: SubtreeOnceDef<T>) -> Admission<T::Ref> {
-        self.core.define_once(definition)
+        self.core.define(definition)
     }
 }
 /// A typed pre-spawn subtree slot.
 pub struct SubtreeSlot<T: Subtree> {
-    pub(super) core: SubtreeSlotCore<StaticSlotEndpoint, T>,
+    pub(super) core: SlotCore<StaticSlotEndpoint, SubtreeKind<T>>,
 }
 
 impl_slot_debug!(SubtreeSlot<T: Subtree>, "SubtreeSlot");
@@ -425,6 +524,6 @@ impl<T: Subtree> SubtreeSlot<T> {
     /// Defines a one-shot subtree and consumes the slot.
     #[must_use]
     pub fn define_once(self, definition: SubtreeOnceDef<T>) -> T::Ref {
-        self.core.define_once(definition)
+        self.core.define(definition)
     }
 }

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -235,7 +235,10 @@ fn actor_types_obey_resource_and_payload_trait_contracts() {
 
 #[test]
 #[allow(clippy::type_complexity)]
-fn slot_method_signatures_remain_nominal_and_parallel() {
+fn nominal_slot_signatures_hide_generic_definition_dispatch() {
+    // Keep both endpoint flavors explicit here. The implementation shares one
+    // private Definition path, but callers must still get concrete parameter
+    // and return types at every named method.
     let _: fn(&ActorSlot<Cell<()>>) -> ActorRef<Cell<()>> = ActorSlot::actor_ref;
     let _: fn(ActorSlot<Cell<()>>, ActorDef<OpaqueActor>) -> ActorRef<Cell<()>> = ActorSlot::define;
     let _: fn(ActorSlot<Cell<()>>, ActorOnceDef<OpaqueActor>) -> ActorRef<Cell<()>> =
@@ -293,7 +296,7 @@ impl RawActor for OpaqueRaw {
 }
 
 #[test]
-fn ordered_and_dynamic_builders_expose_the_parallel_typed_surface() {
+fn nominal_add_methods_preserve_the_parallel_typed_surface() {
     let mut ordered = Tree::new();
     let _: &mut Tree = ordered.intensity(Intensity::default());
     let _: &mut Tree = ordered.defaults(ScopeDefaults::default());


### PR DESCRIPTION
## Summary

- keep all eight nominal public `add_*` entry points and every existing slot method, but route them through one sealed private `Definition` dispatch with associated `Kind` and `Handles`
- centralize static/dynamic reservation in a private `SlotKind` path that owns actor-mailbox attachment and subtree-flavor selection
- make builder and dynamic additions thin concrete wrappers over one generic helper per receiver flavor, preserving definition isolation across eager id/readiness hooks
- record the declaration-matrix ruling in SPEC and keep external conformance checks explicit for every public slot signature

## Decision and tradeoffs

The broad matrix collapse remains rejected. `ActorDef`/`ActorOnceDef`, `RawDef`/`RawOnceDef`, `TaskDef`/`TaskOnceDef`, and `SubtreeDef`/`SubtreeOnceDef` remain nominal public types. Their construction-source bounds, missing one-shot `.restart()` setter, and `TaskOnceDef<T>`'s typed completion handle remain compile-time properties.

The narrower private trait is worthwhile when paired with `SlotKind`: `Definition` alone would only move the same choreography into eight trait impls. Together they reduce sixteen behavior-bearing add bodies to two helpers, six static/dynamic reservation constructors to two generic functions, and remove the endpoint-flavor x definition-mode cross-product from the slot cores. The remaining per-definition impls contain only the irreducible mapping to construction and handle set.

The trait is `pub(super)` and cannot be implemented or named by consumers. Public methods retain concrete definition parameters and concrete return types, preserving rustdoc grouping, autocomplete, inference, and per-kind compiler errors. The three `reserve_*` families also remain public and distinct: actor mailbox type and subtree flavor are fixed before a definition is available.

`api_trait_conformance` intentionally continues spelling out both static and dynamic slot signatures. Shrinking that public inventory would weaken the evidence that the internal generic path did not leak into the API; the test names and comments now state that boundary explicitly.

## Stack / merge order

This draft is stacked on #359 (`agent/review-348-facade`) because it relies on that PR's definition-isolation changes.

1. Merge #359 first.
2. Retarget this PR from `agent/review-348-facade` to `main` (and rebase if GitHub does not carry the stack forward cleanly).
3. Re-run CI, then review/merge this PR.

## Validation

- `./tools/dev cargo nextest run -p shelterwood --test api_trait_conformance --test one_shot_resource_ownership --test dynamic --test raw --test disposal` — 110/110 passed
- `./tools/dev cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`
- `./tools/dev just ci`
  - formatting and warnings-denied Clippy
  - 770/770 nextest tests
  - doctests and rustdoc warnings
  - public API runtime reachability
  - packaged docs and external consumer checks
  - Nix formatting

Closes #353
Tracking #348
