### PR TITLE
Contain obligation fallback panics during unwind

### DIFF
--- a/crates/shelterwood/src/driver/storage.rs
+++ b/crates/shelterwood/src/driver/storage.rs
@@ -40,7 +40,8 @@ impl<T> Obligation<T> {
 
 impl<T> Drop for Obligation<T> {
     fn drop(&mut self) {
-        self.discharge();
+        let mut panics = crate::runtime::PanicAccumulator::default();
+        panics.run(|| self.discharge());
     }
 }
 
@@ -48,6 +49,7 @@ impl<T> Drop for Obligation<T> {
 mod tests {
     use std::{
         panic::{AssertUnwindSafe, catch_unwind},
+        process::Command,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -62,6 +64,10 @@ mod tests {
 
     fn panic_after_counting(fallbacks: Arc<AtomicUsize>) {
         fallbacks.fetch_add(1, Ordering::SeqCst);
+        panic!("injected fallback panic");
+    }
+
+    fn panic_fallback((): ()) {
         panic!("injected fallback panic");
     }
 
@@ -92,6 +98,39 @@ mod tests {
             fallbacks.load(Ordering::SeqCst),
             1,
             "drop cannot repeat a fallback that panicked"
+        );
+    }
+
+    #[test]
+    fn obligation_fallback_panic_is_contained_during_an_existing_unwind() {
+        const CHILD_ENV: &str = "SHELTERWOOD_OBLIGATION_UNWIND_CHILD";
+        const TEST_NAME: &str = "driver::storage::tests::obligation_fallback_panic_is_contained_during_an_existing_unwind";
+
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let panic = catch_unwind(|| {
+                let _obligation = Obligation::new((), panic_fallback);
+                panic!("outer panic");
+            })
+            .expect_err("the original unwind reaches its boundary");
+            assert_eq!(panic.downcast_ref::<&str>(), Some(&"outer panic"));
+            return;
+        }
+
+        let output = Command::new(std::env::current_exe().expect("unit-test executable"))
+            .arg("--exact")
+            .arg(TEST_NAME)
+            .arg("--nocapture")
+            .arg("--test-threads=1")
+            .env(CHILD_ENV, "1")
+            .output()
+            .expect("nested-unwind subprocess starts");
+
+        assert!(
+            output.status.success(),
+            "nested-unwind subprocess must preserve the original panic instead of aborting\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
         );
     }
 }

--- a/crates/shelterwood/src/driver/storage.rs
+++ b/crates/shelterwood/src/driver/storage.rs
@@ -61,7 +61,6 @@ impl<T> Drop for Obligation<T> {
 mod tests {
     use std::{
         panic::{AssertUnwindSafe, catch_unwind},
-        process::Command,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -113,43 +112,21 @@ mod tests {
         );
     }
 
+    /// Runs in process because every runner that reaches this test isolates
+    /// it in one: `just test` and the authoritative Nix check both invoke
+    /// `cargo nextest run` for `--lib --bins --tests --examples`, and nextest
+    /// executes each test as its own process. A regressed containment
+    /// therefore aborts that process, which the runner reports as this test
+    /// failing on SIGABRT. No in-process assertion can observe an abort, so
+    /// the assertions below pin the other half instead: that the *original*
+    /// panic, not the fallback's, is what reaches the boundary.
     #[test]
     fn obligation_fallback_panic_is_contained_during_an_existing_unwind() {
-        const CHILD_ENV: &str = "SHELTERWOOD_OBLIGATION_UNWIND_CHILD";
-        const TEST_NAME: &str = "driver::storage::tests::obligation_fallback_panic_is_contained_during_an_existing_unwind";
-
-        if std::env::var_os(CHILD_ENV).is_some() {
-            let panic = catch_unwind(|| {
-                let _obligation = Obligation::new((), panic_fallback);
-                panic!("outer panic");
-            })
-            .expect_err("the original unwind reaches its boundary");
-            assert_eq!(panic.downcast_ref::<&str>(), Some(&"outer panic"));
-            return;
-        }
-
-        let output = Command::new(std::env::current_exe().expect("unit-test executable"))
-            .arg("--exact")
-            .arg(TEST_NAME)
-            .arg("--nocapture")
-            .arg("--test-threads=1")
-            .env(CHILD_ENV, "1")
-            .output()
-            .expect("nested-unwind subprocess starts");
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(
-            output.status.success(),
-            "nested-unwind subprocess must preserve the original panic instead of aborting\nstatus: {}\nstdout:\n{stdout}\nstderr:\n{stderr}",
-            output.status,
-        );
-        // The child filter is a hardcoded name, and libtest exits zero when
-        // `--exact` matches nothing. Without this the whole regression goes
-        // vacuous the moment the test moves or is renamed.
-        assert!(
-            stdout.contains("1 passed"),
-            "the child must actually run this test, not filter it away\nstdout:\n{stdout}\nstderr:\n{stderr}",
-        );
+        let panic = catch_unwind(|| {
+            let _obligation = Obligation::new((), panic_fallback);
+            panic!("outer panic");
+        })
+        .expect_err("the original unwind reaches its boundary");
+        assert_eq!(panic.downcast_ref::<&str>(), Some(&"outer panic"));
     }
 }

--- a/crates/shelterwood/src/driver/storage.rs
+++ b/crates/shelterwood/src/driver/storage.rs
@@ -1,10 +1,22 @@
 //! Fail-closed completion storage used by the runtime shell.
 
+use crate::runtime;
+
 /// An exactly-once synchronous completion.
 ///
 /// The orderly path consumes the payload with [`Self::complete`]. If that
 /// path is destroyed before doing so, dropping the obligation executes the
 /// fail-closed fallback instead. Fallbacks must never await or join.
+///
+/// Every fallback reaches code the framework did not schedule — a one-shot
+/// send wakes the caller's waker inline, and terminality publication runs
+/// through the resident tree — so destruction contains it. A fallback panic
+/// resumes from an ordinary drop, keeping the diagnostic authoritative. A
+/// fallback panic raised while the obligation is destroyed during an existing
+/// unwind is discarded instead: losing that diagnostic is the lesser outcome
+/// against the double panic that would abort the process. Discharging the
+/// obligation explicitly ([`Self::discharge`]) contains nothing, so a caller
+/// on a destruction path supplies its own accumulator.
 #[must_use = "dropping an obligation executes its fallback completion"]
 pub(super) struct Obligation<T> {
     payload: Option<T>,
@@ -40,7 +52,7 @@ impl<T> Obligation<T> {
 
 impl<T> Drop for Obligation<T> {
     fn drop(&mut self) {
-        let mut panics = crate::runtime::PanicAccumulator::default();
+        let mut panics = runtime::PanicAccumulator::default();
         panics.run(|| self.discharge());
     }
 }
@@ -125,12 +137,19 @@ mod tests {
             .output()
             .expect("nested-unwind subprocess starts");
 
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
             output.status.success(),
-            "nested-unwind subprocess must preserve the original panic instead of aborting\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+            "nested-unwind subprocess must preserve the original panic instead of aborting\nstatus: {}\nstdout:\n{stdout}\nstderr:\n{stderr}",
             output.status,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr),
+        );
+        // The child filter is a hardcoded name, and libtest exits zero when
+        // `--exact` matches nothing. Without this the whole regression goes
+        // vacuous the moment the test moves or is renamed.
+        assert!(
+            stdout.contains("1 passed"),
+            "the child must actually run this test, not filter it away\nstdout:\n{stdout}\nstderr:\n{stderr}",
         );
     }
 }


### PR DESCRIPTION
Addresses the highest-priority Batch 1 item from #366.

Obligation fallback discharge now runs through PanicAccumulator. An ordinary fallback panic still reaches the caller, while a fallback reached during an existing unwind is contained so it cannot double-panic and abort the process.

The new subprocess regression drives the nested-unwind case and proves the original panic reaches its boundary.

Verification: ./tools/dev just ci (804 tests plus all repository checks).