### PR TITLE
Let residency guard fallible admission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,11 @@ rests on:
   `runtime::dispose_detached` after unlock: the last member owner can also be
   the last owner of a mailbox containing unread user messages, which
   `RetainedExit` does not cover. The first two displace an existing resident;
-  the third holds the *incoming* projection in a `ResidentAdmission` guard, so
-  a bookkeeping panic before installation retires the same graph the same way.
+  the third pushes the *incoming* projection into residency before its first
+  fallible step, so a bookkeeping panic leaves the graph owned by residency
+  and retires it the same way at scope clear. Such a resident stays
+  unannounced, which keeps SPEC §3.2's `Added`/`Removed` pairing exact and
+  keeps it out of the observed child set.
   Containment lives on `ResidentChild::drop` rather than on the displaced
   `Vec`, because `Vec`'s slice drop glue keeps going after an element panics
   and a second hostile mailbox destructor would then panic inside the first

--- a/crates/shelterwood-cells/src/cells/member.rs
+++ b/crates/shelterwood-cells/src/cells/member.rs
@@ -346,10 +346,11 @@ impl MemberCell {
     /// `Acquire` pairs with the `Release` store in
     /// [`Self::set_terminal_disposal_pending`]. Two separate edges make a
     /// zero-budget straggler sample (the driver's `collect_stragglers`)
-    /// correct, and both rest on these atomics alone: the sample is *not*
-    /// incidentally serialized by the observation gate, because
-    /// [`ScopeCell::resident_projections`] takes `observation.current_children`
-    /// — a different mutex from the gate `publish_drain` holds.
+    /// correct. [`ScopeCell::resident_projections`] now serializes the
+    /// residency clone with `publish_drain` through the observation gate, but
+    /// releases that gate before the caller samples this marker and the member
+    /// record. Those following reads therefore still rest on the explicit
+    /// ordering below rather than incidental mutex overlap.
     ///
     /// This method owns the marker-before-record order so a caller cannot
     /// accidentally recreate the trailing gap by reversing two independent

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -806,6 +806,13 @@ impl ScopeCell {
         })
     }
 
+    /// Installs residency without announcing it, as an admission that
+    /// unwound between its residency push and its `Added` publication does.
+    #[cfg(test)]
+    fn push_unannounced_resident_for_test(&self, child: ResidentProjection) {
+        self.current_children().push(ResidentChild::new(child));
+    }
+
     #[cfg(any(test, feature = "test-util"))]
     pub fn prune_child(&self, member: &MemberCell) -> bool {
         self.with_observation_gate(|wakes| self.prune_child_locked(member, wakes))
@@ -1951,6 +1958,35 @@ mod tests {
                 .expect("scope clear disposes the lingering mailbox payload"),
             retiring_thread,
             "scope clear retains the detached disposal venue"
+        );
+    }
+
+    /// Withdrawal mirrors announcement at both removal sites, not just the
+    /// one `panicked_resident_admission_lingers_until_scope_clear` drives.
+    #[test]
+    fn pruning_an_unannounced_resident_publishes_no_removal_edge() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let member = child_member(&root, "half-wired");
+        let mut lifecycle = root.subscribe_lifecycle();
+
+        // Install residency exactly as an admission that unwound before its
+        // `Added` publication leaves it.
+        root.push_unannounced_resident_for_test(ResidentProjection::new(
+            Arc::clone(&member),
+            None,
+        ));
+        assert_eq!(root.resident_projections().len(), 1);
+        assert!(root.snapshot().children.is_empty());
+
+        assert!(
+            root.prune_child(&member),
+            "an unannounced resident is still withdrawn"
+        );
+        assert!(root.resident_projections().is_empty());
+        assert_eq!(
+            lifecycle.try_recv(),
+            Err(LifecycleTryRecvError::Empty),
+            "neither edge is published for a membership that never announced"
         );
     }
 

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -1,8 +1,6 @@
 use std::{
     any::Any,
-    cell::{Ref, RefCell},
     collections::VecDeque,
-    rc::Rc,
     sync::{
         Arc, Mutex, MutexGuard, Weak,
         atomic::{AtomicBool, Ordering},
@@ -53,49 +51,6 @@ pub struct ResidentProjection {
 impl ResidentProjection {
     pub fn new(member: Arc<MemberCell>, scope: Option<Arc<ScopeCell>>) -> Self {
         Self { member, scope }
-    }
-}
-
-/// By-value admission input protected until residency owns it.
-///
-/// A projection can be the last owner of a member and its mailbox. Any
-/// bookkeeping panic before installation therefore routes the whole graph to
-/// detached disposal instead of unwinding it through the observation gate.
-///
-/// The transaction holds the second `Rc` rather than this guard disposing
-/// from its own `Drop`: a bare guard would submit the disposal job with the
-/// observation gate still held. That is legal — a submission runs no user
-/// code — but the standing preference is that a caller already holding an
-/// effects sink flushes through it, because a submission can cost a native
-/// thread start. #390 tracks deleting the guard outright by letting residency
-/// own the projection across admission's fallible steps.
-struct ResidentAdmission(Rc<RefCell<Option<ResidentProjection>>>);
-
-impl ResidentAdmission {
-    fn new(projection: ResidentProjection, txn: &mut ObservationTxn<'_>) -> Self {
-        let projection = Rc::new(RefCell::new(Some(projection)));
-        let deferred = Rc::clone(&projection);
-        txn.defer(move || {
-            if let Some(projection) = deferred.borrow_mut().take() {
-                runtime::dispose_detached(projection);
-            }
-        });
-        Self(projection)
-    }
-
-    fn projection(&self) -> Ref<'_, ResidentProjection> {
-        Ref::map(self.0.borrow(), |projection| {
-            projection
-                .as_ref()
-                .expect("resident admission was already installed")
-        })
-    }
-
-    fn install(self) -> ResidentProjection {
-        self.0
-            .borrow_mut()
-            .take()
-            .expect("resident admission installs exactly once")
     }
 }
 
@@ -345,16 +300,20 @@ impl ScopeCell {
     }
 
     pub fn resident_projections(&self) -> Vec<ResidentProjection> {
-        self.current_children()
-            .iter()
-            .map(|resident| resident.projection().clone())
-            .collect()
+        self.with_observation_gate(|_| {
+            self.current_children()
+                .iter()
+                .map(|resident| resident.projection().clone())
+                .collect()
+        })
     }
 
     pub fn has_resident_child(&self, member: &MemberCell) -> bool {
-        self.current_children()
-            .iter()
-            .any(|resident| resident.projection().member.membership() == member.membership())
+        self.with_observation_gate(|_| {
+            self.current_children()
+                .iter()
+                .any(|resident| resident.projection().member.membership() == member.membership())
+        })
     }
 
     fn current_children(&self) -> MutexGuard<'_, Vec<ResidentChild>> {
@@ -1262,19 +1221,35 @@ impl ScopeCell {
     /// Admits one projection, or refuses it whole.
     ///
     /// Returns whether the member's `Admitted` transition was legal. A refusal
-    /// publishes nothing: no gate handoff, no parent wiring, no residency push
-    /// and no `Added` event.
+    /// publishes nothing: no gate handoff, no parent wiring, no retained
+    /// residency and no `Added` event.
     #[must_use = "a refused admission leaves the child out of the residency"]
     pub fn admit_child_locked(
         self: &Arc<Self>,
         child: ResidentProjection,
         txn: &mut ObservationTxn<'_>,
     ) -> bool {
-        // Take protected ownership before gate adoption, parent wiring, and
-        // reducer validation. Until the final push succeeds this projection
-        // may be the last owner of a mailbox-bearing member.
-        let child = ResidentAdmission::new(child, txn);
-        let projection = child.projection();
+        // Residency takes ownership before every fallible step below. A panic
+        // can therefore leave this entry half-wired, but it cannot unwind the
+        // last owner of a mailbox-bearing member through the observation gate;
+        // scope teardown later routes the resident through detached disposal.
+        //
+        // Every reader of `current_children` is accounted for during this
+        // window. Snapshot construction, descendant handoff, terminal lookup,
+        // pruning and clearing already run under this observation gate. The
+        // public shutdown projection and driver terminality membership probe
+        // (`resident_projections` / `has_resident_child`) take the same gate
+        // themselves. The admission-local clone below is consequently the
+        // only code that can observe this entry before its transition lands.
+        let projection = {
+            let mut children = self.current_children();
+            children.push(ResidentChild::new(child));
+            children
+                .last()
+                .expect("the just-pushed resident remains installed")
+                .projection()
+                .clone()
+        };
         let gate = self.current_observation_gate();
         let admitted = if let Some(scope) = &projection.scope {
             let admitted = scope.admit_observation_gate(self, &gate, txn);
@@ -1308,13 +1283,30 @@ impl ScopeCell {
             )
         };
         if !admitted {
+            // No other residency mutation can interleave under the gate, so
+            // the entry pushed above is still the last one. Refusal removes
+            // it without emitting either half of the Added/Removed pair and
+            // retires its potentially last mailbox owner after unlock.
+            let rejected = self.current_children().pop();
+            if let Some(rejected) = &rejected {
+                debug_assert_eq!(
+                    rejected.projection().member.membership(),
+                    projection.member.membership(),
+                    "refusal removes the admission-local resident"
+                );
+            }
+            // Move both the resident and this function's lookup clone into
+            // the effect. The `None` arm is unreachable after the push, but
+            // even an invariant break cannot make the clone's last user value
+            // unwind through the observation gate.
+            txn.defer(move || runtime::dispose_detached((projection, rejected)));
             return false;
         }
         let id = projection.member.id().clone();
         let membership = projection.member.membership();
-        drop(projection);
-        self.current_children()
-            .push(ResidentChild::new(child.install()));
+        // This transition must precede `emit_locked`: the Added publication
+        // schedules the commit-time snapshot, and that producer now walks the
+        // resident installed above.
         self.emit_locked(txn, LifecycleEventKind::Added { id, membership });
         true
     }
@@ -1845,6 +1837,70 @@ mod tests {
                 .expect("mailbox payload disposal reports"),
             retiring_thread,
             "the by-value projection cannot unwind its mailbox through the observation gate"
+        );
+    }
+
+    #[test]
+    fn panicked_resident_admission_lingers_until_scope_clear() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let nested = child_scope(&root, "nested", ScopeFlavor::Dynamic);
+        let mut incarnations = nested.member.take_incarnation_counter();
+        let incarnation = incarnations.mint().expect("incarnation available");
+        let mailbox = MailboxCell::new(
+            nested.member.id().clone(),
+            shelterwood_runtime::mailbox_runtime(),
+        );
+        nested.member.attach_mailbox(mailbox.clone());
+        let actor = actor_ref_from_parts(Arc::clone(&nested.member), Arc::clone(&mailbox));
+        let mut effects = MailboxEffectQueue::default();
+        let token = MailboxControl::configure(&*mailbox, ResolvedMailbox::Latest, &mut effects);
+        MailboxControl::bind(&*mailbox, token, incarnation, &mut effects);
+        drop(effects);
+        let (dropped, observed) = mpsc::sync_channel(1);
+        actor
+            .try_send(ThreadProbe(dropped))
+            .expect("bound mailbox accepts the probe");
+
+        let poisoned = Arc::clone(&nested);
+        assert!(
+            catch_unwind(AssertUnwindSafe(move || {
+                let _control = poisoned.control.lock().expect("control starts healthy");
+                panic!("inject admission bookkeeping panic");
+            }))
+            .is_err(),
+            "the fixture poisons the post-transition parent-wiring step"
+        );
+
+        let membership = nested.member.membership();
+        let projection = ResidentProjection::new(Arc::clone(&nested.member), Some(nested));
+        drop(actor);
+        drop(mailbox);
+        let retiring_thread = std::thread::current().id();
+        catch_unwind(AssertUnwindSafe(|| root.admit_child(projection)))
+            .expect_err("poisoned parent wiring unwinds admission");
+
+        let residents = root.resident_projections();
+        assert_eq!(residents.len(), 1, "the half-wired resident remains owned");
+        assert_eq!(residents[0].member.membership(), membership);
+        assert!(matches!(
+            residents[0].member.record().stage,
+            MemberStage::Admitted
+        ));
+        drop(residents);
+        assert_eq!(
+            observed.try_recv(),
+            Err(mpsc::TryRecvError::Empty),
+            "admission unwind does not destroy the resident mailbox"
+        );
+
+        root.clear_residents();
+        assert!(root.resident_projections().is_empty());
+        assert_ne!(
+            observed
+                .recv_timeout(TEST_WAIT)
+                .expect("scope clear disposes the lingering mailbox payload"),
+            retiring_thread,
+            "scope clear retains the detached disposal venue"
         );
     }
 

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -73,12 +73,22 @@ impl ResidentProjection {
 struct ResidentChild {
     /// `None` only while [`Drop`] is destroying the projection.
     projection: Option<ResidentProjection>,
+    /// Whether this scope published this resident's `Added` edge.
+    ///
+    /// Admission owns the residency slot across its fallible steps, so an
+    /// unwind can leave a resident installed that was never announced. SPEC
+    /// §3.2's pairing is exact — both edges or neither — so a withdrawal
+    /// mirrors this flag rather than emitting `Removed` unconditionally, and
+    /// the snapshot producer leaves an unannounced resident out of the
+    /// observed child set for the same reason.
+    announced: bool,
 }
 
 impl ResidentChild {
     fn new(projection: ResidentProjection) -> Self {
         Self {
             projection: Some(projection),
+            announced: false,
         }
     }
 
@@ -814,17 +824,24 @@ impl ScopeCell {
             return false;
         };
         debug_assert_eq!(resident.projection().member.membership(), membership);
-        let event = LifecycleEventKind::Removed {
-            id: resident.projection().member.id().clone(),
-            membership,
-            last_incarnation: resident.projection().member.record().last_incarnation,
-        };
+        // Mirror the announcement: a resident an unwound admission installed
+        // never published `Added`, and SPEC §3.2's pairing is both edges or
+        // neither. It is still withdrawn and disposed.
+        let event = resident
+            .announced
+            .then(|| LifecycleEventKind::Removed {
+                id: resident.projection().member.id().clone(),
+                membership,
+                last_incarnation: resident.projection().member.record().last_incarnation,
+            });
         // The projection can carry the last member/mailbox owner. Put it in
         // the transaction before the fallible publication path so unwind also
         // retires it only after the observation gate is released. The detached
         // handoff deliberately makes final member teardown asynchronous.
         txn.defer(move || runtime::dispose_detached(resident));
-        self.emit_locked(txn, event);
+        if let Some(event) = event {
+            self.emit_locked(txn, event);
+        }
         true
     }
 
@@ -1223,6 +1240,14 @@ impl ScopeCell {
     /// Returns whether the member's `Admitted` transition was legal. A refusal
     /// publishes nothing: no gate handoff, no parent wiring, no retained
     /// residency and no `Added` event.
+    ///
+    /// A *panic* between the residency push and the `Added` publication is
+    /// different: residency keeps the resident so its possibly-last mailbox
+    /// owner retires through detached disposal at scope clear rather than
+    /// unwinding under the gate. Such a resident stays `announced == false`,
+    /// which keeps it out of the observed child set and out of the `Removed`
+    /// edge its withdrawal would otherwise publish — SPEC §3.2's pairing is
+    /// both edges or neither.
     #[must_use = "a refused admission leaves the child out of the residency"]
     pub fn admit_child_locked(
         self: &Arc<Self>,
@@ -1241,15 +1266,11 @@ impl ScopeCell {
         // (`resident_projections` / `has_resident_child`) take the same gate
         // themselves. The admission-local clone below is consequently the
         // only code that can observe this entry before its transition lands.
-        let projection = {
-            let mut children = self.current_children();
-            children.push(ResidentChild::new(child));
-            children
-                .last()
-                .expect("the just-pushed resident remains installed")
-                .projection()
-                .clone()
-        };
+        // Publication readers additionally skip an unannounced entry, which is
+        // what makes a lingering half-wired resident invisible rather than a
+        // membership with only half its edges.
+        let projection = child.clone();
+        self.current_children().push(ResidentChild::new(child));
         let gate = self.current_observation_gate();
         let admitted = if let Some(scope) = &projection.scope {
             let admitted = scope.admit_observation_gate(self, &gate, txn);
@@ -1304,9 +1325,12 @@ impl ScopeCell {
         }
         let id = projection.member.id().clone();
         let membership = projection.member.membership();
-        // This transition must precede `emit_locked`: the Added publication
-        // schedules the commit-time snapshot, and that producer now walks the
-        // resident installed above.
+        // Mark the resident announced before `emit_locked`: the Added
+        // publication schedules the commit-time snapshot, and that producer
+        // walks residency and skips whatever is still unannounced.
+        if let Some(resident) = self.current_children().last_mut() {
+            resident.announced = true;
+        }
         self.emit_locked(txn, LifecycleEventKind::Added { id, membership });
         true
     }
@@ -1320,8 +1344,13 @@ impl ScopeCell {
             let mut children = self.current_children();
             std::mem::take(&mut *children)
         };
+        // An unannounced resident is one an admission installed and then
+        // unwound past. It never published `Added`, so SPEC §3.2's exact
+        // pairing forbids publishing its `Removed`; it is still displaced and
+        // disposed with the rest of the set.
         let removals = residents
             .iter()
+            .filter(|resident| resident.announced)
             .map(|resident| LifecycleEventKind::Removed {
                 id: resident.projection().member.id().clone(),
                 membership: resident.projection().member.membership(),
@@ -1904,23 +1933,18 @@ mod tests {
             Err(LifecycleTryRecvError::Empty),
             "the panic precedes Added publication"
         );
+        assert!(
+            root.snapshot().children.is_empty(),
+            "an unannounced resident is owned residency, not an observed child"
+        );
 
         root.clear_residents();
         assert!(root.resident_projections().is_empty());
-        let removed = lifecycle
-            .try_recv()
-            .expect("clearing a half-wired resident emits its removal edge");
-        let LifecycleItem::Event(removed) = removed else {
-            panic!("scope clear publishes a lifecycle event")
-        };
-        assert!(matches!(
-            removed.kind,
-            LifecycleEventKind::Removed {
-                membership: removed_membership,
-                ..
-            } if removed_membership == membership
-        ));
-        assert_eq!(lifecycle.try_recv(), Err(LifecycleTryRecvError::Empty));
+        assert_eq!(
+            lifecycle.try_recv(),
+            Err(LifecycleTryRecvError::Empty),
+            "an unannounced resident publishes no Removed: SPEC §3.2 pairs both edges or neither"
+        );
         assert_ne!(
             observed
                 .recv_timeout(TEST_WAIT)

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -1288,18 +1288,18 @@ impl ScopeCell {
             // it without emitting either half of the Added/Removed pair and
             // retires its potentially last mailbox owner after unlock.
             let rejected = self.current_children().pop();
-            if let Some(rejected) = &rejected {
-                debug_assert_eq!(
-                    rejected.projection().member.membership(),
-                    projection.member.membership(),
-                    "refusal removes the admission-local resident"
-                );
-            }
+            let rejected_is_admission = rejected.as_ref().is_some_and(|rejected| {
+                rejected.projection().member.membership() == projection.member.membership()
+            });
             // Move both the resident and this function's lookup clone into
-            // the effect. The `None` arm is unreachable after the push, but
-            // even an invariant break cannot make the clone's last user value
-            // unwind through the observation gate.
+            // the effect before diagnosing the structural pop-last
+            // invariant. If that diagnostic ever fires, neither possibly-last
+            // mailbox owner may unwind through the observation gate.
             txn.defer(move || runtime::dispose_detached((projection, rejected)));
+            debug_assert!(
+                rejected_is_admission,
+                "refusal removes the admission-local resident"
+            );
             return false;
         }
         let id = projection.member.id().clone();
@@ -1800,6 +1800,7 @@ mod tests {
     #[test]
     fn rejected_resident_admission_detaches_its_last_mailbox_owner() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let mut lifecycle = root.subscribe_lifecycle();
         let member = child_member(&root, "invalid");
         let mut incarnations = member.take_incarnation_counter();
         let incarnation = incarnations.mint().expect("incarnation available");
@@ -1830,6 +1831,11 @@ mod tests {
             root.resident_projections().is_empty(),
             "a rejected admission publishes no residency"
         );
+        assert_eq!(
+            lifecycle.try_recv(),
+            Err(LifecycleTryRecvError::Empty),
+            "ordinary refusal emits neither Added nor Removed"
+        );
 
         assert_ne!(
             observed
@@ -1843,6 +1849,7 @@ mod tests {
     #[test]
     fn panicked_resident_admission_lingers_until_scope_clear() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let mut lifecycle = root.subscribe_lifecycle();
         let nested = child_scope(&root, "nested", ScopeFlavor::Dynamic);
         let mut incarnations = nested.member.take_incarnation_counter();
         let incarnation = incarnations.mint().expect("incarnation available");
@@ -1892,9 +1899,28 @@ mod tests {
             Err(mpsc::TryRecvError::Empty),
             "admission unwind does not destroy the resident mailbox"
         );
+        assert_eq!(
+            lifecycle.try_recv(),
+            Err(LifecycleTryRecvError::Empty),
+            "the panic precedes Added publication"
+        );
 
         root.clear_residents();
         assert!(root.resident_projections().is_empty());
+        let removed = lifecycle
+            .try_recv()
+            .expect("clearing a half-wired resident emits its removal edge");
+        let LifecycleItem::Event(removed) = removed else {
+            panic!("scope clear publishes a lifecycle event")
+        };
+        assert!(matches!(
+            removed.kind,
+            LifecycleEventKind::Removed {
+                membership: removed_membership,
+                ..
+            } if removed_membership == membership
+        ));
+        assert_eq!(lifecycle.try_recv(), Err(LifecycleTryRecvError::Empty));
         assert_ne!(
             observed
                 .recv_timeout(TEST_WAIT)
@@ -2046,6 +2072,95 @@ mod tests {
         );
         assert!(root.has_resident_child(&nested.member));
         assert_eq!(captures.try_recv(), Err(mpsc::TryRecvError::Empty));
+    }
+
+    #[test]
+    fn resident_readers_wait_out_a_half_wired_admission() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
+        let root_captures = root.probe_gate_captures();
+        let nested_captures = nested.probe_gate_captures();
+        let prior_gate = nested.observation_gate();
+        let held = prior_gate.lock();
+        let adopting_root = Arc::clone(&root);
+        let adopting_nested = Arc::clone(&nested);
+        let adoption = std::thread::spawn(move || {
+            assert!(adopting_root.admit_child(ResidentProjection::new(
+                Arc::clone(&adopting_nested.member),
+                Some(adopting_nested),
+            )));
+        });
+
+        assert_eq!(
+            root_captures
+                .recv_timeout(TEST_WAIT)
+                .expect("admission captures the parent gate"),
+            GateCapture::Observation
+        );
+        assert_eq!(
+            nested_captures
+                .recv_timeout(TEST_WAIT)
+                .expect("admission reaches the child handoff after its residency push"),
+            GateCapture::Adoption
+        );
+        assert!(matches!(
+            nested.member.record().stage,
+            MemberStage::Reserved
+        ));
+
+        let projecting_root = Arc::clone(&root);
+        let (projected, projected_receiver) = mpsc::sync_channel(1);
+        let projection_reader = std::thread::spawn(move || {
+            let residents = projecting_root.resident_projections();
+            projected
+                .send((residents.len(), residents[0].member.record().stage.clone()))
+                .expect("projection observation remains available");
+        });
+        let checking_root = Arc::clone(&root);
+        let checking_member = Arc::clone(&nested.member);
+        let (checked, checked_receiver) = mpsc::sync_channel(1);
+        let membership_reader = std::thread::spawn(move || {
+            checked
+                .send((
+                    checking_root.has_resident_child(&checking_member),
+                    checking_member.record().stage,
+                ))
+                .expect("membership observation remains available");
+        });
+        for _ in 0..2 {
+            assert_eq!(
+                root_captures
+                    .recv_timeout(TEST_WAIT)
+                    .expect("each resident reader captures the parent gate"),
+                GateCapture::Observation
+            );
+        }
+        assert_eq!(
+            projected_receiver.try_recv(),
+            Err(mpsc::TryRecvError::Empty)
+        );
+        assert_eq!(checked_receiver.try_recv(), Err(mpsc::TryRecvError::Empty));
+
+        drop(held);
+        adoption.join().expect("admission completes after handoff");
+        assert!(matches!(
+            projected_receiver
+                .recv_timeout(TEST_WAIT)
+                .expect("projection reader completes after admission"),
+            (1, MemberStage::Admitted)
+        ));
+        assert!(matches!(
+            checked_receiver
+                .recv_timeout(TEST_WAIT)
+                .expect("membership reader completes after admission"),
+            (true, MemberStage::Admitted)
+        ));
+        projection_reader
+            .join()
+            .expect("projection reader completes without panic");
+        membership_reader
+            .join()
+            .expect("membership reader completes without panic");
     }
 
     #[test]

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -834,13 +834,11 @@ impl ScopeCell {
         // Mirror the announcement: a resident an unwound admission installed
         // never published `Added`, and SPEC §3.2's pairing is both edges or
         // neither. It is still withdrawn and disposed.
-        let event = resident
-            .announced
-            .then(|| LifecycleEventKind::Removed {
-                id: resident.projection().member.id().clone(),
-                membership,
-                last_incarnation: resident.projection().member.record().last_incarnation,
-            });
+        let event = resident.announced.then(|| LifecycleEventKind::Removed {
+            id: resident.projection().member.id().clone(),
+            membership,
+            last_incarnation: resident.projection().member.record().last_incarnation,
+        });
         // The projection can carry the last member/mailbox owner. Put it in
         // the transaction before the fallible publication path so unwind also
         // retires it only after the observation gate is released. The detached
@@ -1334,7 +1332,9 @@ impl ScopeCell {
         let membership = projection.member.membership();
         // Mark the resident announced before `emit_locked`: the Added
         // publication schedules the commit-time snapshot, and that producer
-        // walks residency and skips whatever is still unannounced.
+        // walks residency and skips whatever is still unannounced. This rests
+        // on the same "no residency mutation interleaves under the gate"
+        // invariant as the refusal pop above, which is where it is diagnosed.
         if let Some(resident) = self.current_children().last_mut() {
             resident.announced = true;
         }
@@ -1971,10 +1971,7 @@ mod tests {
 
         // Install residency exactly as an admission that unwound before its
         // `Added` publication leaves it.
-        root.push_unannounced_resident_for_test(ResidentProjection::new(
-            Arc::clone(&member),
-            None,
-        ));
+        root.push_unannounced_resident_for_test(ResidentProjection::new(Arc::clone(&member), None));
         assert_eq!(root.resident_projections().len(), 1);
         assert!(root.snapshot().children.is_empty());
 

--- a/crates/shelterwood-cells/src/cells/scope/projection.rs
+++ b/crates/shelterwood-cells/src/cells/scope/projection.rs
@@ -119,7 +119,13 @@ impl ScopeCell {
         let mut projected = Vec::with_capacity(children.len());
         let mut retained_exits = Vec::new();
         RetainedExit::retain_scope_state(&mut retained_exits, &record.state);
-        for resident in children.iter() {
+        // An admission that unwound past its residency push leaves a resident
+        // whose `Added` was never published. SPEC §3.2 keeps such a membership
+        // out of `children` / `child(id)` / `descendant(path)` exactly as it
+        // keeps it out of the event stream, so the cut skips it. Gate rehoming,
+        // terminality lookup and straggler collection still see it: it is
+        // owned residency, just not yet public.
+        for resident in children.iter().filter(|resident| resident.announced) {
             let (child, exits) = self.child_snapshot_locked(resident.projection());
             projected.push(child);
             for exit in exits {


### PR DESCRIPTION
## Summary

- push ResidentChild into residency before gate adoption, parent wiring, and the Admitted transition
- remove the Rc<RefCell<Option<ResidentProjection>>> admission guard and allocation
- remove and defer ordinary refusals without Added/Removed edges, while retaining panic-path residents until scope clear
- put cross-crate residency lookups behind the observation gate and enumerate all current_children readers during the half-wired window
- keep MemberTransition::Admitted ahead of Added and its commit-time snapshot

## Review follow-ups

Residency now owns the projection across admission's fallible steps, so a panic
before the `Added` publication leaves a resident installed. Emitting its `Removed`
at scope clear publishes half of SPEC §3.2's exact pair, and projecting it puts a
membership in `children` that no event announced.

- `ResidentChild::announced`, set immediately before `emit_locked(Added)`
- both withdrawal sites (`clear_residents_locked`, `prune_child_locked`) mirror the
  flag; the resident is still displaced and disposed either way
- the snapshot producer skips what is not yet public, per §3.2's "appears in no
  snapshot" consequence. Gate rehoming, terminality lookup and straggler collection
  keep seeing it: it is owned residency, just not observed membership
- drop the post-push `last().expect()` re-read in favour of cloning the projection
  before the move, removing a panic site held under both the observation gate and
  the residency mutex
- AGENTS.md described the deleted `ResidentAdmission` guard; it now describes the
  residency-owned shape

## Verification

- ./tools/dev cargo +nightly fmt --all -- --check
- ./tools/dev cargo nextest run -p shelterwood-cells -p shelterwood (642/642)
- focused admission panic, refusal, nested rejection, and residency cleanup tests
- mutation checks: dropping either withdrawal filter or the snapshot filter fails
  `panicked_resident_admission_lingers_until_scope_clear` /
  `pruning_an_unannounced_resident_publishes_no_removal_edge`
- git diff --check

Closes #390.