### PR TITLE
Split Part III into permanent exclusions and a chartered utility tier

### DIFF
--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -17,8 +17,10 @@ until it is deliberately amended.
   optional features. Each is individually adoptable, and each names the
   hook Part I already carries so that adopting it later requires no
   redesign of core.
-- **Part III — Exclusions** (§26, [non-core.md](non-core.md)): capabilities
-  that are deliberately never part of the core library.
+- **Part III — Outside the library** (§26–§27,
+  [non-core.md](non-core.md)): capabilities that are deliberately never
+  part of the library, and the utility tier — first-party crates above
+  the library that compose strictly from the public surface.
 
 Section numbering is global across the three documents: a `§N` reference
 resolves to whichever document carries that section, and the conventions
@@ -60,7 +62,7 @@ scenarios.
   - [15. Construction requirements](#15-construction-requirements)
   - [16. Conformance obligations](#16-conformance-obligations)
 - [Part II — Extensions](core-plus.md) (§17–§25, own document)
-- [Part III — Exclusions](non-core.md) (§26, own document)
+- [Part III — Outside the library](non-core.md) (§26–§27, own document)
 - [Appendix A. Normative defaults and bounds](#appendix-a-normative-defaults-and-bounds)
 - [Appendix B. Surface reference](#appendix-b-surface-reference)
 - [Appendix C. Acceptance scenarios](#appendix-c-acceptance-scenarios-informative-in-prose-normative-in-obligation)
@@ -366,7 +368,8 @@ it still retains the same live lineage; a temporary builder never defines
 the ordering domain. Different ids and different owning scope memberships
 remain incomparable. A small routing/registry adapter for planned handoff
 (a `ServiceRef`/route-cell that the application repoints at cutover) is out
-of core (§26) — it must not weaken exact membership identity.
+of core, packaged in the utility tier (§27) — it must not weaken exact
+membership identity.
 
 ## 4. Construction and restart
 

--- a/specs/core-plus.md
+++ b/specs/core-plus.md
@@ -6,7 +6,7 @@ appendices (which span all parts), and the conventions — normative
 language among them — that govern this document unchanged.
 [non-core.md](non-core.md) holds Part III. Section numbering is global
 across the three documents: references below §17 resolve in SPEC.md, and
-§26 resolves in non-core.md.
+§26–§27 resolve in non-core.md.
 
 Every section here is an optional extension of core: individually
 adoptable, in any order except where a section states a dependency, and
@@ -14,6 +14,15 @@ each names the hook Part I already carries for it. A library that ships
 none of them is still complete (Part I's conformance statement); a
 library that ships one MUST meet that section in full, including the
 Part-II-tagged rows of the appendices and the activated clauses of §16.
+
+Each section (or, where it splits, each part) carries a **placement**
+note recording why it sits in Part II rather than Part III. *Internal
+seam* means the feature reaches machinery no public surface exposes and
+can only live in the library. *Public-surface composition* means the
+hook is public API: the section is in Part II as a packaging decision,
+its packaged form MAY ship in the utility tier (§27) rather than as a
+library feature, and its contract and conformance clauses bind unchanged
+wherever it ships.
 
 ## Table of contents
 
@@ -82,6 +91,13 @@ adds the convenience surface:
 
 Activates the pinning clause of obligation §16.2.
 
+**Placement.** Split. `pinned` is an internal seam: fencing a send to
+one incarnation must be checked on the mailbox admission path — a
+check-then-send outside it races with rebind and delivers to the
+successor. The incarnation-after awaitable and `call_idempotent` are
+public-surface compositions over §3.3's tokens, B.3's errors, and the
+lifecycle stream (§27).
+
 ## 18. Keyed conflation: `latest_by_key`
 
 `latest_by_key(capacity, key_fn)` — conflation per key with a bounded key
@@ -109,6 +125,11 @@ urgent-control-under-flood composes from `try_send` plus adequate key
 capacity; per-view conflation machinery is rejected (§19); and the
 state-plane/control-plane split is real — a barrier cannot safely share
 a keyed conflating mailbox with replaceable state.
+
+**Placement.** Internal seam — conflation, eviction, capacity behavior,
+the §5.3 `call` contract, and the counters all live on the mailbox
+admission path; a front-actor emulation adds a hop and changes
+backpressure semantics.
 
 ## 19. Message mapping: `contramap` and `project`
 
@@ -165,7 +186,16 @@ impl<'a, A: Actor + ?Sized> Context<'a, A> {
   which breaks replay-correct durability — a replayed effect message
   both replays and regenerates, running the effect twice. A design that
   works origin-blind has no need of `project`; implementing `project`
-  without such a consumer is unjustified surface.
+  without such a consumer is unjustified surface. Durable actors are
+  the anticipated consumer (§27's durability adapter): a
+  provenance-explicit wrapper — one that journals decided events or
+  provenance-tagged arms, never the raw inbound stream — is not
+  origin-blind, and is the shape of design that could clear the wall.
+
+**Placement.** Internal seam — a mapped ref shares the outer ref's
+identity, mailbox, and stats attribution, which no wrapper actor can
+provide (the forwarding-actor emulation is exactly what this section
+rejects), and `project` operates on `Context` by definition.
 
 ## 20. Peer monitoring
 
@@ -185,6 +215,12 @@ query, transition evidence is available from events without keeping
 application-side history. In core, sibling-failure reaction routes
 through the supervisor (fate-sharing) or lifecycle-stream subscription;
 watch is the in-mailbox refinement.
+
+**Placement.** Public-surface composition — the lifecycle stream, the
+§3.1 primitive, and ordinary sends can implement this contract (the
+immediate-`Started` dedup rides on incarnation tokens), at the cost of a
+per-watch or multiplexed forwarding task; library placement removes the
+hop, no seam requires it. MAY ship in the utility tier (§27).
 
 ## 21. Group strategies: `OneForAll`, `RestForOne`
 
@@ -209,6 +245,10 @@ charge nothing (mode dispatch, §11) — they are part of the drain.
 Respawn is declared-order and readiness-gated, exactly like ordered
 startup (§7). Activates the group clause of obligation §16.9.
 
+**Placement.** Internal seam — atomic intensity charging and drain-mode
+dispatch live in §11's exit funnel; a lifecycle-driven emulation is racy
+and cannot charge the budget atomically.
+
 ## 22. Observation extensions
 
 All adapters over core's two streams and identity types:
@@ -230,6 +270,12 @@ All adapters over core's two streams and identity types:
   choke point as `tracing`; the debugging surface exposes structured
   snapshots rather than name-filtered tuples.
 
+**Placement.** Split. The statistics fields, counters, and message-size
+measurement are an internal seam (counted inside the mailbox and loop,
+B.6), and the `metrics` feature shares `tracing`'s internal choke point;
+every packaged view above the two streams is a public-surface adapter
+and MAY ship in the utility tier (§27).
+
 ## 23. Outline (`serde` feature)
 
 **Purpose.** The outline is a policy-drift fingerprint: a serializable,
@@ -249,9 +295,14 @@ machine, and distribution (§26) will not build on it — a distribution
 layer needs code identity, args transport, and state handoff, and will
 define its own wire format.
 
-**Placement.** If this exists at all it must be a library feature: the
-orphan rule bars downstream crates from implementing `Serialize` for
-library-owned policy types. Feature-gated `serde` derives cost non-users
+**Placement.** Internal seam — if this exists at all it must be a
+library feature, and the binding reason is access, not the orphan rule:
+the outline captures the *resolved* declaration, everything §10.3's
+inheritance machinery decides silently, and no public surface exposes
+that resolution for traversal. (The orphan rule alone would not decide
+it — a downstream crate could mirror the policy types rather than
+implement `Serialize` on library-owned ones, but it would have nothing
+to fill the mirrors with.) Feature-gated `serde` derives cost non-users
 nothing; core's only obligation is the "serializable where §23 needs it"
 clause on the §9 options record (§15.2).
 
@@ -281,6 +332,10 @@ ordering. It is the seam for embedding and for a future
 `!Send`/thread-per-core mode. Activates the hosted-parity clause of
 obligation §16.7.
 
+**Placement.** Internal seam — the feature *is* the incarnation runner,
+exposed; the downstream substitute is hand-written `catch_unwind` and
+teardown, which is exactly what it exists to eliminate.
+
 ## 25. Lifetime and timing conveniences
 
 - **Cross-actor delayed delivery** (`send_after_to` / `interval_to`): a
@@ -294,3 +349,9 @@ obligation §16.7.
 - **Sibling-readiness barrier**: first-class support for a child
   awaiting a *named sibling's* readiness (a scope-relative readiness
   barrier), replacing offload-the-wait plumbing.
+
+**Placement.** Public-surface composition — respectively: an
+incarnation-owned task that sleeps and sends (subject to the target's
+mailbox semantics by construction), `OneShotTaskRef` awaitables composed
+with `shutdown()`, and packaged offload-the-wait. MAY ship in the
+utility tier (§27).

--- a/specs/non-core.md
+++ b/specs/non-core.md
@@ -1,31 +1,35 @@
-# Part III — Exclusions
+# Part III — Outside the library
 
 This document is Part III of the library specification; [SPEC.md](SPEC.md)
 holds Part I — Core (§1–§16), the normative appendices, and the governing
 conventions, and [core-plus.md](core-plus.md) holds Part II (§17–§25).
 Section numbering is global across the three documents.
 
-## 26. Out of core, permanently
+Part III has two sections of different kinds. §26 lists capabilities that
+are never first-party: they live in downstream applications or separate
+projects, or name internal seams that stay unexposed. §27 charters the
+**utility tier**: first-party crates *above* the library that compose
+strictly from the public surface.
 
-These compose from the public surface and live in separate crates (or
-downstream applications), never in core:
+## 26. Out of the library, permanently
+
+These compose from the public surface and live in downstream applications
+or separate projects — never in the library, and never in §27's utility
+tier:
 
 - **Console / dashboard** — a pure consumer of §14/§22: snapshot
   subscription, lifecycle subscription, and recursive actor statistics
   are a sufficient public surface for a full console, which is the
-  evidence it needs nothing from inside the library.
-- **Registries, routers, name-directories** — userland patterns over
-  typed refs; the framework deliberately omits name→ref messaging
-  (§12): snapshots carry ids and states, never senders, and handle
-  `Eq`/`Hash` by slot identity (B.10) is what makes a userland registry
-  ordinary code.
-- **`ServiceRef`/route-cell handoff adapter** (§3.4) and the
-  **transactional handoff helper** (mount/commit/retire hooks over
-  dynamic scopes): the primitives — direct admission handles (§3.2),
-  idempotent and exact-handle removal (§12), the sibling barrier
-  (§25) — are library surface; the orchestration is a utilities crate,
-  and an in-core version would have to weaken exact membership identity
-  to seem convenient (§3.4 forbids that).
+  evidence it needs nothing from inside the library. That evidentiary
+  role is load-bearing: a first-party console would stop proving the
+  observation surface sufficient to outsiders.
+- **Routers and name-directories** — userland patterns over typed refs;
+  the framework deliberately omits name→ref messaging (§12): snapshots
+  carry ids and states, never senders, and handle `Eq`/`Hash` by slot
+  identity (B.10) is what makes a userland registry ordinary code. The
+  one packaged exception is §27's atomic-rebind directory, which
+  internalizes the handoff-fencing subtleties without adding name→ref
+  messaging to core.
 - **Distribution / remote refs** — a proxy-actor layer over the network,
   not a core capability: it needs code identity, args transport, state
   handoff, and its own wire format and failure model, none of which core
@@ -37,9 +41,52 @@ downstream applications), never in core:
   at-most-once with no hidden buffering (§1 principle 6); durability
   changes mailbox semantics, requires storage the library deliberately
   does not prescribe (§3.3's ledger rule), and belongs to the
-  application or an adapter above the library.
+  application or an adapter above the library. The delivery-model
+  exclusion is permanent; the adapter's seams are §27's durability
+  entry.
 - **Pluggable scheduler as public API** — scheduling remains an internal
   seam behind the runtime façade (§15.1); a public pluggability surface
   would freeze internal execution contracts as API and is adopted, if
   ever, only behind demonstrated performance need (§15.6's
   measure-first posture).
+
+## 27. The utility tier
+
+First-party crates above the library, composing strictly from the public
+surface. A utility crate MUST depend only on the supported `shelterwood`
+façade, never on an internal crate: that dependency edge is the
+structural proof that everything here remains buildable by any consumer,
+and that nothing here can invalidate an internal ruling (the lock rule's
+seam exemptions included). The tier exists to internalize subtle
+constructions once — safety and ergonomics, not capability — and its
+items are eventually re-exported through a prelude. A Part II section
+whose placement note reads *public-surface composition* MAY ship here
+instead of as a library feature; its contract and conformance clauses
+bind unchanged wherever it ships.
+
+- **Transactional handoff helper and `ServiceRef`/route-cell adapter**
+  (§3.4) — the primitives (direct admission handles §3.2, idempotent and
+  exact-handle removal §12, the sibling barrier §25) are library
+  surface; the orchestration — mount → readiness → directory cutover →
+  exact-handle retire, with idempotent operation ids, compensating
+  cleanup, and the crash-window fence — is the utility crate. An
+  in-library version would have to weaken exact membership identity to
+  seem convenient (§3.4 forbids that). Acceptance scenario 1 builds this
+  construction as test userland; the packaged form is its extraction,
+  and scenario 1 doubles as its integration proof.
+- **Atomic-rebind directory** — the registry a planned handoff cuts
+  over: atomic rebind plus stale-handle fencing via incarnation tokens
+  (§3.3). Core's omission of name→ref messaging (§12) stands unchanged;
+  the directory is packaged because its fencing is subtle enough that
+  every consumer would otherwise re-derive it, and because the handoff
+  helper above needs a directory to cut over.
+- **Durability adapter** *(design-gated)* — storage-agnostic journal
+  seams and the journal/ack redelivery boundary (acceptance scenario 5's
+  shape), plus the provenance-explicit durable-actor construction §19
+  anticipates: a wrapper that journals decided events or
+  provenance-tagged arms, never the raw inbound message stream. It
+  changes nothing about core's delivery model (§26) and prescribes no
+  storage (§3.3's ledger rule). This entry reserves placement, not
+  surface: a design round must first clear §19's provenance wall, and
+  that consumer — if its design genuinely needs cross-`Msg` context
+  mapping — is what would justify implementing `project`.


### PR DESCRIPTION
Spec-only restructure recording the placement decisions from today's discussion. No implementation — the utility tier stays empty until after the docs-hardening and Part II rounds.

## Part III (`specs/non-core.md`)

- Retitled **Outside the library**; §26 keeps only the permanent verdicts (console, routers/name-directories, distribution, durable at-least-once *delivery semantics*, pluggable scheduler), each with its exclusion rationale intact.
- New **§27 The utility tier**: first-party crates above the library. One normative rule — a utility crate MUST depend only on the supported `shelterwood` façade, never an internal crate — so "remains buildable by any consumer" and "cannot invalidate an internal ruling" are structural, not conventional. Entries:
  - **Transactional handoff helper + `ServiceRef`/route-cell adapter** — moved from §26, which already called its orchestration "a utilities crate"; acceptance scenario 1 (`acceptance_shard_store.rs`) is named as its incubator and integration proof.
  - **Atomic-rebind directory** — packaged for the fencing subtleties; §12's omission of name→ref messaging in core explicitly stands.
  - **Durability adapter** *(design-gated)* — storage-agnostic journal/ack seams (scenario 5's shape) plus the provenance-explicit durable-actor construction; reserves placement only, and names §19's provenance wall as the design bar (and the eventual justification for `project`, if its design needs cross-`Msg` context mapping).

## Part II (`specs/core-plus.md`)

- Every section now carries a **Placement** note: *internal seam* (§18, §19, §21, §23, §24) vs *public-surface composition*, which MAY ship in the utility tier (§20, §25), with splits where a section divides (§17: `pinned` is a seam, the awaitable and `call_idempotent` compose; §22: counters/measurement/metrics choke point are seams, the packaged views compose).
- §19 names durable actors as the anticipated `project` consumer and states the shape that could clear the wall (journal decided events or provenance-tagged arms, never the raw inbound stream).
- §23's placement argument corrected to the binding reason: no public surface exposes the *resolved* declaration for traversal — the orphan rule alone is sidestepped by mirror types.

## SPEC.md

Structure paragraph, ToC, and the §3.4 `ServiceRef` cross-reference updated to §27; §1 principle 6's durable-delivery reference correctly stays §26. No code references §26–§27, and specs are not in the packaged-docs sync set, so the change is self-contained.

`just ci` passes locally.