### PR TITLE
Run the hostile reply-waker regression in process

### DIFF
--- a/crates/shelterwood/tests/reply_waker_containment.rs
+++ b/crates/shelterwood/tests/reply_waker_containment.rs
@@ -1,6 +1,5 @@
 use std::{
     future::Future,
-    process::Command,
     sync::Arc,
     task::{Context as TaskContext, Poll, Wake, Waker},
     time::Duration,
@@ -11,7 +10,6 @@ use shelterwood::{
     LifecycleItem, Reply, StopReason, Tree,
 };
 
-const CHILD_ENV: &str = "SHELTERWOOD_HOSTILE_REPLY_WAKER_CHILD";
 const HANDLER_PANIC: &str = "injected reply-owning handler panic";
 
 enum Message {
@@ -46,7 +44,19 @@ impl Wake for PanicWake {
     }
 }
 
-async fn run_hostile_reply_waker_child() {
+/// Drops an unanswered [`Reply`] while its owning handler unwinds, with a
+/// hostile waker registered on the matching receiver.
+///
+/// This runs in process rather than behind a subprocess harness. The failure
+/// this pins is an uncontained hostile wake: either the waker panic escapes
+/// onto the unwind path and double-panics into `abort`, or it replaces the
+/// handler panic that the actor must publish. Every test binary already runs
+/// under nextest's process-per-test isolation, so an abort surfaces as a
+/// signal on this test alone and *is* the failure signal — the harness that
+/// used to re-implement that isolation could only ever fail open, since
+/// libtest exits zero when its `--exact` filter matches nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn unanswered_reply_drop_during_handler_panic_contains_hostile_waker() {
     let mut tree = Tree::new();
     let actor = tree
         .add_actor_once(
@@ -103,33 +113,4 @@ async fn run_hostile_reply_waker_child() {
     // released sooner, Tokio would observe a closed receiver and skip the
     // hostile wake that this regression must exercise.
     drop(receive);
-}
-
-#[test]
-fn unanswered_reply_drop_during_handler_panic_contains_hostile_waker() {
-    if std::env::var_os(CHILD_ENV).is_some() {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .expect("test runtime")
-            .block_on(run_hostile_reply_waker_child());
-        return;
-    }
-
-    let output = Command::new(std::env::current_exe().expect("integration-test executable"))
-        .arg("--exact")
-        .arg("unanswered_reply_drop_during_handler_panic_contains_hostile_waker")
-        .arg("--nocapture")
-        .arg("--test-threads=1")
-        .env(CHILD_ENV, "1")
-        .output()
-        .expect("hostile-waker subprocess starts");
-
-    assert!(
-        output.status.success(),
-        "hostile-waker subprocess must survive and publish the actor exit\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
-        output.status,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
 }


### PR DESCRIPTION
`reply_waker_containment.rs` held one test behind a subprocess harness: an
env-var re-entry guard, `std::env::current_exe()`, and a re-exec with
`--exact <hardcoded name> --nocapture --test-threads=1` whose only verdict was
`status.success()`. This collapses it to the child branch it was already
running.

## Why in process is safe

`cargo nextest` runs every test in its own process. A double panic that
`abort`s therefore surfaces as `SIGABRT` on this test alone and cancels the
run — it cannot poison sibling tests. `justfile:25-26` shows nextest is the
only runner for unit and integration tests (`cargo test` is used solely for
`--doc`, which never sees this file), and both CI jobs in
`.github/workflows/ci.yml` go through `nix develop --command just ci`. The
harness was re-implementing isolation the runner already provides, and the
abort *is* the failure signal.

## This deletes a fail-open class rather than patching it

libtest exits `0` when `--exact` matches nothing, so the parent's
`status.success()` assertion passed whenever the hardcoded `TEST_NAME` drifted
away from the real test — the child would have run nothing and reported
success. That is not a bug to be fixed by keeping the name in sync; it is a
property of asserting on a subprocess exit status. Removing the subprocess
removes the class. This file was the original of the idiom; three sibling PRs
(#369, #370, #372) convert their own copies.

## Mutation evidence

The test pins the containment in `OneShotSender::drop`
(`crates/shelterwood-runtime/src/sync.rs:513-531`), which runs Tokio's
sender-drop — and therefore the receiver's caller-supplied waker — inside a
`PanicAccumulator` so a hostile wake cannot double-panic the unwinding
handler.

Replacing that with a bare `drop(channel)`, committed, then run under nextest:

```
thread 'tokio-rt-worker' panicked at library/core/src/panicking.rs:233:5:
panic in a destructor during cleanup
thread caused non-unwinding panic. aborting.
(test aborted with signal 6: SIGABRT)
Summary [0.261s] 1 test run: 0 passed, 1 failed, 0 skipped
```

Plain `cargo test -p shelterwood --test reply_waker_containment` fails just as
loudly on the same mutation (exit 101, `signal: 6, SIGABRT`), so a local
non-nextest run degrades only by taking the whole one-test binary down with
it.

Unmutated: `cargo nextest run --locked --workspace --all-features --lib --bins
--tests --examples` — 803 passed, plus clean `clippy -D warnings` and
`just fmt`.

Every assertion is carried over unchanged: the `Pending` first poll under the
hostile waker, the published `ExitKind::Panicked` carrying the *handler's*
message rather than the waker's, `StopReason::Finished`, and the deliberate
late `drop(receive)` that keeps the hostile waker registered across sender
destruction.