### PR TITLE
Harden observation transaction failure paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,19 @@ rests on:
   traffic and only the last clone submits disposal. Scope state and startup
   results need that protection too: a structured startup failure recursively
   owns the triggering child's `Exit`.
-  `ScopeCell::clear_residents_locked` and `prune_child_locked` route displaced
-  `Arc<MemberCell>`s through `runtime::dispose_detached` after unlock: the last
-  member owner can also be the last owner of a mailbox containing unread user
-  messages, which `RetainedExit` does not cover.
+  `ScopeCell::clear_residents_locked`, `prune_child_locked` and
+  `admit_child_locked` route `Arc<MemberCell>`s through
+  `runtime::dispose_detached` after unlock: the last member owner can also be
+  the last owner of a mailbox containing unread user messages, which
+  `RetainedExit` does not cover. The first two displace an existing resident;
+  the third holds the *incoming* projection in a `ResidentAdmission` guard, so
+  a bookkeeping panic before installation retires the same graph the same way.
+  Containment lives on `ResidentChild::drop` rather than on the displaced
+  `Vec`, because `Vec`'s slice drop glue keeps going after an element panics
+  and a second hostile mailbox destructor would then panic inside the first
+  one's unwind. Per-element containment therefore holds at every depth of a
+  nested residency and on `ScopeCell`'s own drop glue, which is what SPEC §5.5
+  asks of this lane.
 - **Framework `dyn` seams.** `MailboxControl`, `MailboxTermination`,
   `MailboxRuntime`, `MailboxEffectSink`, `ActorIdentity` and `DynamicRoute` are
   implementation seams
@@ -111,8 +120,8 @@ caller, so compute the verdict, release, *then* panic (`MailboxCell::bind` is
 the pattern; where releasing is impossible, `debug_assert!` instead, as
 `MailboxState::take_waiters` does). And a value that may block on destruction
 goes to `runtime::dispose_detached`, not merely past the unlock. That second
-convention is currently met for mailbox payloads, construction closures and
-offloads. Framework-retained `Exit` copies meet it through `RetainedExit`,
+convention is currently met for mailbox payloads, construction closures,
+offloads, displaced resident graphs and rejected admission projections. Framework-retained `Exit` copies meet it through `RetainedExit`,
 including driver completions and pending terminal disposal; exits handed to
 users keep ordinary drop timing. Its fail-safe under exhausted thread
 creation is an unreclaimed queued job — memory held for the life of the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,10 @@ rests on:
   traffic and only the last clone submits disposal. Scope state and startup
   results need that protection too: a structured startup failure recursively
   owns the triggering child's `Exit`.
-  `ScopeCell::clear_residents_locked` and `prune_child_locked` still defer
-  displaced `Arc<MemberCell>`s: the last member owner can also be the last
-  owner of a mailbox containing unread user messages, which `RetainedExit`
-  does not cover.
+  `ScopeCell::clear_residents_locked` and `prune_child_locked` route displaced
+  `Arc<MemberCell>`s through `runtime::dispose_detached` after unlock: the last
+  member owner can also be the last owner of a mailbox containing unread user
+  messages, which `RetainedExit` does not cover.
 - **Framework `dyn` seams.** `MailboxControl`, `MailboxTermination`,
   `MailboxRuntime`, `MailboxEffectSink`, `ActorIdentity` and `DynamicRoute` are
   implementation seams

--- a/crates/shelterwood-cells/src/cells/gate.rs
+++ b/crates/shelterwood-cells/src/cells/gate.rs
@@ -117,21 +117,24 @@ impl<'a> ObservationTxn<'a> {
     }
 
     fn commit(&mut self) {
+        let mut panics = runtime::PanicAccumulator::default();
         // Installation precedes the unlock, and the order is load-bearing:
         // released first, two transactions on one gate could interleave as
         // "T1 unlocks, T2 stages and installs a newer cut, T1 installs its
         // stale one", leaving every ungated borrow behind the tree until some
         // later publication corrected it. SPEC §14 promises this ordering.
-        // This install segment must remain panic-free apart from unreachable
-        // invariant assertions. A panic raised here runs from `Drop`, escapes
-        // before the post-unlock accumulator, and would strand later snapshot
-        // installations plus every queued effect; the current path invokes no
-        // user code and defers generation exhaustion into `effects`.
-        for publication in self.snapshots.drain(..) {
-            publication.install(&mut self.effects);
+        // Installations invoke no user code, but keep even their unreachable
+        // invariant assertions inside the accumulator. A broken installation
+        // must not strand the remaining committed cuts or their queued effects,
+        // and its panic resumes only after the guard is gone.
+        for mut publication in self.snapshots.drain(..) {
+            panics.run(|| publication.install(&mut self.effects));
+            // The projection captures its publishing scope. Transfer the
+            // whole attempted publication to the post-unlock list whether
+            // installation succeeded or panicked.
+            self.effects.push(Box::new(move || drop(publication)));
         }
         drop(self.guard.take());
-        let mut panics = runtime::PanicAccumulator::default();
         for effect in self.effects.drain(..) {
             // One hostile waker must not prevent the remaining committed
             // observation edges from notifying their waiters.

--- a/crates/shelterwood-cells/src/cells/member.rs
+++ b/crates/shelterwood-cells/src/cells/member.rs
@@ -751,6 +751,11 @@ mod tests {
     use super::*;
     use crate::cells::test_support::{ThreadProbe, isolated_scope};
 
+    // The retention this pins only has an observable effect when the
+    // framework invariant it guards is checked, and that check is a
+    // `debug_assert!`. Release builds decline the panic entirely, so the test
+    // is gated on the profile it can hold in rather than left to fail there.
+    #[cfg(debug_assertions)]
     #[test]
     fn illegal_restart_transition_retires_its_user_error_off_thread() {
         let scope = isolated_scope("root", ScopeFlavor::Ordered);

--- a/crates/shelterwood-cells/src/cells/member.rs
+++ b/crates/shelterwood-cells/src/cells/member.rs
@@ -528,7 +528,23 @@ impl MemberCell {
     }
 
     pub fn transition_locked(&self, txn: &mut ObservationTxn<'_>, transition: MemberTransition) {
+        // `RestartScheduled` carries a user error by value. Retain it before
+        // the watch lock and reducer assertions so an invariant panic can
+        // unwind the raw transition as refcount traffic only.
+        let retained_exit = match &transition {
+            MemberTransition::RestartScheduled { exit, .. } => {
+                Some(RetainedExit::new(exit.clone()))
+            }
+            MemberTransition::Admitted
+            | MemberTransition::Starting { .. }
+            | MemberTransition::Running
+            | MemberTransition::Stopping => None,
+        };
         self.update_locked(txn, |record| record.apply_transition(transition));
+        if let Some(retained_exit) = retained_exit {
+            // The record now owns an equivalent retained copy.
+            drop(retained_exit.into_exit());
+        }
     }
 
     pub fn set_options(&self, options: ResolvedCommonOptions) {
@@ -734,6 +750,34 @@ mod tests {
 
     use super::*;
     use crate::cells::test_support::{ThreadProbe, isolated_scope};
+
+    #[test]
+    fn illegal_restart_transition_retires_its_user_error_off_thread() {
+        let scope = isolated_scope("root", ScopeFlavor::Ordered);
+        let (dropped, observed) = mpsc::sync_channel(1);
+        let retiring_thread = std::thread::current().id();
+        let exit = Exit::failed(
+            ExitError::from(ThreadProbe(dropped)),
+            Cancellation::NotObserved,
+        );
+
+        catch_unwind(AssertUnwindSafe(|| {
+            scope.member.transition(MemberTransition::RestartScheduled {
+                exit,
+                restart_count: RestartCount::ZERO.bump(),
+                restart_at: None,
+            });
+        }))
+        .expect_err("a reserved member cannot schedule a restart");
+
+        assert_ne!(
+            observed
+                .recv_timeout(Duration::from_secs(10))
+                .expect("failed exit disposal reports"),
+            retiring_thread,
+            "the incoming user error cannot unwind under the record and observation locks"
+        );
+    }
 
     #[test]
     fn attaching_a_second_mailbox_panics_without_replacing_or_poisoning_the_first() {

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -17,6 +17,7 @@ use shelterwood_core::{
     engine::{Epoch, MembershipStatus, RequestTarget, ScopeEpochs, ScopeState},
     exit::{StartupError, StopReason, stop_reason_precedence},
     identity::{AtomicPoisonedCounter, MembershipReconciliation, MintedMembership, ScopeIdentity},
+    panic::{catch_panic, discard_panic},
     policy::ScopeFlavor,
 };
 use shelterwood_runtime as runtime;
@@ -60,6 +61,14 @@ impl ResidentProjection {
 /// A projection can be the last owner of a member and its mailbox. Any
 /// bookkeeping panic before installation therefore routes the whole graph to
 /// detached disposal instead of unwinding it through the observation gate.
+///
+/// The transaction holds the second `Rc` rather than this guard disposing
+/// from its own `Drop`: a bare guard would submit the disposal job with the
+/// observation gate still held. That is legal — a submission runs no user
+/// code — but the standing preference is that a caller already holding an
+/// effects sink flushes through it, because a submission can cost a native
+/// thread start. #390 tracks deleting the guard outright by letting residency
+/// own the projection across admission's fallible steps.
 struct ResidentAdmission(Rc<RefCell<Option<ResidentProjection>>>);
 
 impl ResidentAdmission {
@@ -90,13 +99,47 @@ impl ResidentAdmission {
     }
 }
 
+/// One slot of a scope's observed child set, with its own unwind boundary.
+///
+/// A displaced set is disposed as a whole `Vec`, and `Vec`'s slice drop glue
+/// keeps destroying the remaining elements after one of them panics. A
+/// resident can own the last handle to a mailbox still holding unread user
+/// messages, so without a boundary here a second hostile destructor in the
+/// same set panics *inside* the first one's unwind, which aborts the process
+/// rather than surfacing anywhere. SPEC §5.5 requires this lane to run with
+/// per-element panic containment; keeping the boundary on the element rather
+/// than on the collection is what makes it hold at every depth of a nested
+/// scope's residency, and on `ScopeCell`'s own drop glue, not merely at the
+/// displaced root.
+///
+/// The diagnostic is discarded rather than reported because every venue that
+/// destroys a resident already discards it: `dispose_detached` passes an
+/// empty completion, and plain drop glue has nobody to report to.
 struct ResidentChild {
-    projection: ResidentProjection,
+    /// `None` only while [`Drop`] is destroying the projection.
+    projection: Option<ResidentProjection>,
 }
 
 impl ResidentChild {
     fn new(projection: ResidentProjection) -> Self {
-        Self { projection }
+        Self {
+            projection: Some(projection),
+        }
+    }
+
+    fn projection(&self) -> &ResidentProjection {
+        self.projection
+            .as_ref()
+            .expect("a resident child owns its projection until it is dropped")
+    }
+}
+
+impl Drop for ResidentChild {
+    fn drop(&mut self) {
+        let Some(projection) = self.projection.take() else {
+            return;
+        };
+        discard_panic(catch_panic(|| drop(projection)).err());
     }
 }
 
@@ -304,14 +347,14 @@ impl ScopeCell {
     pub fn resident_projections(&self) -> Vec<ResidentProjection> {
         self.current_children()
             .iter()
-            .map(|resident| resident.projection.clone())
+            .map(|resident| resident.projection().clone())
             .collect()
     }
 
     pub fn has_resident_child(&self, member: &MemberCell) -> bool {
         self.current_children()
             .iter()
-            .any(|resident| resident.projection.member.membership() == member.membership())
+            .any(|resident| resident.projection().member.membership() == member.membership())
     }
 
     fn current_children(&self) -> MutexGuard<'_, Vec<ResidentChild>> {
@@ -471,7 +514,7 @@ impl ScopeCell {
         let descendants = self
             .current_children()
             .iter()
-            .map(|resident| resident.projection.clone())
+            .map(|resident| resident.projection().clone())
             .collect::<Vec<_>>();
         for descendant in descendants {
             descendant
@@ -671,8 +714,8 @@ impl ScopeCell {
             let resident = self
                 .current_children()
                 .iter()
-                .find(|resident| resident.projection.member.membership() == member.membership())
-                .map(|resident| resident.projection.clone());
+                .find(|resident| resident.projection().member.membership() == member.membership())
+                .map(|resident| resident.projection().clone());
             debug_assert!(
                 resident.is_some(),
                 "a supervised terminal child must remain in parent residency"
@@ -730,17 +773,17 @@ impl ScopeCell {
             let mut children = self.current_children();
             let index = children
                 .iter()
-                .position(|child| child.projection.member.membership() == membership);
+                .position(|child| child.projection().member.membership() == membership);
             index.map(|index| children.remove(index))
         };
         let Some(resident) = resident else {
             return false;
         };
-        debug_assert_eq!(resident.projection.member.membership(), membership);
+        debug_assert_eq!(resident.projection().member.membership(), membership);
         let event = LifecycleEventKind::Removed {
-            id: resident.projection.member.id().clone(),
+            id: resident.projection().member.id().clone(),
             membership,
-            last_incarnation: resident.projection.member.record().last_incarnation,
+            last_incarnation: resident.projection().member.record().last_incarnation,
         };
         // The projection can carry the last member/mailbox owner. Put it in
         // the transaction before the fallible publication path so unwind also
@@ -1175,15 +1218,18 @@ impl ScopeCell {
         let removals = residents
             .iter()
             .map(|resident| LifecycleEventKind::Removed {
-                id: resident.projection.member.id().clone(),
-                membership: resident.projection.member.membership(),
-                last_incarnation: resident.projection.member.record().last_incarnation,
+                id: resident.projection().member.id().clone(),
+                membership: resident.projection().member.membership(),
+                last_incarnation: resident.projection().member.record().last_incarnation,
             })
             .collect::<Vec<_>>();
         // Schedule the whole displaced set before emitting any edge. This
         // both preserves last-owner disposal and makes an unwind retire the
         // untouched suffix after unlock. Detached disposal means final member
-        // teardown may complete after this transaction returns.
+        // teardown may complete after this transaction returns -- and that a
+        // resident's own destructor can never reach an `ObservationTxn`, so
+        // SPEC §15.5's structural `Removed`-on-drop is unavailable on this
+        // lane and the edge is emitted explicitly below instead (#389).
         wakes.defer(move || runtime::dispose_detached(residents));
         for removal in removals {
             self.emit_locked(wakes, removal);
@@ -1392,6 +1438,20 @@ mod tests {
         }
     }
 
+    /// A user payload whose destructor panics, as SPEC §5.5's containment
+    /// clause anticipates.
+    struct HostileDropMessage {
+        entered: mpsc::SyncSender<&'static str>,
+        id: &'static str,
+    }
+
+    impl Drop for HostileDropMessage {
+        fn drop(&mut self) {
+            let _ = self.entered.send(self.id);
+            panic!("hostile resident payload destructor");
+        }
+    }
+
     struct GateDropMessage {
         gate: super::ObservationGate,
         entered: mpsc::SyncSender<(bool, std::thread::ThreadId)>,
@@ -1407,6 +1467,11 @@ mod tests {
         }
     }
 
+    // The retention this pins only has an observable effect when the
+    // framework invariant it guards is checked, and that check is a
+    // `debug_assert!`. Release builds decline the panic entirely, so the test
+    // is gated on the profile it can hold in rather than left to fail there.
+    #[cfg(debug_assertions)]
     #[test]
     fn nonresident_terminal_exit_is_retained_before_the_residency_assertion() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
@@ -1432,6 +1497,11 @@ mod tests {
         );
     }
 
+    // The retention this pins only has an observable effect when the
+    // framework invariant it guards is checked, and that check is a
+    // `debug_assert!`. Release builds decline the panic entirely, so the test
+    // is gated on the profile it can hold in rather than left to fail there.
+    #[cfg(debug_assertions)]
     #[test]
     fn rejected_resident_admission_detaches_its_last_mailbox_owner() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
@@ -1964,5 +2034,62 @@ mod tests {
             drop_thread, clear_thread,
             "last-owner resident disposal runs on the detached lane"
         );
+    }
+
+    #[test]
+    fn clearing_residents_contains_every_hostile_payload_destructor() {
+        let scope = isolated_scope("root", ScopeFlavor::Dynamic);
+        let (entered, observed) = mpsc::sync_channel(2);
+        let mut counters = Vec::new();
+        for id in ["first", "second"] {
+            let child = child_member(&scope, id);
+            let mut incarnations = child.take_incarnation_counter();
+            let incarnation = incarnations.mint().expect("incarnation available");
+            counters.push(incarnations);
+            let mailbox =
+                MailboxCell::new(child.id().clone(), shelterwood_runtime::mailbox_runtime());
+            child.attach_mailbox(mailbox.clone());
+            let actor = actor_ref_from_parts(Arc::clone(&child), Arc::clone(&mailbox));
+            let mut effects = MailboxEffectQueue::default();
+            let token = MailboxControl::configure(&*mailbox, ResolvedMailbox::Latest, &mut effects);
+            MailboxControl::bind(&*mailbox, token, incarnation, &mut effects);
+            drop(effects);
+            actor
+                .try_send(HostileDropMessage {
+                    entered: entered.clone(),
+                    id,
+                })
+                .expect("bound mailbox accepts the hostile payload");
+            scope.admit_child(ResidentProjection::new(Arc::clone(&child), None));
+            drop(actor);
+            drop(mailbox);
+            drop(child);
+        }
+        drop(entered);
+
+        scope.clear_residents();
+
+        // Park behind a job queued after the displaced set. Without a
+        // per-resident boundary the second destructor panics inside the first
+        // one's unwind through `Vec`'s slice drop glue, and the disposal
+        // worker aborts the process before this sentinel can run -- the
+        // sequencing is what makes the regression deterministic rather than a
+        // race against the test's own return.
+        let (sentinel, sequenced) = mpsc::sync_channel(1);
+        runtime::dispose_detached(ThreadProbe(sentinel));
+        sequenced
+            .recv_timeout(TEST_WAIT)
+            .expect("the disposal worker survives every hostile resident");
+
+        let mut reported = Vec::new();
+        for _ in 0..2 {
+            reported.push(
+                observed
+                    .recv_timeout(TEST_WAIT)
+                    .expect("every hostile resident destructor runs"),
+            );
+        }
+        reported.sort_unstable();
+        assert_eq!(reported, ["first", "second"]);
     }
 }

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -1,6 +1,8 @@
 use std::{
     any::Any,
+    cell::{Ref, RefCell},
     collections::VecDeque,
+    rc::Rc,
     sync::{
         Arc, Mutex, MutexGuard, Weak,
         atomic::{AtomicBool, Ordering},
@@ -50,6 +52,41 @@ pub struct ResidentProjection {
 impl ResidentProjection {
     pub fn new(member: Arc<MemberCell>, scope: Option<Arc<ScopeCell>>) -> Self {
         Self { member, scope }
+    }
+}
+
+/// By-value admission input protected until residency owns it.
+///
+/// A projection can be the last owner of a member and its mailbox. Any
+/// bookkeeping panic before installation therefore routes the whole graph to
+/// detached disposal instead of unwinding it through the observation gate.
+struct ResidentAdmission(Rc<RefCell<Option<ResidentProjection>>>);
+
+impl ResidentAdmission {
+    fn new(projection: ResidentProjection, txn: &mut ObservationTxn<'_>) -> Self {
+        let projection = Rc::new(RefCell::new(Some(projection)));
+        let deferred = Rc::clone(&projection);
+        txn.defer(move || {
+            if let Some(projection) = deferred.borrow_mut().take() {
+                runtime::dispose_detached(projection);
+            }
+        });
+        Self(projection)
+    }
+
+    fn projection(&self) -> Ref<'_, ResidentProjection> {
+        Ref::map(self.0.borrow(), |projection| {
+            projection
+                .as_ref()
+                .expect("resident admission was already installed")
+        })
+    }
+
+    fn install(self) -> ResidentProjection {
+        self.0
+            .borrow_mut()
+            .take()
+            .expect("resident admission installs exactly once")
     }
 }
 
@@ -607,7 +644,11 @@ impl ScopeCell {
         exited_incarnation: Option<Incarnation>,
         startup: StartupDisposition,
     ) -> bool {
-        self.with_observation_gate(|wakes| {
+        // Keep a retained owner across the residency assertion and every
+        // fallible cell lookup. If an invariant fails, the raw argument can
+        // unwind under the gate only as refcount traffic.
+        let exit = RetainedExit::new(exit);
+        self.with_observation_gate(move |wakes| {
             let record = member.record();
             if matches!(record.stage, MemberStage::Terminal(_)) {
                 // The outer guard defines losing supervised terminalization:
@@ -615,7 +656,6 @@ impl ScopeCell {
                 // failed exit behind the same isolated-disposal boundary as a
                 // losing direct terminalizer, and do not destroy it under the
                 // observation gate.
-                let exit = RetainedExit::new(exit);
                 wakes.defer(move || drop(exit));
                 return false;
             }
@@ -638,7 +678,10 @@ impl ScopeCell {
                 "a supervised terminal child must remain in parent residency"
             );
             let nested = resident.and_then(|resident| resident.scope);
-            let terminal_exit = member.terminalize_locked(exit, startup, wakes);
+            let terminal_exit = member.terminalize_locked(exit.as_exit().clone(), startup, wakes);
+            // The terminal member record now owns the equivalent retained
+            // copy, so surrender this transient guard as refcount traffic.
+            drop(exit.into_exit());
             self.evict_child_identity(member);
             if record.last_incarnation.is_none()
                 && let Some(scope) = &nested
@@ -701,8 +744,9 @@ impl ScopeCell {
         };
         // The projection can carry the last member/mailbox owner. Put it in
         // the transaction before the fallible publication path so unwind also
-        // retires it only after the observation gate is released.
-        txn.defer(move || drop(resident));
+        // retires it only after the observation gate is released. The detached
+        // handoff deliberately makes final member teardown asynchronous.
+        txn.defer(move || runtime::dispose_detached(resident));
         self.emit_locked(txn, event);
         true
     }
@@ -789,20 +833,24 @@ impl ScopeCell {
     }
 
     pub fn finish_incarnation(&self, epoch: Epoch, reason: StopReason) {
-        self.finish_incarnation_with_terminal(epoch, reason, None);
+        self.finish_incarnation_with_terminal(epoch, RetainedStopReason::new(reason), None);
     }
 
     pub fn finish_root_incarnation(&self, epoch: Epoch, reason: StopReason, exit: Exit) {
-        self.finish_incarnation_with_terminal(epoch, reason, Some(exit));
+        self.finish_incarnation_with_terminal(
+            epoch,
+            RetainedStopReason::new(reason),
+            Some(RetainedExit::new(exit)),
+        );
     }
 
     fn finish_incarnation_with_terminal(
         &self,
         epoch: Epoch,
-        reason: StopReason,
-        terminal_exit: Option<Exit>,
+        reason: RetainedStopReason,
+        mut terminal_exit: Option<RetainedExit>,
     ) {
-        self.with_observation_gate(|wakes| {
+        self.with_observation_gate(move |wakes| {
             let mut control = self.control.lock().expect("scope control mutex poisoned");
             if !control.epochs.finish(epoch) {
                 // A stale driver must not overwrite the observation
@@ -811,9 +859,13 @@ impl ScopeCell {
                 // terminal exit still publishes it exactly once, so declining
                 // the epoch can never strand `wait_terminal`.
                 drop(control);
-                if let Some(exit) = terminal_exit {
-                    self.member
-                        .terminalize_locked(exit, StartupDisposition::Unchanged, wakes);
+                if let Some(exit) = terminal_exit.take() {
+                    self.member.terminalize_locked(
+                        exit.as_exit().clone(),
+                        StartupDisposition::Unchanged,
+                        wakes,
+                    );
+                    drop(exit.into_exit());
                     wakes.pulse(&self.member.record);
                     wakes.pulse(&self.observation.record);
                     self.close_observation_locked(wakes);
@@ -824,7 +876,6 @@ impl ScopeCell {
                 // deferred drop sends a possibly-blocking or panicking user
                 // destructor to `dispose_critical` instead of running it
                 // inline on the committing thread once the gate is released.
-                let reason = RetainedStopReason::new(reason);
                 wakes.defer(move || drop(reason));
                 return;
             }
@@ -840,7 +891,12 @@ impl ScopeCell {
             let terminal = terminal_exit.is_some();
             let membership_terminal =
                 matches!(self.member.record().stage, MemberStage::Terminal(_));
-            self.publish_stopped_locked(wakes, reason, terminal_exit, Some(control));
+            self.publish_stopped_locked(
+                wakes,
+                reason.as_reason().clone(),
+                terminal_exit.as_ref().map(|exit| exit.as_exit().clone()),
+                Some(control),
+            );
             if terminal || membership_terminal {
                 // A parent-driver fallback may have terminalized this nested
                 // membership while its live scope epilogue was still
@@ -848,20 +904,35 @@ impl ScopeCell {
                 // closes observation only after publishing it.
                 self.close_observation_locked(wakes);
             }
+            drop(reason.into_public());
+            if let Some(exit) = terminal_exit.take() {
+                drop(exit.into_exit());
+            }
         });
     }
 
     pub fn finish_live_root_incarnation(&self, reason: StopReason, exit: Exit) {
+        // These wrappers precede the control lookup: a poisoned framework
+        // mutex must not retire either user-bearing input on this thread.
+        let reason = RetainedStopReason::new(reason);
+        let exit = RetainedExit::new(exit);
         let epoch = {
             let control = self.control.lock().expect("scope control mutex poisoned");
             control.epochs.live_epoch()
         };
         if let Some(epoch) = epoch {
-            self.finish_root_incarnation(epoch, reason, exit);
+            self.finish_incarnation_with_terminal(epoch, reason, Some(exit));
         } else {
-            self.with_observation_gate(|wakes| {
-                self.publish_stopped_locked(wakes, reason, Some(exit), None);
+            self.with_observation_gate(move |wakes| {
+                self.publish_stopped_locked(
+                    wakes,
+                    reason.as_reason().clone(),
+                    Some(exit.as_exit().clone()),
+                    None,
+                );
                 self.close_observation_locked(wakes);
+                drop(reason.into_public());
+                drop(exit.into_exit());
             });
         }
     }
@@ -1069,19 +1140,26 @@ impl ScopeCell {
         child: ResidentProjection,
         txn: &mut ObservationTxn<'_>,
     ) {
+        // Take protected ownership before gate adoption, parent wiring, and
+        // reducer assertions. Until the final push succeeds this projection
+        // may be the last owner of a mailbox-bearing member.
+        let child = ResidentAdmission::new(child, txn);
+        let projection = child.projection();
         let gate = self.current_observation_gate();
-        if let Some(scope) = &child.scope {
+        if let Some(scope) = &projection.scope {
             scope.adopt_observation_gate(self, &gate, txn);
             scope.set_parent(self, txn);
         } else {
-            child.member.adopt_observation_gate(&gate, txn);
+            projection.member.adopt_observation_gate(&gate, txn);
         }
-        let id = child.member.id().clone();
-        let membership = child.member.membership();
-        child
+        let id = projection.member.id().clone();
+        let membership = projection.member.membership();
+        projection
             .member
             .transition_locked(txn, MemberTransition::Admitted);
-        self.current_children().push(ResidentChild::new(child));
+        drop(projection);
+        self.current_children()
+            .push(ResidentChild::new(child.install()));
         self.emit_locked(txn, LifecycleEventKind::Added { id, membership });
     }
 
@@ -1104,8 +1182,9 @@ impl ScopeCell {
             .collect::<Vec<_>>();
         // Schedule the whole displaced set before emitting any edge. This
         // both preserves last-owner disposal and makes an unwind retire the
-        // untouched suffix after unlock.
-        wakes.defer(move || drop(residents));
+        // untouched suffix after unlock. Detached disposal means final member
+        // teardown may complete after this transaction returns.
+        wakes.defer(move || runtime::dispose_detached(residents));
         for removal in removals {
             self.emit_locked(wakes, removal);
         }
@@ -1315,13 +1394,79 @@ mod tests {
 
     struct GateDropMessage {
         gate: super::ObservationGate,
-        dropped: mpsc::SyncSender<bool>,
+        entered: mpsc::SyncSender<(bool, std::thread::ThreadId)>,
+        release: mpsc::Receiver<()>,
     }
 
     impl Drop for GateDropMessage {
         fn drop(&mut self) {
-            let _ = self.dropped.send(!self.gate.is_held());
+            let _ = self
+                .entered
+                .send((!self.gate.is_held(), std::thread::current().id()));
+            let _ = self.release.recv_timeout(TEST_WAIT);
         }
+    }
+
+    #[test]
+    fn nonresident_terminal_exit_is_retained_before_the_residency_assertion() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let member = child_member(&root, "missing");
+        let (dropped, observed) = mpsc::sync_channel(1);
+        let retiring_thread = std::thread::current().id();
+        let exit = Exit::failed(
+            ExitError::from(ThreadProbe(dropped)),
+            Cancellation::NotObserved,
+        );
+
+        catch_unwind(AssertUnwindSafe(|| {
+            root.terminalize_child(&member, exit, None, StartupDisposition::Unchanged);
+        }))
+        .expect_err("a supervised child must remain resident");
+
+        assert_ne!(
+            observed
+                .recv_timeout(TEST_WAIT)
+                .expect("failed exit disposal reports"),
+            retiring_thread,
+            "the incoming error cannot unwind through the observation gate"
+        );
+    }
+
+    #[test]
+    fn rejected_resident_admission_detaches_its_last_mailbox_owner() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let member = child_member(&root, "invalid");
+        let mut incarnations = member.take_incarnation_counter();
+        let incarnation = incarnations.mint().expect("incarnation available");
+        let mailbox = MailboxCell::new(member.id().clone(), shelterwood_runtime::mailbox_runtime());
+        member.attach_mailbox(mailbox.clone());
+        let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
+        let mut effects = MailboxEffectQueue::default();
+        let token = MailboxControl::configure(&*mailbox, ResolvedMailbox::Latest, &mut effects);
+        MailboxControl::bind(&*mailbox, token, incarnation, &mut effects);
+        drop(effects);
+        // Admission below is intentionally illegal, but the projection is
+        // still the final owner of this mailbox-bearing member when it fails.
+        member.transition(MemberTransition::Admitted);
+        let (dropped, observed) = mpsc::sync_channel(1);
+        actor
+            .try_send(ThreadProbe(dropped))
+            .expect("bound mailbox accepts the probe");
+        let projection = ResidentProjection::new(member, None);
+        drop(actor);
+        drop(mailbox);
+        let retiring_thread = std::thread::current().id();
+
+        catch_unwind(AssertUnwindSafe(|| root.admit_child(projection)))
+            .expect_err("an admitted member cannot be admitted twice");
+
+        assert_ne!(
+            observed
+                .recv_timeout(TEST_WAIT)
+                .expect("mailbox payload disposal reports"),
+            retiring_thread,
+            "the by-value projection cannot unwind its mailbox through the observation gate"
+        );
     }
 
     #[test]
@@ -1653,6 +1798,56 @@ mod tests {
     }
 
     #[test]
+    fn poisoned_finish_bookkeeping_retires_user_inputs_off_thread() {
+        let scope = isolated_scope("root", ScopeFlavor::Ordered);
+        let epoch = scope
+            .begin_incarnation(ScopeState::Starting)
+            .expect("the fixture begins one incarnation");
+        let poison = Arc::clone(&scope);
+        assert!(
+            catch_unwind(AssertUnwindSafe(move || {
+                let _control = poison.control.lock().expect("control starts healthy");
+                panic!("inject control poison");
+            }))
+            .is_err()
+        );
+
+        let retiring_thread = std::thread::current().id();
+        let (reason_dropped, reason_observed) = mpsc::sync_channel(1);
+        let reason_exit = Exit::failed(
+            ExitError::from(ThreadProbe(reason_dropped)),
+            Cancellation::NotObserved,
+        );
+        let reason = StopReason::StartupFailed(StartupFailure {
+            cause: StartupFailureCause::Child {
+                id: ChildId::from("failed-child"),
+                membership: scope.member.membership(),
+                exit: reason_exit,
+            },
+        });
+        let (terminal_dropped, terminal_observed) = mpsc::sync_channel(1);
+        let terminal_exit = Exit::failed(
+            ExitError::from(ThreadProbe(terminal_dropped)),
+            Cancellation::NotObserved,
+        );
+
+        catch_unwind(AssertUnwindSafe(|| {
+            scope.finish_root_incarnation(epoch, reason, terminal_exit);
+        }))
+        .expect_err("the poisoned control mutex rejects finish bookkeeping");
+
+        for observed in [reason_observed, terminal_observed] {
+            assert_ne!(
+                observed
+                    .recv_timeout(TEST_WAIT)
+                    .expect("failed exit disposal reports"),
+                retiring_thread,
+                "scope-finish inputs cannot unwind through the observation gate"
+            );
+        }
+    }
+
+    #[test]
     fn mailbox_control_wakes_are_deferred_past_the_observation_gate() {
         let id = ChildId::from("root");
         let mut identity = ScopeIdentity::new();
@@ -1691,7 +1886,7 @@ mod tests {
     }
 
     #[test]
-    fn clearing_residents_releases_the_last_mailbox_owner_after_unlock() {
+    fn clearing_residents_detaches_the_last_mailbox_owner_after_unlock() {
         let root_id = ChildId::from("root");
         let mut root_identity = ScopeIdentity::new();
         let root_member = MemberCell::new(
@@ -1720,22 +1915,54 @@ mod tests {
         let token = MailboxControl::configure(&*mailbox, ResolvedMailbox::Latest, &mut effects);
         MailboxControl::bind(&*mailbox, token, incarnation, &mut effects);
         drop(effects);
-        let (dropped, observed) = mpsc::sync_channel(1);
+        let (entered, observed) = mpsc::sync_channel(1);
+        let (release, release_drop) = mpsc::sync_channel(1);
         actor
-            .try_send(GateDropMessage { gate, dropped })
+            .try_send(GateDropMessage {
+                gate,
+                entered,
+                release: release_drop,
+            })
             .expect("bound mailbox accepts the probe");
         scope.admit_child(ResidentProjection::new(Arc::clone(&child), None));
         drop(actor);
         drop(mailbox);
         drop(child);
 
-        scope.clear_residents();
+        let (cleared, clear_observed) = mpsc::sync_channel(1);
+        let clearing = std::thread::spawn(move || {
+            let thread = std::thread::current().id();
+            scope.clear_residents();
+            cleared
+                .send(thread)
+                .expect("clear observer remains available");
+        });
+        let (unlocked, drop_thread) = observed
+            .recv_timeout(TEST_WAIT)
+            .expect("resident mailbox payload destructor reports");
+        let clear_before_release = clear_observed.recv_timeout(Duration::from_millis(100)).ok();
+        let returned_before_release = clear_before_release.is_some();
+        release
+            .send(())
+            .expect("the blocking destructor remains parked");
+        let clear_thread = clear_before_release.unwrap_or_else(|| {
+            clear_observed
+                .recv_timeout(TEST_WAIT)
+                .expect("resident clearing eventually returns")
+        });
+        clearing.join().expect("resident clearing thread joins");
 
         assert!(
-            observed
-                .recv_timeout(Duration::from_secs(10))
-                .expect("resident mailbox payload destructor reports"),
+            unlocked,
             "the displaced resident owner is released after the gate unlocks"
+        );
+        assert!(
+            returned_before_release,
+            "resident clearing must not wait for a blocking user destructor"
+        );
+        assert_ne!(
+            drop_thread, clear_thread,
+            "last-owner resident disposal runs on the detached lane"
         );
     }
 }

--- a/crates/shelterwood-cells/src/cells/scope/projection.rs
+++ b/crates/shelterwood-cells/src/cells/scope/projection.rs
@@ -120,7 +120,7 @@ impl ScopeCell {
         let mut retained_exits = Vec::new();
         RetainedExit::retain_scope_state(&mut retained_exits, &record.state);
         for resident in children.iter() {
-            let (child, exits) = self.child_snapshot_locked(&resident.projection);
+            let (child, exits) = self.child_snapshot_locked(resident.projection());
             projected.push(child);
             for exit in exits {
                 RetainedExit::retain_owned(&mut retained_exits, exit);

--- a/crates/shelterwood-cells/src/observe.rs
+++ b/crates/shelterwood-cells/src/observe.rs
@@ -519,8 +519,9 @@ struct SnapshotHubState {
 ///
 /// The producer is `FnMut` rather than `FnOnce` so that running it does not
 /// also destroy it: it captures an `Arc<ScopeCell>` whose release belongs
-/// after the gate is unlocked, like every other user-bearing drop. `install`
-/// hands the spent producer to the effect list rather than dropping it.
+/// after the gate is unlocked, like every other user-bearing drop. The
+/// transaction hands the whole spent publication to its effect list after
+/// each attempted install, including one that trips an invariant.
 pub(crate) struct SnapshotProjection(Box<dyn FnMut() -> Option<RetainedScopeSnapshot>>);
 
 impl SnapshotProjection {
@@ -593,25 +594,16 @@ impl SnapshotPublication {
     /// displaces, and the generation-exhaustion panic. The producer runs
     /// before the watch's own lock is taken, so building a cut — which walks
     /// the resident tree — never nests that tree's locks inside the watch.
-    pub(crate) fn install(self, effects: &mut Vec<Box<dyn FnOnce()>>) {
-        let Self {
-            sender,
-            mut projection,
-            published,
-            closed,
-        } = self;
+    pub(crate) fn install(&mut self, effects: &mut Vec<Box<dyn FnOnce()>>) {
         // A hub closed by an earlier transaction keeps the authoritative
         // terminal projection `close` installed; this cut is never built.
-        let mut snapshot = (!sender.read_with(|state| state.closed)).then(|| projection.build());
-        // Retire the producer first: until the effect list owns it, the
-        // publishing scope has no provable owner here, and every drop below
-        // reaches it through that scope.
-        effects.push(Box::new(move || drop(projection)));
+        let mut snapshot =
+            (!self.sender.read_with(|state| state.closed)).then(|| self.projection.build());
         let mut retired = None;
         let mut modified = false;
         let mut generation_exhausted = false;
         if snapshot.is_some() {
-            sender.modify_silently(|state| {
+            self.sender.modify_silently(|state| {
                 debug_assert!(
                     !state.closed,
                     "the gate serializes closure against installation"
@@ -622,10 +614,10 @@ impl SnapshotPublication {
                         .take()
                         .expect("a staged snapshot is installed exactly once"),
                 ));
-                if published && state.generation.mint().is_none() {
+                if self.published && state.generation.mint().is_none() {
                     generation_exhausted = true;
                 }
-                state.closed = closed;
+                state.closed = self.closed;
                 modified = true;
             });
         }
@@ -636,6 +628,7 @@ impl SnapshotPublication {
             effects.push(Box::new(|| panic!("snapshot generation space exhausted")));
         }
         if modified {
+            let sender = self.sender.clone();
             effects.push(Box::new(move || sender.pulse()));
         }
     }
@@ -1137,6 +1130,44 @@ mod tests {
             "an ungated borrow taken mid-transaction reads the preceding cut"
         );
         assert_eq!(receiver.borrow_latest().state, ScopeState::Running);
+    }
+
+    #[test]
+    fn panicking_snapshot_install_does_not_strand_later_cuts_or_effects() {
+        let failing = SnapshotHub::default();
+        let succeeding = SnapshotHub::default();
+        let mut txn = crate::cells::ObservationTxn::detached();
+        let _failing_receiver = failing.subscribe(snapshot(ScopeState::Unstarted), &mut txn);
+        let succeeding_receiver = succeeding.subscribe(snapshot(ScopeState::Unstarted), &mut txn);
+        drop(txn);
+
+        let effects = Arc::new(AtomicUsize::new(0));
+        let payload = catch_unwind(AssertUnwindSafe({
+            let effects = Arc::clone(&effects);
+            move || {
+                let mut txn = crate::cells::ObservationTxn::detached();
+                failing.publish(&mut txn, || panic!("injected snapshot installation panic"));
+                succeeding.publish(&mut txn, || snapshot(ScopeState::Running));
+                txn.defer(move || {
+                    effects.fetch_add(1, Ordering::SeqCst);
+                });
+            }
+        }))
+        .expect_err("the first installation panic resumes after commit drains");
+
+        assert_eq!(
+            payload.downcast_ref::<&str>(),
+            Some(&"injected snapshot installation panic")
+        );
+        assert_eq!(
+            succeeding_receiver.borrow_latest().state,
+            ScopeState::Running
+        );
+        assert_eq!(
+            effects.load(Ordering::SeqCst),
+            1,
+            "installation failure cannot suppress the queued effect suffix"
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -1660,10 +1660,14 @@ fn residency_can_release_the_last_member_arc_with_a_failed_exit() {
 
     root.clear_residents();
 
-    assert!(
-        weak.upgrade().is_none(),
-        "residency held the final member Arc"
-    );
+    let deadline = std::time::Instant::now() + CAPTURE_PROBE_WAIT;
+    while weak.upgrade().is_some() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for detached resident disposal"
+        );
+        std::thread::sleep(Duration::from_millis(1));
+    }
     assert!(
         !wait_for_gate_probe(&held_at_drop),
         "retiring the member record must not run its payload under the observation gate"


### PR DESCRIPTION
Part of #366: the consolidated Batch 3 hardening pass.

This closes the three internal-invariant gaps without changing supported-path behavior:

- creates `ObservationTxn`'s `PanicAccumulator` before snapshot installation, contains each install independently, transfers every attempted publication to post-unlock disposal, and drains later cuts/effects before resuming the first panic
- retains user-bearing by-value inputs before fallible bookkeeping at restart scheduling, supervised child terminalization, scope finish, and resident admission
- routes pruned and cleared resident graphs through `dispose_detached`, making final member/mailbox teardown explicitly asynchronous, with per-element panic containment on `ResidentChild::drop` so SPEC §5.5's containment clause holds at every depth rather than once around the displaced `Vec`

Fault-injection regressions cover a panicking staged install, illegal restart and residency transitions, a poisoned scope-finish mutex, a rejected last-owner admission, and two hostile resident payload destructors in one displaced set. A blocking mailbox-payload destructor regression proves resident clearing returns before the destructor is released and that destruction runs on the detached lane. Existing immediate-release coverage was updated for the asynchronous contract, and `AGENTS.md` now records every detached-disposal route including `admit_child_locked`'s.

The three regressions that depend on a `debug_assert!` firing are gated on `#[cfg(debug_assertions)]`; without the gate they fail (not merely go inert) under `--release`. See #393.

Deferred to issues: #389 (SPEC §15.5's structural `Removed`-on-drop is unreachable from a disposal worker), #390 (let residency own the projection so `ResidentAdmission` can be deleted), #393 (no release-profile test lane).

Validation: `./tools/dev just ci`, plus `cargo nextest run --release --workspace` (803/803).
