### PR TITLE
Document Handler error teardown asymmetry

### DIFF
--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -484,12 +484,22 @@ impl<A: Actor> RawActor for Handler<A> {
     /// decorator — not the raw runner — may resume after this future
     /// returns, and it must not observe still-live incarnation resources;
     /// every error exit therefore freezes and joins them here first. That
-    /// half-teardown deliberately does not freeze the mailbox, so a decorator
-    /// may inspect the returned error with the mailbox still live and the
-    /// resource capabilities now rejected. Resuming the raw loop past this
-    /// point is unsupported; once the decorated raw stack returns, the raw
-    /// incarnation boundary freezes the mailbox before destroying the context
-    /// and actor.
+    /// half-teardown touches only the resource half: it leaves the mailbox
+    /// binding exactly as this loop left it — still accepting when the error
+    /// preceded any intake freeze, already frozen when it was raised during
+    /// frozen-prefix drain or after a `Context::stop` request, since
+    /// [`RawContext::stop`] and the [`recv`](RawContext::recv) /
+    /// [`try_recv`](RawContext::try_recv) shutdown boundary freeze intake
+    /// themselves. Either way the decorator finds the resource capabilities
+    /// already rejected. Resuming the raw loop past this point is
+    /// unsupported, and unenforced beyond a second call to this method
+    /// panicking: receives keep delivering whatever the mailbox state still
+    /// allows, while `continue_with`, `set_timeout`, `set_interval` and
+    /// `offload` silently return `Rejected` instead of diagnosing. Once the
+    /// decorated raw stack returns, the raw incarnation boundary freezes the
+    /// mailbox before joining resources and destroying the context and
+    /// actor, which is where acceptance closes for an incarnation that ends
+    /// without a stop phase (§5.4).
     async fn run(&mut self, raw: &mut RawContext<Self::Msg>) -> ExitResult {
         let HandlerState::Uninit(args) = std::mem::replace(&mut self.state, HandlerState::Spent)
         else {
@@ -551,10 +561,12 @@ impl<A: Actor> RawActor for Handler<A> {
 /// Propagates a callback error after §6.5's orderly teardown: incarnation-owned
 /// work is frozen, cancelled, and joined before control returns to the caller,
 /// which at the advertised composition point may be a raw decorator rather
-/// than the raw incarnation boundary itself. This helper leaves the mailbox
-/// live for that decorator; the outer raw incarnation boundary freezes it when
-/// the decorated stack returns. Returning to the loop after this resource-only
-/// teardown is unsupported.
+/// than the raw incarnation boundary itself. This helper touches only the
+/// resource half, leaving the mailbox binding as it found it: still accepting
+/// when the error preceded any intake freeze, already frozen when it was
+/// raised during frozen-prefix drain or after a stop request. The outer raw
+/// incarnation boundary freezes the mailbox when the decorated stack returns.
+/// Returning to the loop after this resource-only teardown is unsupported.
 async fn fail_after_teardown<M: Send + 'static>(
     raw: &mut RawContext<M>,
     error: ExitError,

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -483,7 +483,12 @@ impl<A: Actor> RawActor for Handler<A> {
     /// this wrapper is the advertised raw-decorator composition point, so a
     /// decorator — not the raw runner — may resume after this future
     /// returns, and it must not observe still-live incarnation resources;
-    /// every error exit therefore freezes and joins them here first.
+    /// every error exit therefore freezes and joins them here first. That
+    /// half-teardown deliberately does not freeze the mailbox: an incarnation
+    /// ending without a stop phase remains accepting until exit publication
+    /// (SPEC §5.4). A decorator may inspect the returned error and the now-
+    /// rejected resource capabilities, but resuming the raw loop past this
+    /// point is unsupported.
     async fn run(&mut self, raw: &mut RawContext<Self::Msg>) -> ExitResult {
         let HandlerState::Uninit(args) = std::mem::replace(&mut self.state, HandlerState::Spent)
         else {
@@ -545,7 +550,9 @@ impl<A: Actor> RawActor for Handler<A> {
 /// Propagates a callback error after §6.5's orderly teardown: incarnation-owned
 /// work is frozen, cancelled, and joined before control returns to the caller,
 /// which at the advertised composition point may be a raw decorator rather
-/// than the raw incarnation boundary itself.
+/// than the raw incarnation boundary itself. The mailbox stays bound until
+/// the raw incarnation boundary publishes the exit, as SPEC §5.4 requires;
+/// returning to the loop after this resource-only teardown is unsupported.
 async fn fail_after_teardown<M: Send + 'static>(
     raw: &mut RawContext<M>,
     error: ExitError,

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -484,11 +484,12 @@ impl<A: Actor> RawActor for Handler<A> {
     /// decorator — not the raw runner — may resume after this future
     /// returns, and it must not observe still-live incarnation resources;
     /// every error exit therefore freezes and joins them here first. That
-    /// half-teardown deliberately does not freeze the mailbox: an incarnation
-    /// ending without a stop phase remains accepting until exit publication
-    /// (SPEC §5.4). A decorator may inspect the returned error and the now-
-    /// rejected resource capabilities, but resuming the raw loop past this
-    /// point is unsupported.
+    /// half-teardown deliberately does not freeze the mailbox, so a decorator
+    /// may inspect the returned error with the mailbox still live and the
+    /// resource capabilities now rejected. Resuming the raw loop past this
+    /// point is unsupported; once the decorated raw stack returns, the raw
+    /// incarnation boundary freezes the mailbox before destroying the context
+    /// and actor.
     async fn run(&mut self, raw: &mut RawContext<Self::Msg>) -> ExitResult {
         let HandlerState::Uninit(args) = std::mem::replace(&mut self.state, HandlerState::Spent)
         else {
@@ -550,9 +551,10 @@ impl<A: Actor> RawActor for Handler<A> {
 /// Propagates a callback error after §6.5's orderly teardown: incarnation-owned
 /// work is frozen, cancelled, and joined before control returns to the caller,
 /// which at the advertised composition point may be a raw decorator rather
-/// than the raw incarnation boundary itself. The mailbox stays bound until
-/// the raw incarnation boundary publishes the exit, as SPEC §5.4 requires;
-/// returning to the loop after this resource-only teardown is unsupported.
+/// than the raw incarnation boundary itself. This helper leaves the mailbox
+/// live for that decorator; the outer raw incarnation boundary freezes it when
+/// the decorated stack returns. Returning to the loop after this resource-only
+/// teardown is unsupported.
 async fn fail_after_teardown<M: Send + 'static>(
     raw: &mut RawContext<M>,
     error: ExitError,

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -404,6 +404,123 @@ impl<R: RawActor> RawActor for ResumeProbeDecorator<R> {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ErrorReturnCapabilities {
+    continuation_rejected: bool,
+    timer_rejected: bool,
+    offload_rejected: bool,
+}
+
+struct ErrorReturnProbe<R> {
+    inner: R,
+    observed: Arc<Mutex<Option<ErrorReturnCapabilities>>>,
+}
+
+impl<R: RawActor<Msg = ()>> RawActor for ErrorReturnProbe<R> {
+    type Msg = ();
+
+    fn readiness() -> Readiness {
+        R::readiness()
+    }
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        let result = self.inner.run(context).await;
+        assert!(result.is_err(), "the probe requires an inner error return");
+        let capabilities = ErrorReturnCapabilities {
+            continuation_rejected: context.continue_with(()).is_err(),
+            timer_rejected: context
+                .set_timeout("after-inner-error", (), Duration::from_secs(1))
+                .is_err(),
+            offload_rejected: context.offload(async {}, |_| (), Duration::MAX).is_err(),
+        };
+        *self
+            .observed
+            .lock()
+            .expect("error-return observation mutex poisoned") = Some(capabilities);
+        result
+    }
+}
+
+struct InitErrorActor;
+
+impl Actor for InitErrorActor {
+    type Msg = ();
+    type Args = ();
+
+    async fn init((): (), _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Err(ExitError::message("injected handler init error"))
+    }
+
+    async fn handle(&mut self, (): Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+        unreachable!("failed initialization never enters the handler loop")
+    }
+}
+
+struct PlainRawError;
+
+impl RawActor for PlainRawError {
+    type Msg = ();
+
+    fn readiness() -> Readiness {
+        Readiness::Manual
+    }
+
+    async fn run(&mut self, _: &mut RawContext<Self::Msg>) -> ExitResult {
+        Err(ExitError::message("injected raw error"))
+    }
+}
+
+async fn capabilities_after_inner_error<R: RawActor<Msg = ()>>(
+    inner: R,
+) -> ErrorReturnCapabilities {
+    let observed = Arc::new(Mutex::new(None));
+    let mut tree = Tree::new();
+    tree.add_raw_once(
+        "error-return",
+        RawOnceDef::new(ErrorReturnProbe {
+            inner,
+            observed: Arc::clone(&observed),
+        }),
+    )
+    .expect("valid decorated actor");
+    let system = tree.spawn().expect("runtime is available");
+    system
+        .wait_started()
+        .await
+        .expect_err("the pre-readiness error aborts startup");
+    let capabilities = observed
+        .lock()
+        .expect("error-return observation mutex poisoned")
+        .expect("the decorator observed its returned context");
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("failed-startup tree shuts down");
+    capabilities
+}
+
+#[tokio::test]
+async fn handler_error_freezes_resources_while_plain_raw_error_leaves_them_live() {
+    assert_eq!(
+        capabilities_after_inner_error(Handler::<InitErrorActor>::new(())).await,
+        ErrorReturnCapabilities {
+            continuation_rejected: true,
+            timer_rejected: true,
+            offload_rejected: true,
+        },
+        "Handler errors return only after their resource half is frozen"
+    );
+    assert_eq!(
+        capabilities_after_inner_error(PlainRawError).await,
+        ErrorReturnCapabilities {
+            continuation_rejected: false,
+            timer_rejected: false,
+            offload_rejected: false,
+        },
+        "plain RawActor errors reach their decorator before raw-boundary teardown"
+    );
+}
+
 struct TeardownDropLog {
     log: Arc<Mutex<Vec<&'static str>>>,
 }

--- a/crates/shelterwood/tests/actor.rs
+++ b/crates/shelterwood/tests/actor.rs
@@ -409,6 +409,11 @@ struct ErrorReturnCapabilities {
     continuation_rejected: bool,
     timer_rejected: bool,
     offload_rejected: bool,
+    /// Outcome of a self-`try_send` at the moment the decorator resumes:
+    /// `Ok` while the mailbox binding is still accepting, `Err(NotRunning)`
+    /// once intake has been frozen. This is the half `fail_after_teardown`
+    /// must leave exactly as the inner loop left it.
+    mailbox_send: Result<(), SendErrorKind>,
 }
 
 struct ErrorReturnProbe<R> {
@@ -432,6 +437,11 @@ impl<R: RawActor<Msg = ()>> RawActor for ErrorReturnProbe<R> {
                 .set_timeout("after-inner-error", (), Duration::from_secs(1))
                 .is_err(),
             offload_rejected: context.offload(async {}, |_| (), Duration::MAX).is_err(),
+            mailbox_send: context
+                .myself()
+                .try_send(())
+                .map(|_| ())
+                .map_err(|error| error.kind),
         };
         *self
             .observed
@@ -470,10 +480,43 @@ impl RawActor for PlainRawError {
     }
 }
 
+/// Self-sends two messages during `init`, stops on the first live delivery so
+/// the second becomes the frozen accepted prefix, then fails while draining
+/// that prefix. This is the default-configuration path (`MailboxShutdown` is
+/// `Drain`) on which the error reaches the decorator with intake *already*
+/// frozen — by `ctx.stop()` and the `recv`/`try_recv` shutdown boundary, not
+/// by the error teardown.
+struct DrainErrorActor;
+
+impl Actor for DrainErrorActor {
+    type Msg = ();
+    type Args = ();
+
+    async fn init((): (), context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        let myself = context.myself();
+        myself
+            .try_send(())
+            .expect("a spawned incarnation accepts sends during init");
+        myself
+            .try_send(())
+            .expect("a spawned incarnation accepts sends during init");
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
+        if context.is_draining() {
+            Err(ExitError::message("injected drain error"))
+        } else {
+            context.stop();
+            Ok(())
+        }
+    }
+}
+
 async fn capabilities_after_inner_error<R: RawActor<Msg = ()>>(
     inner: R,
 ) -> ErrorReturnCapabilities {
-    let observed = Arc::new(Mutex::new(None));
+    let observed: Arc<Mutex<Option<ErrorReturnCapabilities>>> = Arc::new(Mutex::new(None));
     let mut tree = Tree::new();
     tree.add_raw_once(
         "error-return",
@@ -484,10 +527,14 @@ async fn capabilities_after_inner_error<R: RawActor<Msg = ()>>(
     )
     .expect("valid decorated actor");
     let system = tree.spawn().expect("runtime is available");
-    system
-        .wait_started()
-        .await
-        .expect_err("the pre-readiness error aborts startup");
+    // Startup either fails (pre-readiness errors) or succeeds and the child
+    // fails afterwards, so wait on the observation itself rather than on a
+    // readiness verdict that differs per case.
+    assert_eventually!(|| observed
+        .lock()
+        .expect("error-return observation mutex poisoned")
+        .is_some())
+    .await;
     let capabilities = observed
         .lock()
         .expect("error-return observation mutex poisoned")
@@ -495,20 +542,26 @@ async fn capabilities_after_inner_error<R: RawActor<Msg = ()>>(
     system
         .shutdown(Duration::from_secs(1))
         .await
-        .expect("failed-startup tree shuts down");
+        .expect("the tree shuts down after the failed child");
     capabilities
 }
 
+/// `fail_after_teardown` owns the resource half and only the resource half.
+/// The pre-readiness cases pin both directions of that split: a `Handler`
+/// error returns with resources frozen and the mailbox binding untouched —
+/// still accepting, because nothing in this path froze intake — while a plain
+/// `RawActor` error reaches its decorator before any framework teardown.
 #[tokio::test]
-async fn handler_error_freezes_resources_while_plain_raw_error_leaves_them_live() {
+async fn handler_error_freezes_resources_while_leaving_an_unfrozen_mailbox_alone() {
     assert_eq!(
         capabilities_after_inner_error(Handler::<InitErrorActor>::new(())).await,
         ErrorReturnCapabilities {
             continuation_rejected: true,
             timer_rejected: true,
             offload_rejected: true,
+            mailbox_send: Ok(()),
         },
-        "Handler errors return only after their resource half is frozen"
+        "Handler errors return with the resource half frozen and the mailbox half as found"
     );
     assert_eq!(
         capabilities_after_inner_error(PlainRawError).await,
@@ -516,8 +569,26 @@ async fn handler_error_freezes_resources_while_plain_raw_error_leaves_them_live(
             continuation_rejected: false,
             timer_rejected: false,
             offload_rejected: false,
+            mailbox_send: Ok(()),
         },
         "plain RawActor errors reach their decorator before raw-boundary teardown"
+    );
+}
+
+/// The mailbox half in the other direction: on the normative default drain
+/// path the binding the decorator observes is already frozen. "Left as found"
+/// is the guarantee, not "left live".
+#[tokio::test]
+async fn handler_drain_error_returns_with_intake_already_frozen() {
+    assert_eq!(
+        capabilities_after_inner_error(Handler::<DrainErrorActor>::new(())).await,
+        ErrorReturnCapabilities {
+            continuation_rejected: true,
+            timer_rejected: true,
+            offload_rejected: true,
+            mailbox_send: Err(SendErrorKind::NotRunning),
+        },
+        "a drain-phase Handler error returns to its decorator with intake already frozen"
     );
 }
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -1051,12 +1051,13 @@ handlers non-blocking. Contracts:
   on every path.
 - At the raw-decorator composition point, an inner `Handler` returning
   `Err` has already frozen and joined its incarnation-owned resource half;
-  continuing that raw loop is unsupported. It deliberately has **not**
-  frozen the mailbox: an incarnation ending without a stop phase keeps the
-  §5.4 acceptance window open until the raw boundary publishes its exit. A
-  plain `RawActor` returning `Err` has not performed either teardown step;
-  its decorator still observes a live context until it returns to that
-  boundary.
+  continuing that raw loop is unsupported. The handler deliberately has
+  **not** frozen the mailbox, so its decorator observes that half still live.
+  When the decorated raw stack returns, the raw incarnation boundary freezes
+  the mailbox before destroying the context and actor; this precedes exit
+  publication. A plain `RawActor` returning `Err` has not performed either
+  teardown step, so its decorator observes both halves live until it returns
+  to that boundary.
 
 ## 7. Readiness
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -1049,6 +1049,14 @@ handlers non-blocking. Contracts:
   `StopContext::run_blocking` may therefore start work after the
   async-resource freeze. The mailbox binding outlives actor destruction
   on every path.
+- At the raw-decorator composition point, an inner `Handler` returning
+  `Err` has already frozen and joined its incarnation-owned resource half;
+  continuing that raw loop is unsupported. It deliberately has **not**
+  frozen the mailbox: an incarnation ending without a stop phase keeps the
+  §5.4 acceptance window open until the raw boundary publishes its exit. A
+  plain `RawActor` returning `Err` has not performed either teardown step;
+  its decorator still observes a live context until it returns to that
+  boundary.
 
 ## 7. Readiness
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -724,8 +724,16 @@ starts) and closes at the intake freeze when the incarnation begins
 stopping (§6.2 — the freeze precedes drain and `on_stop`, which is what
 makes the drained log exactly the accepted prefix; under `latest()`, its
 surviving slot) or, for an incarnation that ends without a stop phase
-(panic, hard abort, plain return), at its exit publication (§8); outside
-that window sends park (`send`) or fail fast (`try_send`, `NotRunning`).
+(plain return, error return, or panic), at the raw incarnation boundary's
+mailbox freeze — taken the moment the incarnation body returns or
+unwinds, before its resources are joined and before the context and actor
+are destroyed (§6.5), and therefore strictly before exit publication (§8).
+A hard abort is reachable only as a grace-ladder escalation (§11) of a
+stop request that already froze intake, so its close point is that stop's
+freeze; abrupt driver teardown freezes and closes together. On every path
+acceptance is closed no later than exit publication. Outside the
+acceptance window sends park (`send`) or fail fast (`try_send`,
+`NotRunning`).
 
 Readiness (§7) never gates acceptance — a gated child's mailbox accepts
 during its handshake, which is what lets cross-wired siblings send to a
@@ -1050,14 +1058,22 @@ handlers non-blocking. Contracts:
   async-resource freeze. The mailbox binding outlives actor destruction
   on every path.
 - At the raw-decorator composition point, an inner `Handler` returning
-  `Err` has already frozen and joined its incarnation-owned resource half;
-  continuing that raw loop is unsupported. The handler deliberately has
-  **not** frozen the mailbox, so its decorator observes that half still live.
-  When the decorated raw stack returns, the raw incarnation boundary freezes
-  the mailbox before destroying the context and actor; this precedes exit
-  publication. A plain `RawActor` returning `Err` has not performed either
-  teardown step, so its decorator observes both halves live until it returns
-  to that boundary.
+  `Err` has already frozen and joined its incarnation-owned resource half.
+  It touches **only** that half: the mailbox binding is left exactly as the
+  callback loop left it — still accepting when the error preceded any intake
+  freeze (an `init` or live-handler error with no stop request), already
+  frozen when the error was raised while draining the frozen prefix or after
+  a `ctx.stop()`, because the stop call and the `recv`/`try_recv` shutdown
+  boundary freeze intake themselves (§6.2). Continuing to drive that raw loop
+  is unsupported, and unenforced beyond a second `Handler` initialization
+  panicking: receives keep delivering whatever the mailbox state still
+  allows, while the incarnation-resource capabilities silently reject
+  instead of diagnosing. The framework performs neither teardown step
+  on a plain `RawActor`'s behalf, so its decorator observes whatever that
+  loop itself froze. On both paths the raw incarnation boundary freezes the
+  mailbox when the decorated stack returns, before joining resources and
+  destroying the context and actor — §5.4's close point for an incarnation
+  that ends without a stop phase.
 
 ## 7. Readiness
 


### PR DESCRIPTION
Addresses the Handler/raw decorator contract item from #366.

Pins where a callback error's teardown stops and where mailbox acceptance actually closes.

- `Handler` errors return to their immediate decorator with the incarnation-resource half already frozen and joined. That half-teardown touches **only** the resource half, so it leaves the mailbox binding exactly as the callback loop left it: still accepting when the error preceded any intake freeze, already frozen when the error was raised during frozen-prefix drain or after a stop request — `RawContext::stop` and the `recv`/`try_recv` shutdown boundary freeze intake themselves. The guarantee is "left as found", not "left live".
- Continuing to drive that raw loop is unsupported, and the docs now say the enforcement is partial: a second `Handler::run` panics, but receives keep delivering while `continue_with`/`set_timeout`/`set_interval`/`offload` silently return `Rejected`.
- The framework performs neither teardown step on a plain `RawActor`'s behalf; its decorator observes whatever that loop itself froze.
- SPEC §5.4 is reconciled with this. Its second clause named exit publication as the close point for an incarnation ending without a stop phase; the raw incarnation boundary freezes the mailbox as soon as the body returns or unwinds, before `join_resources` and both user destructors, so that freeze is the close point. A hard abort is reachable only as a grace-ladder escalation of a stop request that already froze intake, so its close point is that stop's freeze; abrupt driver teardown freezes and closes together. Acceptance is closed no later than exit publication on every path.

Façade regressions pin both halves. The decorator probe records the resource capabilities *and* a self-`try_send`, and all verdicts are compared in the test body. `handler_error_freezes_resources_while_leaving_an_unfrozen_mailbox_alone` pins the still-accepting direction for a `Handler` init error and a plain `RawActor` error; the new `handler_drain_error_returns_with_intake_already_frozen` pins the already-frozen direction on the normative default `MailboxShutdown::Drain` path.

Validation: `cargo nextest run -p shelterwood` (555), clippy `-D warnings`, doctests, `cargo doc --no-deps`, packaged-docs check. Mutation checks for each new assertion are recorded in the review-response comment.
