### PR TITLE
Isolate reply waker retirement behind proxy

### DIFF
--- a/crates/shelterwood-mailbox/src/capability.rs
+++ b/crates/shelterwood-mailbox/src/capability.rs
@@ -4,8 +4,14 @@ use std::{
     marker::PhantomData,
     pin::Pin,
     sync::Arc,
-    task::{Context, Poll},
+    task::{Context, Poll, Waker},
     time::Instant,
+};
+
+use crate::{
+    cell::waker_slot::{WakerAction, WakerEffects},
+    panic::PanicAccumulator,
+    waker_proxy::WakerProxy,
 };
 
 pub type BoxedSleep = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
@@ -160,6 +166,7 @@ pub(crate) fn dispose<T: Send + 'static>(runtime: &Arc<dyn MailboxRuntime>, valu
 pub(crate) struct DisposingReceiver<T> {
     inner: Option<OneShotReceiver<T>>,
     runtime: Arc<dyn MailboxRuntime>,
+    reply_waker: Option<WakerProxy>,
 }
 
 impl<T: Send + 'static> DisposingReceiver<T> {
@@ -167,8 +174,33 @@ impl<T: Send + 'static> DisposingReceiver<T> {
         Self {
             inner: Some(inner),
             runtime,
+            reply_waker: None,
         }
     }
+}
+
+fn poll_one_shot_with_proxy<T: Send + 'static, R>(
+    inner: &mut OneShotReceiver<T>,
+    reply_waker: &mut Option<WakerProxy>,
+    context: &mut Context<'_>,
+    mut poll: impl FnMut(&mut OneShotReceiver<T>, &mut Context<'_>) -> R,
+    is_pending: impl Fn(&R) -> bool,
+) -> R {
+    if reply_waker.is_none() {
+        let mut probe = Context::from_waker(Waker::noop());
+        let result = poll(inner, &mut probe);
+        if !is_pending(&result) {
+            return result;
+        }
+        *reply_waker = Some(WakerProxy::new());
+    }
+
+    let reply_waker = reply_waker
+        .as_ref()
+        .expect("a parked reply receiver retains its waker proxy");
+    reply_waker.register(context.waker());
+    let mut proxy_context = Context::from_waker(reply_waker.waker());
+    poll(inner, &mut proxy_context)
 }
 
 impl<T> DisposingReceiver<T> {
@@ -184,16 +216,68 @@ impl<T> DisposingReceiver<T> {
 
     pub(crate) fn close(&mut self) {
         self.inner_mut().close();
+        let mut panics = PanicAccumulator::default();
+        self.retire_reply_waker(&mut panics);
+    }
+
+    fn retire_reply_waker(&mut self, panics: &mut PanicAccumulator) {
+        let reply_waker = self.reply_waker.take();
+        let mut effects = WakerEffects::default();
+        if let Some(reply_waker) = &reply_waker {
+            reply_waker.retire(WakerAction::DropInline, &mut effects);
+        }
+        effects.flush(panics);
+        panics.run(|| drop(reply_waker));
     }
 }
 
 impl<T: Send + 'static> DisposingReceiver<T> {
     pub(crate) fn poll_receive(&mut self, context: &mut Context<'_>) -> Poll<Option<T>> {
-        self.inner_mut().poll_receive(context)
+        // In pinned Tokio 1.53.1, `Receiver::poll` first obtains the result,
+        // then clears its `Inner`; the last `Inner::drop` calls
+        // `rx_task.drop_task` while that result can own the delivered value.
+        // Probe with a framework waker, then leave only the proxy registered
+        // across a pending return so Tokio never destroys a caller waker at
+        // that seam.
+        let result = poll_one_shot_with_proxy(
+            self.inner
+                .as_mut()
+                .expect("a live disposing receiver retains its channel"),
+            &mut self.reply_waker,
+            context,
+            OneShotReceiver::poll_receive,
+            Poll::is_pending,
+        );
+        if result.is_ready() {
+            // `result` may own a user value. The caller-waker diagnostic is
+            // subordinate to delivering it, so retire synchronously but
+            // contain any hostile destructor panic before returning.
+            let mut panics = PanicAccumulator::default();
+            self.retire_reply_waker(&mut panics);
+            crate::panic::discard_panic(panics.take());
+        }
+        result
     }
 
     pub(crate) fn close_and_poll_receive(&mut self, context: &mut Context<'_>) -> OneShotClose<T> {
-        self.inner_mut().close_and_poll_receive(context)
+        let result = poll_one_shot_with_proxy(
+            self.inner
+                .as_mut()
+                .expect("a live disposing receiver retains its channel"),
+            &mut self.reply_waker,
+            context,
+            OneShotReceiver::close_and_poll_receive,
+            |result| matches!(result, OneShotClose::Pending),
+        );
+        if !matches!(result, OneShotClose::Pending) {
+            // Timeout arbitration can return a concurrently delivered user
+            // value, so it uses the same synchronous contained precedence as
+            // the ordinary ready path.
+            let mut panics = PanicAccumulator::default();
+            self.retire_reply_waker(&mut panics);
+            crate::panic::discard_panic(panics.take());
+        }
+        result
     }
 }
 
@@ -204,7 +288,7 @@ impl<T> Drop for DisposingReceiver<T> {
             .take()
             .expect("a live disposing receiver retains its channel");
         let mut value = None;
-        let mut panics = crate::panic::PanicAccumulator::default();
+        let mut panics = PanicAccumulator::default();
         // Tokio's one-shot close is atomics-only, so cancellation never
         // required the timer path's blocking-disposal venue. The old ruling
         // that this justified leaving the one-shot registration unproxied is
@@ -230,6 +314,7 @@ impl<T> Drop for DisposingReceiver<T> {
             }
         });
         panics.run(|| drop(inner));
+        self.retire_reply_waker(&mut panics);
     }
 }
 

--- a/crates/shelterwood-mailbox/src/capability.rs
+++ b/crates/shelterwood-mailbox/src/capability.rs
@@ -216,10 +216,35 @@ impl<T> DisposingReceiver<T> {
 
     pub(crate) fn close(&mut self) {
         self.inner_mut().close();
+        // Contained rather than re-raised, for the same reason as the delivery
+        // seams: `close`'s callers can own a live user value while they call
+        // it. `CallOperation::fail_send` holds the recovered `SendError<M>`
+        // message in its frame, so letting a hostile caller-waker destructor
+        // unwind out of here would put that panic in flight while the message
+        // is still to be destroyed -- the double-panic abort this proxy exists
+        // to remove.
         let mut panics = PanicAccumulator::default();
         self.retire_reply_waker(&mut panics);
+        crate::panic::discard_panic(panics.take());
     }
 
+    /// Takes the caller waker out of the proxy and queues its destructor into
+    /// an effects sink, so it runs with no proxy mutex held.
+    ///
+    /// The delivery seams then *discard* whatever that destructor raises. Two
+    /// costs ride on that, both accepted by #398 ruling 3:
+    ///
+    /// * The panic is swallowed with no diagnostic. A delivered user value has
+    ///   to be returned by value, so there is no point after the handoff at
+    ///   which a retained payload could be resumed -- resuming before it would
+    ///   destroy the value the caller is owed. `shelterwood-core`'s `panic`
+    ///   module holds that containment is false on a normal return path; this
+    ///   is the deliberate exception to that guidance, not an oversight.
+    /// * A caller-waker destructor that *blocks* stalls the delivering task
+    ///   synchronously. The same ruling weighed a per-delivery disposal-lane
+    ///   submission against it: delivery is the hot path of every successful
+    ///   `call` and `recv`, and a lane submission there is real cost on every
+    ///   reply, where a contained drop of a benign waker is nearly free.
     fn retire_reply_waker(&mut self, panics: &mut PanicAccumulator) {
         let reply_waker = self.reply_waker.take();
         let mut effects = WakerEffects::default();
@@ -251,7 +276,8 @@ impl<T: Send + 'static> DisposingReceiver<T> {
         if result.is_ready() {
             // `result` may own a user value. The caller-waker diagnostic is
             // subordinate to delivering it, so retire synchronously but
-            // contain any hostile destructor panic before returning.
+            // contain any hostile destructor panic before returning. See
+            // `retire_reply_waker` for the two costs that ride on the discard.
             let mut panics = PanicAccumulator::default();
             self.retire_reply_waker(&mut panics);
             crate::panic::discard_panic(panics.take());
@@ -272,7 +298,7 @@ impl<T: Send + 'static> DisposingReceiver<T> {
         if !matches!(result, OneShotClose::Pending) {
             // Timeout arbitration can return a concurrently delivered user
             // value, so it uses the same synchronous contained precedence as
-            // the ordinary ready path.
+            // the ordinary ready path, and accepts the same two costs.
             let mut panics = PanicAccumulator::default();
             self.retire_reply_waker(&mut panics);
             crate::panic::discard_panic(panics.take());
@@ -289,13 +315,20 @@ impl<T> Drop for DisposingReceiver<T> {
             .expect("a live disposing receiver retains its channel");
         let mut value = None;
         let mut panics = PanicAccumulator::default();
-        // Tokio's one-shot close is atomics-only, so cancellation never
-        // required the timer path's blocking-disposal venue. The old ruling
-        // that this justified leaving the one-shot registration unproxied is
-        // nevertheless superseded by #398: reply polling registers a proxy
-        // uniformly because delivery, not cancellation, is the abort-class
-        // seam. Cancellation inherits that containment without retaining a
-        // special raw-waker path of its own.
+        // Cancellation never required the timer path's blocking-disposal
+        // venue, which is a claim about venue only: closing a one-shot runs on
+        // the receiver's own thread with no shared driver or wheel mutex held,
+        // so a slow caller-waker destructor there stalls this future alone
+        // rather than every timer registration in the process. It is not that
+        // close touches no wakers -- in the pinned 1.53.1, `Inner::close`
+        // wakes a set tx task and calls `rx_task.drop_task()` when the channel
+        // is not yet complete, so pre-proxy this path did destroy a caller
+        // waker inline. The old ruling that the venue argument justified
+        // leaving the one-shot registration unproxied is superseded by #398:
+        // reply polling registers a proxy uniformly because delivery, not
+        // cancellation, is the abort-class seam, so the waker Tokio drops here
+        // is now only ever a framework proxy clone. Cancellation inherits that
+        // containment without retaining a special raw-waker path of its own.
         // Recovery runs first so an unclaimed value reaches isolated disposal
         // before the receiver -- and therefore before the waker clone it
         // registered -- is retired; a hostile waker destructor can neither

--- a/crates/shelterwood-mailbox/src/reply.rs
+++ b/crates/shelterwood-mailbox/src/reply.rs
@@ -218,7 +218,10 @@ mod tests {
         }
     }
 
-    struct DropCounter(Arc<AtomicUsize>);
+    struct DropCounter {
+        drops: Arc<AtomicUsize>,
+        hostile: bool,
+    }
 
     unsafe fn clone_counted_drop_waker(data: *const ()) -> RawWaker {
         // SAFETY: every pointer using this vtable came from an Arc of the
@@ -241,7 +244,8 @@ mod tests {
     unsafe fn drop_counted_drop_waker(data: *const ()) {
         // SAFETY: drop consumes the Arc reference represented by this waker.
         let state = unsafe { Arc::<DropCounter>::from_raw(data.cast()) };
-        state.0.fetch_add(1, Ordering::SeqCst);
+        state.drops.fetch_add(1, Ordering::SeqCst);
+        assert!(!state.hostile, "injected reply caller-waker drop panic");
     }
 
     static COUNTED_DROP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
@@ -251,14 +255,22 @@ mod tests {
         drop_counted_drop_waker,
     );
 
-    fn counted_drop_waker(drops: Arc<AtomicUsize>) -> Waker {
+    fn drop_waker(drops: Arc<AtomicUsize>, hostile: bool) -> Waker {
         let raw = RawWaker::new(
-            Arc::into_raw(Arc::new(DropCounter(drops))).cast(),
+            Arc::into_raw(Arc::new(DropCounter { drops, hostile })).cast(),
             &COUNTED_DROP_WAKER_VTABLE,
         );
         // SAFETY: `raw` owns one Arc reference and its vtable maintains that
         // ownership across clone, wake, and drop.
         unsafe { Waker::from_raw(raw) }
+    }
+
+    fn counted_drop_waker(drops: Arc<AtomicUsize>) -> Waker {
+        drop_waker(drops, false)
+    }
+
+    fn hostile_drop_waker(drops: Arc<AtomicUsize>) -> Waker {
+        drop_waker(drops, true)
     }
 
     struct CountWake(Arc<AtomicUsize>);
@@ -371,6 +383,43 @@ mod tests {
             drops.load(Ordering::SeqCst),
             1,
             "timeout arbitration retires the proxy's caller clone before returning the value"
+        );
+    }
+
+    #[test]
+    fn close_retires_the_reply_caller_waker_and_contains_a_hostile_destructor() {
+        let runtime = Arc::new(
+            crate::capability::tests::TestRuntime::new().with_oneshot(|| {
+                (
+                    Box::new(RejectingSender),
+                    Box::pin(SeamReceiver {
+                        pending_polls: usize::MAX,
+                        value: None,
+                        value_on_close: false,
+                    }),
+                )
+            }),
+        );
+        let (_, inner) = oneshot::<u8>(&(runtime.clone() as Arc<dyn crate::MailboxRuntime>));
+        let mut receiver = DisposingReceiver::new(inner, runtime);
+        let drops = Arc::new(AtomicUsize::new(0));
+        let caller = ManuallyDrop::new(hostile_drop_waker(Arc::clone(&drops)));
+        let mut context = Context::from_waker(&caller);
+
+        assert!(receiver.poll_receive(&mut context).is_pending());
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+
+        // Returning normally is the assertion: `close` is reached from frames
+        // that own a live user value (`CallOperation::fail_send` holds the
+        // recovered message), so a hostile caller-waker destructor has to be
+        // contained here rather than re-raised. A `catch_unwind` around this
+        // call would pass even if containment were removed.
+        receiver.close();
+
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            1,
+            "close retires the proxy's caller clone"
         );
     }
 

--- a/crates/shelterwood-mailbox/src/reply.rs
+++ b/crates/shelterwood-mailbox/src/reply.rs
@@ -154,15 +154,20 @@ impl<T: Send + 'static> DeadlineOperation for ReplyOperation<T> {
 mod tests {
     use std::{
         future::Future,
+        mem::ManuallyDrop,
+        pin::Pin,
         sync::{
             Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
         },
-        task::{Context, Poll, Wake, Waker},
+        task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker},
         time::Duration,
     };
 
-    use crate::{ErasedOneShotSender, ErasedValue};
+    use crate::{
+        ErasedOneShotClose, ErasedOneShotReceiver, ErasedOneShotSender, ErasedValue,
+        capability::{DisposingReceiver, OneShotClose, oneshot},
+    };
 
     use super::super::cell::tests::{actor, actor_for_with_runtime};
 
@@ -172,6 +177,88 @@ mod tests {
         fn send(self: Box<Self>, value: ErasedValue) -> Result<(), ErasedValue> {
             Err(value)
         }
+    }
+
+    struct SeamReceiver {
+        pending_polls: usize,
+        value: Option<ErasedValue>,
+        value_on_close: bool,
+    }
+
+    impl ErasedOneShotReceiver for SeamReceiver {
+        fn poll_receive(
+            mut self: Pin<&mut Self>,
+            _context: &mut Context<'_>,
+        ) -> Poll<Option<ErasedValue>> {
+            if self.pending_polls > 0 {
+                self.pending_polls -= 1;
+                Poll::Pending
+            } else {
+                Poll::Ready(self.value.take())
+            }
+        }
+
+        fn close_and_poll_receive(
+            mut self: Pin<&mut Self>,
+            _context: &mut Context<'_>,
+        ) -> ErasedOneShotClose {
+            if self.value_on_close {
+                self.value
+                    .take()
+                    .map_or(ErasedOneShotClose::SenderClosed, ErasedOneShotClose::Value)
+            } else {
+                ErasedOneShotClose::Pending
+            }
+        }
+
+        fn close(self: Pin<&mut Self>) {}
+
+        fn close_and_take(mut self: Pin<&mut Self>) -> Option<ErasedValue> {
+            self.value.take()
+        }
+    }
+
+    struct DropCounter(Arc<AtomicUsize>);
+
+    unsafe fn clone_counted_drop_waker(data: *const ()) -> RawWaker {
+        // SAFETY: every pointer using this vtable came from an Arc of the
+        // matching type. ManuallyDrop preserves the represented reference;
+        // the returned raw waker owns only the new clone.
+        let state = ManuallyDrop::new(unsafe { Arc::<DropCounter>::from_raw(data.cast()) });
+        RawWaker::new(
+            Arc::into_raw(Arc::clone(&state)).cast(),
+            &COUNTED_DROP_WAKER_VTABLE,
+        )
+    }
+
+    unsafe fn wake_counted_drop_waker(data: *const ()) {
+        // SAFETY: wake consumes the Arc reference represented by this waker.
+        drop(unsafe { Arc::<DropCounter>::from_raw(data.cast()) });
+    }
+
+    unsafe fn wake_by_ref_counted_drop_waker(_data: *const ()) {}
+
+    unsafe fn drop_counted_drop_waker(data: *const ()) {
+        // SAFETY: drop consumes the Arc reference represented by this waker.
+        let state = unsafe { Arc::<DropCounter>::from_raw(data.cast()) };
+        state.0.fetch_add(1, Ordering::SeqCst);
+    }
+
+    static COUNTED_DROP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+        clone_counted_drop_waker,
+        wake_counted_drop_waker,
+        wake_by_ref_counted_drop_waker,
+        drop_counted_drop_waker,
+    );
+
+    fn counted_drop_waker(drops: Arc<AtomicUsize>) -> Waker {
+        let raw = RawWaker::new(
+            Arc::into_raw(Arc::new(DropCounter(drops))).cast(),
+            &COUNTED_DROP_WAKER_VTABLE,
+        );
+        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+        // ownership across clone, wake, and drop.
+        unsafe { Waker::from_raw(raw) }
     }
 
     struct CountWake(Arc<AtomicUsize>);
@@ -221,6 +308,70 @@ mod tests {
         let (reply, receiver) = actor.reply_channel::<u8>();
         drop(receiver);
         reply.send(9);
+    }
+
+    #[crate::runtime::test]
+    async fn ready_race_retires_the_reply_caller_waker_before_returning() {
+        let runtime = Arc::new(
+            crate::capability::tests::TestRuntime::new().with_oneshot(|| {
+                (
+                    Box::new(RejectingSender),
+                    Box::pin(SeamReceiver {
+                        pending_polls: 1,
+                        value: Some(Box::new(7_u8)),
+                        value_on_close: false,
+                    }),
+                )
+            }),
+        );
+        let (_, actor) = actor_for_with_runtime::<()>(runtime);
+        let (_reply, receiver) = actor.reply_channel::<u8>();
+        let mut receive = Box::pin(receiver.recv(Duration::from_secs(1)));
+        let drops = Arc::new(AtomicUsize::new(0));
+        let caller = ManuallyDrop::new(counted_drop_waker(Arc::clone(&drops)));
+
+        assert!(matches!(
+            receive.as_mut().poll(&mut Context::from_waker(&caller)),
+            Poll::Ready(Ok(7))
+        ));
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            1,
+            "the proxy's caller clone retires synchronously at the ready seam"
+        );
+    }
+
+    #[test]
+    fn timeout_arbitration_value_retires_the_reply_caller_waker_before_returning() {
+        let runtime = Arc::new(
+            crate::capability::tests::TestRuntime::new().with_oneshot(|| {
+                (
+                    Box::new(RejectingSender),
+                    Box::pin(SeamReceiver {
+                        pending_polls: usize::MAX,
+                        value: Some(Box::new(9_u8)),
+                        value_on_close: true,
+                    }),
+                )
+            }),
+        );
+        let (_, inner) = oneshot::<u8>(&(runtime.clone() as Arc<dyn crate::MailboxRuntime>));
+        let mut receiver = DisposingReceiver::new(inner, runtime);
+        let drops = Arc::new(AtomicUsize::new(0));
+        let caller = ManuallyDrop::new(counted_drop_waker(Arc::clone(&drops)));
+        let mut context = Context::from_waker(&caller);
+
+        assert!(receiver.poll_receive(&mut context).is_pending());
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+        assert!(matches!(
+            receiver.close_and_poll_receive(&mut context),
+            OneShotClose::Value(9)
+        ));
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            1,
+            "timeout arbitration retires the proxy's caller clone before returning the value"
+        );
     }
 
     #[crate::runtime::test(start_paused = true)]

--- a/crates/shelterwood/tests/reply_delivery_waker_proxy.rs
+++ b/crates/shelterwood/tests/reply_delivery_waker_proxy.rs
@@ -133,22 +133,38 @@ impl Drop for HostileReply {
     }
 }
 
+/// An actor handle is the only public route to a reply channel, and
+/// `reply_channel` reads nothing from it but the installed runtime. This actor
+/// therefore exists to be declared and never spawned, messaged, or stopped.
+struct ChannelSource;
+
+impl Actor for ChannelSource {
+    type Msg = ();
+    type Args = ();
+
+    async fn init(_: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, _: (), _: &mut Context<'_, Self>) -> ExitResult {
+        Ok(())
+    }
+}
+
 /// Combines the hostile registered-waker destructor with a delivered value
 /// whose own destructor panics. Before the proxy, Tokio 1.53.1 dropped the
 /// registered caller waker while its ready result owned this value; the two
 /// unwinds aborted the process. Nextest's process-per-test isolation makes
 /// that SIGABRT a failure of this exact regression.
+///
+/// The reply is sent directly rather than through an actor: this seam is the
+/// receiver's, and driving a live actor would add scheduling the test cannot
+/// pin without teaching it nothing about the retirement order.
 #[tokio::test]
 async fn successful_recv_cannot_double_panic_with_hostile_waker_and_value_drops() {
     let mut tree = Tree::new();
     let actor = tree
-        .add_actor_once(
-            "reply-waker-recv",
-            ActorOnceDef::<ReplyingActor>::new((
-                ReleaseGate::default(),
-                tokio::sync::mpsc::unbounded_channel().0,
-            )),
-        )
+        .add_actor_once("reply-waker-recv", ActorOnceDef::<ChannelSource>::new(()))
         .expect("valid actor");
     let (reply, receiver) = actor.reply_channel::<HostileReply>();
     let hostile = ManuallyDrop::new(panicking_drop_waker());

--- a/crates/shelterwood/tests/reply_delivery_waker_proxy.rs
+++ b/crates/shelterwood/tests/reply_delivery_waker_proxy.rs
@@ -1,0 +1,174 @@
+mod common;
+
+use std::{
+    future::Future,
+    mem::ManuallyDrop,
+    sync::Arc,
+    task::{Context as TaskContext, Poll, RawWaker, RawWakerVTable, Waker},
+    time::Duration,
+};
+
+use common::{POLL_TIMEOUT, ReleaseGate};
+use shelterwood::{Actor, ActorOnceDef, Context, ExitError, ExitResult, Reply, Tree};
+
+unsafe fn clone_panicking_drop_waker(data: *const ()) -> RawWaker {
+    // SAFETY: every pointer using this vtable came from an Arc of the
+    // matching type. ManuallyDrop preserves the reference represented by
+    // `data`; the returned raw waker owns only the new clone.
+    let state = ManuallyDrop::new(unsafe { Arc::<()>::from_raw(data.cast()) });
+    RawWaker::new(
+        Arc::into_raw(Arc::clone(&state)).cast(),
+        &PANICKING_DROP_WAKER_VTABLE,
+    )
+}
+
+unsafe fn wake_panicking_drop_waker(data: *const ()) {
+    // SAFETY: wake consumes the Arc reference represented by this raw waker.
+    drop(unsafe { Arc::<()>::from_raw(data.cast()) });
+}
+
+unsafe fn wake_by_ref_panicking_drop_waker(_data: *const ()) {}
+
+unsafe fn drop_panicking_drop_waker(data: *const ()) {
+    // SAFETY: drop consumes the Arc reference represented by this raw waker.
+    drop(unsafe { Arc::<()>::from_raw(data.cast()) });
+    panic!("injected reply caller-waker drop panic");
+}
+
+static PANICKING_DROP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    clone_panicking_drop_waker,
+    wake_panicking_drop_waker,
+    wake_by_ref_panicking_drop_waker,
+    drop_panicking_drop_waker,
+);
+
+fn panicking_drop_waker() -> Waker {
+    let raw = RawWaker::new(
+        Arc::into_raw(Arc::new(())).cast(),
+        &PANICKING_DROP_WAKER_VTABLE,
+    );
+    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+    // ownership across clone, wake, and drop.
+    unsafe { Waker::from_raw(raw) }
+}
+
+enum Message {
+    Ask(Reply<u8>),
+}
+
+struct ReplyingActor {
+    allow_reply: ReleaseGate,
+    delivered: tokio::sync::mpsc::UnboundedSender<()>,
+}
+
+impl Actor for ReplyingActor {
+    type Msg = Message;
+    type Args = (ReleaseGate, tokio::sync::mpsc::UnboundedSender<()>);
+
+    async fn init(
+        (allow_reply, delivered): Self::Args,
+        _: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        Ok(Self {
+            allow_reply,
+            delivered,
+        })
+    }
+
+    async fn handle(&mut self, message: Message, _: &mut Context<'_, Self>) -> ExitResult {
+        let Message::Ask(reply) = message;
+        self.allow_reply.wait().await;
+        reply.send(7);
+        let _ = self.delivered.send(());
+        Ok(())
+    }
+}
+
+/// Drives the ordinary public `call` success path after ensuring its one-shot
+/// has parked with a caller waker whose drop vtable panics.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn successful_call_contains_reply_caller_waker_retirement() {
+    let allow_reply = ReleaseGate::default();
+    let (delivered_tx, mut delivered_rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "reply-waker-call",
+            ActorOnceDef::<ReplyingActor>::new((allow_reply.clone(), delivered_tx)),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+
+    let hostile = ManuallyDrop::new(panicking_drop_waker());
+    let mut call = Box::pin(actor.call(Message::Ask, Duration::from_secs(30)));
+    assert!(matches!(
+        call.as_mut().poll(&mut TaskContext::from_waker(&hostile)),
+        Poll::Pending
+    ));
+    allow_reply.release();
+    tokio::time::timeout(POLL_TIMEOUT, delivered_rx.recv())
+        .await
+        .expect("the actor delivers its reply")
+        .expect("the delivery signal remains open");
+
+    let Poll::Ready(Ok(replied)) = call.as_mut().poll(&mut TaskContext::from_waker(&hostile))
+    else {
+        panic!("the successful call returns its reply")
+    };
+    assert_eq!(replied.value, 7);
+
+    drop(call);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("actor stops");
+}
+
+struct HostileReply;
+
+impl Drop for HostileReply {
+    fn drop(&mut self) {
+        panic!("injected delivered-value drop panic");
+    }
+}
+
+/// Combines the hostile registered-waker destructor with a delivered value
+/// whose own destructor panics. Before the proxy, Tokio 1.53.1 dropped the
+/// registered caller waker while its ready result owned this value; the two
+/// unwinds aborted the process. Nextest's process-per-test isolation makes
+/// that SIGABRT a failure of this exact regression.
+#[tokio::test]
+async fn successful_recv_cannot_double_panic_with_hostile_waker_and_value_drops() {
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "reply-waker-recv",
+            ActorOnceDef::<ReplyingActor>::new((
+                ReleaseGate::default(),
+                tokio::sync::mpsc::unbounded_channel().0,
+            )),
+        )
+        .expect("valid actor");
+    let (reply, receiver) = actor.reply_channel::<HostileReply>();
+    let hostile = ManuallyDrop::new(panicking_drop_waker());
+    let mut receive = Box::pin(receiver.recv(Duration::from_secs(30)));
+    assert!(matches!(
+        receive
+            .as_mut()
+            .poll(&mut TaskContext::from_waker(&hostile)),
+        Poll::Pending
+    ));
+
+    reply.send(HostileReply);
+    let Poll::Ready(Ok(value)) = receive
+        .as_mut()
+        .poll(&mut TaskContext::from_waker(&hostile))
+    else {
+        panic!("the successful receive returns its reply")
+    };
+    // Its destructor is the abort's second half. A passing implementation
+    // returns it intact, so the test intentionally leaves it undestroyed.
+    std::mem::forget(value);
+    drop(receive);
+}


### PR DESCRIPTION
Implements PR 3 of #398 and closes #383.

This is stacked on #403. It registers the one-shot reply channel with a stable framework proxy, retires the real caller waker synchronously and with panic containment at the successful delivery seam, covers timeout arbitration, and adds public-path regressions for hostile waker and delivered-value destructors.

Local verification: `./tools/dev just ci` (860 tests).