### PR TITLE
Finish issue 366 Batch 1 contract fixes

### DIFF
--- a/crates/shelterwood-core/src/policy.rs
+++ b/crates/shelterwood-core/src/policy.rs
@@ -469,6 +469,7 @@ impl Backoff {
                     half_duration(delay)
                 } else {
                     duration_from_nanos(duration_nanos(delay) * (0.5 + sample * 0.5))
+                        .max(half_duration(delay))
                 }
             }
         };
@@ -1363,6 +1364,18 @@ mod tests {
         assert_eq!(
             even.next_delay(RestartAttempt(1), JitterSample::new(0.0)),
             Duration::from_nanos(1 << 59)
+        );
+    }
+
+    #[test]
+    fn smallest_positive_sample_equal_jitter_respects_the_exact_half_delay() {
+        let odd = Duration::from_nanos((1 << 60) + 1);
+        let fixed = Backoff::fixed(odd, Jitter::Equal).expect("valid backoff");
+        let smallest_positive = JitterSample::new(f64::from_bits(1));
+        assert_ne!(smallest_positive, JitterSample::new(0.0));
+        assert_eq!(
+            fixed.next_delay(RestartAttempt(1), smallest_positive),
+            Duration::from_nanos((1 << 59) + 1)
         );
     }
 

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -184,7 +184,12 @@ impl<'a, A: Actor> Context<'a, A> {
         }
     }
 
-    /// Requests a clean local stop after the current callback.
+    /// Requests a clean local stop.
+    ///
+    /// External intake and incarnation-owned continuations, timers, and
+    /// offloads freeze at this call. The current callback may finish, but any
+    /// later attempt from it to queue such work is rejected. Terminal
+    /// publication follows callback completion.
     ///
     /// During a successful initializer with effective [`Readiness::AfterInit`],
     /// the automatic readiness edge is published before this request becomes

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -134,6 +134,9 @@ fn classify_retained_root_driver_join(
 
 impl Drop for SystemRun {
     fn drop(&mut self) {
+        if self.driver.is_none() {
+            return;
+        }
         // After a clean shutdown the root epochs are `Idle`, not `Exhausted`,
         // so this writes a real `ScopeRequest` — targeting the pending next
         // incarnation — into dead control state and pulses the member record.

--- a/crates/shelterwood/src/tree/system.rs
+++ b/crates/shelterwood/src/tree/system.rs
@@ -241,7 +241,13 @@ impl<R> System<R> {
 
 #[cfg(test)]
 mod tests {
-    use super::{DynamicTree, Tree, sealed::Sealed};
+    use std::{
+        pin::pin,
+        sync::Arc,
+        task::{Context, Poll, Waker},
+    };
+
+    use super::{DynamicTree, StopReason, Tree, sealed::Sealed};
     use crate::identity::ScopeIdentity;
 
     #[test]
@@ -257,5 +263,35 @@ mod tests {
         let core = <DynamicTree as Sealed>::into_core(tree);
         assert_eq!(ScopeIdentity::current_thread_creations(), after_tree);
         drop(core);
+    }
+
+    /// `SystemRun::drop` requests root shutdown so a dropped owner tears the
+    /// tree down. Once the driver has been joined that request has no
+    /// consumer, and writing it anyway would publish a live `ScopeRequest`
+    /// against the pending next incarnation and pulse the root member
+    /// record. The early return makes the drop inert instead; this pins it
+    /// through the pulse, which fires only when the request is published.
+    #[crate::runtime::test]
+    async fn joined_system_run_drop_publishes_no_root_scope_request() {
+        let mut system = Tree::new().spawn().expect("runtime is available");
+        let root = Arc::clone(&system.run.root);
+        system.scope().request_shutdown();
+        assert_eq!(system.run.wait().await, StopReason::ShutdownRequested);
+
+        // Subscribed after the join, so the only pulse it can observe is one
+        // the drop below publishes.
+        let mut watcher = root.signal().watcher();
+        drop(system);
+
+        let mut changed = pin!(watcher.changed());
+        assert!(
+            matches!(
+                changed
+                    .as_mut()
+                    .poll(&mut Context::from_waker(Waker::noop())),
+                Poll::Pending
+            ),
+            "a joined driver's SystemRun drop must not publish a root scope request"
+        );
     }
 }

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -133,6 +133,137 @@ async fn handler_actor_runs_init_handle_and_stop_through_the_raw_wrapper() {
     );
 }
 
+#[derive(Clone, Copy, Debug)]
+enum StopSurfaceMessage {
+    Stop,
+    Continuation,
+    Timer,
+    Offload,
+}
+
+const STOP_CONTINUATION_REJECTED: usize = 1 << 0;
+const STOP_TIMEOUT_REJECTED: usize = 1 << 1;
+const STOP_INTERVAL_REJECTED: usize = 1 << 2;
+const STOP_CLEAR_REPORTS_EMPTY: usize = 1 << 3;
+const STOP_OFFLOAD_REJECTED: usize = 1 << 4;
+const STOP_SCOPED_OFFLOAD_REJECTED: usize = 1 << 5;
+const ALL_STOP_RESULTS: usize = STOP_CONTINUATION_REJECTED
+    | STOP_TIMEOUT_REJECTED
+    | STOP_INTERVAL_REJECTED
+    | STOP_CLEAR_REPORTS_EMPTY
+    | STOP_OFFLOAD_REJECTED
+    | STOP_SCOPED_OFFLOAD_REJECTED;
+
+struct StopSurfaceActor(Arc<AtomicUsize>);
+
+impl Actor for StopSurfaceActor {
+    type Msg = StopSurfaceMessage;
+    type Args = Arc<AtomicUsize>;
+
+    async fn init(observed: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self(observed))
+    }
+
+    async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        if !matches!(message, StopSurfaceMessage::Stop) {
+            return Ok(());
+        }
+
+        context.stop();
+        let mut observed = 0;
+        if context
+            .continue_with(StopSurfaceMessage::Continuation)
+            .is_err_and(|rejected| {
+                matches!(rejected.into_inner(), StopSurfaceMessage::Continuation)
+            })
+        {
+            observed |= STOP_CONTINUATION_REJECTED;
+        }
+        if context
+            .set_timeout("timeout", StopSurfaceMessage::Timer, Duration::ZERO)
+            .is_err_and(|rejected| {
+                matches!(
+                    rejected.into_inner(),
+                    ("timeout", StopSurfaceMessage::Timer)
+                )
+            })
+        {
+            observed |= STOP_TIMEOUT_REJECTED;
+        }
+        if context
+            .set_interval(
+                "interval",
+                StopSurfaceMessage::Timer,
+                Duration::from_secs(1),
+            )
+            .is_err_and(|rejected| {
+                matches!(
+                    rejected.into_inner(),
+                    ("interval", StopSurfaceMessage::Timer)
+                )
+            })
+        {
+            observed |= STOP_INTERVAL_REJECTED;
+        }
+        // Clearing does not queue work. The stop already emptied the timer
+        // store, so the live callback facade reports that there is nothing
+        // left to retract.
+        if matches!(context.clear_timer(&"timer"), Ok(false)) {
+            observed |= STOP_CLEAR_REPORTS_EMPTY;
+        }
+        if context
+            .offload(
+                async {},
+                |_| StopSurfaceMessage::Offload,
+                Duration::from_secs(1),
+            )
+            .is_err_and(|rejected| {
+                let (work, continuation) = rejected.into_inner();
+                drop(work);
+                matches!(continuation(Ok(())), StopSurfaceMessage::Offload)
+            })
+        {
+            observed |= STOP_OFFLOAD_REJECTED;
+        }
+        if context
+            .offload_scoped(
+                async {},
+                |_| StopSurfaceMessage::Offload,
+                Duration::from_secs(1),
+            )
+            .is_err_and(|rejected| {
+                let (work, continuation) = rejected.into_inner();
+                drop(work);
+                matches!(continuation(Ok(())), StopSurfaceMessage::Offload)
+            })
+        {
+            observed |= STOP_SCOPED_OFFLOAD_REJECTED;
+        }
+        self.0.store(observed, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn stop_immediately_rejects_every_public_local_work_submission() {
+    let observed = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "stop-surface",
+            ActorOnceDef::<StopSurfaceActor>::new(Arc::clone(&observed)),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    actor
+        .send(StopSurfaceMessage::Stop)
+        .await
+        .expect("stop message is accepted");
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert_eq!(observed.load(Ordering::SeqCst), ALL_STOP_RESULTS);
+}
+
 #[tokio::test]
 async fn handler_decorator_reenters_the_inner_actor_context_across_callbacks() {
     let events = Arc::new(Mutex::new(Vec::new()));

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -141,18 +141,22 @@ enum StopSurfaceMessage {
     Offload,
 }
 
-const STOP_CONTINUATION_REJECTED: usize = 1 << 0;
-const STOP_TIMEOUT_REJECTED: usize = 1 << 1;
-const STOP_INTERVAL_REJECTED: usize = 1 << 2;
-const STOP_CLEAR_REPORTS_EMPTY: usize = 1 << 3;
-const STOP_OFFLOAD_REJECTED: usize = 1 << 4;
-const STOP_SCOPED_OFFLOAD_REJECTED: usize = 1 << 5;
-const ALL_STOP_RESULTS: usize = STOP_CONTINUATION_REJECTED
+const STOP_TIMER_ARMED_BEFORE: usize = 1 << 0;
+const STOP_CONTINUATION_REJECTED: usize = 1 << 1;
+const STOP_TIMEOUT_REJECTED: usize = 1 << 2;
+const STOP_INTERVAL_REJECTED: usize = 1 << 3;
+const STOP_CLEAR_REPORTS_EMPTY: usize = 1 << 4;
+const STOP_OFFLOAD_REJECTED: usize = 1 << 5;
+const STOP_SCOPED_OFFLOAD_REJECTED: usize = 1 << 6;
+const STOP_INTAKE_FROZEN: usize = 1 << 7;
+const ALL_STOP_RESULTS: usize = STOP_TIMER_ARMED_BEFORE
+    | STOP_CONTINUATION_REJECTED
     | STOP_TIMEOUT_REJECTED
     | STOP_INTERVAL_REJECTED
     | STOP_CLEAR_REPORTS_EMPTY
     | STOP_OFFLOAD_REJECTED
-    | STOP_SCOPED_OFFLOAD_REJECTED;
+    | STOP_SCOPED_OFFLOAD_REJECTED
+    | STOP_INTAKE_FROZEN;
 
 struct StopSurfaceActor(Arc<AtomicUsize>);
 
@@ -169,8 +173,20 @@ impl Actor for StopSurfaceActor {
             return Ok(());
         }
 
-        context.stop();
+        // Arm a real timer first. Without it the post-stop retraction check
+        // below reads an empty store either way and cannot see the freeze.
         let mut observed = 0;
+        if context
+            .set_timeout(
+                "armed",
+                StopSurfaceMessage::Timer,
+                Duration::from_secs(3600),
+            )
+            .is_ok()
+        {
+            observed |= STOP_TIMER_ARMED_BEFORE;
+        }
+        context.stop();
         if context
             .continue_with(StopSurfaceMessage::Continuation)
             .is_err_and(|rejected| {
@@ -205,10 +221,10 @@ impl Actor for StopSurfaceActor {
         {
             observed |= STOP_INTERVAL_REJECTED;
         }
-        // Clearing does not queue work. The stop already emptied the timer
-        // store, so the live callback facade reports that there is nothing
-        // left to retract.
-        if matches!(context.clear_timer(&"timer"), Ok(false)) {
+        // Clearing does not queue work, so it is not rejected here. It
+        // observes the other half of the freeze instead: the timer armed
+        // before the stop is already gone, so there is nothing to retract.
+        if matches!(context.clear_timer(&"armed"), Ok(false)) {
             observed |= STOP_CLEAR_REPORTS_EMPTY;
         }
         if context
@@ -239,6 +255,15 @@ impl Actor for StopSurfaceActor {
         {
             observed |= STOP_SCOPED_OFFLOAD_REJECTED;
         }
+        // External intake froze at the same call, so even this actor's own
+        // membership-addressed handle fails fast rather than queueing.
+        if context
+            .myself()
+            .try_send(StopSurfaceMessage::Continuation)
+            .is_err_and(|error| error.kind == SendErrorKind::NotRunning)
+        {
+            observed |= STOP_INTAKE_FROZEN;
+        }
         self.0.store(observed, Ordering::SeqCst);
         Ok(())
     }
@@ -262,6 +287,117 @@ async fn stop_immediately_rejects_every_public_local_work_submission() {
         .expect("stop message is accepted");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert_eq!(observed.load(Ordering::SeqCst), ALL_STOP_RESULTS);
+}
+
+const INIT_STOP_TIMER_ARMED_BEFORE: usize = 1 << 0;
+const INIT_STOP_CONTINUATION_REJECTED: usize = 1 << 1;
+const INIT_STOP_TIMEOUT_REJECTED: usize = 1 << 2;
+const INIT_STOP_CLEAR_REPORTS_EMPTY: usize = 1 << 3;
+const INIT_STOP_OFFLOAD_REJECTED: usize = 1 << 4;
+const INIT_STOP_INTAKE_FROZEN: usize = 1 << 5;
+const ALL_INIT_STOP_RESULTS: usize = INIT_STOP_TIMER_ARMED_BEFORE
+    | INIT_STOP_CONTINUATION_REJECTED
+    | INIT_STOP_TIMEOUT_REJECTED
+    | INIT_STOP_CLEAR_REPORTS_EMPTY
+    | INIT_STOP_OFFLOAD_REJECTED
+    | INIT_STOP_INTAKE_FROZEN;
+
+struct StopInInitSurfaceActor;
+
+impl Actor for StopInInitSurfaceActor {
+    type Msg = StopSurfaceMessage;
+    type Args = Arc<AtomicUsize>;
+
+    async fn init(
+        observed: Self::Args,
+        context: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        let mut seen = 0;
+        if context
+            .set_timeout(
+                "armed",
+                StopSurfaceMessage::Timer,
+                Duration::from_secs(3600),
+            )
+            .is_ok()
+        {
+            seen |= INIT_STOP_TIMER_ARMED_BEFORE;
+        }
+        // Effective readiness is the `Actor` default, `AfterInit`, so this
+        // stop is published only after the automatic readiness edge this
+        // initializer's `Ok` establishes. The freeze it performs is not
+        // deferred with it.
+        context.stop();
+        if context
+            .continue_with(StopSurfaceMessage::Continuation)
+            .is_err_and(|rejected| {
+                matches!(rejected.into_inner(), StopSurfaceMessage::Continuation)
+            })
+        {
+            seen |= INIT_STOP_CONTINUATION_REJECTED;
+        }
+        if context
+            .set_timeout("timeout", StopSurfaceMessage::Timer, Duration::ZERO)
+            .is_err_and(|rejected| {
+                matches!(
+                    rejected.into_inner(),
+                    ("timeout", StopSurfaceMessage::Timer)
+                )
+            })
+        {
+            seen |= INIT_STOP_TIMEOUT_REJECTED;
+        }
+        if matches!(context.clear_timer(&"armed"), Ok(false)) {
+            seen |= INIT_STOP_CLEAR_REPORTS_EMPTY;
+        }
+        if context
+            .offload(
+                async {},
+                |_| StopSurfaceMessage::Offload,
+                Duration::from_secs(1),
+            )
+            .is_err_and(|rejected| {
+                let (work, continuation) = rejected.into_inner();
+                drop(work);
+                matches!(continuation(Ok(())), StopSurfaceMessage::Offload)
+            })
+        {
+            seen |= INIT_STOP_OFFLOAD_REJECTED;
+        }
+        if context
+            .myself()
+            .try_send(StopSurfaceMessage::Continuation)
+            .is_err_and(|error| error.kind == SendErrorKind::NotRunning)
+        {
+            seen |= INIT_STOP_INTAKE_FROZEN;
+        }
+        observed.store(seen, Ordering::SeqCst);
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, _: Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+        unreachable!("intake froze inside the initializer, so no delivery follows")
+    }
+}
+
+/// The effective-`AfterInit` initializer still publishes its readiness edge
+/// before the self-stop, but the intake and resource freeze is immediate.
+#[tokio::test]
+async fn stop_in_an_after_init_initializer_freezes_before_the_initializer_returns() {
+    let observed = Arc::new(AtomicUsize::new(0));
+    let mut tree = Tree::new();
+    tree.add_actor_once(
+        "stop-in-init-surface",
+        ActorOnceDef::<StopInInitSurfaceActor>::new(Arc::clone(&observed)),
+    )
+    .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect("a successful AfterInit initializer establishes readiness");
+    assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
+    assert_eq!(observed.load(Ordering::SeqCst), ALL_INIT_STOP_RESULTS);
 }
 
 #[tokio::test]

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -428,8 +428,9 @@ trait Actor: Sized + Send + 'static {
   classifies `Failed`; §8). Infallible handlers write `Ok(())`; there is
   no `IntoExitResult` conversion trait. There is deliberately no
   stop-outcome return type: clean self-stop is `ctx.stop()` alone (B.1 —
-  effective after the current callback, `Err` outcome wins, idempotent),
-  so the return channel carries errors only and stop has one mechanism
+  intake and incarnation-owned resources freeze at the call, terminal
+  publication follows the callback, `Err` outcome wins, idempotent), so
+  the return channel carries errors only and stop has one mechanism
   (§1 principle 2). Constraints that MUST hold:
   - The blanket loop applies its own `?` only after awaiting the
     callback's exact `ExitResult`.
@@ -2095,17 +2096,20 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
   accepted while the membership has *no live incarnation* (a restart
   window — B.9's `shutdown_and_wait` landing between incarnations) is
   held on the membership and armed onto the next incarnation at its
-  start, which then starts and immediately begins teardown. A stop latched
-  before the driver's first settlement likewise still constructs the first
-  incarnation and then immediately tears it down. The two rules partition by
-  target and never conflict: fresh-restart-starts-
-  clear says a latch *consumed by* incarnation N never carries to N+1;
-  the pending latch holds a request that arrived with no incarnation to
-  consume it — it was never any incarnation's spent latch, and it waits
-  for its first. What cannot exist is a stop request silently dropped in
-  the window. Cancelling an awaited membership operation never rides the
-  channel either: it is a per-operation level latch on the operation's
-  cell (§9's linearization rule).
+  start, which then starts and immediately begins teardown. The
+  scope-level latch has its own version of that window: a stop latched
+  before the driver's first settlement is read only at the top of the
+  driver's first loop pass, after the initial incarnations are already
+  published, so it too constructs and then immediately tears down. The
+  two carry rules partition by target and never conflict:
+  fresh-restart-starts-clear says a latch *consumed by* incarnation N
+  never carries to N+1; the pending latch holds a request that arrived
+  with no incarnation to consume it — it was never any incarnation's
+  spent latch, and it waits for its first. What cannot exist is a stop
+  request silently dropped in the window. Cancelling an awaited
+  membership operation never rides the channel either: it is a
+  per-operation level latch on the operation's cell (§9's linearization
+  rule).
 - Rebinding-transparent `send` during teardown can park against an
   unbound sibling; teardown-window notifications use `try_send`. This
   tradeoff is prominent shutdown guidance, alongside the

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -2095,8 +2095,10 @@ cooperative cancel → grace expiry → tidy-abort beat → hard abort
   accepted while the membership has *no live incarnation* (a restart
   window — B.9's `shutdown_and_wait` landing between incarnations) is
   held on the membership and armed onto the next incarnation at its
-  start, which then starts and immediately begins teardown. The two
-  rules partition by target and never conflict: fresh-restart-starts-
+  start, which then starts and immediately begins teardown. A stop latched
+  before the driver's first settlement likewise still constructs the first
+  incarnation and then immediately tears it down. The two rules partition by
+  target and never conflict: fresh-restart-starts-
   clear says a latch *consumed by* incarnation N never carries to N+1;
   the pending latch holds a request that arrived with no incarnation to
   consume it — it was never any incarnation's spent latch, and it waits
@@ -3280,7 +3282,7 @@ in `on_stop`. ✓ = available; **R** = MUST be `Rejected`-or-absent (§6.4);
 | `recv()` / `try_recv()` (the merged event source: mailbox, offload completions, fired timers, queued continuations, §6.1 priority; `recv` yields `None` on stop request, biased; `try_recv` ignores the stop token — the drain primitive for raw loops: under `Drain`, exhaust the frozen prefix via `try_recv` after `recv` yields `None`, §11's raw-loop obligation) | ✓ | — | — | — |
 | `mailbox_shutdown()` (the resolved §11 policy for this actor's mailbox — what a raw loop consults to honor `Drain` vs `Discard`) | ✓ | — | — | — |
 | `mark_ready()` (one-shot effect by construction; meaningful only under gated readiness, else a documented no-op — B.2's rule, uniformly; during drain always the no-op) | ✓ | ✓ | ✓ | — |
-| `stop()` (clean self-stop; `Err` outcome wins; idempotent — during drain the already-stopping no-op; arms the child's configured §11 ladder as the stop bound. Live/Drain: effective after the current callback; in a successful effective-`AfterInit` initializer, after its automatic readiness edge. Raw: freezes intake at the call — drain the frozen prefix via `try_recv` after `recv` yields `None`; §1 principle 5's public primitive for the blanket loop's `stop()`) | ✓ | ✓ | ✓ | — |
+| `stop()` (clean self-stop; `Err` outcome wins; idempotent — during drain the already-stopping no-op; arms the child's configured §11 ladder as the stop bound. Live: freezes intake and incarnation-owned resources at the call, so later same-callback work is rejected; the callback may finish before terminal publication. In a successful effective-`AfterInit` initializer, stop publication follows its automatic readiness edge, while the freeze remains immediate. Drain is already frozen. Raw: freezes intake at the call — drain the frozen prefix via `try_recv` after `recv` yields `None`; §1 principle 5's public primitive for the blanket loop's `stop()`) | ✓ | ✓ | ✓ | — |
 | `is_draining()` | — | ✓ | ✓ | — |
 | `continue_with(msg)` (next-message continuation; no mailbox capacity; anti-starvation per §6.1) | ✓ | ✓ | **R** | — |
 | Keyed timers: `set_timeout` / `set_interval` / `clear_timer` (§6.3) | ✓ | ✓ | **R** | — |


### PR DESCRIPTION
Part of #366.

Completes the remaining small Batch 1 items:

- clamps equal jitter to its exact integer half-delay lower bound and covers the smallest positive sample
- makes `SystemRun::drop` inert after its driver has already been joined
- documents the immediate `Context::stop` intake/resource freeze and pins every local-work facade result after a same-callback stop
- records the stop-before-first-settlement construction behavior in SPEC §11

Validation: `./tools/dev just ci` (805 tests).

Stack: independent Batch 1 slice; targets `main`.