### PR TITLE
Add framework-owned waker proxy foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,12 @@ rests on:
   stays inside the rule — the record is framework-owned data and the retained
   clone is provably non-last — but it is the deepest the exemption goes, so a
   new operation added to the doubled section needs the same accounting.
+  `WakerProxy`'s mutex (`shelterwood-mailbox/src/waker_proxy.rs`) sits at the
+  other end of that order: it is a **leaf**. `wake_by_ref` acquires it from
+  whatever thread drives the external primitive — the timer driver, a sender,
+  any executor — so no framework lock may be taken under it, and a wider lock
+  may sit above it only through the effects-sink shapes, which move every
+  caller-waker clone, wake and drop past the unlock.
 
 Two conventions that are not the rule itself but travel with it: panicking
 while holding a mutex the codebase `.expect()`s poisons it for every later

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -108,7 +108,7 @@ pub(super) struct OperationState<M> {
     registration: Option<WaiterId>,
 }
 
-mod waker_slot;
+pub(crate) mod waker_slot;
 
 use waker_slot::{WakerAction, WakerEffects, WakerSlot};
 

--- a/crates/shelterwood-mailbox/src/cell/waker_slot.rs
+++ b/crates/shelterwood-mailbox/src/cell/waker_slot.rs
@@ -47,7 +47,7 @@ impl WakerSlot {
 }
 
 impl WakerEffects {
-    pub(crate) fn is_empty(&self) -> bool {
+    pub(super) fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
@@ -59,7 +59,7 @@ impl WakerEffects {
         });
     }
 
-    pub(crate) fn flush(&mut self, panics: &mut PanicAccumulator) {
+    pub(super) fn flush(&mut self, panics: &mut PanicAccumulator) {
         for effect in self.0.drain(..) {
             match effect {
                 WakerEffect::Wake(waker) => panics.run(|| waker.wake()),

--- a/crates/shelterwood-mailbox/src/cell/waker_slot.rs
+++ b/crates/shelterwood-mailbox/src/cell/waker_slot.rs
@@ -9,9 +9,9 @@ use crate::{MailboxRuntime, capability::dispose, panic::PanicAccumulator};
 /// `Option<Waker>` and accidentally dropping it beside a guard does not
 /// type-check.
 #[derive(Default)]
-pub(super) struct WakerSlot(Option<Waker>);
+pub(crate) struct WakerSlot(Option<Waker>);
 
-pub(super) enum WakerAction {
+pub(crate) enum WakerAction {
     Wake,
     DropInline,
     Dispose(Arc<dyn MailboxRuntime>),
@@ -24,22 +24,22 @@ enum WakerEffect {
 }
 
 #[derive(Default)]
-pub(super) struct WakerEffects(Vec<WakerEffect>);
+pub(crate) struct WakerEffects(Vec<WakerEffect>);
 
 impl WakerSlot {
-    pub(super) fn will_wake(&self, waker: &Waker) -> bool {
+    pub(crate) fn will_wake(&self, waker: &Waker) -> bool {
         self.0
             .as_ref()
             .is_some_and(|registered| registered.will_wake(waker))
     }
 
-    pub(super) fn replace(&mut self, waker: Waker, effects: &mut WakerEffects) {
+    pub(crate) fn replace(&mut self, waker: Waker, effects: &mut WakerEffects) {
         if let Some(displaced) = self.0.replace(waker) {
             effects.push(displaced, WakerAction::DropInline);
         }
     }
 
-    pub(super) fn take(&mut self, action: WakerAction, effects: &mut WakerEffects) {
+    pub(crate) fn take(&mut self, action: WakerAction, effects: &mut WakerEffects) {
         if let Some(waker) = self.0.take() {
             effects.push(waker, action);
         }
@@ -47,7 +47,7 @@ impl WakerSlot {
 }
 
 impl WakerEffects {
-    pub(super) fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
@@ -59,7 +59,7 @@ impl WakerEffects {
         });
     }
 
-    pub(super) fn flush(&mut self, panics: &mut PanicAccumulator) {
+    pub(crate) fn flush(&mut self, panics: &mut PanicAccumulator) {
         for effect in self.0.drain(..) {
             match effect {
                 WakerEffect::Wake(waker) => panics.run(|| waker.wake()),

--- a/crates/shelterwood-mailbox/src/lib.rs
+++ b/crates/shelterwood-mailbox/src/lib.rs
@@ -34,6 +34,11 @@ mod futures;
 mod reply;
 #[cfg(test)]
 mod test_support;
+#[allow(
+    dead_code,
+    reason = "the foundation primitive is wired into deadlines by the next stacked change"
+)]
+mod waker_proxy;
 
 #[doc(hidden)]
 pub use capability::{

--- a/crates/shelterwood-mailbox/src/waker_proxy.rs
+++ b/crates/shelterwood-mailbox/src/waker_proxy.rs
@@ -1,4 +1,5 @@
 use std::{
+    mem,
     sync::{Arc, Mutex},
     task::{Wake, Waker},
 };
@@ -11,14 +12,26 @@ use crate::cell::waker_slot::{WakerAction, WakerEffects, WakerSlot};
 /// `Arc` bookkeeping over framework-owned state. The caller's real waker stays
 /// in the private slot and every path that removes it queues the resulting
 /// user-code effect before releasing the slot mutex.
+///
+/// The proxy mutex is a **leaf**: [`Wake::wake_by_ref`] takes it from whatever
+/// thread drives the external primitive, so nothing this type does under it may
+/// take another framework lock.
 pub(crate) struct WakerProxy {
     proxy: Waker,
     state: Arc<WakerProxyState>,
 }
 
+/// The proxy's mutable half: the caller's waker beside the record of a wake
+/// that has not yet reached the caller who is polling now.
+#[derive(Default)]
+struct Registration {
+    caller: WakerSlot,
+    woken: bool,
+}
+
 #[derive(Default)]
 struct WakerProxyState {
-    caller: Mutex<WakerSlot>,
+    caller: Mutex<Registration>,
 }
 
 impl WakerProxy {
@@ -30,6 +43,31 @@ impl WakerProxy {
 
     /// Installs the current caller without cloning or dropping its waker
     /// while the proxy mutex is held.
+    ///
+    /// # The lost-wake handshake
+    ///
+    /// Cloning `current` dispatches a caller-owned vtable, so it has to happen
+    /// between two critical sections. A wake landing in that window finds
+    /// either an empty slot or the *previous* poll's waker, and once a future
+    /// has migrated between tasks that previous waker no longer wakes the task
+    /// polling now. Installing the fresh waker on top of that would leave no
+    /// record the wake ever happened, and the future would never be polled
+    /// again.
+    ///
+    /// So [`Wake::wake_by_ref`] records `woken` in the same critical section in
+    /// which it takes the slot, and every registration that installs a waker
+    /// reads-and-clears that flag: a set flag takes the just-installed waker
+    /// straight back out and hands it to the effects sink, which wakes it after
+    /// unlock. No waker vtable is invoked or cloned under the mutex, and no
+    /// wake is lost. The cost is a spurious re-poll, which the `Future`
+    /// contract permits — a lost wake is not.
+    ///
+    /// The `will_wake` short-circuit rides the same read-and-clear rather than
+    /// returning early. It cannot in fact observe a set flag: `wake_by_ref`
+    /// empties the slot in the critical section that sets the flag, so a slot
+    /// still holding a matching waker proves nothing has woken since that waker
+    /// was installed. Handling it anyway costs one branch and keeps the "no
+    /// wake is lost" claim from resting on that invariant.
     pub(crate) fn register(&self, current: &Waker) {
         let mut replacement = None;
         loop {
@@ -37,19 +75,25 @@ impl WakerProxy {
             // releases the mutex before a displaced RawWaker vtable runs.
             let mut effects = WakerEffects::default();
             let needs_clone = {
-                let mut caller = self
+                let mut registration = self
                     .state
                     .caller
                     .lock()
                     .expect("waker proxy mutex poisoned");
-                if caller.will_wake(current) {
-                    false
-                } else if let Some(replacement) = replacement.take() {
-                    caller.replace(replacement, &mut effects);
-                    false
-                } else {
+                let installed = if registration.caller.will_wake(current) {
                     true
+                } else if let Some(replacement) = replacement.take() {
+                    registration.caller.replace(replacement, &mut effects);
+                    true
+                } else {
+                    // Nothing was installed, so the flag stays set for the
+                    // registration that eventually succeeds.
+                    false
+                };
+                if installed && mem::take(&mut registration.woken) {
+                    registration.caller.take(WakerAction::Wake, &mut effects);
                 }
+                !installed
             };
             drop(effects);
 
@@ -68,18 +112,37 @@ impl WakerProxy {
         &self.proxy
     }
 
-    /// Moves the caller waker into an explicitly chosen post-unlock effect.
+    /// Moves the caller waker into an explicitly chosen post-unlock effect,
+    /// discarding any unconsumed wake record with it.
+    ///
+    /// `retire` tears the registration down rather than replacing it: its
+    /// callers have either observed the readiness the wake would have announced
+    /// or are abandoning the registration outright, so there is no later poll
+    /// for a retained flag to reach. Keeping the flag would only mean the next
+    /// caller to register on a reused proxy is woken once for an event that
+    /// predates it.
     pub(crate) fn retire(&self, action: WakerAction, effects: &mut WakerEffects) {
-        let mut caller = self
+        let mut registration = self
             .state
             .caller
             .lock()
             .expect("waker proxy mutex poisoned");
-        caller.take(action, effects);
+        registration.woken = false;
+        registration.caller.take(action, effects);
     }
 }
 
 impl Drop for WakerProxy {
+    /// Retires the stored caller waker **inline, on the dropping thread**: drop
+    /// glue has no effects sink to hand the disposition to, so the waker's drop
+    /// vtable runs here (contained, but synchronously).
+    ///
+    /// A caller whose retirement must reach the disposal lane — because the
+    /// waker's destructor may block, or because the dropping thread holds a
+    /// lock the destructor could re-enter — must call [`WakerProxy::retire`]
+    /// with the chosen [`WakerAction`] before the proxy is dropped. Reaching
+    /// this `Drop` with a waker still installed is the fallback, not the
+    /// contract.
     fn drop(&mut self) {
         let mut effects = WakerEffects::default();
         self.retire(WakerAction::DropInline, &mut effects);
@@ -94,8 +157,13 @@ impl Wake for WakerProxyState {
     fn wake_by_ref(self: &Arc<Self>) {
         let mut effects = WakerEffects::default();
         {
-            let mut caller = self.caller.lock().expect("waker proxy mutex poisoned");
-            caller.take(WakerAction::Wake, &mut effects);
+            let mut registration = self.caller.lock().expect("waker proxy mutex poisoned");
+            // Recorded whether or not a caller waker is installed: an empty
+            // slot means the wake landed in `register`'s clone window, and the
+            // flag is the only thing that will carry it to the caller polling
+            // now. See `WakerProxy::register`.
+            registration.woken = true;
+            registration.caller.take(WakerAction::Wake, &mut effects);
         }
     }
 }
@@ -106,12 +174,13 @@ mod tests {
         mem::ManuallyDrop,
         sync::{
             Arc, Weak,
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
         },
         task::{RawWaker, RawWakerVTable, Wake, Waker},
     };
 
     use super::{WakerProxy, WakerProxyState};
+    use crate::cell::waker_slot::{WakerAction, WakerEffects};
 
     #[derive(Default)]
     struct CountWake(AtomicUsize);
@@ -207,18 +276,151 @@ mod tests {
         unsafe { Waker::from_raw(raw) }
     }
 
+    /// A caller waker that wakes the proxy from inside its own `clone` vtable.
+    ///
+    /// `register` clones outside the proxy mutex, so this is a single-threaded
+    /// replica of a driver thread waking between `register`'s two critical
+    /// sections — the window the `woken` handshake exists to close.
+    struct WindowWake {
+        proxy: Weak<WakerProxyState>,
+        armed: AtomicBool,
+        wakes: Arc<AtomicUsize>,
+    }
+
+    unsafe fn clone_window(data: *const ()) -> RawWaker {
+        // SAFETY: every pointer using this vtable came from an Arc of the
+        // matching type. ManuallyDrop preserves the reference represented by
+        // `data`; the returned raw waker owns only the new clone.
+        let probe = ManuallyDrop::new(unsafe { Arc::<WindowWake>::from_raw(data.cast()) });
+        if probe.armed.swap(false, Ordering::SeqCst) {
+            let state = probe.proxy.upgrade().expect("the proxy remains live");
+            state.wake_by_ref();
+        }
+        RawWaker::new(Arc::into_raw(Arc::clone(&probe)).cast(), &WINDOW_VTABLE)
+    }
+
+    unsafe fn wake_window(data: *const ()) {
+        // SAFETY: wake consumes the Arc reference represented by this waker.
+        let waker = unsafe { Arc::<WindowWake>::from_raw(data.cast()) };
+        waker.wakes.fetch_add(1, Ordering::SeqCst);
+    }
+
+    unsafe fn wake_by_ref_window(data: *const ()) {
+        // SAFETY: wake_by_ref borrows the Arc reference represented by this
+        // waker, which ManuallyDrop preserves.
+        let probe = ManuallyDrop::new(unsafe { Arc::<WindowWake>::from_raw(data.cast()) });
+        probe.wakes.fetch_add(1, Ordering::SeqCst);
+    }
+
+    unsafe fn drop_window(data: *const ()) {
+        // SAFETY: drop consumes the Arc reference represented by this waker.
+        drop(unsafe { Arc::<WindowWake>::from_raw(data.cast()) });
+    }
+
+    static WINDOW_VTABLE: RawWakerVTable =
+        RawWakerVTable::new(clone_window, wake_window, wake_by_ref_window, drop_window);
+
+    fn window_wake_waker(proxy: Weak<WakerProxyState>, wakes: Arc<AtomicUsize>) -> Waker {
+        let raw = RawWaker::new(
+            Arc::into_raw(Arc::new(WindowWake {
+                proxy,
+                armed: AtomicBool::new(true),
+                wakes,
+            }))
+            .cast(),
+            &WINDOW_VTABLE,
+        );
+        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+        // ownership across clone, wake, and drop.
+        unsafe { Waker::from_raw(raw) }
+    }
+
     #[test]
-    fn registration_preserves_the_proxy_identity_and_short_circuits_matching_callers() {
+    fn registration_keeps_a_stable_proxy_identity_across_replacements() {
         let proxy = WakerProxy::new();
+        // Minted before any registration: the identity an external primitive's
+        // own `will_wake` short-circuit keys on has to survive every later
+        // caller swap, which is the whole point of a stable proxy.
+        let minted = proxy.waker().clone();
+
+        let first = Arc::new(CountWake::default());
+        let second = Arc::new(CountWake::default());
+        proxy.register(&Waker::from(first));
+        proxy.register(&Waker::from(second));
+
+        assert!(minted.will_wake(proxy.waker()));
+    }
+
+    #[test]
+    fn re_registering_the_same_caller_never_reaches_its_clone_vtable() {
+        let proxy = WakerProxy::new();
+        let clones = Arc::new(AtomicUsize::new(0));
+        let caller = reentrant_clone_waker(Arc::downgrade(&proxy.state), Arc::clone(&clones));
+
+        proxy.register(&caller);
+        proxy.register(&caller);
+
+        // One clone for the initial install and none for the repeat: the
+        // `will_wake` short-circuit is what keeps the caller's vtable out of
+        // the second registration.
+        assert_eq!(clones.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn a_wake_in_the_registration_window_reaches_the_caller_registering_now() {
+        let proxy = WakerProxy::new();
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let caller = window_wake_waker(Arc::downgrade(&proxy.state), Arc::clone(&wakes));
+
+        // The wake fires while the slot is still empty, so the `woken` record
+        // is the only thing that can carry it forward.
+        proxy.register(&caller);
+
+        assert_eq!(
+            wakes.load(Ordering::SeqCst),
+            1,
+            "a wake landing in the clone window must reach the waker that same registration installs"
+        );
+    }
+
+    #[test]
+    fn a_window_wake_consuming_the_previous_caller_still_reaches_the_new_one() {
+        let proxy = WakerProxy::new();
+        let previous = Arc::new(CountWake::default());
+        proxy.register(&Waker::from(Arc::clone(&previous)));
+
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let caller = window_wake_waker(Arc::downgrade(&proxy.state), Arc::clone(&wakes));
+        proxy.register(&caller);
+
+        // The window wake took the previous poll's waker, which after a future
+        // migrates between tasks belongs to a task that no longer holds it...
+        assert_eq!(previous.0.load(Ordering::SeqCst), 1);
+        // ...so the caller polling now has to be woken as well.
+        assert_eq!(
+            wakes.load(Ordering::SeqCst),
+            1,
+            "waking the previous caller does not discharge the wake for the current one"
+        );
+    }
+
+    #[test]
+    fn retirement_discards_an_unconsumed_wake_record() {
+        let proxy = WakerProxy::new();
+        proxy.waker().wake_by_ref();
+
+        let mut effects = WakerEffects::default();
+        proxy.retire(WakerAction::DropInline, &mut effects);
+        drop(effects);
+
         let target = Arc::new(CountWake::default());
-        let caller = Waker::from(Arc::clone(&target));
+        proxy.register(&Waker::from(Arc::clone(&target)));
 
-        proxy.register(&caller);
-        let registered_count = Arc::strong_count(&target);
-        proxy.register(&caller);
-
-        assert_eq!(Arc::strong_count(&target), registered_count);
-        assert!(proxy.waker().will_wake(proxy.waker()));
+        assert_eq!(
+            target.0.load(Ordering::SeqCst),
+            0,
+            "a retired registration leaves no wake for the next caller to inherit"
+        );
     }
 
     #[test]

--- a/crates/shelterwood-mailbox/src/waker_proxy.rs
+++ b/crates/shelterwood-mailbox/src/waker_proxy.rs
@@ -103,11 +103,12 @@ impl Wake for WakerProxyState {
 #[cfg(test)]
 mod tests {
     use std::{
+        mem::ManuallyDrop,
         sync::{
             Arc, Weak,
             atomic::{AtomicUsize, Ordering},
         },
-        task::{Wake, Waker},
+        task::{RawWaker, RawWakerVTable, Wake, Waker},
     };
 
     use super::{WakerProxy, WakerProxyState};
@@ -155,6 +156,57 @@ mod tests {
         }
     }
 
+    struct ReentrantClone {
+        proxy: Weak<WakerProxyState>,
+        clones: Arc<AtomicUsize>,
+    }
+
+    unsafe fn clone_reentrant(data: *const ()) -> RawWaker {
+        // SAFETY: every pointer using this vtable came from an Arc of the
+        // matching type. ManuallyDrop preserves the reference represented by
+        // `data`; the returned raw waker owns only the new clone.
+        let probe = ManuallyDrop::new(unsafe { Arc::<ReentrantClone>::from_raw(data.cast()) });
+        let state = probe.proxy.upgrade().expect("the proxy remains live");
+        let _guard = state
+            .caller
+            .try_lock()
+            .expect("a caller waker clones after the proxy mutex is released");
+        probe.clones.fetch_add(1, Ordering::SeqCst);
+        RawWaker::new(
+            Arc::into_raw(Arc::clone(&probe)).cast(),
+            &REENTRANT_CLONE_VTABLE,
+        )
+    }
+
+    unsafe fn wake_reentrant(data: *const ()) {
+        // SAFETY: wake consumes the Arc reference represented by this waker.
+        drop(unsafe { Arc::<ReentrantClone>::from_raw(data.cast()) });
+    }
+
+    unsafe fn wake_by_ref_reentrant(_data: *const ()) {}
+
+    unsafe fn drop_reentrant(data: *const ()) {
+        // SAFETY: drop consumes the Arc reference represented by this waker.
+        drop(unsafe { Arc::<ReentrantClone>::from_raw(data.cast()) });
+    }
+
+    static REENTRANT_CLONE_VTABLE: RawWakerVTable = RawWakerVTable::new(
+        clone_reentrant,
+        wake_reentrant,
+        wake_by_ref_reentrant,
+        drop_reentrant,
+    );
+
+    fn reentrant_clone_waker(proxy: Weak<WakerProxyState>, clones: Arc<AtomicUsize>) -> Waker {
+        let raw = RawWaker::new(
+            Arc::into_raw(Arc::new(ReentrantClone { proxy, clones })).cast(),
+            &REENTRANT_CLONE_VTABLE,
+        );
+        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+        // ownership across clone, wake, and drop.
+        unsafe { Waker::from_raw(raw) }
+    }
+
     #[test]
     fn registration_preserves_the_proxy_identity_and_short_circuits_matching_callers() {
         let proxy = WakerProxy::new();
@@ -167,6 +219,18 @@ mod tests {
 
         assert_eq!(Arc::strong_count(&target), registered_count);
         assert!(proxy.waker().will_wake(proxy.waker()));
+    }
+
+    #[test]
+    fn registration_clones_the_caller_after_unlock() {
+        let proxy = WakerProxy::new();
+        let clones = Arc::new(AtomicUsize::new(0));
+        let caller = reentrant_clone_waker(Arc::downgrade(&proxy.state), Arc::clone(&clones));
+
+        proxy.register(&caller);
+        proxy.register(&caller);
+
+        assert_eq!(clones.load(Ordering::SeqCst), 1);
     }
 
     #[test]
@@ -193,5 +257,15 @@ mod tests {
         drop(caller);
 
         proxy.register(Waker::noop());
+    }
+
+    #[test]
+    fn proxy_drop_retires_the_caller_after_unlock() {
+        let proxy = WakerProxy::new();
+        let caller = Waker::from(Arc::new(ReentrantDrop(Arc::downgrade(&proxy.state))));
+        proxy.register(&caller);
+        drop(caller);
+
+        drop(proxy);
     }
 }

--- a/crates/shelterwood-mailbox/src/waker_proxy.rs
+++ b/crates/shelterwood-mailbox/src/waker_proxy.rs
@@ -1,0 +1,197 @@
+use std::{
+    sync::{Arc, Mutex},
+    task::{Wake, Waker},
+};
+
+use crate::cell::waker_slot::{WakerAction, WakerEffects, WakerSlot};
+
+/// Stable framework-owned waker registered with an external primitive.
+///
+/// The external primitive sees only `proxy`, whose clone and drop vtable is
+/// `Arc` bookkeeping over framework-owned state. The caller's real waker stays
+/// in the private slot and every path that removes it queues the resulting
+/// user-code effect before releasing the slot mutex.
+pub(crate) struct WakerProxy {
+    proxy: Waker,
+    state: Arc<WakerProxyState>,
+}
+
+#[derive(Default)]
+struct WakerProxyState {
+    caller: Mutex<WakerSlot>,
+}
+
+impl WakerProxy {
+    pub(crate) fn new() -> Self {
+        let state = Arc::new(WakerProxyState::default());
+        let proxy = Waker::from(Arc::clone(&state));
+        Self { proxy, state }
+    }
+
+    /// Installs the current caller without cloning or dropping its waker
+    /// while the proxy mutex is held.
+    pub(crate) fn register(&self, current: &Waker) {
+        let mut replacement = None;
+        loop {
+            // Effects precede the guard, so a bookkeeping unwind still
+            // releases the mutex before a displaced RawWaker vtable runs.
+            let mut effects = WakerEffects::default();
+            let needs_clone = {
+                let mut caller = self
+                    .state
+                    .caller
+                    .lock()
+                    .expect("waker proxy mutex poisoned");
+                if caller.will_wake(current) {
+                    false
+                } else if let Some(replacement) = replacement.take() {
+                    caller.replace(replacement, &mut effects);
+                    false
+                } else {
+                    true
+                }
+            };
+            drop(effects);
+
+            if !needs_clone {
+                return;
+            }
+            // `Waker::clone` dispatches through a caller-owned RawWaker
+            // vtable, so it belongs outside the proxy mutex. Re-check after
+            // cloning because a concurrent wake can empty the slot between
+            // the two critical sections.
+            replacement = Some(current.clone());
+        }
+    }
+
+    pub(crate) fn waker(&self) -> &Waker {
+        &self.proxy
+    }
+
+    /// Moves the caller waker into an explicitly chosen post-unlock effect.
+    pub(crate) fn retire(&self, action: WakerAction, effects: &mut WakerEffects) {
+        let mut caller = self
+            .state
+            .caller
+            .lock()
+            .expect("waker proxy mutex poisoned");
+        caller.take(action, effects);
+    }
+}
+
+impl Drop for WakerProxy {
+    fn drop(&mut self) {
+        let mut effects = WakerEffects::default();
+        self.retire(WakerAction::DropInline, &mut effects);
+    }
+}
+
+impl Wake for WakerProxyState {
+    fn wake(self: Arc<Self>) {
+        self.wake_by_ref();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        let mut effects = WakerEffects::default();
+        {
+            let mut caller = self.caller.lock().expect("waker proxy mutex poisoned");
+            caller.take(WakerAction::Wake, &mut effects);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            Arc, Weak,
+            atomic::{AtomicUsize, Ordering},
+        },
+        task::{Wake, Waker},
+    };
+
+    use super::{WakerProxy, WakerProxyState};
+
+    #[derive(Default)]
+    struct CountWake(AtomicUsize);
+
+    impl Wake for CountWake {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct ReentrantWake {
+        proxy: Weak<WakerProxyState>,
+        wakes: Arc<AtomicUsize>,
+    }
+
+    impl Wake for ReentrantWake {
+        fn wake(self: Arc<Self>) {
+            let state = self.proxy.upgrade().expect("the proxy remains live");
+            let _guard = state
+                .caller
+                .try_lock()
+                .expect("a forwarded wake runs after the proxy mutex is released");
+            self.wakes.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct ReentrantDrop(Weak<WakerProxyState>);
+
+    impl Wake for ReentrantDrop {
+        fn wake(self: Arc<Self>) {
+            panic!("the replacement test never wakes its caller")
+        }
+    }
+
+    impl Drop for ReentrantDrop {
+        fn drop(&mut self) {
+            let state = self.0.upgrade().expect("the proxy remains live");
+            let _guard = state
+                .caller
+                .try_lock()
+                .expect("a displaced waker drops after the proxy mutex is released");
+        }
+    }
+
+    #[test]
+    fn registration_preserves_the_proxy_identity_and_short_circuits_matching_callers() {
+        let proxy = WakerProxy::new();
+        let target = Arc::new(CountWake::default());
+        let caller = Waker::from(Arc::clone(&target));
+
+        proxy.register(&caller);
+        let registered_count = Arc::strong_count(&target);
+        proxy.register(&caller);
+
+        assert_eq!(Arc::strong_count(&target), registered_count);
+        assert!(proxy.waker().will_wake(proxy.waker()));
+    }
+
+    #[test]
+    fn forwarding_takes_the_caller_before_invoking_its_wake_vtable() {
+        let proxy = WakerProxy::new();
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let caller = Waker::from(Arc::new(ReentrantWake {
+            proxy: Arc::downgrade(&proxy.state),
+            wakes: Arc::clone(&wakes),
+        }));
+        proxy.register(&caller);
+
+        proxy.waker().wake_by_ref();
+        proxy.waker().wake_by_ref();
+
+        assert_eq!(wakes.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn replacement_drops_the_displaced_caller_after_unlock() {
+        let proxy = WakerProxy::new();
+        let caller = Waker::from(Arc::new(ReentrantDrop(Arc::downgrade(&proxy.state))));
+        proxy.register(&caller);
+        drop(caller);
+
+        proxy.register(Waker::noop());
+    }
+}


### PR DESCRIPTION
Implements PR 1 of #398. Promotes the effects-mediated waker slot to crate-internal visibility and adds a stable framework-owned proxy that keeps caller RawWaker vtables outside its mutex. This is the no-behavior-change foundation for the stacked timer and reply integrations.

Local verification: `./tools/dev just ci` (853 tests plus docs, API reachability, external consumer, and Nix formatting).