### PR TITLE
Lay the instrumentation foundation as a pin and a requirement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,12 +21,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
-name = "once_cell"
-version = "1.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,7 +70,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn",
 ]
 
 [[package]]
@@ -102,7 +96,6 @@ dependencies = [
  "shelterwood-runtime",
  "thiserror",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -151,17 +144,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.119"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
@@ -188,7 +170,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn",
 ]
 
 [[package]]
@@ -209,38 +191,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,12 @@ thiserror = "2.0.19"
 # Blocking-pool rejection ownership is verified against this exact Tokio
 # release. Any upgrade must re-audit and re-run the adapter regressions.
 tokio = { version = "=1.53.1", features = ["macros", "rt", "sync", "time"] }
-tracing = "0.1.44"
+# `tracing` is deliberately absent, and its absence is the pin: no workspace
+# crate may name it, so an emission written anywhere today fails to compile
+# rather than landing outside the instrumentation seam SPEC §15.7 requires.
+# The relaxation is planned, not forbidden: when instrumentation lands, this
+# entry returns and the pin narrows to "only the `shelterwood` façade crate
+# may depend on `tracing`" — the same shape as the tokio pin, where only
+# `shelterwood-runtime` names the adapter's runtime. Lower crates surface
+# facts as data through the existing effects and event machinery; the top
+# crate is the only emitter.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,12 +41,3 @@ thiserror = "2.0.19"
 # Blocking-pool rejection ownership is verified against this exact Tokio
 # release. Any upgrade must re-audit and re-run the adapter regressions.
 tokio = { version = "=1.53.1", features = ["macros", "rt", "sync", "time"] }
-# `tracing` is deliberately absent, and its absence is the pin: no workspace
-# crate may name it, so an emission written anywhere today fails to compile
-# rather than landing outside the instrumentation seam SPEC §15.7 requires.
-# The relaxation is planned, not forbidden: when instrumentation lands, this
-# entry returns and the pin narrows to "only the `shelterwood` façade crate
-# may depend on `tracing`" — the same shape as the tokio pin, where only
-# `shelterwood-runtime` names the adapter's runtime. Lower crates surface
-# facts as data through the existing effects and event machinery; the top
-# crate is the only emitter.

--- a/crates/shelterwood/Cargo.toml
+++ b/crates/shelterwood/Cargo.toml
@@ -18,7 +18,6 @@ shelterwood-core.workspace = true
 shelterwood-mailbox.workspace = true
 shelterwood-runtime.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
 shelterwood-cells = { workspace = true, features = ["test-util"] }

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -696,12 +696,11 @@ impl<M> Default for RawResources<M> {
 }
 
 impl<M> RawResources<M> {
-    fn freeze(&mut self) -> usize {
+    fn freeze(&mut self) {
         if !self.accepting {
-            return 0;
+            return;
         }
         self.accepting = false;
-        let dropped_continuations = self.continuations.len();
         // Treat the whole freeze as one cleanup transaction. Cancellation
         // contains each latch wake, future disposal and task abort
         // independently, while this outer accumulator keeps one failure from
@@ -728,7 +727,6 @@ impl<M> RawResources<M> {
             // synchronous cleanup has completed without losing the diagnostic.
             self.disposal.panic.restore_first(payload);
         }
-        dropped_continuations
     }
 
     /// Drops ledger entries for offloads that already finished, keeping a
@@ -765,7 +763,6 @@ impl<M> RawResources<M> {
                             "library-owned offload task panicked without a string payload"
                                 .to_owned()
                         });
-                        tracing::error!(%message, "library-owned offload task panicked");
                         self.disposal.panic.record(Box::new(message));
                     }
                 }
@@ -778,10 +775,7 @@ impl<M> RawResources<M> {
 
 impl<M> Drop for RawResources<M> {
     fn drop(&mut self) {
-        let freeze_panic = catch_panic(|| {
-            let _ = self.freeze();
-        })
-        .err();
+        let freeze_panic = catch_panic(|| self.freeze()).err();
         let mut panics = PanicAccumulator::default();
         // `freeze` can transfer a destructor panic into the shared slot. Take
         // that retained application diagnostic after cleanup and preserve it
@@ -933,7 +927,7 @@ impl<M: Send + 'static> RawContext<M> {
     /// from the epilogue.
     pub fn stop(&mut self) {
         self.receiver.freeze();
-        self.freeze_and_report();
+        self.freeze_resources();
         self.local_stop.fire();
     }
 
@@ -949,7 +943,7 @@ impl<M: Send + 'static> RawContext<M> {
         // publishes it through the initializer context's Drop fallback.
         self.deferred_init_stop = true;
         self.receiver.freeze();
-        self.freeze_and_report();
+        self.freeze_resources();
     }
 
     /// Closes the callback initializer boundary. Consuming the pending bit
@@ -1135,7 +1129,7 @@ impl<M: Send + 'static> RawContext<M> {
         loop {
             if self.local_stop.is_fired() {
                 self.receiver.freeze();
-                self.freeze_and_report();
+                self.freeze_resources();
                 // `stop()` originates on this task, but the configured
                 // shutdown ladder is owned by the driver. The driver's helper
                 // only observes the local-stop latch and forwards
@@ -1152,7 +1146,7 @@ impl<M: Send + 'static> RawContext<M> {
                 // also freezes before cancellation, but correctness of this
                 // receive boundary does not depend on that remote ordering.
                 self.receiver.freeze();
-                self.freeze_and_report();
+                self.freeze_resources();
                 self.resources.resume_pending_panic();
                 return None;
             }
@@ -1194,7 +1188,7 @@ impl<M: Send + 'static> RawContext<M> {
             // not rely on the driver's mailbox-freeze ordering relative to
             // the shutdown latch this call observes.
             self.receiver.freeze();
-            self.freeze_and_report();
+            self.freeze_resources();
             self.resources.resume_pending_panic();
             self.receiver.try_recv()
         } else {
@@ -1565,22 +1559,10 @@ impl<M: Send + 'static> RawContext<M> {
         .await;
     }
 
+    /// Freezes incarnation resources on the exit path, discarding §6.2's
+    /// queued continuations.
     pub(crate) fn freeze_resources(&mut self) {
-        self.freeze_and_report();
-    }
-
-    /// Freezes incarnation resources, reporting §6.2's discarded
-    /// continuations on the exit path.
-    fn freeze_and_report(&mut self) {
-        let dropped = self.resources.freeze();
-        if dropped > 0 {
-            tracing::debug!(
-                id = %self.id,
-                incarnation = ?self.incarnation,
-                dropped_continuations = dropped,
-                "queued continuations discarded at the stop freeze"
-            );
-        }
+        self.resources.freeze();
     }
 
     pub(crate) async fn join_resources(&mut self) {
@@ -2437,7 +2419,7 @@ mod tests {
             task: None,
         });
 
-        assert_eq!(resources.freeze(), 1);
+        resources.freeze();
         assert_eq!(drops.load(Ordering::SeqCst), 1);
         let payload = resources
             .disposal
@@ -2477,7 +2459,7 @@ mod tests {
             task: None,
         });
 
-        assert_eq!(resources.freeze(), 0);
+        resources.freeze();
         assert_eq!(drops.load(Ordering::SeqCst), 1);
         let payload = resources
             .disposal
@@ -2498,9 +2480,13 @@ mod tests {
             .continuations
             .push_back(PanickingDrop(Arc::clone(&drops)));
 
-        assert_eq!(resources.freeze(), 1);
-        assert_eq!(resources.freeze(), 0, "the freeze transition is one-shot");
-        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        resources.freeze();
+        resources.freeze();
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            1,
+            "the freeze transition is one-shot"
+        );
 
         let payload = catch_unwind(AssertUnwindSafe(|| drop(resources)))
             .expect_err("drop resumes the failure retained by the first freeze");
@@ -2540,7 +2526,7 @@ mod tests {
             None,
         );
 
-        assert_eq!(resources.freeze(), 2);
+        resources.freeze();
         assert_eq!(
             drops.load(Ordering::SeqCst),
             4,

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -772,7 +772,6 @@ fairness:
    message), with one fairness exception: immediately after a continuation
    runs, one ready mailbox/offload delivery gets a turn before the next
    continuation, so a continuation chain cannot starve external input;
-   dropped-continuation reporting on exit is preserved;
 3. mailbox and offload deliveries;
 4. keyed timers.
 
@@ -781,8 +780,8 @@ applied to the loop). Continuations form a FIFO queue: multiple
 `continue_with` calls from one callback are all retained, in call order —
 no last-wins replacement and no single-pending cap (the queue is unbounded
 and consumes no mailbox capacity, B.1; discard happens only at the stop
-freeze, reported on exit) — each running as a "next message" ahead of
-queued mail, with the fairness interleave above applying between
+freeze) — each running as a "next message" ahead of queued mail, with
+the fairness interleave above applying between
 successive continuations. Timers whose deadlines fire at the same instant
 deliver in **arming order** — the order their *current* armings were
 established; re-arming a key (§6.3's replacement) takes the new position —
@@ -851,8 +850,8 @@ at the freeze, in acceptance order; under `latest()`, the surviving slot
 *replaced* per §5.4's replacement ordering, and is never handled). At the
 freeze, outstanding offloads are cancelled (incarnation-owned work of a
 stopping incarnation — continuations suppressed per §6.5), queued
-continuations are discarded and reported on exit (priority item 2 above),
-and armed timers are dropped (§6.3) — so for a cooperative `Drain` that
+continuations are discarded (priority item 2 above), and armed timers
+are dropped (§6.3) — so for a cooperative `Drain` that
 runs to completion, "the handled log equals the accepted prefix" (§16.15)
 has no asterisks beyond the one conflation already states: under `queue`
 the two are identical; under `latest()` the handled log is the accepted
@@ -2526,8 +2525,10 @@ final cut, never a partial batch. Watch conflation remains permitted only
 *between committed transaction cuts*; it is not permission to expose the
 transaction's internal publications.
 
-`tracing` spans emit from one choke point (the optional `metrics` surface
-is Part II §22). Everything else observational — peer monitoring, actor
+Diagnostic instrumentation is not one of these contracts and core
+requires none; where a conforming library adds it, §15.7 constrains how
+(the optional `metrics` surface is Part II §22, a second emitter over the
+same seam). Everything else observational — peer monitoring, actor
 statistics, the self-recovering child-observation reducer, the packaged
 restart-counter view — is Part II (§20, §22): all are adapters over these
 two streams and the §3 identity types, which is what makes them safely
@@ -2850,14 +2851,58 @@ publication skipped when no subscriber exists — a subscriber-channel
 optimization only: pull-side `snapshot()` is an on-demand projection and
 can never go stale from the skip, and a fresh subscription's initial
 value is computed at subscribe time (§14) — (the conflating watch already
-makes cost O(observations), not O(events)); per-message `tracing` built
-lazily and near-zero with no active subscriber. What stays unsanctioned
-even under measured pressure: clock reads or randomness inside decision
-modules (pass `now` and samples in — it costs nothing), dispatch paths
-that bypass the exit funnel, and per-call-site staleness shortcuts —
+makes cost O(observations), not O(events)); per-message diagnostic
+instrumentation, if §15.7 ever adds any, built lazily so that it costs
+approximately nothing with no active subscriber — the cached-interest
+check of a conventional instrumentation library already supplies this, so
+the requirement is the property, not a bespoke mechanism for it. What
+stays unsanctioned even under measured pressure: clock reads or
+randomness inside decision modules (pass `now` and samples in — it costs
+nothing), dispatch paths that bypass the exit funnel, and per-call-site
+staleness shortcuts —
 each of these is a known failure mode of impure supervision engines in a
 performance costume, and no supervision engine has been observed hot
 enough to justify one. Measure before relaxing anything else.
+
+### 15.7 Instrumentation
+
+Diagnostic instrumentation — trace events, spans, and the Part II
+`metrics` feature (§22) — is **not** part of the observable contract:
+nothing in §§1–14 may be stated in terms of what a trace prints, and a
+conforming library MAY ship none at all. What is normative is the shape
+instrumentation MUST take *when* it is added, because the alternative —
+emission written wherever it seemed useful — retracts the guarantees
+§15.4 makes structural, one call site at a time.
+
+- **One layer emits.** Emission is confined to the top (façade) layer and
+  the confinement is a dependency pin, checkable at the manifest: the
+  instrumentation library is nameable only there, the same shape as the
+  runtime adapter being the only layer allowed to name a concrete
+  executor. Layers below surface facts as *data*, on the effects and
+  event values they already carry, and let the façade decide whether that
+  data becomes an event. A pin is enforceable; a convention about where
+  macros get written is not.
+- **A typed vocabulary, not free-form call sites.** Events are built
+  through named constructors whose signatures admit only framework-owned
+  data — discriminants, the §3 identity types, sequence numbers, counts,
+  durations. A user `Debug`/`Display` appears in no signature, which
+  states §15.4's field constraint once, structurally, instead of
+  re-deciding it at each call site. An operator who wants a failed
+  incarnation's error reads it from the `Exit` (§8) and formats it on
+  their own thread.
+- **Emission rides the effects flush.** An event arising inside a
+  critical section is recorded in that transaction's deferred-effect list
+  and emitted after the guard is released. A subscriber is arbitrary user
+  code — it may panic, block, or re-enter the library — so it is exactly
+  what §15.4 forbids under a framework lock, and the flush is where such
+  work already belongs.
+- **Spans attach at one site.** Spans, when added, attach per
+  incarnation, at the single site that already owns the incarnation
+  boundary, rather than being opened per operation across the loop.
+
+The `metrics` feature is a second emitter over this same vocabulary, not
+a shared runtime funnel that both must be routed through: it consumes the
+same typed events and inherits all four rules above.
 
 ## 16. Conformance obligations
 

--- a/specs/core-plus.md
+++ b/specs/core-plus.md
@@ -266,14 +266,18 @@ All adapters over core's two streams and identity types:
 - **Packaged restart-counter view** — subscription plus cumulative total
   that survives `Lagged`, deduplicated, making breaker patterns turnkey
   without hand-carried totals.
-- **`metrics` feature** — optional metric emission from the same single
-  choke point as `tracing`; the debugging surface exposes structured
-  snapshots rather than name-filtered tuples.
+- **`metrics` feature** — optional metric emission built over the same
+  typed event vocabulary as diagnostic tracing (Part I §15.7), as a
+  second emitter rather than a funnel both are routed through; the
+  debugging surface exposes structured snapshots rather than
+  name-filtered tuples.
 
 **Placement.** Split. The statistics fields, counters, and message-size
 measurement are an internal seam (counted inside the mailbox and loop,
-B.6), and the `metrics` feature shares `tracing`'s internal choke point;
-every packaged view above the two streams is a public-surface adapter
+B.6), and the `metrics` feature emits from the instrumentation seam Part
+I §15.7 requires — the same typed events, the same effects-flush timing,
+the same confinement to the façade layer. Every packaged view above the
+two streams is a public-surface adapter
 and MAY ship in the utility tier (§27).
 
 ## 23. Outline (`serde` feature)

--- a/tools/external-consumer/Cargo.lock
+++ b/tools/external-consumer/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
-name = "once_cell"
-version = "1.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +41,6 @@ dependencies = [
  "shelterwood-mailbox",
  "shelterwood-runtime",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -96,17 +89,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.119"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
@@ -133,7 +115,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn",
 ]
 
 [[package]]
@@ -154,38 +136,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
+ "syn",
 ]
 
 [[package]]


### PR DESCRIPTION
## The decision

SPEC §14 said `tracing` spans emit from one choke point. There were no spans, and the two surviving events emitted from unrelated places inside the raw context — the sentence was a target read as a description (#240).

The choke point ships as **three structural decisions, not a runtime funnel**:

1. **A dependency pin.** `tracing` is gone from the workspace and from `crates/shelterwood`. Its absence *is* the pin: an emission written anywhere in the workspace today fails to compile. The workspace manifest carries the comment recording the planned relaxation — when instrumentation lands, the pin narrows to "only the `shelterwood` façade crate may name `tracing`", the same shape as the tokio pin, where only `shelterwood-runtime` names the executor. Lower crates surface facts as data on the effects and event values they already carry; the top crate is the only emitter.
2. **A typed event vocabulary.** Required by spec, not built yet: constructors whose signatures admit only framework-owned data — discriminants, §3 identity types, sequence numbers, counts, durations — and never a user `Debug`/`Display`. That states §15.4's field constraint once, structurally, instead of re-deciding it per call site.
3. **Emission rides the effects flush.** An event arising inside a critical section is deferred onto the transaction and emitted after the guard is released, because a subscriber is arbitrary user code and §15.4 forbids that under a framework lock.

## Why the two events were removed rather than migrated

Neither has a consumer.

- The offload-panic `tracing::error!` duplicated a diagnostic the same path already retains through `self.disposal.panic.record(...)`, which is what actually surfaces to the actor. The record stays; only the log line goes.
- The freeze `tracing::debug!` was the sole reader of the discarded-continuation count, so `freeze_and_report` collapses into `freeze_resources` and `RawResources::freeze` no longer computes a count nobody reads. The unit tests that asserted the count already pin the disposal they are about through their drop counters; the one-shot claim rides on "drops stay at 1 across a second freeze".

Migrating them into a vocabulary that does not exist would have built the funnel to carry two events that nothing observes. The foundation is laid instead, and the first real instrumentation gets to design its own events under §15.7's constraints.

## Spec amendments

- **§14** — the choke-point claim becomes a cross-reference: instrumentation is not one of the two observational contracts, core requires none, and §15.7 governs it where a library adds it. The Part II `metrics` forward reference survives as a second emitter over the same seam.
- **§15.7 (new)** — instrumentation as a construction requirement on future code: one emitting layer held by a dependency pin, the typed vocabulary, the effects-flush rule, and spans attaching per incarnation at one site. Placed in §15 because it constrains how the library is built, not what it observably does; no renumbering (it appends after §15.6).
- **§15.6** — "per-message `tracing` built lazily and near-zero with no active subscriber" becomes a conditional requirement on per-message instrumentation *if* it is ever added, and notes that a conventional library's cached-interest check already supplies the property, so the requirement is the property and not a bespoke mechanism.
- **§6.1 and §6.2** — three sites claimed discarded continuations were "reported on exit". The report *was* the deleted debug event and no observable surface carries the count (diagnostic output is non-contractual here), so the claim goes; the discard itself is unchanged.
- **core-plus.md §22** — "same single choke point as `tracing`" and "shares `tracing`'s internal choke point" become the same typed vocabulary and seam, second emitter.

## Validation

`./tools/dev just ci` — green. Both lockfiles updated (the external-consumer probe has its own).

Closes #240.