### PR TITLE
Reject illegal member projection transitions in release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,11 +116,19 @@ rests on:
   gate is outermost: everything else is taken under it or standalone, never
   around it. Inside, the documented orders are cells' member mailbox →
   `MailboxCell::state`, and `MailboxCell::state` → `SendOperation::state`.
-  Gate-to-gate is the one exception to "outermost": `adopt_observation_gate`
-  takes the adoptee's *current* gate while the adopting parent's is held, in
-  the parent-to-child direction only, and re-reads the installed pointer
-  under the acquired guard so a concurrent handoff retries rather than
-  deadlocks.
+  Gate-to-gate is the one exception to "outermost":
+  `MemberCell::with_handoff_gate` takes the adoptee's *current* gate while the
+  adopting parent's is held, in the parent-to-child direction only, and
+  re-reads the installed pointer under the acquired guard so a concurrent
+  handoff retries rather than deadlocks. Both of its users — plain adoption
+  (`ScopeCell::adopt_observation_gate`) and admission
+  (`ScopeCell::admit_observation_gate`, `ScopeCell::admit_child_locked`) —
+  hold the exemption. Admission widens what runs inside the doubled section:
+  the member record's watch-value mutex is taken there, and admission's
+  `MemberTransition` reaches `RetainedExit` clone/drop under both gates. That
+  stays inside the rule — the record is framework-owned data and the retained
+  clone is provably non-last — but it is the deepest the exemption goes, so a
+  new operation added to the doubled section needs the same accounting.
 
 Two conventions that are not the rule itself but travel with it: panicking
 while holding a mutex the codebase `.expect()`s poisons it for every later

--- a/crates/shelterwood-cells/src/cells/member.rs
+++ b/crates/shelterwood-cells/src/cells/member.rs
@@ -29,20 +29,6 @@ pub enum MemberStage {
     Terminal(Exit),
 }
 
-impl MemberStage {
-    fn tag(&self) -> &'static str {
-        match self {
-            Self::Reserved => "Reserved",
-            Self::Admitted => "Admitted",
-            Self::Starting => "Starting",
-            Self::Running => "Running",
-            Self::Restarting => "Restarting",
-            Self::Stopping => "Stopping",
-            Self::Terminal(_) => "Terminal",
-        }
-    }
-}
-
 /// One non-terminal member-record transition owned by the cell layer.
 pub enum MemberTransition {
     Admitted,
@@ -108,48 +94,52 @@ impl MemberRecord {
     /// Applies one driver-requested transition.
     ///
     /// Every watch-channel writer routes stage changes through here (see
-    /// [`MemberCell::transition`] for the wake-bus contract), so each arm
-    /// asserts the source stages its driver call sites can actually present.
+    /// [`MemberCell::transition`] for the wake-bus contract). The reducer
+    /// rejects an event whose source stage is not one its driver call sites
+    /// can present, including in release builds.
     ///
     /// Exits are safe to retire inside the watch mutation: the record's guard
     /// set still covers the displaced value, and [`Self::refresh_retained_exits`]
     /// re-establishes that cover before the mutation returns.
-    fn apply_transition(&mut self, transition: MemberTransition) {
+    fn apply_transition(&mut self, transition: MemberTransition) -> Result<(), MemberTransition> {
+        let legal = matches!(
+            (&self.stage, &transition),
+            (MemberStage::Reserved, MemberTransition::Admitted)
+                | (
+                    MemberStage::Admitted | MemberStage::Restarting,
+                    MemberTransition::Starting { .. }
+                )
+                | (
+                    MemberStage::Starting | MemberStage::Reserved,
+                    MemberTransition::Running
+                )
+                | (
+                    MemberStage::Starting | MemberStage::Running,
+                    MemberTransition::Stopping
+                )
+                | (
+                    MemberStage::Starting | MemberStage::Running | MemberStage::Stopping,
+                    MemberTransition::RestartScheduled { .. }
+                )
+        );
+        if !legal {
+            return Err(transition);
+        }
+
         match transition {
             MemberTransition::Admitted => {
-                debug_assert!(
-                    matches!(self.stage, MemberStage::Reserved),
-                    "admission must consume a fresh reservation, not {}",
-                    self.stage.tag()
-                );
                 self.stage = MemberStage::Admitted;
             }
             MemberTransition::Starting { incarnation } => {
-                debug_assert!(
-                    matches!(self.stage, MemberStage::Admitted | MemberStage::Restarting),
-                    "a spawn must start an admitted or restarting member, not {}",
-                    self.stage.tag()
-                );
                 self.stage = MemberStage::Starting;
                 self.incarnation = Some(incarnation);
                 self.last_incarnation = Some(incarnation);
                 self.restart_at = None;
             }
             MemberTransition::Running => {
-                debug_assert!(
-                    matches!(self.stage, MemberStage::Starting | MemberStage::Reserved),
-                    "readiness must promote a starting member (or the root scope's own \
-                     never-admitted reservation), not {}",
-                    self.stage.tag()
-                );
                 self.stage = MemberStage::Running;
             }
             MemberTransition::Stopping => {
-                debug_assert!(
-                    matches!(self.stage, MemberStage::Starting | MemberStage::Running),
-                    "a stop ladder must begin on a starting or running member, not {}",
-                    self.stage.tag()
-                );
                 self.stage = MemberStage::Stopping;
             }
             MemberTransition::RestartScheduled {
@@ -157,14 +147,6 @@ impl MemberRecord {
                 restart_count,
                 restart_at,
             } => {
-                debug_assert!(
-                    matches!(
-                        self.stage,
-                        MemberStage::Starting | MemberStage::Running | MemberStage::Stopping
-                    ),
-                    "a restart must be scheduled from an active incarnation's exit, not {}",
-                    self.stage.tag()
-                );
                 self.stage = MemberStage::Restarting;
                 self.incarnation = None;
                 self.last_exit = Some(exit);
@@ -172,6 +154,7 @@ impl MemberRecord {
                 self.restart_at = restart_at;
             }
         }
+        Ok(())
     }
 }
 
@@ -407,8 +390,8 @@ impl MemberCell {
     /// field read by a loop precondition must be changed through a pulsing path
     /// like this one, never by a silent write outside an observation gate.
     #[cfg(any(test, feature = "test-util"))]
-    pub fn transition(&self, transition: MemberTransition) {
-        self.with_observation_txn(|txn| self.transition_locked(txn, transition));
+    pub fn transition(&self, transition: MemberTransition) -> bool {
+        self.with_observation_txn(|txn| self.transition_locked(txn, transition))
     }
 
     fn with_observation_txn<R>(&self, operation: impl FnOnce(&mut ObservationTxn<'_>) -> R) -> R {
@@ -527,9 +510,13 @@ impl MemberCell {
         txn.pulse(&self.record);
     }
 
-    pub fn transition_locked(&self, txn: &mut ObservationTxn<'_>, transition: MemberTransition) {
+    pub fn transition_locked(
+        &self,
+        txn: &mut ObservationTxn<'_>,
+        transition: MemberTransition,
+    ) -> bool {
         // `RestartScheduled` carries a user error by value. Retain it before
-        // the watch lock and reducer assertions so an invariant panic can
+        // the watch lock and reducer validation so an unrelated panic can
         // unwind the raw transition as refcount traffic only.
         let retained_exit = match &transition {
             MemberTransition::RestartScheduled { exit, .. } => {
@@ -540,11 +527,29 @@ impl MemberCell {
             | MemberTransition::Running
             | MemberTransition::Stopping => None,
         };
-        self.update_locked(txn, |record| record.apply_transition(transition));
+        let mut rejected = None;
+        self.record
+            .modify_silently(|record| match record.apply_transition(transition) {
+                Ok(()) => record.refresh_retained_exits(),
+                Err(transition) => rejected = Some(transition),
+            });
+        if let Some(rejected) = rejected {
+            // Rejection is a total no-op. The rejected event may own a failed
+            // exit, so retire it with the transaction rather than under the
+            // observation gate or watch lock.
+            txn.defer(move || runtime::dispose_detached(rejected));
+            if let Some(retained_exit) = retained_exit {
+                // The deferred transition proves this clone cannot be last.
+                drop(retained_exit.into_exit());
+            }
+            return false;
+        }
+        txn.pulse(&self.record);
         if let Some(retained_exit) = retained_exit {
             // The record now owns an equivalent retained copy.
             drop(retained_exit.into_exit());
         }
+        true
     }
 
     pub fn set_options(&self, options: ResolvedCommonOptions) {
@@ -757,8 +762,9 @@ mod tests {
     // is gated on the profile it can hold in rather than left to fail there.
     #[cfg(debug_assertions)]
     #[test]
-    fn illegal_restart_transition_retires_its_user_error_off_thread() {
+    fn illegal_restart_transition_is_rejected_in_every_build() {
         let scope = isolated_scope("root", ScopeFlavor::Ordered);
+        let mut watcher = scope.member.record_watcher();
         let (dropped, observed) = mpsc::sync_channel(1);
         let retiring_thread = std::thread::current().id();
         let exit = Exit::failed(
@@ -766,21 +772,30 @@ mod tests {
             Cancellation::NotObserved,
         );
 
-        catch_unwind(AssertUnwindSafe(|| {
-            scope.member.transition(MemberTransition::RestartScheduled {
+        assert!(
+            !scope.member.transition(MemberTransition::RestartScheduled {
                 exit,
                 restart_count: RestartCount::ZERO.bump(),
                 restart_at: None,
-            });
-        }))
-        .expect_err("a reserved member cannot schedule a restart");
+            }),
+            "a reserved member cannot schedule a restart"
+        );
+        assert!(matches!(scope.member.record().stage, MemberStage::Reserved));
+        let mut changed = Box::pin(watcher.changed());
+        assert!(
+            changed
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending(),
+            "a rejected transition publishes no record edge"
+        );
 
         assert_ne!(
             observed
                 .recv_timeout(Duration::from_secs(10))
                 .expect("failed exit disposal reports"),
             retiring_thread,
-            "the incoming user error cannot unwind under the record and observation locks"
+            "a rejected user error retires on the detached lane"
         );
     }
 

--- a/crates/shelterwood-cells/src/cells/member.rs
+++ b/crates/shelterwood-cells/src/cells/member.rs
@@ -44,6 +44,37 @@ pub enum MemberTransition {
     },
 }
 
+impl MemberTransition {
+    /// The legality matrix for driver-requested stage transitions.
+    ///
+    /// This is the single definition of which source stages each event may
+    /// consume. [`MemberRecord::apply_transition`] enforces it, and
+    /// [`MemberCell::would_accept`] probes it ahead of an operation that must
+    /// commit other state before the transition itself lands.
+    fn is_legal_from(&self, stage: &MemberStage) -> bool {
+        matches!(
+            (stage, self),
+            (MemberStage::Reserved, MemberTransition::Admitted)
+                | (
+                    MemberStage::Admitted | MemberStage::Restarting,
+                    MemberTransition::Starting { .. }
+                )
+                | (
+                    MemberStage::Starting | MemberStage::Reserved,
+                    MemberTransition::Running
+                )
+                | (
+                    MemberStage::Starting | MemberStage::Running,
+                    MemberTransition::Stopping
+                )
+                | (
+                    MemberStage::Starting | MemberStage::Running | MemberStage::Stopping,
+                    MemberTransition::RestartScheduled { .. }
+                )
+        )
+    }
+}
+
 /// Whether a terminal child incarnation failed during aggregate startup.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum StartupDisposition {
@@ -102,27 +133,7 @@ impl MemberRecord {
     /// set still covers the displaced value, and [`Self::refresh_retained_exits`]
     /// re-establishes that cover before the mutation returns.
     fn apply_transition(&mut self, transition: MemberTransition) -> Result<(), MemberTransition> {
-        let legal = matches!(
-            (&self.stage, &transition),
-            (MemberStage::Reserved, MemberTransition::Admitted)
-                | (
-                    MemberStage::Admitted | MemberStage::Restarting,
-                    MemberTransition::Starting { .. }
-                )
-                | (
-                    MemberStage::Starting | MemberStage::Reserved,
-                    MemberTransition::Running
-                )
-                | (
-                    MemberStage::Starting | MemberStage::Running,
-                    MemberTransition::Stopping
-                )
-                | (
-                    MemberStage::Starting | MemberStage::Running | MemberStage::Stopping,
-                    MemberTransition::RestartScheduled { .. }
-                )
-        );
-        if !legal {
+        if !transition.is_legal_from(&self.stage) {
             return Err(transition);
         }
 
@@ -389,7 +400,11 @@ impl MemberCell {
     /// The driver also treats this channel as its control-plane wake bus: any
     /// field read by a loop precondition must be changed through a pulsing path
     /// like this one, never by a silent write outside an observation gate.
+    ///
+    /// Returns whether the reducer accepted the event; see
+    /// [`Self::transition_locked`].
     #[cfg(any(test, feature = "test-util"))]
+    #[must_use = "an illegal member transition is rejected, not applied"]
     pub fn transition(&self, transition: MemberTransition) -> bool {
         self.with_observation_txn(|txn| self.transition_locked(txn, transition))
     }
@@ -465,44 +480,37 @@ impl MemberCell {
         );
     }
 
+    /// Adopts `gate` unconditionally, running `install` when it differs from
+    /// this member's current gate.
     pub(super) fn adopt_observation_gate_with(
         &self,
         gate: &ObservationGate,
-        mut report_capture: impl FnMut(),
+        report_capture: impl FnMut(),
         install: impl FnOnce(&ObservationGate),
     ) {
-        let mut install = Some(install);
-        loop {
-            let current = self.current_observation_gate();
-            if current.shares_gate(gate) {
-                return;
+        let adopted = self.with_handoff_gate(gate, report_capture, |current| {
+            if !current.shares_gate(gate) {
+                install(current);
             }
-            report_capture();
-            // An operation that passed the pointer check may finish its
-            // complete edge before handoff. One that merely captured this
-            // obsolete gate retries after acquiring it and observing the
-            // replacement.
-            let current_guard = current.lock();
-            if current.shares_gate(&self.current_observation_gate()) {
-                let install = install
-                    .take()
-                    .expect("observation gate adoption installs exactly once");
-                install(&current);
-                drop(current_guard);
-                return;
-            }
-            drop(current_guard);
-        }
+            true
+        });
+        debug_assert!(adopted, "unconditional adoption never refuses");
     }
 
-    /// Runs an admission attempt under this member's current observation gate.
+    /// Runs `attempt` with this member's current observation gate held.
     ///
-    /// The caller already holds the destination gate. When the gates differ,
-    /// this takes the current child gate in the one permitted parent-to-child
-    /// direction and keeps it held through `attempt`, allowing validation,
-    /// transition, and handoff to form one cut. The attempt installs the new
-    /// gate itself only after it has accepted the transition.
-    pub(super) fn try_adopt_observation_gate_with(
+    /// The caller already holds the destination `gate`. When the member is
+    /// already on it, `attempt` runs directly under the caller's guard.
+    /// Otherwise this takes the member's current gate in the one permitted
+    /// parent-to-child direction and holds it across `attempt`, so validation,
+    /// record mutation and the recursive handoff form a single cut; `attempt`
+    /// owns the decision to install `gate` and returns whether it accepted.
+    ///
+    /// An operation that passed the pointer check may finish its complete edge
+    /// before handoff. One that merely captured an obsolete gate retries after
+    /// acquiring it and observing the replacement, so `report_capture` fires
+    /// once per differing-gate iteration.
+    pub(super) fn with_handoff_gate(
         &self,
         gate: &ObservationGate,
         mut report_capture: impl FnMut(),
@@ -514,20 +522,20 @@ impl MemberCell {
             if current.shares_gate(gate) {
                 return attempt
                     .take()
-                    .expect("observation gate admission runs exactly once")(
+                    .expect("an observation gate handoff attempt runs exactly once")(
                     &current
                 );
             }
             report_capture();
             let current_guard = current.lock();
             if current.shares_gate(&self.current_observation_gate()) {
-                let admitted = attempt
+                let accepted = attempt
                     .take()
-                    .expect("observation gate admission runs exactly once")(
+                    .expect("an observation gate handoff attempt runs exactly once")(
                     &current
                 );
                 drop(current_guard);
-                return admitted;
+                return accepted;
             }
             drop(current_guard);
         }
@@ -548,6 +556,24 @@ impl MemberCell {
         txn.pulse(&self.record);
     }
 
+    /// Probes the legality matrix without mutating anything.
+    ///
+    /// The stage can only change through a gated writer, so a caller holding
+    /// this member's observation gate across the probe and the matching
+    /// [`Self::transition_locked`] sees no window between them. That lets an
+    /// operation which must commit other state first refuse before it starts.
+    pub(super) fn would_accept(&self, transition: &MemberTransition) -> bool {
+        self.record
+            .read_with(|record| transition.is_legal_from(&record.stage))
+    }
+
+    /// Applies `transition` and returns whether the reducer accepted it.
+    ///
+    /// A rejection is a total no-op *within the cell layer*: no record field
+    /// changes, no watch version advances, and no lifecycle event is emitted.
+    /// It says nothing about state the caller committed before calling — see
+    /// the driver call sites, each of which asserts legality in debug builds.
+    #[must_use = "an illegal member transition is rejected, not applied"]
     pub fn transition_locked(
         &self,
         txn: &mut ObservationTxn<'_>,
@@ -572,9 +598,9 @@ impl MemberCell {
                 Err(transition) => rejected = Some(transition),
             });
         if let Some(rejected) = rejected {
-            // Rejection is a total no-op. The rejected event may own a failed
-            // exit, so retire it with the transaction rather than under the
-            // observation gate or watch lock.
+            // Rejection leaves this cell exactly as it was. The rejected event
+            // may own a failed exit, so retire it with the transaction rather
+            // than under the observation gate or watch lock.
             txn.defer(move || runtime::dispose_detached(rejected));
             if let Some(retained_exit) = retained_exit {
                 // The deferred transition proves this clone cannot be last.

--- a/crates/shelterwood-cells/src/cells/member.rs
+++ b/crates/shelterwood-cells/src/cells/member.rs
@@ -495,6 +495,44 @@ impl MemberCell {
         }
     }
 
+    /// Runs an admission attempt under this member's current observation gate.
+    ///
+    /// The caller already holds the destination gate. When the gates differ,
+    /// this takes the current child gate in the one permitted parent-to-child
+    /// direction and keeps it held through `attempt`, allowing validation,
+    /// transition, and handoff to form one cut. The attempt installs the new
+    /// gate itself only after it has accepted the transition.
+    pub(super) fn try_adopt_observation_gate_with(
+        &self,
+        gate: &ObservationGate,
+        mut report_capture: impl FnMut(),
+        attempt: impl FnOnce(&ObservationGate) -> bool,
+    ) -> bool {
+        let mut attempt = Some(attempt);
+        loop {
+            let current = self.current_observation_gate();
+            if current.shares_gate(gate) {
+                return attempt
+                    .take()
+                    .expect("observation gate admission runs exactly once")(
+                    &current
+                );
+            }
+            report_capture();
+            let current_guard = current.lock();
+            if current.shares_gate(&self.current_observation_gate()) {
+                let admitted = attempt
+                    .take()
+                    .expect("observation gate admission runs exactly once")(
+                    &current
+                );
+                drop(current_guard);
+                return admitted;
+            }
+            drop(current_guard);
+        }
+    }
+
     pub(super) fn update_locked(
         &self,
         txn: &mut ObservationTxn<'_>,

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -647,18 +647,24 @@ impl ScopeCell {
         member: &MemberCell,
         transition: MemberTransition,
         event: Option<LifecycleEventKind>,
-    ) {
+    ) -> bool {
         // Routed through `transition_locked` rather than a record-only update
         // so a restart schedule's displaced exit leaves the gate on this path
         // too.
         self.with_observation_gate(|wakes| {
-            member.transition_locked(wakes, transition);
+            if !member.transition_locked(wakes, transition) {
+                if let Some(event) = event {
+                    wakes.defer(move || runtime::dispose_detached(event));
+                }
+                return false;
+            }
             if let Some(event) = event {
                 self.emit_locked(wakes, event);
             } else {
                 self.publish_snapshot_chain_locked(wakes);
             }
-        });
+            true
+        })
     }
 
     pub fn publish_child_restart(
@@ -668,16 +674,20 @@ impl ScopeCell {
         transition: MemberTransition,
         exited: LifecycleEventKind,
         scheduled: LifecycleEventKind,
-    ) {
+    ) -> bool {
         self.with_observation_gate(|wakes| {
+            if !member.transition_locked(wakes, transition) {
+                wakes.defer(move || runtime::dispose_detached((exited, scheduled)));
+                return false;
+            }
             self.observation.record.modify_silently(|scope| {
                 scope.total_restarts = total_restarts;
             });
             wakes.pulse(&self.observation.record);
-            member.transition_locked(wakes, transition);
             self.emit_locked(wakes, exited);
             self.emit_locked(wakes, scheduled);
-        });
+            true
+        })
     }
 
     pub fn terminalize_child(
@@ -1174,17 +1184,17 @@ impl ScopeCell {
     }
 
     #[cfg(any(test, feature = "test-util"))]
-    pub fn admit_child(self: &Arc<Self>, child: ResidentProjection) {
-        self.with_observation_gate(|wakes| self.admit_child_locked(child, wakes));
+    pub fn admit_child(self: &Arc<Self>, child: ResidentProjection) -> bool {
+        self.with_observation_gate(|wakes| self.admit_child_locked(child, wakes))
     }
 
     pub fn admit_child_locked(
         self: &Arc<Self>,
         child: ResidentProjection,
         txn: &mut ObservationTxn<'_>,
-    ) {
+    ) -> bool {
         // Take protected ownership before gate adoption, parent wiring, and
-        // reducer assertions. Until the final push succeeds this projection
+        // reducer validation. Until the final push succeeds this projection
         // may be the last owner of a mailbox-bearing member.
         let child = ResidentAdmission::new(child, txn);
         let projection = child.projection();
@@ -1197,13 +1207,17 @@ impl ScopeCell {
         }
         let id = projection.member.id().clone();
         let membership = projection.member.membership();
-        projection
+        if !projection
             .member
-            .transition_locked(txn, MemberTransition::Admitted);
+            .transition_locked(txn, MemberTransition::Admitted)
+        {
+            return false;
+        }
         drop(projection);
         self.current_children()
             .push(ResidentChild::new(child.install()));
         self.emit_locked(txn, LifecycleEventKind::Added { id, membership });
+        true
     }
 
     pub fn clear_residents(&self) {
@@ -1463,7 +1477,7 @@ mod tests {
     use super::*;
     use crate::{
         cells::test_support::{TEST_WAIT, ThreadProbe, child_member, child_scope, isolated_scope},
-        observe::LifecycleItem,
+        observe::{LifecycleItem, LifecycleTryRecvError},
     };
 
     struct GateCheckingWake {
@@ -1703,7 +1717,7 @@ mod tests {
         drop(effects);
         // Admission below is intentionally illegal, but the projection is
         // still the final owner of this mailbox-bearing member when it fails.
-        member.transition(MemberTransition::Admitted);
+        assert!(member.transition(MemberTransition::Admitted));
         let (dropped, observed) = mpsc::sync_channel(1);
         actor
             .try_send(ThreadProbe(dropped))
@@ -1713,8 +1727,14 @@ mod tests {
         drop(mailbox);
         let retiring_thread = std::thread::current().id();
 
-        catch_unwind(AssertUnwindSafe(|| root.admit_child(projection)))
-            .expect_err("an admitted member cannot be admitted twice");
+        assert!(
+            !root.admit_child(projection),
+            "an admitted member cannot be admitted twice"
+        );
+        assert!(
+            root.resident_projections().is_empty(),
+            "a rejected admission publishes no residency"
+        );
 
         assert_ne!(
             observed
@@ -1723,6 +1743,36 @@ mod tests {
             retiring_thread,
             "the by-value projection cannot unwind its mailbox through the observation gate"
         );
+    }
+
+    #[test]
+    fn rejected_stage_transition_suppresses_its_lifecycle_publication() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let member = child_member(&root, "invalid");
+        let mut events = root.subscribe_lifecycle();
+
+        assert!(
+            !root.transition_child_stage(
+                &member,
+                MemberTransition::RestartScheduled {
+                    exit: Exit::completed(Cancellation::NotObserved),
+                    restart_count: RestartCount::ZERO.bump(),
+                    restart_at: None,
+                },
+                Some(LifecycleEventKind::Exited {
+                    id: member.id().clone(),
+                    membership: member.membership(),
+                    incarnation: member
+                        .take_incarnation_counter()
+                        .mint()
+                        .expect("incarnation available"),
+                    exit: Exit::completed(Cancellation::NotObserved),
+                }),
+            ),
+            "the Reserved-to-Restarting projection transition is illegal"
+        );
+        assert!(matches!(member.record().stage, MemberStage::Reserved));
+        assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Empty));
     }
 
     #[test]

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -485,6 +485,13 @@ impl ScopeCell {
         );
     }
 
+    /// Admits this scope's subtree onto `gate`, or refuses without touching it.
+    ///
+    /// Legality is probed before anything is committed and applied only after
+    /// the recursive handoff has succeeded. Both halves run under the child's
+    /// own gate, held across the whole attempt, so no writer can change the
+    /// stage between them; and an unwind out of the handoff's `assert!` leaves
+    /// the record still reading its pre-admission stage.
     fn admit_observation_gate(
         &self,
         parent: &ScopeCell,
@@ -495,32 +502,39 @@ impl ScopeCell {
             !std::ptr::eq(self, parent),
             "a scope cannot be admitted into itself"
         );
+        // The caller holds `gate` through `parent.with_observation_gate`.
+        // Re-homing the parent would first have to acquire that same gate, so
+        // rereading its installed pointer here cannot race a parent handoff.
         debug_assert!(
             gate.shares_gate(&parent.current_observation_gate()),
             "observation gates are admitted only in the parent-to-child direction"
         );
-        self.member.try_adopt_observation_gate_with(
+        self.member.with_handoff_gate(
             gate,
             || {
                 #[cfg(any(test, feature = "test-util"))]
                 self.report_gate_capture(GateCapture::Adoption);
             },
             |current| {
-                if !self
-                    .member
-                    .transition_locked(txn, MemberTransition::Admitted)
-                {
+                if !self.member.would_accept(&MemberTransition::Admitted) {
                     return false;
                 }
                 if !current.shares_gate(gate) {
-                    debug_assert!(
-                        self.dynamic_route_in(txn).is_none(),
-                        "a scope with a live dynamic route is never re-homed"
-                    );
+                    // A live dynamic route needs a started driver, which needs
+                    // a stage past `Reserved`; the probe above already refused
+                    // every such stage, so re-homing one is unconstructible
+                    // rather than merely unreached.
                     self.member.install_observation_gate_locked(current, gate);
                     self.adopt_descendant_observation_gates_locked(current, gate, txn);
                 }
-                true
+                let admitted = self
+                    .member
+                    .transition_locked(txn, MemberTransition::Admitted);
+                debug_assert!(
+                    admitted,
+                    "the probed admission cannot be refused under the same held gate"
+                );
+                admitted
             },
         )
     }
@@ -682,6 +696,12 @@ impl ScopeCell {
         });
     }
 
+    /// Applies `transition` and publishes `event`, or refuses both.
+    ///
+    /// Returns whether the reducer accepted the transition. A refusal is a
+    /// no-op *for this scope*; the caller is responsible for whatever it
+    /// committed beforehand.
+    #[must_use = "an illegal member transition is rejected, not applied"]
     pub fn transition_child_stage(
         &self,
         member: &MemberCell,
@@ -707,6 +727,11 @@ impl ScopeCell {
         })
     }
 
+    /// Publishes one restart schedule, or refuses the whole publication.
+    ///
+    /// Returns whether the reducer accepted the transition. The restart
+    /// bookkeeping its caller already charged is not rolled back here.
+    #[must_use = "an illegal member transition is rejected, not applied"]
     pub fn publish_child_restart(
         &self,
         member: &MemberCell,
@@ -1214,20 +1239,32 @@ impl ScopeCell {
             || (self.membership_terminal() && self.joined())
     }
 
-    pub fn set_admitted_children(self: &Arc<Self>, children: Vec<ResidentProjection>) {
+    /// Replaces this scope's residency, returning whether every child was
+    /// admitted. A refused child is left out of the residency entirely.
+    #[must_use = "a refused admission leaves the child out of the residency"]
+    pub fn set_admitted_children(self: &Arc<Self>, children: Vec<ResidentProjection>) -> bool {
         self.with_observation_gate(|wakes| {
             self.clear_residents_locked(wakes);
+            let mut admitted = true;
             for child in children {
-                self.admit_child_locked(child, wakes);
+                admitted &= self.admit_child_locked(child, wakes);
             }
-        });
+            admitted
+        })
     }
 
     #[cfg(any(test, feature = "test-util"))]
+    #[must_use = "a refused admission leaves the child out of the residency"]
     pub fn admit_child(self: &Arc<Self>, child: ResidentProjection) -> bool {
         self.with_observation_gate(|wakes| self.admit_child_locked(child, wakes))
     }
 
+    /// Admits one projection, or refuses it whole.
+    ///
+    /// Returns whether the member's `Admitted` transition was legal. A refusal
+    /// publishes nothing: no gate handoff, no parent wiring, no residency push
+    /// and no `Added` event.
+    #[must_use = "a refused admission leaves the child out of the residency"]
     pub fn admit_child_locked(
         self: &Arc<Self>,
         child: ResidentProjection,
@@ -1246,14 +1283,12 @@ impl ScopeCell {
             }
             admitted
         } else {
-            projection.member.try_adopt_observation_gate_with(
+            // Same probe-handoff-apply order as the nested-scope path above.
+            projection.member.with_handoff_gate(
                 &gate,
                 || {},
                 |current| {
-                    if !projection
-                        .member
-                        .transition_locked(txn, MemberTransition::Admitted)
-                    {
+                    if !projection.member.would_accept(&MemberTransition::Admitted) {
                         return false;
                     }
                     if !current.shares_gate(&gate) {
@@ -1261,7 +1296,14 @@ impl ScopeCell {
                             .member
                             .install_observation_gate_locked(current, &gate);
                     }
-                    true
+                    let admitted = projection
+                        .member
+                        .transition_locked(txn, MemberTransition::Admitted);
+                    debug_assert!(
+                        admitted,
+                        "the probed admission cannot be refused under the same held gate"
+                    );
+                    admitted
                 },
             )
         };
@@ -1808,11 +1850,16 @@ mod tests {
         let destination = isolated_scope("destination", ScopeFlavor::Ordered);
         let nested = child_scope(&original, "nested", ScopeFlavor::Dynamic);
         let descendant = child_member(&nested, "descendant");
-        nested.set_admitted_children(vec![ResidentProjection::new(Arc::clone(&descendant), None)]);
-        original.set_admitted_children(vec![ResidentProjection::new(
+        assert!(
+            nested.set_admitted_children(vec![ResidentProjection::new(
+                Arc::clone(&descendant),
+                None
+            )])
+        );
+        assert!(original.set_admitted_children(vec![ResidentProjection::new(
             Arc::clone(&nested.member),
             Some(Arc::clone(&nested)),
-        )]);
+        )]));
         let original_gate = original.observation_gate();
         assert!(original_gate.same_gate(&nested.observation_gate()));
         assert!(original_gate.same_gate(&descendant.observation_gate()));
@@ -1873,6 +1920,33 @@ mod tests {
         assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Empty));
     }
 
+    #[cfg(debug_assertions)]
+    struct InertRoute;
+
+    #[cfg(debug_assertions)]
+    impl DynamicRoute for InertRoute {
+        fn close_admission(&self, _txn: &mut ObservationTxn<'_>) {}
+    }
+
+    /// Coverage for the surviving live-route assertion.
+    ///
+    /// `admit_observation_gate` no longer needs one: its legality probe
+    /// refuses every stage a started driver can present, so a re-homed live
+    /// route is unconstructible there. The reservation-time adoption path has
+    /// no such probe, and this is its regression.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "a scope with a live dynamic route is never re-homed")]
+    fn plain_gate_adoption_rejects_a_scope_with_a_live_dynamic_route() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
+        nested.set_dynamic_route(Some(Arc::new(InertRoute)));
+
+        root.with_observation_gate(|txn| {
+            root.adopt_child_observation_gate(&nested.member, Some(&nested), txn);
+        });
+    }
+
     #[test]
     fn adoption_retries_when_the_captured_child_gate_has_already_been_replaced() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
@@ -1884,10 +1958,10 @@ mod tests {
         let adopting_root = Arc::clone(&root);
         let adopting_nested = Arc::clone(&nested);
         let adoption = std::thread::spawn(move || {
-            adopting_root.admit_child(ResidentProjection::new(
+            assert!(adopting_root.admit_child(ResidentProjection::new(
                 Arc::clone(&adopting_nested.member),
                 Some(adopting_nested),
-            ));
+            )));
         });
 
         assert_eq!(
@@ -1926,20 +2000,24 @@ mod tests {
         // a subtree of depth 1 cannot tell the loop from the recursion. Only
         // this grandchild is reachable exclusively through the recursive call.
         let grandchild = child_member(&leaf_scope, "grandchild");
-        leaf_scope
-            .set_admitted_children(vec![ResidentProjection::new(Arc::clone(&grandchild), None)]);
-        nested.set_admitted_children(vec![
+        assert!(
+            leaf_scope.set_admitted_children(vec![ResidentProjection::new(
+                Arc::clone(&grandchild),
+                None
+            )])
+        );
+        assert!(nested.set_admitted_children(vec![
             ResidentProjection::new(
                 Arc::clone(&leaf_scope.member),
                 Some(Arc::clone(&leaf_scope)),
             ),
             ResidentProjection::new(Arc::clone(&leaf_member), None),
-        ]);
+        ]));
 
-        root.admit_child(ResidentProjection::new(
+        assert!(root.admit_child(ResidentProjection::new(
             Arc::clone(&nested.member),
             Some(Arc::clone(&nested)),
-        ));
+        )));
 
         let root_gate = root.observation_gate();
         for gate in [
@@ -1967,7 +2045,9 @@ mod tests {
     fn drain_publication_installs_terminal_disposal_intent_with_the_state() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
         let child = child_member(&root, "child");
-        root.set_admitted_children(vec![ResidentProjection::new(Arc::clone(&child), None)]);
+        assert!(
+            root.set_admitted_children(vec![ResidentProjection::new(Arc::clone(&child), None)])
+        );
 
         root.publish_drain(ScopeState::Draining, None, &[Arc::clone(&child)]);
 
@@ -1984,10 +2064,10 @@ mod tests {
         let leaf_membership = leaf.membership();
         let mut lifecycle = root.subscribe_lifecycle();
 
-        root.set_admitted_children(vec![
+        assert!(root.set_admitted_children(vec![
             ResidentProjection::new(Arc::clone(&nested.member), Some(Arc::clone(&nested))),
             ResidentProjection::new(Arc::clone(&leaf), None),
-        ]);
+        ]));
         assert_eq!(root.resident_projections().len(), 2);
         assert!(root.has_resident_child(&nested.member));
         assert!(root.has_resident_child(&leaf));
@@ -2328,7 +2408,7 @@ mod tests {
                 release: release_drop,
             })
             .expect("bound mailbox accepts the probe");
-        scope.admit_child(ResidentProjection::new(Arc::clone(&child), None));
+        assert!(scope.admit_child(ResidentProjection::new(Arc::clone(&child), None)));
         drop(actor);
         drop(mailbox);
         drop(child);

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -485,6 +485,46 @@ impl ScopeCell {
         );
     }
 
+    fn admit_observation_gate(
+        &self,
+        parent: &ScopeCell,
+        gate: &ObservationGate,
+        txn: &mut ObservationTxn<'_>,
+    ) -> bool {
+        debug_assert!(
+            !std::ptr::eq(self, parent),
+            "a scope cannot be admitted into itself"
+        );
+        debug_assert!(
+            gate.shares_gate(&parent.current_observation_gate()),
+            "observation gates are admitted only in the parent-to-child direction"
+        );
+        self.member.try_adopt_observation_gate_with(
+            gate,
+            || {
+                #[cfg(any(test, feature = "test-util"))]
+                self.report_gate_capture(GateCapture::Adoption);
+            },
+            |current| {
+                if !self
+                    .member
+                    .transition_locked(txn, MemberTransition::Admitted)
+                {
+                    return false;
+                }
+                if !current.shares_gate(gate) {
+                    debug_assert!(
+                        self.dynamic_route_in(txn).is_none(),
+                        "a scope with a live dynamic route is never re-homed"
+                    );
+                    self.member.install_observation_gate_locked(current, gate);
+                    self.adopt_descendant_observation_gates_locked(current, gate, txn);
+                }
+                true
+            },
+        )
+    }
+
     pub fn adopt_child_observation_gate(
         self: &Arc<Self>,
         member: &MemberCell,
@@ -1199,20 +1239,37 @@ impl ScopeCell {
         let child = ResidentAdmission::new(child, txn);
         let projection = child.projection();
         let gate = self.current_observation_gate();
-        if let Some(scope) = &projection.scope {
-            scope.adopt_observation_gate(self, &gate, txn);
-            scope.set_parent(self, txn);
+        let admitted = if let Some(scope) = &projection.scope {
+            let admitted = scope.admit_observation_gate(self, &gate, txn);
+            if admitted {
+                scope.set_parent(self, txn);
+            }
+            admitted
         } else {
-            projection.member.adopt_observation_gate(&gate, txn);
+            projection.member.try_adopt_observation_gate_with(
+                &gate,
+                || {},
+                |current| {
+                    if !projection
+                        .member
+                        .transition_locked(txn, MemberTransition::Admitted)
+                    {
+                        return false;
+                    }
+                    if !current.shares_gate(&gate) {
+                        projection
+                            .member
+                            .install_observation_gate_locked(current, &gate);
+                    }
+                    true
+                },
+            )
+        };
+        if !admitted {
+            return false;
         }
         let id = projection.member.id().clone();
         let membership = projection.member.membership();
-        if !projection
-            .member
-            .transition_locked(txn, MemberTransition::Admitted)
-        {
-            return false;
-        }
         drop(projection);
         self.current_children()
             .push(ResidentChild::new(child.install()));
@@ -1742,6 +1799,47 @@ mod tests {
                 .expect("mailbox payload disposal reports"),
             retiring_thread,
             "the by-value projection cannot unwind its mailbox through the observation gate"
+        );
+    }
+
+    #[test]
+    fn rejected_nested_admission_preserves_original_parent_and_gate() {
+        let original = isolated_scope("original", ScopeFlavor::Ordered);
+        let destination = isolated_scope("destination", ScopeFlavor::Ordered);
+        let nested = child_scope(&original, "nested", ScopeFlavor::Dynamic);
+        let descendant = child_member(&nested, "descendant");
+        nested.set_admitted_children(vec![ResidentProjection::new(Arc::clone(&descendant), None)]);
+        original.set_admitted_children(vec![ResidentProjection::new(
+            Arc::clone(&nested.member),
+            Some(Arc::clone(&nested)),
+        )]);
+        let original_gate = original.observation_gate();
+        assert!(original_gate.same_gate(&nested.observation_gate()));
+        assert!(original_gate.same_gate(&descendant.observation_gate()));
+
+        assert!(
+            !destination.admit_child(ResidentProjection::new(
+                Arc::clone(&nested.member),
+                Some(Arc::clone(&nested)),
+            )),
+            "an already-admitted subtree cannot move to a second parent"
+        );
+
+        assert!(original.has_resident_child(&nested.member));
+        assert!(destination.resident_projections().is_empty());
+        assert!(Arc::ptr_eq(
+            &nested
+                .parent()
+                .expect("the original parent remains installed"),
+            &original
+        ));
+        assert!(original_gate.same_gate(&nested.observation_gate()));
+        assert!(original_gate.same_gate(&descendant.observation_gate()));
+        assert!(
+            !destination
+                .observation_gate()
+                .same_gate(&nested.observation_gate()),
+            "rejection leaves the subtree on its original observation gate"
         );
     }
 

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -1629,30 +1629,34 @@ mod tests {
         for parent_first in [true, false] {
             let root = isolated_scope("root", ScopeFlavor::Ordered);
             let nested = child_scope(&root, "nested", ScopeFlavor::Ordered);
-            root.admit_child(ResidentProjection::new(
+            assert!(root.admit_child(ResidentProjection::new(
                 Arc::clone(&nested.member),
                 Some(Arc::clone(&nested)),
-            ));
+            )));
             let mut incarnations = nested.member.take_incarnation_counter();
             let first = incarnations.mint().expect("first incarnation available");
-            nested
-                .member
-                .transition(MemberTransition::Starting { incarnation: first });
+            assert!(
+                nested
+                    .member
+                    .transition(MemberTransition::Starting { incarnation: first })
+            );
             let epoch = nested
                 .begin_incarnation(ScopeState::Starting)
                 .expect("first incarnation begins");
             nested.finish_incarnation(epoch, StopReason::Finished);
-            nested
-                .member
-                .transition(MemberTransition::RestartScheduled {
-                    exit: Exit::completed(Cancellation::NotObserved),
-                    restart_count: RestartCount::ZERO.bump(),
-                    restart_at: None,
-                });
+            assert!(
+                nested
+                    .member
+                    .transition(MemberTransition::RestartScheduled {
+                        exit: Exit::completed(Cancellation::NotObserved),
+                        restart_count: RestartCount::ZERO.bump(),
+                        restart_at: None,
+                    })
+            );
             let restarted = incarnations.mint().expect("restart incarnation available");
-            nested.member.transition(MemberTransition::Starting {
+            assert!(nested.member.transition(MemberTransition::Starting {
                 incarnation: restarted,
-            });
+            }));
             let snapshots = nested.subscribe_snapshots();
 
             // The restart body is dropped before its first poll, so it never

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -2474,7 +2474,7 @@ mod tests {
                     id,
                 })
                 .expect("bound mailbox accepts the hostile payload");
-            scope.admit_child(ResidentProjection::new(Arc::clone(&child), None));
+            assert!(scope.admit_child(ResidentProjection::new(Arc::clone(&child), None)));
             drop(actor);
             drop(mailbox);
             drop(child);

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -538,11 +538,18 @@ impl ScopeRuntime {
         if let Some(control) = &self.dynamic {
             self.root.set_dynamic_route(Some(control.clone()));
         }
-        self.root.set_admitted_children(
+        // Every slot here is a fresh reservation, so the projection reducer
+        // accepts each `Admitted` edge. A refusal would leave the child out of
+        // the residency while its driver record still expects it.
+        let admitted = self.root.set_admitted_children(
             self.children
                 .values()
                 .map(|child| resident_projection(&child.slot))
                 .collect(),
+        );
+        debug_assert!(
+            admitted,
+            "initial children are admitted from their reservation exactly once"
         );
         #[cfg(test)]
         self.record_storage();
@@ -786,7 +793,15 @@ impl ScopeRuntime {
                 .entry_mut(id)
                 .expect("the matching reservation was just resolved");
             entry.promote(key, request.fused_cancel.take(), txn);
-            root.admit_child_locked(resident_projection(&request.slot), txn);
+            // The slot was minted `Reserved` by this reservation and nothing
+            // can have started it, so the projection reducer accepts. A
+            // refusal here would leave the entry promoted with no residency
+            // behind it — see the partial-effect note on issue #392.
+            let admitted = root.admit_child_locked(resident_projection(&request.slot), txn);
+            debug_assert!(
+                admitted,
+                "a promoted reservation is admitted from `Reserved` exactly once"
+            );
             AdmissionInstall::Admitted(key)
         });
         let key = match installed {
@@ -1029,8 +1044,15 @@ async fn run_scope_incarnation(
     let root = Arc::clone(&plan.root);
     if role.is_root() {
         root.with_observation_gate(|txn| {
-            root.member
+            // The root scope is never admitted, so its own reservation is the
+            // documented `Reserved -> Running` source stage.
+            let running = root
+                .member
                 .transition_locked(txn, MemberTransition::Running);
+            debug_assert!(
+                running,
+                "a root incarnation promotes its own never-admitted reservation"
+            );
         });
     }
     // Both lanes are unbounded so their producers can publish synchronously.

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -747,7 +747,12 @@ impl ScopeRuntime {
                 .expect("configuration or close supplies each bind token");
             mailbox.bind(token, incarnation, &mut effects);
         }
-        self.root.transition_child_stage(
+        // A spawn reaches here only from `Admitted` (first incarnation) or
+        // `Restarting` (a scheduled restart), both accepted sources. The body
+        // and the mailbox bind above are already committed, so a refusal would
+        // run the incarnation with no `Started` edge — see the partial-effect
+        // note on issue #392.
+        let started = self.root.transition_child_stage(
             &child.slot.member,
             MemberTransition::Starting { incarnation },
             Some(LifecycleEventKind::Started {
@@ -755,6 +760,10 @@ impl ScopeRuntime {
                 membership: child.slot.member.membership(),
                 incarnation,
             }),
+        );
+        debug_assert!(
+            started,
+            "a spawn starts an admitted or restarting member's projection"
         );
 
         let mut readiness = ReadinessGate::new();
@@ -850,8 +859,17 @@ impl ScopeRuntime {
                 .active
                 .as_mut()
                 .expect("the stopped child remains active");
-            self.root
-                .transition_child_stage(&child.slot.member, MemberTransition::Stopping, None);
+            // The stop ladder is armed only for an active incarnation, whose
+            // projection is `Starting` or `Running`.
+            let stopping = self.root.transition_child_stage(
+                &child.slot.member,
+                MemberTransition::Stopping,
+                None,
+            );
+            debug_assert!(
+                stopping,
+                "a stop ladder begins on a starting or running member"
+            );
             if let Some(mailbox) = &child.mailbox {
                 let mut effects = MailboxEffectQueue::default();
                 mailbox.freeze(active.incarnation, &mut effects);
@@ -1080,7 +1098,14 @@ impl ScopeRuntime {
                     now,
                     sample,
                 );
-                self.root.publish_child_restart(
+                // The exiting incarnation's projection is `Starting`,
+                // `Running` or `Stopping`, all accepted sources.
+                // `schedule_restart` above has already charged this attempt
+                // against the child and the intensity window, so a refusal
+                // would restart the child with neither `Exited` nor
+                // `RestartScheduled` published — see the partial-effect note
+                // on issue #392.
+                let published = self.root.publish_child_restart(
                     &child.slot.member,
                     decision.total_restarts(),
                     MemberTransition::RestartScheduled {
@@ -1103,6 +1128,10 @@ impl ScopeRuntime {
                         attempt: decision.attempt(),
                         delay: decision.delay(),
                     },
+                );
+                debug_assert!(
+                    published,
+                    "a restart is scheduled from an active incarnation's exit"
                 );
                 let trip = decision.intensity_trip();
                 if trip.is_none()

--- a/crates/shelterwood/src/driver/startup.rs
+++ b/crates/shelterwood/src/driver/startup.rs
@@ -64,7 +64,9 @@ impl ScopeRuntime {
                 if removing {
                     return false;
                 }
-                self.root.transition_child_stage(
+                // Readiness fires only for the live incarnation, whose
+                // projection is `Starting`.
+                let ready = self.root.transition_child_stage(
                     &child.slot.member,
                     MemberTransition::Running,
                     Some(LifecycleEventKind::Ready {
@@ -73,6 +75,7 @@ impl ScopeRuntime {
                         incarnation,
                     }),
                 );
+                debug_assert!(ready, "readiness promotes a starting member");
                 true
             }
             ReadinessEffect::TimedOut { deadline } => {

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -625,11 +625,13 @@ async fn dispatching_a_spent_one_shot_task_construction_panics() {
     let _epoch = root
         .begin_incarnation(ScopeState::Starting)
         .expect("test scope epoch is available");
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
+    assert!(
+        root.set_admitted_children(
+            plan.children
+                .iter()
+                .map(|child| resident_projection(&child.slot))
+                .collect(),
+        )
     );
     let defaults = plan.defaults.clone();
     let mut child = ChildRuntime::from_plan(plan.children.pop().expect("one child plan"), &root);

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -155,7 +155,7 @@ fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
             .expect("child membership available"),
     );
     let slot = SlotCell::new(Arc::clone(&member), None);
-    root.set_admitted_children(vec![resident_projection(&slot)]);
+    assert!(root.set_admitted_children(vec![resident_projection(&slot)]));
     let (events, _receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events);
     let (sender, mut response) = crate::runtime::oneshot();
@@ -302,7 +302,7 @@ fn dynamic_removal_waits_for_the_observation_gate_before_mutating_state() {
             .expect("child membership available"),
     );
     let slot = SlotCell::new(Arc::clone(&member), None);
-    root.set_admitted_children(vec![resident_projection(&slot)]);
+    assert!(root.set_admitted_children(vec![resident_projection(&slot)]));
     let (events, _receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events);
     let key = ChildKey::fixture(1);

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -23,7 +23,7 @@ async fn reserve_error_identity_exhausted_maps_the_membership_domain() {
     let (events, _receiver) = crate::runtime::unbounded_mpsc();
     let control = DynamicControl::new(events);
     root.set_dynamic_route(Some(control));
-    root.set_admitted_children(Vec::new());
+    assert!(root.set_admitted_children(Vec::new()));
 
     root.mint_membership(&worker_id)
         .expect("the final membership is usable");
@@ -64,29 +64,29 @@ fn member_transitions_own_their_complete_record_projection() {
     let mut incarnations = member.take_incarnation_counter();
     let incarnation = incarnations.mint().expect("incarnation available");
 
-    member.transition(MemberTransition::Admitted);
+    assert!(member.transition(MemberTransition::Admitted));
     assert_eq!(member.record().stage, MemberStage::Admitted);
 
-    member.transition(MemberTransition::Starting { incarnation });
+    assert!(member.transition(MemberTransition::Starting { incarnation }));
     let record = member.record();
     assert_eq!(record.stage, MemberStage::Starting);
     assert_eq!(record.incarnation, Some(incarnation));
     assert_eq!(record.last_incarnation, Some(incarnation));
     assert_eq!(record.restart_at, None);
 
-    member.transition(MemberTransition::Running);
+    assert!(member.transition(MemberTransition::Running));
     assert_eq!(member.record().stage, MemberStage::Running);
-    member.transition(MemberTransition::Stopping);
+    assert!(member.transition(MemberTransition::Stopping));
     assert_eq!(member.record().stage, MemberStage::Stopping);
 
     let exit = Exit::completed(Cancellation::NotObserved);
     let restart_count = RestartCount::ZERO.bump();
     let restart_at = crate::runtime::now();
-    member.transition(MemberTransition::RestartScheduled {
+    assert!(member.transition(MemberTransition::RestartScheduled {
         exit: exit.clone(),
         restart_count,
         restart_at: Some(restart_at),
-    });
+    }));
     let record = member.record();
     assert_eq!(record.stage, MemberStage::Restarting);
     assert_eq!(record.incarnation, None);
@@ -96,9 +96,9 @@ fn member_transitions_own_their_complete_record_projection() {
     assert_eq!(record.restart_at, Some(restart_at));
 
     let second = incarnations.mint().expect("restart incarnation available");
-    member.transition(MemberTransition::Starting {
+    assert!(member.transition(MemberTransition::Starting {
         incarnation: second,
-    });
+    }));
     let record = member.record();
     assert_eq!(record.stage, MemberStage::Starting);
     assert_eq!(record.incarnation, Some(second));
@@ -127,13 +127,13 @@ fn incarnation_mint_exhaustion_has_no_terminal_side_effects() {
     let spent = setup_incarnations
         .mint()
         .expect("setup incarnation available");
-    member.transition(MemberTransition::Admitted);
-    member.transition(MemberTransition::Starting { incarnation: spent });
-    member.transition(MemberTransition::RestartScheduled {
+    assert!(member.transition(MemberTransition::Admitted));
+    assert!(member.transition(MemberTransition::Starting { incarnation: spent }));
+    assert!(member.transition(MemberTransition::RestartScheduled {
         exit: previous.clone(),
         restart_count: RestartCount::ZERO,
         restart_at: None,
-    });
+    }));
     let mut counter = IncarnationCounter::near_exhaustion(member.membership());
 
     assert!(counter.mint().is_some());
@@ -567,7 +567,7 @@ async fn scope_incarnation_exhaustion_closes_nested_observation() {
         ScopeIdentity::new(),
     );
     let slot = SlotCell::new(Arc::clone(&member), Some(Arc::clone(&scope)));
-    parent.set_admitted_children(vec![resident_projection(&slot)]);
+    assert!(parent.set_admitted_children(vec![resident_projection(&slot)]));
     let mut snapshots = scope.subscribe_snapshots();
     let mut events = scope.subscribe_lifecycle();
     let mut counter = IncarnationCounter::near_exhaustion(member.membership());
@@ -621,7 +621,7 @@ async fn never_started_nested_terminal_publishes_one_final_parent_snapshot() {
     let nested = isolated_scope("nested", ScopeFlavor::Ordered);
     resolve_fixture_options(&nested.member);
     let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
-    parent.set_admitted_children(vec![resident_projection(&slot)]);
+    assert!(parent.set_admitted_children(vec![resident_projection(&slot)]));
     let mut snapshots = parent.subscribe_snapshots();
 
     assert!(parent.terminalize_child(

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -11,7 +11,7 @@ fn snapshot_rejects_a_resident_whose_options_were_never_resolved() {
             .expect("child membership available"),
     );
 
-    root.admit_child(ResidentProjection::new(member, None));
+    assert!(root.admit_child(ResidentProjection::new(member, None)));
     let _ = root.snapshot();
 }
 
@@ -232,7 +232,7 @@ async fn terminal_scope_waits_for_its_live_incarnation_to_stop() {
     let parent = isolated_scope("parent", ScopeFlavor::Ordered);
     let nested = isolated_scope("nested", ScopeFlavor::Ordered);
     let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
-    parent.set_admitted_children(vec![resident_projection(&slot)]);
+    assert!(parent.set_admitted_children(vec![resident_projection(&slot)]));
 
     let epoch = nested
         .begin_incarnation(ScopeState::Starting)
@@ -318,7 +318,7 @@ async fn terminal_scope_in_drain_waits_for_its_live_incarnation_to_stop() {
     let parent = isolated_scope("parent", ScopeFlavor::Ordered);
     let nested = isolated_scope("nested", ScopeFlavor::Ordered);
     let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
-    parent.set_admitted_children(vec![resident_projection(&slot)]);
+    assert!(parent.set_admitted_children(vec![resident_projection(&slot)]));
 
     let epoch = nested
         .begin_incarnation(ScopeState::Starting)
@@ -381,7 +381,7 @@ impl AbortedNestedDriverFixture {
         let parent = isolated_scope("parent", ScopeFlavor::Ordered);
         let nested = isolated_scope("nested", ScopeFlavor::Ordered);
         let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
-        parent.set_admitted_children(vec![resident_projection(&slot)]);
+        assert!(parent.set_admitted_children(vec![resident_projection(&slot)]));
 
         let epoch = ScopeEpochGuard::begin(&nested).expect("nested scope epoch is available");
         let mut incarnations = IncarnationCounter::fixture(nested.member.membership());
@@ -558,7 +558,7 @@ async fn wait_for_child_reloads_after_its_predicate_closes_the_snapshot_stream()
     let child = MemberCell::new(child_id, membership);
     resolve_fixture_options(&child);
     let slot = SlotCell::new(Arc::clone(&child), None);
-    scope.set_admitted_children(vec![resident_projection(&slot)]);
+    assert!(scope.set_admitted_children(vec![resident_projection(&slot)]));
     let scope_ref = ScopeRef {
         cell: Arc::clone(&scope),
     };
@@ -597,7 +597,7 @@ async fn terminality_fallback_preserves_restart_window_scope_reason() {
     let parent = isolated_scope("parent", ScopeFlavor::Ordered);
     let nested = isolated_scope("nested", ScopeFlavor::Ordered);
     let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
-    parent.set_admitted_children(vec![resident_projection(&slot)]);
+    assert!(parent.set_admitted_children(vec![resident_projection(&slot)]));
 
     let mut incarnations = IncarnationCounter::fixture(nested.member.membership());
     let last_incarnation = incarnations.mint().expect("child incarnation is available");
@@ -927,7 +927,7 @@ fn admitted_subtrees_share_their_parent_observation_gate() {
     let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
     let slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
 
-    root.set_admitted_children(vec![resident_projection(&slot)]);
+    assert!(root.set_admitted_children(vec![resident_projection(&slot)]));
 
     assert!(
         root.observation_gate()
@@ -949,10 +949,10 @@ fn admitted_subtree_rehomes_existing_descendants_to_one_gate() {
     );
     let leaf_slot = SlotCell::new(Arc::clone(&leaf.member), Some(Arc::clone(&leaf)));
     let raw_leaf_slot = SlotCell::new(Arc::clone(&raw_leaf), None);
-    nested.set_admitted_children(vec![
+    assert!(nested.set_admitted_children(vec![
         resident_projection(&leaf_slot),
         resident_projection(&raw_leaf_slot),
-    ]);
+    ]));
     assert!(
         nested
             .observation_gate()
@@ -965,7 +965,7 @@ fn admitted_subtree_rehomes_existing_descendants_to_one_gate() {
     );
 
     let nested_slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
-    root.set_admitted_children(vec![resident_projection(&nested_slot)]);
+    assert!(root.set_admitted_children(vec![resident_projection(&nested_slot)]));
 
     let root_gate = root.observation_gate();
     assert!(root_gate.same_gate(&nested.observation_gate()));
@@ -1035,12 +1035,12 @@ fn snapshot_watch_batch_admission_is_one_committed_cut() {
 
     root.with_observation_gate(|txn| {
         root.clear_residents_locked(txn);
-        root.admit_child_locked(resident_projection(&first_slot), txn);
+        assert!(root.admit_child_locked(resident_projection(&first_slot), txn));
         assert!(
             snapshots.borrow_latest().children.is_empty(),
             "the first admission must remain staged until the batch commits"
         );
-        root.admit_child_locked(resident_projection(&second_slot), txn);
+        assert!(root.admit_child_locked(resident_projection(&second_slot), txn));
         assert!(
             snapshots.borrow_latest().children.is_empty(),
             "the complete batch must remain staged until its transaction commits"
@@ -1060,7 +1060,7 @@ fn snapshot_watch_batch_admission_mints_one_generation_per_hub() {
     resolve_fixture_options(&branch.member);
     let branch_slot = SlotCell::new(Arc::clone(&branch.member), Some(Arc::clone(&branch)));
     root.with_observation_gate(|txn| {
-        root.admit_child_locked(resident_projection(&branch_slot), txn);
+        assert!(root.admit_child_locked(resident_projection(&branch_slot), txn));
     });
 
     let first = isolated_scope("first", ScopeFlavor::Dynamic);
@@ -1080,8 +1080,8 @@ fn snapshot_watch_batch_admission_mints_one_generation_per_hub() {
     let branch_generation = branch_snapshots.current_generation();
 
     branch.with_observation_gate(|txn| {
-        branch.admit_child_locked(resident_projection(&first_slot), txn);
-        branch.admit_child_locked(resident_projection(&second_slot), txn);
+        assert!(branch.admit_child_locked(resident_projection(&first_slot), txn));
+        assert!(branch.admit_child_locked(resident_projection(&second_slot), txn));
     });
 
     assert_eq!(
@@ -1132,10 +1132,10 @@ fn plain_resident_state_is_released_before_recursive_removed_publication() {
     let mut events = root.subscribe_lifecycle();
     let snapshots = root.subscribe_snapshots();
 
-    root.set_admitted_children(vec![
+    assert!(root.set_admitted_children(vec![
         resident_projection(&first_slot),
         resident_projection(&second_slot),
-    ]);
+    ]));
     root.clear_residents();
 
     assert!(root.resident_projections().is_empty());
@@ -1159,12 +1159,12 @@ fn plain_parent_state_preserves_nested_snapshot_propagation() {
     let mut incarnations = IncarnationCounter::near_exhaustion(nested.member.membership());
     resolve_fixture_options(&nested.member);
     let nested_slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
-    root.set_admitted_children(vec![resident_projection(&nested_slot)]);
+    assert!(root.set_admitted_children(vec![resident_projection(&nested_slot)]));
     // Start the nested member along the production admit-then-spawn order so
     // the transition-source assertions in `apply_transition` hold here too.
-    nested.member.transition(MemberTransition::Starting {
+    assert!(nested.member.transition(MemberTransition::Starting {
         incarnation: incarnations.mint().expect("incarnation available"),
-    });
+    }));
     let snapshots = root.subscribe_snapshots();
     let intensity = Intensity::new(7, Duration::from_secs(11)).expect("valid intensity");
 
@@ -1185,7 +1185,7 @@ fn lifecycle_emit_resolves_the_ancestor_chain_once() {
     let root = isolated_scope("root", ScopeFlavor::Ordered);
     let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
     let nested_slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));
-    root.set_admitted_children(vec![resident_projection(&nested_slot)]);
+    assert!(root.set_admitted_children(vec![resident_projection(&nested_slot)]));
     let mut root_events = root.subscribe_lifecycle();
 
     let _ = nested.take_ancestor_parent_reads();
@@ -1280,7 +1280,7 @@ fn gate_handoff_waits_for_an_in_flight_observation_edge() {
     let adopting_root = Arc::clone(&root);
     let (adopted, adopted_receiver) = std::sync::mpsc::sync_channel(0);
     let adoption = std::thread::spawn(move || {
-        adopting_root.set_admitted_children(vec![resident_projection(&slot)]);
+        assert!(adopting_root.set_admitted_children(vec![resident_projection(&slot)]));
         adopted.send(()).expect("test receiver remains available");
     });
 
@@ -1338,7 +1338,10 @@ fn gate_handoff_rejects_a_scope_with_an_unadmitted_dynamic_reservation_without_r
 
     // Public layering cannot reach this adoption: a reservation requires a
     // started driver, while a scope is parented before its driver starts.
-    root.set_admitted_children(vec![resident_projection(&slot)]);
+    assert!(
+        !root.set_admitted_children(vec![resident_projection(&slot)]),
+        "the reducer refuses an already-running member's admission"
+    );
     assert!(
         root.resident_projections().is_empty(),
         "the illegal running-to-admitted transition publishes no residency"
@@ -1385,7 +1388,7 @@ fn a_losing_supervised_terminal_exit_is_a_complete_noop_outside_the_gate() {
             .expect("child membership available"),
     );
     resolve_fixture_options(&member);
-    root.admit_child(ResidentProjection::new(Arc::clone(&member), None));
+    assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None)));
     member.terminalize(
         Exit::completed(Cancellation::NotObserved),
         StartupDisposition::NotAborted,
@@ -1425,7 +1428,7 @@ fn a_retired_snapshot_payload_is_destroyed_outside_the_gate() {
             .expect("child membership available"),
     );
     resolve_fixture_options(&member);
-    root.admit_child(ResidentProjection::new(Arc::clone(&member), None));
+    assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None)));
     let subscription = root.subscribe_snapshots();
 
     let (exit, held_at_drop) = gate_probe_exit(&root);
@@ -1458,11 +1461,11 @@ fn a_superseded_restart_exit_payload_is_destroyed_outside_the_gate() {
     let (root, member, mut incarnations) = restarting_member_fixture();
 
     let (probe, held_at_drop) = gate_probe_exit(&root);
-    member.transition(MemberTransition::RestartScheduled {
+    assert!(member.transition(MemberTransition::RestartScheduled {
         exit: probe,
         restart_count: RestartCount::ZERO.bump(),
         restart_at: None,
-    });
+    }));
     assert_eq!(
         gate_probe_verdict(&held_at_drop),
         None,
@@ -1470,14 +1473,14 @@ fn a_superseded_restart_exit_payload_is_destroyed_outside_the_gate() {
     );
 
     let second = incarnations.mint().expect("restart incarnation available");
-    member.transition(MemberTransition::Starting {
+    assert!(member.transition(MemberTransition::Starting {
         incarnation: second,
-    });
-    member.transition(MemberTransition::RestartScheduled {
+    }));
+    assert!(member.transition(MemberTransition::RestartScheduled {
         exit: Exit::completed(Cancellation::NotObserved),
         restart_count: RestartCount::ZERO.bump().bump(),
         restart_at: None,
-    });
+    }));
     assert!(
         !wait_for_gate_probe(&held_at_drop),
         "a superseded restart exit payload must outlive the gate"
@@ -1491,11 +1494,11 @@ fn a_restart_exit_payload_superseded_by_terminalization_outlives_the_gate() {
     let (root, member, _incarnations) = restarting_member_fixture();
 
     let (probe, held_at_drop) = gate_probe_exit(&root);
-    member.transition(MemberTransition::RestartScheduled {
+    assert!(member.transition(MemberTransition::RestartScheduled {
         exit: probe,
         restart_count: RestartCount::ZERO.bump(),
         restart_at: None,
-    });
+    }));
     assert_eq!(
         gate_probe_verdict(&held_at_drop),
         None,
@@ -1524,7 +1527,7 @@ fn a_snapshot_retired_by_observation_closure_is_destroyed_outside_the_gate() {
             .expect("child membership available"),
     );
     resolve_fixture_options(&member);
-    root.admit_child(ResidentProjection::new(Arc::clone(&member), None));
+    assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None)));
     let subscription = root.subscribe_snapshots();
 
     let (exit, held_at_drop) = gate_probe_exit(&root);
@@ -1661,7 +1664,7 @@ fn residency_can_release_the_last_member_arc_with_a_failed_exit() {
             .expect("child membership available"),
     );
     resolve_fixture_options(&member);
-    root.admit_child(ResidentProjection::new(Arc::clone(&member), None));
+    assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None)));
     let weak = Arc::downgrade(&member);
     let (exit, held_at_drop) = gate_probe_exit(&root);
     member.terminalize(exit, StartupDisposition::Unchanged);

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -1312,12 +1312,11 @@ fn gate_handoff_waits_for_an_in_flight_observation_edge() {
     );
 }
 
-#[cfg(debug_assertions)]
 #[test]
-#[should_panic(expected = "a scope with a live dynamic route is never re-homed")]
-fn gate_handoff_rejects_a_scope_with_an_unadmitted_dynamic_reservation() {
+fn gate_handoff_rejects_a_scope_with_an_unadmitted_dynamic_reservation_without_rehoming() {
     let root = isolated_scope("root", ScopeFlavor::Ordered);
     let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
+    let original_gate = nested.observation_gate();
     nested
         .member
         .update(|record| record.stage = MemberStage::Running);
@@ -1340,6 +1339,14 @@ fn gate_handoff_rejects_a_scope_with_an_unadmitted_dynamic_reservation() {
     // Public layering cannot reach this adoption: a reservation requires a
     // started driver, while a scope is parented before its driver starts.
     root.set_admitted_children(vec![resident_projection(&slot)]);
+    assert!(
+        root.resident_projections().is_empty(),
+        "the illegal running-to-admitted transition publishes no residency"
+    );
+    assert!(
+        original_gate.same_gate(&nested.observation_gate()),
+        "a rejected admission leaves the live subtree on its original gate"
+    );
 }
 
 /// SPEC §15.4's lock rule: nothing user-owned is destroyed inside a framework

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -37,11 +37,13 @@ fn pre_admission_restart_shutdown_is_published_when_the_scope_gets_a_parent() {
         .request_shutdown()
         .expect("the pre-admission shutdown targets the first epoch");
     assert!(root.take_control_events().is_empty());
-    root.set_admitted_children(
-        plan.children
-            .iter()
-            .map(|child| resident_projection(&child.slot))
-            .collect(),
+    assert!(
+        root.set_admitted_children(
+            plan.children
+                .iter()
+                .map(|child| resident_projection(&child.slot))
+                .collect(),
+        )
     );
 
     assert_eq!(

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -201,7 +201,7 @@ pub(super) fn insert_dynamic_fixture(
                     .expect("the promoted fixture resident transitions to Removing");
             }
         }
-        root.admit_child_locked(resident_projection(&reservation.slot), txn);
+        assert!(root.admit_child_locked(resident_projection(&reservation.slot), txn));
         key
     });
     (reservation, key)
@@ -577,9 +577,9 @@ pub(super) fn restarting_member_fixture() -> (Arc<ScopeCell>, Arc<MemberCell>, I
     );
     resolve_fixture_options(&member);
     let mut incarnations = member.take_incarnation_counter();
-    root.admit_child(ResidentProjection::new(Arc::clone(&member), None));
+    assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None)));
     let first = incarnations.mint().expect("incarnation available");
-    member.transition(MemberTransition::Starting { incarnation: first });
+    assert!(member.transition(MemberTransition::Starting { incarnation: first }));
     (root, member, incarnations)
 }
 

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -787,7 +787,7 @@ fn supervised_terminality_pulse_follows_mailbox_termination() {
         id.clone(),
         identity.mint_membership(&id).expect("membership available"),
     );
-    root.admit_child(ResidentProjection::new(Arc::clone(&member), None));
+    assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None)));
     let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     member.attach_mailbox(mailbox);
@@ -851,7 +851,7 @@ fn supervised_mailbox_teardown_panic_precedes_terminal_pulse_panic() {
         id.clone(),
         identity.mint_membership(&id).expect("membership available"),
     );
-    root.admit_child(ResidentProjection::new(Arc::clone(&member), None));
+    assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None)));
     let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     member.attach_mailbox(mailbox);

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -697,11 +697,13 @@ mod tests {
             .lower(ResolvedDefaults::default(), None)
             .expect("the defined builder lowers");
         let root = Arc::clone(&plan.root);
-        root.set_admitted_children(
-            plan.children
-                .iter()
-                .map(|child| ResidentProjection::new(Arc::clone(&child.slot.member), None))
-                .collect(),
+        assert!(
+            root.set_admitted_children(
+                plan.children
+                    .iter()
+                    .map(|child| ResidentProjection::new(Arc::clone(&child.slot.member), None))
+                    .collect(),
+            )
         );
         let mut first_terminal = Box::pin(slots[0].member.wait_terminal());
         let hostile = Waker::from(Arc::new(PanicWake(PANIC)));


### PR DESCRIPTION
Addresses the reducer-legality item from #366 and is stacked on #380.

Converts member projection transitions from debug-only source-stage assertions to a fallible reducer result, and makes residency, lifecycle, snapshot, and restart publication conditional on acceptance. Rejected user-bearing inputs leave through post-unlock detached disposal.

Admission probes legality, performs the recursive gate handoff under the child subtree's current observation gate, and applies the transition only after that handoff succeeds. A rejected repeated admission therefore cannot rehome a subtree that remains resident under its original parent, and an unwind out of `install_observation_gate_locked`'s `assert!` cannot publish `Admitted` for a half-re-homed subtree. The regression pins original residency, parent identity, and descendant gate identity; the formerly debug-only live-route handoff test now asserts fail-closed behavior in release too.

**Scope of the "rejection is a no-op" claim.** A refusal is a total no-op *inside the cell layer*: no record field changes, no watch version advances, no lifecycle event is emitted, no residency is pushed. It says nothing about state the caller committed before presenting the transition. Three driver sites have such a prefix — `publish_child_restart` after `schedule_restart` has charged the child and the intensity window, the spawn `Starting` after the mailbox bind and body dispatch, and `admit_child_locked` after `entry.promote` — so a refusal there is a half-applied operation, not silence. Those are filed as #392; each site carries a comment pointing at it.

What keeps the class detectable in the meantime:

- every function returning the verdict is `#[must_use]` (`MemberCell::transition{,_locked}`, `ScopeCell::transition_child_stage`, `publish_child_restart`, `admit_child{,_locked}`, `set_admitted_children`), so it cannot be discarded by writing `;`;
- each of the seven driver sites binds the verdict and `debug_assert!`s it, naming the source stages it may present. That restores the debug-lane abort the deleted reducer assertions provided, and does it outside every framework lock — the old ones panicked under the watch mutex and the observation gate, poisoning both.

Also in this PR after review: one gate-handoff retry loop (`MemberCell::with_handoff_gate`) instead of two; AGENTS.md's gate-to-gate exemption updated to name it and both of its users; the live-dynamic-route `debug_assert!` dropped from the admission path (the legality probe makes it unconstructible there) with its regression restored on the reservation-time adoption path that still carries the assert.

Validation:

- `./tools/dev just ci` (811 tests)
- `cargo nextest run --workspace --release` (807 pass; `nonresident_terminal_exit_is_retained_before_the_residency_assertion` is a base-branch artifact — #380's tip already gates it on `debug_assertions`, this PR is based on an older #380 commit)
- mutation-checked: accept-everything matrix, handoff-before-probe ordering, discarded per-child verdict in `set_admitted_children`, and the removed live-route assert each fail their pinning test

Stack: keep based on #380 until that Batch 3 foundation lands, then retarget to `main`.
