### PR TITLE
Close never-started nested scope bodies

### DIFF
--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -1263,6 +1263,19 @@ impl ScopeCell {
         self.with_observation_gate(|txn| self.terminalize_never_started_locked(txn));
     }
 
+    /// Publishes and closes a nested scope body that was spawned but never
+    /// began its own incarnation. The parent driver remains responsible for
+    /// the shared membership's terminal exit.
+    pub fn close_never_started_body(&self) {
+        self.with_observation_gate(|txn| {
+            if self.observation.closed.load(Ordering::Acquire) {
+                return;
+            }
+            self.publish_stopped_locked(txn, StopReason::NeverStarted, None, None);
+            self.close_observation_locked(txn);
+        });
+    }
+
     pub fn terminalize_never_started_locked(&self, txn: &mut ObservationTxn<'_>) {
         if self.observation.closed.load(Ordering::Acquire) {
             return;
@@ -1304,6 +1317,31 @@ mod tests {
     struct GateCheckingWake {
         gate: super::ObservationGate,
         woke_after_unlock: Arc<AtomicBool>,
+    }
+
+    #[test]
+    fn never_started_restart_body_replaces_the_stale_prior_reason_and_closes() {
+        let scope = isolated_scope("nested", ScopeFlavor::Ordered);
+        let epoch = scope
+            .begin_incarnation(ScopeState::Starting)
+            .expect("first incarnation begins");
+        scope.finish_incarnation(epoch, StopReason::Finished);
+        let snapshots = scope.subscribe_snapshots();
+
+        scope.close_never_started_body();
+
+        let (snapshot, closed) = snapshots.borrow_latest_and_closed();
+        assert!(closed);
+        assert!(matches!(
+            snapshot.state,
+            ScopeState::Stopped {
+                reason: StopReason::NeverStarted
+            }
+        ));
+        assert!(
+            !matches!(scope.member.record().stage, MemberStage::Terminal(_)),
+            "the parent driver still owns membership terminality"
+        );
     }
 
     impl Wake for GateCheckingWake {

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -1267,22 +1267,37 @@ impl ScopeCell {
     /// incarnation. The parent driver remains responsible for the shared
     /// membership's terminal exit and, unless it already published that exit,
     /// closes observation after the terminal parent projection.
+    ///
+    /// `Unstarted` is precisely SPEC B.6's "no incarnation has ever spawned"
+    /// in the scope plane, and `Stopped { NeverStarted }` is its terminal
+    /// twin; publishing that pair is what makes the record agree with
+    /// `wait_stopped`'s own `Unstarted` answer. A body dropped before its
+    /// *restart* incarnation began is a different case: that scope already
+    /// published a real prior-incarnation reason, which is both its final
+    /// verdict and terminal, so the fallback must leave it alone. Publishing
+    /// `NeverStarted` over it would contradict the shared membership's exit
+    /// (`Aborted` with `last_incarnation: Some(..)`) and — because the parent
+    /// path can terminalize and close first — would only land in one of two
+    /// arrival orders. The fallback therefore supplies a missing terminal
+    /// projection and never replaces a published one; closure is the only
+    /// effect it owns unconditionally. `total_restarts` and `startup` need no
+    /// reset under this gate: an `Unstarted` scope never charged a restart,
+    /// and a startup result installed without an incarnation (identity
+    /// exhaustion) is the structured cause `wait_started` must keep.
     pub fn close_never_started_body(&self) {
         self.with_observation_gate(|txn| {
             if self.observation.closed.load(Ordering::Acquire) {
                 return;
             }
-            // A never-polled restart never reaches `begin_incarnation`, so
-            // perform that boundary's projection reset before publishing the
-            // replacement terminal state. Otherwise the prior incarnation's
-            // startup result and restart total leak into this one.
-            self.observation.record.modify_silently(|record| {
-                record.total_restarts = TotalRestarts::ZERO;
-                record.startup = None;
-                record.refresh_retained_exits();
-            });
-            self.publish_stopped_locked(txn, StopReason::NeverStarted, None, None);
-            if self.membership_terminal() {
+            if matches!(self.record().state, ScopeState::Unstarted) {
+                self.publish_stopped_locked(txn, StopReason::NeverStarted, None, None);
+            }
+            // The same guard `terminalize_child` applies to its trailing
+            // close: a stream whose payload is still `Starting`/`Running`
+            // must not end on that projection.
+            if self.membership_terminal()
+                && matches!(self.record().state, ScopeState::Stopped { .. })
+            {
                 self.close_observation_locked(txn);
             }
         });
@@ -1312,9 +1327,9 @@ mod tests {
     };
 
     use shelterwood_core::{
-        Cancellation, ExitError, IntensityTrip, StartupFailure, StartupFailureCause,
+        Cancellation, ExitError, GracePhase, IntensityTrip, StartupFailure, StartupFailureCause,
         identity::ScopeIdentity,
-        policy::{ResolvedMailbox, ScopeFlavor},
+        policy::{ResolvedMailbox, RestartCount, ScopeFlavor},
     };
     use shelterwood_mailbox::{
         MailboxCell, MailboxControl, MailboxEffectQueue, MailboxReceiver, actor_ref_from_parts,
@@ -1332,16 +1347,8 @@ mod tests {
     }
 
     #[test]
-    fn never_started_restart_body_resets_before_membership_closes_observation() {
+    fn never_started_body_publishes_before_membership_closes_observation() {
         let scope = isolated_scope("nested", ScopeFlavor::Ordered);
-        let epoch = scope
-            .begin_incarnation(ScopeState::Starting)
-            .expect("first incarnation begins");
-        scope.finish_incarnation(epoch, StopReason::Finished);
-        scope.observation.record.modify_silently(|record| {
-            record.total_restarts = TotalRestarts::ZERO.bump();
-            record.startup = Some(Ok(()));
-        });
         let snapshots = scope.subscribe_snapshots();
 
         scope.close_never_started_body();
@@ -1367,6 +1374,122 @@ mod tests {
         scope.terminalize_never_started();
         let (_, closed) = snapshots.borrow_latest_and_closed();
         assert!(closed, "terminal membership closes observation");
+    }
+
+    /// A body dropped before its *restart* incarnation began keeps the prior
+    /// incarnation's published reason, whichever of the two owners of that
+    /// scope's terminality runs first.
+    ///
+    /// The parent path (`terminalize_child`) and the body fallback race on a
+    /// current-thread runtime only by a few instructions, and on a
+    /// multi-thread runtime genuinely. Publishing `NeverStarted` here would
+    /// both depend on that order and contradict the membership exit, which
+    /// carries `last_incarnation: Some(..)` — SPEC B.6's stop-reason lattice
+    /// requires the projection and the exit to agree in either order.
+    #[test]
+    fn never_polled_restart_body_keeps_its_prior_reason_in_either_arrival_order() {
+        for parent_first in [true, false] {
+            let root = isolated_scope("root", ScopeFlavor::Ordered);
+            let nested = child_scope(&root, "nested", ScopeFlavor::Ordered);
+            root.admit_child(ResidentProjection::new(
+                Arc::clone(&nested.member),
+                Some(Arc::clone(&nested)),
+            ));
+            let mut incarnations = nested.member.take_incarnation_counter();
+            let first = incarnations.mint().expect("first incarnation available");
+            nested
+                .member
+                .transition(MemberTransition::Starting { incarnation: first });
+            let epoch = nested
+                .begin_incarnation(ScopeState::Starting)
+                .expect("first incarnation begins");
+            nested.finish_incarnation(epoch, StopReason::Finished);
+            nested
+                .member
+                .transition(MemberTransition::RestartScheduled {
+                    exit: Exit::completed(Cancellation::NotObserved),
+                    restart_count: RestartCount::ZERO.bump(),
+                    restart_at: None,
+                });
+            let restarted = incarnations.mint().expect("restart incarnation available");
+            nested.member.transition(MemberTransition::Starting {
+                incarnation: restarted,
+            });
+            let snapshots = nested.subscribe_snapshots();
+
+            // The restart body is dropped before its first poll, so it never
+            // reaches `begin_incarnation` and the parent aborts it.
+            let terminalize = || {
+                root.terminalize_child(
+                    &nested.member,
+                    Exit::aborted(GracePhase::WithinGrace, Cancellation::Observed),
+                    Some(restarted),
+                    StartupDisposition::NotAborted,
+                )
+            };
+            if parent_first {
+                terminalize();
+                nested.close_never_started_body();
+            } else {
+                nested.close_never_started_body();
+                terminalize();
+            }
+
+            let (snapshot, closed) = snapshots.borrow_latest_and_closed();
+            assert_eq!(
+                snapshot.state,
+                ScopeState::Stopped {
+                    reason: StopReason::Finished
+                },
+                "a never-polled restart keeps its prior incarnation's reason \
+                 (parent_first={parent_first})"
+            );
+            assert!(
+                closed,
+                "membership terminality closes observation (parent_first={parent_first})"
+            );
+            let record = nested.member.record();
+            assert!(
+                matches!(record.stage, MemberStage::Terminal(_)),
+                "the parent owns the shared membership's terminal exit"
+            );
+            assert!(
+                record.last_incarnation.is_some(),
+                "a restarted membership has spawned, so `NeverStarted` cannot describe it"
+            );
+        }
+    }
+
+    /// Identity exhaustion installs a structured startup failure and then
+    /// discharges the body obligation without an incarnation. The fallback
+    /// supplies the missing terminal projection without overwriting that
+    /// cause, so `wait_started` keeps reporting it.
+    #[test]
+    fn never_started_body_preserves_a_structured_startup_failure() {
+        let scope = isolated_scope("nested", ScopeFlavor::Ordered);
+        let failure = StartupFailure {
+            cause: StartupFailureCause::IdentityExhausted {
+                id: scope.member.id().clone(),
+            },
+        };
+        scope.set_startup(Err(StartupError::StartupFailed(failure)));
+
+        scope.close_never_started_body();
+
+        assert!(
+            matches!(
+                scope.record().startup,
+                Some(Err(StartupError::StartupFailed(_)))
+            ),
+            "a structured startup cause survives the never-started fallback: {:?}",
+            scope.record().startup
+        );
+        assert!(matches!(
+            scope.record().state,
+            ScopeState::Stopped {
+                reason: StopReason::NeverStarted
+            }
+        ));
     }
 
     impl Wake for GateCheckingWake {

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -1263,16 +1263,28 @@ impl ScopeCell {
         self.with_observation_gate(|txn| self.terminalize_never_started_locked(txn));
     }
 
-    /// Publishes and closes a nested scope body that was spawned but never
-    /// began its own incarnation. The parent driver remains responsible for
-    /// the shared membership's terminal exit.
+    /// Publishes a nested scope body that was spawned but never began its own
+    /// incarnation. The parent driver remains responsible for the shared
+    /// membership's terminal exit and, unless it already published that exit,
+    /// closes observation after the terminal parent projection.
     pub fn close_never_started_body(&self) {
         self.with_observation_gate(|txn| {
             if self.observation.closed.load(Ordering::Acquire) {
                 return;
             }
+            // A never-polled restart never reaches `begin_incarnation`, so
+            // perform that boundary's projection reset before publishing the
+            // replacement terminal state. Otherwise the prior incarnation's
+            // startup result and restart total leak into this one.
+            self.observation.record.modify_silently(|record| {
+                record.total_restarts = TotalRestarts::ZERO;
+                record.startup = None;
+                record.refresh_retained_exits();
+            });
             self.publish_stopped_locked(txn, StopReason::NeverStarted, None, None);
-            self.close_observation_locked(txn);
+            if self.membership_terminal() {
+                self.close_observation_locked(txn);
+            }
         });
     }
 
@@ -1320,28 +1332,41 @@ mod tests {
     }
 
     #[test]
-    fn never_started_restart_body_replaces_the_stale_prior_reason_and_closes() {
+    fn never_started_restart_body_resets_before_membership_closes_observation() {
         let scope = isolated_scope("nested", ScopeFlavor::Ordered);
         let epoch = scope
             .begin_incarnation(ScopeState::Starting)
             .expect("first incarnation begins");
         scope.finish_incarnation(epoch, StopReason::Finished);
+        scope.observation.record.modify_silently(|record| {
+            record.total_restarts = TotalRestarts::ZERO.bump();
+            record.startup = Some(Ok(()));
+        });
         let snapshots = scope.subscribe_snapshots();
 
         scope.close_never_started_body();
 
         let (snapshot, closed) = snapshots.borrow_latest_and_closed();
-        assert!(closed);
+        assert!(!closed, "membership terminality owns observation closure");
         assert!(matches!(
             snapshot.state,
             ScopeState::Stopped {
                 reason: StopReason::NeverStarted
             }
         ));
+        assert_eq!(snapshot.total_restarts, TotalRestarts::ZERO);
+        assert!(matches!(
+            scope.record().startup,
+            Some(Err(StartupError::ShutdownRequested))
+        ));
         assert!(
             !matches!(scope.member.record().stage, MemberStage::Terminal(_)),
             "the parent driver still owns membership terminality"
         );
+
+        scope.terminalize_never_started();
+        let (_, closed) = snapshots.borrow_latest_and_closed();
+        assert!(closed, "terminal membership closes observation");
     }
 
     impl Wake for GateCheckingWake {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -837,8 +837,9 @@ fn nested_scope_start(scope: &Arc<ScopeCell>) -> NestedScopeStart {
 }
 
 fn close_never_started_scope_body(scope: Arc<ScopeCell>) {
-    let mut panics = runtime::PanicAccumulator::default();
-    panics.run(|| scope.close_never_started_body());
+    // Bare like every sibling fallback: `Obligation::drop` is this
+    // obligation's only discharge path and contains the call itself.
+    scope.close_never_started_body();
 }
 
 impl ScopeEpochGuard {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -830,6 +830,17 @@ struct ScopeEpochGuard {
     retained_exits: Vec<RetainedExit>,
 }
 
+type NestedScopeStart = Obligation<Arc<ScopeCell>>;
+
+fn nested_scope_start(scope: &Arc<ScopeCell>) -> NestedScopeStart {
+    Obligation::new(Arc::clone(scope), close_never_started_scope_body)
+}
+
+fn close_never_started_scope_body(scope: Arc<ScopeCell>) {
+    let mut panics = runtime::PanicAccumulator::default();
+    panics.run(|| scope.close_never_started_body());
+}
+
 impl ScopeEpochGuard {
     fn begin(scope: &Arc<ScopeCell>) -> Option<Self> {
         let lifecycle = ScopeLifecycle::starting();
@@ -880,8 +891,10 @@ async fn run_nested_tree(
     scope: Arc<ScopeCell>,
     inherited: ResolvedDefaults,
     latches: NestedScopeLatches,
+    mut start: NestedScopeStart,
 ) -> crate::ExitResult {
     let epoch = begin_nested_incarnation(&scope)?;
+    start.complete(drop);
     run_nested_tree_with_epoch(tree, scope, inherited, latches, epoch).await
 }
 
@@ -894,8 +907,10 @@ async fn run_nested_factory(
     scope: Arc<ScopeCell>,
     inherited: ResolvedDefaults,
     latches: NestedScopeLatches,
+    mut start: NestedScopeStart,
 ) -> crate::ExitResult {
     let epoch = begin_nested_incarnation(&scope)?;
+    start.complete(drop);
     let tree = factory();
     run_nested_tree_with_epoch(tree, scope, inherited, latches, epoch).await
 }

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -274,12 +274,14 @@ enum SpawnBody {
         scope: Arc<ScopeCell>,
         inherited: ResolvedDefaults,
         latches: NestedScopeLatches,
+        start: NestedScopeStart,
     },
     ScopeOnce {
         tree: Box<BuilderCore>,
         scope: Arc<ScopeCell>,
         inherited: ResolvedDefaults,
         latches: NestedScopeLatches,
+        start: NestedScopeStart,
     },
 }
 
@@ -490,6 +492,7 @@ fn dispatch_child_construction(
                 (
                     SpawnBody::ScopeRestartable {
                         factory: Arc::clone(factory),
+                        start: nested_scope_start(&scope),
                         scope,
                         inherited,
                         latches: latches.nested_scope(),
@@ -502,6 +505,7 @@ fn dispatch_child_construction(
                         tree: definition
                             .take_one_shot()
                             .expect("one-shot subtree construction invoked more than once"),
+                        start: nested_scope_start(&scope),
                         scope,
                         inherited,
                         latches: latches.nested_scope(),
@@ -572,13 +576,15 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
                     scope,
                     inherited,
                     latches,
-                } => run_nested_factory(factory, scope, inherited, latches).await,
+                    start,
+                } => run_nested_factory(factory, scope, inherited, latches, start).await,
                 SpawnBody::ScopeOnce {
                     tree,
                     scope,
                     inherited,
                     latches,
-                } => run_nested_tree(*tree, scope, inherited, latches).await,
+                    start,
+                } => run_nested_tree(*tree, scope, inherited, latches, start).await,
             }
         };
         let outcome = CatchUnwindFuture::new(body).await;

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -263,6 +263,17 @@ async fn nested_body_aborted_before_first_poll_publishes_never_started_and_close
         "the never-polled nested task to join",
     )
     .await;
+    let (pre_terminal, closed) = snapshots.borrow_latest_and_closed();
+    assert!(matches!(
+        pre_terminal.state,
+        ScopeState::Stopped {
+            reason: StopReason::NeverStarted
+        }
+    ));
+    assert!(
+        !closed,
+        "the body cannot close observation ahead of its parent terminal projection"
+    );
     drop(scope);
     assert_eq!(nested.wait_stopped().await, StopReason::NeverStarted);
     let (latest, closed) = snapshots.borrow_latest_and_closed();

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -239,6 +239,106 @@ async fn converted_nested_child_without_residency_closes_its_scope_on_drop() {
     assert!(snapshots.changed().await.is_err());
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn nested_body_aborted_before_first_poll_publishes_never_started_and_closes() {
+    let mut tree = Tree::new();
+    let nested = tree
+        .add_subtree_once("nested", SubtreeOnceDef::new(Tree::new()))
+        .expect("valid nested scope");
+    let mut snapshots = nested.subscribe_snapshots();
+    let fixture = OrderedScopeFixture::new(tree);
+    let key = fixture.children.keys().next().expect("nested child key");
+    let (mut scope, mut events) = fixture.build();
+
+    scope.spawn_child(key);
+    scope.children[key]
+        .active
+        .as_ref()
+        .expect("nested child is active")
+        .abort_handle
+        .abort();
+    let _exit = recv_child_exit(
+        &mut events,
+        DRIVER_PROGRESS_WAIT,
+        "the never-polled nested task to join",
+    )
+    .await;
+    drop(scope);
+    assert_eq!(nested.wait_stopped().await, StopReason::NeverStarted);
+    let (latest, closed) = snapshots.borrow_latest_and_closed();
+    assert!(
+        closed,
+        "never-polled nested observation is closed: {latest:?}"
+    );
+    assert!(matches!(
+        latest.state,
+        ScopeState::Stopped {
+            reason: StopReason::NeverStarted
+        }
+    ));
+    let terminal = snapshots
+        .changed()
+        .await
+        .expect("the final nested snapshot is published");
+    assert!(matches!(
+        terminal.state,
+        ScopeState::Stopped {
+            reason: StopReason::NeverStarted
+        }
+    ));
+    assert!(snapshots.changed().await.is_err());
+}
+
+#[test]
+fn nested_body_spawned_after_runtime_shutdown_closes_its_observation() {
+    let mut tree = Tree::new();
+    let nested = tree
+        .add_subtree_once("nested", SubtreeOnceDef::new(Tree::new()))
+        .expect("valid nested scope");
+    let mut snapshots = nested.subscribe_snapshots();
+    let fixture = OrderedScopeFixture::new(tree);
+    let key = fixture.children.keys().next().expect("nested child key");
+    let (mut scope, _events) = fixture.build();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("test runtime");
+    let dead_handle = runtime.handle().clone();
+    runtime.shutdown_background();
+    let entered = dead_handle.enter();
+    scope.spawn_child(key);
+    drop(entered);
+    drop(scope);
+
+    let observer = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("observer runtime");
+    observer.block_on(async {
+        assert!(matches!(
+            crate::runtime::timeout(DRIVER_PROGRESS_WAIT, nested.wait_stopped()).await,
+            crate::runtime::Timeout::Completed(StopReason::NeverStarted)
+        ));
+        let (latest, closed) = snapshots.borrow_latest_and_closed();
+        assert!(
+            closed,
+            "post-shutdown nested observation is closed: {latest:?}"
+        );
+        assert!(matches!(
+            latest.state,
+            ScopeState::Stopped {
+                reason: StopReason::NeverStarted
+            }
+        ));
+        snapshots
+            .changed()
+            .await
+            .expect("the final nested snapshot is published");
+        assert!(snapshots.changed().await.is_err());
+    });
+}
+
 #[crate::runtime::test]
 async fn scope_plan_conversion_panic_terminalizes_every_child() {
     let mut tree = Tree::new();

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -418,6 +418,7 @@ async fn nested_membership_exhaustion_is_structured_and_fail_closed() {
                 abort_ack: Latch::default(),
             },
         },
+        nested_scope_start(&scope),
     )
     .await
     .expect_err("the stable child-id domain is exhausted");

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -820,6 +820,7 @@ async fn panicking_nested_factory_releases_its_pre_driver_epoch() {
     let scope = isolated_scope("nested", ScopeFlavor::Ordered);
     let driver_scope = Arc::clone(&scope);
     let driver = crate::runtime::spawn(async move {
+        let start = nested_scope_start(&driver_scope);
         let factory = Arc::new(|| -> crate::plan::BuilderCore {
             panic!("injected nested factory panic");
         });
@@ -836,6 +837,7 @@ async fn panicking_nested_factory_releases_its_pre_driver_epoch() {
                     abort_ack: Latch::default(),
                 },
             },
+            start,
         )
         .await
     });

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -134,8 +134,8 @@ pub(super) use super::super::{
     ResidentProjection, RetainedRecordedOutcome, RuntimeStorage, ScopeCell, ScopeControlEvent,
     ScopeEpochGuard, ScopeFlavor, ScopeRole, ScopeRuntime, ScopeRuntimeTestWiring,
     StartupDisposition, cancel_dynamic_reservation, child::dispatch_child_construction_for_test,
-    discharge_child_terminality, events::collect_driver_events, monitor_root_driver, report_slot,
-    nested_scope_start, reserve_dynamic, resident_projection, restart_shutdown_work,
+    discharge_child_terminality, events::collect_driver_events, monitor_root_driver,
+    nested_scope_start, report_slot, reserve_dynamic, resident_projection, restart_shutdown_work,
     run_nested_factory, run_nested_tree, run_scope, run_scope_incarnation, storage::Obligation,
 };
 

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -135,8 +135,8 @@ pub(super) use super::super::{
     ScopeEpochGuard, ScopeFlavor, ScopeRole, ScopeRuntime, ScopeRuntimeTestWiring,
     StartupDisposition, cancel_dynamic_reservation, child::dispatch_child_construction_for_test,
     discharge_child_terminality, events::collect_driver_events, monitor_root_driver, report_slot,
-    reserve_dynamic, resident_projection, restart_shutdown_work, run_nested_factory,
-    run_nested_tree, run_scope, run_scope_incarnation, storage::Obligation,
+    nested_scope_start, reserve_dynamic, resident_projection, restart_shutdown_work,
+    run_nested_factory, run_nested_tree, run_scope, run_scope_incarnation, storage::Obligation,
 };
 
 pub(super) async fn begin_admission(

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -17,8 +17,8 @@ use shelterwood::{
     Backoff, ChildState, DynamicScopeRef, DynamicTree, Intensity, Jitter, LifecycleEvent,
     LifecycleEventKind, LifecycleEvents, LifecycleItem, LifecycleSeq, LifecycleTryRecvError,
     MembershipStatus, RemoveOutcome, RestartCondition, RestartCount, RestartPolicy, Retention,
-    ScopeFlavor, ScopeRef, ScopeState, StopReason, Strategy, SubtreeDef, SubtreeOnceDef, TaskDef,
-    TaskOnceDef, TaskRef, TotalRestarts, Tree, WaitError,
+    ScopeFlavor, ScopeRef, ScopeState, SnapshotClosed, StopReason, Strategy, SubtreeDef,
+    SubtreeOnceDef, TaskDef, TaskOnceDef, TaskRef, TotalRestarts, Tree, WaitError,
 };
 
 // The ring width is an implementation choice, not façade API. This black-box
@@ -1484,4 +1484,28 @@ async fn state_predicates_hold_only_for_terminal_projections() {
     let stopped = scope.as_scope().snapshot().state.clone();
     assert!(matches!(stopped, ScopeState::Stopped { .. }));
     assert!(stopped.is_stopped());
+}
+
+#[tokio::test]
+async fn snapshot_subscription_yields_snapshot_closed_after_terminal_shutdown() {
+    let mut tree = Tree::new();
+    tree.add_task("worker", waiting_task())
+        .expect("valid waiting task");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+    let mut snapshots = scope.subscribe_snapshots();
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root stops");
+
+    let terminal = snapshots
+        .changed()
+        .await
+        .expect("the final snapshot precedes closure");
+    assert!(terminal.state.is_stopped());
+    assert_eq!(snapshots.changed().await, Err(SnapshotClosed));
+    assert_eq!(snapshots.borrow_latest(), terminal);
 }


### PR DESCRIPTION
Part of #366.

This closes the observation surface for nested scope bodies that are spawned but never begin their first incarnation:

- attaches a `NestedScopeStart` obligation to the spawned body before runtime submission
- publishes a final `Stopped { NeverStarted }` snapshot/lifecycle state if the body is dropped before first poll — gated on the scope never having begun an incarnation (`ScopeState::Unstarted`, SPEC B.6's "no incarnation has ever spawned" in the scope plane)
- preserves parent-driver ownership of the shared membership's terminal exit and delays stream closure until that terminal parent projection is visible
- leaves a body dropped before its *restart* incarnation alone: that scope already published a real, terminal prior-incarnation reason, so the fallback only closes its stream. (An earlier revision replaced that reason with `NeverStarted`; that was unsound — it depended on which of the two terminality owners ran first, and the winning branch contradicted the shared membership's `Aborted` exit. See the review thread.)
- keeps a structured startup result installed without an incarnation (identity exhaustion) rather than refilling it with `ShutdownRequested`
- verifies public `SnapshotClosed` behavior after terminal root shutdown

Regression coverage includes immediate abort on a current-thread runtime, submission through an already-shut-down runtime handle, both arrival orders of the never-polled-restart case, structured-startup preservation, pre-terminal stream ordering, and the public final-snapshot-before-closure contract.

Validation: `./tools/dev cargo nextest run --workspace` (813 tests on the #375 stack), workspace clippy `-D warnings`, `cargo +nightly fmt --all --check`.

Stack: Batch 2 follow-up on #375 to avoid their shared test-support conflict.



---

Supersedes #377, which GitHub closed permanently when its base branch (#375) was merged and deleted. Same branch, same commits, rebased onto `main`; the full review thread and finding-by-finding resolution live on #377.
