### PR TITLE
Contain completed output destruction in panic boundary

### DIFF
--- a/crates/shelterwood/src/raw/disposal.rs
+++ b/crates/shelterwood/src/raw/disposal.rs
@@ -43,7 +43,10 @@ impl<F: Future> Future for CatchUnwindFuture<F> {
                 let future = this.future.take();
                 match catch_panic(|| drop(future)) {
                     Ok(()) => Poll::Ready(Ok(value)),
-                    Err(payload) => Poll::Ready(Err(payload)),
+                    Err(payload) => {
+                        discard_panic(catch_panic(|| drop(value)).err());
+                        Poll::Ready(Err(payload))
+                    }
                 }
             }
             Ok(Poll::Pending) => Poll::Pending,
@@ -179,5 +182,193 @@ impl<T> Drop for Contained<T> {
         if let Some(value) = self.value.take() {
             self.disposal.dispose(value);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::Future,
+        panic::panic_any,
+        pin::Pin,
+        process::Command,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        task::{Context, Poll, Waker},
+    };
+
+    use super::{CatchUnwindFuture, PanicPayload, discard_panic};
+
+    struct PanickingOutput {
+        drops: Arc<AtomicUsize>,
+    }
+
+    impl Drop for PanickingOutput {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::SeqCst);
+            panic!("injected output destructor panic");
+        }
+    }
+
+    struct RecursivelyPanickingPayload;
+
+    impl Drop for RecursivelyPanickingPayload {
+        fn drop(&mut self) {
+            panic_any(RecursivelyPanickingPayload);
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum FutureDropPayload {
+        Message,
+        Recursive,
+    }
+
+    struct ReadyThenDropPanics {
+        output: Option<PanickingOutput>,
+        drops: Arc<AtomicUsize>,
+        payload: FutureDropPayload,
+    }
+
+    impl Future for ReadyThenDropPanics {
+        type Output = PanickingOutput;
+
+        fn poll(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Ready(self.output.take().expect("the test future is polled once"))
+        }
+    }
+
+    impl Drop for ReadyThenDropPanics {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::SeqCst);
+            match self.payload {
+                FutureDropPayload::Message => panic!("injected future destructor panic"),
+                FutureDropPayload::Recursive => panic_any(RecursivelyPanickingPayload),
+            }
+        }
+    }
+
+    struct PollThenDropPanics {
+        drops: Arc<AtomicUsize>,
+    }
+
+    impl Future for PollThenDropPanics {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+            panic!("injected poll panic");
+        }
+    }
+
+    impl Drop for PollThenDropPanics {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::SeqCst);
+            panic!("injected future destructor panic");
+        }
+    }
+
+    fn ready_error<T>(polled: Poll<Result<T, PanicPayload>>) -> PanicPayload {
+        match polled {
+            Poll::Ready(Err(payload)) => payload,
+            Poll::Ready(Ok(_)) => panic!("the hostile future unexpectedly succeeded"),
+            Poll::Pending => panic!("the hostile future unexpectedly remained pending"),
+        }
+    }
+
+    fn panic_message(payload: &PanicPayload) -> Option<&str> {
+        payload
+            .downcast_ref::<&'static str>()
+            .copied()
+            .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+    }
+
+    #[test]
+    fn completed_future_drop_panic_wins_and_output_drop_is_contained() {
+        let future_drops = Arc::new(AtomicUsize::new(0));
+        let output_drops = Arc::new(AtomicUsize::new(0));
+        let mut boundary = Box::pin(CatchUnwindFuture::new(ReadyThenDropPanics {
+            output: Some(PanickingOutput {
+                drops: Arc::clone(&output_drops),
+            }),
+            drops: Arc::clone(&future_drops),
+            payload: FutureDropPayload::Message,
+        }));
+
+        let payload = ready_error(
+            boundary
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop())),
+        );
+        assert_eq!(
+            panic_message(&payload),
+            Some("injected future destructor panic")
+        );
+        discard_panic(Some(payload));
+        assert_eq!(future_drops.load(Ordering::SeqCst), 1);
+        assert_eq!(output_drops.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn poll_panic_wins_and_future_drop_panic_is_contained() {
+        let future_drops = Arc::new(AtomicUsize::new(0));
+        let mut boundary = Box::pin(CatchUnwindFuture::new(PollThenDropPanics {
+            drops: Arc::clone(&future_drops),
+        }));
+
+        let payload = ready_error(
+            boundary
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop())),
+        );
+        assert_eq!(panic_message(&payload), Some("injected poll panic"));
+        discard_panic(Some(payload));
+        assert_eq!(future_drops.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn hostile_output_cannot_abort_while_a_hostile_future_panic_is_retained() {
+        const CHILD_ENV: &str = "SHELTERWOOD_CATCH_UNWIND_OUTPUT_CHILD";
+        const TEST_NAME: &str = "raw::disposal::tests::hostile_output_cannot_abort_while_a_hostile_future_panic_is_retained";
+
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let future_drops = Arc::new(AtomicUsize::new(0));
+            let output_drops = Arc::new(AtomicUsize::new(0));
+            let mut boundary = Box::pin(CatchUnwindFuture::new(ReadyThenDropPanics {
+                output: Some(PanickingOutput {
+                    drops: Arc::clone(&output_drops),
+                }),
+                drops: Arc::clone(&future_drops),
+                payload: FutureDropPayload::Recursive,
+            }));
+
+            let payload = ready_error(
+                boundary
+                    .as_mut()
+                    .poll(&mut Context::from_waker(Waker::noop())),
+            );
+            discard_panic(Some(payload));
+            assert_eq!(future_drops.load(Ordering::SeqCst), 1);
+            assert_eq!(output_drops.load(Ordering::SeqCst), 1);
+            return;
+        }
+
+        let output = Command::new(std::env::current_exe().expect("unit-test executable"))
+            .arg("--exact")
+            .arg(TEST_NAME)
+            .arg("--nocapture")
+            .arg("--test-threads=1")
+            .env(CHILD_ENV, "1")
+            .output()
+            .expect("hostile-output subprocess starts");
+
+        assert!(
+            output.status.success(),
+            "hostile-output subprocess must return the retained panic instead of aborting\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
     }
 }

--- a/crates/shelterwood/src/raw/disposal.rs
+++ b/crates/shelterwood/src/raw/disposal.rs
@@ -329,10 +329,15 @@ mod tests {
     }
 
     /// Both destructors here are hostile: the output panics, and the retained
-    /// future-destructor payload panics again when it is dropped. Combining
-    /// them uncontained is an abort, which needs no subprocess harness to
-    /// observe — nextest gives every test its own process, so the abort is
-    /// this test's own failure signal rather than a poisoned run.
+    /// future-destructor payload panics again when it is dropped. Uncontained,
+    /// that pair does not abort — the output destructor's panic escapes `poll`,
+    /// inverting the documented precedence, and the retained payload leaks
+    /// rather than double-panicking, because an unwinding function never drops
+    /// its return place. An escaping panic is an ordinary caught failure, so
+    /// the assertions below are the signal and no subprocess is needed. Should
+    /// a future regression turn this pair into a genuine double panic, nextest
+    /// gives every test its own process, so the abort would still be this
+    /// test's own failure rather than a poisoned run.
     #[test]
     fn hostile_output_destructor_cannot_escape_while_a_hostile_future_panic_is_retained() {
         let future_drops = Arc::new(AtomicUsize::new(0));
@@ -450,6 +455,11 @@ mod tests {
         assert_eq!(future_drops.load(Ordering::SeqCst), 1);
     }
 
+    /// The one genuine abort in this module: uncontained, the inner
+    /// destructor's panic lands inside the primary unwind, which is a
+    /// non-unwinding double panic rather than a catchable failure. Nextest's
+    /// process-per-test isolation is what makes that abort this test's own
+    /// signal, so no subprocess harness is needed here either.
     #[test]
     fn a_boundary_dropped_during_an_unwind_contains_its_future_destructor_panic() {
         let future_drops = Arc::new(AtomicUsize::new(0));

--- a/crates/shelterwood/src/raw/disposal.rs
+++ b/crates/shelterwood/src/raw/disposal.rs
@@ -193,7 +193,6 @@ mod tests {
         future::Future,
         panic::panic_any,
         pin::Pin,
-        process::Command,
         sync::{
             Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
@@ -329,55 +328,38 @@ mod tests {
         assert_eq!(future_drops.load(Ordering::SeqCst), 1);
     }
 
+    /// Both destructors here are hostile: the output panics, and the retained
+    /// future-destructor payload panics again when it is dropped. Combining
+    /// them uncontained is an abort, which needs no subprocess harness to
+    /// observe — nextest gives every test its own process, so the abort is
+    /// this test's own failure signal rather than a poisoned run.
     #[test]
     fn hostile_output_destructor_cannot_escape_while_a_hostile_future_panic_is_retained() {
-        const CHILD_ENV: &str = "SHELTERWOOD_CATCH_UNWIND_OUTPUT_CHILD";
-        const TEST_NAME: &str = "raw::disposal::tests::hostile_output_destructor_cannot_escape_while_a_hostile_future_panic_is_retained";
+        let future_drops = Arc::new(AtomicUsize::new(0));
+        let output_drops = Arc::new(AtomicUsize::new(0));
+        let mut boundary = Box::pin(CatchUnwindFuture::new(ReadyThenDropPanics {
+            output: Some(PanickingOutput {
+                drops: Arc::clone(&output_drops),
+            }),
+            drops: Arc::clone(&future_drops),
+            payload: FutureDropPayload::Recursive,
+        }));
 
-        if std::env::var_os(CHILD_ENV).is_some() {
-            let future_drops = Arc::new(AtomicUsize::new(0));
-            let output_drops = Arc::new(AtomicUsize::new(0));
-            let mut boundary = Box::pin(CatchUnwindFuture::new(ReadyThenDropPanics {
-                output: Some(PanickingOutput {
-                    drops: Arc::clone(&output_drops),
-                }),
-                drops: Arc::clone(&future_drops),
-                payload: FutureDropPayload::Recursive,
-            }));
-
-            let payload = ready_error(
-                boundary
-                    .as_mut()
-                    .poll(&mut Context::from_waker(Waker::noop())),
-            );
-            discard_panic(Some(payload));
-            assert_eq!(future_drops.load(Ordering::SeqCst), 1);
-            assert_eq!(output_drops.load(Ordering::SeqCst), 1);
-            return;
-        }
-
-        let output = Command::new(std::env::current_exe().expect("unit-test executable"))
-            .arg("--exact")
-            .arg(TEST_NAME)
-            .arg("--nocapture")
-            .arg("--test-threads=1")
-            .env(CHILD_ENV, "1")
-            .output()
-            .expect("hostile-output subprocess starts");
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(
-            output.status.success(),
-            "hostile-output subprocess must return the retained panic instead of escaping the boundary\nstatus: {}\nstdout:\n{stdout}\nstderr:\n{}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr),
+        let payload = ready_error(
+            boundary
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop())),
         );
-        // A filter matching nothing is a passing libtest run, so the status
-        // check alone goes vacuous the moment this test is renamed or moved.
+        // Establish the verdict before disposing of the payload: this one
+        // cannot be dropped by an assertion's own unwind.
+        let future_payload_survived = payload.is::<RecursivelyPanickingPayload>();
+        discard_panic(Some(payload));
         assert!(
-            stdout.contains("1 passed"),
-            "the subprocess must actually run {TEST_NAME}\nstdout:\n{stdout}",
+            future_payload_survived,
+            "the retained future-destructor payload must survive the hostile output destructor"
         );
+        assert_eq!(future_drops.load(Ordering::SeqCst), 1);
+        assert_eq!(output_drops.load(Ordering::SeqCst), 1);
     }
 
     struct LoggedDrop {

--- a/crates/shelterwood/src/raw/disposal.rs
+++ b/crates/shelterwood/src/raw/disposal.rs
@@ -13,7 +13,9 @@ use crate::runtime::{PanicAccumulator, PanicPayload, Signal, catch_panic, discar
 ///
 /// Once the inner future returns `Ready`, it is destroyed before the output is
 /// released. If that destruction panics, the already-produced output is
-/// discarded and the destructor panic becomes this future's error.
+/// discarded and the destructor panic becomes this future's error. Discarding
+/// is itself contained: a hostile output destructor's own panic is swallowed
+/// rather than replacing the retained destructor panic or escaping the poll.
 pub(crate) struct CatchUnwindFuture<F> {
     future: Option<Pin<Box<F>>>,
 }
@@ -193,13 +195,13 @@ mod tests {
         pin::Pin,
         process::Command,
         sync::{
-            Arc,
+            Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
         },
         task::{Context, Poll, Waker},
     };
 
-    use super::{CatchUnwindFuture, PanicPayload, discard_panic};
+    use super::{CatchUnwindFuture, PanicPayload, catch_panic, discard_panic};
 
     struct PanickingOutput {
         drops: Arc<AtomicUsize>,
@@ -328,9 +330,9 @@ mod tests {
     }
 
     #[test]
-    fn hostile_output_cannot_abort_while_a_hostile_future_panic_is_retained() {
+    fn hostile_output_destructor_cannot_escape_while_a_hostile_future_panic_is_retained() {
         const CHILD_ENV: &str = "SHELTERWOOD_CATCH_UNWIND_OUTPUT_CHILD";
-        const TEST_NAME: &str = "raw::disposal::tests::hostile_output_cannot_abort_while_a_hostile_future_panic_is_retained";
+        const TEST_NAME: &str = "raw::disposal::tests::hostile_output_destructor_cannot_escape_while_a_hostile_future_panic_is_retained";
 
         if std::env::var_os(CHILD_ENV).is_some() {
             let future_drops = Arc::new(AtomicUsize::new(0));
@@ -363,12 +365,125 @@ mod tests {
             .output()
             .expect("hostile-output subprocess starts");
 
+        let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
             output.status.success(),
-            "hostile-output subprocess must return the retained panic instead of aborting\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+            "hostile-output subprocess must return the retained panic instead of escaping the boundary\nstatus: {}\nstdout:\n{stdout}\nstderr:\n{}",
             output.status,
-            String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr),
         );
+        // A filter matching nothing is a passing libtest run, so the status
+        // check alone goes vacuous the moment this test is renamed or moved.
+        assert!(
+            stdout.contains("1 passed"),
+            "the subprocess must actually run {TEST_NAME}\nstdout:\n{stdout}",
+        );
+    }
+
+    struct LoggedDrop {
+        label: &'static str,
+        log: DropLog,
+    }
+
+    impl Drop for LoggedDrop {
+        fn drop(&mut self) {
+            self.log
+                .lock()
+                .expect("drop log mutex poisoned")
+                .push(self.label);
+        }
+    }
+
+    type DropLog = Arc<Mutex<Vec<&'static str>>>;
+
+    fn drop_log_entries(log: &DropLog) -> Vec<&'static str> {
+        log.lock().expect("drop log mutex poisoned").clone()
+    }
+
+    struct ReadyThenLogsDrop {
+        output: Option<LoggedDrop>,
+        log: DropLog,
+    }
+
+    impl Future for ReadyThenLogsDrop {
+        type Output = LoggedDrop;
+
+        fn poll(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Ready(self.output.take().expect("the test future is polled once"))
+        }
+    }
+
+    impl Drop for ReadyThenLogsDrop {
+        fn drop(&mut self) {
+            self.log
+                .lock()
+                .expect("drop log mutex poisoned")
+                .push("future");
+        }
+    }
+
+    #[test]
+    fn a_completed_future_is_destroyed_once_before_its_output_is_released() {
+        let log: DropLog = Arc::new(Mutex::new(Vec::new()));
+        let mut boundary = Box::pin(CatchUnwindFuture::new(ReadyThenLogsDrop {
+            output: Some(LoggedDrop {
+                label: "output",
+                log: Arc::clone(&log),
+            }),
+            log: Arc::clone(&log),
+        }));
+
+        let output = match boundary
+            .as_mut()
+            .poll(&mut Context::from_waker(Waker::noop()))
+        {
+            Poll::Ready(Ok(output)) => output,
+            Poll::Ready(Err(_)) => panic!("the clean future must not report a panic"),
+            Poll::Pending => panic!("the clean future completes on its first poll"),
+        };
+        assert_eq!(
+            drop_log_entries(&log),
+            vec!["future"],
+            "the inner future is destroyed exactly once, before the output is released"
+        );
+
+        drop(output);
+        assert_eq!(drop_log_entries(&log), vec!["future", "output"]);
+    }
+
+    #[test]
+    fn an_unpolled_boundary_resumes_its_future_destructor_panic_from_drop_glue() {
+        let future_drops = Arc::new(AtomicUsize::new(0));
+        let boundary = CatchUnwindFuture::new(PollThenDropPanics {
+            drops: Arc::clone(&future_drops),
+        });
+
+        let payload = catch_panic(|| drop(boundary))
+            .expect_err("drop glue resumes the inner destructor panic outside an unwind");
+        assert_eq!(
+            panic_message(&payload),
+            Some("injected future destructor panic")
+        );
+        discard_panic(Some(payload));
+        assert_eq!(future_drops.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn a_boundary_dropped_during_an_unwind_contains_its_future_destructor_panic() {
+        let future_drops = Arc::new(AtomicUsize::new(0));
+        let payload = catch_panic({
+            let future_drops = Arc::clone(&future_drops);
+            move || {
+                let _boundary = CatchUnwindFuture::new(PollThenDropPanics {
+                    drops: future_drops,
+                });
+                panic!("injected primary panic");
+            }
+        })
+        .expect_err("the primary panic reaches the boundary");
+
+        assert_eq!(panic_message(&payload), Some("injected primary panic"));
+        discard_panic(Some(payload));
+        assert_eq!(future_drops.load(Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
Addresses the `CatchUnwindFuture` Batch 1 item from #366.

When a completed inner future panics during destruction, the already-produced output is now destroyed inside containment before the future-destructor panic is returned.

**Corrected justification (the original "abort class" framing does not hold).** Reverting the fix on a committed tree and driving the hostile-output/hostile-payload combination in a subprocess produces **exit 101, not SIGABRT**: when the output destructor panics, the retained payload has already moved into the return place, and Rust never drops the return place of an unwinding function, so the payload is *leaked* rather than double-dropped. The real pre-fix defects, both fixed here, are:

1. **Precedence inversion with an escape.** The output-destructor panic unwound out of `poll` instead of the documented future-destructor panic becoming the error — contradicting the type's own rustdoc. At `raw/definition.rs:253` that escape skips mailbox freeze, resource join and the ordered epilogue; at `driver/child.rs:580` it skips `report.record(...)`.
2. **A leaked panic payload** on that same escape.

The hostile-destructor pair is now a plain in-process test. Nextest runs every test in its own process and every workspace lane reaches the unit tests through it, so a double-panic abort already fails exactly one test — the subprocess harness was re-implementing that isolation, and its stale-name guard existed only to keep the harness honest. Collapsing it also lets the test identify the *surviving payload*, which it could not do across a process boundary, so it now discriminates an inverted precedence too.

**Coverage.** Both poll arms are pinned for containment *and* precedence; the doc's ordering promise (a clean inner future destroyed exactly once before the output is released) and the drop-glue accumulator (resumes outside an unwind, contains during one) are pinned too.

**Verification.** `./tools/dev just ci` on the first commit (806 tests plus all repository checks). On the follow-up commits: 559/559 `-p shelterwood`, `just fmt`, clippy clean, plus a mutation battery in which each mutation is caught by the intended test — revert the fix; invert the Ok-arm precedence; invert the Err-arm precedence; bare drop in the Err arm; skip the Ok-arm future destruction; drop glue discarding instead of resuming; drop glue dropping bare (SIGABRT).

