### PR TITLE
Detach opaque panic payload disposal

### DIFF
--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -446,8 +446,38 @@ pub(super) fn contain_panic_payload(payload: PanicPayload) -> Option<String> {
     // A custom panic payload is user-owned too. Its destructor may panic or
     // block, so retire it on the detached disposal lane before publishing
     // completion.
-    dispose_detached(payload);
+    dispose_detached(DiscardedPanicPayload(Some(payload)));
     message
+}
+
+/// Terminal, off-executor destruction for an opaque user panic payload.
+///
+/// The wrapper is load-bearing, not ceremony: submitting a bare payload to
+/// [`dispose_detached`] closes a cycle. `DisposalJob::finish` classifies a
+/// destructor panic by calling [`contain_panic_payload`], which submits the
+/// replacement payload for detached disposal, whose destructor panics again.
+/// A self-regenerating payload — one whose `Drop` `panic_any`s a fresh copy
+/// of itself — then spins the disposal lane for the life of the process,
+/// firing the panic hook every iteration.
+///
+/// [`discard_panic`] is what breaks the cycle, and does so by construction:
+/// it catches the replacement and `mem::forget`s it precisely because
+/// dropping the replacement would recurse outside the boundary
+/// (`shelterwood_core::panic`, pinned by that module's
+/// `discarding_a_recursively_hostile_panic_payload_is_contained`). Running it
+/// from this destructor keeps the venue guarantee — the payload is still
+/// destroyed off the exit-publishing executor — while the disposal job
+/// itself never observes a panic to classify.
+///
+/// Removing this wrapper reintroduces the unbounded spin; the regression is
+/// pinned by `blocking_panic_payload_does_not_stall_current_thread_exit_publication`'s
+/// sibling `a_self_regenerating_panic_payload_is_destroyed_a_bounded_number_of_times`.
+struct DiscardedPanicPayload(Option<PanicPayload>);
+
+impl Drop for DiscardedPanicPayload {
+    fn drop(&mut self) {
+        discard_panic(self.0.take());
+    }
 }
 
 fn panic_message(payload: &(dyn Any + Send + 'static)) -> Option<String> {

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -443,9 +443,10 @@ pub(super) fn contain_panic_payload(payload: PanicPayload) -> Option<String> {
             None
         }
     };
-    // A custom panic payload is user-owned too. Its destructor may panic, so
-    // discard it under a fresh unwind boundary before publishing completion.
-    discard_panic(Some(payload));
+    // A custom panic payload is user-owned too. Its destructor may panic or
+    // block, so retire it on the detached disposal lane before publishing
+    // completion.
+    dispose_detached(payload);
     message
 }
 

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -16,7 +16,7 @@ use std::{
 
 use crate::common::{
     DestructorBlocker, DestructorGate, POLL_TIMEOUT, PanicOnDrop, ReleaseGate, assert_eventually,
-    next_event, policy::never, poll_once,
+    assert_quiet, next_event, policy::never, poll_once,
 };
 use shelterwood::{
     Backoff, CallErrorKind, Cancellation, ChildId, ChildState, DynamicTree, ExitError, ExitKind,
@@ -158,6 +158,20 @@ struct PanickingPanicPayload;
 impl Drop for PanickingPanicPayload {
     fn drop(&mut self) {
         panic!("panic payload destructor");
+    }
+}
+
+/// A panic payload whose own destructor panics with a fresh copy of itself.
+///
+/// The counter records how many copies the framework destroys, which is the
+/// property under test: the terminal discard must stop the chain rather than
+/// let each replacement queue the next one.
+struct SelfRegeneratingPanicPayload(Arc<AtomicUsize>);
+
+impl Drop for SelfRegeneratingPanicPayload {
+    fn drop(&mut self) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        std::panic::panic_any(SelfRegeneratingPanicPayload(Arc::clone(&self.0)));
     }
 }
 
@@ -507,7 +521,7 @@ fn blocking_panic_payload_does_not_stall_current_thread_exit_publication() {
         let destructor_thread = started_rx
             .recv_timeout(POLL_TIMEOUT)
             .expect("panic payload destruction starts");
-        let released_after_publication = release_rx.recv_timeout(Duration::from_secs(1)).is_ok();
+        let released_after_publication = release_rx.recv_timeout(POLL_TIMEOUT).is_ok();
         release_gate.release();
         (destructor_thread, released_after_publication)
     });
@@ -546,6 +560,47 @@ fn blocking_panic_payload_does_not_stall_current_thread_exit_publication() {
     );
     assert_ne!(destructor_thread, driver_thread);
     assert!(matches!(exit.kind(), ExitKind::Panicked { message: None }));
+}
+
+/// Detaching the payload must not cost the chain's terminal step.
+///
+/// The disposal lane classifies a destructor panic by calling back into
+/// `contain_panic_payload`, so a payload submitted bare would queue its own
+/// replacement forever. `shelterwood_core::panic`'s
+/// `discarding_a_recursively_hostile_panic_payload_is_contained` pins the
+/// terminal discard in isolation; this pins it on the path a user reaches,
+/// where the payload leaves an actor through `panic_any`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_self_regenerating_panic_payload_is_destroyed_a_bounded_number_of_times() {
+    let destructions = Arc::new(AtomicUsize::new(0));
+    let payload = SelfRegeneratingPanicPayload(Arc::clone(&destructions));
+    let mut tree = Tree::new();
+    let (task, _completion) = tree
+        .add_task_once(
+            "regenerating",
+            TaskOnceDef::new(move |_| async move {
+                std::panic::panic_any(payload);
+                #[allow(unreachable_code)]
+                Ok::<(), ExitError>(())
+            }),
+        )
+        .expect("valid task");
+    let system = tree.spawn().expect("runtime is available");
+    assert!(matches!(
+        task.wait().await.kind(),
+        ExitKind::Panicked { message: None }
+    ));
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+
+    // Exactly one copy is destroyed: the replacement its destructor raises is
+    // the already-panicking diagnostic the terminal discard leaks on purpose.
+    // Without that step the count climbs by six figures per second, so the
+    // quiet window fails on its first sample instead of spinning.
+    assert_eventually!(|| destructions.load(Ordering::SeqCst) >= 1).await;
+    assert_quiet(Duration::from_millis(200), || {
+        destructions.load(Ordering::SeqCst) > 1
+    })
+    .await;
 }
 
 #[test]

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -7,6 +7,7 @@ use std::{
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
+        mpsc,
     },
     task::{Context, Poll, Wake, Waker},
     thread::{self, ThreadId},
@@ -60,6 +61,26 @@ impl Drop for DropProbe {
 struct BlockingDropProbe {
     dropped: tokio::sync::mpsc::UnboundedSender<ThreadId>,
     _blocker: DestructorBlocker,
+}
+
+struct BlockingPanicPayload {
+    started: mpsc::Sender<ThreadId>,
+    _blocker: DestructorBlocker,
+}
+
+impl BlockingPanicPayload {
+    fn new(gate: &DestructorGate, started: mpsc::Sender<ThreadId>) -> Self {
+        Self {
+            started,
+            _blocker: gate.blocker(),
+        }
+    }
+}
+
+impl Drop for BlockingPanicPayload {
+    fn drop(&mut self) {
+        let _ = self.started.send(thread::current().id());
+    }
 }
 
 impl BlockingDropProbe {
@@ -473,6 +494,58 @@ fn final_factory_capture_is_destroyed_outside_the_current_thread_driver() {
         drops.recv().await.expect("factory capture was destroyed")
     });
     assert_ne!(dropped, driver_thread);
+}
+
+#[test]
+fn blocking_panic_payload_does_not_stall_current_thread_exit_publication() {
+    let driver_thread = thread::current().id();
+    let gate = DestructorGate::default();
+    let (started, started_rx) = mpsc::channel();
+    let (release, release_rx) = mpsc::channel();
+    let release_gate = gate.clone();
+    let helper = thread::spawn(move || {
+        let destructor_thread = started_rx
+            .recv_timeout(POLL_TIMEOUT)
+            .expect("panic payload destruction starts");
+        let released_after_publication = release_rx.recv_timeout(Duration::from_secs(1)).is_ok();
+        release_gate.release();
+        (destructor_thread, released_after_publication)
+    });
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("test runtime");
+    let exit = runtime.block_on(async {
+        let mut tree = Tree::new();
+        let payload = BlockingPanicPayload::new(&gate, started);
+        let (task, _completion) = tree
+            .add_task_once(
+                "panic",
+                TaskOnceDef::new(move |_| async move {
+                    std::panic::panic_any(payload);
+                    #[allow(unreachable_code)]
+                    Ok::<(), ExitError>(())
+                }),
+            )
+            .expect("valid task");
+        let system = tree.spawn().expect("runtime is available");
+        let exit = task.wait().await;
+        release
+            .send(())
+            .expect("payload remains blocked until exit publication");
+        assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+        exit
+    });
+
+    let (destructor_thread, released_after_publication) =
+        helper.join().expect("destructor helper joins");
+    assert!(
+        released_after_publication,
+        "a blocking panic-payload destructor stalled exit publication"
+    );
+    assert_ne!(destructor_thread, driver_thread);
+    assert!(matches!(exit.kind(), ExitKind::Panicked { message: None }));
 }
 
 #[test]

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -750,10 +750,12 @@ surfaces on that task even though the replacement remains accepted.
 Framework-initiated disposal of externally submitted mailbox or
 reply-bearing payloads — including mailbox teardown, timeout/withdrawal
 cleanup, and accepted-prefix batch disposal — runs detached from the
-initiating task with per-element panic containment. Incarnation-owned
-continuations, timer messages, and offload state instead follow §6.5 and
-§8's incarnation teardown and verdict rules. No single disposal-thread
-identity is promised.
+initiating task with per-element panic containment. After extracting any
+string diagnostic, the framework likewise destroys an opaque user panic
+payload on the detached disposal lane rather than on the executor publishing
+the exit. Incarnation-owned continuations, timer messages, and offload state
+instead follow §6.5 and §8's incarnation teardown and verdict rules. No single
+disposal-thread identity is promised.
 
 (The synchronization discipline behind every mailbox transition — the
 effects sink paired with the state guard, and the structural waker slot —

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -752,10 +752,15 @@ reply-bearing payloads — including mailbox teardown, timeout/withdrawal
 cleanup, and accepted-prefix batch disposal — runs detached from the
 initiating task with per-element panic containment. After extracting any
 string diagnostic, the framework likewise destroys an opaque user panic
-payload on the detached disposal lane rather than on the executor publishing
-the exit. Incarnation-owned continuations, timer messages, and offload state
-instead follow §6.5 and §8's incarnation teardown and verdict rules. No single
-disposal-thread identity is promised.
+payload *carried by a child exit* on the detached disposal lane rather than
+on the executor publishing the exit (§6.5's thread-exhaustion exception
+applies), and that destruction is terminal: a payload whose own destructor
+panics has its replacement discarded, never requeued. A panic payload
+*displaced* by one that outranks it — a rejected panic-slot record, a losing
+cleanup panic — is still discarded inline, since it is already a spent
+diagnostic. Incarnation-owned continuations, timer messages, and offload
+state instead follow §6.5 and §8's incarnation teardown and verdict rules. No
+single disposal-thread identity is promised.
 
 (The synchronization discipline behind every mailbox transition — the
 effects sink paired with the state guard, and the structural waker slot —


### PR DESCRIPTION
Part of #366.

Moves opaque user panic-payload destruction onto the detached disposal lane after extracting any string diagnostic. This prevents a blocking or panicking payload destructor from running on the executor that publishes the child exit.

Detaching alone is not sufficient, because the disposal lane classifies a destructor panic by calling back into `contain_panic_payload`: a bare submission would let a payload whose `Drop` `panic_any`s a fresh copy of itself requeue forever. `DiscardedPanicPayload`'s destructor runs the existing terminal discard (`discard_panic`, which `mem::forget`s the replacement by construction), so the venue guarantee holds while the disposal job never observes a panic to classify. The doc comment records why the wrapper cannot be inlined away.

SPEC §5.5 is scoped to what the code delivers: the guarantee covers an opaque payload *carried by a child exit*, states that the destruction is terminal, cross-references §6.5's thread-exhaustion exception, and records that a *displaced* payload (a rejected panic-slot record, a losing cleanup panic) is still discarded inline.

Two regressions in `crates/shelterwood/tests/disposal.rs`, both plain `#[test]`/`#[tokio::test]` that CI runs unconditionally — "gate" here refers to the `DestructorGate` fixture, not a `cfg` or feature gate:

- `blocking_panic_payload_does_not_stall_current_thread_exit_publication` — a current-thread runtime proving exit publication completes while the payload destructor remains blocked, and that the destructor runs off the driver thread.
- `a_self_regenerating_panic_payload_is_destroyed_a_bounded_number_of_times` — a self-regenerating payload driven through the public actor API, pinning terminality on the path a user reaches (the isolated pin lives beside `shelterwood_core::panic`'s `discarding_a_recursively_hostile_panic_payload_is_contained`).

Measured destruction counts for a self-regenerating payload, before and after the terminal discard:

| path | without the terminal step | with it |
|---|---|---|
| direct `dispose_detached` | 109,618 @300ms → 219,592 @600ms | 2, then stops |
| public actor API (`panic_any` from a `TaskOnceDef`) | 63,356 @300ms → 125,151 @600ms | 1, then stops |

Validation: `./tools/dev just ci`; both regressions mutation-checked (removing the newtype fails the terminality test in 5 ms; reverting the venue change fails the venue test in 5.0 s, bounded rather than hanging).

Stack: independent Batch 1 slice; targets `main`.
