### PR TITLE
Proxy public timer registrations

### DIFF
--- a/crates/shelterwood-mailbox/src/capability.rs
+++ b/crates/shelterwood-mailbox/src/capability.rs
@@ -374,7 +374,7 @@ pub(crate) mod tests {
 
     use crate::runtime::{
         OneShotClose, OneShotReceiver, OneShotSender, Signal, SignalWatcher, dispose_detached, now,
-        oneshot, sleep_until,
+        oneshot, raw_sleep_until,
     };
 
     use super::{
@@ -455,7 +455,7 @@ pub(crate) mod tests {
         fn sleep_until(&self, deadline: Option<Instant>) -> BoxedSleep {
             deadline.map_or_else(
                 || Box::pin(std::future::pending()) as BoxedSleep,
-                sleep_until,
+                raw_sleep_until,
             )
         }
     }

--- a/crates/shelterwood-mailbox/src/deadline.rs
+++ b/crates/shelterwood-mailbox/src/deadline.rs
@@ -2,17 +2,12 @@ use std::{
     future::Future,
     pin::Pin,
     sync::Arc,
-    task::{Context, Poll, Waker},
+    task::{Context, Poll},
 };
 
 use shelterwood_core::DeadlineBudget;
 
-use crate::{
-    BoxedSleep, MailboxRuntime,
-    cell::waker_slot::{WakerAction, WakerEffects},
-    panic::PanicAccumulator,
-    waker_proxy::WakerProxy,
-};
+use crate::{MailboxRuntime, ProxiedSleep, panic::PanicAccumulator};
 
 pub(crate) use shelterwood_core::deadline::Deadline;
 
@@ -63,8 +58,7 @@ pub(super) struct Deadlined<F> {
     runtime: Arc<dyn MailboxRuntime>,
     budget_width: DeadlineBudget,
     budget: Option<crate::deadline::Deadline>,
-    timer: Option<BoxedSleep>,
-    timer_waker: Option<WakerProxy>,
+    timer: Option<ProxiedSleep>,
     pub(super) started: bool,
     phase: DeadlinePhase,
 }
@@ -83,7 +77,6 @@ impl<F> Deadlined<F> {
             budget_width: budget_width.into(),
             budget: None,
             timer: None,
-            timer_waker: None,
             started: false,
             phase: DeadlinePhase::InitialAttempt,
         }
@@ -116,32 +109,12 @@ impl<F> Deadlined<F> {
             // so it stays as free as it was before the proxy.
             return Poll::Pending;
         }
-        if self.timer_waker.is_none() {
-            let mut probe = Context::from_waker(Waker::noop());
-            if self
-                .timer
+        Pin::new(
+            self.timer
                 .as_mut()
-                .expect("an unelapsed deadline future retains its timer")
-                .as_mut()
-                .poll(&mut probe)
-                .is_ready()
-            {
-                return Poll::Ready(());
-            }
-            self.timer_waker = Some(WakerProxy::new());
-        }
-
-        let timer_waker = self
-            .timer_waker
-            .as_ref()
-            .expect("a parked timer retains its waker proxy");
-        timer_waker.register(context.waker());
-        let mut proxy_context = Context::from_waker(timer_waker.waker());
-        self.timer
-            .as_mut()
-            .expect("an unelapsed deadline future retains its timer")
-            .as_mut()
-            .poll(&mut proxy_context)
+                .expect("an unelapsed deadline future retains its timer"),
+        )
+        .poll(context)
     }
 
     /// Retires the caller waker on this thread, then synchronously removes the
@@ -156,47 +129,13 @@ impl<F> Deadlined<F> {
     /// lane submission on every completed `send_timeout`/`call`/`recv` is real
     /// cost where a contained drop of a benign waker is nearly free. Only drop
     /// glue -- where the absorbing party is whatever is tearing the future down
-    /// -- keeps the lane, in [`Self::retire_timer_disposing`].
+    /// -- keeps the lane through `ProxiedSleep`'s drop implementation.
     fn retire_timer_inline(&mut self, panics: &mut PanicAccumulator) {
-        self.retire_timer(WakerAction::DropInline, panics);
-    }
-
-    /// Retires the caller waker through the blocking disposal lane, then
-    /// synchronously removes the framework-only wheel registration.
-    ///
-    /// The cancel venue, per #398 ruling 3. Drop glue runs on whatever thread
-    /// is discarding the future -- during an unwind, inside another future's
-    /// teardown, or on a runtime worker -- and has no result to trade the
-    /// diagnostic against, so a destructor that blocks goes to the lane rather
-    /// than stalling that thread.
-    fn retire_timer_disposing(&mut self, panics: &mut PanicAccumulator) {
-        self.retire_timer(WakerAction::Dispose(Arc::clone(&self.runtime)), panics);
-    }
-
-    fn retire_timer(&mut self, action: WakerAction, panics: &mut PanicAccumulator) {
-        let mut effects = WakerEffects::default();
-        let timer_waker = self.timer_waker.as_ref();
-        // Inside the boundary rather than beside it. The proxy mutex guards
-        // framework-owned data only and is documented unpoisonable, so nothing
-        // here is expected to unwind -- but this runs from drop glue too, and
-        // a cleanup step that escapes an accumulator during an unwind is the
-        // double panic the accumulator exists to prevent. Cheaper to contain
-        // than to make every reader re-derive the proof.
-        panics.run(|| {
-            if let Some(timer_waker) = timer_waker {
-                timer_waker.retire(action, &mut effects);
-            }
-        });
-        effects.flush(panics);
-
-        // Slot first, timer second: emptying the proxy before the wheel entry
-        // goes means the entry cannot deliver a wake to a caller that already
-        // has its answer, and dropping the timer synchronously means the entry
-        // is gone when this returns rather than whenever a worker reaches it.
-        let timer = self.timer.take();
+        let mut timer = self.timer.take();
+        if let Some(timer) = timer.as_mut() {
+            timer.retire_inline(panics);
+        }
         panics.run(|| drop(timer));
-        let timer_waker = self.timer_waker.take();
-        panics.run(|| drop(timer_waker));
     }
 }
 
@@ -210,8 +149,11 @@ impl<F: DeadlineOperation + Unpin> Future for Deadlined<F> {
             let budget =
                 crate::deadline::Deadline::after(this.runtime.now(), this.budget_width.duration());
             this.budget = Some(budget);
-            if !this.budget_width.is_zero() {
-                this.timer = Some(this.runtime.sleep_until(budget.instant()));
+            if !this.budget_width.is_zero()
+                && let Some(deadline) = budget.instant()
+            {
+                let timer = this.runtime.sleep_until(Some(deadline));
+                this.timer = Some(ProxiedSleep::new(timer, Arc::clone(&this.runtime)));
             }
         }
         // A zero budget short-circuits: the operation is never attempted, so
@@ -293,8 +235,7 @@ impl<F> Drop for Deadlined<F> {
     /// of its own to stall, so a destructor that blocks is handed off rather
     /// than run here.
     fn drop(&mut self) {
-        let mut panics = PanicAccumulator::default();
-        self.retire_timer_disposing(&mut panics);
+        drop(self.timer.take());
     }
 }
 
@@ -379,11 +320,9 @@ mod tests {
 
     /// Counts the clones a poll takes of the caller's waker.
     ///
-    /// A proxy allocation is not observable as a retained field: every path
-    /// that allocates one also retires it, emptying `timer_waker` again before
-    /// the poll returns. The artifact a lazy path must leave untouched is
-    /// therefore the caller's own `clone` vtable, which only
-    /// `WakerProxy::register` reaches.
+    /// A proxy allocation is not observable after retirement. The artifact a
+    /// lazy path must leave untouched is therefore the caller's own `clone`
+    /// vtable, which only `WakerProxy::register` reaches.
     #[derive(Default)]
     struct CloneCounter(AtomicUsize);
 
@@ -516,11 +455,16 @@ mod tests {
             std::time::Duration::from_secs(1),
             crate::capability::tests::runtime(),
         ));
-        let mut context = Context::from_waker(Waker::noop());
+        let counter = Arc::new(CloneCounter::default());
+        let waker = counting_waker(&counter);
+        let mut context = Context::from_waker(&waker);
 
-        assert!(future.timer_waker.is_none());
         assert!(future.as_mut().poll(&mut context).is_ready());
-        assert!(future.timer_waker.is_none());
+        assert_eq!(
+            counter.0.load(Ordering::SeqCst),
+            0,
+            "an operation ready before the timer poll never clones the caller waker"
+        );
     }
 
     /// The documented lazy path: a timer that is *already* elapsed when the
@@ -583,8 +527,8 @@ mod tests {
         assert!(future.as_mut().poll(&mut context).is_pending());
 
         assert!(
-            future.timer_waker.is_none(),
-            "an unbounded deadline registers no waker proxy"
+            future.timer.is_none(),
+            "an unbounded deadline constructs no timer or waker proxy"
         );
         assert_eq!(
             counter.0.load(Ordering::SeqCst),

--- a/crates/shelterwood-mailbox/src/lib.rs
+++ b/crates/shelterwood-mailbox/src/lib.rs
@@ -34,6 +34,7 @@ mod futures;
 mod reply;
 #[cfg(test)]
 mod test_support;
+mod timer;
 mod waker_proxy;
 
 #[doc(hidden)]
@@ -45,6 +46,8 @@ pub use cell::*;
 pub use errors::*;
 pub use futures::*;
 pub use reply::*;
+#[doc(hidden)]
+pub use timer::ProxiedSleep;
 
 mod identity {
     pub(crate) use shelterwood_core::identity::*;

--- a/crates/shelterwood-mailbox/src/timer.rs
+++ b/crates/shelterwood-mailbox/src/timer.rs
@@ -61,7 +61,9 @@ impl ProxiedSleep {
     /// Public only as a sibling-crate implementation seam. Runtime selection
     /// helpers call it when a non-timer branch wins, so that semantic poll
     /// path retains the synchronous-contained half of the venue split even
-    /// though the timer itself is the losing future.
+    /// though the timer itself is the losing future. Retirement fuses the
+    /// sleep: a later poll reports ready rather than reaching for the
+    /// emptied timer slot.
     #[doc(hidden)]
     pub fn cancel_inline(&mut self) {
         let mut panics = PanicAccumulator::default();
@@ -95,6 +97,10 @@ impl ProxiedSleep {
         panics.run(|| drop(timer));
         let timer_waker = self.timer_waker.take();
         panics.run(|| drop(timer_waker));
+        // Retirement is the single point that empties both slots, so it also
+        // fuses the future: without this, a poll after `cancel_inline` would
+        // panic on the emptied timer slot instead of reporting ready.
+        self.completed = true;
     }
 }
 
@@ -310,6 +316,16 @@ mod tests {
         );
         assert!(timer.timer.is_none());
         assert!(timer.timer_waker.is_none());
+
+        assert!(
+            Pin::new(&mut timer).poll(&mut context).is_ready(),
+            "a cancelled proxied timer is fused rather than reaching for its emptied slots"
+        );
+        assert_eq!(
+            state.clones.load(Ordering::SeqCst),
+            1,
+            "repolling a cancelled timer never reaches the caller vtable"
+        );
     }
 
     struct ThreadDrop(mpsc::Sender<ThreadId>);

--- a/crates/shelterwood-mailbox/src/timer.rs
+++ b/crates/shelterwood-mailbox/src/timer.rs
@@ -255,6 +255,16 @@ mod tests {
             timer.timer_waker.is_none(),
             "the no-op probe allocates no proxy on the ready path"
         );
+
+        assert!(
+            timer.as_mut().poll(&mut context).is_ready(),
+            "a completed proxied timer is fused"
+        );
+        assert_eq!(
+            state.clones.load(Ordering::SeqCst),
+            0,
+            "repolling a completed timer never reaches the caller vtable"
+        );
     }
 
     #[test]

--- a/crates/shelterwood-mailbox/src/timer.rs
+++ b/crates/shelterwood-mailbox/src/timer.rs
@@ -1,0 +1,368 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll, Waker},
+};
+
+use crate::{
+    BoxedSleep, MailboxRuntime,
+    cell::waker_slot::{WakerAction, WakerEffects},
+    panic::PanicAccumulator,
+    waker_proxy::WakerProxy,
+};
+
+/// Timer future that keeps a caller-owned waker out of the runtime's wheel.
+///
+/// Runtime adapters supply the raw timer, while this wrapper owns the common
+/// framework boundary: the external primitive registers only a stable proxy,
+/// and the caller's waker stays in the proxy's effects-mediated private slot.
+/// A timer that is ready on the first no-op probe allocates no proxy.
+///
+/// Poll-path retirement is synchronous and contained. Drop-glue retirement
+/// first hands the caller waker to the runtime's disposal lane, then cancels
+/// the framework-only wheel entry synchronously. This is the venue split
+/// established for public mailbox deadlines by #398.
+#[doc(hidden)]
+pub struct ProxiedSleep {
+    runtime: Arc<dyn MailboxRuntime>,
+    timer: Option<BoxedSleep>,
+    timer_waker: Option<WakerProxy>,
+    completed: bool,
+}
+
+impl ProxiedSleep {
+    /// Wraps one raw runtime timer.
+    ///
+    /// The timer must be framework-owned: its poll and drop implementations
+    /// are invoked inside framework containment boundaries, and the supported
+    /// façade exposes no way for an application to construct this type.
+    #[doc(hidden)]
+    pub fn new(timer: BoxedSleep, runtime: Arc<dyn MailboxRuntime>) -> Self {
+        Self {
+            runtime,
+            timer: Some(timer),
+            timer_waker: None,
+            completed: false,
+        }
+    }
+
+    /// Retires an armed timer on the polling thread.
+    ///
+    /// Used when a containing future completes by a non-timer branch. The
+    /// caller-waker destructor is fully drained before the containing future
+    /// hands its result back, and the wheel entry is synchronously removed.
+    pub(crate) fn retire_inline(&mut self, panics: &mut PanicAccumulator) {
+        self.retire(WakerAction::DropInline, panics);
+    }
+
+    /// Cancels this timer on a containing future's successful poll path.
+    ///
+    /// Public only as a sibling-crate implementation seam. Runtime selection
+    /// helpers call it when a non-timer branch wins, so that semantic poll
+    /// path retains the synchronous-contained half of the venue split even
+    /// though the timer itself is the losing future.
+    #[doc(hidden)]
+    pub fn cancel_inline(&mut self) {
+        let mut panics = PanicAccumulator::default();
+        self.retire_inline(&mut panics);
+        crate::panic::discard_panic(panics.take());
+    }
+
+    fn retire_disposing(&mut self, panics: &mut PanicAccumulator) {
+        self.retire(WakerAction::Dispose(Arc::clone(&self.runtime)), panics);
+    }
+
+    fn retire(&mut self, action: WakerAction, panics: &mut PanicAccumulator) {
+        let mut effects = WakerEffects::default();
+        let timer_waker = self.timer_waker.as_ref();
+        // The proxy mutex guards framework-owned data and is documented
+        // unpoisonable, but this path also runs during unwind. Keep every
+        // cleanup step inside the accumulator so a bookkeeping defect cannot
+        // turn a caller panic into an abort.
+        panics.run(|| {
+            if let Some(timer_waker) = timer_waker {
+                timer_waker.retire(action, &mut effects);
+            }
+        });
+        effects.flush(panics);
+
+        // Slot first, timer second: once the caller waker is gone, cancelling
+        // the wheel entry can deliver no stale wake to a caller that already
+        // has its answer. The timer still drops synchronously so the entry is
+        // gone when retirement returns.
+        let timer = self.timer.take();
+        panics.run(|| drop(timer));
+        let timer_waker = self.timer_waker.take();
+        panics.run(|| drop(timer_waker));
+    }
+}
+
+impl Future for ProxiedSleep {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<()> {
+        let this = self.as_mut().get_mut();
+        if this.completed {
+            return Poll::Ready(());
+        }
+        if this.timer_waker.is_none() {
+            let mut probe = Context::from_waker(Waker::noop());
+            if this
+                .timer
+                .as_mut()
+                .expect("an incomplete proxied sleep retains its timer")
+                .as_mut()
+                .poll(&mut probe)
+                .is_ready()
+            {
+                this.completed = true;
+                let mut panics = PanicAccumulator::default();
+                this.retire_inline(&mut panics);
+                crate::panic::discard_panic(panics.take());
+                return Poll::Ready(());
+            }
+            this.timer_waker = Some(WakerProxy::new());
+        }
+
+        let timer_waker = this
+            .timer_waker
+            .as_ref()
+            .expect("a parked proxied sleep retains its waker proxy");
+        timer_waker.register(context.waker());
+        let mut proxy_context = Context::from_waker(timer_waker.waker());
+        if this
+            .timer
+            .as_mut()
+            .expect("an incomplete proxied sleep retains its timer")
+            .as_mut()
+            .poll(&mut proxy_context)
+            .is_pending()
+        {
+            return Poll::Pending;
+        }
+
+        this.completed = true;
+        let mut panics = PanicAccumulator::default();
+        this.retire_inline(&mut panics);
+        crate::panic::discard_panic(panics.take());
+        Poll::Ready(())
+    }
+}
+
+impl Drop for ProxiedSleep {
+    fn drop(&mut self) {
+        let mut panics = PanicAccumulator::default();
+        self.retire_disposing(&mut panics);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::Future,
+        mem::ManuallyDrop,
+        pin::Pin,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+            mpsc,
+        },
+        task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+        thread::{self, ThreadId},
+        time::Duration,
+    };
+
+    use super::ProxiedSleep;
+
+    #[derive(Default)]
+    struct WakerCounts {
+        clones: AtomicUsize,
+        drops: AtomicUsize,
+    }
+
+    unsafe fn clone_counting(data: *const ()) -> RawWaker {
+        // SAFETY: every pointer using this vtable came from an Arc of the
+        // matching type. ManuallyDrop preserves the reference represented by
+        // `data`; the returned raw waker owns only the new clone.
+        let state = ManuallyDrop::new(unsafe { Arc::<WakerCounts>::from_raw(data.cast()) });
+        state.clones.fetch_add(1, Ordering::SeqCst);
+        RawWaker::new(Arc::into_raw(Arc::clone(&state)).cast(), &COUNTING_VTABLE)
+    }
+
+    unsafe fn wake_counting(data: *const ()) {
+        // SAFETY: wake consumes the Arc reference represented by this waker.
+        drop(unsafe { Arc::<WakerCounts>::from_raw(data.cast()) });
+    }
+
+    unsafe fn wake_by_ref_counting(_data: *const ()) {}
+
+    unsafe fn drop_counting(data: *const ()) {
+        // SAFETY: drop consumes the Arc reference represented by this waker.
+        let state = unsafe { Arc::<WakerCounts>::from_raw(data.cast()) };
+        state.drops.fetch_add(1, Ordering::SeqCst);
+    }
+
+    static COUNTING_VTABLE: RawWakerVTable = RawWakerVTable::new(
+        clone_counting,
+        wake_counting,
+        wake_by_ref_counting,
+        drop_counting,
+    );
+
+    fn counting_waker(state: &Arc<WakerCounts>) -> Waker {
+        let raw = RawWaker::new(Arc::into_raw(Arc::clone(state)).cast(), &COUNTING_VTABLE);
+        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+        // ownership across clone, wake, and drop.
+        unsafe { Waker::from_raw(raw) }
+    }
+
+    struct ParkThenReady {
+        polls: usize,
+        registered: Option<Waker>,
+    }
+
+    impl Future for ParkThenReady {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<()> {
+            self.polls += 1;
+            self.registered = Some(context.waker().clone());
+            if self.polls < 3 {
+                Poll::Pending
+            } else {
+                Poll::Ready(())
+            }
+        }
+    }
+
+    #[test]
+    fn immediately_ready_timer_never_clones_the_caller_waker() {
+        let state = Arc::new(WakerCounts::default());
+        let waker = ManuallyDrop::new(counting_waker(&state));
+        let mut context = Context::from_waker(&waker);
+        let raw: crate::BoxedSleep = Box::pin(std::future::ready(()));
+        let mut timer = Box::pin(ProxiedSleep::new(raw, crate::capability::tests::runtime()));
+
+        assert!(timer.as_mut().poll(&mut context).is_ready());
+        assert_eq!(state.clones.load(Ordering::SeqCst), 0);
+        assert_eq!(state.drops.load(Ordering::SeqCst), 0);
+        assert!(
+            timer.timer.is_none(),
+            "the already-ready raw timer leaves no wheel entry to cancel"
+        );
+        assert!(
+            timer.timer_waker.is_none(),
+            "the no-op probe allocates no proxy on the ready path"
+        );
+    }
+
+    #[test]
+    fn ready_poll_retires_the_caller_waker_inline_before_returning() {
+        let state = Arc::new(WakerCounts::default());
+        let waker = ManuallyDrop::new(counting_waker(&state));
+        let mut context = Context::from_waker(&waker);
+        let raw: crate::BoxedSleep = Box::pin(ParkThenReady {
+            polls: 0,
+            registered: None,
+        });
+        let mut timer = Box::pin(ProxiedSleep::new(raw, crate::capability::tests::runtime()));
+
+        assert!(timer.as_mut().poll(&mut context).is_pending());
+        assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+        assert_eq!(state.drops.load(Ordering::SeqCst), 0);
+
+        assert!(timer.as_mut().poll(&mut context).is_ready());
+        assert_eq!(
+            state.drops.load(Ordering::SeqCst),
+            1,
+            "the caller clone is gone synchronously when the ready poll returns"
+        );
+    }
+
+    #[test]
+    fn containing_ready_path_cancels_the_losing_timer_inline() {
+        let state = Arc::new(WakerCounts::default());
+        let waker = ManuallyDrop::new(counting_waker(&state));
+        let mut context = Context::from_waker(&waker);
+        let raw: crate::BoxedSleep = Box::pin(std::future::pending());
+        let mut timer = ProxiedSleep::new(raw, crate::capability::tests::runtime());
+
+        assert!(Pin::new(&mut timer).poll(&mut context).is_pending());
+        assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+
+        timer.cancel_inline();
+
+        assert_eq!(
+            state.drops.load(Ordering::SeqCst),
+            1,
+            "a sibling branch returning Ready retires the timer caller before handing its value back"
+        );
+        assert!(timer.timer.is_none());
+        assert!(timer.timer_waker.is_none());
+    }
+
+    struct ThreadDrop(mpsc::Sender<ThreadId>);
+
+    unsafe fn clone_thread_drop(data: *const ()) -> RawWaker {
+        // SAFETY: every pointer using this vtable came from an Arc of the
+        // matching type. ManuallyDrop preserves the reference represented by
+        // `data`; the returned raw waker owns only the new clone.
+        let state = ManuallyDrop::new(unsafe { Arc::<ThreadDrop>::from_raw(data.cast()) });
+        RawWaker::new(
+            Arc::into_raw(Arc::clone(&state)).cast(),
+            &THREAD_DROP_VTABLE,
+        )
+    }
+
+    unsafe fn wake_thread_drop(data: *const ()) {
+        // SAFETY: wake consumes the Arc reference represented by this waker.
+        drop(unsafe { Arc::<ThreadDrop>::from_raw(data.cast()) });
+    }
+
+    unsafe fn wake_by_ref_thread_drop(_data: *const ()) {}
+
+    unsafe fn drop_thread_drop(data: *const ()) {
+        // SAFETY: drop consumes the Arc reference represented by this waker.
+        let state = unsafe { Arc::<ThreadDrop>::from_raw(data.cast()) };
+        let _ = state.0.send(thread::current().id());
+    }
+
+    static THREAD_DROP_VTABLE: RawWakerVTable = RawWakerVTable::new(
+        clone_thread_drop,
+        wake_thread_drop,
+        wake_by_ref_thread_drop,
+        drop_thread_drop,
+    );
+
+    fn thread_drop_waker(sender: mpsc::Sender<ThreadId>) -> Waker {
+        let raw = RawWaker::new(
+            Arc::into_raw(Arc::new(ThreadDrop(sender))).cast(),
+            &THREAD_DROP_VTABLE,
+        );
+        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+        // ownership across clone, wake, and drop.
+        unsafe { Waker::from_raw(raw) }
+    }
+
+    #[crate::runtime::test]
+    async fn drop_glue_retires_the_caller_waker_on_the_disposal_lane() {
+        let (dropped_tx, dropped_rx) = mpsc::channel();
+        let caller_thread = thread::current().id();
+        let waker = ManuallyDrop::new(thread_drop_waker(dropped_tx));
+        let mut context = Context::from_waker(&waker);
+        let raw: crate::BoxedSleep = Box::pin(std::future::pending());
+        let mut timer = Box::pin(ProxiedSleep::new(raw, crate::capability::tests::runtime()));
+
+        assert!(timer.as_mut().poll(&mut context).is_pending());
+        drop(timer);
+
+        let destructor_thread = dropped_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("the disposal lane retires the stored caller clone");
+        assert_ne!(
+            destructor_thread, caller_thread,
+            "drop glue must not run the caller-waker destructor on its own thread"
+        );
+    }
+}

--- a/crates/shelterwood-runtime/src/mailbox.rs
+++ b/crates/shelterwood-runtime/src/mailbox.rs
@@ -13,7 +13,7 @@ use shelterwood_mailbox::{
 
 use crate::{
     OneShotClose, OneShotReceiver, OneShotSender, Signal, SignalWatcher, dispose_detached, now,
-    oneshot, sleep_until,
+    oneshot, raw_sleep_until,
 };
 
 struct TokioMailboxRuntime;
@@ -53,7 +53,7 @@ impl MailboxRuntime for TokioMailboxRuntime {
     fn sleep_until(&self, deadline: Option<Instant>) -> BoxedSleep {
         deadline.map_or_else(
             || Box::pin(std::future::pending()) as BoxedSleep,
-            sleep_until,
+            raw_sleep_until,
         )
     }
 }

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -11,8 +11,8 @@ use tokio::{sync::mpsc, task};
 use shelterwood_core::exit::JoinOutcome;
 
 use super::{
-    DisposingReceiver, OneShotReceiver, OneShotSender, PanicPayload, catch_panic, discard_panic,
-    dispose_detached, oneshot, sleep_until_std,
+    DisposingReceiver, OneShotReceiver, OneShotSender, PanicPayload, Timeout, catch_panic,
+    discard_panic, dispose_detached, oneshot, timeout_at,
 };
 
 const BLOCKING_FALLBACK_THREAD: &str = "shelterwood-blocking";
@@ -559,31 +559,36 @@ where
         signal,
         parent_shutdown,
     } = wait;
-    tokio::pin!(signal);
-    tokio::pin!(parent_shutdown);
-    let deadline = async move {
-        if let Some(deadline) = deadline {
-            sleep_until_std(deadline).await;
-        } else {
-            std::future::pending::<()>().await;
+    let event = async move {
+        tokio::pin!(signal);
+        tokio::pin!(parent_shutdown);
+        let control_message = async move {
+            if let Some(receiver) = control_receiver {
+                receiver.recv().await
+            } else {
+                std::future::pending().await
+            }
+        };
+        tokio::pin!(control_message);
+        tokio::select! {
+            biased;
+            () = &mut signal => ScopeWake::Signal,
+            () = &mut parent_shutdown => ScopeWake::ParentShutdown,
+            message = receiver.recv() => ScopeWake::Message(message),
+            message = &mut control_message => ScopeWake::ControlMessage(message),
         }
     };
-    let control_message = async move {
-        if let Some(receiver) = control_receiver {
-            receiver.recv().await
-        } else {
-            std::future::pending().await
-        }
-    };
-    tokio::pin!(deadline);
-    tokio::pin!(control_message);
-    tokio::select! {
-        biased;
-        () = &mut signal => ScopeWake::Signal,
-        () = &mut parent_shutdown => ScopeWake::ParentShutdown,
-        message = receiver.recv() => ScopeWake::Message(message),
-        message = &mut control_message => ScopeWake::ControlMessage(message),
-        () = &mut deadline => ScopeWake::Deadline,
+    // The deadline stays outside the whole event selection so every event
+    // winner retires the timer through `timeout_at`'s synchronous poll-path
+    // boundary. Burying the sleep in a select arm would run its drop-glue
+    // disposal venue every time another arm won -- one blocking-lane
+    // submission per driver wakeup while any deadline is armed.
+    match deadline {
+        Some(deadline) => match timeout_at(deadline, event).await {
+            Timeout::Completed(wake) => wake,
+            Timeout::Elapsed => ScopeWake::Deadline,
+        },
+        None => event.await,
     }
 }
 

--- a/crates/shelterwood-runtime/src/timer.rs
+++ b/crates/shelterwood-runtime/src/timer.rs
@@ -272,6 +272,49 @@ mod tests {
         ));
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn zero_timeout_preserves_operation_first_arbitration() {
+        assert!(matches!(
+            timeout(Duration::ZERO, std::future::ready(7_u8)).await,
+            super::Timeout::Completed(7)
+        ));
+        assert!(matches!(
+            timeout(Duration::ZERO, std::future::pending::<()>()).await,
+            super::Timeout::Elapsed
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn operation_ready_at_the_exact_deadline_wins() {
+        let deadline = super::now() + Duration::from_secs(1);
+        let operation = std::future::poll_fn(|_| {
+            if super::now() >= deadline {
+                Poll::Ready(7_u8)
+            } else {
+                Poll::Pending
+            }
+        });
+        let mut timed = std::pin::pin!(super::timeout_at(deadline, operation));
+        let mut context = Context::from_waker(Waker::noop());
+
+        assert!(timed.as_mut().poll(&mut context).is_pending());
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert!(matches!(
+            timed.as_mut().poll(&mut context),
+            Poll::Ready(super::Timeout::Completed(7))
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn maximum_timeout_stays_unbounded() {
+        let mut timed = std::pin::pin!(timeout(Duration::MAX, std::future::pending::<()>()));
+        let mut context = Context::from_waker(Waker::noop());
+
+        assert!(timed.as_mut().poll(&mut context).is_pending());
+        tokio::time::advance(MAX_TIMER_SLICE * 2).await;
+        assert!(timed.as_mut().poll(&mut context).is_pending());
+    }
+
     #[test]
     fn already_due_clock_limit_needs_no_timer_arm() {
         let edge = latest_representable(std::time::Instant::now());

--- a/crates/shelterwood-runtime/src/timer.rs
+++ b/crates/shelterwood-runtime/src/timer.rs
@@ -4,6 +4,9 @@ use tokio::time;
 
 use shelterwood_core::deadline::Deadline;
 pub use shelterwood_mailbox::BoxedSleep;
+use shelterwood_mailbox::ProxiedSleep;
+
+use crate::mailbox_runtime;
 
 /// Advances a paused test clock, keeping timer control in this module.
 #[cfg(any(test, feature = "test-util"))]
@@ -45,7 +48,26 @@ fn deadline(duration: Duration) -> Deadline {
 pub fn sleep_until(deadline: std::time::Instant) -> BoxedSleep {
     Box::pin(sleep_until_std(deadline))
 }
+
 pub async fn sleep_until_std(deadline: std::time::Instant) {
+    proxied_sleep_until(deadline).await;
+}
+
+fn proxied_sleep_until(deadline: std::time::Instant) -> ProxiedSleep {
+    ProxiedSleep::new(raw_sleep_until(deadline), mailbox_runtime())
+}
+
+/// Raw timer capability supplied to `shelterwood-mailbox`.
+///
+/// Public only as a sibling-crate implementation seam. User-polled façade
+/// futures must use [`sleep_until`] or [`sleep_until_std`], which install the
+/// caller-waker proxy.
+#[doc(hidden)]
+pub fn raw_sleep_until(deadline: std::time::Instant) -> BoxedSleep {
+    Box::pin(raw_sleep_until_std(deadline))
+}
+
+async fn raw_sleep_until_std(deadline: std::time::Instant) {
     // Every absolute-deadline arming crosses the runtime boundary here:
     // tokio rounds the deadline up to the next whole millisecond with a
     // panicking add before tick conversion, so a deadline flush against
@@ -68,6 +90,29 @@ pub async fn sleep_until_std(deadline: std::time::Instant) {
 pub enum Timeout<T> {
     Completed(T),
     Elapsed,
+}
+
+/// Selects a future against one absolute deadline with proxied timer
+/// registration.
+///
+/// Public only as a sibling-crate implementation seam for façade futures that
+/// already own an absolute deadline.
+#[doc(hidden)]
+pub async fn timeout_at<F>(deadline: std::time::Instant, future: F) -> Timeout<F::Output>
+where
+    F: Future,
+{
+    let mut future = std::pin::pin!(future);
+    let mut timer = std::pin::pin!(proxied_sleep_until(deadline));
+    std::future::poll_fn(|context| {
+        // Operation first preserves Tokio timeout's exact-boundary rule.
+        if let std::task::Poll::Ready(value) = future.as_mut().poll(context) {
+            timer.as_mut().get_mut().cancel_inline();
+            return std::task::Poll::Ready(Timeout::Completed(value));
+        }
+        timer.as_mut().poll(context).map(|()| Timeout::Elapsed)
+    })
+    .await
 }
 
 pub async fn timeout<F>(duration: Duration, future: F) -> Timeout<F::Output>
@@ -101,22 +146,7 @@ where
         })
         .await;
     }
-    if duration <= MAX_TIMER_SLICE {
-        return match time::timeout(duration, future).await {
-            Ok(value) => Timeout::Completed(value),
-            Err(_) => Timeout::Elapsed,
-        };
-    }
-    let sleep = sleep_until_std(deadline);
-    tokio::pin!(future);
-    tokio::pin!(sleep);
-    tokio::select! {
-        // Match tokio::time::timeout's boundary rule: the operation receives
-        // the first poll when it and a zero-duration timer are both ready.
-        biased;
-        value = &mut future => Timeout::Completed(value),
-        () = &mut sleep => Timeout::Elapsed,
-    }
+    timeout_at(deadline, future).await
 }
 #[cfg(test)]
 mod tests {

--- a/crates/shelterwood-runtime/src/timer.rs
+++ b/crates/shelterwood-runtime/src/timer.rs
@@ -152,7 +152,8 @@ where
 mod tests {
     use std::{
         future::Future,
-        task::{Context, Poll, Waker},
+        sync::atomic::{AtomicUsize, Ordering},
+        task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
         time::Duration,
     };
 
@@ -307,12 +308,34 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn maximum_timeout_stays_unbounded() {
+        // Unique to this test: counts caller-waker clones so the assertion
+        // below can see whether a `ProxiedSleep` ever parked.
+        static CALLER_CLONES: AtomicUsize = AtomicUsize::new(0);
+        unsafe fn clone_counting(data: *const ()) -> RawWaker {
+            CALLER_CLONES.fetch_add(1, Ordering::SeqCst);
+            RawWaker::new(data, &COUNTING_VTABLE)
+        }
+        unsafe fn noop(_data: *const ()) {}
+        static COUNTING_VTABLE: RawWakerVTable =
+            RawWakerVTable::new(clone_counting, noop, noop, noop);
+        // SAFETY: the vtable owns no state; every function is a no-op apart
+        // from the clone counter.
+        let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &COUNTING_VTABLE)) };
+
         let mut timed = std::pin::pin!(timeout(Duration::MAX, std::future::pending::<()>()));
-        let mut context = Context::from_waker(Waker::noop());
+        let mut context = Context::from_waker(&waker);
 
         assert!(timed.as_mut().poll(&mut context).is_pending());
         tokio::time::advance(MAX_TIMER_SLICE * 2).await;
         assert!(timed.as_mut().poll(&mut context).is_pending());
+        // The overflow guard constructs no timer and no proxy at all: a
+        // parked `ProxiedSleep` clones the caller waker on its first pending
+        // poll, so an armed path would be visible here.
+        assert_eq!(
+            CALLER_CLONES.load(Ordering::SeqCst),
+            0,
+            "an unrepresentable budget must never arm a timer or park a proxy"
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -996,9 +996,14 @@ impl<M: Send + 'static> RawContext<M> {
             let completion = async move {
                 let work = CatchUnwindFuture::new(work.into_inner());
                 if let Some(expires_at) = expires_at {
-                    match runtime::select_two(work, runtime::sleep_until(expires_at)).await {
-                        runtime::Either::Left(result) => result.map(Ok),
-                        runtime::Either::Right(()) => Ok(Err(DeadlineElapsed)),
+                    // The deadline stays outside the work future so a
+                    // completing offload retires the timer through
+                    // `timeout_at`'s synchronous poll-path boundary instead
+                    // of paying the drop-glue disposal venue on every
+                    // deadlined completion.
+                    match runtime::timeout_at(expires_at, work).await {
+                        runtime::Timeout::Completed(result) => result.map(Ok),
+                        runtime::Timeout::Elapsed => Ok(Err(DeadlineElapsed)),
                     }
                 } else {
                     work.await.map(Ok)

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -1255,26 +1255,28 @@ impl<M: Send + 'static> RawContext<M> {
         // backstop for the one case that reclaim could not have seen: an
         // offload finishing on another thread between the two calls.
         self.resources.reclaim_finished();
-        let sleep = self.next_timer_deadline().map_or_else(
-            || Box::pin(std::future::pending()) as runtime::BoxedSleep,
-            runtime::sleep_until,
-        );
+        let deadline = self.next_timer_deadline();
         let shutdown = self.shutdown.clone();
         let local_stop = self.local_stop.clone();
         let mailbox = &mut self.receiver;
         let event_watcher = &mut self.resources.event_watcher;
         let delivery = async move {
-            let _ = runtime::select_two(
-                mailbox.changed(),
-                runtime::select_two(event_watcher.changed(), sleep),
-            )
-            .await;
+            let _ = runtime::select_two(mailbox.changed(), event_watcher.changed()).await;
         };
-        let _ = runtime::select_two(
+        let event = runtime::select_two(
             shutdown.cancelled(),
             runtime::select_two(local_stop.fired(), delivery),
-        )
-        .await;
+        );
+        // The timer stays outside the whole event selection so every event
+        // winner -- especially the warm mailbox path -- retires its caller
+        // waker through timeout_at's synchronous poll-path boundary. Burying
+        // the sleep in a nested select would run its drop-glue disposal venue
+        // every time another arm won.
+        if let Some(deadline) = deadline {
+            let _ = runtime::timeout_at(deadline, event).await;
+        } else {
+            let _ = event.await;
+        }
     }
 
     /// Freezes incarnation resources on the exit path, discarding §6.2's

--- a/crates/shelterwood/src/scope.rs
+++ b/crates/shelterwood/src/scope.rs
@@ -159,16 +159,20 @@ impl ScopeRef {
             if expires.is_due(crate::runtime::now()) {
                 return Err(WaitError::TimedOut);
             }
-            match crate::runtime::select_two(snapshots.changed(), async {
-                match expires.instant() {
-                    Some(expires) => crate::runtime::sleep_until_std(expires).await,
-                    None => std::future::pending().await,
+            // Keep the timer in `timeout_at` rather than a nested async sleep:
+            // when a snapshot wins, that helper retires the timer's caller
+            // waker synchronously on this poll path. Dropping a losing sleep
+            // future here would instead select the drop-glue disposal venue.
+            match expires.instant() {
+                Some(expires) => {
+                    match crate::runtime::timeout_at(expires, snapshots.changed()).await {
+                        crate::runtime::Timeout::Completed(Ok(_) | Err(_))
+                        | crate::runtime::Timeout::Elapsed => continue,
+                    }
                 }
-            })
-            .await
-            {
-                crate::runtime::Either::Left(Ok(_) | Err(_))
-                | crate::runtime::Either::Right(()) => continue,
+                None => {
+                    let _ = snapshots.changed().await;
+                }
             }
         }
     }

--- a/crates/shelterwood/tests/timer_waker_proxy.rs
+++ b/crates/shelterwood/tests/timer_waker_proxy.rs
@@ -3,9 +3,10 @@ mod common;
 use std::{
     future::Future,
     mem::ManuallyDrop,
+    pin::Pin,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         mpsc,
     },
     task::{Context as TaskContext, Poll, RawWaker, RawWakerVTable, Waker},
@@ -14,7 +15,10 @@ use std::{
 };
 
 use common::{DestructorBlocker, DestructorGate, POLL_TIMEOUT};
-use shelterwood::{Actor, ActorOnceDef, Context, ExitError, ExitResult, Tree};
+use shelterwood::{
+    Actor, ActorOnceDef, Context, DynamicTree, ExitError, ExitResult, RawActor, RawContext,
+    RawOnceDef, ScopeRef, Shutdown, TaskDef, Tree,
+};
 
 struct IdleActor;
 
@@ -90,6 +94,284 @@ fn blocking_drop_waker(gate: &DestructorGate, entered: mpsc::Sender<ThreadId>) -
     // SAFETY: `raw` owns one Arc reference and its vtable maintains that
     // ownership across clone, wake, and drop.
     unsafe { Waker::from_raw(raw) }
+}
+
+#[derive(Default)]
+struct CloneCounter(AtomicUsize);
+
+unsafe fn clone_counting_waker(data: *const ()) -> RawWaker {
+    // SAFETY: every pointer using this vtable came from an Arc of the
+    // matching type. ManuallyDrop preserves the reference represented by
+    // `data`; the returned raw waker owns only the new clone.
+    let state = ManuallyDrop::new(unsafe { Arc::<CloneCounter>::from_raw(data.cast()) });
+    state.0.fetch_add(1, Ordering::SeqCst);
+    RawWaker::new(
+        Arc::into_raw(Arc::clone(&state)).cast(),
+        &COUNTING_WAKER_VTABLE,
+    )
+}
+
+unsafe fn wake_counting_waker(data: *const ()) {
+    // SAFETY: wake consumes the Arc reference represented by this raw waker.
+    drop(unsafe { Arc::<CloneCounter>::from_raw(data.cast()) });
+}
+
+unsafe fn wake_by_ref_counting_waker(_data: *const ()) {}
+
+unsafe fn drop_counting_waker(data: *const ()) {
+    // SAFETY: drop consumes the Arc reference represented by this raw waker.
+    drop(unsafe { Arc::<CloneCounter>::from_raw(data.cast()) });
+}
+
+static COUNTING_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    clone_counting_waker,
+    wake_counting_waker,
+    wake_by_ref_counting_waker,
+    drop_counting_waker,
+);
+
+fn counting_waker(counter: &Arc<CloneCounter>) -> Waker {
+    let raw = RawWaker::new(
+        Arc::into_raw(Arc::clone(counter)).cast(),
+        &COUNTING_WAKER_VTABLE,
+    );
+    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+    // ownership across clone, wake, and drop.
+    unsafe { Waker::from_raw(raw) }
+}
+
+struct OrdinalWaker {
+    ordinal: usize,
+    shared: Arc<OrdinalWakerState>,
+}
+
+struct OrdinalWakerState {
+    clones: AtomicUsize,
+    target: usize,
+    blocked: AtomicBool,
+    blocker: Mutex<Option<DestructorBlocker>>,
+    entered: mpsc::Sender<ThreadId>,
+}
+
+unsafe fn clone_ordinal_waker(data: *const ()) -> RawWaker {
+    // SAFETY: every pointer using this vtable came from an Arc of the
+    // matching type. ManuallyDrop preserves the reference represented by
+    // `data`; the returned raw waker owns only the new clone.
+    let current = ManuallyDrop::new(unsafe { Arc::<OrdinalWaker>::from_raw(data.cast()) });
+    let ordinal = current.shared.clones.fetch_add(1, Ordering::SeqCst) + 1;
+    RawWaker::new(
+        Arc::into_raw(Arc::new(OrdinalWaker {
+            ordinal,
+            shared: Arc::clone(&current.shared),
+        }))
+        .cast(),
+        &ORDINAL_WAKER_VTABLE,
+    )
+}
+
+unsafe fn wake_ordinal_waker(data: *const ()) {
+    // SAFETY: wake consumes the Arc reference represented by this raw waker.
+    unsafe { drop_ordinal_waker(data) };
+}
+
+unsafe fn wake_by_ref_ordinal_waker(_data: *const ()) {}
+
+unsafe fn drop_ordinal_waker(data: *const ()) {
+    // SAFETY: drop consumes the Arc reference represented by this raw waker.
+    let current = unsafe { Arc::<OrdinalWaker>::from_raw(data.cast()) };
+    if current.ordinal == current.shared.target
+        && !current.shared.blocked.swap(true, Ordering::SeqCst)
+    {
+        let blocker = current
+            .shared
+            .blocker
+            .lock()
+            .expect("ordinal waker mutex poisoned")
+            .take()
+            .expect("the targeted framework clone owns the blocker");
+        let _ = current.shared.entered.send(thread::current().id());
+        drop(blocker);
+    }
+}
+
+static ORDINAL_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    clone_ordinal_waker,
+    wake_ordinal_waker,
+    wake_by_ref_ordinal_waker,
+    drop_ordinal_waker,
+);
+
+fn ordinal_waker(
+    target: usize,
+    gate: &DestructorGate,
+    entered: mpsc::Sender<ThreadId>,
+) -> (Waker, Arc<OrdinalWakerState>) {
+    let shared = Arc::new(OrdinalWakerState {
+        clones: AtomicUsize::new(0),
+        target,
+        blocked: AtomicBool::new(false),
+        blocker: Mutex::new(Some(gate.blocker())),
+        entered,
+    });
+    let raw = RawWaker::new(
+        Arc::into_raw(Arc::new(OrdinalWaker {
+            ordinal: 0,
+            shared: Arc::clone(&shared),
+        }))
+        .cast(),
+        &ORDINAL_WAKER_VTABLE,
+    );
+    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+    // ownership across clone, wake, and drop.
+    (unsafe { Waker::from_raw(raw) }, shared)
+}
+
+fn poll_until_registered<F>(
+    runtime: &tokio::runtime::Runtime,
+    future: Pin<&mut F>,
+    minimum_clones: usize,
+    path: &str,
+) where
+    F: Future,
+{
+    let counter = Arc::new(CloneCounter::default());
+    let waker = counting_waker(&counter);
+    let mut future = future;
+    for _ in 0..100 {
+        {
+            let _runtime = runtime.handle().enter();
+            assert!(
+                future
+                    .as_mut()
+                    .poll(&mut TaskContext::from_waker(&waker))
+                    .is_pending(),
+                "{path} must park before its timeout"
+            );
+        }
+        if counter.0.load(Ordering::SeqCst) >= minimum_clones {
+            return;
+        }
+        runtime.block_on(tokio::task::yield_now());
+    }
+    panic!("{path} never reached its timer registration");
+}
+
+/// Parks a public future with an ordinal waker, cancels it while the timer's
+/// caller-waker destructor blocks, and proves unrelated wheel traffic stays
+/// live. Earlier registrations use a benign counting waker so lifecycle
+/// transitions can settle without making the timer's ordinal unstable.
+fn assert_public_timer_cancellation_isolated<F>(
+    runtime: &tokio::runtime::Runtime,
+    mut future: Pin<Box<F>>,
+    prepare_clones: usize,
+    timer_ordinal: usize,
+    path: &str,
+) where
+    F: Future + Send + 'static,
+{
+    poll_until_registered(runtime, future.as_mut(), prepare_clones, path);
+
+    let gate = DestructorGate::default();
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (hostile, state) = ordinal_waker(timer_ordinal, &gate, entered_tx);
+    let hostile = ManuallyDrop::new(hostile);
+    {
+        let _runtime = runtime.handle().enter();
+        assert!(
+            future
+                .as_mut()
+                .poll(&mut TaskContext::from_waker(&hostile))
+                .is_pending(),
+            "{path} stays pending after replacing its registrations"
+        );
+    }
+    assert_eq!(
+        state.clones.load(Ordering::SeqCst),
+        timer_ordinal,
+        "{path} registers the timer at the documented caller-clone ordinal"
+    );
+
+    let cancel_handle = runtime.handle().clone();
+    let (cancelled_tx, cancelled_rx) = mpsc::channel();
+    let cancel = thread::Builder::new()
+        .name(format!("{path}-cancel"))
+        .spawn(move || {
+            let _runtime = cancel_handle.enter();
+            drop(future);
+            let _ = cancelled_tx.send(thread::current().id());
+        })
+        .expect("cancellation thread starts");
+
+    let destructor_thread = entered_rx
+        .recv_timeout(POLL_TIMEOUT)
+        .unwrap_or_else(|_| panic!("{path} retires its targeted timer caller waker"));
+
+    let probe_handle = runtime.handle().clone();
+    let (probe_tx, probe_rx) = mpsc::channel();
+    let probe = thread::Builder::new()
+        .name(format!("{path}-unrelated-timer"))
+        .spawn(move || {
+            let _runtime = probe_handle.enter();
+            let mut timer = Box::pin(tokio::time::sleep(Duration::from_secs(30)));
+            assert!(
+                timer
+                    .as_mut()
+                    .poll(&mut TaskContext::from_waker(Waker::noop()))
+                    .is_pending()
+            );
+            drop(timer);
+            let _ = probe_tx.send(thread::current().id());
+        })
+        .expect("unrelated timer thread starts");
+
+    let probe_thread = probe_rx.recv_timeout(POLL_TIMEOUT).ok();
+    let cancel_thread = cancelled_rx.recv_timeout(POLL_TIMEOUT).ok();
+    gate.release();
+    cancel.join().expect("cancellation thread does not panic");
+    probe.join().expect("unrelated timer thread does not panic");
+
+    let probe_thread = probe_thread.unwrap_or_else(|| {
+        panic!(
+            "{path}: a blocking caller-waker destructor on {destructor_thread:?} held Tokio's time-driver mutex"
+        )
+    });
+    let cancel_thread = cancel_thread
+        .unwrap_or_else(|| panic!("{path}: cancellation waited for caller-waker destruction"));
+    assert_ne!(destructor_thread, cancel_thread);
+    assert_ne!(destructor_thread, probe_thread);
+    assert_ne!(destructor_thread, thread::current().id());
+}
+
+fn request_shutdown_and_wait_for_draining<F>(
+    runtime: &tokio::runtime::Runtime,
+    mut future: Pin<&mut F>,
+    scope: &ScopeRef,
+) where
+    F: Future,
+{
+    {
+        let _runtime = runtime.handle().enter();
+        assert!(
+            future
+                .as_mut()
+                .poll(&mut TaskContext::from_waker(Waker::noop()))
+                .is_pending(),
+            "the stubborn child keeps shutdown pending"
+        );
+    }
+    runtime
+        .block_on(async {
+            tokio::time::timeout(POLL_TIMEOUT, async {
+                loop {
+                    if matches!(scope.snapshot().state, shelterwood::ScopeState::Draining) {
+                        return;
+                    }
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+        })
+        .expect("the root publishes its Draining edge");
 }
 
 /// Cancels a whole public deadline future while one caller-waker destructor
@@ -197,5 +479,202 @@ fn blocking_timer_waker_retirement_does_not_stall_unrelated_timer_traffic() {
         destructor_thread,
         thread::current().id(),
         "a blocking caller-waker destructor must not run on the polling thread"
+    );
+}
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_time()
+        .build()
+        .expect("test runtime")
+}
+
+fn add_stubborn_task(tree: &mut Tree) {
+    tree.add_task(
+        "stubborn",
+        TaskDef::new(|_| std::future::pending::<ExitResult>())
+            .shutdown(Shutdown::graceful(Duration::from_secs(60)).expect("grace is non-zero")),
+    )
+    .expect("valid stubborn task");
+}
+
+#[test]
+fn wait_for_child_timer_cancellation_does_not_stall_unrelated_timer_traffic() {
+    let runtime = runtime();
+    let system = {
+        let _runtime = runtime.handle().enter();
+        DynamicTree::new().spawn().expect("runtime is available")
+    };
+    runtime
+        .block_on(system.wait_started())
+        .expect("dynamic root starts");
+    let scope = system.scope();
+    let waiting_scope = scope.clone();
+    let future = Box::pin(async move {
+        waiting_scope
+            .as_scope()
+            .wait_for_child("missing", |_| false, Duration::from_secs(30))
+            .await
+    });
+
+    // Snapshot change is clone one; the timer proxy's caller is clone two.
+    assert_public_timer_cancellation_isolated(&runtime, future, 2, 2, "wait-for-child");
+
+    runtime
+        .block_on(system.shutdown(Duration::ZERO))
+        .expect("dynamic root shuts down");
+}
+
+#[test]
+fn scope_shutdown_timer_cancellation_does_not_stall_unrelated_timer_traffic() {
+    let runtime = runtime();
+    let mut tree = Tree::new();
+    add_stubborn_task(&mut tree);
+    let system = {
+        let _runtime = runtime.handle().enter();
+        tree.spawn().expect("runtime is available")
+    };
+    runtime
+        .block_on(system.wait_started())
+        .expect("stubborn tree starts");
+    let scope = system.scope();
+    let shutting_scope = scope.clone();
+    let mut future = Box::pin(async move {
+        shutting_scope
+            .shutdown_and_wait(Duration::from_secs(30))
+            .await
+    });
+    request_shutdown_and_wait_for_draining(&runtime, future.as_mut(), &scope);
+
+    // At the stable timeout cut the two live registrations are incarnation
+    // change, then timer.
+    assert_public_timer_cancellation_isolated(&runtime, future, 2, 2, "scope-shutdown");
+
+    let _ = runtime.block_on(system.shutdown(Duration::ZERO));
+}
+
+#[test]
+fn system_shutdown_timer_cancellation_does_not_stall_unrelated_timer_traffic() {
+    let runtime = runtime();
+    let mut tree = Tree::new();
+    add_stubborn_task(&mut tree);
+    let system = {
+        let _runtime = runtime.handle().enter();
+        tree.spawn().expect("runtime is available")
+    };
+    runtime
+        .block_on(system.wait_started())
+        .expect("stubborn tree starts");
+    let cleanup_scope = system.scope();
+    let mut future = Box::pin(async move { system.shutdown(Duration::from_secs(30)).await });
+    request_shutdown_and_wait_for_draining(&runtime, future.as_mut(), &cleanup_scope);
+
+    assert_public_timer_cancellation_isolated(&runtime, future, 2, 2, "system-shutdown");
+
+    let _ = runtime.block_on(cleanup_scope.shutdown_and_wait(Duration::ZERO));
+}
+
+struct RawRecvTimerProbe {
+    hostile: Option<Waker>,
+    clones: Arc<OrdinalWakerState>,
+    polled: mpsc::Sender<usize>,
+    cancelled: mpsc::Sender<ThreadId>,
+}
+
+impl RawActor for RawRecvTimerProbe {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        context
+            .set_timeout("timer", (), Duration::from_secs(30))
+            .expect("live raw context accepts the timer");
+        let hostile = self.hostile.take().expect("the probe polls only once");
+        let mut receive = Box::pin(context.recv());
+        assert!(
+            receive
+                .as_mut()
+                .poll(&mut TaskContext::from_waker(&hostile))
+                .is_pending()
+        );
+        let _ = self.polled.send(self.clones.clones.load(Ordering::SeqCst));
+        drop(receive);
+        let _ = self.cancelled.send(thread::current().id());
+        Ok(())
+    }
+}
+
+#[test]
+fn raw_recv_timer_cancellation_does_not_stall_unrelated_timer_traffic() {
+    let runtime = runtime();
+    let gate = DestructorGate::default();
+    let (entered_tx, entered_rx) = mpsc::channel();
+    // shutdown, local stop, mailbox, offload event, then the raw timer.
+    let (hostile, state) = ordinal_waker(5, &gate, entered_tx);
+    let (polled_tx, polled_rx) = mpsc::channel();
+    let (cancelled_tx, cancelled_rx) = mpsc::channel();
+    let mut tree = Tree::new();
+    tree.add_raw_once(
+        "raw-timer-proxy",
+        RawOnceDef::new(RawRecvTimerProbe {
+            hostile: Some(hostile),
+            clones: Arc::clone(&state),
+            polled: polled_tx,
+            cancelled: cancelled_tx,
+        }),
+    )
+    .expect("valid raw actor");
+    let system = {
+        let _runtime = runtime.handle().enter();
+        tree.spawn().expect("runtime is available")
+    };
+
+    assert_eq!(
+        polled_rx
+            .recv_timeout(POLL_TIMEOUT)
+            .expect("the raw actor manually parks recv"),
+        5,
+        "the fifth caller clone belongs to the armed raw timer"
+    );
+    let destructor_thread = entered_rx
+        .recv_timeout(POLL_TIMEOUT)
+        .expect("dropping raw recv retires the timer's caller waker");
+
+    let probe_handle = runtime.handle().clone();
+    let (probe_tx, probe_rx) = mpsc::channel();
+    let probe = thread::Builder::new()
+        .name("raw-recv-unrelated-timer".into())
+        .spawn(move || {
+            let _runtime = probe_handle.enter();
+            let mut timer = Box::pin(tokio::time::sleep(Duration::from_secs(30)));
+            assert!(
+                timer
+                    .as_mut()
+                    .poll(&mut TaskContext::from_waker(Waker::noop()))
+                    .is_pending()
+            );
+            drop(timer);
+            let _ = probe_tx.send(thread::current().id());
+        })
+        .expect("unrelated timer thread starts");
+
+    let probe_thread = probe_rx.recv_timeout(POLL_TIMEOUT).ok();
+    let actor_thread = cancelled_rx.recv_timeout(POLL_TIMEOUT).ok();
+    gate.release();
+    probe.join().expect("unrelated timer thread does not panic");
+
+    let probe_thread = probe_thread.unwrap_or_else(|| {
+        panic!(
+            "a raw recv caller-waker destructor on {destructor_thread:?} held Tokio's time-driver mutex"
+        )
+    });
+    let actor_thread = actor_thread.expect("raw recv cancellation does not await destruction");
+    assert_ne!(destructor_thread, actor_thread);
+    assert_ne!(destructor_thread, probe_thread);
+    assert_ne!(destructor_thread, thread::current().id());
+
+    assert_eq!(
+        runtime.block_on(system.wait()),
+        shelterwood::StopReason::Finished
     );
 }


### PR DESCRIPTION
## Summary

- Extracts the timer half of `Deadlined` into a public-hidden, runtime-neutral `ProxiedSleep` above the `MailboxRuntime` seam. Runtime adapters supply only raw framework timers; the external wheel therefore retains the stable framework proxy and never the caller's `RawWaker`.
- Routes the runtime's `sleep_until`, `sleep_until_std`, `timeout`, and new absolute `timeout_at` selection through that boundary. Poll-path readiness and a sibling branch winning retire synchronously and contained; cancellation/drop glue submits the caller-waker destructor to the blocking disposal lane before synchronously clearing the framework-only wheel entry.
- Reuses `ProxiedSleep` from `Deadlined`, preserving #403's no-op first probe, stable identity, lost-wake handshake, unbounded no-allocation path, synchronous ready retirement, and drop-glue disposal venue.
- Closes all public user-polled timer seams found by the #408 audit: `ScopeRef::wait_for_child`, shared `shutdown_scope` (`ScopeRef::shutdown_and_wait`, `System::shutdown`, and rollback), and `RawContext::recv` while raw timers are armed. The warm raw-receive path keeps the timer outside the entire event selection so mailbox/event/control winners cancel it inline rather than paying the drop lane on every turn.

## Audit

The production sweep covered every `sleep_until_std`, `runtime::timeout`, and `runtime::sleep_until` site plus direct Tokio time calls.

- The only direct `tokio::time::sleep_until` registration remains the runtime adapter's public-hidden raw capability.
- Mailbox `Deadlined` wraps the raw `MailboxRuntime` capability directly.
- All façade/runtime `sleep_until*` and `timeout*` callers are proxied, including the three public seams above.
- The raw offload deadline and scope-driver wait also inherit the proxy even though they are polled only with framework wakers and are outside the hostile caller-waker class.

## Regression coverage

- Bounded cross-thread hostile-waker tests drive whole public futures for:
  - `ScopeRef::wait_for_child`
  - `ScopeRef::shutdown_and_wait`
  - `System::shutdown`
  - manually user-polled `RawContext::recv` with an armed timer
  - the existing `Deadlined` public mailbox path
- Each targets the timer's exact caller-clone ordinal, blocks that destructor, and proves another native thread can still arm and cancel an unrelated Tokio timer while the cancellation thread returns promptly.
- Focused `ProxiedSleep` tests pin immediate-ready no-entry/no-clone behavior, fused ready repolling, ready inline retirement, containing-branch inline cancellation, and drop-glue disposal on another thread. Runtime timeout tests pin zero-budget and exact-boundary operation precedence, bounded long-deadline slicing, and maximum/unarmable deadlines. Existing `Deadlined` tests continue to pin immediately-ready, already-elapsed, unbounded, synchronous cancellation, and no-spurious-wake behavior.

## Validation

- `./tools/dev just ci`
  - formatting and clippy with warnings denied
  - 897 nextest tests
  - doctests and rustdoc with warnings denied
  - public API reachability checks
  - packaged-doc and external-consumer checks
  - Nix formatting
- `./tools/dev cargo nextest run -p shelterwood --test timer_waker_proxy` (5/5)
- `./tools/dev cargo test -p shelterwood-mailbox -p shelterwood-runtime --lib` (74 mailbox + 66 runtime)

## Cross-PR coordination

#407 independently exposes a public-hidden post-unlock retirement callback on the same mailbox `WakerProxy` and adds a runtime-private venue wrapper for Tokio one-shots. This PR does not copy or move the primitive: `ProxiedSleep` uses that single mailbox implementation directly. The branches target `main` independently; they overlap additively in the mailbox module exports, so whichever merges second should rebase that small boundary edit.

Closes #408
