### PR TITLE
Make driver transition refusals fail closed

### DIFF
--- a/crates/shelterwood-cells/src/cells/gate.rs
+++ b/crates/shelterwood-cells/src/cells/gate.rs
@@ -45,6 +45,16 @@ impl ObservationGate {
     pub fn is_held(&self) -> bool {
         matches!(self.0.try_lock(), Err(std::sync::TryLockError::WouldBlock))
     }
+
+    /// Whether a panic crossed this gate while its mutex was held.
+    ///
+    /// This is test instrumentation for assertions that must resume only
+    /// after an observation transaction has released its guard.
+    #[cfg(any(test, feature = "test-util"))]
+    #[must_use]
+    pub fn is_poisoned(&self) -> bool {
+        self.0.is_poisoned()
+    }
 }
 
 /// Capability for one observation-gate transaction.

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -547,7 +547,7 @@ impl ScopeRuntime {
                 .map(|child| resident_projection(&child.slot))
                 .collect(),
         );
-        debug_assert!(
+        assert!(
             admitted,
             "initial children are admitted from their reservation exactly once"
         );
@@ -747,7 +747,10 @@ impl ScopeRuntime {
         // so driver teardown can still close reservations and removals.
         let child = ChildRuntime::from_plan(plan, &self.root);
         enum AdmissionInstall {
-            Admitted(ChildKey),
+            Admitted {
+                key: ChildKey,
+                projection_admitted: bool,
+            },
             Rejected {
                 child: Box<ChildRuntime>,
                 removed: Option<DynamicEntry>,
@@ -798,14 +801,22 @@ impl ScopeRuntime {
             // refusal here would leave the entry promoted with no residency
             // behind it — see the partial-effect note on issue #392.
             let admitted = root.admit_child_locked(resident_projection(&request.slot), txn);
-            debug_assert!(
-                admitted,
-                "a promoted reservation is admitted from `Reserved` exactly once"
-            );
-            AdmissionInstall::Admitted(key)
+            AdmissionInstall::Admitted {
+                key,
+                projection_admitted: admitted,
+            }
         });
         let key = match installed {
-            AdmissionInstall::Admitted(key) => key,
+            AdmissionInstall::Admitted {
+                key,
+                projection_admitted,
+            } => {
+                assert!(
+                    projection_admitted,
+                    "a promoted reservation is admitted from `Reserved` exactly once"
+                );
+                key
+            }
             AdmissionInstall::Rejected {
                 mut child,
                 removed,
@@ -1043,17 +1054,16 @@ async fn run_scope_incarnation(
 ) -> StopReason {
     let root = Arc::clone(&plan.root);
     if role.is_root() {
-        root.with_observation_gate(|txn| {
+        let running = root.with_observation_gate(|txn| {
             // The root scope is never admitted, so its own reservation is the
             // documented `Reserved -> Running` source stage.
-            let running = root
-                .member
-                .transition_locked(txn, MemberTransition::Running);
-            debug_assert!(
-                running,
-                "a root incarnation promotes its own never-admitted reservation"
-            );
+            root.member
+                .transition_locked(txn, MemberTransition::Running)
         });
+        assert!(
+            running,
+            "a root incarnation promotes its own never-admitted reservation"
+        );
     }
     // Both lanes are unbounded so their producers can publish synchronously.
     // Keep child lifecycle events separate from externally generated dynamic

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -761,7 +761,7 @@ impl ScopeRuntime {
                 incarnation,
             }),
         );
-        debug_assert!(
+        assert!(
             started,
             "a spawn starts an admitted or restarting member's projection"
         );
@@ -866,7 +866,7 @@ impl ScopeRuntime {
                 MemberTransition::Stopping,
                 None,
             );
-            debug_assert!(
+            assert!(
                 stopping,
                 "a stop ladder begins on a starting or running member"
             );
@@ -1129,7 +1129,7 @@ impl ScopeRuntime {
                         delay: decision.delay(),
                     },
                 );
-                debug_assert!(
+                assert!(
                     published,
                     "a restart is scheduled from an active incarnation's exit"
                 );

--- a/crates/shelterwood/src/driver/startup.rs
+++ b/crates/shelterwood/src/driver/startup.rs
@@ -75,7 +75,7 @@ impl ScopeRuntime {
                         incarnation,
                     }),
                 );
-                debug_assert!(ready, "readiness promotes a starting member");
+                assert!(ready, "readiness promotes a starting member");
                 true
             }
             ReadinessEffect::TimedOut { deadline } => {

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -1,5 +1,56 @@
 use super::support::*;
 
+#[crate::runtime::test]
+async fn refused_dynamic_admission_panics_after_control_plane_unlock() {
+    let (mut scope, _events, mut dynamic_events, control) = running_dynamic_fixture();
+    let root = Arc::clone(&scope.root);
+    let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
+        .expect("running dynamic scope reserves the child");
+    let member = Arc::clone(&reservation.slot.member);
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new(|_| future::pending()).erase(),
+    ));
+    let (_response, request) = begin_admission(&reservation, &mut dynamic_events, None).await;
+
+    // Corrupt only the projection source stage. Admission still commits its
+    // arena insertion and dynamic-entry promotion before the cell reducer
+    // refuses Running -> Admitted, reaching the driver invariant exactly.
+    member.update(|record| record.stage = MemberStage::Running);
+    let refusal = catch_unwind(AssertUnwindSafe(|| scope.handle_admission(request)));
+
+    assert!(
+        refusal.is_err(),
+        "a refused dynamic admission fails closed in every profile"
+    );
+    assert!(
+        !root.observation_gate().is_poisoned(),
+        "the admission verdict is asserted after ObservationTxn releases the gate"
+    );
+    assert!(
+        !control.state.is_poisoned(),
+        "the admission verdict is asserted after the dynamic-state guard is released"
+    );
+    assert!(
+        !scope.children.is_empty(),
+        "the fixture reaches the committing admission site after arena insertion"
+    );
+    assert!(
+        control
+            .state
+            .lock()
+            .expect("dynamic-state mutex remains healthy")
+            .entries
+            .get(member.id())
+            .is_some_and(|entry| !entry.is_reserved()),
+        "the fixture reaches the committing admission site after entry promotion"
+    );
+
+    // Restore the source stage and missing residency so ScopeRuntime's normal
+    // fail-closed epilogue can discharge this deliberately corrupted fixture.
+    member.update(|record| record.stage = MemberStage::Reserved);
+    assert!(root.admit_child(resident_projection(&reservation.slot)));
+}
+
 #[crate::runtime::test(start_paused = true)]
 async fn dynamic_high_cycle_add_remove_keeps_only_live_runtime_storage() {
     const CYCLES: usize = 1_000;

--- a/crates/shelterwood/src/driver/tests/startup.rs
+++ b/crates/shelterwood/src/driver/tests/startup.rs
@@ -1,6 +1,30 @@
 use super::support::*;
 
 #[test]
+fn refused_root_running_transition_panics_after_the_observation_transaction() {
+    let plan = Tree::new().lower_for_test();
+    let root = Arc::clone(&plan.root);
+    root.member
+        .update(|record| record.stage = MemberStage::Running);
+
+    let mut driver = Box::pin(run_scope(plan, ScopeRole::Root));
+    let refusal = catch_unwind(AssertUnwindSafe(|| {
+        let mut context = Context::from_waker(Waker::noop());
+        let _ = driver.as_mut().poll(&mut context);
+    }));
+
+    assert!(
+        refusal.is_err(),
+        "a refused root Running transition fails closed in every profile"
+    );
+    assert!(
+        !root.observation_gate().is_poisoned(),
+        "the transition verdict is asserted after ObservationTxn releases the gate"
+    );
+    drop(driver);
+}
+
+#[test]
 fn empty_control_peeks_skip_the_tree_observation_gate() {
     let root = isolated_scope("root", ScopeFlavor::Ordered);
     let epoch = root


### PR DESCRIPTION
## Summary

- promote all seven driver transition-verdict diagnostics to always-on assertions
- carry the dynamic-admission verdict out of the observation and control-plane critical sections before asserting
- carry the root Running verdict out of its observation transaction before asserting

The latter two preserve the lock rule because those checks were still inside framework locks on main despite the premise recorded in #392.

## Verification

- ./tools/dev cargo +nightly fmt --all -- --check
- ./tools/dev cargo test -p shelterwood
- git diff --check

Stage A of #395.
Closes #392.