### PR TITLE
Contain mailbox deadline and receiver retirement

### DIFF
--- a/crates/shelterwood-mailbox/src/capability.rs
+++ b/crates/shelterwood-mailbox/src/capability.rs
@@ -158,41 +158,58 @@ pub(crate) fn dispose<T: Send + 'static>(runtime: &Arc<dyn MailboxRuntime>, valu
 
 /// Receive state that keeps an unclaimed user value out of holder drop glue.
 pub(crate) struct DisposingReceiver<T> {
-    inner: OneShotReceiver<T>,
+    inner: Option<OneShotReceiver<T>>,
     runtime: Arc<dyn MailboxRuntime>,
 }
 
 impl<T: Send + 'static> DisposingReceiver<T> {
     pub(crate) fn new(inner: OneShotReceiver<T>, runtime: Arc<dyn MailboxRuntime>) -> Self {
-        Self { inner, runtime }
+        Self {
+            inner: Some(inner),
+            runtime,
+        }
     }
 }
 
 impl<T> DisposingReceiver<T> {
+    fn inner_mut(&mut self) -> &mut OneShotReceiver<T> {
+        self.inner
+            .as_mut()
+            .expect("a live disposing receiver retains its channel")
+    }
+
     pub(crate) fn runtime(&self) -> Arc<dyn MailboxRuntime> {
         Arc::clone(&self.runtime)
     }
 
     pub(crate) fn close(&mut self) {
-        self.inner.close();
+        self.inner_mut().close();
     }
 }
 
 impl<T: Send + 'static> DisposingReceiver<T> {
     pub(crate) fn poll_receive(&mut self, context: &mut Context<'_>) -> Poll<Option<T>> {
-        self.inner.poll_receive(context)
+        self.inner_mut().poll_receive(context)
     }
 
     pub(crate) fn close_and_poll_receive(&mut self, context: &mut Context<'_>) -> OneShotClose<T> {
-        self.inner.close_and_poll_receive(context)
+        self.inner_mut().close_and_poll_receive(context)
     }
 }
 
 impl<T> Drop for DisposingReceiver<T> {
     fn drop(&mut self) {
-        if let Some(value) = self.inner.close_and_take_erased() {
+        let mut inner = self
+            .inner
+            .take()
+            .expect("a live disposing receiver retains its channel");
+        let mut value = None;
+        let mut panics = crate::panic::PanicAccumulator::default();
+        panics.run(|| value = inner.close_and_take_erased());
+        if let Some(value) = value {
             self.runtime.dispose(value);
         }
+        panics.run(|| drop(inner));
     }
 }
 

--- a/crates/shelterwood-mailbox/src/capability.rs
+++ b/crates/shelterwood-mailbox/src/capability.rs
@@ -205,10 +205,23 @@ impl<T> Drop for DisposingReceiver<T> {
             .expect("a live disposing receiver retains its channel");
         let mut value = None;
         let mut panics = crate::panic::PanicAccumulator::default();
+        // Recovery runs first so an unclaimed value reaches isolated disposal
+        // before the receiver -- and therefore before the waker clone it
+        // registered -- is retired; a hostile waker destructor can neither
+        // divert nor destroy it. If recovery itself unwinds, the value stays
+        // in the channel and `inner`'s own drop glue destroys it inline
+        // rather than through the isolated lane: accepted, because reaching
+        // it requires a destructor that has already panicked, and the
+        // alternative is retrying a step that just failed.
         panics.run(|| value = inner.close_and_take_erased());
-        if let Some(value) = value {
-            self.runtime.dispose(value);
-        }
+        // `dispose` can fall back to destroying the value on this thread when
+        // task and native-thread creation are exhausted, so submission belongs
+        // inside the boundary too.
+        panics.run(|| {
+            if let Some(value) = value {
+                self.runtime.dispose(value);
+            }
+        });
         panics.run(|| drop(inner));
     }
 }

--- a/crates/shelterwood-mailbox/src/deadline.rs
+++ b/crates/shelterwood-mailbox/src/deadline.rs
@@ -111,7 +111,24 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             this.operation
                 .poll_deadlined(context, budget, DeadlinePhase::InitialAttempt)
         {
-            this.timer = None;
+            // Completion retires the wheel entry here, and only here: a
+            // future held past its result would otherwise keep a timer armed
+            // with a clone of the caller's waker and deliver that expiry to a
+            // caller who already has its answer. Retirement must therefore be
+            // synchronous -- handing the timer to isolated disposal leaves the
+            // entry armed until a worker thread reaches it, which is the
+            // spurious wake this exists to prevent.
+            //
+            // A `RawWaker` vtable is caller code, and `result` -- which may
+            // own a user value -- is a live local across that destructor. A
+            // resuming boundary would destroy the completed output instead of
+            // returning it, and a hostile output destructor would turn that
+            // into a double panic and a process abort, so the panic is
+            // contained rather than resumed: a delivered result outranks a
+            // waker-cleanup diagnostic. This is the precedence
+            // `CatchUnwindFuture`'s completed-output arm already applies.
+            let timer = this.timer.take();
+            crate::panic::discard_panic(crate::panic::catch_panic(|| drop(timer)).err());
             return Poll::Ready(result);
         }
         if this.phase == DeadlinePhase::InitialAttempt {
@@ -137,6 +154,14 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
 }
 
 impl<F> Drop for Deadlined<F> {
+    /// Retires an unelapsed timer inside a boundary.
+    ///
+    /// Cancelling an armed timer destroys the clone of the caller's waker it
+    /// registered, and a `RawWaker` vtable is caller code. There is no caller
+    /// left to surface a panic to here, and during an existing unwind a bare
+    /// destructor panic is a double panic and a process abort, so the
+    /// retirement runs through an accumulator: it resumes on an ordinary drop
+    /// and is contained while another unwind is already in progress.
     fn drop(&mut self) {
         let timer = self.timer.take();
         let mut panics = crate::panic::PanicAccumulator::default();
@@ -148,7 +173,11 @@ impl<F> Drop for Deadlined<F> {
 mod tests {
     use std::{
         future::Future,
-        task::{Context, Poll, Waker},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        task::{Context, Poll, Wake, Waker},
     };
 
     /// Stays pending on its first elapsed poll, modelling an atomic
@@ -158,9 +187,15 @@ mod tests {
         elapsed_polls: usize,
     }
 
-    struct ReadyImmediately;
+    /// Parks once, then completes strictly before its deadline -- the only
+    /// arrangement in which a retained future can still hold an armed wheel
+    /// entry carrying a clone of the caller's waker.
+    #[derive(Default)]
+    struct ReadyAfterParking {
+        polls: usize,
+    }
 
-    impl super::DeadlineOperation for ReadyImmediately {
+    impl super::DeadlineOperation for ReadyAfterParking {
         type Output = ();
 
         fn poll_deadlined(
@@ -169,10 +204,30 @@ mod tests {
             _budget: crate::deadline::Deadline,
             _phase: super::DeadlinePhase,
         ) -> Poll<()> {
-            Poll::Ready(())
+            self.polls += 1;
+            if self.polls < 2 {
+                Poll::Pending
+            } else {
+                Poll::Ready(())
+            }
         }
 
         fn short_circuit(&mut self) {}
+    }
+
+    /// Records wakes so an armed wheel entry is observable as the spurious
+    /// wake it would deliver rather than as a cleared field.
+    #[derive(Default)]
+    struct WakeRecorder(AtomicUsize);
+
+    impl Wake for WakeRecorder {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
     }
 
     impl super::DeadlineOperation for PendingOnFirstExpiry {
@@ -220,22 +275,35 @@ mod tests {
         assert!(matches!(future.as_mut().poll(&mut context), Poll::Ready(2)));
     }
 
-    #[crate::runtime::test]
-    async fn a_completed_operation_retires_its_timer_immediately() {
+    #[crate::runtime::test(start_paused = true)]
+    async fn a_completed_operation_leaves_no_timer_to_wake_its_caller() {
+        let width = std::time::Duration::from_secs(1);
         let mut future = Box::pin(super::Deadlined::no_attempt(
-            ReadyImmediately,
-            std::time::Duration::from_secs(30),
+            ReadyAfterParking::default(),
+            width,
             crate::capability::tests::runtime(),
         ));
-        let mut context = Context::from_waker(Waker::noop());
+        let recorder = Arc::new(WakeRecorder::default());
+        let waker = Waker::from(Arc::clone(&recorder));
+        let mut context = Context::from_waker(&waker);
 
+        // Parking arms the timer with a clone of this waker; the operation
+        // then completes while that deadline is still in the future.
+        assert!(future.as_mut().poll(&mut context).is_pending());
         assert!(matches!(
             future.as_mut().poll(&mut context),
             Poll::Ready(())
         ));
-        assert!(
-            future.timer.is_none(),
-            "a completed but retained deadline future leaves no armed timer"
+        let woken_before = recorder.0.load(Ordering::SeqCst);
+
+        crate::runtime::advance(width * 2).await;
+
+        // The future is still held, so a timer left armed by completion would
+        // deliver its expiry to the caller that already has its result.
+        assert_eq!(
+            recorder.0.load(Ordering::SeqCst),
+            woken_before,
+            "a completed but retained deadline future must not wake its caller when the deadline elapses"
         );
     }
 

--- a/crates/shelterwood-mailbox/src/deadline.rs
+++ b/crates/shelterwood-mailbox/src/deadline.rs
@@ -111,6 +111,7 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             this.operation
                 .poll_deadlined(context, budget, DeadlinePhase::InitialAttempt)
         {
+            this.timer = None;
             return Poll::Ready(result);
         }
         if this.phase == DeadlinePhase::InitialAttempt {
@@ -135,6 +136,14 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
     }
 }
 
+impl<F> Drop for Deadlined<F> {
+    fn drop(&mut self) {
+        let timer = self.timer.take();
+        let mut panics = crate::panic::PanicAccumulator::default();
+        panics.run(|| drop(timer));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -147,6 +156,23 @@ mod tests {
     #[derive(Default)]
     struct PendingOnFirstExpiry {
         elapsed_polls: usize,
+    }
+
+    struct ReadyImmediately;
+
+    impl super::DeadlineOperation for ReadyImmediately {
+        type Output = ();
+
+        fn poll_deadlined(
+            &mut self,
+            _context: &mut Context<'_>,
+            _budget: crate::deadline::Deadline,
+            _phase: super::DeadlinePhase,
+        ) -> Poll<()> {
+            Poll::Ready(())
+        }
+
+        fn short_circuit(&mut self) {}
     }
 
     impl super::DeadlineOperation for PendingOnFirstExpiry {
@@ -192,6 +218,25 @@ mod tests {
         assert!(future.as_mut().poll(&mut context).is_pending());
 
         assert!(matches!(future.as_mut().poll(&mut context), Poll::Ready(2)));
+    }
+
+    #[crate::runtime::test]
+    async fn a_completed_operation_retires_its_timer_immediately() {
+        let mut future = Box::pin(super::Deadlined::no_attempt(
+            ReadyImmediately,
+            std::time::Duration::from_secs(30),
+            crate::capability::tests::runtime(),
+        ));
+        let mut context = Context::from_waker(Waker::noop());
+
+        assert!(matches!(
+            future.as_mut().poll(&mut context),
+            Poll::Ready(())
+        ));
+        assert!(
+            future.timer.is_none(),
+            "a completed but retained deadline future leaves no armed timer"
+        );
     }
 
     #[test]

--- a/crates/shelterwood/tests/mailbox_future_drop_containment.rs
+++ b/crates/shelterwood/tests/mailbox_future_drop_containment.rs
@@ -1,0 +1,194 @@
+use std::{
+    future::Future,
+    mem::ManuallyDrop,
+    panic::{AssertUnwindSafe, catch_unwind},
+    process::Command,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    task::{Context as TaskContext, Poll, RawWaker, RawWakerVTable, Waker},
+    time::Duration,
+};
+
+use shelterwood::{Actor, ActorOnceDef, Context, ExitError, ExitResult, Reply, Tree};
+
+const CHILD_ENV: &str = "SHELTERWOOD_MAILBOX_FUTURE_DROP_CHILD";
+const OUTER_PANIC: &str = "injected outer panic";
+
+enum Message {
+    Value,
+    Hold(Reply<u8>),
+}
+
+struct HoldingActor {
+    reply: Option<Reply<u8>>,
+}
+
+impl Actor for HoldingActor {
+    type Msg = Message;
+    type Args = ();
+
+    async fn init((): (), _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self { reply: None })
+    }
+
+    async fn handle(&mut self, message: Message, _: &mut Context<'_, Self>) -> ExitResult {
+        if let Message::Hold(reply) = message {
+            self.reply = Some(reply);
+        }
+        Ok(())
+    }
+}
+
+struct FirstWakerDropPanics(AtomicBool);
+
+unsafe fn clone_panicking_drop_waker(data: *const ()) -> RawWaker {
+    // SAFETY: every pointer using this vtable came from an Arc of the matching
+    // type. ManuallyDrop preserves the reference represented by data; the
+    // returned raw waker owns only the new clone.
+    let probe = ManuallyDrop::new(unsafe { Arc::<FirstWakerDropPanics>::from_raw(data.cast()) });
+    RawWaker::new(
+        Arc::into_raw(Arc::clone(&probe)).cast(),
+        &PANICKING_DROP_WAKER_VTABLE,
+    )
+}
+
+unsafe fn wake_panicking_drop_waker(data: *const ()) {
+    // SAFETY: wake consumes the reference represented by this raw waker.
+    drop(unsafe { Arc::<FirstWakerDropPanics>::from_raw(data.cast()) });
+    panic!("injected waker wake panic");
+}
+
+unsafe fn wake_by_ref_panicking_drop_waker(_data: *const ()) {
+    panic!("injected waker wake panic");
+}
+
+unsafe fn drop_panicking_drop_waker(data: *const ()) {
+    // SAFETY: drop consumes the reference represented by this raw waker.
+    let probe = unsafe { Arc::<FirstWakerDropPanics>::from_raw(data.cast()) };
+    if !probe.0.swap(true, Ordering::SeqCst) {
+        panic!("injected waker drop panic");
+    }
+}
+
+static PANICKING_DROP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    clone_panicking_drop_waker,
+    wake_panicking_drop_waker,
+    wake_by_ref_panicking_drop_waker,
+    drop_panicking_drop_waker,
+);
+
+fn panicking_drop_waker() -> Waker {
+    let raw = RawWaker::new(
+        Arc::into_raw(Arc::new(FirstWakerDropPanics(AtomicBool::new(false)))).cast(),
+        &PANICKING_DROP_WAKER_VTABLE,
+    );
+    // SAFETY: raw owns one Arc reference and its vtable maintains that
+    // ownership across clone, wake, and drop.
+    unsafe { Waker::from_raw(raw) }
+}
+
+fn assert_pending_then_unwind<F: Future>(mut future: std::pin::Pin<Box<F>>) {
+    // The caller-owned raw waker is deliberately leaked in this subprocess.
+    // Only the clones registered by the public future are under test.
+    let hostile = ManuallyDrop::new(panicking_drop_waker());
+    assert!(matches!(
+        future.as_mut().poll(&mut TaskContext::from_waker(&hostile)),
+        Poll::Pending
+    ));
+
+    let payload = catch_unwind(AssertUnwindSafe(move || {
+        let _future = future;
+        std::panic::panic_any(OUTER_PANIC);
+    }))
+    .expect_err("the original unwind reaches its boundary");
+    assert_eq!(payload.downcast_ref::<&str>(), Some(&OUTER_PANIC));
+}
+
+fn actor_ref() -> (Tree, shelterwood::ActorRef<Message>) {
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once("waker-drop", ActorOnceDef::<HoldingActor>::new(()))
+        .expect("valid actor");
+    (tree, actor)
+}
+
+fn run_subprocess(test_name: &str) {
+    let output = Command::new(std::env::current_exe().expect("integration-test executable"))
+        .arg("--exact")
+        .arg(test_name)
+        .arg("--nocapture")
+        .arg("--test-threads=1")
+        .env(CHILD_ENV, "1")
+        .output()
+        .expect("hostile-waker subprocess starts");
+
+    assert!(
+        output.status.success(),
+        "hostile-waker subprocess must preserve the original panic instead of aborting\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn send_timeout_drop_contains_timer_waker_during_unwind() {
+    if std::env::var_os(CHILD_ENV).is_some() {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(async {
+                let (_tree, actor) = actor_ref();
+                assert_pending_then_unwind(Box::pin(
+                    actor.send_timeout(Message::Value, Duration::from_secs(30)),
+                ));
+            });
+        return;
+    }
+
+    run_subprocess("send_timeout_drop_contains_timer_waker_during_unwind");
+}
+
+#[test]
+fn call_drop_contains_reply_receiver_waker_during_unwind() {
+    if std::env::var_os(CHILD_ENV).is_some() {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(async {
+                let (tree, actor) = actor_ref();
+                let system = tree.spawn().expect("runtime is available");
+                system.wait_started().await.expect("actor starts");
+                assert_pending_then_unwind(Box::pin(actor.call(Message::Hold, Duration::MAX)));
+                system
+                    .shutdown(Duration::from_secs(1))
+                    .await
+                    .expect("actor stops");
+            });
+        return;
+    }
+
+    run_subprocess("call_drop_contains_reply_receiver_waker_during_unwind");
+}
+
+#[test]
+fn recv_drop_contains_receiver_waker_during_unwind() {
+    if std::env::var_os(CHILD_ENV).is_some() {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(async {
+                let (_tree, actor) = actor_ref();
+                let (_reply, receiver) = actor.reply_channel::<u8>();
+                assert_pending_then_unwind(Box::pin(receiver.recv(Duration::MAX)));
+            });
+        return;
+    }
+
+    run_subprocess("recv_drop_contains_receiver_waker_during_unwind");
+}

--- a/crates/shelterwood/tests/mailbox_future_drop_containment.rs
+++ b/crates/shelterwood/tests/mailbox_future_drop_containment.rs
@@ -2,10 +2,11 @@ use std::{
     future::Future,
     mem::ManuallyDrop,
     panic::{AssertUnwindSafe, catch_unwind},
+    pin::Pin,
     process::Command,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     task::{Context as TaskContext, Poll, RawWaker, RawWakerVTable, Waker},
     time::Duration,
@@ -124,12 +125,20 @@ fn run_subprocess(test_name: &str) {
         .output()
         .expect("hostile-waker subprocess starts");
 
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
     assert!(
         output.status.success(),
-        "hostile-waker subprocess must preserve the original panic instead of aborting\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+        "hostile-waker subprocess must preserve the original panic instead of aborting\nstatus: {}\nstdout:\n{stdout}\nstderr:\n{stderr}",
         output.status,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
+    );
+    // A libtest filter that matches nothing also exits zero, so a renamed or
+    // mistyped test would let this assertion pass without ever running the
+    // child body. Require the child to report exactly one executed test.
+    assert!(
+        stdout.contains("1 passed"),
+        "the child must actually run {test_name}, not filter it away\nstdout:\n{stdout}\nstderr:\n{stderr}",
     );
 }
 
@@ -191,4 +200,100 @@ fn recv_drop_contains_receiver_waker_during_unwind() {
     }
 
     run_subprocess("recv_drop_contains_receiver_waker_during_unwind");
+}
+
+/// Numbers the clones a single poll hands out so the regression can aim at
+/// one of them. `Deadlined::poll` registers the operation's clone first and
+/// the timer's second, so ordinal two is the timer's.
+static CLONES_MINTED: AtomicUsize = AtomicUsize::new(0);
+const TIMER_WAKER_ORDINAL: usize = 2;
+
+unsafe fn clone_ordinal_waker(_data: *const ()) -> RawWaker {
+    let ordinal = CLONES_MINTED.fetch_add(1, Ordering::SeqCst) + 1;
+    RawWaker::new(std::ptr::without_provenance(ordinal), &ORDINAL_WAKER_VTABLE)
+}
+
+unsafe fn wake_ordinal_waker(_data: *const ()) {}
+
+unsafe fn wake_by_ref_ordinal_waker(_data: *const ()) {}
+
+unsafe fn drop_ordinal_waker(data: *const ()) {
+    if data.addr() == TIMER_WAKER_ORDINAL {
+        panic!("injected timer waker drop panic");
+    }
+}
+
+static ORDINAL_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    clone_ordinal_waker,
+    wake_ordinal_waker,
+    wake_by_ref_ordinal_waker,
+    drop_ordinal_waker,
+);
+
+fn ordinal_waker() -> Waker {
+    // SAFETY: the vtable never dereferences its data pointer -- it carries a
+    // clone ordinal, not an address -- so every operation on it is a no-op, a
+    // counter bump, or a panic.
+    unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &ORDINAL_WAKER_VTABLE)) }
+}
+
+/// Stands in for a user reply whose destructor is hostile. Only the abort
+/// half of the regression destroys one; the success path forgets it.
+struct HostileReply;
+
+impl Drop for HostileReply {
+    fn drop(&mut self) {
+        panic!("injected reply destructor panic");
+    }
+}
+
+/// A deadline future that completes *after* parking still holds an armed
+/// timer carrying a clone of the caller's waker. Retiring that timer on the
+/// ready return runs a `RawWaker` destructor while the completed reply is a
+/// live local, so an unwinding one would destroy the delivered value and --
+/// with a hostile value destructor -- abort the process.
+#[test]
+fn recv_ready_after_parking_contains_the_retired_timer_waker() {
+    if std::env::var_os(CHILD_ENV).is_some() {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(async {
+                let (_tree, actor) = actor_ref();
+                let (reply, receiver) = actor.reply_channel::<HostileReply>();
+                let mut future = Box::pin(receiver.recv(Duration::from_secs(30)));
+                // The caller-owned waker is deliberately leaked in this
+                // subprocess. Only the clones the public future registers are
+                // under test.
+                let hostile = ManuallyDrop::new(ordinal_waker());
+
+                // Parking registers one clone in the reply channel and one in
+                // the timer; only the timer's destructor is hostile.
+                assert!(matches!(
+                    future.as_mut().poll(&mut TaskContext::from_waker(&hostile)),
+                    Poll::Pending
+                ));
+
+                assert_eq!(
+                    CLONES_MINTED.load(Ordering::SeqCst),
+                    TIMER_WAKER_ORDINAL,
+                    "parking must register exactly the operation and timer clones"
+                );
+
+                reply.send(HostileReply);
+                let completed = future.as_mut().poll(&mut TaskContext::from_waker(&hostile));
+
+                let Poll::Ready(Ok(value)) = completed else {
+                    panic!("the delivered reply must reach the caller")
+                };
+                // Its destructor is the abort's second half; the point of the
+                // test is that it was never reached.
+                std::mem::forget(value);
+                drop::<Pin<Box<_>>>(future);
+            });
+        return;
+    }
+
+    run_subprocess("recv_ready_after_parking_contains_the_retired_timer_waker");
 }

--- a/crates/shelterwood/tests/mailbox_future_drop_containment.rs
+++ b/crates/shelterwood/tests/mailbox_future_drop_containment.rs
@@ -1,9 +1,20 @@
+//! Containment regressions for the mailbox futures' drop and completion
+//! paths.
+//!
+//! Every test here injects a destructor that panics where the framework must
+//! not let one escape, so the failure these pin is a double panic and a
+//! process abort rather than an assertion. That needs no subprocess harness:
+//! `just test` runs the integration targets under `cargo nextest`, which
+//! executes each test in its own process, so an abort fails exactly the test
+//! that caused it and leaves the rest of the run intact. Under a shared-process
+//! runner (`cargo test`) an abort would instead take the whole binary down --
+//! still a loud failure, but an unattributed one.
+
 use std::{
     future::Future,
     mem::ManuallyDrop,
     panic::{AssertUnwindSafe, catch_unwind},
     pin::Pin,
-    process::Command,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -14,7 +25,6 @@ use std::{
 
 use shelterwood::{Actor, ActorOnceDef, Context, ExitError, ExitResult, Reply, Tree};
 
-const CHILD_ENV: &str = "SHELTERWOOD_MAILBOX_FUTURE_DROP_CHILD";
 const OUTER_PANIC: &str = "injected outer panic";
 
 enum Message {
@@ -90,9 +100,9 @@ fn panicking_drop_waker() -> Waker {
     unsafe { Waker::from_raw(raw) }
 }
 
-fn assert_pending_then_unwind<F: Future>(mut future: std::pin::Pin<Box<F>>) {
-    // The caller-owned raw waker is deliberately leaked in this subprocess.
-    // Only the clones registered by the public future are under test.
+fn assert_pending_then_unwind<F: Future>(mut future: Pin<Box<F>>) {
+    // The caller-owned raw waker is deliberately leaked. Only the clones the
+    // public future registers are under test.
     let hostile = ManuallyDrop::new(panicking_drop_waker());
     assert!(matches!(
         future.as_mut().poll(&mut TaskContext::from_waker(&hostile)),
@@ -115,96 +125,40 @@ fn actor_ref() -> (Tree, shelterwood::ActorRef<Message>) {
     (tree, actor)
 }
 
-fn run_subprocess(test_name: &str) {
-    let output = Command::new(std::env::current_exe().expect("integration-test executable"))
-        .arg("--exact")
-        .arg(test_name)
-        .arg("--nocapture")
-        .arg("--test-threads=1")
-        .env(CHILD_ENV, "1")
-        .output()
-        .expect("hostile-waker subprocess starts");
-
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-
-    assert!(
-        output.status.success(),
-        "hostile-waker subprocess must preserve the original panic instead of aborting\nstatus: {}\nstdout:\n{stdout}\nstderr:\n{stderr}",
-        output.status,
-    );
-    // A libtest filter that matches nothing also exits zero, so a renamed or
-    // mistyped test would let this assertion pass without ever running the
-    // child body. Require the child to report exactly one executed test.
-    assert!(
-        stdout.contains("1 passed"),
-        "the child must actually run {test_name}, not filter it away\nstdout:\n{stdout}\nstderr:\n{stderr}",
-    );
+#[tokio::test]
+async fn send_timeout_drop_contains_timer_waker_during_unwind() {
+    let (_tree, actor) = actor_ref();
+    assert_pending_then_unwind(Box::pin(
+        actor.send_timeout(Message::Value, Duration::from_secs(30)),
+    ));
 }
 
-#[test]
-fn send_timeout_drop_contains_timer_waker_during_unwind() {
-    if std::env::var_os(CHILD_ENV).is_some() {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("test runtime")
-            .block_on(async {
-                let (_tree, actor) = actor_ref();
-                assert_pending_then_unwind(Box::pin(
-                    actor.send_timeout(Message::Value, Duration::from_secs(30)),
-                ));
-            });
-        return;
-    }
-
-    run_subprocess("send_timeout_drop_contains_timer_waker_during_unwind");
+#[tokio::test]
+async fn call_drop_contains_reply_receiver_waker_during_unwind() {
+    let (tree, actor) = actor_ref();
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    assert_pending_then_unwind(Box::pin(actor.call(Message::Hold, Duration::MAX)));
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("actor stops");
 }
 
-#[test]
-fn call_drop_contains_reply_receiver_waker_during_unwind() {
-    if std::env::var_os(CHILD_ENV).is_some() {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("test runtime")
-            .block_on(async {
-                let (tree, actor) = actor_ref();
-                let system = tree.spawn().expect("runtime is available");
-                system.wait_started().await.expect("actor starts");
-                assert_pending_then_unwind(Box::pin(actor.call(Message::Hold, Duration::MAX)));
-                system
-                    .shutdown(Duration::from_secs(1))
-                    .await
-                    .expect("actor stops");
-            });
-        return;
-    }
-
-    run_subprocess("call_drop_contains_reply_receiver_waker_during_unwind");
-}
-
-#[test]
-fn recv_drop_contains_receiver_waker_during_unwind() {
-    if std::env::var_os(CHILD_ENV).is_some() {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("test runtime")
-            .block_on(async {
-                let (_tree, actor) = actor_ref();
-                let (_reply, receiver) = actor.reply_channel::<u8>();
-                assert_pending_then_unwind(Box::pin(receiver.recv(Duration::MAX)));
-            });
-        return;
-    }
-
-    run_subprocess("recv_drop_contains_receiver_waker_during_unwind");
+#[tokio::test]
+async fn recv_drop_contains_receiver_waker_during_unwind() {
+    let (_tree, actor) = actor_ref();
+    let (_reply, receiver) = actor.reply_channel::<u8>();
+    assert_pending_then_unwind(Box::pin(receiver.recv(Duration::MAX)));
 }
 
 /// Numbers the clones a single poll hands out so the regression can aim at
 /// one of them. `Deadlined::poll` registers the operation's clone first and
 /// the timer's second, so ordinal two is the timer's.
+///
+/// This counter is process-global but only this vtable bumps it, and only the
+/// one test below installs this vtable, so the ordinals stay dense under any
+/// runner.
 static CLONES_MINTED: AtomicUsize = AtomicUsize::new(0);
 const TIMER_WAKER_ORDINAL: usize = 2;
 
@@ -252,48 +206,36 @@ impl Drop for HostileReply {
 /// ready return runs a `RawWaker` destructor while the completed reply is a
 /// live local, so an unwinding one would destroy the delivered value and --
 /// with a hostile value destructor -- abort the process.
-#[test]
-fn recv_ready_after_parking_contains_the_retired_timer_waker() {
-    if std::env::var_os(CHILD_ENV).is_some() {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("test runtime")
-            .block_on(async {
-                let (_tree, actor) = actor_ref();
-                let (reply, receiver) = actor.reply_channel::<HostileReply>();
-                let mut future = Box::pin(receiver.recv(Duration::from_secs(30)));
-                // The caller-owned waker is deliberately leaked in this
-                // subprocess. Only the clones the public future registers are
-                // under test.
-                let hostile = ManuallyDrop::new(ordinal_waker());
+#[tokio::test]
+async fn recv_ready_after_parking_contains_the_retired_timer_waker() {
+    let (_tree, actor) = actor_ref();
+    let (reply, receiver) = actor.reply_channel::<HostileReply>();
+    let mut future = Box::pin(receiver.recv(Duration::from_secs(30)));
+    // The caller-owned waker is deliberately leaked. Only the clones the
+    // public future registers are under test.
+    let hostile = ManuallyDrop::new(ordinal_waker());
 
-                // Parking registers one clone in the reply channel and one in
-                // the timer; only the timer's destructor is hostile.
-                assert!(matches!(
-                    future.as_mut().poll(&mut TaskContext::from_waker(&hostile)),
-                    Poll::Pending
-                ));
+    // Parking registers one clone in the reply channel and one in the timer;
+    // only the timer's destructor is hostile.
+    assert!(matches!(
+        future.as_mut().poll(&mut TaskContext::from_waker(&hostile)),
+        Poll::Pending
+    ));
 
-                assert_eq!(
-                    CLONES_MINTED.load(Ordering::SeqCst),
-                    TIMER_WAKER_ORDINAL,
-                    "parking must register exactly the operation and timer clones"
-                );
+    assert_eq!(
+        CLONES_MINTED.load(Ordering::SeqCst),
+        TIMER_WAKER_ORDINAL,
+        "parking must register exactly the operation and timer clones"
+    );
 
-                reply.send(HostileReply);
-                let completed = future.as_mut().poll(&mut TaskContext::from_waker(&hostile));
+    reply.send(HostileReply);
+    let completed = future.as_mut().poll(&mut TaskContext::from_waker(&hostile));
 
-                let Poll::Ready(Ok(value)) = completed else {
-                    panic!("the delivered reply must reach the caller")
-                };
-                // Its destructor is the abort's second half; the point of the
-                // test is that it was never reached.
-                std::mem::forget(value);
-                drop::<Pin<Box<_>>>(future);
-            });
-        return;
-    }
-
-    run_subprocess("recv_ready_after_parking_contains_the_retired_timer_waker");
+    let Poll::Ready(Ok(value)) = completed else {
+        panic!("the delivered reply must reach the caller")
+    };
+    // Its destructor is the abort's second half; the point of the test is
+    // that it was never reached.
+    std::mem::forget(value);
+    drop::<Pin<Box<_>>>(future);
 }


### PR DESCRIPTION
Addresses the Deadlined and DisposingReceiver Batch 1 item from #366, including the later timer-retirement addition.

Deadlined now retires its timer on drop through PanicAccumulator, and retires it synchronously inside a non-resuming boundary when the operation completes. Retirement at completion cannot be deferred to a disposal worker: the wheel entry would stay armed until that worker reached it, which is the spurious wake the clear exists to prevent. It cannot resume either — the completed result is a live local across the waker destructor, so a resuming boundary would destroy the delivered output instead of returning it, and a hostile output destructor would make that a double panic and a process abort. A delivered result therefore outranks a waker-cleanup diagnostic, the same precedence CatchUnwindFuture's completed-output arm applies.

DisposingReceiver now owns its channel through an explicit take path and accumulates panics across close, value recovery, disposal submission and final receiver retirement.

Regressions drive the complete public send_timeout, call, and recv futures with a hostile registered waker during an existing unwind, and drive recv through the ready-after-parking arrangement — the only shape in which a completing future still holds an armed timer — with a hostile timer-waker destructor and a hostile reply destructor. These are plain in-process tests: `just test` runs the integration targets under `cargo nextest`, which gives every test its own process, so a double-panic abort fails exactly the test that caused it. A unit regression parks, completes before the deadline, then advances a paused clock past that deadline and requires the retained future not to wake its caller.

Verification: ./tools/dev cargo nextest run --workspace (808 tests), fmt and clippy clean. Each production change is mutation-checked against the test that pins it, and each abort-class regression was confirmed to report SIGABRT against its mutation.
