### PR TITLE
Isolate timer waker retirement behind proxy

### DIFF
--- a/crates/shelterwood-mailbox/src/capability.rs
+++ b/crates/shelterwood-mailbox/src/capability.rs
@@ -205,6 +205,13 @@ impl<T> Drop for DisposingReceiver<T> {
             .expect("a live disposing receiver retains its channel");
         let mut value = None;
         let mut panics = crate::panic::PanicAccumulator::default();
+        // Tokio's one-shot close is atomics-only, so cancellation never
+        // required the timer path's blocking-disposal venue. The old ruling
+        // that this justified leaving the one-shot registration unproxied is
+        // nevertheless superseded by #398: reply polling registers a proxy
+        // uniformly because delivery, not cancellation, is the abort-class
+        // seam. Cancellation inherits that containment without retaining a
+        // special raw-waker path of its own.
         // Recovery runs first so an unclaimed value reaches isolated disposal
         // before the receiver -- and therefore before the waker clone it
         // registered -- is retired; a hostile waker destructor can neither

--- a/crates/shelterwood-mailbox/src/cell/waker_slot.rs
+++ b/crates/shelterwood-mailbox/src/cell/waker_slot.rs
@@ -59,7 +59,7 @@ impl WakerEffects {
         });
     }
 
-    pub(super) fn flush(&mut self, panics: &mut PanicAccumulator) {
+    pub(crate) fn flush(&mut self, panics: &mut PanicAccumulator) {
         for effect in self.0.drain(..) {
             match effect {
                 WakerEffect::Wake(waker) => panics.run(|| waker.wake()),

--- a/crates/shelterwood-mailbox/src/deadline.rs
+++ b/crates/shelterwood-mailbox/src/deadline.rs
@@ -2,12 +2,17 @@ use std::{
     future::Future,
     pin::Pin,
     sync::Arc,
-    task::{Context, Poll},
+    task::{Context, Poll, Waker},
 };
 
 use shelterwood_core::DeadlineBudget;
 
-use crate::{BoxedSleep, MailboxRuntime};
+use crate::{
+    BoxedSleep, MailboxRuntime,
+    cell::waker_slot::{WakerAction, WakerEffects},
+    panic::PanicAccumulator,
+    waker_proxy::WakerProxy,
+};
 
 pub(crate) use shelterwood_core::deadline::Deadline;
 
@@ -59,6 +64,7 @@ pub(super) struct Deadlined<F> {
     budget_width: DeadlineBudget,
     budget: Option<crate::deadline::Deadline>,
     timer: Option<BoxedSleep>,
+    timer_waker: Option<WakerProxy>,
     pub(super) started: bool,
     phase: DeadlinePhase,
 }
@@ -77,9 +83,64 @@ impl<F> Deadlined<F> {
             budget_width: budget_width.into(),
             budget: None,
             timer: None,
+            timer_waker: None,
             started: false,
             phase: DeadlinePhase::InitialAttempt,
         }
+    }
+
+    /// Polls the timer with a stable framework-owned waker.
+    ///
+    /// The first probe uses the static no-op waker. An already-ready timer
+    /// therefore allocates nothing; only a timer that actually parks gets a
+    /// proxy and a clone of the caller waker. A completion racing the probe is
+    /// observed by the immediate second poll, so the no-op registration
+    /// cannot lose a wake.
+    fn poll_timer(&mut self, context: &mut Context<'_>) -> Poll<()> {
+        if self.timer_waker.is_none() {
+            let mut probe = Context::from_waker(Waker::noop());
+            if self
+                .timer
+                .as_mut()
+                .expect("an unelapsed deadline future retains its timer")
+                .as_mut()
+                .poll(&mut probe)
+                .is_ready()
+            {
+                return Poll::Ready(());
+            }
+            self.timer_waker = Some(WakerProxy::new());
+        }
+
+        let timer_waker = self
+            .timer_waker
+            .as_ref()
+            .expect("a parked timer retains its waker proxy");
+        timer_waker.register(context.waker());
+        let mut proxy_context = Context::from_waker(timer_waker.waker());
+        self.timer
+            .as_mut()
+            .expect("an unelapsed deadline future retains its timer")
+            .as_mut()
+            .poll(&mut proxy_context)
+    }
+
+    /// Retires the caller waker through the blocking disposal lane, then
+    /// synchronously removes the framework-only wheel registration.
+    fn retire_timer(&mut self, panics: &mut PanicAccumulator) {
+        let mut effects = WakerEffects::default();
+        if let Some(timer_waker) = &self.timer_waker {
+            timer_waker.retire(
+                WakerAction::Dispose(Arc::clone(&self.runtime)),
+                &mut effects,
+            );
+        }
+        effects.flush(panics);
+
+        let timer = self.timer.take();
+        panics.run(|| drop(timer));
+        let timer_waker = self.timer_waker.take();
+        panics.run(|| drop(timer_waker));
     }
 }
 
@@ -119,34 +180,26 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             // entry armed until a worker thread reaches it, which is the
             // spurious wake this exists to prevent.
             //
-            // A `RawWaker` vtable is caller code, and `result` -- which may
-            // own a user value -- is a live local across that destructor. A
-            // resuming boundary would destroy the completed output instead of
-            // returning it, and a hostile output destructor would turn that
-            // into a double panic and a process abort, so the panic is
-            // contained rather than resumed: a delivered result outranks a
-            // waker-cleanup diagnostic. This is the precedence
-            // `CatchUnwindFuture`'s completed-output arm already applies.
-            let timer = this.timer.take();
-            crate::panic::discard_panic(crate::panic::catch_panic(|| drop(timer)).err());
+            // Tokio now destroys only a framework-owned proxy under the time
+            // driver mutex. The caller waker may block, so move it to the
+            // disposal lane before synchronously removing the wheel entry.
+            // `result` may own a user value, so a failure to submit cleanup
+            // remains subordinate to returning the completed output.
+            let mut panics = PanicAccumulator::default();
+            this.retire_timer(&mut panics);
+            crate::panic::discard_panic(panics.take());
             return Poll::Ready(result);
         }
         if this.phase == DeadlinePhase::InitialAttempt {
-            if this
-                .timer
-                .as_mut()
-                .expect("an unelapsed deadline future retains its timer")
-                .as_mut()
-                .poll(context)
-                .is_pending()
-            {
+            if this.poll_timer(context).is_pending() {
                 return Poll::Pending;
             }
             // The timer is a one-shot future: polling it again after it
             // resolves panics. Latch the transition and release it, so an
             // elapsed poll that stays pending re-polls only the operation.
             this.phase = DeadlinePhase::TimeoutArbitration;
-            this.timer = None;
+            let mut panics = PanicAccumulator::default();
+            this.retire_timer(&mut panics);
         }
         this.operation
             .poll_deadlined(context, budget, DeadlinePhase::TimeoutArbitration)
@@ -156,16 +209,15 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
 impl<F> Drop for Deadlined<F> {
     /// Retires an unelapsed timer inside a boundary.
     ///
-    /// Cancelling an armed timer destroys the clone of the caller's waker it
-    /// registered, and a `RawWaker` vtable is caller code. There is no caller
-    /// left to surface a panic to here, and during an existing unwind a bare
-    /// destructor panic is a double panic and a process abort, so the
-    /// retirement runs through an accumulator: it resumes on an ordinary drop
-    /// and is contained while another unwind is already in progress.
+    /// Tokio's wheel holds only a framework-owned proxy. The real caller
+    /// waker retires through the blocking disposal lane before the wheel entry
+    /// is synchronously cancelled, so its destructor can neither hold the
+    /// global time-driver mutex nor run in this drop glue. The accumulator
+    /// still protects capability submission and framework retirement during
+    /// an existing unwind.
     fn drop(&mut self) {
-        let timer = self.timer.take();
-        let mut panics = crate::panic::PanicAccumulator::default();
-        panics.run(|| drop(timer));
+        let mut panics = PanicAccumulator::default();
+        self.retire_timer(&mut panics);
     }
 }
 
@@ -193,6 +245,23 @@ mod tests {
     #[derive(Default)]
     struct ReadyAfterParking {
         polls: usize,
+    }
+
+    struct ImmediatelyReady;
+
+    impl super::DeadlineOperation for ImmediatelyReady {
+        type Output = ();
+
+        fn poll_deadlined(
+            &mut self,
+            _context: &mut Context<'_>,
+            _budget: crate::deadline::Deadline,
+            _phase: super::DeadlinePhase,
+        ) -> Poll<()> {
+            Poll::Ready(())
+        }
+
+        fn short_circuit(&mut self) {}
     }
 
     impl super::DeadlineOperation for ReadyAfterParking {
@@ -305,6 +374,20 @@ mod tests {
             woken_before,
             "a completed but retained deadline future must not wake its caller when the deadline elapses"
         );
+    }
+
+    #[crate::runtime::test(start_paused = true)]
+    async fn an_immediately_ready_operation_never_allocates_a_timer_proxy() {
+        let mut future = Box::pin(super::Deadlined::no_attempt(
+            ImmediatelyReady,
+            std::time::Duration::from_secs(1),
+            crate::capability::tests::runtime(),
+        ));
+        let mut context = Context::from_waker(Waker::noop());
+
+        assert!(future.timer_waker.is_none());
+        assert!(future.as_mut().poll(&mut context).is_ready());
+        assert!(future.timer_waker.is_none());
     }
 
     #[test]

--- a/crates/shelterwood-mailbox/src/deadline.rs
+++ b/crates/shelterwood-mailbox/src/deadline.rs
@@ -96,7 +96,26 @@ impl<F> Deadlined<F> {
     /// proxy and a clone of the caller waker. A completion racing the probe is
     /// observed by the immediate second poll, so the no-op registration
     /// cannot lose a wake.
+    ///
+    /// An unbounded deadline never reaches either step: it is answered from
+    /// the captured budget alone, so it registers nothing to retire.
     fn poll_timer(&mut self, context: &mut Context<'_>) -> Poll<()> {
+        if self
+            .budget
+            .expect("a started deadline future retains its captured budget")
+            .instant()
+            .is_none()
+        {
+            // An unrepresentable deadline never arrives, and the capability
+            // answers it with `std::future::pending()` -- a future that
+            // resolves for nobody and wakes nobody. Registering a caller waker
+            // with it would allocate a proxy and dispatch the caller's `clone`
+            // vtable for a wake that cannot happen, and then dispatch its
+            // `drop` vtable again at retirement. This is the documented
+            // unbounded-wait idiom (`docs/observation.md`), not an edge case,
+            // so it stays as free as it was before the proxy.
+            return Poll::Pending;
+        }
         if self.timer_waker.is_none() {
             let mut probe = Context::from_waker(Waker::noop());
             if self
@@ -125,18 +144,55 @@ impl<F> Deadlined<F> {
             .poll(&mut proxy_context)
     }
 
+    /// Retires the caller waker on this thread, then synchronously removes the
+    /// framework-only wheel registration.
+    ///
+    /// This is the poll-path venue. Post-proxy, Tokio's wheel holds only a
+    /// framework-owned proxy, so no caller waker is ever destroyed under the
+    /// global time-driver mutex on *any* path; the only question left is who
+    /// absorbs a hostile destructor. On a poll path that is the caller's own
+    /// task, which is the trade #398 ruling 3 already accepted for the reply
+    /// delivery seam: retirement here is per-completion hot-path work, and a
+    /// lane submission on every completed `send_timeout`/`call`/`recv` is real
+    /// cost where a contained drop of a benign waker is nearly free. Only drop
+    /// glue -- where the absorbing party is whatever is tearing the future down
+    /// -- keeps the lane, in [`Self::retire_timer_disposing`].
+    fn retire_timer_inline(&mut self, panics: &mut PanicAccumulator) {
+        self.retire_timer(WakerAction::DropInline, panics);
+    }
+
     /// Retires the caller waker through the blocking disposal lane, then
     /// synchronously removes the framework-only wheel registration.
-    fn retire_timer(&mut self, panics: &mut PanicAccumulator) {
+    ///
+    /// The cancel venue, per #398 ruling 3. Drop glue runs on whatever thread
+    /// is discarding the future -- during an unwind, inside another future's
+    /// teardown, or on a runtime worker -- and has no result to trade the
+    /// diagnostic against, so a destructor that blocks goes to the lane rather
+    /// than stalling that thread.
+    fn retire_timer_disposing(&mut self, panics: &mut PanicAccumulator) {
+        self.retire_timer(WakerAction::Dispose(Arc::clone(&self.runtime)), panics);
+    }
+
+    fn retire_timer(&mut self, action: WakerAction, panics: &mut PanicAccumulator) {
         let mut effects = WakerEffects::default();
-        if let Some(timer_waker) = &self.timer_waker {
-            timer_waker.retire(
-                WakerAction::Dispose(Arc::clone(&self.runtime)),
-                &mut effects,
-            );
-        }
+        let timer_waker = self.timer_waker.as_ref();
+        // Inside the boundary rather than beside it. The proxy mutex guards
+        // framework-owned data only and is documented unpoisonable, so nothing
+        // here is expected to unwind -- but this runs from drop glue too, and
+        // a cleanup step that escapes an accumulator during an unwind is the
+        // double panic the accumulator exists to prevent. Cheaper to contain
+        // than to make every reader re-derive the proof.
+        panics.run(|| {
+            if let Some(timer_waker) = timer_waker {
+                timer_waker.retire(action, &mut effects);
+            }
+        });
         effects.flush(panics);
 
+        // Slot first, timer second: emptying the proxy before the wheel entry
+        // goes means the entry cannot deliver a wake to a caller that already
+        // has its answer, and dropping the timer synchronously means the entry
+        // is gone when this returns rather than whenever a worker reaches it.
         let timer = self.timer.take();
         panics.run(|| drop(timer));
         let timer_waker = self.timer_waker.take();
@@ -181,12 +237,20 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             // spurious wake this exists to prevent.
             //
             // Tokio now destroys only a framework-owned proxy under the time
-            // driver mutex. The caller waker may block, so move it to the
-            // disposal lane before synchronously removing the wheel entry.
-            // `result` may own a user value, so a failure to submit cleanup
-            // remains subordinate to returning the completed output.
+            // driver mutex, so the stored caller waker retires here, on this
+            // task, rather than through the disposal lane -- the poll-path
+            // venue of #398 ruling 3. See `retire_timer_inline`.
+            //
+            // `result` may own a user value. The retirement is therefore fully
+            // drained *before* the handoff: the accumulator is emptied by
+            // `take` and its payload discarded, so nothing can unwind out of
+            // this frame while it owns the completed output. An escaping
+            // cleanup panic would destroy that value mid-unwind and -- with a
+            // hostile value destructor -- abort the process. The swallowed
+            // diagnostic is the accepted cost, exactly as at the reply
+            // delivery seam.
             let mut panics = PanicAccumulator::default();
-            this.retire_timer(&mut panics);
+            this.retire_timer_inline(&mut panics);
             crate::panic::discard_panic(panics.take());
             return Poll::Ready(result);
         }
@@ -198,8 +262,16 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             // resolves panics. Latch the transition and release it, so an
             // elapsed poll that stays pending re-polls only the operation.
             this.phase = DeadlinePhase::TimeoutArbitration;
+            // The same poll-path venue and the same containment. Contained
+            // rather than re-raised because the arbitration poll immediately
+            // below can hand back a value that landed at the boundary: letting
+            // a caller-waker destructor unwind out of `poll` would tear the
+            // whole future down inside that unwind -- operation state, an
+            // unsent user message and all -- which is the double-panic abort
+            // this seam exists to remove.
             let mut panics = PanicAccumulator::default();
-            this.retire_timer(&mut panics);
+            this.retire_timer_inline(&mut panics);
+            crate::panic::discard_panic(panics.take());
         }
         this.operation
             .poll_deadlined(context, budget, DeadlinePhase::TimeoutArbitration)
@@ -215,9 +287,14 @@ impl<F> Drop for Deadlined<F> {
     /// global time-driver mutex nor run in this drop glue. The accumulator
     /// still protects capability submission and framework retirement during
     /// an existing unwind.
+    ///
+    /// This is the half of #398 ruling 3's venue split that keeps the lane:
+    /// cancellation has no result to weigh the diagnostic against and no task
+    /// of its own to stall, so a destructor that blocks is handed off rather
+    /// than run here.
     fn drop(&mut self) {
         let mut panics = PanicAccumulator::default();
-        self.retire_timer(&mut panics);
+        self.retire_timer_disposing(&mut panics);
     }
 }
 
@@ -225,11 +302,12 @@ impl<F> Drop for Deadlined<F> {
 mod tests {
     use std::{
         future::Future,
+        mem::ManuallyDrop,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
         },
-        task::{Context, Poll, Wake, Waker},
+        task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker},
     };
 
     /// Stays pending on its first elapsed poll, modelling an atomic
@@ -299,6 +377,51 @@ mod tests {
         }
     }
 
+    /// Counts the clones a poll takes of the caller's waker.
+    ///
+    /// A proxy allocation is not observable as a retained field: every path
+    /// that allocates one also retires it, emptying `timer_waker` again before
+    /// the poll returns. The artifact a lazy path must leave untouched is
+    /// therefore the caller's own `clone` vtable, which only
+    /// `WakerProxy::register` reaches.
+    #[derive(Default)]
+    struct CloneCounter(AtomicUsize);
+
+    unsafe fn clone_counting_waker(data: *const ()) -> RawWaker {
+        // SAFETY: every pointer using this vtable came from an Arc of the
+        // matching type. ManuallyDrop preserves the reference represented by
+        // `data`; the returned raw waker owns only the new clone.
+        let probe = ManuallyDrop::new(unsafe { Arc::<CloneCounter>::from_raw(data.cast()) });
+        probe.0.fetch_add(1, Ordering::SeqCst);
+        RawWaker::new(Arc::into_raw(Arc::clone(&probe)).cast(), &COUNTING_VTABLE)
+    }
+
+    unsafe fn wake_counting_waker(data: *const ()) {
+        // SAFETY: wake consumes the Arc reference represented by this waker.
+        drop(unsafe { Arc::<CloneCounter>::from_raw(data.cast()) });
+    }
+
+    unsafe fn wake_by_ref_counting_waker(_data: *const ()) {}
+
+    unsafe fn drop_counting_waker(data: *const ()) {
+        // SAFETY: drop consumes the Arc reference represented by this waker.
+        drop(unsafe { Arc::<CloneCounter>::from_raw(data.cast()) });
+    }
+
+    static COUNTING_VTABLE: RawWakerVTable = RawWakerVTable::new(
+        clone_counting_waker,
+        wake_counting_waker,
+        wake_by_ref_counting_waker,
+        drop_counting_waker,
+    );
+
+    fn counting_waker(counter: &Arc<CloneCounter>) -> Waker {
+        let raw = RawWaker::new(Arc::into_raw(Arc::clone(counter)).cast(), &COUNTING_VTABLE);
+        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+        // ownership across clone, wake, and drop.
+        unsafe { Waker::from_raw(raw) }
+    }
+
     impl super::DeadlineOperation for PendingOnFirstExpiry {
         type Output = usize;
 
@@ -365,6 +488,16 @@ mod tests {
         ));
         let woken_before = recorder.0.load(Ordering::SeqCst);
 
+        // The direct artifact, asserted first: retirement empties the proxy
+        // slot before it drops the timer, so a wheel entry left armed here
+        // would fire into an empty slot and stay invisible to the observation
+        // below. Only the dropped `Sleep` proves the entry is synchronously
+        // gone rather than merely harmless.
+        assert!(
+            future.timer.is_none(),
+            "completion must synchronously cancel the wheel entry, not merely silence it"
+        );
+
         crate::runtime::advance(width * 2).await;
 
         // The future is still held, so a timer left armed by completion would
@@ -388,6 +521,76 @@ mod tests {
         assert!(future.timer_waker.is_none());
         assert!(future.as_mut().poll(&mut context).is_ready());
         assert!(future.timer_waker.is_none());
+    }
+
+    /// The documented lazy path: a timer that is *already* elapsed when the
+    /// operation parks.
+    ///
+    /// The test above never enters `poll_timer` at all -- its operation is
+    /// ready on the first poll -- so the no-op probe it names goes untested
+    /// there. Reaching the probe needs an operation that stays pending beside
+    /// a timer that is ready, which is what dating the capability clock into
+    /// the past arranges: the budget is captured from that stale `now`, so the
+    /// deadline it derives is already behind the real clock and
+    /// `sleep_until` resolves on its first poll.
+    #[crate::runtime::test(start_paused = true)]
+    async fn an_already_elapsed_timer_never_clones_the_caller_waker() {
+        let stale = crate::runtime::now()
+            .checked_sub(std::time::Duration::from_secs(60))
+            .expect("the test clock is far enough past its origin to date a budget backwards");
+        let runtime =
+            Arc::new(crate::capability::tests::TestRuntime::new().with_now(move || stale));
+        let mut future = Box::pin(super::Deadlined::no_attempt(
+            PendingOnFirstExpiry::default(),
+            std::time::Duration::from_secs(1),
+            runtime,
+        ));
+        let counter = Arc::new(CloneCounter::default());
+        let waker = counting_waker(&counter);
+        let mut context = Context::from_waker(&waker);
+
+        // Pending because the operation withholds its first elapsed poll, not
+        // because the timer parked.
+        assert!(future.as_mut().poll(&mut context).is_pending());
+
+        assert_eq!(
+            counter.0.load(Ordering::SeqCst),
+            0,
+            "an already-ready timer is answered by the static no-op probe, so no proxy allocates and the caller's clone vtable is never dispatched"
+        );
+        assert!(
+            future.timer.is_none(),
+            "an elapsed timer is retired at once"
+        );
+    }
+
+    /// An unbounded deadline is `std::future::pending()`: it wakes nobody, so
+    /// registering with it would clone a caller waker for an event that cannot
+    /// happen. This is `docs/observation.md`'s unbounded-wait idiom, reached
+    /// by every `Duration::MAX` budget in the public API.
+    #[crate::runtime::test(start_paused = true)]
+    async fn an_unbounded_deadline_never_allocates_a_timer_proxy() {
+        let mut future = Box::pin(super::Deadlined::no_attempt(
+            PendingOnFirstExpiry::default(),
+            std::time::Duration::MAX,
+            crate::capability::tests::runtime(),
+        ));
+        let counter = Arc::new(CloneCounter::default());
+        let waker = counting_waker(&counter);
+        let mut context = Context::from_waker(&waker);
+
+        assert!(future.as_mut().poll(&mut context).is_pending());
+        assert!(future.as_mut().poll(&mut context).is_pending());
+
+        assert!(
+            future.timer_waker.is_none(),
+            "an unbounded deadline registers no waker proxy"
+        );
+        assert_eq!(
+            counter.0.load(Ordering::SeqCst),
+            0,
+            "an unbounded deadline never dispatches the caller's clone vtable"
+        );
     }
 
     #[test]

--- a/crates/shelterwood-mailbox/src/lib.rs
+++ b/crates/shelterwood-mailbox/src/lib.rs
@@ -34,10 +34,6 @@ mod futures;
 mod reply;
 #[cfg(test)]
 mod test_support;
-#[allow(
-    dead_code,
-    reason = "the foundation primitive is wired into deadlines by the next stacked change"
-)]
 mod waker_proxy;
 
 #[doc(hidden)]

--- a/crates/shelterwood-mailbox/src/reply.rs
+++ b/crates/shelterwood-mailbox/src/reply.rs
@@ -269,10 +269,17 @@ mod tests {
             .expect("staged reply publisher mutex")
             .take()
             .expect("reply channel installed its publisher");
+        // Measured as a delta, not an absolute. The expired timer already
+        // woke the *previous* poll's waker, and the waker proxy replays that
+        // record into whichever caller registers next -- a spurious wake the
+        // `Future` contract permits, and the price of never losing a real one.
+        // The property under test is that publishing the winning value wakes
+        // the deferred caller exactly once.
+        let woken_before_publish = wakes.load(Ordering::SeqCst);
         publisher
             .publish(Box::new(7_u8))
             .unwrap_or_else(|_| panic!("the staged receiver remains live"));
-        assert_eq!(wakes.load(Ordering::SeqCst), 1);
+        assert_eq!(wakes.load(Ordering::SeqCst), woken_before_publish + 1);
         assert!(matches!(
             receive.as_mut().poll(&mut Context::from_waker(&waker)),
             Poll::Ready(Ok(7))

--- a/crates/shelterwood/tests/mailbox_future_drop_containment.rs
+++ b/crates/shelterwood/tests/mailbox_future_drop_containment.rs
@@ -134,7 +134,13 @@ async fn send_timeout_drop_contains_timer_waker_during_unwind() {
 }
 
 #[tokio::test]
-async fn call_drop_contains_reply_receiver_waker_during_unwind() {
+async fn call_acceptance_phase_drop_contains_timer_waker_during_unwind() {
+    let (_tree, actor) = actor_ref();
+    assert_pending_then_unwind(Box::pin(actor.call(Message::Hold, Duration::MAX)));
+}
+
+#[tokio::test]
+async fn call_reply_phase_drop_contains_caller_wakers_during_unwind() {
     let (tree, actor) = actor_ref();
     let system = tree.spawn().expect("runtime is available");
     system.wait_started().await.expect("actor starts");
@@ -152,15 +158,17 @@ async fn recv_drop_contains_receiver_waker_during_unwind() {
     assert_pending_then_unwind(Box::pin(receiver.recv(Duration::MAX)));
 }
 
-/// Numbers the clones a single poll hands out so the regression can aim at
-/// one of them. `Deadlined::poll` registers the operation's clone first and
-/// the timer's second, so ordinal two is the timer's.
+/// Numbers the caller-waker clones a single poll hands out so the regression
+/// can aim at one of them. `Deadlined::poll` registers the operation's clone
+/// first and the timer proxy's stored caller second. The timer itself sees
+/// only the stable framework-owned proxy, so it does not mint another clone
+/// through this hostile vtable.
 ///
 /// This counter is process-global but only this vtable bumps it, and only the
 /// one test below installs this vtable, so the ordinals stay dense under any
 /// runner.
 static CLONES_MINTED: AtomicUsize = AtomicUsize::new(0);
-const TIMER_WAKER_ORDINAL: usize = 2;
+const TIMER_CALLER_WAKER_ORDINAL: usize = 2;
 
 unsafe fn clone_ordinal_waker(_data: *const ()) -> RawWaker {
     let ordinal = CLONES_MINTED.fetch_add(1, Ordering::SeqCst) + 1;
@@ -172,8 +180,8 @@ unsafe fn wake_ordinal_waker(_data: *const ()) {}
 unsafe fn wake_by_ref_ordinal_waker(_data: *const ()) {}
 
 unsafe fn drop_ordinal_waker(data: *const ()) {
-    if data.addr() == TIMER_WAKER_ORDINAL {
-        panic!("injected timer waker drop panic");
+    if data.addr() == TIMER_CALLER_WAKER_ORDINAL {
+        panic!("injected timer-proxy caller-waker drop panic");
     }
 }
 
@@ -201,11 +209,11 @@ impl Drop for HostileReply {
     }
 }
 
-/// A deadline future that completes *after* parking still holds an armed
-/// timer carrying a clone of the caller's waker. Retiring that timer on the
-/// ready return runs a `RawWaker` destructor while the completed reply is a
-/// live local, so an unwinding one would destroy the delivered value and --
-/// with a hostile value destructor -- abort the process.
+/// A deadline future that completes *after* parking still holds a caller-waker
+/// clone behind its timer proxy. Retiring that clone on the ready return must
+/// use contained disposal while the completed reply is a live local; an
+/// escaping cleanup panic would destroy that value and -- with a hostile value
+/// destructor -- abort the process.
 #[tokio::test]
 async fn recv_ready_after_parking_contains_the_retired_timer_waker() {
     let (_tree, actor) = actor_ref();
@@ -215,8 +223,8 @@ async fn recv_ready_after_parking_contains_the_retired_timer_waker() {
     // public future registers are under test.
     let hostile = ManuallyDrop::new(ordinal_waker());
 
-    // Parking registers one clone in the reply channel and one in the timer;
-    // only the timer's destructor is hostile.
+    // Parking registers one clone in the reply channel and one behind the
+    // timer proxy; only the proxy-owned caller clone's destructor is hostile.
     assert!(matches!(
         future.as_mut().poll(&mut TaskContext::from_waker(&hostile)),
         Poll::Pending
@@ -224,8 +232,8 @@ async fn recv_ready_after_parking_contains_the_retired_timer_waker() {
 
     assert_eq!(
         CLONES_MINTED.load(Ordering::SeqCst),
-        TIMER_WAKER_ORDINAL,
-        "parking must register exactly the operation and timer clones"
+        TIMER_CALLER_WAKER_ORDINAL,
+        "parking must register exactly the operation and timer-proxy caller clones"
     );
 
     reply.send(HostileReply);

--- a/crates/shelterwood/tests/mailbox_future_drop_containment.rs
+++ b/crates/shelterwood/tests/mailbox_future_drop_containment.rs
@@ -136,7 +136,10 @@ async fn send_timeout_drop_contains_timer_waker_during_unwind() {
 #[tokio::test]
 async fn call_acceptance_phase_drop_contains_timer_waker_during_unwind() {
     let (_tree, actor) = actor_ref();
-    assert_pending_then_unwind(Box::pin(actor.call(Message::Hold, Duration::MAX)));
+    // A bounded budget, deliberately: `Duration::MAX` overflows to an
+    // unbounded deadline, which registers no timer waker at all and would
+    // leave this test named after a clone it never mints.
+    assert_pending_then_unwind(Box::pin(actor.call(Message::Hold, Duration::from_secs(30))));
 }
 
 #[tokio::test]
@@ -210,10 +213,17 @@ impl Drop for HostileReply {
 }
 
 /// A deadline future that completes *after* parking still holds a caller-waker
-/// clone behind its timer proxy. Retiring that clone on the ready return must
-/// use contained disposal while the completed reply is a live local; an
-/// escaping cleanup panic would destroy that value and -- with a hostile value
-/// destructor -- abort the process.
+/// clone behind its timer proxy, and the completion path retires that clone
+/// **on this thread** -- the poll-path half of #398 ruling 3's venue split.
+/// The destructor injected below therefore runs synchronously inside
+/// `Deadlined::poll`, while the delivered reply is a live local in the same
+/// frame. An escaping cleanup panic would destroy that value mid-unwind and --
+/// with the hostile value destructor this test installs -- abort the process.
+///
+/// Judged by the ordinary return: the poll must hand back `Ready` with the
+/// delivered value. Wrapping the poll in `catch_unwind` would make the test
+/// vacuous -- it would pass on a framework that contains nothing, because the
+/// harness would be doing the containing.
 #[tokio::test]
 async fn recv_ready_after_parking_contains_the_retired_timer_waker() {
     let (_tree, actor) = actor_ref();

--- a/crates/shelterwood/tests/timer_waker_proxy.rs
+++ b/crates/shelterwood/tests/timer_waker_proxy.rs
@@ -1,0 +1,180 @@
+mod common;
+
+use std::{
+    future::Future,
+    mem::ManuallyDrop,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
+    task::{Context as TaskContext, Poll, RawWaker, RawWakerVTable, Waker},
+    thread::{self, ThreadId},
+    time::Duration,
+};
+
+use common::{DestructorBlocker, DestructorGate, POLL_TIMEOUT};
+use shelterwood::{Actor, ActorOnceDef, Context, ExitError, ExitResult, Tree};
+
+struct IdleActor;
+
+impl Actor for IdleActor {
+    type Msg = ();
+    type Args = ();
+
+    async fn init((): (), _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, (): (), _: &mut Context<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+}
+
+struct BlockingDropWaker {
+    blocked: AtomicBool,
+    blocker: Mutex<Option<DestructorBlocker>>,
+    entered: mpsc::Sender<ThreadId>,
+}
+
+unsafe fn clone_blocking_drop_waker(data: *const ()) -> RawWaker {
+    // SAFETY: every pointer using this vtable came from an Arc of the
+    // matching type. ManuallyDrop preserves the reference represented by
+    // `data`; the returned raw waker owns only the new clone.
+    let state = ManuallyDrop::new(unsafe { Arc::<BlockingDropWaker>::from_raw(data.cast()) });
+    RawWaker::new(
+        Arc::into_raw(Arc::clone(&state)).cast(),
+        &BLOCKING_DROP_WAKER_VTABLE,
+    )
+}
+
+unsafe fn wake_blocking_drop_waker(data: *const ()) {
+    // SAFETY: wake consumes the Arc reference represented by this raw waker.
+    drop(unsafe { Arc::<BlockingDropWaker>::from_raw(data.cast()) });
+}
+
+unsafe fn wake_by_ref_blocking_drop_waker(_data: *const ()) {}
+
+unsafe fn drop_blocking_drop_waker(data: *const ()) {
+    // SAFETY: drop consumes the Arc reference represented by this raw waker.
+    let state = unsafe { Arc::<BlockingDropWaker>::from_raw(data.cast()) };
+    if !state.blocked.swap(true, Ordering::SeqCst) {
+        let blocker = state
+            .blocker
+            .lock()
+            .expect("blocking waker mutex poisoned")
+            .take()
+            .expect("the first framework clone owns the blocker");
+        let _ = state.entered.send(thread::current().id());
+        drop(blocker);
+    }
+}
+
+static BLOCKING_DROP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    clone_blocking_drop_waker,
+    wake_blocking_drop_waker,
+    wake_by_ref_blocking_drop_waker,
+    drop_blocking_drop_waker,
+);
+
+fn blocking_drop_waker(gate: &DestructorGate, entered: mpsc::Sender<ThreadId>) -> Waker {
+    let raw = RawWaker::new(
+        Arc::into_raw(Arc::new(BlockingDropWaker {
+            blocked: AtomicBool::new(false),
+            blocker: Mutex::new(Some(gate.blocker())),
+            entered,
+        }))
+        .cast(),
+        &BLOCKING_DROP_WAKER_VTABLE,
+    );
+    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+    // ownership across clone, wake, and drop.
+    unsafe { Waker::from_raw(raw) }
+}
+
+/// Cancels a whole public deadline future while one caller-waker destructor
+/// blocks, then proves a second thread can still arm and cancel a Tokio timer.
+///
+/// Tokio 1.53.1 drops a timer's registered waker in `Handle::clear_entry`
+/// while holding the global time-driver mutex. Before the proxy, the cancel
+/// thread therefore held that mutex for the duration of the hostile
+/// destructor and the probe thread could not register. The two-worker runtime
+/// bounds the scheduler footprint on shared CI hosts; the relevant work is
+/// driven from two named native threads so a blocked worker cannot starve the
+/// assertion itself.
+#[test]
+fn blocking_timer_waker_retirement_does_not_stall_unrelated_timer_traffic() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_time()
+        .build()
+        .expect("test runtime");
+    let handle = runtime.handle().clone();
+
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once("timer-proxy", ActorOnceDef::<IdleActor>::new(()))
+        .expect("valid actor");
+    let mut future = Box::pin(actor.send_timeout((), Duration::from_secs(30)));
+    let gate = DestructorGate::default();
+    let (entered_tx, entered_rx) = mpsc::channel();
+    // Only the clones registered by the public future are under test. Keeping
+    // the caller-owned handle alive also prevents its own destructor from
+    // winning the one-shot blocking gate.
+    let hostile = ManuallyDrop::new(blocking_drop_waker(&gate, entered_tx));
+    {
+        let _runtime = handle.enter();
+        assert!(matches!(
+            future.as_mut().poll(&mut TaskContext::from_waker(&hostile)),
+            Poll::Pending
+        ));
+    }
+
+    let cancel_handle = handle.clone();
+    let (cancelled_tx, cancelled_rx) = mpsc::channel();
+    let cancel = thread::Builder::new()
+        .name("timer-proxy-cancel".into())
+        .spawn(move || {
+            let _runtime = cancel_handle.enter();
+            drop(future);
+            let _ = cancelled_tx.send(());
+        })
+        .expect("cancellation thread starts");
+
+    let destructor_thread = entered_rx
+        .recv_timeout(POLL_TIMEOUT)
+        .expect("a framework-owned caller-waker clone reaches retirement");
+
+    let probe_handle = handle.clone();
+    let (probe_tx, probe_rx) = mpsc::channel();
+    let probe = thread::Builder::new()
+        .name("timer-proxy-unrelated".into())
+        .spawn(move || {
+            let _runtime = probe_handle.enter();
+            let mut timer = Box::pin(tokio::time::sleep(Duration::from_secs(30)));
+            assert!(
+                timer
+                    .as_mut()
+                    .poll(&mut TaskContext::from_waker(Waker::noop()))
+                    .is_pending()
+            );
+            drop(timer);
+            let _ = probe_tx.send(());
+        })
+        .expect("unrelated timer thread starts");
+
+    let probe_completed = probe_rx.recv_timeout(POLL_TIMEOUT).is_ok();
+    let cancel_completed = cancelled_rx.recv_timeout(POLL_TIMEOUT).is_ok();
+    gate.release();
+    cancel.join().expect("cancellation thread does not panic");
+    probe.join().expect("unrelated timer thread does not panic");
+
+    assert!(
+        probe_completed,
+        "a blocking caller-waker destructor on {destructor_thread:?} held Tokio's time-driver mutex"
+    );
+    assert!(
+        cancel_completed,
+        "timer cancellation waited for disposal-lane waker destruction"
+    );
+}

--- a/crates/shelterwood/tests/timer_waker_proxy.rs
+++ b/crates/shelterwood/tests/timer_waker_proxy.rs
@@ -137,7 +137,7 @@ fn blocking_timer_waker_retirement_does_not_stall_unrelated_timer_traffic() {
         .spawn(move || {
             let _runtime = cancel_handle.enter();
             drop(future);
-            let _ = cancelled_tx.send(());
+            let _ = cancelled_tx.send(thread::current().id());
         })
         .expect("cancellation thread starts");
 
@@ -159,22 +159,43 @@ fn blocking_timer_waker_retirement_does_not_stall_unrelated_timer_traffic() {
                     .is_pending()
             );
             drop(timer);
-            let _ = probe_tx.send(());
+            let _ = probe_tx.send(thread::current().id());
         })
         .expect("unrelated timer thread starts");
 
-    let probe_completed = probe_rx.recv_timeout(POLL_TIMEOUT).is_ok();
-    let cancel_completed = cancelled_rx.recv_timeout(POLL_TIMEOUT).is_ok();
+    let probe_thread = probe_rx.recv_timeout(POLL_TIMEOUT).ok();
+    let cancel_thread = cancelled_rx.recv_timeout(POLL_TIMEOUT).ok();
     gate.release();
     cancel.join().expect("cancellation thread does not panic");
     probe.join().expect("unrelated timer thread does not panic");
 
-    assert!(
-        probe_completed,
-        "a blocking caller-waker destructor on {destructor_thread:?} held Tokio's time-driver mutex"
+    // Unwrapped rather than compared as options, so the identity assertions
+    // below cannot pass merely because a thread never reported in.
+    let probe_thread = probe_thread.unwrap_or_else(|| {
+        panic!(
+            "a blocking caller-waker destructor on {destructor_thread:?} held Tokio's time-driver mutex"
+        )
+    });
+    let cancel_thread =
+        cancel_thread.expect("timer cancellation waited for disposal-lane waker destruction");
+
+    // The premise, stated rather than assumed: this test only means anything
+    // while `Deadlined::drop` keeps the disposal-lane venue that #398 ruling 3
+    // grants drop glue. Were the drop path to adopt the poll path's
+    // synchronous containment, the destructor would run on the cancelling
+    // thread -- naming the threads it must avoid says so directly instead of
+    // leaving it to be inferred from two liveness waits.
+    assert_ne!(
+        destructor_thread, cancel_thread,
+        "a blocking caller-waker destructor must not run on the thread cancelling the future"
     );
-    assert!(
-        cancel_completed,
-        "timer cancellation waited for disposal-lane waker destruction"
+    assert_ne!(
+        destructor_thread, probe_thread,
+        "a blocking caller-waker destructor must not run on an unrelated timer thread"
+    );
+    assert_ne!(
+        destructor_thread,
+        thread::current().id(),
+        "a blocking caller-waker destructor must not run on the polling thread"
     );
 }


### PR DESCRIPTION
Implements PR 2 of #398 and closes #367. Registers the stable framework-owned proxy with every parked `Deadlined` timer and preserves lazy allocation with a framework no-op probe.

Retirement venue follows #398 ruling 3's split rather than taking one lane everywhere. Post-proxy, Tokio's wheel holds only a framework-owned proxy, so no caller waker is destroyed under the global time-driver mutex on any path; what remains is who absorbs a hostile destructor. `Deadlined::drop` — cancellation — keeps the **disposal lane**: the absorbing party there is whatever is tearing the future down, and it has no result to weigh the diagnostic against. Completion and timeout arbitration retire **synchronously and contained** on the polling task, the shape the reply seam uses for the same cost reasoning: a lane submission on every completed `send_timeout`/`call`/`recv` is real hot-path cost where a contained drop of a benign waker is nearly free. The containment is drained before the value handoff, so no unwind can cross the frame that owns the completed output.

`Deadline::after(now, Duration::MAX)` overflows to an unbounded deadline — `std::future::pending()`, the documented unbounded-wait idiom. That path is now guarded so it allocates no proxy, clones no caller waker, and has nothing to retire, as it did before the proxy.

Regressions, each mutation-checked:

- the bounded cross-thread time-driver stall test now asserts the hostile destructor ran on neither the cancelling thread nor the probe thread nor the poller, so its dependence on the drop path's lane venue is stated rather than inferred;
- completion is pinned on the artifact — the wheel entry is synchronously gone — instead of only on the absence of a spurious wake, which retirement's slot-before-timer ordering made unfalsifiable;
- lazy allocation gains the two cases the old test never reached: an already-elapsed timer answered by the no-op probe, and an unbounded deadline, both judged by the caller's `clone` vtable never being dispatched;
- the ready-path containment regression is now a real on-thread test, judged by the poll returning `Ready` with the delivered value;
- whole-public-future coverage for `send_timeout`, `recv`, and both `call` phases.

Rebased onto the amended #401 foundation. One pre-existing reply test measured an absolute wake count that the foundation's lost-wake handshake now precedes with one permitted spurious wake; it measures the publish delta instead.

Stacked on #401.

Local verification: `./tools/dev just ci` (862 tests plus docs, API reachability, external consumer, and Nix formatting).

Closes #367
