### PR TITLE
Clarify residency and stop-plane specification

### DIFF
--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -1341,8 +1341,8 @@ impl ScopeCell {
         // untouched suffix after unlock. Detached disposal means final member
         // teardown may complete after this transaction returns -- and that a
         // resident's own destructor can never reach an `ObservationTxn`, so
-        // SPEC §15.5's structural `Removed`-on-drop is unavailable on this
-        // lane and the edge is emitted explicitly below instead (#389).
+        // SPEC §15.5 requires this removal site to emit the edge explicitly
+        // below instead (#389).
         wakes.defer(move || runtime::dispose_detached(residents));
         for removal in removals {
             self.emit_locked(wakes, removal);
@@ -1506,22 +1506,22 @@ impl ScopeCell {
     /// membership's terminal exit and, unless it already published that exit,
     /// closes observation after the terminal parent projection.
     ///
-    /// `Unstarted` is precisely SPEC B.6's "no incarnation has ever spawned"
-    /// in the scope plane, and `Stopped { NeverStarted }` is its terminal
+    /// `Unstarted` is precisely SPEC B.6's "no scope incarnation ever began"
+    /// state, and `Stopped { NeverStarted }` is its terminal
     /// twin; publishing that pair is what makes the record agree with
     /// `wait_stopped`'s own `Unstarted` answer. A body dropped before its
     /// *restart* incarnation began is a different case: that scope already
     /// published a real prior-incarnation reason, which is both its final
     /// verdict and terminal, so the fallback must leave it alone. Publishing
-    /// `NeverStarted` over it would contradict the shared membership's exit
-    /// (`Aborted` with `last_incarnation: Some(..)`) and — because the parent
-    /// path can terminalize and close first — would only land in one of two
-    /// arrival orders. The fallback therefore supplies a missing terminal
-    /// projection and never replaces a published one; closure is the only
-    /// effect it owns unconditionally. `total_restarts` and `startup` need no
-    /// reset under this gate: an `Unstarted` scope never charged a restart,
-    /// and a startup result installed without an incarnation (identity
-    /// exhaustion) is the structured cause `wait_started` must keep.
+    /// `NeverStarted` over it would falsely claim that no scope incarnation
+    /// ever began and — because the parent path can terminalize and close
+    /// first — would only land in one of two arrival orders. The fallback
+    /// therefore supplies a missing terminal projection and never replaces a
+    /// published one; closure is the only effect it owns unconditionally.
+    /// `total_restarts` and `startup` need no reset under this gate: an
+    /// `Unstarted` scope never charged a restart, and a startup result
+    /// installed without an incarnation (identity exhaustion) is the
+    /// structured cause `wait_started` must keep.
     pub fn close_never_started_body(&self) {
         self.with_observation_gate(|txn| {
             if self.observation.closed.load(Ordering::Acquire) {
@@ -1621,9 +1621,9 @@ mod tests {
     /// The parent path (`terminalize_child`) and the body fallback race on a
     /// current-thread runtime only by a few instructions, and on a
     /// multi-thread runtime genuinely. Publishing `NeverStarted` here would
-    /// both depend on that order and contradict the membership exit, which
-    /// carries `last_incarnation: Some(..)` — SPEC B.6's stop-reason lattice
-    /// requires the projection and the exit to agree in either order.
+    /// both depend on that order and falsely claim that no scope incarnation
+    /// ever began; SPEC B.6's stop-reason lattice instead preserves the real
+    /// prior-incarnation verdict within the scope plane in either order.
     #[test]
     fn never_polled_restart_body_keeps_its_prior_reason_in_either_arrival_order() {
         for parent_first in [true, false] {
@@ -1697,7 +1697,7 @@ mod tests {
             );
             assert!(
                 record.last_incarnation.is_some(),
-                "a restarted membership has spawned, so `NeverStarted` cannot describe it"
+                "a restarted membership has spawned, so `ExitKind::NeverStarted` cannot describe its exit"
             );
         }
     }

--- a/crates/shelterwood-core/src/exit.rs
+++ b/crates/shelterwood-core/src/exit.rs
@@ -79,11 +79,11 @@ pub fn stop_reason_precedence(reason: &StopReason) -> u8 {
 /// that began on natural completion says nothing about how the teardown
 /// itself ended. `ShutdownRequested` outranks the structured failures because
 /// a requested stop supersedes whatever the incarnation would otherwise have
-/// reported. `NeverStarted` is the top element because it is not a live
-/// incarnation's verdict at all but the membership-terminal twin of §8's
-/// `Exit::never_started()` (SPEC B.6): whenever a membership terminalizes
-/// without ever spawning, the scope-state projection must agree with the
-/// membership exit, in either arrival order.
+/// reported. `NeverStarted` is the top element because it states that no scope
+/// incarnation ever began rather than giving a live scope incarnation's
+/// verdict. The precedence rule makes every scope-plane projection agree in
+/// either arrival order; it does not require the membership exit kind to match
+/// (SPEC B.6).
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 enum StopPrecedence {
     Finished,
@@ -1195,7 +1195,7 @@ mod tests {
         );
         assert!(
             StopPrecedence::ShutdownRequested < StopPrecedence::NeverStarted,
-            "a membership that never started is the top element"
+            "no begun scope incarnation is the top scope-plane verdict"
         );
 
         let trip = IntensityTrip {

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -395,7 +395,7 @@ async fn never_started_outranks_an_earlier_shutdown_requested() {
         ScopeState::Stopped {
             reason: StopReason::NeverStarted
         },
-        "the scope state must agree with a never-started membership exit"
+        "the stronger scope-plane verdict replaces the earlier state"
     );
     assert_eq!(
         states,

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -2871,11 +2871,17 @@ guarantor: when a driver future is destroyed at any await point —
 hard-abort cascade, panic, natural return with events still queued —
 unwinding alone MUST discharge every outstanding promise (§11's
 driver-death rule, §16.17's test anchor). Two corollaries are normative.
-Residency in a scope's observed child set is itself such a value — its
-drop emits `Removed`, making §3.2's exact pairing structural rather than
-remembered. And each cell has exactly **one** change signal from which
-every compound wait derives — a second wake path is a lost wakeup
-waiting to be written.
+Residency in a scope's observed child set is paired with `Removed` at the
+sites that remove it (`clear_residents_locked` / `prune_child_locked`),
+before the displaced resident is handed to detached disposal; residency's
+own drop does not emit the edge. A resident can own the last handle to a
+mailbox containing unread user messages, so its destructor runs on a detached
+disposal worker rather than under the observation gate and has no observation
+transaction through which to publish. Enforcing the pairing at the removal
+sites therefore makes §3.2's exact pairing structural at the transition that
+displaces the resident while preserving §5.5's required disposal venue. And
+each cell has exactly **one** change signal from which every compound wait
+derives — a second wake path is a lost wakeup waiting to be written.
 
 ### 15.6 Performance posture
 
@@ -3772,14 +3778,19 @@ order is severity-ascending: `Finished` is the weakest claim, since a
 drain that began on natural completion says nothing about how the
 teardown itself ended; `ShutdownRequested` supersedes the structured
 failures, matching §11's drain-upgrade rule, which joins through this
-same lattice; and `NeverStarted` is the top element because it is not a
-live incarnation's verdict but the membership-terminal twin of §8's
-`NeverStarted` exit, so the scope-state projection and the membership
-exit agree whichever publication lands first. The consequences are that
-`wait_stopped()`, the final snapshot, and the stream's last `ScopeState`
-event always report the same, highest-precedence verdict, and that a
-root driver that dies mid-drain reports the join monitor's
-`ShutdownRequested` rather than the abandoned drain's `Finished`.
+same lattice; and `NeverStarted` is the top element because it states that
+no scope incarnation ever began, rather than giving a live scope
+incarnation's verdict. This lattice and its agreement guarantee apply within
+the scope plane: `wait_stopped()`, the final snapshot, and the stream's last
+`ScopeState` event always report the same, highest-precedence verdict. They do
+not require the membership plane's exit kind to match. In particular, a
+nested scope body dropped before its first poll is the sanctioned
+cross-plane divergence: the scope projection is `Stopped { NeverStarted }`
+because no scope incarnation began, while the membership exit is
+`Aborted { WithinGrace }` with `last_incarnation: Some(1)` because an
+incarnation was spawned and then aborted. A root driver that dies mid-drain
+reports the join monitor's `ShutdownRequested` rather than the abandoned
+drain's `Finished`.
 
 ```text
 ActorStats (II §22)

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -2863,24 +2863,23 @@ Every cross-task promise — an admission or removal awaiting resolution,
 an exit report awaiting publication, a member cell awaiting terminality,
 a waiter awaiting a wake — is held as an owned value whose destructor
 discharges it, fail-closed, with a **synchronous** fallback: complete with
-the terminal rejection, publish the coarse exit, emit the edge, pulse the
-signal — never an await, never a join. The event loop that services the
+the terminal rejection, publish the coarse exit, pulse the signal — never
+an await, never a join. The event loop that services the
 orderly path is an optimization of these values' consumption, never the
 sole guarantor: when a driver future is destroyed at any await point —
 hard-abort cascade, panic, natural return with events still queued —
 unwinding alone MUST discharge every outstanding promise (§11's
 driver-death rule, §16.17's test anchor). Two corollaries are normative.
 Residency in a scope's observed child set is the exception to a
-drop-emitted edge: the sites that remove it (`clear_residents_locked` /
-`prune_child_locked`) MUST publish `Removed` in the observation transaction
-that displaces it. The same transaction hands the displaced resident to
-detached disposal after unlock; residency's own drop does not emit the edge. A
-resident can own the last handle to a mailbox containing unread user messages,
-so removal schedules its destructor on a detached disposal worker rather than
-under the observation gate; that worker has no observation transaction through
-which to publish. These emission-site obligations enforce §3.2's exact pairing
-at the only residency-withdrawal transitions while preserving §5.5's required
-disposal venue. And each cell has exactly **one** change signal from which
+drop-emitted edge: a resident can own the last handle to a mailbox
+containing unread user messages, so its destructor is scheduled on a
+detached disposal worker (§5.5's venue) which has no observation
+transaction through which to publish. Each residency withdrawal MUST
+therefore emit `Removed` in the observation transaction that displaces
+it, and MUST emit it for exactly those residents whose `Added` the same
+scope already published — residency records which of the two it is, so
+§3.2's exact pairing survives a residency installed by an admission that
+then unwound. And each cell has exactly **one** change signal from which
 every compound wait derives — a second wake path is a lost wakeup waiting to
 be written.
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -2860,28 +2860,29 @@ unlock.
 ### 15.5 Promises are owned completions
 
 Every cross-task promise — an admission or removal awaiting resolution,
-an exit report awaiting publication, a resident child awaiting its
-`Removed` edge, a member cell awaiting terminality, a waiter awaiting a
-wake — is held as an owned value whose destructor discharges it,
-fail-closed, with a **synchronous** fallback: complete with the terminal
-rejection, publish the coarse exit, emit the edge, pulse the signal —
-never an await, never a join. The event loop that services the orderly
-path is an optimization of these values' consumption, never the sole
-guarantor: when a driver future is destroyed at any await point —
+an exit report awaiting publication, a member cell awaiting terminality,
+a waiter awaiting a wake — is held as an owned value whose destructor
+discharges it, fail-closed, with a **synchronous** fallback: complete with
+the terminal rejection, publish the coarse exit, emit the edge, pulse the
+signal — never an await, never a join. The event loop that services the
+orderly path is an optimization of these values' consumption, never the
+sole guarantor: when a driver future is destroyed at any await point —
 hard-abort cascade, panic, natural return with events still queued —
 unwinding alone MUST discharge every outstanding promise (§11's
 driver-death rule, §16.17's test anchor). Two corollaries are normative.
-Residency in a scope's observed child set is paired with `Removed` at the
-sites that remove it (`clear_residents_locked` / `prune_child_locked`),
-before the displaced resident is handed to detached disposal; residency's
-own drop does not emit the edge. A resident can own the last handle to a
-mailbox containing unread user messages, so its destructor runs on a detached
-disposal worker rather than under the observation gate and has no observation
-transaction through which to publish. Enforcing the pairing at the removal
-sites therefore makes §3.2's exact pairing structural at the transition that
-displaces the resident while preserving §5.5's required disposal venue. And
-each cell has exactly **one** change signal from which every compound wait
-derives — a second wake path is a lost wakeup waiting to be written.
+Residency in a scope's observed child set is the exception to a
+drop-emitted edge: the sites that remove it (`clear_residents_locked` /
+`prune_child_locked`) MUST publish `Removed` in the observation transaction
+that displaces it. The same transaction hands the displaced resident to
+detached disposal after unlock; residency's own drop does not emit the edge. A
+resident can own the last handle to a mailbox containing unread user messages,
+so removal schedules its destructor on a detached disposal worker rather than
+under the observation gate; that worker has no observation transaction through
+which to publish. These emission-site obligations enforce §3.2's exact pairing
+at the only residency-withdrawal transitions while preserving §5.5's required
+disposal venue. And each cell has exactly **one** change signal from which
+every compound wait derives — a second wake path is a lost wakeup waiting to
+be written.
 
 ### 15.6 Performance posture
 
@@ -3746,14 +3747,14 @@ ScopeSnapshot   { state: Unstarted                              // membership ex
                                            | IntensityTripped   // carries §10.2's structured trip data
                                            | StartupFailed      // nested rollback complete (§12);
                                                                 //   carries the startup-failure data
-                                           | NeverStarted },    // membership terminal, no incarnation
-                                                                //   ever spawned (§3.2): dropped-unspawned
-                                                                //   tree, rejected/withdrawn insertion,
-                                                                //   removal before first spawn, startup-
-                                                                //   aborted ordered sibling (§7) — the
-                                                                //   scope-state twin of §8's exit, an
-                                                                //   invariant the stop-reason lattice
-                                                                //   below preserves in either order
+                                           | NeverStarted },    // no scope incarnation ever began:
+                                                                //   dropped-unspawned tree, rejected/
+                                                                //   withdrawn insertion, removal before
+                                                                //   first spawn, startup-aborted ordered
+                                                                //   sibling (§7), or a spawned nested body
+                                                                //   dropped before first poll; this is a
+                                                                //   scope-plane verdict, not necessarily
+                                                                //   the membership exit's twin (below)
                   kind: Ordered | Dynamic, strategy (ordered only), intensity,
                   total_restarts: TotalRestarts,         // charges per §10.2 — group respawns count
                   lifecycle_seq: LifecycleSeq,           // aligns events with snapshots (§14)
@@ -3788,9 +3789,9 @@ nested scope body dropped before its first poll is the sanctioned
 cross-plane divergence: the scope projection is `Stopped { NeverStarted }`
 because no scope incarnation began, while the membership exit is
 `Aborted { WithinGrace }` with `last_incarnation: Some(1)` because an
-incarnation was spawned and then aborted. A root driver that dies mid-drain
-reports the join monitor's `ShutdownRequested` rather than the abandoned
-drain's `Finished`.
+incarnation was spawned on the membership plane and then aborted. A root
+driver that dies mid-drain reports the join monitor's `ShutdownRequested`
+rather than the abandoned drain's `Finished`.
 
 ```text
 ActorStats (II §22)


### PR DESCRIPTION
## Summary

- define residency Removed pairing at the explicit removal sites and explain detached disposal
- scope the stop-reason agreement guarantee to the scope plane
- name the sanctioned never-polled nested-body divergence across scope and membership planes

## Review follow-ups

- keep §15.5 implementation-neutral: it no longer names `clear_residents_locked` /
  `prune_child_locked`, which were the only non-public identifiers SPEC referred to
- drop the "emit the edge" clause from the promise fallback list; its antecedent left
  with residency when residency stopped being enumerated as a promise
- state the withdrawal obligation as covering exactly the residents whose `Added` was
  published. #402 lets an admission install residency and then unwind, so an
  unconditional `Removed` at withdrawal would publish half of §3.2's exact pair; #402
  implements the matching `announced` bit

## Verification

- ./tools/dev just packaged-docs-check
- git diff --check

Closes #389.
Closes #391.