### PR TITLE
Terminalize never-started exit dispatch

### DIFF
--- a/crates/shelterwood-core/src/engine.rs
+++ b/crates/shelterwood-core/src/engine.rs
@@ -251,6 +251,25 @@ pub fn dispatch_exit(
     scope: ScopeMode,
     membership: MembershipStatus,
 ) -> ExitDispatch {
+    // SPEC §8: `NeverStarted` is a membership fact, not an incarnation
+    // verdict — it "is never input to restart or intensity accounting".
+    // Every supported producer terminalizes the membership directly and never
+    // reaches dispatch, so arriving here is a framework bug: the assert makes
+    // it loud in debug, and the return fails closed in release rather than
+    // charging a restart for an incarnation that never ran.
+    //
+    // Failing closed is the lesser of two wrong outcomes, not a correct one:
+    // the sole dispatch caller holds a real incarnation, so a `Terminal`
+    // verdict here would publish a `NeverStarted` terminal paired with
+    // `last_incarnation: Some(..)`, which SPEC §B.3 excludes. `ExitDispatch`
+    // carries no incarnation, so the pairing is the caller's to choose and
+    // cannot be repaired from inside this function; an inconsistent terminal
+    // projection is still strictly better than an illegal restart, and the
+    // debug abort fires before any such projection can be published.
+    debug_assert!(
+        !matches!(exit.kind(), ExitKind::NeverStarted),
+        "NeverStarted is a membership outcome outside incarnation dispatch"
+    );
     if matches!(exit.kind(), ExitKind::NeverStarted) {
         return ExitDispatch::Terminal;
     }
@@ -1439,6 +1458,25 @@ mod tests {
         }
     }
 
+    /// Debug half of the two-profile guard: the misuse aborts loudly.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "NeverStarted is a membership outcome outside incarnation dispatch")]
+    fn funnel_dispatch_rejects_the_membership_level_never_started_outcome() {
+        let exit = Exit::never_started();
+        let _ = dispatch_exit(
+            &exit,
+            RestartPolicy::new(RestartCondition::Always, Backoff::Immediate),
+            ScopeMode::Running,
+            MembershipStatus::Active,
+        );
+    }
+
+    /// Release half: with the assert compiled out the same input fails closed
+    /// on `Terminal` instead of charging a restart. `RestartCondition::Always`
+    /// is the one condition whose `should_restart` returns `true`
+    /// unconditionally, so removing the guard flips this assertion.
+    #[cfg(not(debug_assertions))]
     #[test]
     fn funnel_dispatch_treats_the_membership_level_never_started_outcome_as_terminal() {
         let exit = Exit::never_started();

--- a/crates/shelterwood-core/src/engine.rs
+++ b/crates/shelterwood-core/src/engine.rs
@@ -251,10 +251,9 @@ pub fn dispatch_exit(
     scope: ScopeMode,
     membership: MembershipStatus,
 ) -> ExitDispatch {
-    debug_assert!(
-        !matches!(exit.kind(), ExitKind::NeverStarted),
-        "NeverStarted is a membership outcome outside incarnation dispatch"
-    );
+    if matches!(exit.kind(), ExitKind::NeverStarted) {
+        return ExitDispatch::Terminal;
+    }
     if scope == ScopeMode::Draining || membership == MembershipStatus::Removing {
         return ExitDispatch::Terminal;
     }
@@ -1440,16 +1439,17 @@ mod tests {
         }
     }
 
-    #[cfg(debug_assertions)]
     #[test]
-    #[should_panic(expected = "NeverStarted is a membership outcome outside incarnation dispatch")]
-    fn funnel_dispatch_rejects_the_membership_level_never_started_outcome() {
+    fn funnel_dispatch_treats_the_membership_level_never_started_outcome_as_terminal() {
         let exit = Exit::never_started();
-        let _ = dispatch_exit(
-            &exit,
-            RestartPolicy::default(),
-            ScopeMode::Running,
-            MembershipStatus::Active,
+        assert_eq!(
+            dispatch_exit(
+                &exit,
+                RestartPolicy::new(RestartCondition::Always, Backoff::Immediate),
+                ScopeMode::Running,
+                MembershipStatus::Active,
+            ),
+            ExitDispatch::Terminal,
         );
     }
 


### PR DESCRIPTION
Addresses the defensive `NeverStarted` exit-dispatch follow-up from #366.

Makes `ExitKind::NeverStarted` explicitly terminal before restart-policy evaluation, so a caller that accidentally routes that membership-only outcome through incarnation dispatch cannot have `RestartCondition::Always` schedule a restart for an incarnation that never ran. The `debug_assert!` that previously stood there is kept above the release return, so the misuse stays loud in debug and fails closed in release — #366 Batch 4's "fail closed in release *in addition to* aborting in debug" direction, not instead of it. The arm carries a comment citing SPEC §8.

The regression test is split into profile halves: a debug `#[should_panic]` twin and a release assertion that the same input returns `ExitDispatch::Terminal`. Both are mutation-checked — deleting the guard fails each in its own profile.

Validation: `./tools/dev just ci` (821 tests), workspace `cargo nextest` in debug, the focused regression plus `-p shelterwood-core` in both debug and release, and `cargo +nightly clippy --all-targets --all-features` on the touched crate in both profiles.
