### PR TITLE
Contain offload completion wakes

### DIFF
--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -2036,6 +2036,60 @@ mod tests {
         assert!(!resources.offloads[0].finished.is_fired());
     }
 
+    #[crate::runtime::test]
+    async fn ordinary_offload_completion_retains_a_finished_waiter_wake_panic() {
+        let mut resources = RawResources::<()>::default();
+        let mut panic_signal = resources.disposal.signal.watcher();
+        let finished = Latch::default();
+        let mut waiter = Box::pin(finished.fired());
+        let hostile = Waker::from(Arc::new(PanickingWake("ordinary finished wake panic")));
+        assert!(
+            waiter
+                .as_mut()
+                .poll(&mut Context::from_waker(&hostile))
+                .is_pending()
+        );
+
+        let state = SharedOffloadState::new(
+            Box::pin(async {}),
+            resources.disposal.clone(),
+            finished.clone(),
+        );
+        resources.offloads.push(OffloadResource {
+            cancellation: Latch::default(),
+            finished: finished.clone(),
+            state: Some(Arc::clone(&state)),
+            task: None,
+        });
+        let mut work = SharedOffloadFuture(state);
+        assert!(
+            Pin::new(&mut work)
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_ready(),
+            "a caller wake panic does not escape through the offload task"
+        );
+
+        assert!(finished.is_fired(), "all completion waiters were released");
+        resources.reclaim_finished();
+        assert!(
+            resources.offloads.is_empty(),
+            "ledger reclamation cannot discard the retained diagnostic"
+        );
+        assert!(matches!(
+            crate::runtime::timeout(Duration::from_secs(1), panic_signal.changed()).await,
+            crate::runtime::Timeout::Completed(())
+        ));
+        let payload = resources
+            .disposal
+            .panic
+            .take()
+            .expect("the caller wake panic survives ledger reclamation");
+        assert_eq!(
+            panic_message(&payload),
+            Some("ordinary finished wake panic")
+        );
+    }
+
     /// `freeze` is the drain that normally empties the continuation queue, but
     /// it is not a guaranteed one: `Drop for RawResources` skips it once the
     /// incarnation is already frozen, and runs it under `catch_panic` so an

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -740,7 +740,13 @@ impl<M> RawResources<M> {
     /// count, so a per-turn walk of it is proportional to work the actor
     /// itself has outstanding.
     fn reclaim_finished(&mut self) {
-        self.offloads.retain(|offload| !offload.finished.is_fired());
+        self.offloads.retain(|offload| {
+            if let Some(state) = &offload.state {
+                !state.finished_published()
+            } else {
+                !offload.finished.is_fired()
+            }
+        });
     }
 
     fn resume_pending_panic(&self) {
@@ -1736,6 +1742,12 @@ mod tests {
 
     struct PanickingWake(&'static str);
 
+    struct BlockingPanickingWake {
+        entered: Arc<Barrier>,
+        release: Arc<Barrier>,
+        message: &'static str,
+    }
+
     impl Wake for PanickingWake {
         fn wake(self: Arc<Self>) {
             panic!("{}", self.0);
@@ -1743,6 +1755,24 @@ mod tests {
 
         fn wake_by_ref(self: &Arc<Self>) {
             panic!("{}", self.0);
+        }
+    }
+
+    impl BlockingPanickingWake {
+        fn block_then_panic(&self) {
+            self.entered.wait();
+            self.release.wait();
+            panic!("{}", self.message);
+        }
+    }
+
+    impl Wake for BlockingPanickingWake {
+        fn wake(self: Arc<Self>) {
+            self.block_then_panic();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.block_then_panic();
         }
     }
 
@@ -2036,13 +2066,19 @@ mod tests {
         assert!(!resources.offloads[0].finished.is_fired());
     }
 
-    #[crate::runtime::test]
-    async fn ordinary_offload_completion_retains_a_finished_waiter_wake_panic() {
+    #[test]
+    fn ordinary_offload_completion_retains_a_finished_waiter_wake_panic() {
         let mut resources = RawResources::<()>::default();
-        let mut panic_signal = resources.disposal.signal.watcher();
+        let panic = Arc::clone(&resources.disposal.panic);
         let finished = Latch::default();
         let mut waiter = Box::pin(finished.fired());
-        let hostile = Waker::from(Arc::new(PanickingWake("ordinary finished wake panic")));
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let hostile = Waker::from(Arc::new(BlockingPanickingWake {
+            entered: Arc::clone(&entered),
+            release: Arc::clone(&release),
+            message: "ordinary finished wake panic",
+        }));
         assert!(
             waiter
                 .as_mut()
@@ -2061,27 +2097,36 @@ mod tests {
             state: Some(Arc::clone(&state)),
             task: None,
         });
-        let mut work = SharedOffloadFuture(state);
-        assert!(
-            Pin::new(&mut work)
-                .poll(&mut Context::from_waker(Waker::noop()))
-                .is_ready(),
-            "a caller wake panic does not escape through the offload task"
-        );
+        let poller = thread::spawn(move || {
+            let mut work = SharedOffloadFuture(state);
+            assert!(
+                Pin::new(&mut work)
+                    .poll(&mut Context::from_waker(Waker::noop()))
+                    .is_ready(),
+                "a caller wake panic does not escape through the offload task"
+            );
+        });
+        entered.wait();
 
         assert!(finished.is_fired(), "all completion waiters were released");
         resources.reclaim_finished();
         assert!(
-            resources.offloads.is_empty(),
-            "ledger reclamation cannot discard the retained diagnostic"
+            !resources.offloads.is_empty(),
+            "the fired bit cannot retire work before its hostile wake is contained"
         );
-        assert!(matches!(
-            crate::runtime::timeout(Duration::from_secs(1), panic_signal.changed()).await,
-            crate::runtime::Timeout::Completed(())
-        ));
-        let payload = resources
-            .disposal
-            .panic
+        assert!(
+            panic.take().is_none(),
+            "an actor turn can precede the blocked wake's panic"
+        );
+
+        release.wait();
+        poller.join().expect("the caller wake panic is contained");
+        resources.reclaim_finished();
+        assert!(
+            resources.offloads.is_empty(),
+            "the ledger retires work after notification publication"
+        );
+        let payload = panic
             .take()
             .expect("the caller wake panic survives ledger reclamation");
         assert_eq!(

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -1787,7 +1787,7 @@ mod tests {
     /// Generous enough to survive a loaded shared machine, finite so that a
     /// mutation which suppresses the fire under test reports instead of
     /// wedging the runner.
-    const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+    const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
     /// A single-use, timeout-bounded signal between two threads.
     ///
@@ -2207,18 +2207,25 @@ mod tests {
         });
         entered.wait("the completion wake to reach the hostile waiter");
 
-        assert!(finished.is_fired(), "all completion waiters were released");
+        // Sample the mid-wake state, then release before asserting on it: an
+        // assertion that fires while the wake is still parked would strand the
+        // peer on its timeout and report the expiry instead of the mismatch.
+        let fired_mid_wake = finished.is_fired();
         resources.reclaim_finished();
-        assert!(
-            !resources.offloads.is_empty(),
+        let pinned_mid_wake = resources.offloads.len();
+        let recorded_mid_wake = panic.take();
+        release.open();
+
+        assert!(fired_mid_wake, "all completion waiters were released");
+        assert_eq!(
+            pinned_mid_wake, 1,
             "the fired bit cannot retire work before its hostile wake is contained"
         );
         assert!(
-            panic.take().is_none(),
+            recorded_mid_wake.is_none(),
             "an actor turn can precede the blocked wake's panic"
         );
 
-        release.open();
         poller.join().expect("the caller wake panic is contained");
         resources.reclaim_finished();
         assert!(
@@ -2275,15 +2282,17 @@ mod tests {
         });
 
         entered.wait("the completion wake to reach the hostile waiter");
-        assert!(finished.is_fired(), "all completion waiters were released");
+        let fired_mid_wake = finished.is_fired();
         resources.reclaim_finished();
+        let pinned_mid_wake = resources.offloads.len();
+        release.open();
+
+        assert!(fired_mid_wake, "all completion waiters were released");
         assert_eq!(
-            resources.offloads.len(),
-            1,
+            pinned_mid_wake, 1,
             "the ledger keeps the task handle teardown must join while the wake runs"
         );
 
-        release.open();
         resources.join_offloads().await;
         assert!(
             resources.offloads.is_empty(),

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -742,8 +742,18 @@ impl<M> RawResources<M> {
     fn reclaim_finished(&mut self) {
         self.offloads.retain(|offload| {
             if let Some(state) = &offload.state {
+                // Deliberately not the latch's fired bit: that is set before
+                // completion waiters are woken, so it would let this retire
+                // the entry — and with it the task handle teardown must join
+                // — while a caller's `Guard::finished()` waker is still
+                // running.
                 !state.finished_published()
             } else {
+                // Only the zero-deadline short-circuit builds a resource with
+                // no shared state. It fires its latch while the `Guard` is
+                // still on the way back to the caller, so the waiter registry
+                // is provably empty: there is no wake for the fired bit to
+                // outrun, and no task handle to lose.
                 !offload.finished.is_fired()
             }
         });
@@ -759,6 +769,14 @@ impl<M> RawResources<M> {
         });
     }
 
+    /// Awaits every offload task the ledger still holds.
+    ///
+    /// Reclamation retires an entry only once its completion wake has
+    /// returned, so an offload whose caller-owned `Guard::finished()` waker
+    /// blocks is necessarily still here and is joined. That is the accepted
+    /// cost of never retiring work whose wake is in flight: caller code can
+    /// delay incarnation teardown, and therefore exit publication, for as
+    /// long as it blocks in that waker.
     async fn join_offloads(&mut self) {
         for offload in &mut self.offloads {
             if let Some(task) = offload.task.take() {
@@ -1108,15 +1126,24 @@ impl<M: Send + 'static> RawContext<M> {
     ///
     /// Any incarnation-owned disposal panic retained by the time this path
     /// runs resumes here before another event is delivered or a stop is
-    /// reported: an offload-work panic, and — because the stop branches
-    /// freeze first — a destructor panic from the queued continuations,
-    /// armed timers, queued offload completions and offload futures that the
-    /// freeze releases, a waker panic from the `Guard::finished()` waiters
-    /// and cancellation latches that cancelling those offloads wakes, and a
-    /// panic raised by aborting an offload task. Retention is the guarantee,
-    /// not a join: a payload recorded after this check is still the
-    /// incarnation's exit, but is classified by the epilogue and cannot
-    /// suppress `on_stop`.
+    /// reported: an offload-work panic, a waker panic from the
+    /// `Guard::finished()` waiters that *ordinary* offload completion wakes,
+    /// and — because the stop branches freeze first — a destructor panic from
+    /// the queued continuations, armed timers, queued offload completions and
+    /// offload futures that the freeze releases, a waker panic from the
+    /// cancellation latches and completion notifications that cancelling
+    /// those offloads wakes, and a panic raised by aborting an offload task.
+    /// The completion-waiter class is not teardown-only: a third party
+    /// awaiting `Guard::finished()` with a panicking waker fails a live
+    /// incarnation here, and per SPEC §6.2 a failed incarnation skips
+    /// `on_stop`. Retention is the guarantee, not a join: a payload recorded
+    /// after this check is still the incarnation's exit, but is classified by
+    /// the epilogue and cannot suppress `on_stop`. The one exception is that
+    /// same completion wake: because retention has to be established before
+    /// the ledger may forget the work, a completion waker that *blocks*
+    /// instead of panicking pins its entry, and incarnation teardown then
+    /// joins it — an accepted trade against retiring work whose wake is still
+    /// in flight.
     ///
     /// A panic in an offload's continuation closure — the `FnOnce` that
     /// builds the message from the offload result, not a
@@ -1169,17 +1196,24 @@ impl<M: Send + 'static> RawContext<M> {
     /// returning another event; a panic in an offload's continuation closure
     /// (the message-building `FnOnce`, not a
     /// [`continue_with`](Self::continue_with) continuation, which is a plain
-    /// stored message) surfaces directly from this call. During drain it
-    /// freezes first, then resumes any incarnation-owned disposal panic
-    /// retained by that point — an offload-work panic, a destructor panic
-    /// from the continuations, timers, queued completions and offload futures
-    /// the freeze releases, a waker panic from the `Guard::finished()`
-    /// waiters and cancellation latches that cancelling those offloads wakes,
-    /// or a panic raised by aborting an offload task — before reading the
-    /// frozen accepted mailbox
+    /// stored message) surfaces directly from this call. The outside-drain
+    /// class is not only offload work: a waker panic from the
+    /// `Guard::finished()` waiters that ordinary offload completion wakes is
+    /// retained the same way, so a third party awaiting `Guard::finished()`
+    /// with a panicking waker fails a live incarnation here and, per SPEC
+    /// §6.2, skips its `on_stop`. During drain it freezes first, then resumes
+    /// any incarnation-owned disposal panic retained by that point — those
+    /// two, plus a destructor panic from the continuations, timers, queued
+    /// completions and offload futures the freeze releases, a waker panic
+    /// from the cancellation latches and completion notifications that
+    /// cancelling those offloads wakes, or a panic raised by aborting an
+    /// offload task — before reading the frozen accepted mailbox
     /// prefix. Retention is the guarantee, not a join: a payload recorded
     /// after the check is still the incarnation's exit, but is classified by
-    /// the epilogue and cannot suppress `on_stop`.
+    /// the epilogue and cannot suppress `on_stop`. A completion waker that
+    /// blocks rather than panicking is the accepted exception: it pins its
+    /// ledger entry until it returns, so incarnation teardown joins that
+    /// completion.
     ///
     /// A panic escaping this call leaves the fired selection cut installed,
     /// so the next receive retries the same timer arming rather than
@@ -1261,6 +1295,11 @@ impl<M: Send + 'static> RawContext<M> {
                 cancellation: cancellation.clone(),
                 make_message: Box::new(move || continuation.into_inner()(Err(DeadlineElapsed))),
             });
+            // The one uncontained completion fire in this file, and safe only
+            // because `guard` has not been handed back yet: no caller can hold
+            // this latch, so its waiter registry is empty and this wake runs
+            // nothing. Nothing structural enforces that — keep the fire ahead
+            // of the `return Ok(guard)` below.
             finished.fire();
             self.resources.offloads.push(OffloadResource {
                 cancellation,
@@ -1584,11 +1623,12 @@ impl<M: Send + 'static> RawContext<M> {
 mod tests {
     use std::{
         future::Future,
-        panic::{AssertUnwindSafe, catch_unwind},
+        panic::{AssertUnwindSafe, catch_unwind, panic_any},
         pin::Pin,
         sync::{
-            Arc, Barrier,
+            Arc, Barrier, Mutex,
             atomic::{AtomicUsize, Ordering},
+            mpsc,
         },
         task::{Context, Poll, Wake, Waker},
         thread,
@@ -1742,9 +1782,60 @@ mod tests {
 
     struct PanickingWake(&'static str);
 
+    /// How long a bounded handshake waits before failing its test.
+    ///
+    /// Generous enough to survive a loaded shared machine, finite so that a
+    /// mutation which suppresses the fire under test reports instead of
+    /// wedging the runner.
+    const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+    /// A single-use, timeout-bounded signal between two threads.
+    ///
+    /// `Barrier` is the wrong oracle for these tests: a mutation that stops
+    /// the completion latch firing at all would block the waiting side
+    /// forever, turning a regression into a hang. Every wait here expires and
+    /// panics on the waiting thread instead, where nothing swallows it.
+    struct Gate {
+        sender: mpsc::SyncSender<()>,
+        receiver: Mutex<mpsc::Receiver<()>>,
+    }
+
+    impl Gate {
+        fn new() -> Arc<Self> {
+            let (sender, receiver) = mpsc::sync_channel(1);
+            Arc::new(Self {
+                sender,
+                receiver: Mutex::new(receiver),
+            })
+        }
+
+        fn open(&self) {
+            // A dropped peer means its wait already expired and failed the
+            // test; there is nothing left to report here.
+            let _ = self.sender.try_send(());
+        }
+
+        fn wait(&self, expected: &str) {
+            self.receiver
+                .lock()
+                .expect("gate receiver mutex poisoned")
+                .recv_timeout(HANDSHAKE_TIMEOUT)
+                .unwrap_or_else(|_| panic!("timed out waiting for {expected}"));
+        }
+    }
+
+    /// A wake panic payload that is deliberately not a string.
+    ///
+    /// An uncontained wake panic reaches the incarnation only as the offload
+    /// task's join result, which the framework can preserve solely as a
+    /// `String`. Panicking with an opaque payload is therefore what lets these
+    /// tests tell the caller's own payload apart from that stand-in.
+    #[derive(Debug, Eq, PartialEq)]
+    struct OpaqueWakePanic(&'static str);
+
     struct BlockingPanickingWake {
-        entered: Arc<Barrier>,
-        release: Arc<Barrier>,
+        entered: Arc<Gate>,
+        release: Arc<Gate>,
         message: &'static str,
     }
 
@@ -1760,9 +1851,9 @@ mod tests {
 
     impl BlockingPanickingWake {
         fn block_then_panic(&self) {
-            self.entered.wait();
-            self.release.wait();
-            panic!("{}", self.message);
+            self.entered.open();
+            self.release.wait("the test to release the completion wake");
+            panic_any(OpaqueWakePanic(self.message));
         }
     }
 
@@ -2066,14 +2157,22 @@ mod tests {
         assert!(!resources.offloads[0].finished.is_fired());
     }
 
+    /// The ordinary completion path — no freeze, no cancellation — retains a
+    /// `Guard::finished()` waiter's wake panic, and the ledger may not retire
+    /// the work until it has.
+    ///
+    /// The `Release` store that publishes completion is *not* pinned here:
+    /// `poller.join()` is a full fence, so weakening it to `Relaxed` would
+    /// still pass. Only the comment at that store constrains it. The
+    /// companion below covers the `task`-bearing chain this one omits.
     #[test]
     fn ordinary_offload_completion_retains_a_finished_waiter_wake_panic() {
         let mut resources = RawResources::<()>::default();
         let panic = Arc::clone(&resources.disposal.panic);
         let finished = Latch::default();
         let mut waiter = Box::pin(finished.fired());
-        let entered = Arc::new(Barrier::new(2));
-        let release = Arc::new(Barrier::new(2));
+        let entered = Gate::new();
+        let release = Gate::new();
         let hostile = Waker::from(Arc::new(BlockingPanickingWake {
             entered: Arc::clone(&entered),
             release: Arc::clone(&release),
@@ -2106,7 +2205,7 @@ mod tests {
                 "a caller wake panic does not escape through the offload task"
             );
         });
-        entered.wait();
+        entered.wait("the completion wake to reach the hostile waiter");
 
         assert!(finished.is_fired(), "all completion waiters were released");
         resources.reclaim_finished();
@@ -2119,7 +2218,7 @@ mod tests {
             "an actor turn can precede the blocked wake's panic"
         );
 
-        release.wait();
+        release.open();
         poller.join().expect("the caller wake panic is contained");
         resources.reclaim_finished();
         assert!(
@@ -2130,8 +2229,76 @@ mod tests {
             .take()
             .expect("the caller wake panic survives ledger reclamation");
         assert_eq!(
-            panic_message(&payload),
-            Some("ordinary finished wake panic")
+            payload.downcast_ref::<OpaqueWakePanic>(),
+            Some(&OpaqueWakePanic("ordinary finished wake panic")),
+            "the caller's original payload is retained, not a stringified stand-in"
+        );
+    }
+
+    /// The chain the fix exists to protect, with a real task handle: the
+    /// ledger keeps the entry while the completion wake is in flight, so
+    /// teardown still owns the `ActorWork` it must join, and the caller's own
+    /// payload — not the task join's stringified panic — reaches the
+    /// post-join resource take.
+    ///
+    /// Multi-threaded on purpose: the test thread blocks on the handshake
+    /// while the offload task runs the hostile wake on a worker.
+    #[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_pinned_completion_wake_panic_survives_the_offload_task_join() {
+        let mut resources = RawResources::<()>::default();
+        let finished = Latch::default();
+        let mut waiter = Box::pin(finished.fired());
+        let entered = Gate::new();
+        let release = Gate::new();
+        let hostile = Waker::from(Arc::new(BlockingPanickingWake {
+            entered: Arc::clone(&entered),
+            release: Arc::clone(&release),
+            message: "joined finished wake panic",
+        }));
+        assert!(
+            waiter
+                .as_mut()
+                .poll(&mut Context::from_waker(&hostile))
+                .is_pending()
+        );
+
+        let state = SharedOffloadState::new(
+            Box::pin(async {}),
+            resources.disposal.clone(),
+            finished.clone(),
+        );
+        resources.offloads.push(OffloadResource {
+            cancellation: Latch::default(),
+            finished: finished.clone(),
+            state: Some(Arc::clone(&state)),
+            task: Some(crate::runtime::spawn_actor_work(SharedOffloadFuture(state))),
+        });
+
+        entered.wait("the completion wake to reach the hostile waiter");
+        assert!(finished.is_fired(), "all completion waiters were released");
+        resources.reclaim_finished();
+        assert_eq!(
+            resources.offloads.len(),
+            1,
+            "the ledger keeps the task handle teardown must join while the wake runs"
+        );
+
+        release.open();
+        resources.join_offloads().await;
+        assert!(
+            resources.offloads.is_empty(),
+            "joining clears the ledger it pinned"
+        );
+
+        let payload = resources
+            .disposal
+            .panic
+            .take()
+            .expect("the caller wake panic reaches the post-join resource take");
+        assert_eq!(
+            payload.downcast_ref::<OpaqueWakePanic>(),
+            Some(&OpaqueWakePanic("joined finished wake panic")),
+            "the caller's original payload is retained, not the task join's stringified result"
         );
     }
 

--- a/crates/shelterwood/src/raw/offload.rs
+++ b/crates/shelterwood/src/raw/offload.rs
@@ -196,6 +196,15 @@ impl SharedOffloadState {
         self.disposal.record(payload);
     }
 
+    fn fire_finished(&self) {
+        if let Err(payload) = catch_panic(|| self.finished.fire()) {
+            // Completion waiters are caller-owned. Keep their wake panics in
+            // the incarnation slot instead of letting them escape through the
+            // framework-owned offload task's join result.
+            self.record(payload);
+        }
+    }
+
     pub(super) fn dispose(&self, future: Option<OffloadFuture>) {
         if let Some(future) = future {
             self.disposal.dispose(future);
@@ -232,7 +241,7 @@ impl Future for SharedOffloadFuture {
                 let dispose = self.0.finish_poll(future, OffloadPoll::Pending);
                 if dispose.is_some() {
                     self.0.dispose(dispose);
-                    self.0.finished.fire();
+                    self.0.fire_finished();
                     Poll::Ready(())
                 } else {
                     Poll::Pending
@@ -241,14 +250,14 @@ impl Future for SharedOffloadFuture {
             Ok(Poll::Ready(())) => {
                 let dispose = self.0.finish_poll(future, OffloadPoll::Finished);
                 self.0.dispose(dispose);
-                self.0.finished.fire();
+                self.0.fire_finished();
                 Poll::Ready(())
             }
             Err(payload) => {
                 let dispose = self.0.finish_poll(future, OffloadPoll::Finished);
                 self.0.record(payload);
                 self.0.dispose(dispose);
-                self.0.finished.fire();
+                self.0.fire_finished();
                 Poll::Ready(())
             }
         }

--- a/crates/shelterwood/src/raw/offload.rs
+++ b/crates/shelterwood/src/raw/offload.rs
@@ -4,7 +4,10 @@ use std::{
     fmt,
     future::Future,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU8, Ordering},
+    },
     task::{Context as TaskPollContext, Poll},
 };
 
@@ -14,6 +17,10 @@ use super::disposal::{PanicSlot, RawDisposal};
 
 type OffloadFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 type SharedWork = Arc<SharedOffloadState>;
+
+const FINISHED_PENDING: u8 = 0;
+const FINISHED_PUBLISHING: u8 = 1;
+const FINISHED_PUBLISHED: u8 = 2;
 
 /// Marker returned to an offload continuation when its one deadline expires.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
@@ -147,6 +154,7 @@ pub(super) struct SharedOffloadState {
     pub(super) state: Mutex<OffloadFutureState>,
     disposal: RawDisposal,
     finished: Latch,
+    finished_publication: AtomicU8,
 }
 
 impl SharedOffloadState {
@@ -159,6 +167,7 @@ impl SharedOffloadState {
             }),
             disposal,
             finished,
+            finished_publication: AtomicU8::new(FINISHED_PENDING),
         })
     }
 
@@ -197,12 +206,37 @@ impl SharedOffloadState {
     }
 
     fn fire_finished(&self) {
+        // The latch exposes its fired bit before invoking caller wakers. Claim
+        // that notification once so a concurrent cancellation cannot call a
+        // no-op second `fire` and mark publication complete while the winning
+        // caller is still inside a hostile wake.
+        if self
+            .finished_publication
+            .compare_exchange(
+                FINISHED_PENDING,
+                FINISHED_PUBLISHING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return;
+        }
         if let Err(payload) = catch_panic(|| self.finished.fire()) {
             // Completion waiters are caller-owned. Keep their wake panics in
             // the incarnation slot instead of letting them escape through the
             // framework-owned offload task's join result.
             self.record(payload);
         }
+        // Release-publish only after a hostile wake has either returned or
+        // had its panic installed in the incarnation slot. Ledger reclamation
+        // uses this edge instead of the latch's earlier fired bit.
+        self.finished_publication
+            .store(FINISHED_PUBLISHED, Ordering::Release);
+    }
+
+    pub(super) fn finished_published(&self) -> bool {
+        self.finished_publication.load(Ordering::Acquire) == FINISHED_PUBLISHED
     }
 
     pub(super) fn dispose(&self, future: Option<OffloadFuture>) {
@@ -222,7 +256,7 @@ impl SharedOffloadState {
             }
         };
         self.dispose(future);
-        self.finished.fire();
+        self.fire_finished();
     }
 }
 

--- a/crates/shelterwood/src/raw/offload.rs
+++ b/crates/shelterwood/src/raw/offload.rs
@@ -6,7 +6,7 @@ use std::{
     pin::Pin,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicU8, Ordering},
+        atomic::{AtomicBool, Ordering},
     },
     task::{Context as TaskPollContext, Poll},
 };
@@ -17,10 +17,6 @@ use super::disposal::{PanicSlot, RawDisposal};
 
 type OffloadFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 type SharedWork = Arc<SharedOffloadState>;
-
-const FINISHED_PENDING: u8 = 0;
-const FINISHED_PUBLISHING: u8 = 1;
-const FINISHED_PUBLISHED: u8 = 2;
 
 /// Marker returned to an offload continuation when its one deadline expires.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
@@ -63,6 +59,17 @@ impl Guard {
     /// Waits for work completion or an incarnation-teardown cancellation request.
     ///
     /// This notification does not join work that is being hard-aborted.
+    ///
+    /// The waker driving this await is caller-owned, but the incarnation is
+    /// what runs it, so it belongs to SPEC §6.2's incarnation-owned disposal
+    /// funnel on the *ordinary* completion path and not only at teardown. A
+    /// waker that panics while being woken has its payload retained, which
+    /// fails the incarnation at its next receive boundary and suppresses
+    /// `on_stop` — a third party awaiting this can therefore kill the actor.
+    /// A waker that blocks instead holds the work in the incarnation's
+    /// resource ledger until it returns, so incarnation teardown joins that
+    /// completion rather than sailing past it. Await this from a task whose
+    /// waker does neither.
     pub async fn finished(&self) {
         self.finished.fired().await;
     }
@@ -154,7 +161,7 @@ pub(super) struct SharedOffloadState {
     pub(super) state: Mutex<OffloadFutureState>,
     disposal: RawDisposal,
     finished: Latch,
-    finished_publication: AtomicU8,
+    finished_published: AtomicBool,
 }
 
 impl SharedOffloadState {
@@ -167,7 +174,7 @@ impl SharedOffloadState {
             }),
             disposal,
             finished,
-            finished_publication: AtomicU8::new(FINISHED_PENDING),
+            finished_published: AtomicBool::new(false),
         })
     }
 
@@ -205,38 +212,44 @@ impl SharedOffloadState {
         self.disposal.record(payload);
     }
 
+    /// Fires the completion notification once, and publishes it only after
+    /// this thread's wake has finished.
+    ///
+    /// [`Latch::fire`] sets its fired bit inside `fire_silently`, before it
+    /// wakes anything, so that bit cannot be the ledger's retirement
+    /// predicate: reclamation would be free to retire the entry — dropping the
+    /// task handle teardown still has to join — while a caller's completion
+    /// waker is mid-wake, after which a payload recorded by that wake lands in
+    /// a slot nobody reads again. Splitting the transition from the wake and
+    /// claiming the *latch's own* transition, rather than a second claim
+    /// beside it, keeps the wake-running thread and the publishing thread the
+    /// same thread by construction: two claims could disagree, letting a
+    /// concurrent canceller win the latch and run the wake while the publisher
+    /// marked completion around it.
     fn fire_finished(&self) {
-        // The latch exposes its fired bit before invoking caller wakers. Claim
-        // that notification once so a concurrent cancellation cannot call a
-        // no-op second `fire` and mark publication complete while the winning
-        // caller is still inside a hostile wake.
-        if self
-            .finished_publication
-            .compare_exchange(
-                FINISHED_PENDING,
-                FINISHED_PUBLISHING,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            )
-            .is_err()
-        {
+        if !self.finished.fire_silently() {
             return;
         }
-        if let Err(payload) = catch_panic(|| self.finished.fire()) {
+        if let Err(payload) = catch_panic(|| self.finished.notify()) {
             // Completion waiters are caller-owned. Keep their wake panics in
             // the incarnation slot instead of letting them escape through the
             // framework-owned offload task's join result.
             self.record(payload);
         }
-        // Release-publish only after a hostile wake has either returned or
-        // had its panic installed in the incarnation slot. Ledger reclamation
-        // uses this edge instead of the latch's earlier fired bit.
-        self.finished_publication
-            .store(FINISHED_PUBLISHED, Ordering::Release);
+        // Release-publish only after the wake above returned or had its panic
+        // installed in the incarnation slot. Ledger reclamation consumes this
+        // edge with the matching `Acquire` in `finished_published`; weakening
+        // either side would let a reclaiming actor observe retirement without
+        // observing the recorded payload. No test pins that pairing — only
+        // this comment does.
+        self.finished_published.store(true, Ordering::Release);
     }
 
+    /// Reports whether completion has been notified *and* its wake has
+    /// returned. See [`Self::fire_finished`] for why this, not
+    /// [`Latch::is_fired`], is what may retire ledger state.
     pub(super) fn finished_published(&self) -> bool {
-        self.finished_publication.load(Ordering::Acquire) == FINISHED_PUBLISHED
+        self.finished_published.load(Ordering::Acquire)
     }
 
     pub(super) fn dispose(&self, future: Option<OffloadFuture>) {
@@ -313,9 +326,11 @@ impl OffloadResource {
         });
         panics.record(retained.take());
         if let Some(state) = &self.state {
-            // `state.cancel` disposes the future before firing `finished`.
-            // Pull that contained destructor failure into the accumulator
-            // before recording a later wake panic escaping the call.
+            // `state.cancel` disposes the future and then contains its own
+            // completion wake, so neither a destructor panic nor a caller
+            // waker panic escapes the call: both arrive through the retained
+            // slot, where `PanicSlot`'s first-wins policy discards the loser.
+            // `state_panic` can therefore only be a poisoned-mutex `expect`.
             let state_panic = catch_panic(|| state.cancel()).err();
             panics.record(retained.take());
             panics.record(state_panic);
@@ -329,6 +344,12 @@ impl OffloadResource {
             panics.run(|| task.abort());
             panics.record(retained.take());
         }
+        // Unconditional on purpose. Once any contained fire has claimed the
+        // latch this is a no-op, which is what keeps a caller's completion
+        // wake off the actor thread while the offload task is running it. It
+        // is not redundant, though: a `state.cancel` that panicked before
+        // reaching its own fire — only a poisoned mutex can do that — would
+        // otherwise leave `Guard::finished()` waiters unwoken forever.
         panics.run(|| {
             self.finished.fire();
         });

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -875,20 +875,18 @@ the intake freeze, plus the wakers of `Guard::finished()`'s own
 completion waiters, which are caller-owned but run by the incarnation on
 the ordinary completion path as well as at the freeze; the frozen
 mailbox prefix's own detached disposal above is not part of it and stays
-a disposal fault. A disposal panic
-**already retained when a receive boundary is reached** therefore fails
-the incarnation before any further delivery or `on_stop`. As with
-`Guard::finished()` (§6.5) this is not a join: a panic that lands after
-the last receive boundary is still the incarnation's exit, but cannot
-suppress `on_stop`. The completion notification of §6.5 is the one
-carve-out in the other direction: because its wake panic MUST be
-retained before the framework may forget the work, a completion waiter
-whose waker *blocks* rather than panicking holds that work in the
-incarnation's resource ledger, and teardown joins it — so caller code
-can delay teardown and exit publication there. Grace bounds drain plus
-`on_stop` together (§11) —
-including after a local `ctx.stop()`, which arms the child's own
-configured ladder (§11).
+a disposal fault. A disposal panic **already retained when a receive
+boundary is reached** therefore fails the incarnation before any further
+delivery or `on_stop`. As with `Guard::finished()` (§6.5) this is not a
+join: a panic that lands after the last receive boundary is still the
+incarnation's exit, but cannot suppress `on_stop`. The completion
+notification of §6.5 is the one carve-out in the other direction:
+because its wake panic MUST be retained before the framework may forget
+the work, a completion waiter whose waker *blocks* rather than panicking
+holds that work in the incarnation's resource ledger, and teardown joins
+it — so caller code can delay teardown and exit publication there. Grace
+bounds drain plus `on_stop` together (§11) — including after a local
+`ctx.stop()`, which arms the child's own configured ladder (§11).
 
 ### 6.3 One timer facility
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -871,13 +871,22 @@ any incarnation-owned disposal panic is observed at a receive boundary
 destroyed). Incarnation-owned disposal is §6.5's resource funnel — the
 offloaded future and its continuation closure, plus the queued
 continuations, armed timers and queued offload completions released at
-the intake freeze; the frozen mailbox prefix's own detached disposal
-above is not part of it and stays a disposal fault. A disposal panic
+the intake freeze, plus the wakers of `Guard::finished()`'s own
+completion waiters, which are caller-owned but run by the incarnation on
+the ordinary completion path as well as at the freeze; the frozen
+mailbox prefix's own detached disposal above is not part of it and stays
+a disposal fault. A disposal panic
 **already retained when a receive boundary is reached** therefore fails
 the incarnation before any further delivery or `on_stop`. As with
 `Guard::finished()` (§6.5) this is not a join: a panic that lands after
 the last receive boundary is still the incarnation's exit, but cannot
-suppress `on_stop`. Grace bounds drain plus `on_stop` together (§11) —
+suppress `on_stop`. The completion notification of §6.5 is the one
+carve-out in the other direction: because its wake panic MUST be
+retained before the framework may forget the work, a completion waiter
+whose waker *blocks* rather than panicking holds that work in the
+incarnation's resource ledger, and teardown joins it — so caller code
+can delay teardown and exit publication there. Grace bounds drain plus
+`on_stop` together (§11) —
 including after a local `ctx.stop()`, which arms the child's own
 configured ladder (§11).
 
@@ -1007,7 +1016,14 @@ handlers non-blocking. Contracts:
   observed completion guarantees the panic is retained for §6.2's next
   receive boundary; a teardown cancellation fires the same notification
   without that ordering, which is why §6.2 conditions its guarantee on
-  retention rather than on the panic having happened.
+  retention rather than on the panic having happened. The notification's
+  own wake belongs to §6.2's funnel too: a completion waiter whose waker
+  panics has that payload retained as incarnation-owned disposal — on
+  the ordinary completion path, not only at the freeze — so a third
+  party awaiting `finished()` can fail the incarnation and suppress its
+  `on_stop`, and one whose waker blocks delays teardown as §6.2
+  describes. Callers are expected to await `finished()` from a task
+  whose waker neither panics nor blocks.
 - Any higher-level helper that composes `call` inside `offload` MUST
   preserve: incarnation ownership; completion through the actor loop; a
   total timeout continuation; and no await inside the handler.


### PR DESCRIPTION
Part of #366.

This contains caller-owned `Guard::finished()` wake panics on every ordinary `SharedOffloadFuture` completion path. Instead of escaping through the framework-owned offload task and reaching the incarnation only as the join result's stringified stand-in, the caller's original payload is retained in the incarnation panic slot and the actor signal is pulsed.

Completion notification and its publication are now separate edges. `fire_finished` claims the completion latch's *own* transition with `Latch::fire_silently`, runs the waker-visible `notify` under `catch_panic`, and only then release-stores a `finished_published` flag that ledger reclamation consults instead of the latch's earlier fired bit. Because the claim is the latch's own, the thread that runs the wake is by construction the thread that publishes: a concurrent cancellation can neither retire the work mid-wake nor win a second, divergent claim and run the wake beside the publisher.

**This changes when an incarnation fails**, and the change is now written down. A `Guard::finished()` waiter's waker panic is incarnation-owned disposal on the *ordinary* completion path, not only at the intake freeze, so a third party awaiting `finished()` with a panicking waker fails a live incarnation at its next receive boundary and suppresses `on_stop`. SPEC §6.2's funnel enumeration, §6.5's `Guard` bullet, `Guard::finished`'s own rustdoc, and the `recv`/`try_recv` retention lists all say so. The accepted trade in the other direction is recorded with it: pinning the entry until publication means a completion waker that *blocks* rather than panicking holds the work in the ledger, so teardown joins it and caller code can delay exit publication.

Two deterministic regressions, both with timeout-bounded handshakes so a suppressed fire reports instead of wedging the runner, and both panicking with an opaque payload so a retained original is distinguishable from the join's `String` stand-in. The first blocks inside a hostile finished waiter and checks that reclamation cannot retire the work until the exact caller panic is retained. The second uses a real `ActorWork` on a multi-threaded runtime to exercise the chain the fix protects in production: entry retained mid-wake → `join_offloads` awaits the task → the original payload reaches the post-join resource take.

Validation: `./tools/dev just ci` (805 tests), after rebasing onto current `main`.
