### PR TITLE
Eliminate load-bearing debug assertions

### DIFF
--- a/crates/shelterwood-cells/src/cells/member.rs
+++ b/crates/shelterwood-cells/src/cells/member.rs
@@ -489,13 +489,12 @@ impl MemberCell {
         report_capture: impl FnMut(),
         install: impl FnOnce(&ObservationGate),
     ) {
-        let adopted = self.with_handoff_gate(gate, report_capture, |current| {
+        self.with_handoff_gate(gate, report_capture, |current| {
             if !current.shares_gate(gate) {
                 install(current);
             }
             true
         });
-        debug_assert!(adopted, "unconditional adoption never refuses");
     }
 
     /// Runs `attempt` with this member's current observation gate held.
@@ -652,23 +651,25 @@ impl MemberCell {
                         exit,
                         teardown,
                     } => {
-                        debug_assert!(teardown.is_none());
-                        *teardown = mailbox.prepare_termination(txn);
-                        *control = Some(mailbox);
-                        Some(exit.as_exit().clone())
+                        if teardown.is_some() {
+                            rejected = Some(mailbox);
+                            None
+                        } else {
+                            *teardown = mailbox.prepare_termination(txn);
+                            *control = Some(mailbox);
+                            Some(exit.as_exit().clone())
+                        }
                     }
                 }
             };
-            // Follow the mailbox layer's convention and release the lock before
-            // panicking, so a driver-contract violation stays on this thread
-            // instead of poisoning the mutex under every later mailbox lookup.
-            // The rejected mailbox still owns unread user messages, so the
-            // transaction destroys it after the gate is released -- during this
-            // panic's unwind, which is exactly when an inline destructor would
-            // be a double panic.
+            // Raise the contract failure as the first post-unlock effect so
+            // it keeps precedence over a hostile rejected-mailbox destructor.
+            // The transaction accumulator still runs the disposal effect
+            // before it resumes that panic.
             if let Some(rejected) = rejected {
-                txn.defer(move || drop(rejected));
-                panic!("a member can own only one mailbox");
+                txn.defer(|| panic!("a member can own only one mailbox"));
+                txn.defer(move || runtime::dispose_detached(rejected));
+                return;
             }
             if let Some(terminal_exit) = terminal_exit {
                 self.terminalize_locked(terminal_exit, StartupDisposition::Unchanged, txn);
@@ -775,10 +776,9 @@ impl MemberCell {
                 None
             }
         };
-        debug_assert!(
-            !nonterminal_mailbox,
-            "terminal publication requires terminal mailbox state"
-        );
+        if nonterminal_mailbox {
+            txn.defer(|| panic!("terminal publication requires terminal mailbox state"));
+        }
         if let Some(teardown) = teardown {
             txn.defer(move || {
                 runtime::dispose_detached(teardown.finish());
@@ -821,11 +821,6 @@ mod tests {
     use super::*;
     use crate::cells::test_support::{ThreadProbe, isolated_scope};
 
-    // The retention this pins only has an observable effect when the
-    // framework invariant it guards is checked, and that check is a
-    // `debug_assert!`. Release builds decline the panic entirely, so the test
-    // is gated on the profile it can hold in rather than left to fail there.
-    #[cfg(debug_assertions)]
     #[test]
     fn illegal_restart_transition_is_rejected_in_every_build() {
         let scope = isolated_scope("root", ScopeFlavor::Ordered);

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -426,17 +426,19 @@ impl ScopeCell {
         gate: &ObservationGate,
         txn: &mut ObservationTxn<'_>,
     ) {
-        debug_assert!(
-            !std::ptr::eq(self, parent),
-            "a scope cannot adopt from itself"
-        );
+        if std::ptr::eq(self, parent) {
+            txn.defer(|| panic!("a scope cannot adopt from itself"));
+            return;
+        }
         // The caller holds `gate` through `parent.with_observation_gate`.
         // Re-homing the parent would first have to acquire that same gate, so
         // rereading its installed pointer here cannot race a parent handoff.
-        debug_assert!(
-            gate.shares_gate(&parent.current_observation_gate()),
-            "observation gates are adopted only in the parent-to-child direction"
-        );
+        if !gate.shares_gate(&parent.current_observation_gate()) {
+            txn.defer(|| {
+                panic!("observation gates are adopted only in the parent-to-child direction")
+            });
+            return;
+        }
         self.member.adopt_observation_gate_with(
             gate,
             || {
@@ -444,10 +446,10 @@ impl ScopeCell {
                 self.report_gate_capture(GateCapture::Adoption);
             },
             |current| {
-                debug_assert!(
-                    self.dynamic_route_in(txn).is_none(),
-                    "a scope with a live dynamic route is never re-homed"
-                );
+                if self.dynamic_route_in(txn).is_some() {
+                    txn.defer(|| panic!("a scope with a live dynamic route is never re-homed"));
+                    return;
+                }
                 self.member.install_observation_gate_locked(current, gate);
                 self.adopt_descendant_observation_gates_locked(current, gate, txn);
             },
@@ -467,17 +469,19 @@ impl ScopeCell {
         gate: &ObservationGate,
         txn: &mut ObservationTxn<'_>,
     ) -> bool {
-        debug_assert!(
-            !std::ptr::eq(self, parent),
-            "a scope cannot be admitted into itself"
-        );
+        if std::ptr::eq(self, parent) {
+            txn.defer(|| panic!("a scope cannot be admitted into itself"));
+            return false;
+        }
         // The caller holds `gate` through `parent.with_observation_gate`.
         // Re-homing the parent would first have to acquire that same gate, so
         // rereading its installed pointer here cannot race a parent handoff.
-        debug_assert!(
-            gate.shares_gate(&parent.current_observation_gate()),
-            "observation gates are admitted only in the parent-to-child direction"
-        );
+        if !gate.shares_gate(&parent.current_observation_gate()) {
+            txn.defer(|| {
+                panic!("observation gates are admitted only in the parent-to-child direction")
+            });
+            return false;
+        }
         self.member.with_handoff_gate(
             gate,
             || {
@@ -499,10 +503,11 @@ impl ScopeCell {
                 let admitted = self
                     .member
                     .transition_locked(txn, MemberTransition::Admitted);
-                debug_assert!(
-                    admitted,
-                    "the probed admission cannot be refused under the same held gate"
-                );
+                if !admitted {
+                    txn.defer(|| {
+                        panic!("the probed admission cannot be refused under the same held gate")
+                    });
+                }
                 admitted
             },
         )
@@ -589,13 +594,32 @@ impl ScopeCell {
         startup: Option<Result<(), StartupError>>,
         terminal_disposals: &[Arc<MemberCell>],
     ) {
-        debug_assert!(matches!(state, ScopeState::Draining));
-        self.with_observation_gate(|txn| {
-            if let Some(startup) = startup {
+        assert!(matches!(state, ScopeState::Draining));
+        let mut state = Some(state);
+        let mut startup = startup;
+        let published = self.with_observation_gate(|txn| {
+            if !terminal_disposals.iter().all(|member| {
+                self.current_observation_gate()
+                    .shares_gate(&member.current_observation_gate())
+            }) {
+                return false;
+            }
+            if let Some(startup) = startup.take() {
                 self.set_startup_locked(startup, txn);
             }
-            self.set_state_locked(state, terminal_disposals, txn);
+            self.set_state_locked(
+                state
+                    .take()
+                    .expect("validated drain state is published once"),
+                terminal_disposals,
+                txn,
+            );
+            true
         });
+        assert!(
+            published,
+            "a drain entry may mark only a resident member on its observation gate"
+        );
     }
 
     fn set_state_locked(
@@ -609,11 +633,6 @@ impl ScopeCell {
         // stored before the `Draining` record write whose release edge makes
         // it visible to zero-budget shutdown samplers on other workers.
         for member in terminal_disposals {
-            debug_assert!(
-                self.current_observation_gate()
-                    .shares_gate(&member.current_observation_gate()),
-                "a drain entry may mark only a resident member on its observation gate"
-            );
             member.set_terminal_disposal_pending(true);
         }
         let mut transient_retained = Vec::new();
@@ -735,7 +754,7 @@ impl ScopeCell {
         // fallible cell lookup. If an invariant fails, the raw argument can
         // unwind under the gate only as refcount traffic.
         let exit = RetainedExit::new(exit);
-        self.with_observation_gate(move |wakes| {
+        let terminalized = self.with_observation_gate(move |wakes| {
             let record = member.record();
             if matches!(record.stage, MemberStage::Terminal(_)) {
                 // The outer guard defines losing supervised terminalization:
@@ -744,7 +763,7 @@ impl ScopeCell {
                 // losing direct terminalizer, and do not destroy it under the
                 // observation gate.
                 wakes.defer(move || drop(exit));
-                return false;
+                return Some(false);
             }
             // Nested publication and closure are reached only through this
             // residency lookup, so a supervised child must still be resident
@@ -760,11 +779,14 @@ impl ScopeCell {
                 .iter()
                 .find(|resident| resident.projection().member.membership() == member.membership())
                 .map(|resident| resident.projection().clone());
-            debug_assert!(
-                resident.is_some(),
-                "a supervised terminal child must remain in parent residency"
-            );
-            let nested = resident.and_then(|resident| resident.scope);
+            let Some(resident) = resident else {
+                // Retire the incoming failed exit before the post-unlock
+                // assertion resumes, preserving the retention-before-verdict
+                // ordering in every profile.
+                wakes.defer(move || drop(exit));
+                return None;
+            };
+            let nested = resident.scope;
             let terminal_exit = member.terminalize_locked(exit.as_exit().clone(), startup, wakes);
             // The terminal member record now owns the equivalent retained
             // copy, so surrender this transient guard as refcount traffic.
@@ -802,8 +824,13 @@ impl ScopeCell {
                 // terminal stream carrying Starting/Running as its payload.
                 scope.close_observation_locked(wakes);
             }
-            true
-        })
+            Some(true)
+        });
+        assert!(
+            terminalized.is_some(),
+            "a supervised terminal child must remain in parent residency"
+        );
+        terminalized.unwrap_or(false)
     }
 
     /// Installs residency without announcing it, as an admission that
@@ -830,7 +857,7 @@ impl ScopeCell {
         let Some(resident) = resident else {
             return false;
         };
-        debug_assert_eq!(resident.projection().member.membership(), membership);
+        let resident_matches = resident.projection().member.membership() == membership;
         // Mirror the announcement: a resident an unwound admission installed
         // never published `Added`, and SPEC §3.2's pairing is both edges or
         // neither. It is still withdrawn and disposed.
@@ -839,11 +866,22 @@ impl ScopeCell {
             membership,
             last_incarnation: resident.projection().member.record().last_incarnation,
         });
+        // Queue the framework diagnostic ahead of every other effect. The
+        // accumulator keeps the first panic, so this is the one ordering under
+        // which an invariant failure cannot be displaced by an effect that
+        // panics for an unrelated reason. Every deferred-diagnostic site in
+        // the tree uses it.
+        if !resident_matches {
+            txn.defer(|| panic!("pruning must remove the requested resident membership"));
+        }
         // The projection can carry the last member/mailbox owner. Put it in
         // the transaction before the fallible publication path so unwind also
         // retires it only after the observation gate is released. The detached
         // handoff deliberately makes final member teardown asynchronous.
         txn.defer(move || runtime::dispose_detached(resident));
+        if !resident_matches {
+            return false;
+        }
         if let Some(event) = event {
             self.emit_locked(txn, event);
         }
@@ -895,25 +933,27 @@ impl ScopeCell {
     }
 
     pub fn begin_incarnation(&self, state: ScopeState) -> Option<Epoch> {
-        debug_assert!(
+        assert!(
             matches!(state, ScopeState::Starting),
             "a fresh incarnation publishes its lifecycle machine's initial state"
         );
-        self.with_observation_gate(|wakes| {
+        let (epoch, projection_idle) = self.with_observation_gate(|wakes| {
+            let projection_idle = matches!(
+                self.record().state,
+                ScopeState::Unstarted | ScopeState::Stopped { .. }
+            );
+            if !projection_idle {
+                return (None, false);
+            }
             let mut control = self.control.lock().expect("scope control mutex poisoned");
-            let epoch = control.epochs.begin()?;
+            let Some(epoch) = control.epochs.begin() else {
+                return (None, true);
+            };
             // The idle epoch plane pairs only with a settled projection:
             // `Unstarted` before any mint, `Stopped` after every finish. That
             // pairing is what lets `settled` treat terminal membership
             // plus a settled projection as final without stranding a scope
             // that still owns a live incarnation.
-            debug_assert!(
-                matches!(
-                    self.record().state,
-                    ScopeState::Unstarted | ScopeState::Stopped { .. }
-                ),
-                "an idle scope projection is Unstarted or Stopped before a fresh incarnation mints"
-            );
             self.observation.record.modify_silently(|record| {
                 record.total_restarts = TotalRestarts::ZERO;
                 record.startup = None;
@@ -927,8 +967,13 @@ impl ScopeCell {
             wakes.pulse(&self.observation.record);
             wakes.pulse(&self.member.record);
             self.emit_locked(wakes, LifecycleEventKind::ScopeState { state });
-            Some(epoch)
-        })
+            (Some(epoch), true)
+        });
+        assert!(
+            projection_idle,
+            "an idle scope projection is Unstarted or Stopped before a fresh incarnation mints"
+        );
+        epoch
     }
 
     pub fn finish_incarnation(&self, epoch: Epoch, reason: StopReason) {
@@ -1300,10 +1345,13 @@ impl ScopeCell {
                     let admitted = projection
                         .member
                         .transition_locked(txn, MemberTransition::Admitted);
-                    debug_assert!(
-                        admitted,
-                        "the probed admission cannot be refused under the same held gate"
-                    );
+                    if !admitted {
+                        txn.defer(|| {
+                            panic!(
+                                "the probed admission cannot be refused under the same held gate"
+                            )
+                        });
+                    }
                     admitted
                 },
             )
@@ -1322,10 +1370,9 @@ impl ScopeCell {
             // invariant. If that diagnostic ever fires, neither possibly-last
             // mailbox owner may unwind through the observation gate.
             txn.defer(move || runtime::dispose_detached((projection, rejected)));
-            debug_assert!(
-                rejected_is_admission,
-                "refusal removes the admission-local resident"
-            );
+            if !rejected_is_admission {
+                txn.defer(|| panic!("refusal removes the admission-local resident"));
+            }
             return false;
         }
         let id = projection.member.id().clone();
@@ -1798,11 +1845,6 @@ mod tests {
         }
     }
 
-    // The retention this pins only has an observable effect when the
-    // framework invariant it guards is checked, and that check is a
-    // `debug_assert!`. Release builds decline the panic entirely, so the test
-    // is gated on the profile it can hold in rather than left to fail there.
-    #[cfg(debug_assertions)]
     #[test]
     fn nonresident_terminal_exit_is_retained_before_the_residency_assertion() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
@@ -1828,11 +1870,6 @@ mod tests {
         );
     }
 
-    // The retention this pins only has an observable effect when the
-    // framework invariant it guards is checked, and that check is a
-    // `debug_assert!`. Release builds decline the panic entirely, so the test
-    // is gated on the profile it can hold in rather than left to fail there.
-    #[cfg(debug_assertions)]
     #[test]
     fn rejected_resident_admission_detaches_its_last_mailbox_owner() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
@@ -2063,10 +2100,8 @@ mod tests {
         assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Empty));
     }
 
-    #[cfg(debug_assertions)]
     struct InertRoute;
 
-    #[cfg(debug_assertions)]
     impl DynamicRoute for InertRoute {
         fn close_admission(&self, _txn: &mut ObservationTxn<'_>) {}
     }
@@ -2077,7 +2112,6 @@ mod tests {
     /// refuses every stage a started driver can present, so a re-homed live
     /// route is unconstructible there. The reservation-time adoption path has
     /// no such probe, and this is its regression.
-    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "a scope with a live dynamic route is never re-homed")]
     fn plain_gate_adoption_rejects_a_scope_with_a_live_dynamic_route() {

--- a/crates/shelterwood-cells/src/cells/scope.rs
+++ b/crates/shelterwood-cells/src/cells/scope.rs
@@ -826,11 +826,7 @@ impl ScopeCell {
             }
             Some(true)
         });
-        assert!(
-            terminalized.is_some(),
-            "a supervised terminal child must remain in parent residency"
-        );
-        terminalized.unwrap_or(false)
+        terminalized.expect("a supervised terminal child must remain in parent residency")
     }
 
     /// Installs residency without announcing it, as an admission that

--- a/crates/shelterwood-cells/src/cells/scope/projection.rs
+++ b/crates/shelterwood-cells/src/cells/scope/projection.rs
@@ -82,30 +82,34 @@ impl ScopeCell {
     }
 
     pub fn subscribe_snapshots(&self) -> SnapshotReceiver {
-        self.with_observation_gate(|wakes| {
+        let (receiver, closed_consistent) = self.with_observation_gate(|wakes| {
             let receiver = self
                 .observation
                 .snapshots
                 .subscribe(self.snapshot_locked(), wakes);
-            debug_assert!(
-                !self.observation.closed.load(Ordering::Acquire)
-                    || receiver.borrow_latest_and_closed().1,
-                "closed snapshot state is installed before later subscriptions"
-            );
-            receiver
-        })
+            let closed_consistent = !self.observation.closed.load(Ordering::Acquire)
+                || receiver.borrow_latest_and_closed().1;
+            (receiver, closed_consistent)
+        });
+        assert!(
+            closed_consistent,
+            "closed snapshot state is installed before later subscriptions"
+        );
+        receiver
     }
 
     pub fn subscribe_lifecycle(&self) -> LifecycleEvents {
-        self.with_observation_gate(|txn| {
+        let (events, closed_consistent) = self.with_observation_gate(|txn| {
             let events = self.observation.lifecycle.subscribe(txn);
-            debug_assert!(
-                !self.observation.closed.load(Ordering::Acquire)
-                    || self.observation.lifecycle.is_closed(),
-                "closed lifecycle state is installed before later subscriptions"
-            );
-            events
-        })
+            let closed_consistent = !self.observation.closed.load(Ordering::Acquire)
+                || self.observation.lifecycle.is_closed();
+            (events, closed_consistent)
+        });
+        assert!(
+            closed_consistent,
+            "closed lifecycle state is installed before later subscriptions"
+        );
+        events
     }
 
     fn snapshot_locked(&self) -> RetainedScopeSnapshot {

--- a/crates/shelterwood-cells/src/observe.rs
+++ b/crates/shelterwood-cells/src/observe.rs
@@ -580,8 +580,12 @@ impl SnapshotPublication {
     }
 
     pub(crate) fn coalesce(&mut self, newer: Self) -> SnapshotProjection {
-        debug_assert!(self.same_hub(&newer));
-        debug_assert!(!self.closed, "a closed snapshot hub cannot publish again");
+        // `ObservationTxn::stage_snapshot` selects this publication with
+        // `same_hub`, so hub identity is structural. Closure is total: once
+        // staged, it wins over every later publication in the transaction.
+        if self.closed {
+            return newer.projection;
+        }
         self.published |= newer.published;
         self.closed = newer.closed;
         std::mem::replace(&mut self.projection, newer.projection)
@@ -604,10 +608,9 @@ impl SnapshotPublication {
         let mut generation_exhausted = false;
         if snapshot.is_some() {
             self.sender.modify_silently(|state| {
-                debug_assert!(
-                    !state.closed,
-                    "the gate serializes closure against installation"
-                );
+                if state.closed {
+                    return;
+                }
                 retired = Some(std::mem::replace(
                     &mut state.snapshot,
                     snapshot
@@ -620,6 +623,12 @@ impl SnapshotPublication {
                 state.closed = self.closed;
                 modified = true;
             });
+        }
+        if let Some(uninstalled) = snapshot.take() {
+            // A prior committed close remains authoritative. The cut was
+            // already built, so retire its user-bearing snapshot after both
+            // the watch mutex and observation gate are released.
+            effects.push(Box::new(move || drop(uninstalled)));
         }
         if let Some(retired) = retired {
             effects.push(Box::new(move || drop(retired)));
@@ -850,7 +859,7 @@ impl LifecycleEvents {
             // already a power of two, so the effective capacity is exact.
             if self.events.len() > LIFECYCLE_EVENT_CAPACITY {
                 let overflow = self.events.try_receive();
-                debug_assert!(
+                assert!(
                     matches!(&overflow, runtime::BroadcastReceive::Lagged(_)),
                     "a lagging broadcast receiver should report its dropped prefix"
                 );

--- a/crates/shelterwood-cells/src/observe.rs
+++ b/crates/shelterwood-cells/src/observe.rs
@@ -827,6 +827,11 @@ pub struct LifecycleEvents {
     events: runtime::BroadcastReceiver<RetainedLifecycleEvent>,
     signal: runtime::WatchReceiver<LifecycleSignal>,
     seen_explicit_lag: u64,
+    // Total fallback for a broadcast implementation that returns an item
+    // despite reporting a length beyond its effective capacity. The explicit
+    // marker remains first and the retained event is not destroyed on an
+    // invariant-panic stack.
+    pending: Option<RetainedLifecycleEvent>,
 }
 
 impl LifecycleEvents {
@@ -857,17 +862,21 @@ impl LifecycleEvents {
             // evict the oldest unread event. Tokio guarantees the next read
             // reports lag when `len` exceeds the effective capacity; 128 is
             // already a power of two, so the effective capacity is exact.
-            if self.events.len() > LIFECYCLE_EVENT_CAPACITY {
-                let overflow = self.events.try_receive();
-                assert!(
-                    matches!(&overflow, runtime::BroadcastReceive::Lagged(_)),
-                    "a lagging broadcast receiver should report its dropped prefix"
-                );
-                if let runtime::BroadcastReceive::Lagged(overflow) = overflow {
-                    dropped = dropped.saturating_add(overflow);
+            if self.pending.is_none() && self.events.len() > LIFECYCLE_EVENT_CAPACITY {
+                match self.events.try_receive() {
+                    runtime::BroadcastReceive::Lagged(overflow) => {
+                        dropped = dropped.saturating_add(overflow);
+                    }
+                    runtime::BroadcastReceive::Item(event) => {
+                        self.pending = Some(event);
+                    }
+                    runtime::BroadcastReceive::Empty | runtime::BroadcastReceive::Closed => {}
                 }
             }
             return Ok(LifecycleItem::Lagged { dropped });
+        }
+        if let Some(event) = self.pending.take() {
+            return Ok(LifecycleItem::Event(event.into_public()));
         }
         match self.events.try_receive() {
             runtime::BroadcastReceive::Item(event) => Ok(LifecycleItem::Event(event.into_public())),
@@ -883,7 +892,10 @@ impl fmt::Debug for LifecycleEvents {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("LifecycleEvents")
-            .field("queued", &self.events.len())
+            .field(
+                "queued",
+                &(self.events.len() + usize::from(self.pending.is_some())),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -922,6 +934,7 @@ impl LifecycleHub {
             events: self.events.subscribe(),
             signal,
             seen_explicit_lag,
+            pending: None,
         }
     }
 

--- a/crates/shelterwood-core/src/engine.rs
+++ b/crates/shelterwood-core/src/engine.rs
@@ -254,8 +254,7 @@ pub fn dispatch_exit(
     // SPEC §8: `NeverStarted` is a membership fact, not an incarnation
     // verdict — it "is never input to restart or intensity accounting".
     // Every supported producer terminalizes the membership directly and never
-    // reaches dispatch, so arriving here is a framework bug: the assert makes
-    // it loud in debug, and the return fails closed in release rather than
+    // reaches dispatch, so arriving here is a framework bug. Fail before
     // charging a restart for an incarnation that never ran.
     //
     // Failing closed is the lesser of two wrong outcomes, not a correct one:
@@ -263,10 +262,9 @@ pub fn dispatch_exit(
     // verdict here would publish a `NeverStarted` terminal paired with
     // `last_incarnation: Some(..)`, which SPEC §B.3 excludes. `ExitDispatch`
     // carries no incarnation, so the pairing is the caller's to choose and
-    // cannot be repaired from inside this function; an inconsistent terminal
-    // projection is still strictly better than an illegal restart, and the
-    // debug abort fires before any such projection can be published.
-    debug_assert!(
+    // cannot be repaired from inside this function, so every profile stops
+    // before publishing an inconsistent terminal projection.
+    assert!(
         !matches!(exit.kind(), ExitKind::NeverStarted),
         "NeverStarted is a membership outcome outside incarnation dispatch"
     );
@@ -309,7 +307,7 @@ struct IntensityCharge {
 impl IntensityTrip {
     fn new(charge: IntensityCharge) -> Self {
         let policy = charge.policy;
-        debug_assert_eq!(charge.tripped, charge.in_window > policy.max_restarts());
+        assert_eq!(charge.tripped, charge.in_window > policy.max_restarts());
         Self {
             max_restarts: policy.max_restarts(),
             observed_restarts: charge.in_window,
@@ -674,7 +672,7 @@ impl ScopeEpochs {
         // A shutdown wait settles on `finished(target)`, so a freshly minted
         // epoch must not already read as finished — that would settle a wait
         // against the incarnation it just started.
-        debug_assert!(
+        assert!(
             !self.finished(current),
             "a freshly minted epoch is not already finished"
         );
@@ -715,7 +713,7 @@ impl ScopeEpochs {
                 // every later `finished(epoch)` — including one asked across a
                 // subsequent incarnation — keeps reporting it. A waiter that
                 // missed the pulse can therefore never park forever.
-                debug_assert!(
+                assert!(
                     self.finished(epoch),
                     "a finished epoch stays observably finished"
                 );
@@ -902,7 +900,7 @@ impl ScopeLifecycle {
     /// exists only for the initial transition: upgrades change the eventual
     /// verdict without repeating teardown side effects.
     pub fn begin_drain(&mut self, reason: StopReason) -> Option<(bool, ScopeState)> {
-        debug_assert!(
+        assert!(
             !matches!(reason, StopReason::NeverStarted),
             "NeverStarted is not a live-incarnation drain reason"
         );
@@ -996,7 +994,7 @@ impl<K> DeadlineQueue<K> {
     pub fn push(&mut self, at: Instant, key: K) -> DeadlineHandle {
         let handle = self.next_handle();
         let replaced = self.registrations.insert(handle, key);
-        debug_assert!(
+        assert!(
             replaced.is_none(),
             "monotonic deadline keys are never reused"
         );
@@ -1458,8 +1456,6 @@ mod tests {
         }
     }
 
-    /// Debug half of the two-profile guard: the misuse aborts loudly.
-    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "NeverStarted is a membership outcome outside incarnation dispatch")]
     fn funnel_dispatch_rejects_the_membership_level_never_started_outcome() {
@@ -1469,25 +1465,6 @@ mod tests {
             RestartPolicy::new(RestartCondition::Always, Backoff::Immediate),
             ScopeMode::Running,
             MembershipStatus::Active,
-        );
-    }
-
-    /// Release half: with the assert compiled out the same input fails closed
-    /// on `Terminal` instead of charging a restart. `RestartCondition::Always`
-    /// is the one condition whose `should_restart` returns `true`
-    /// unconditionally, so removing the guard flips this assertion.
-    #[cfg(not(debug_assertions))]
-    #[test]
-    fn funnel_dispatch_treats_the_membership_level_never_started_outcome_as_terminal() {
-        let exit = Exit::never_started();
-        assert_eq!(
-            dispatch_exit(
-                &exit,
-                RestartPolicy::new(RestartCondition::Always, Backoff::Immediate),
-                ScopeMode::Running,
-                MembershipStatus::Active,
-            ),
-            ExitDispatch::Terminal,
         );
     }
 

--- a/crates/shelterwood-core/src/engine.rs
+++ b/crates/shelterwood-core/src/engine.rs
@@ -672,7 +672,11 @@ impl ScopeEpochs {
         // A shutdown wait settles on `finished(target)`, so a freshly minted
         // epoch must not already read as finished — that would settle a wait
         // against the incarnation it just started.
-        assert!(
+        // Diagnostic-only: the assignment above constructs the exact state
+        // `finished` reads. Cells calls this while holding scope control, so
+        // an always-on panic would poison that mutex without changing any
+        // reachable verdict.
+        debug_assert!(
             !self.finished(current),
             "a freshly minted epoch is not already finished"
         );
@@ -713,7 +717,10 @@ impl ScopeEpochs {
                 // every later `finished(epoch)` — including one asked across a
                 // subsequent incarnation — keeps reporting it. A waiter that
                 // missed the pulse can therefore never park forever.
-                assert!(
+                // Diagnostic-only for the same state written immediately
+                // above. The cells caller holds scope control here, and no
+                // correctness path depends on this redundant observation.
+                debug_assert!(
                     self.finished(epoch),
                     "a finished epoch stays observably finished"
                 );

--- a/crates/shelterwood-core/src/identity.rs
+++ b/crates/shelterwood-core/src/identity.rs
@@ -153,7 +153,7 @@ impl PoisonedCounter {
     }
 
     fn from_current(current: u64) -> Self {
-        debug_assert_ne!(current, u64::MAX);
+        assert_ne!(current, u64::MAX);
         Self { current }
     }
 
@@ -437,7 +437,7 @@ impl ScopeIdentity {
                 MembershipReconciliation::Minted(MintedMembership::new(membership))
             }
             Entry::Vacant(entry) => {
-                debug_assert_ne!(provisional.0.generation, Generation::POISON);
+                assert_ne!(provisional.0.generation, Generation::POISON);
                 entry.insert(FenceCounter::from_fence(provisional.0));
                 MembershipReconciliation::Adopted
             }

--- a/crates/shelterwood-core/src/identity.rs
+++ b/crates/shelterwood-core/src/identity.rs
@@ -153,7 +153,11 @@ impl PoisonedCounter {
     }
 
     fn from_current(current: u64) -> Self {
-        assert_ne!(current, u64::MAX);
+        // Diagnostic-only: every caller extracts a constructible Generation,
+        // which excludes poison. The cells path reaches this while its child-
+        // identity mutex is held, so reachable behavior must not rely on a
+        // panic here.
+        debug_assert_ne!(current, u64::MAX);
         Self { current }
     }
 
@@ -437,7 +441,10 @@ impl ScopeIdentity {
                 MembershipReconciliation::Minted(MintedMembership::new(membership))
             }
             Entry::Vacant(entry) => {
-                assert_ne!(provisional.0.generation, Generation::POISON);
+                // Diagnostic-only under the cells child-identity mutex. A
+                // public Membership cannot contain the private poison value;
+                // insertion behavior therefore does not rely on this check.
+                debug_assert_ne!(provisional.0.generation, Generation::POISON);
                 entry.insert(FenceCounter::from_fence(provisional.0));
                 MembershipReconciliation::Adopted
             }

--- a/crates/shelterwood-core/src/panic.rs
+++ b/crates/shelterwood-core/src/panic.rs
@@ -70,20 +70,20 @@ pub fn resume_preferred_panic(panics: UnwindPanics) {
     }
 }
 
-/// Resumes exactly as [`resume_preferred_panic`], but never contains the
-/// payload.
+/// Resumes exactly as [`resume_preferred_panic`] on its ordinary non-unwinding
+/// call path.
 ///
 /// This is the variant for call sites that are not destructors and have
 /// already taken sole ownership of the panic. Silently discarding there would
 /// erase the authoritative diagnostic and let the caller continue past a
-/// failure it believes it re-raised, so the caller's non-unwinding precondition
-/// is asserted rather than absorbed.
+/// failure it believes it re-raised. A defensive unwinding call is nonetheless
+/// contained: asserting that precondition would itself be a double panic and
+/// could abort before either opaque payload was safely retired.
 pub fn resume_preferred_panic_outside_unwind(panics: UnwindPanics) {
+    if std::thread::panicking() {
+        return resume_preferred_panic(panics);
+    }
     let UnwindPanics { primary, cleanup } = panics;
-    assert!(
-        !std::thread::panicking(),
-        "an unwinding caller must contain its payloads with resume_preferred_panic"
-    );
     if let Some(payload) = primary {
         discard_panic(cleanup);
         resume_panic(payload);
@@ -172,6 +172,20 @@ mod tests {
         cleanup_drops: Arc<AtomicUsize>,
     }
 
+    struct OutsideResumeDuringUnwind {
+        primary_drops: Arc<AtomicUsize>,
+        cleanup_drops: Arc<AtomicUsize>,
+    }
+
+    impl Drop for OutsideResumeDuringUnwind {
+        fn drop(&mut self) {
+            resume_preferred_panic_outside_unwind(UnwindPanics {
+                primary: Some(Box::new(DropCount(Arc::clone(&self.primary_drops)))),
+                cleanup: Some(Box::new(DropCount(Arc::clone(&self.cleanup_drops)))),
+            });
+        }
+    }
+
     impl Drop for ResumeDuringUnwind {
         fn drop(&mut self) {
             resume_preferred_panic(UnwindPanics {
@@ -190,6 +204,28 @@ mod tests {
             let cleanup_drops = Arc::clone(&cleanup_drops);
             move || {
                 let _resume = ResumeDuringUnwind {
+                    primary_drops,
+                    cleanup_drops,
+                };
+                std::panic::panic_any("outer panic");
+            }
+        }))
+        .expect_err("the original unwind reaches its boundary");
+
+        assert_eq!(payload.downcast_ref::<&str>(), Some(&"outer panic"));
+        assert_eq!(primary_drops.load(Ordering::SeqCst), 1);
+        assert_eq!(cleanup_drops.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn outside_unwind_variant_defensively_contains_a_reentrant_unwind() {
+        let primary_drops = Arc::new(AtomicUsize::new(0));
+        let cleanup_drops = Arc::new(AtomicUsize::new(0));
+        let payload = catch_unwind(AssertUnwindSafe({
+            let primary_drops = Arc::clone(&primary_drops);
+            let cleanup_drops = Arc::clone(&cleanup_drops);
+            move || {
+                let _resume = OutsideResumeDuringUnwind {
                     primary_drops,
                     cleanup_drops,
                 };

--- a/crates/shelterwood-core/src/panic.rs
+++ b/crates/shelterwood-core/src/panic.rs
@@ -80,7 +80,7 @@ pub fn resume_preferred_panic(panics: UnwindPanics) {
 /// is asserted rather than absorbed.
 pub fn resume_preferred_panic_outside_unwind(panics: UnwindPanics) {
     let UnwindPanics { primary, cleanup } = panics;
-    debug_assert!(
+    assert!(
         !std::thread::panicking(),
         "an unwinding caller must contain its payloads with resume_preferred_panic"
     );

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -374,6 +374,10 @@ impl SupervisorState {
                 spawned_once: false,
             },
         );
+        // No "one live membership maps to exactly one child key" assertion is
+        // written here any more: the `child_keys.contains_key` guard at the
+        // top of this function makes a displacing insert unwritable rather
+        // than merely unfired, which is the stronger form of the same claim.
         self.child_keys.insert(membership, child);
         if initial && self.flavor == ScopeFlavor::Ordered && self.next_ordered_start.is_none() {
             self.next_ordered_start = Some(child);

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -354,7 +354,14 @@ impl SupervisorState {
         }
         let raw = self.keys.mint()?;
         let child = ChildKey(raw);
-        let replaced = self.children.insert(
+        // Keep a future key-domain regression total. Admission callers can
+        // hold wider framework locks while they retain an incoming user
+        // construction, so this pure reducer must never diagnose a collision
+        // by unwinding through them or displace the existing record.
+        if self.children.contains_key(&child) {
+            return None;
+        }
+        let _ = self.children.insert(
             child,
             ChildRecord {
                 membership,
@@ -367,12 +374,7 @@ impl SupervisorState {
                 spawned_once: false,
             },
         );
-        assert!(replaced.is_none(), "monotonic child keys are never reused");
-        let replaced = self.child_keys.insert(membership, child);
-        assert!(
-            replaced.is_none(),
-            "one live membership maps to exactly one child key"
-        );
+        self.child_keys.insert(membership, child);
         if initial && self.flavor == ScopeFlavor::Ordered && self.next_ordered_start.is_none() {
             self.next_ordered_start = Some(child);
         }
@@ -629,8 +631,12 @@ impl SupervisorState {
                 }
                 let membership = record.membership;
                 self.children.remove(&child);
-                let removed = self.child_keys.remove(&membership);
-                assert_eq!(removed, Some(child));
+                // The membership index is derived bookkeeping. A mismatch is
+                // fail-closed (the stale membership remains unavailable) and
+                // cannot justify unwinding a runtime resource owner.
+                if self.child_keys.get(&membership) == Some(&child) {
+                    let _ = self.child_keys.remove(&membership);
+                }
             }
             Event::FailStartup => {
                 let _ = self.fail_startup();
@@ -682,6 +688,11 @@ impl SupervisorState {
             self.keys.mint().is_none(),
             "the child-key domain reaches its permanent poison state"
         );
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn reuse_child_keys_for_test(&mut self) {
+        self.keys = PoisonedCounter::new();
     }
 
     #[cfg(test)]
@@ -1185,6 +1196,19 @@ mod tests {
             super::admit(&mut state, members[3], false).is_none(),
             "poisoned exhaustion remains fail closed"
         );
+        state.check_invariants();
+    }
+
+    #[test]
+    fn registration_key_collision_preserves_the_resident_record() {
+        let members = memberships(2);
+        let mut state = SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::running());
+        let resident = admit(&mut state, members[0], false);
+        state.reuse_child_keys_for_test();
+
+        assert_eq!(super::admit(&mut state, members[1], false), None);
+        assert_eq!(state.key_for(members[0]), Some(resident));
+        assert_eq!(state.key_for(members[1]), None);
         state.check_invariants();
     }
 

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -367,7 +367,7 @@ impl SupervisorState {
                 spawned_once: false,
             },
         );
-        debug_assert!(replaced.is_none(), "monotonic child keys are never reused");
+        assert!(replaced.is_none(), "monotonic child keys are never reused");
         let replaced = self.child_keys.insert(membership, child);
         assert!(
             replaced.is_none(),
@@ -630,7 +630,7 @@ impl SupervisorState {
                 let membership = record.membership;
                 self.children.remove(&child);
                 let removed = self.child_keys.remove(&membership);
-                debug_assert_eq!(removed, Some(child));
+                assert_eq!(removed, Some(child));
             }
             Event::FailStartup => {
                 let _ = self.fail_startup();

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -148,6 +148,10 @@ impl<M> SendOperation<M> {
 
     fn register(&self, registration: WaiterId) {
         let mut state = self.state.lock().expect("send operation mutex poisoned");
+        // Diagnostic-only under the send-operation mutex: a fresh operation
+        // is parked once and remains Waiting until the outer mailbox edge
+        // completes. Reachable behavior therefore does not depend on either
+        // check, and no test expects these diagnostics to panic.
         debug_assert!(state.registration.is_none());
         debug_assert!(matches!(state.outcome, OperationOutcome::Waiting { .. }));
         state.registration = Some(registration);
@@ -160,6 +164,8 @@ impl<M> SendOperation<M> {
         } else {
             // A cancellation can win after terminal teardown detaches the
             // queue but before it discharges this entry.
+            // Diagnostic-only: that race leaves `None`; any other identity is
+            // preserved by the total fallback. No test expects this panic.
             debug_assert!(state.registration.is_none());
         }
     }
@@ -288,25 +294,18 @@ impl<M> MailboxState<M> {
 
     /// Replaces one binding only after its waiter identity domain is empty.
     ///
-    /// The check is not an `assert!` because every caller holds the mailbox
-    /// mutex and a violated framework invariant must not poison it. Both
-    /// builds therefore keep the old binding: debug diagnoses first, and
-    /// release declines the replacement rather than dropping a live
-    /// `WaiterQueue` here. That drop would release the queue's
-    /// `Arc<SendOperation<M>>`s under the mutex, so wherever one is the last
-    /// owner a user message destructor would run in the critical section.
+    /// The state-level operation returns a rejected replacement because every
+    /// caller holds the mailbox mutex. `MailboxTxn` transfers that binding to
+    /// its effects, then raises the invariant panic only after unlock. Thus a
+    /// live `WaiterQueue` and its `Arc<SendOperation<M>>`s can never be
+    /// destroyed in the critical section.
     ///
-    /// The guard covers the *old* binding only. `replacement` is taken by
-    /// value, so declining destroys it — and any operation it carries —
-    /// right here, still under the mutex. The decline is therefore a
-    /// last-resort diagnostic, not a safe fallback. At every waiter-carrying
-    /// call site it is unreachable by construction: `take_waiters` moves the
-    /// parked senders out of the old binding into the replacement first, so
-    /// the domain this check reads is already empty. The remaining callers
-    /// pass an `Available` or empty binding. Reaching the decline would mean
-    /// a terminal misuse in which either outcome destroys user values in the
-    /// critical section.
-    fn replace_binding(&mut self, replacement: MailboxBinding<M>) {
+    /// At every waiter-carrying call site rejection is unreachable by
+    /// construction: `take_waiters` moves the parked senders out of the old
+    /// binding into the replacement first, so the domain this check reads is
+    /// already empty. The remaining callers pass an `Available` or empty
+    /// binding.
+    fn replace_binding(&mut self, replacement: MailboxBinding<M>) -> Result<(), MailboxBinding<M>> {
         let replaceable = match &self.binding {
             MailboxBinding::Unbound(waiters)
             | MailboxBinding::Frozen { waiters, .. }
@@ -314,14 +313,11 @@ impl<M> MailboxState<M> {
             MailboxBinding::Bound(BoundState::Available(_)) => true,
             MailboxBinding::Terminal(_) => false,
         };
-        debug_assert!(
-            replaceable,
-            "mailbox binding replacement requires an empty waiter queue"
-        );
         if !replaceable {
-            return;
+            return Err(replacement);
         }
         self.binding = replacement;
+        Ok(())
     }
 
     fn park(&mut self, operation: &Arc<SendOperation<M>>) -> bool {
@@ -335,16 +331,22 @@ impl<M> MailboxState<M> {
                 let Some(MailboxKind::Queue(capacity)) = self.kind else {
                     unreachable!("only a capacity-bound queue can park while bound")
                 };
+                // Diagnostic-only under the mailbox mutex: `Available` parks
+                // only after the accepting transition filled this configured
+                // queue. The Full transition remains total without the check,
+                // and no test expects the diagnostic panic.
                 debug_assert_eq!(self.queue.len(), capacity.get());
                 let incarnation = *incarnation;
                 let mut waiters = WaiterQueue::default();
                 if !waiters.park(operation) {
                     return false;
                 }
-                self.replace_binding(MailboxBinding::Bound(BoundState::Full {
+                // This arm just matched `Available`, so no waiter identity
+                // domain can be displaced by the direct replacement.
+                self.binding = MailboxBinding::Bound(BoundState::Full {
                     incarnation,
                     waiters,
-                }));
+                });
             }
             MailboxBinding::Terminal(_) => {
                 unreachable!("terminal submissions return their payload directly")
@@ -366,8 +368,9 @@ impl<M> MailboxState<M> {
             MailboxBinding::Terminal(_) => {
                 // Terminalization takes the waiters exactly once and no live
                 // transition follows it. This runs under the mailbox mutex
-                // with no way to release it first, so diagnose in debug rather
-                // than poisoning the lock for every sender in release.
+                // with no way to release it first, so this is diagnostic-only
+                // rather than an always-on panic. Returning an empty queue is
+                // the total behavior, and no test expects this diagnostic.
                 debug_assert!(false, "a terminal mailbox has no live transition");
                 WaiterQueue::default()
             }
@@ -412,7 +415,7 @@ impl<M> MailboxState<M> {
             MailboxBinding::Bound(BoundState::Available(_)) | MailboxBinding::Terminal(_) => None,
         };
         if let Some(incarnation) = available {
-            self.replace_binding(MailboxBinding::Bound(BoundState::Available(incarnation)));
+            self.binding = MailboxBinding::Bound(BoundState::Available(incarnation));
         }
         removed
     }
@@ -503,6 +506,9 @@ impl<M> WaiterQueue<M> {
     fn push_back(&mut self, operation: Arc<SendOperation<M>>) -> Option<WaiterId> {
         let next = WaiterId(self.ids.mint()?);
         let replaced = self.entries.insert(next, operation);
+        // Diagnostic-only under the mailbox mutex: the poisoned monotonic
+        // counter never reuses an identity. The insertion is authoritative,
+        // and no test expects this unreachable diagnostic to panic.
         debug_assert!(replaced.is_none());
         Some(next)
     }
@@ -558,6 +564,8 @@ struct MailboxEffects<'a, 's, M: Send + 'static> {
     wakers: WakerEffects,
     returned: Option<M>,
     accepted_sequence_exhausted: bool,
+    rejected_bindings: Vec<MailboxBinding<M>>,
+    invariant_panic: Option<&'static str>,
 }
 
 impl<'a, 's, M: Send + 'static> MailboxEffects<'a, 's, M> {
@@ -582,6 +590,8 @@ impl<'a, 's, M: Send + 'static> MailboxEffects<'a, 's, M> {
             wakers: WakerEffects::default(),
             returned: None,
             accepted_sequence_exhausted: false,
+            rejected_bindings: Vec::new(),
+            invariant_panic: None,
         }
     }
 
@@ -601,6 +611,8 @@ impl<M: Send + 'static> Drop for MailboxEffects<'_, '_, M> {
             && self.wakers.is_empty()
             && self.returned.is_none()
             && !self.accepted_sequence_exhausted
+            && self.rejected_bindings.is_empty()
+            && self.invariant_panic.is_none()
         {
             return;
         }
@@ -613,6 +625,8 @@ impl<M: Send + 'static> Drop for MailboxEffects<'_, '_, M> {
             wakers: std::mem::take(&mut self.wakers),
             returned: self.returned.take(),
             accepted_sequence_exhausted: self.accepted_sequence_exhausted,
+            rejected_bindings: std::mem::take(&mut self.rejected_bindings),
+            invariant_panic: self.invariant_panic.take(),
         };
         if let Some(external) = self.external.take() {
             external.defer_mailbox_effect(Box::new(move || {
@@ -633,6 +647,8 @@ struct MailboxEffectBatch<M> {
     wakers: WakerEffects,
     returned: Option<M>,
     accepted_sequence_exhausted: bool,
+    rejected_bindings: Vec<MailboxBinding<M>>,
+    invariant_panic: Option<&'static str>,
 }
 
 /// A received message remains isolated until every post-unlock effect has
@@ -665,6 +681,15 @@ impl<M: Send + 'static> Drop for ReturnedMessage<M> {
 impl<M: Send + 'static> MailboxEffectBatch<M> {
     fn flush(mut self) {
         let mut panics = PanicAccumulator::default();
+        if let Some(message) = self.invariant_panic {
+            panics.run(|| panic!("{message}"));
+        }
+        for rejected in self.rejected_bindings.drain(..) {
+            // A rejected binding can own parked user messages. Submit every
+            // binding separately so neither this caller nor a sibling job's
+            // unwind destroys it inline.
+            panics.run(|| dispose_value(self.runtime.as_ref(), rejected));
+        }
         if self.pulse {
             panics.run(|| self.changed.pulse());
         }
@@ -776,21 +801,28 @@ impl<'a, 's, M: Send + 'static> MailboxTxn<'a, 's, M> {
         self.state_mut().last_bound = Some(incarnation);
     }
 
+    fn replace_binding(&mut self, replacement: MailboxBinding<M>) {
+        let rejected = self.state_mut().replace_binding(replacement).err();
+        if let Some(rejected) = rejected {
+            self.effects.rejected_bindings.push(rejected);
+            self.effects.invariant_panic =
+                Some("mailbox binding replacement requires an empty waiter queue");
+        }
+    }
+
     fn bind_available(&mut self, incarnation: Incarnation) {
-        self.state_mut()
-            .replace_binding(MailboxBinding::Bound(BoundState::Available(incarnation)));
+        self.replace_binding(MailboxBinding::Bound(BoundState::Available(incarnation)));
     }
 
     fn bind_full(&mut self, incarnation: Incarnation, waiters: WaiterQueue<M>) {
-        self.state_mut()
-            .replace_binding(MailboxBinding::Bound(BoundState::Full {
-                incarnation,
-                waiters,
-            }));
+        self.replace_binding(MailboxBinding::Bound(BoundState::Full {
+            incarnation,
+            waiters,
+        }));
     }
 
     fn freeze_binding(&mut self, incarnation: Incarnation, waiters: WaiterQueue<M>) {
-        self.state_mut().replace_binding(MailboxBinding::Frozen {
+        self.replace_binding(MailboxBinding::Frozen {
             incarnation,
             waiters,
         });
@@ -806,13 +838,11 @@ impl<'a, 's, M: Send + 'static> MailboxTxn<'a, 's, M> {
     }
 
     fn unbind(&mut self, waiters: WaiterQueue<M>) {
-        self.state_mut()
-            .replace_binding(MailboxBinding::Unbound(waiters));
+        self.replace_binding(MailboxBinding::Unbound(waiters));
     }
 
     fn terminalize(&mut self, final_incarnation: Option<Incarnation>) {
-        self.state_mut()
-            .replace_binding(MailboxBinding::Terminal(final_incarnation));
+        self.replace_binding(MailboxBinding::Terminal(final_incarnation));
     }
 
     fn reset_bind_permit(&mut self) -> MailboxBindToken {
@@ -1253,6 +1283,9 @@ impl<M: Send + 'static> MailboxCell<M> {
                     // Acceptance took the waker in the same critical section
                     // that published this outcome, so no registration survives
                     // it for withdrawal to release.
+                    // Diagnostic-only under the operation mutex: withdrawal's
+                    // returned outcome is complete without this observation,
+                    // and no test expects the diagnostic panic.
                     debug_assert!(state.waker.is_empty());
                     Ok((
                         WithdrawalOutcome::Accepted(incarnation),
@@ -1266,6 +1299,8 @@ impl<M: Send + 'static> MailboxCell<M> {
                     Some(message) => {
                         let observed = *final_incarnation;
                         // Termination likewise took the waker before publishing.
+                        // Diagnostic-only under the operation mutex: the total
+                        // outcome is unchanged, and no test expects a panic.
                         debug_assert!(state.waker.is_empty());
                         Ok((
                             WithdrawalOutcome::Terminated { message, observed },
@@ -1284,17 +1319,35 @@ impl<M: Send + 'static> MailboxCell<M> {
                 panic!("{message}");
             }
         };
+        let mut unexpected_removed = None;
+        let mut missing_nonterminal_registration = false;
         if let Some(registration) = registration {
             if let Some(removed) = transaction.remove_waiter(registration) {
-                debug_assert!(Arc::ptr_eq(&removed, operation));
+                if Arc::ptr_eq(&removed, operation) {
+                    // The caller's Arc proves this locked refcount decrement
+                    // cannot destroy the operation or its user message.
+                    drop(removed);
+                } else {
+                    unexpected_removed = Some(removed);
+                }
             } else {
-                debug_assert!(matches!(transaction.status(), BindingStatus::Terminal(_)));
+                missing_nonterminal_registration =
+                    !matches!(transaction.status(), BindingStatus::Terminal(_));
             }
         }
-        transaction.finish(Withdrawal {
+        let withdrawal = transaction.finish(Withdrawal {
             outcome: Some(outcome),
             _waker_effects: waker_effects,
-        })
+        });
+        if let Some(unexpected_removed) = unexpected_removed {
+            self.dispose(unexpected_removed);
+            panic!("a waiter registration must identify its send operation");
+        }
+        assert!(
+            !missing_nonterminal_registration,
+            "only terminal teardown may detach a live waiter registration"
+        );
+        withdrawal
     }
 }
 
@@ -1386,6 +1439,9 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             let MailboxKind::Queue(capacity) = kind else {
                 unreachable!("a latest mailbox finishes all waiting submissions")
             };
+            // Diagnostic-only under the mailbox mutex: promotion leaves
+            // waiters only after filling a configured queue. Binding Full is
+            // total without the check, and no test expects this panic.
             debug_assert_eq!(transaction.queue.len(), capacity.get());
             transaction.bind_full(incarnation, waiters);
         }
@@ -1481,12 +1537,19 @@ where
 {
     match &state.binding {
         MailboxBinding::Bound(BoundState::Available(current)) => {
+            // Diagnostic-only under the mailbox mutex: `incarnation` was read
+            // from this same binding by the surrounding transaction. The
+            // acceptance path is unchanged without the check, and no test
+            // expects the diagnostic panic.
             debug_assert_eq!(*current, incarnation);
         }
         MailboxBinding::Bound(BoundState::Full {
             incarnation: current,
             ..
         }) => {
+            // Diagnostic-only for the same single-transaction status sample
+            // as the Available arm. Full still returns the message intact,
+            // and no test expects the diagnostic panic.
             debug_assert_eq!(*current, incarnation);
             return AcceptTransition::Full(message);
         }
@@ -1554,7 +1617,7 @@ fn promote_waiters<M: Send + 'static>(
         effects,
     );
     if waiters.is_empty() {
-        state.replace_binding(MailboxBinding::Bound(BoundState::Available(incarnation)));
+        state.binding = MailboxBinding::Bound(BoundState::Available(incarnation));
     }
 }
 

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -505,12 +505,17 @@ impl<M> WaiterQueue<M> {
 
     fn push_back(&mut self, operation: Arc<SendOperation<M>>) -> Option<WaiterId> {
         let next = WaiterId(self.ids.mint()?);
-        let replaced = self.entries.insert(next, operation);
-        // Diagnostic-only under the mailbox mutex: the poisoned monotonic
-        // counter never reuses an identity. The insertion is authoritative,
-        // and no test expects this unreachable diagnostic to panic.
-        debug_assert!(replaced.is_none());
-        Some(next)
+        // Keep a counter regression total. `park` retains the caller's Arc,
+        // so declining this clone is refcount traffic and cannot destroy its
+        // user message under the mailbox mutex; the resident operation is not
+        // displaced at all.
+        match self.entries.entry(next) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(operation);
+                Some(next)
+            }
+            std::collections::btree_map::Entry::Occupied(_) => None,
+        }
     }
 
     fn park(&mut self, operation: &Arc<SendOperation<M>>) -> bool {
@@ -1281,12 +1286,18 @@ impl<M: Send + 'static> MailboxCell<M> {
                 OperationOutcome::Accepted(incarnation) => {
                     let incarnation = *incarnation;
                     // Acceptance took the waker in the same critical section
-                    // that published this outcome, so no registration survives
-                    // it for withdrawal to release.
-                    // Diagnostic-only under the operation mutex: withdrawal's
-                    // returned outcome is complete without this observation,
-                    // and no test expects the diagnostic panic.
-                    debug_assert!(state.waker.is_empty());
+                    // that published this outcome. Keep a future regression
+                    // total by transferring any leftover waker to the same
+                    // post-unlock effect set as an ordinary withdrawal.
+                    state.waker.take(
+                        match disposition {
+                            WithdrawalDisposition::Inline => WakerAction::DropInline,
+                            WithdrawalDisposition::Isolated => {
+                                WakerAction::Dispose(Arc::clone(&self.runtime))
+                            }
+                        },
+                        &mut waker_effects,
+                    );
                     Ok((
                         WithdrawalOutcome::Accepted(incarnation),
                         state.registration.take(),
@@ -1298,10 +1309,19 @@ impl<M: Send + 'static> MailboxCell<M> {
                 } => match message.take() {
                     Some(message) => {
                         let observed = *final_incarnation;
-                        // Termination likewise took the waker before publishing.
-                        // Diagnostic-only under the operation mutex: the total
-                        // outcome is unchanged, and no test expects a panic.
-                        debug_assert!(state.waker.is_empty());
+                        // Termination likewise normally took the waker before
+                        // publishing. Transfer a leftover instead of letting a
+                        // diagnostic unwind this by-value message under the
+                        // operation mutex.
+                        state.waker.take(
+                            match disposition {
+                                WithdrawalDisposition::Inline => WakerAction::DropInline,
+                                WithdrawalDisposition::Isolated => {
+                                    WakerAction::Dispose(Arc::clone(&self.runtime))
+                                }
+                            },
+                            &mut waker_effects,
+                        );
                         Ok((
                             WithdrawalOutcome::Terminated { message, observed },
                             state.registration.take(),
@@ -1339,14 +1359,27 @@ impl<M: Send + 'static> MailboxCell<M> {
             outcome: Some(outcome),
             _waker_effects: waker_effects,
         });
-        if let Some(unexpected_removed) = unexpected_removed {
-            self.dispose(unexpected_removed);
-            panic!("a waiter registration must identify its send operation");
+        let invariant = if unexpected_removed.is_some() {
+            Some("a waiter registration must identify its send operation")
+        } else if missing_nonterminal_registration {
+            Some("only terminal teardown may detach a live waiter registration")
+        } else {
+            None
+        };
+        if let Some(invariant) = invariant {
+            // Establish the framework diagnostic first, then submit both the
+            // unexpectedly removed operation and this withdrawal's by-value
+            // message/waker effects before resuming it. Neither can therefore
+            // be destroyed on the invariant panic's stack.
+            let mut panics = PanicAccumulator::default();
+            panics.run(|| panic!("{invariant}"));
+            if let Some(unexpected_removed) = unexpected_removed {
+                panics.run(|| self.dispose(unexpected_removed));
+            }
+            panics.run(|| self.dispose(withdrawal));
+            drop(panics);
+            unreachable!("the recorded mailbox invariant panic must resume");
         }
-        assert!(
-            !missing_nonterminal_registration,
-            "only terminal teardown may detach a live waiter registration"
-        );
         withdrawal
     }
 }
@@ -1439,10 +1472,10 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
             let MailboxKind::Queue(capacity) = kind else {
                 unreachable!("a latest mailbox finishes all waiting submissions")
             };
-            // Diagnostic-only under the mailbox mutex: promotion leaves
-            // waiters only after filling a configured queue. Binding Full is
-            // total without the check, and no test expects this panic.
-            debug_assert_eq!(transaction.queue.len(), capacity.get());
+            // Promotion leaves waiters only after filling a configured queue.
+            // Binding Full is the total fallback too: diagnosing here would
+            // unwind the waiter queue's user messages under the mailbox mutex.
+            let _ = capacity;
             transaction.bind_full(incarnation, waiters);
         }
         transaction.effects.pulse();
@@ -1537,20 +1570,14 @@ where
 {
     match &state.binding {
         MailboxBinding::Bound(BoundState::Available(current)) => {
-            // Diagnostic-only under the mailbox mutex: `incarnation` was read
-            // from this same binding by the surrounding transaction. The
-            // acceptance path is unchanged without the check, and no test
-            // expects the diagnostic panic.
-            debug_assert_eq!(*current, incarnation);
+            // `incarnation` was read from this same binding by the surrounding
+            // transaction. Keep a future mismatch total so the by-value user
+            // message returns through the caller's post-unlock path.
+            if *current != incarnation {
+                return AcceptTransition::Full(message);
+            }
         }
-        MailboxBinding::Bound(BoundState::Full {
-            incarnation: current,
-            ..
-        }) => {
-            // Diagnostic-only for the same single-transaction status sample
-            // as the Available arm. Full still returns the message intact,
-            // and no test expects the diagnostic panic.
-            debug_assert_eq!(*current, incarnation);
+        MailboxBinding::Bound(BoundState::Full { .. }) => {
             return AcceptTransition::Full(message);
         }
         MailboxBinding::Unbound(_)

--- a/crates/shelterwood-mailbox/src/cell.rs
+++ b/crates/shelterwood-mailbox/src/cell.rs
@@ -333,8 +333,10 @@ impl<M> MailboxState<M> {
                 };
                 // Diagnostic-only under the mailbox mutex: `Available` parks
                 // only after the accepting transition filled this configured
-                // queue. The Full transition remains total without the check,
-                // and no test expects the diagnostic panic.
+                // queue, or after that transition's own incarnation-mismatch
+                // fallback, which has already recorded its invariant panic on
+                // the effects sink. The Full transition remains total without
+                // this check, and no test expects the diagnostic panic.
                 debug_assert_eq!(self.queue.len(), capacity.get());
                 let incarnation = *incarnation;
                 let mut waiters = WaiterQueue::default();
@@ -810,8 +812,11 @@ impl<'a, 's, M: Send + 'static> MailboxTxn<'a, 's, M> {
         let rejected = self.state_mut().replace_binding(replacement).err();
         if let Some(rejected) = rejected {
             self.effects.rejected_bindings.push(rejected);
-            self.effects.invariant_panic =
-                Some("mailbox binding replacement requires an empty waiter queue");
+            // First-wins, like every other precedence site: the earliest
+            // invariant failure in a transaction is the informative one.
+            self.effects
+                .invariant_panic
+                .get_or_insert("mailbox binding replacement requires an empty waiter queue");
         }
     }
 
@@ -1367,18 +1372,35 @@ impl<M: Send + 'static> MailboxCell<M> {
             None
         };
         if let Some(invariant) = invariant {
+            // `withdraw` is reached from `SendFuture`'s drop glue, so this can
+            // run on an already-unwinding stack. `PanicAccumulator` contains
+            // rather than resumes there -- raising the invariant would be a
+            // double panic and an abort, which is the outcome this whole lane
+            // exists to prevent -- so decide the disposition up front instead
+            // of assuming the accumulator will resume.
+            let unwinding = std::thread::panicking();
+            let mut panics = PanicAccumulator::default();
             // Establish the framework diagnostic first, then submit both the
             // unexpectedly removed operation and this withdrawal's by-value
             // message/waker effects before resuming it. Neither can therefore
-            // be destroyed on the invariant panic's stack.
-            let mut panics = PanicAccumulator::default();
-            panics.run(|| panic!("{invariant}"));
+            // be destroyed on the invariant panic's stack, and neither can
+            // displace the diagnostic: the accumulator keeps the first panic.
+            if !unwinding {
+                panics.run(|| panic!("{invariant}"));
+            }
             if let Some(unexpected_removed) = unexpected_removed {
                 panics.run(|| self.dispose(unexpected_removed));
             }
-            panics.run(|| self.dispose(withdrawal));
+            if !unwinding {
+                panics.run(|| self.dispose(withdrawal));
+                drop(panics);
+                unreachable!("a non-unwinding accumulator resumes its recorded panic");
+            }
+            // Contained: the caller is already unwinding and still owns this
+            // withdrawal's ordinary disposal path, so hand it back rather than
+            // taking it over.
             drop(panics);
-            unreachable!("the recorded mailbox invariant panic must resume");
+            return withdrawal;
         }
         withdrawal
     }
@@ -1571,9 +1593,14 @@ where
     match &state.binding {
         MailboxBinding::Bound(BoundState::Available(current)) => {
             // `incarnation` was read from this same binding by the surrounding
-            // transaction. Keep a future mismatch total so the by-value user
-            // message returns through the caller's post-unlock path.
+            // transaction, so a mismatch is a framework invariant failure.
+            // Keep it total -- the by-value user message returns through the
+            // caller's post-unlock path rather than being destroyed under the
+            // mailbox mutex -- and raise the diagnostic through the same
+            // effects sink, which flushes it after unlock.
             if *current != incarnation {
+                effects.invariant_panic =
+                    Some("an accepting transition observes its own binding's incarnation");
                 return AcceptTransition::Full(message);
             }
         }

--- a/crates/shelterwood-mailbox/src/cell/tests.rs
+++ b/crates/shelterwood-mailbox/src/cell/tests.rs
@@ -627,9 +627,8 @@ fn termination_finish_completes_waiters_and_isolates_payload_after_signal_panic(
     }
 }
 
-#[cfg(debug_assertions)]
 #[test]
-fn binding_replacement_rejects_a_live_waiter_identity_domain() {
+fn binding_replacement_preserves_a_live_waiter_identity_domain() {
     let operation = super::SendOperation::new(1_u8);
     let mut waiters = super::WaiterQueue::default();
     waiters.park(&operation);
@@ -642,15 +641,41 @@ fn binding_replacement_rejects_a_live_waiter_identity_domain() {
         latest: None,
     };
 
-    assert!(
-        catch_unwind(AssertUnwindSafe(|| {
-            state.replace_binding(super::MailboxBinding::Unbound(super::WaiterQueue::default()));
-        }))
-        .is_err(),
-        "a live waiter queue cannot be replaced"
-    );
+    let rejected =
+        state.replace_binding(super::MailboxBinding::Unbound(super::WaiterQueue::default()));
+    assert!(rejected.is_err(), "a live waiter queue cannot be replaced");
     assert!(matches!(
         &state.binding,
+        super::MailboxBinding::Unbound(waiters) if waiters.len() == 1
+    ));
+}
+
+#[test]
+fn binding_replacement_invariant_panics_after_unlock() {
+    let mailbox = MailboxCell::new(ChildId::from("actor"), crate::capability::tests::runtime());
+    let operation = super::SendOperation::new(1_u8);
+    let mut waiters = super::WaiterQueue::default();
+    assert!(waiters.park(&operation));
+    mailbox.state.lock().expect("mailbox mutex healthy").binding =
+        super::MailboxBinding::Unbound(waiters);
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        let mut transaction = super::MailboxTxn::new(&mailbox);
+        transaction.bind_available(mint_actor_incarnation());
+        transaction.finish(())
+    }))
+    .expect_err("a live waiter identity domain refuses replacement");
+
+    assert_eq!(
+        panic.downcast_ref::<String>().map(String::as_str),
+        Some("mailbox binding replacement requires an empty waiter queue")
+    );
+    assert!(
+        mailbox.state.try_lock().is_ok(),
+        "the invariant resumes only after the mailbox guard is released"
+    );
+    assert!(matches!(
+        &mailbox.state.lock().expect("mailbox mutex remains healthy").binding,
         super::MailboxBinding::Unbound(waiters) if waiters.len() == 1
     ));
 }

--- a/crates/shelterwood-mailbox/src/cell/tests.rs
+++ b/crates/shelterwood-mailbox/src/cell/tests.rs
@@ -737,6 +737,97 @@ fn withdrawal_registration_invariant_disposes_messages_before_resuming() {
     drop(mailbox.state.lock().expect("mailbox mutex remains healthy"));
 }
 
+/// `withdraw` is reached from `SendFuture`'s drop glue, so its invariant path
+/// can run on an already-unwinding stack. Raising there would be a double
+/// panic and a process abort -- exactly the outcome this lane exists to
+/// prevent -- so the diagnostic is contained and the withdrawal is handed back
+/// to its ordinary owner. Without the containment this test aborts the
+/// process rather than failing.
+#[test]
+fn withdrawal_registration_invariant_is_contained_during_an_unwind() {
+    struct WithdrawOnDrop<'a> {
+        mailbox: &'a MailboxCell<ThreadRecordingMessage>,
+        operation: Arc<super::SendOperation<ThreadRecordingMessage>>,
+    }
+
+    impl Drop for WithdrawOnDrop<'_> {
+        fn drop(&mut self) {
+            let mut withdrawal = self
+                .mailbox
+                .withdraw(&self.operation, super::WithdrawalDisposition::Isolated);
+            // The contained path returns the withdrawal intact, so its
+            // by-value message is still this caller's to retire.
+            match withdrawal.take_outcome() {
+                super::WithdrawalOutcome::Withdrawn { message, .. }
+                | super::WithdrawalOutcome::Terminated { message, .. } => {
+                    self.mailbox.dispose(message);
+                }
+                super::WithdrawalOutcome::Accepted(_) => {}
+            }
+        }
+    }
+
+    let mailbox = MailboxCell::new(ChildId::from("actor"), crate::capability::tests::runtime());
+    let (first_dropped, first_observed) = mpsc::channel();
+    let (second_dropped, second_observed) = mpsc::channel();
+    let first = match mailbox.submit(ThreadRecordingMessage(Some(first_dropped))) {
+        super::Submission::Parked(operation) => operation,
+        super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+            panic!("an unbound mailbox parks its first send")
+        }
+    };
+    let second = match mailbox.submit(ThreadRecordingMessage(Some(second_dropped))) {
+        super::Submission::Parked(operation) => operation,
+        super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+            panic!("an unbound mailbox parks its second send")
+        }
+    };
+    let second_registration = second
+        .state
+        .lock()
+        .expect("second operation mutex healthy")
+        .registration
+        .expect("the second operation is registered");
+    first
+        .state
+        .lock()
+        .expect("first operation mutex healthy")
+        .registration = Some(second_registration);
+    drop(second);
+    let caller = std::thread::current().id();
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        let _withdraw_on_drop = WithdrawOnDrop {
+            mailbox: &mailbox,
+            operation: Arc::clone(&first),
+        };
+        std::panic::panic_any("the caller's own unwind");
+    }))
+    .expect_err("the caller's unwind reaches its boundary");
+
+    assert_eq!(
+        panic.downcast_ref::<&str>().copied(),
+        Some("the caller's own unwind"),
+        "the contained invariant cannot replace the unwind already in flight"
+    );
+    for observed in [first_observed, second_observed] {
+        assert_ne!(
+            observed
+                .recv_timeout(Duration::from_secs(5))
+                .expect("every user message still leaves the caller"),
+            caller,
+            "containment does not strand a user message on the unwinding thread"
+        );
+    }
+    drop(
+        first
+            .state
+            .lock()
+            .expect("first operation mutex remains healthy"),
+    );
+    drop(mailbox.state.lock().expect("mailbox mutex remains healthy"));
+}
+
 #[test]
 fn waiter_identity_collision_preserves_the_resident_operation() {
     let resident = super::SendOperation::new(1_u8);

--- a/crates/shelterwood-mailbox/src/cell/tests.rs
+++ b/crates/shelterwood-mailbox/src/cell/tests.rs
@@ -681,6 +681,85 @@ fn binding_replacement_invariant_panics_after_unlock() {
 }
 
 #[test]
+fn withdrawal_registration_invariant_disposes_messages_before_resuming() {
+    let mailbox = MailboxCell::new(ChildId::from("actor"), crate::capability::tests::runtime());
+    let (first_dropped, first_observed) = mpsc::channel();
+    let (second_dropped, second_observed) = mpsc::channel();
+    let first = match mailbox.submit(ThreadRecordingMessage(Some(first_dropped))) {
+        super::Submission::Parked(operation) => operation,
+        super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+            panic!("an unbound mailbox parks its first send")
+        }
+    };
+    let second = match mailbox.submit(ThreadRecordingMessage(Some(second_dropped))) {
+        super::Submission::Parked(operation) => operation,
+        super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
+            panic!("an unbound mailbox parks its second send")
+        }
+    };
+    let second_registration = second
+        .state
+        .lock()
+        .expect("second operation mutex healthy")
+        .registration
+        .expect("the second operation is registered");
+    first
+        .state
+        .lock()
+        .expect("first operation mutex healthy")
+        .registration = Some(second_registration);
+    drop(second);
+    let caller = std::thread::current().id();
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        let _ = mailbox.withdraw(&first, super::WithdrawalDisposition::Inline);
+    }))
+    .expect_err("a registration cannot identify another operation");
+    assert_eq!(
+        panic.downcast_ref::<String>().map(String::as_str),
+        Some("a waiter registration must identify its send operation")
+    );
+    for observed in [first_observed, second_observed] {
+        assert_ne!(
+            observed
+                .recv_timeout(Duration::from_secs(5))
+                .expect("the invariant path submits every user message"),
+            caller,
+            "the framework panic cannot unwind a user message on its caller"
+        );
+    }
+    drop(
+        first
+            .state
+            .lock()
+            .expect("first operation mutex remains healthy"),
+    );
+    drop(mailbox.state.lock().expect("mailbox mutex remains healthy"));
+}
+
+#[test]
+fn waiter_identity_collision_preserves_the_resident_operation() {
+    let resident = super::SendOperation::new(1_u8);
+    let incoming = super::SendOperation::new(2_u8);
+    let mut waiters = super::WaiterQueue::default();
+    waiters
+        .entries
+        .insert(super::WaiterId(1), Arc::clone(&resident));
+
+    assert!(
+        !waiters.park(&incoming),
+        "a reused identity refuses the incoming operation"
+    );
+    assert!(Arc::ptr_eq(
+        waiters
+            .entries
+            .get(&super::WaiterId(1))
+            .expect("resident remains"),
+        &resident
+    ));
+}
+
+#[test]
 fn receive_modes_pin_live_cutoffs_and_frozen_drain() {
     let (mailbox, actor) = actor();
     let token = configure(

--- a/crates/shelterwood-mailbox/src/cell/waker_slot.rs
+++ b/crates/shelterwood-mailbox/src/cell/waker_slot.rs
@@ -44,10 +44,6 @@ impl WakerSlot {
             effects.push(waker, action);
         }
     }
-
-    pub(super) fn is_empty(&self) -> bool {
-        self.0.is_none()
-    }
 }
 
 impl WakerEffects {

--- a/crates/shelterwood-runtime/src/disposal.rs
+++ b/crates/shelterwood-runtime/src/disposal.rs
@@ -207,7 +207,7 @@ fn enqueue_fallback_disposal_with(
     // the job just appended even when older critical jobs are still queued.
     let rejected = state.queue.pop_back();
     drop(state);
-    debug_assert!(rejected.is_some());
+    assert!(rejected.is_some());
     drop(rejected);
     false
 }

--- a/crates/shelterwood-runtime/src/disposal.rs
+++ b/crates/shelterwood-runtime/src/disposal.rs
@@ -207,7 +207,10 @@ fn enqueue_fallback_disposal_with(
     // the job just appended even when older critical jobs are still queued.
     let rejected = state.queue.pop_back();
     drop(state);
-    assert!(rejected.is_some());
+    // Keep even a future queue regression total. The caller retains the
+    // original job Arc and will finish it on the ordinary fallback path; an
+    // assertion here could instead unwind that user payload through disposal
+    // infrastructure.
     drop(rejected);
     false
 }

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -103,11 +103,10 @@ pub struct ActorWork {
 
 impl ActorWork {
     pub fn abort(&self) {
-        // A handle is taken only by `join`, which consumes the work, so the
-        // slot is populated on every reachable call. Assert rather than
-        // panic: this shares its shape with the locked callers of
-        // `OneShotSender::is_closed`, and aborting nothing is the harmless
-        // reading of an already-joined handle.
+        // Diagnostic-only: a handle is taken only by `join`, which consumes
+        // the work, so the slot is populated on every reachable call. This
+        // can be sampled from a locked control path, so aborting nothing is
+        // the total release behavior and no test depends on the diagnostic.
         debug_assert!(
             self.handle.is_some(),
             "actor work retains its join handle until join"
@@ -417,7 +416,7 @@ pub async fn join<T>(handle: JoinHandle<T>) -> JoinOutcome<T> {
             message: contain_panic_payload(error.into_panic()),
         },
         Err(error) => {
-            debug_assert!(error.is_cancelled());
+            assert!(error.is_cancelled());
             JoinOutcome::Cancelled
         }
     }
@@ -429,7 +428,7 @@ pub async fn join_resuming<T>(handle: JoinHandle<T>) -> T {
         Ok(value) => value,
         Err(error) if error.is_panic() => resume_unwind(error.into_panic()),
         Err(error) => {
-            debug_assert!(error.is_cancelled());
+            assert!(error.is_cancelled());
             panic!("library-owned operation task was unexpectedly cancelled")
         }
     }

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -321,7 +321,7 @@ impl CompletionGatedLatch {
             return false;
         }
         let transitioned = self.fired.fire();
-        debug_assert!(transitioned);
+        assert!(transitioned);
         true
     }
 
@@ -360,7 +360,7 @@ impl CompletionGatedLatch {
                 .is_ok()
             {
                 let transitioned = self.completed.fire();
-                debug_assert!(transitioned);
+                assert!(transitioned);
                 return fired;
             }
         }
@@ -497,11 +497,13 @@ impl<T> OneShotSender<T> {
     }
 
     pub fn is_closed(&self) -> bool {
-        // Observed under the observation gate and the dynamic-state mutex
+        // Diagnostic-only: this is observed under the observation gate and
+        // the dynamic-state mutex
         // (`RemovalResponses::subscribe`), so the missing-channel verdict
         // cannot be raised as a panic without poisoning both for every later
-        // caller. The total form reports the taken channel as closed, which
-        // is what a sender past `send` is.
+        // caller. No correctness property depends on the diagnostic: the
+        // total form reports the taken channel as closed, which is what a
+        // sender past `send` is, and no test expects this assertion to fire.
         debug_assert!(
             self.channel.is_some(),
             "an observable one-shot sender retains its channel"
@@ -681,9 +683,9 @@ impl<T> WatchShared<T> {
     ///
     /// `modify_silently` and `read_with` run a caller closure under this
     /// guard, and those closures do real work: a lifecycle publication sends
-    /// on a broadcast channel here, and a snapshot installation evaluates a
-    /// `debug_assert!` and mints a generation. A panic in any of them would
-    /// otherwise wedge every later read, publication, subscription and
+    /// on a broadcast channel here, and a snapshot installation mints a
+    /// generation. A panic in any of them would
+    /// would otherwise wedge every later read, publication, subscription and
     /// terminal wait on the channel. The guarded data is plain framework
     /// state with no invariant spanning the closure, so the surviving value
     /// stays usable; this matches `ObservationGate::lock`, which tolerates
@@ -724,6 +726,9 @@ impl<T> Clone for WatchSender<T> {
 impl<T> Drop for WatchSender<T> {
     fn drop(&mut self) {
         let previous = self.shared.senders.fetch_sub(1, Ordering::AcqRel);
+        // Diagnostic-only: safe ownership cannot drop one endpoint twice.
+        // The wake decision below remains total without this check, and no
+        // test depends on the diagnostic panic.
         debug_assert!(previous > 0, "a watch sender is released at most once");
         if previous == 1 {
             self.shared.waiters.wake_all();
@@ -810,6 +815,9 @@ impl<T> Clone for WatchReceiver<T> {
 impl<T> Drop for WatchReceiver<T> {
     fn drop(&mut self) {
         let previous = self.shared.receivers.fetch_sub(1, Ordering::AcqRel);
+        // Diagnostic-only: safe ownership cannot drop one endpoint twice.
+        // There is no downstream action whose correctness depends on this
+        // check, and no test depends on the diagnostic panic.
         debug_assert!(previous > 0, "a watch receiver is released at most once");
     }
 }

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -684,8 +684,8 @@ impl<T> WatchShared<T> {
     /// `modify_silently` and `read_with` run a caller closure under this
     /// guard, and those closures do real work: a lifecycle publication sends
     /// on a broadcast channel here, and a snapshot installation mints a
-    /// generation. A panic in any of them would
-    /// would otherwise wedge every later read, publication, subscription and
+    /// generation. A panic in any of them would otherwise wedge every later
+    /// read, publication, subscription and
     /// terminal wait on the channel. The guarded data is plain framework
     /// state with no invariant spanning the closure, so the surviving value
     /// stays usable; this matches `ObservationGate::lock`, which tolerates

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -167,7 +167,7 @@ impl<'a, A: Actor> Context<'a, A> {
     }
 
     fn initialization_returned(&mut self) {
-        debug_assert_eq!(self.stage, DeliveryStage::Initializing);
+        assert_eq!(self.stage, DeliveryStage::Initializing);
         self.owns_init_boundary = false;
     }
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -576,11 +576,10 @@ impl ScopeRuntime {
     }
 
     fn stage_disposal_panic(&mut self, child: ChildKey, panic: Option<runtime::DisposalPanic>) {
-        let replaced = self.arrived_disposal_panics.insert(child, panic);
-        assert!(
-            replaced.is_none(),
-            "a terminal disposes its retained construction once, under a never-reused key"
-        );
+        // A terminal normally reports construction disposal exactly once.
+        // Preserve the first completion if that producer contract regresses:
+        // this also keeps driver teardown total when it is already unwinding.
+        self.arrived_disposal_panics.entry(child).or_insert(panic);
     }
 
     fn take_arrived_disposal_panic(&mut self, child: ChildKey) -> Option<runtime::DisposalPanic> {
@@ -597,20 +596,15 @@ impl ScopeRuntime {
     fn drain_arrived_disposal_events(&mut self, panics: &mut runtime::PanicAccumulator) {
         while let Some(event) = self.disposal_event_receiver.try_recv() {
             // The lane has one producer, which sends exactly one variant.
-            // Diagnostic-only: do not let a pattern-matching loop condition
-            // drop an unexpected event and silently abandon the rest of the
-            // drain. Teardown can run during an unwind, so this cannot become
-            // an always-on panic; the match below remains total, and no test
-            // depends on the diagnostic firing.
-            debug_assert!(
-                matches!(
-                    event,
-                    DriverEvent::Child(ChildEvent::ConstructionDisposed { .. })
-                ),
-                "the disposal lane carries only construction-disposal completions"
-            );
-            if let DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) = event {
-                self.stage_disposal_panic(child, panic);
+            // Keep the impossible foreign-event fallback total even during a
+            // driver unwind: an admission/removal request can retain user
+            // construction and response wakers, so contain its drop through
+            // the teardown accumulator instead of diagnosing on this stack.
+            match event {
+                DriverEvent::Child(ChildEvent::ConstructionDisposed { child, panic }) => {
+                    self.stage_disposal_panic(child, panic);
+                }
+                unexpected => panics.run(|| drop(unexpected)),
             }
         }
         // Folding empties the staging map, so the batch entries these
@@ -668,11 +662,14 @@ impl ScopeRuntime {
         let Some(key) = supervisor_admit(&mut self.supervisor, membership, initial) else {
             return Err(Box::new(child));
         };
-        let replaced = self.children.insert(key, child);
-        assert!(
-            replaced.is_none(),
-            "the reducer's monotonic child key is new to runtime resources"
-        );
+        // This method can run under both the observation gate and dynamic-
+        // state mutex. Probe before insertion so even a future key-domain
+        // regression returns the incoming user construction intact instead
+        // of displacing and unwinding a resident child through those locks.
+        if self.children.get(key).is_some() {
+            return Err(Box::new(child));
+        }
+        let _ = self.children.insert(key, child);
         Ok(key)
     }
 
@@ -1109,8 +1106,14 @@ async fn run_scope_incarnation(
         let Some(key) = supervisor_admit(&mut supervisor, membership, true) else {
             unreachable!("a fresh child-key domain accommodates an in-memory child collection")
         };
-        let replaced = children.insert(key, child);
-        assert!(replaced.is_none());
+        if children.get(key).is_some() {
+            // Keep both constructions out of the framework-panic unwind. The
+            // resident remains owned by `children`; this rejected incoming
+            // child is submitted before the invariant is raised.
+            runtime::dispose_detached(child);
+            panic!("the reducer's monotonic child key is new to runtime resources");
+        }
+        let _ = children.insert(key, child);
     }
     if let Some(control) = &dynamic {
         root.with_observation_gate(|txn| {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -319,6 +319,10 @@ impl<T> ChildResources<T> {
         self.0.values()
     }
 
+    fn into_values(self) -> impl Iterator<Item = T> {
+        self.0.into_values()
+    }
+
     #[cfg(test)]
     fn len(&self) -> usize {
         self.0.len()
@@ -814,11 +818,26 @@ impl ScopeRuntime {
                 entry_promoted,
                 projection_admitted,
             } => {
-                assert!(entry_promoted, "only a reservation can become resident");
-                assert!(
-                    projection_admitted,
-                    "a promoted reservation is admitted from `Reserved` exactly once"
-                );
+                let invariant = if !entry_promoted {
+                    Some("only a reservation can become resident")
+                } else if !projection_admitted {
+                    Some("a promoted reservation is admitted from `Reserved` exactly once")
+                } else {
+                    None
+                };
+                if let Some(invariant) = invariant {
+                    // The control-plane guards are gone, but `request` still
+                    // owns the caller's response waker. Publish and contain
+                    // that fail-closed completion only after recording the
+                    // framework diagnostic, so neither its wake nor its drop
+                    // runs as ordinary panic-stack destruction and neither
+                    // can replace the primary invariant.
+                    let mut panics = runtime::PanicAccumulator::default();
+                    panics.run(|| panic!("{invariant}"));
+                    panics.run(|| request.complete_lost());
+                    drop(panics);
+                    unreachable!("the admission invariant panic must resume");
+                }
                 key
             }
             AdmissionInstall::Rejected {
@@ -1064,10 +1083,19 @@ async fn run_scope_incarnation(
             root.member
                 .transition_locked(txn, MemberTransition::Running)
         });
-        assert!(
-            running,
-            "a root incarnation promotes its own never-admitted reservation"
-        );
+        if !running {
+            // A refused root projection cannot support a driver. Establish
+            // the invariant first, then retire the still-owned plan and epoch
+            // through contained ordinary calls before resuming it. Definitions,
+            // response wakes, and resident projections therefore cannot run
+            // as ordinary framework-panic stack destruction.
+            let mut panics = runtime::PanicAccumulator::default();
+            panics.run(|| panic!("a root incarnation promotes its own never-admitted reservation"));
+            panics.run(|| drop(plan));
+            panics.run(|| epoch.finish(StopReason::NeverStarted));
+            drop(panics);
+            unreachable!("the root projection invariant panic must resume");
+        }
     }
     // Both lanes are unbounded so their producers can publish synchronously.
     // Keep child lifecycle events separate from externally generated dynamic
@@ -1099,21 +1127,32 @@ async fn run_scope_incarnation(
     // exactly one terminality owner for every child.
     let mut supervisor = SupervisorState::new(root.flavor, epoch.lifecycle());
     let mut children = ChildResources::default();
+    let mut rejected_child = None;
     plan.children.reverse();
     while let Some(child) = plan.children.pop() {
         let child = ChildRuntime::from_plan(child, &root);
         let membership = child.slot.member.membership();
         let Some(key) = supervisor_admit(&mut supervisor, membership, true) else {
-            unreachable!("a fresh child-key domain accommodates an in-memory child collection")
+            rejected_child = Some(child);
+            break;
         };
         if children.get(key).is_some() {
-            // Keep both constructions out of the framework-panic unwind. The
-            // resident remains owned by `children`; this rejected incoming
-            // child is submitted before the invariant is raised.
-            runtime::dispose_detached(child);
-            panic!("the reducer's monotonic child key is new to runtime resources");
+            rejected_child = Some(child);
+            break;
         }
         let _ = children.insert(key, child);
+    }
+    if let Some(child) = rejected_child {
+        // A fresh domain cannot exhaust for an in-memory plan, but the total
+        // fallback still owns real user constructions. Join their terminality
+        // obligations on the ordinary path, let ScopePlan retire the suffix,
+        // and finish this never-started epoch without a framework unwind.
+        let mut rejected = children.into_values().collect::<Vec<_>>();
+        rejected.push(child);
+        runtime::dispose_all(rejected).fired().await;
+        drop(plan);
+        epoch.finish(StopReason::NeverStarted);
+        return StopReason::NeverStarted;
     }
     if let Some(control) = &dynamic {
         root.with_observation_gate(|txn| {
@@ -1238,9 +1277,20 @@ async fn run_scope_incarnation(
                     // Every lane sender is retained by the scope runtime or
                     // one of its registered children until this loop exits.
                     // A closed receiver would otherwise make this select arm
-                    // permanently ready and spin, so fail closed where the
-                    // ownership regression is first observable.
-                    panic!("a driver event lane closed before its receive loop exited");
+                    // permanently ready and spin. Fail closed by returning a
+                    // retained shutdown completion: a framework panic here
+                    // would unwind the other receiver and any queued admission
+                    // response wakers outside ScopeRuntime's contained epilogue.
+                    let reason = StopReason::ShutdownRequested;
+                    let root_exit = scope
+                        .role
+                        .is_root()
+                        .then(|| RetainedExit::new(stop_reason_root_exit(&reason)));
+                    scope.completion = Some(ScopeCompletion {
+                        reason: RetainedStopReason::new(reason.clone()),
+                        root_exit,
+                    });
+                    return reason;
                 }
                 runtime::ScopeWake::Deadline => {
                     // A producer becoming ready at the same instant owns the

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -71,10 +71,12 @@ use admission_control::{
     reject_admission_after_disposal,
 };
 pub(crate) use admission_control::{
-    DynamicReservation, LATCHED_REMOVAL_OUTCOME, LOST_ADMISSION_RESPONSE_ERROR, RemovalResponse,
-    cancel_dynamic_reservation, remove_dynamic, reserve_dynamic, signal_fused_cancel,
-    start_admission,
+    DynamicReservation, RemovalResponse, cancel_dynamic_reservation, remove_dynamic,
+    reserve_dynamic, signal_fused_cancel, start_admission,
 };
+
+#[cfg(test)]
+pub(crate) use admission_control::{LATCHED_REMOVAL_OUTCOME, LOST_ADMISSION_RESPONSE_ERROR};
 
 #[cfg(test)]
 use crate::cells::{GateCapture, RuntimeStorage};
@@ -575,7 +577,7 @@ impl ScopeRuntime {
 
     fn stage_disposal_panic(&mut self, child: ChildKey, panic: Option<runtime::DisposalPanic>) {
         let replaced = self.arrived_disposal_panics.insert(child, panic);
-        debug_assert!(
+        assert!(
             replaced.is_none(),
             "a terminal disposes its retained construction once, under a never-reused key"
         );
@@ -595,10 +597,11 @@ impl ScopeRuntime {
     fn drain_arrived_disposal_events(&mut self, panics: &mut runtime::PanicAccumulator) {
         while let Some(event) = self.disposal_event_receiver.try_recv() {
             // The lane has one producer, which sends exactly one variant.
-            // Assert rather than let a pattern-matching loop condition drop
-            // an unexpected event and silently abandon the rest of the
-            // drain; teardown runs this during an unwind, where a panic
-            // would abort.
+            // Diagnostic-only: do not let a pattern-matching loop condition
+            // drop an unexpected event and silently abandon the rest of the
+            // drain. Teardown can run during an unwind, so this cannot become
+            // an always-on panic; the match below remains total, and no test
+            // depends on the diagnostic firing.
             debug_assert!(
                 matches!(
                     event,
@@ -666,7 +669,7 @@ impl ScopeRuntime {
             return Err(Box::new(child));
         };
         let replaced = self.children.insert(key, child);
-        debug_assert!(
+        assert!(
             replaced.is_none(),
             "the reducer's monotonic child key is new to runtime resources"
         );
@@ -749,6 +752,7 @@ impl ScopeRuntime {
         enum AdmissionInstall {
             Admitted {
                 key: ChildKey,
+                entry_promoted: bool,
                 projection_admitted: bool,
             },
             Rejected {
@@ -795,7 +799,7 @@ impl ScopeRuntime {
             let entry = state
                 .entry_mut(id)
                 .expect("the matching reservation was just resolved");
-            entry.promote(key, request.fused_cancel.take(), txn);
+            let entry_promoted = entry.promote(key, request.fused_cancel.take(), txn);
             // The slot was minted `Reserved` by this reservation and nothing
             // can have started it, so the projection reducer accepts. A
             // refusal here would leave the entry promoted with no residency
@@ -803,14 +807,17 @@ impl ScopeRuntime {
             let admitted = root.admit_child_locked(resident_projection(&request.slot), txn);
             AdmissionInstall::Admitted {
                 key,
+                entry_promoted,
                 projection_admitted: admitted,
             }
         });
         let key = match installed {
             AdmissionInstall::Admitted {
                 key,
+                entry_promoted,
                 projection_admitted,
             } => {
+                assert!(entry_promoted, "only a reservation can become resident");
                 assert!(
                     projection_admitted,
                     "a promoted reservation is admitted from `Reserved` exactly once"
@@ -1103,7 +1110,7 @@ async fn run_scope_incarnation(
             unreachable!("a fresh child-key domain accommodates an in-memory child collection")
         };
         let replaced = children.insert(key, child);
-        debug_assert!(replaced.is_none());
+        assert!(replaced.is_none());
     }
     if let Some(control) = &dynamic {
         root.with_observation_gate(|txn| {
@@ -1228,12 +1235,9 @@ async fn run_scope_incarnation(
                     // Every lane sender is retained by the scope runtime or
                     // one of its registered children until this loop exits.
                     // A closed receiver would otherwise make this select arm
-                    // permanently ready and spin, so diagnose any future
-                    // ownership change where it is first observable.
-                    debug_assert!(
-                        false,
-                        "a driver event lane closed before its receive loop exited"
-                    );
+                    // permanently ready and spin, so fail closed where the
+                    // ownership regression is first observable.
+                    panic!("a driver event lane closed before its receive loop exited");
                 }
                 runtime::ScopeWake::Deadline => {
                     // A producer becoming ready at the same instant owns the

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -832,11 +832,18 @@ impl ScopeRuntime {
                     // framework diagnostic, so neither its wake nor its drop
                     // runs as ordinary panic-stack destruction and neither
                     // can replace the primary invariant.
+                    //
+                    // `PanicAccumulator` contains rather than resumes on an
+                    // already-unwinding stack, so record the diagnostic only
+                    // when there is a stack to raise it on. Assuming a resume
+                    // would turn a contained failure into a double panic.
                     let mut panics = runtime::PanicAccumulator::default();
-                    panics.run(|| panic!("{invariant}"));
+                    if !std::thread::panicking() {
+                        panics.run(|| panic!("{invariant}"));
+                    }
                     panics.run(|| request.complete_lost());
                     drop(panics);
-                    unreachable!("the admission invariant panic must resume");
+                    return;
                 }
                 key
             }
@@ -1089,12 +1096,23 @@ async fn run_scope_incarnation(
             // through contained ordinary calls before resuming it. Definitions,
             // response wakes, and resident projections therefore cannot run
             // as ordinary framework-panic stack destruction.
+            //
+            // `PanicAccumulator` contains rather than resumes on an
+            // already-unwinding stack, so record the diagnostic only when
+            // there is a stack to raise it on and fall through to the drain
+            // verdict otherwise. `begin_incarnation` already published
+            // `Starting`, so the epoch finishes as a requested stop rather
+            // than claiming no incarnation ever began.
             let mut panics = runtime::PanicAccumulator::default();
-            panics.run(|| panic!("a root incarnation promotes its own never-admitted reservation"));
+            if !std::thread::panicking() {
+                panics.run(|| {
+                    panic!("a root incarnation promotes its own never-admitted reservation")
+                });
+            }
             panics.run(|| drop(plan));
-            panics.run(|| epoch.finish(StopReason::NeverStarted));
+            panics.run(|| epoch.finish(StopReason::ShutdownRequested));
             drop(panics);
-            unreachable!("the root projection invariant panic must resume");
+            return StopReason::ShutdownRequested;
         }
     }
     // Both lanes are unbounded so their producers can publish synchronously.
@@ -1146,13 +1164,16 @@ async fn run_scope_incarnation(
         // A fresh domain cannot exhaust for an in-memory plan, but the total
         // fallback still owns real user constructions. Join their terminality
         // obligations on the ordinary path, let ScopePlan retire the suffix,
-        // and finish this never-started epoch without a framework unwind.
+        // and finish this epoch without a framework unwind. The verdict is
+        // `ShutdownRequested`, not `NeverStarted`: `begin_incarnation` already
+        // published `Starting`, and SPEC B.6's `NeverStarted` states that no
+        // scope incarnation ever began.
         let mut rejected = children.into_values().collect::<Vec<_>>();
         rejected.push(child);
         runtime::dispose_all(rejected).fired().await;
         drop(plan);
-        epoch.finish(StopReason::NeverStarted);
-        return StopReason::NeverStarted;
+        epoch.finish(StopReason::ShutdownRequested);
+        return StopReason::ShutdownRequested;
     }
     if let Some(control) = &dynamic {
         root.with_observation_gate(|txn| {

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -590,6 +590,10 @@ impl AdmissionRequest {
             let _ = sender.send(result);
         });
     }
+
+    pub(super) fn complete_lost(&mut self) {
+        self.complete(Err(LOST_ADMISSION_RESPONSE_ERROR));
+    }
 }
 
 pub(super) fn reject_admission_after_disposal(

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -149,9 +149,10 @@ impl DynamicEntry {
         key: ChildKey,
         fused_cancel: Option<Latch>,
         _txn: &mut ObservationTxn<'_>,
-    ) {
-        debug_assert!(self.is_reserved(), "only a reservation can become resident");
+    ) -> bool {
+        let was_reserved = self.is_reserved();
         self.state = DynamicMembershipState::Resident { key, fused_cancel };
+        was_reserved
     }
 
     pub(super) fn mark_removing(&mut self, _txn: &mut ObservationTxn<'_>) -> Option<ChildKey> {
@@ -259,6 +260,10 @@ impl DynamicControl {
     fn in_scope(scope: &ScopeCell, txn: &ObservationTxn<'_>) -> Option<Arc<DynamicControl>> {
         let route: Arc<dyn Any + Send + Sync> = scope.dynamic_route_in(txn)?;
         let control = Arc::downcast(route).ok();
+        // Diagnostic-only: the façade is the sole route installer and always
+        // stores `DynamicControl`. The callers already treat a foreign route
+        // as absent, so no correctness decision relies on this check and no
+        // test expects its panic.
         debug_assert!(
             control.is_some(),
             "the façade installs only its concrete dynamic control"

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -1196,6 +1196,10 @@ impl ScopeRuntime {
         exited_incarnation: Option<Incarnation>,
         startup: StartupDisposition,
     ) {
+        // Retain before every refusal and invariant verdict. A failed Exit can
+        // own hostile user error drop glue, so no path may unwind or return it
+        // directly on the driver thread.
+        let mut exit = Some(RetainedExit::new(exit));
         if !self.supervisor.contains(key)
             || self.supervisor.is_disposing(key)
             || self.supervisor.joined(key)
@@ -1218,7 +1222,9 @@ impl ScopeRuntime {
                 return;
             }
             child.pending_terminal = Some(PendingTerminal {
-                exit: RetainedExit::new(exit),
+                exit: exit
+                    .take()
+                    .expect("terminal disposal installs its retained exit once"),
                 exited_incarnation,
                 startup,
             });

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -654,6 +654,10 @@ impl ScopeRuntime {
         exited_incarnation: Option<Incarnation>,
         startup: StartupDisposition,
     ) -> bool {
+        // Protect the raw user error before every resource lookup and reducer
+        // invariant. A malformed key may still be diagnosed, but it cannot
+        // unwind the Exit payload on the driver stack.
+        let mut exit = Some(RetainedExit::new(exit));
         // Production terminal publication follows joined construction
         // disposal.  A few structural test/fallback paths synthesize that
         // already-joined boundary directly, so normalize them through the
@@ -666,7 +670,14 @@ impl ScopeRuntime {
             .children
             .get_mut(key)
             .expect("terminalized child remains registered")
-            .terminalize(&self.root, exit, exited_incarnation, startup);
+            .terminalize(
+                &self.root,
+                exit.take()
+                    .expect("terminal publication consumes its retained exit once")
+                    .into_exit(),
+                exited_incarnation,
+                startup,
+            );
         self.reduce(SupervisorEvent::Terminalized { child: key });
         // The reducer drops an event whose predecessor never ran, which keeps
         // `step` total but leaves the shell no return channel. A child that

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -673,7 +673,7 @@ impl ScopeRuntime {
         // published terminality without reaching `Joined` would never count
         // toward completion, so the scope would simply never finish. Assert
         // the transition landed rather than discovering it as a stall.
-        debug_assert!(
+        assert!(
             self.supervisor.joined(key),
             "terminal publication must leave the reducer's membership joined"
         );
@@ -1206,7 +1206,7 @@ impl ScopeRuntime {
         // Same reasoning as `terminalize_child`: a dropped `DisposalStarted`
         // would make the later `Terminalized` unreachable too, stranding the
         // membership short of `Joined` with no loud failure.
-        debug_assert!(
+        assert!(
             self.supervisor.is_disposing(key),
             "terminal disposal must leave the reducer's incarnation disposing"
         );

--- a/crates/shelterwood/src/driver/removal.rs
+++ b/crates/shelterwood/src/driver/removal.rs
@@ -119,13 +119,17 @@ impl ScopeRuntime {
     }
 
     pub(super) fn reclaim_child(&mut self, key: ChildKey) {
-        let Some(mut child) = self.children.remove(key) else {
+        if self.children.get(key).is_none() {
             return;
-        };
-        debug_assert!(
+        }
+        assert!(
             self.supervisor.joined(key),
             "reclaim runs only after joined terminal completion"
         );
+        let mut child = self
+            .children
+            .remove(key)
+            .expect("the just-observed child remains registered");
         if let Some(deadline) = child.restart_deadline.take() {
             self.deadlines.cancel(deadline);
         }

--- a/crates/shelterwood/src/driver/shutdown.rs
+++ b/crates/shelterwood/src/driver/shutdown.rs
@@ -145,7 +145,7 @@ impl ScopeRuntime {
         else {
             return;
         };
-        debug_assert!(startup.is_some() || !startup_pending);
+        assert!(startup.is_some() || !startup_pending);
         // Ordered drain exposes its first stop only through `Settle`; derive
         // that command before publication so both scope flavors can commit an
         // inactive child's terminal-cleanup intent with the `Draining` edge.

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -10,17 +10,29 @@ async fn refused_dynamic_admission_panics_after_control_plane_unlock() {
     reservation.slot.define(ChildConstruction::Task(
         TaskDef::new(|_| future::pending()).erase(),
     ));
-    let (_response, request) = begin_admission(&reservation, &mut dynamic_events, None).await;
+    let (response, request) = begin_admission(&reservation, &mut dynamic_events, None).await;
+    let mut response = Box::pin(response.receive());
+    let hostile = Waker::from(Arc::new(PanicWake(
+        "injected admission response waker panic",
+    )));
+    assert!(
+        response
+            .as_mut()
+            .poll(&mut Context::from_waker(&hostile))
+            .is_pending(),
+        "the response waiter is parked before the invariant"
+    );
 
     // Corrupt only the projection source stage. Admission still commits its
     // arena insertion and dynamic-entry promotion before the cell reducer
     // refuses Running -> Admitted, reaching the driver invariant exactly.
     member.update(|record| record.stage = MemberStage::Running);
-    let refusal = catch_unwind(AssertUnwindSafe(|| scope.handle_admission(request)));
-
-    assert!(
-        refusal.is_err(),
-        "a refused dynamic admission fails closed in every profile"
+    let refusal = catch_unwind(AssertUnwindSafe(|| scope.handle_admission(request)))
+        .expect_err("a refused dynamic admission fails closed in every profile");
+    assert_eq!(
+        refusal.downcast_ref::<String>().map(String::as_str),
+        Some("a promoted reservation is admitted from `Reserved` exactly once"),
+        "the framework invariant stays primary over the hostile response wake"
     );
     assert!(
         !root.observation_gate().is_poisoned(),
@@ -44,6 +56,14 @@ async fn refused_dynamic_admission_panics_after_control_plane_unlock() {
             .is_some_and(|entry| !entry.is_reserved()),
         "the fixture reaches the committing admission site after entry promotion"
     );
+    assert!(matches!(
+        response
+            .as_mut()
+            .poll(&mut Context::from_waker(Waker::noop())),
+        Poll::Ready(Some(Err(ReserveError::NotAdmitting(
+            crate::NotAdmittingCause::Terminal
+        ))))
+    ));
 
     // Restore the source stage and missing residency so ScopeRuntime's normal
     // fail-closed epilogue can discharge this deliberately corrupted fixture.

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -55,6 +55,56 @@ async fn reserve_error_identity_exhausted_maps_the_child_key_domain() {
     ));
 }
 
+#[crate::runtime::test]
+async fn reused_child_key_rejects_and_disposes_after_control_plane_unlock() {
+    let (mut scope, _events, mut dynamic_events, control) = running_dynamic_fixture();
+    let resident = reserve_dynamic(&scope.root, ChildId::from("resident"), None)
+        .expect("the resident reservation succeeds");
+    resident.slot.define(ChildConstruction::Task(
+        TaskDef::new(|_| future::pending()).erase(),
+    ));
+    let (resident_response, resident_request) =
+        begin_admission(&resident, &mut dynamic_events, None).await;
+    scope.handle_admission(resident_request);
+    assert!(matches!(resident_response.receive().await, Some(Ok(()))));
+
+    scope.supervisor.reuse_child_keys_for_test();
+    let rejected = reserve_dynamic(&scope.root, ChildId::from("rejected"), None)
+        .expect("the second membership domain still has capacity");
+    let (probe, disposed) = thread_reporting_error();
+    rejected.slot.define(ChildConstruction::Task(
+        TaskDef::new(move |_| {
+            let _ = &probe;
+            future::pending::<crate::ExitResult>()
+        })
+        .erase(),
+    ));
+    let (rejected_response, rejected_request) =
+        begin_admission(&rejected, &mut dynamic_events, None).await;
+    let driver_thread = std::thread::current().id();
+
+    scope.handle_admission(rejected_request);
+
+    assert!(matches!(
+        rejected_response.receive().await,
+        Some(Err(ReserveError::IdentityExhausted))
+    ));
+    assert_ne!(
+        disposed
+            .recv_timeout(DRIVER_PROGRESS_WAIT)
+            .expect("the rejected construction capture is disposed"),
+        driver_thread,
+        "a key collision cannot destroy the rejected construction on the driver"
+    );
+    assert!(!scope.root.observation_gate().is_poisoned());
+    assert!(!control.state.is_poisoned());
+    assert_eq!(
+        scope.children.len(),
+        1,
+        "the collision preserves the resident child resource"
+    );
+}
+
 #[test]
 fn member_transitions_own_their_complete_record_projection() {
     let mut identity = ScopeIdentity::new();

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -288,6 +288,74 @@ async fn an_arrived_disposal_panic_disposes_its_losing_application_error_off_the
     );
 }
 
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+async fn refused_terminal_disposal_retires_its_exit_off_the_driver() {
+    let (mut scope, _events) = OrderedScopeFixture::new(Tree::new()).build();
+    let (error, disposed) = thread_reporting_error();
+    let driver_thread = std::thread::current().id();
+
+    scope.begin_terminal_disposal(
+        ChildKey::fixture(999),
+        Exit::failed(error, Cancellation::NotObserved),
+        None,
+        StartupDisposition::NotAborted,
+    );
+
+    assert_ne!(
+        disposed
+            .recv_timeout(DRIVER_PROGRESS_WAIT)
+            .expect("the refused terminal exit is disposed"),
+        driver_thread,
+        "a refusal cannot destroy the user error on the driver"
+    );
+}
+
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+async fn missing_terminal_resource_retires_its_exit_before_panicking() {
+    let (mut scope, _events) = OrderedScopeFixture::new(Tree::new()).build();
+    let (error, disposed) = thread_reporting_error();
+    let driver_thread = std::thread::current().id();
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        scope.terminalize_child(
+            ChildKey::fixture(999),
+            Exit::failed(error, Cancellation::NotObserved),
+            None,
+            StartupDisposition::NotAborted,
+        );
+    }))
+    .expect_err("a missing terminal resource remains a framework invariant");
+
+    assert_eq!(
+        panic.downcast_ref::<String>().map(String::as_str),
+        Some("terminalized child remains registered"),
+    );
+    assert_ne!(
+        disposed
+            .recv_timeout(DRIVER_PROGRESS_WAIT)
+            .expect("the rejected terminal exit is disposed"),
+        driver_thread,
+        "the framework panic cannot unwind the user error on the driver"
+    );
+}
+
+#[test]
+fn duplicate_disposal_completion_preserves_the_first_report() {
+    let (mut scope, _events) = OrderedScopeFixture::new(Tree::new()).build();
+    let child = ChildKey::fixture(999);
+    let first = crate::runtime::DisposalPanic {
+        message: Some("first disposal panic".to_owned()),
+    };
+    let second = crate::runtime::DisposalPanic {
+        message: Some("second disposal panic".to_owned()),
+    };
+
+    scope.stage_disposal_panic(child, Some(first.clone()));
+    scope.stage_disposal_panic(child, Some(second));
+
+    assert_eq!(scope.take_arrived_disposal_panic(child), Some(first));
+}
+
 fn assert_arrived_disposal_panic_published(member: &Arc<MemberCell>) {
     assert!(matches!(
         member.record().stage,

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -155,12 +155,11 @@ impl<M> EventQueue<M> {
                 .lock()
                 .expect("actor event queue mutex poisoned")
                 .pop_front();
+            // The guard is a temporary, so this is raised with the queue mutex
+            // already released. It replaces the release-profile clamp that
+            // used to zero the budget on a missing event.
             assert!(event.is_some(), "a timer watermark covers queued events");
-            if event.is_some() {
-                *remaining -= 1;
-            } else {
-                *remaining = 0;
-            }
+            *remaining -= 1;
             event
         }
     }

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -155,7 +155,7 @@ impl<M> EventQueue<M> {
                 .lock()
                 .expect("actor event queue mutex poisoned")
                 .pop_front();
-            debug_assert!(event.is_some(), "a timer watermark covers queued events");
+            assert!(event.is_some(), "a timer watermark covers queued events");
             if event.is_some() {
                 *remaining -= 1;
             } else {
@@ -275,8 +275,8 @@ impl ReadyBatch {
         mailbox_through: AcceptedSequence,
         offloads_remaining: usize,
     ) {
-        debug_assert!(!armings.is_empty());
-        debug_assert!(matches!(self.phase, ReadyBatchPhase::Steady { .. }));
+        assert!(!armings.is_empty());
+        assert!(matches!(self.phase, ReadyBatchPhase::Steady { .. }));
         self.phase = ReadyBatchPhase::Fired {
             armings,
             continuations_remaining,
@@ -316,14 +316,14 @@ impl ReadyBatch {
             ..
         } = &mut self.phase
         {
-            debug_assert!(*continuations_remaining > 0);
+            assert!(*continuations_remaining > 0);
             *continuations_remaining -= 1;
         }
     }
 
     fn record_mailbox_delivery(&mut self) {
         if let ReadyBatchPhase::Steady { mailbox_budget } = &mut self.phase {
-            debug_assert!(*mailbox_budget > 0);
+            assert!(*mailbox_budget > 0);
             *mailbox_budget -= 1;
         }
     }
@@ -337,11 +337,10 @@ impl ReadyBatch {
 
     fn commit_arming(&mut self, arming: ArmingOrder) {
         let ReadyBatchPhase::Fired { armings, .. } = &mut self.phase else {
-            debug_assert!(false, "only a fired batch delivers timer armings");
-            return;
+            panic!("only a fired batch delivers timer armings");
         };
         let removed = armings.pop_front();
-        debug_assert_eq!(removed, Some(arming));
+        assert_eq!(removed, Some(arming));
     }
 }
 
@@ -1179,7 +1178,7 @@ impl<M: Send + 'static> RawContext<M> {
         batch: ReadyBatch,
         operation: impl FnOnce(&mut Self) -> R,
     ) -> (ReadyBatch, R) {
-        debug_assert!(self.resources.ready_batch.is_none());
+        assert!(self.resources.ready_batch.is_none());
         self.resources.ready_batch = Some(batch);
         let result = operation(self);
         let batch = self

--- a/crates/shelterwood/src/raw/context/timers.rs
+++ b/crates/shelterwood/src/raw/context/timers.rs
@@ -144,7 +144,7 @@ impl<M> TimerStore<M> {
             period,
         });
         let previous = self.armings.insert(arming_order, hash);
-        debug_assert!(previous.is_none());
+        assert!(previous.is_none());
         if let Some(deadline) = deadline {
             self.deadlines.insert((deadline, arming_order));
         }
@@ -244,7 +244,7 @@ impl<M> TimerStore<M> {
         // through this method. Their agreement is therefore structural, so
         // check it where a broken invariant is cheap to see rather than
         // paying two extra map lookups on every removal.
-        debug_assert_eq!(
+        assert_eq!(
             self.armings.get(&entry.arming_order),
             Some(&location.hash),
             "a timer's key and arming indexes must agree"

--- a/crates/shelterwood/src/raw/context/timers.rs
+++ b/crates/shelterwood/src/raw/context/timers.rs
@@ -124,16 +124,20 @@ impl<M> TimerStore<M> {
     where
         K: Hash + Eq + Send + 'static,
     {
-        let arming_order = ArmingOrder(
-            self.arming_orders
-                .mint()
-                .expect("timer arming-order space exhausted"),
-        );
-        // Hash and equality are user code. Keep incoming ownership behind the
-        // disposal boundary until those callbacks finish so a callback panic
-        // cannot unwind through a hostile key or message destructor.
+        // Every verdict below is framework-owned. Contain incoming ownership
+        // before even minting the arming id so exhaustion cannot unwind a
+        // hostile key or message destructor on the framework panic's stack.
+        // Hash and equality are user code and need the same boundary.
         let key = Contained::new(key, self.disposal.clone());
         let message = Contained::new(message, self.disposal.clone());
+        let Some(arming_order) = self.arming_orders.mint().map(ArmingOrder) else {
+            // Dispose both inputs before establishing the diagnostic. Their
+            // destructor panics are retained by RawDisposal and cannot replace
+            // the arming-space invariant.
+            drop(message);
+            drop(key);
+            panic!("timer arming-order space exhausted");
+        };
         let hash = self.hash_key(key.get());
         self.remove_hashed(hash, key.get());
         self.keyed.entry(hash).or_default().push(TimerEntry {
@@ -366,7 +370,7 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use super::{IntervalRearm, TimerMessage, TimerStore};
+    use super::{IntervalRearm, PoisonedCounter, TimerMessage, TimerStore};
 
     #[derive(Eq, PartialEq)]
     struct CollidingKey(u8);
@@ -690,6 +694,43 @@ mod tests {
                 Some("timer message destructor panic" | "timer key destructor panic")
             ),
             "a hostile incoming destructor is recorded"
+        );
+        assert!(timers.is_empty());
+    }
+
+    #[test]
+    fn arming_exhaustion_disposes_inputs_before_the_framework_panic() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut timers = TimerStore::default();
+        timers.arming_orders = PoisonedCounter::near_exhaustion();
+        assert!(
+            timers.arming_orders.mint().is_some(),
+            "the fixture consumes the final arming id"
+        );
+
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            timers.replace(
+                PanickingDropKey(Arc::clone(&drops)),
+                None,
+                TimerMessage::Once(PanickingTimerMessage(Arc::clone(&drops))),
+                None,
+            );
+        }))
+        .expect_err("the exhausted arming domain remains a framework panic");
+
+        assert_eq!(
+            panic.downcast_ref::<&'static str>().copied(),
+            Some("timer arming-order space exhausted"),
+            "hostile input destructors cannot replace the invariant"
+        );
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            2,
+            "both inputs are disposed before the framework panic begins"
+        );
+        assert!(
+            timers.disposal.panic.take().is_some(),
+            "the first hostile destructor panic remains cleanup evidence"
         );
         assert!(timers.is_empty());
     }

--- a/crates/shelterwood/src/raw/context/timers.rs
+++ b/crates/shelterwood/src/raw/context/timers.rs
@@ -241,14 +241,10 @@ impl<M> TimerStore<M> {
         // `replace` writes the key bucket and the arming index in one window
         // that cannot panic between them — the user `Hash`/`Eq` callbacks run
         // strictly before it — and an entry never migrates buckets except
-        // through this method. Their agreement is therefore structural, so
-        // check it where a broken invariant is cheap to see rather than
-        // paying two extra map lookups on every removal.
-        assert_eq!(
-            self.armings.get(&entry.arming_order),
-            Some(&location.hash),
-            "a timer's key and arming indexes must agree"
-        );
+        // through this method. Their agreement is structural. Do not diagnose
+        // a future regression here: `entry` already owns the user's key and
+        // message, so an assertion would destroy both on a framework-panic
+        // stack. The cleanup below is total for either recorded hash.
         if empty {
             self.keyed.remove(&location.hash);
         }
@@ -762,6 +758,26 @@ mod tests {
         assert_eq!(
             cleanup.downcast_ref::<&'static str>().copied(),
             Some("timer key destructor panic")
+        );
+        assert!(timers.is_empty());
+    }
+
+    #[test]
+    fn unlink_is_total_when_the_arming_hash_disagrees() {
+        let mut timers = TimerStore::default();
+        let arming = timers.replace(7_u8, None, TimerMessage::Once("message"), None);
+        let recorded = timers.armings[&arming];
+        timers
+            .armings
+            .insert(arming, super::KeyHash(recorded.0.wrapping_add(1)));
+
+        assert_eq!(
+            once(
+                timers
+                    .take(&7_u8)
+                    .expect("the keyed entry remains removable")
+            ),
+            "message"
         );
         assert!(timers.is_empty());
     }

--- a/crates/shelterwood/src/raw/definition.rs
+++ b/crates/shelterwood/src/raw/definition.rs
@@ -213,7 +213,7 @@ impl<R: RawActor> RawIncarnationOwner<R> {
     }
 
     fn record_primary_panic(&mut self, payload: PanicPayload) {
-        debug_assert!(self.primary_panic.is_none());
+        assert!(self.primary_panic.is_none());
         self.primary_panic = Some(payload);
     }
 

--- a/crates/shelterwood/src/raw/definition.rs
+++ b/crates/shelterwood/src/raw/definition.rs
@@ -213,8 +213,11 @@ impl<R: RawActor> RawIncarnationOwner<R> {
     }
 
     fn record_primary_panic(&mut self, payload: PanicPayload) {
-        assert!(self.primary_panic.is_none());
-        self.primary_panic = Some(payload);
+        // The actor's first panic is authoritative. A second opaque payload
+        // may itself have hostile drop glue, so route the loser through the
+        // same contained precedence helper as teardown rather than asserting
+        // and destroying it during the assertion's unwind.
+        keep_first_panic(&mut self.primary_panic, Some(payload));
     }
 
     fn take_primary_panic(&mut self) -> Option<PanicPayload> {

--- a/crates/shelterwood/src/raw/offload.rs
+++ b/crates/shelterwood/src/raw/offload.rs
@@ -180,10 +180,9 @@ impl SharedOffloadState {
 
     pub(super) fn take_for_poll(&self) -> Option<OffloadFuture> {
         let mut state = self.state.lock().expect("offload future mutex poisoned");
-        if state.cancelled {
+        if state.cancelled || state.polling {
             return None;
         }
-        debug_assert!(!state.polling, "offload work must have one poller");
         let future = state.future.take();
         state.polling = future.is_some();
         future
@@ -197,9 +196,15 @@ impl SharedOffloadState {
         let mut state = self.state.lock().expect("offload future mutex poisoned");
         state.polling = false;
         if outcome == OffloadPoll::Pending && !state.cancelled {
-            debug_assert!(state.future.is_none());
-            state.future = Some(future);
-            None
+            if state.future.is_none() {
+                state.future = Some(future);
+                None
+            } else {
+                // A duplicate poll completion cannot overwrite and destroy
+                // the already-retained user future under this mutex. Return
+                // the duplicate to the caller's disposal path instead.
+                Some(future)
+            }
         } else {
             Some(future)
         }

--- a/crates/shelterwood/src/tree/admission.rs
+++ b/crates/shelterwood/src/tree/admission.rs
@@ -22,8 +22,16 @@ use super::slots::AdmissionOwnership;
 /// Fused additions abort on drop; split definitions detach after their first
 /// poll starts admission. Reservation and that first poll require an ambient
 /// Tokio runtime. A first poll outside one returns [`ReserveError::NoRuntime`]
-/// and releases the reservation. Losing the driver's internal completion
-/// route is a framework invariant failure in every profile.
+/// and releases the reservation.
+///
+/// The driver's admission obligation publishes an outcome on every path,
+/// including its own drop fallback, so this future always resolves through
+/// [`ReserveError`]. If that obligation is ever destroyed without publishing,
+/// awaiting the admission **panics** rather than resolving: reporting a
+/// terminal scope would be a false outcome for a reservation that may still be
+/// live, and a caller that reconciles on it would be reconciling against a
+/// lie. The panic is a framework invariant failure in every profile, not a
+/// condition callers can encounter or handle.
 /// Like a fused future, it remains pending if polled again after completion.
 #[must_use]
 pub struct Admission<H> {
@@ -207,8 +215,12 @@ impl<H> Drop for Admission<H> {
 }
 /// Observation future for a synchronously latched dynamic removal.
 ///
-/// Losing the driver's internal completion route after the request is latched
-/// is a framework invariant failure in every profile.
+/// The driver publishes the latched outcome on every destruction path. If that
+/// obligation is ever destroyed without publishing, awaiting the removal
+/// **panics** rather than resolving, for the same reason as [`Admission`]: a
+/// synthesized `Removed` would report a completed withdrawal that no driver
+/// performed. It is a framework invariant failure in every profile, not a
+/// condition callers can encounter or handle.
 #[must_use]
 pub struct Removal {
     inner: Pin<Box<dyn Future<Output = RemoveOutcome> + Send + 'static>>,

--- a/crates/shelterwood/src/tree/admission.rs
+++ b/crates/shelterwood/src/tree/admission.rs
@@ -8,9 +8,12 @@ use std::{
 
 use crate::{
     admission::{RemoveOutcome, ReserveError},
-    driver::{DynamicReservation, LATCHED_REMOVAL_OUTCOME, LOST_ADMISSION_RESPONSE_ERROR},
+    driver::DynamicReservation,
     runtime::Latch,
 };
+
+#[cfg(test)]
+use crate::driver::{LATCHED_REMOVAL_OUTCOME, LOST_ADMISSION_RESPONSE_ERROR};
 
 use super::slots::AdmissionOwnership;
 
@@ -49,10 +52,9 @@ impl<H> PendingAdmission<H> {
                 // The driver's admission `Obligation` publishes an outcome on
                 // every path, including its drop fallback. Treat a missing
                 // response as the scope having gone terminal so a caller is
-                // never stranded, but fail loudly in debug builds: silence
-                // here would mask an obligation regression.
-                debug_assert!(false, "admission response obligation must complete");
-                Err(LOST_ADMISSION_RESPONSE_ERROR)
+                // never stranded, but fail loudly: silence here would mask
+                // an obligation regression.
+                panic!("admission response obligation must complete");
             })
         }))
     }
@@ -230,9 +232,8 @@ impl Removal {
                     // on every destruction path. A missing response therefore
                     // means the terminal route vanished after removal latched:
                     // preserve the removal goal, but flag the invariant break
-                    // in debug builds just as admission does above.
-                    debug_assert!(false, "removal response obligation must complete");
-                    LATCHED_REMOVAL_OUTCOME
+                    // just as admission does above.
+                    panic!("removal response obligation must complete");
                 })
             }),
         }
@@ -302,9 +303,6 @@ mod tests {
 
     #[test]
     fn lost_removal_response_policy_fails_closed() {
-        // Profile-independent: the release fallback below is unreachable in
-        // the debug builds CI runs, so the policy itself is pinned here rather
-        // than only through the value a release build happens to observe.
         assert_eq!(
             super::LATCHED_REMOVAL_OUTCOME,
             crate::RemoveOutcome::Removed,
@@ -313,7 +311,7 @@ mod tests {
     }
 
     #[test]
-    fn closed_removal_response_fails_closed_after_debug_diagnostic() {
+    fn closed_removal_response_panics_in_every_profile() {
         let (sender, response) = crate::runtime::oneshot();
         drop(sender);
         let mut removal = Removal::new(response);
@@ -322,15 +320,9 @@ mod tests {
             Pin::new(&mut removal).poll(&mut context)
         }));
 
-        #[cfg(debug_assertions)]
         assert!(
             observed.is_err(),
-            "debug builds expose the broken removal response obligation"
-        );
-        #[cfg(not(debug_assertions))]
-        assert_eq!(
-            observed.expect("release fallback does not panic"),
-            std::task::Poll::Ready(super::LATCHED_REMOVAL_OUTCOME)
+            "every profile exposes the broken removal response obligation"
         );
     }
 

--- a/crates/shelterwood/src/tree/admission.rs
+++ b/crates/shelterwood/src/tree/admission.rs
@@ -22,10 +22,8 @@ use super::slots::AdmissionOwnership;
 /// Fused additions abort on drop; split definitions detach after their first
 /// poll starts admission. Reservation and that first poll require an ambient
 /// Tokio runtime. A first poll outside one returns [`ReserveError::NoRuntime`]
-/// and releases the reservation. If the driver's internal completion route is
-/// lost, release builds fail closed with [`ReserveError::NotAdmitting`] and a
-/// [`crate::NotAdmittingCause::Terminal`] cause. Debug builds additionally
-/// assert that the completion obligation regressed.
+/// and releases the reservation. Losing the driver's internal completion
+/// route is a framework invariant failure in every profile.
 /// Like a fused future, it remains pending if polled again after completion.
 #[must_use]
 pub struct Admission<H> {
@@ -209,9 +207,8 @@ impl<H> Drop for Admission<H> {
 }
 /// Observation future for a synchronously latched dynamic removal.
 ///
-/// If the driver's internal completion route is lost after the request is
-/// latched, release builds fail closed with [`RemoveOutcome::Removed`]; debug
-/// builds additionally assert that the completion obligation regressed.
+/// Losing the driver's internal completion route after the request is latched
+/// is a framework invariant failure in every profile.
 #[must_use]
 pub struct Removal {
     inner: Pin<Box<dyn Future<Output = RemoveOutcome> + Send + 'static>>,


### PR DESCRIPTION
## Stack

Based on #402 because the admission-shape change must precede the global sweep.
It also depends on #400; the first two commits are patch-equivalent replays of that
reviewed Stage A head (verified: the combined patches are byte-identical).

## Summary

- promote unlocked invariant checks to always-on assertions
- carry releasable locked verdicts past their guards or defer their panics through transaction effects
- make irrecoverable locked fallbacks total without dropping user-bearing state in a critical section
- retain only 14 explicitly certified diagnostic-only debug assertions
- remove every debug-assertion profile gate, including the three retention regressions from #380
- harden review-discovered mailbox, timer, driver-teardown, supervisor-collision, lifecycle-overflow, retained-exit, and panic-precedence failure paths so framework panics cannot unwind user values, wakers, or opaque panic payloads

## Review follow-ups

**Abort hazard (the one real defect).** Three sites recorded an invariant in a
`PanicAccumulator`, disposed user-bearing state through it, then `drop`ped it
expecting a resume. The accumulator does *not* resume while
`std::thread::panicking()` — it contains, by design — so the following
`unreachable!` became a panic during an unwind and aborted the process.
`MailboxCell::withdraw` is reached from `SendFuture`'s drop glue, which routinely
runs on an unwinding stack, so that one is a real shape rather than
unreachable-squared. All three now decide the disposition up front and take an
ordinary contained exit instead. Pinned by
`withdrawal_registration_invariant_is_contained_during_an_unwind`, which SIGABRTs
against the previous shape.

**Public contract change, stated explicitly.** `Admission` and `Removal` now panic
where they used to synthesize `NotAdmitting(Terminal)` / `RemoveOutcome::Removed`.
The driver-side obligation still fail-closes on every path including its drop, so
the receiver-side arm is unreachable; the rustdoc now says what a caller observes
and why a synthesized outcome would be a lie rather than a fallback.

Remaining points:

- `accept_locked`'s incarnation mismatch was the one site where the new
  `invariant_panic` slot applied and was not used; it records through it now, and
  `park`'s certification names the fallback that can reach it
- `MailboxTxn::replace_binding` takes the *first* invariant, like every other
  precedence site
- both driver key-exhaustion fallbacks finish the epoch as `ShutdownRequested`:
  `begin_incarnation` already published `Starting`, and SPEC B.6's `NeverStarted`
  claims no incarnation ever began
- `prune_child_locked` queues its diagnostic ahead of the disposal effect, matching
  `MailboxEffectBatch::flush` and `attach_mailbox`; the tree had one convention
  documented in both directions
- two dead fallbacks left behind by promotion (`EventQueue::pop_through`'s budget
  clamp, `terminalize_child`'s `unwrap_or`) collapsed
- name the guard that makes `SupervisorState::admit`'s deleted membership assertion
  unwritable rather than merely unfired

## Verification

- ./tools/dev just ci (865/865 nextest plus clippy, docs, API reachability, packaged docs, external consumer, nixfmt)
- ./tools/dev cargo nextest run --release --workspace (865/865, 0 skipped) — the #395 exit criterion
- 14 `debug_assert!` sites remain, each carrying its diagnostic-only certification
- no `cfg(debug_assertions)` or `cfg(not(debug_assertions))` sites remain under crates
- git diff --check

Closes #395.
Closes #393.