### PR TITLE
Isolate runtime one-shot caller wakers behind proxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,12 @@ rests on:
   sub-capabilities `MailboxRuntime` mints: `MailboxSignal`,
   `MailboxSignalWatcher` and the `ErasedOneShot*` family are public unsealed
   cross-crate traits for the same reason and ride under the same ruling.
+  `WakerProxy` and its `retire_with` seam ride with them: the proxy is a
+  public doc-hidden cross-crate type whose `retire_with` takes a
+  caller-supplied `fn(Waker)`, but the effect is queued under the proxy's
+  leaf mutex and invoked only after unlock, so no foreign code runs under
+  the lock, and the supported façade re-exports neither the type nor
+  anything that could install one.
   `MailboxEffectSink` is the sharpest case: the framework calls
   `defer_mailbox_effect` while holding both the resident-tree observation gate
   and `MemberCell::mailbox`, and its `MailboxEffectQueue` implementation is

--- a/crates/shelterwood-mailbox/src/cell/waker_slot.rs
+++ b/crates/shelterwood-mailbox/src/cell/waker_slot.rs
@@ -15,12 +15,14 @@ pub(crate) enum WakerAction {
     Wake,
     DropInline,
     Dispose(Arc<dyn MailboxRuntime>),
+    Run(fn(Waker)),
 }
 
 enum WakerEffect {
     Wake(Waker),
     DropInline(Waker),
     Dispose(Arc<dyn MailboxRuntime>, Waker),
+    Run(fn(Waker), Waker),
 }
 
 #[derive(Default)]
@@ -56,6 +58,7 @@ impl WakerEffects {
             WakerAction::Wake => WakerEffect::Wake(waker),
             WakerAction::DropInline => WakerEffect::DropInline(waker),
             WakerAction::Dispose(runtime) => WakerEffect::Dispose(runtime, waker),
+            WakerAction::Run(effect) => WakerEffect::Run(effect, waker),
         });
     }
 
@@ -67,6 +70,7 @@ impl WakerEffects {
                 WakerEffect::Dispose(runtime, waker) => {
                     panics.run(|| dispose(&runtime, waker));
                 }
+                WakerEffect::Run(effect, waker) => panics.run(|| effect(waker)),
             }
         }
     }

--- a/crates/shelterwood-mailbox/src/lib.rs
+++ b/crates/shelterwood-mailbox/src/lib.rs
@@ -45,6 +45,8 @@ pub use cell::*;
 pub use errors::*;
 pub use futures::*;
 pub use reply::*;
+#[doc(hidden)]
+pub use waker_proxy::WakerProxy;
 
 mod identity {
     pub(crate) use shelterwood_core::identity::*;

--- a/crates/shelterwood-mailbox/src/waker_proxy.rs
+++ b/crates/shelterwood-mailbox/src/waker_proxy.rs
@@ -4,7 +4,10 @@ use std::{
     task::{Wake, Waker},
 };
 
-use crate::cell::waker_slot::{WakerAction, WakerEffects, WakerSlot};
+use crate::{
+    cell::waker_slot::{WakerAction, WakerEffects, WakerSlot},
+    panic::PanicAccumulator,
+};
 
 /// Stable framework-owned waker registered with an external primitive.
 ///
@@ -16,7 +19,8 @@ use crate::cell::waker_slot::{WakerAction, WakerEffects, WakerSlot};
 /// The proxy mutex is a **leaf**: [`Wake::wake_by_ref`] takes it from whatever
 /// thread drives the external primitive, so nothing this type does under it may
 /// take another framework lock.
-pub(crate) struct WakerProxy {
+#[doc(hidden)]
+pub struct WakerProxy {
     proxy: Waker,
     state: Arc<WakerProxyState>,
 }
@@ -35,7 +39,8 @@ struct WakerProxyState {
 }
 
 impl WakerProxy {
-    pub(crate) fn new() -> Self {
+    #[doc(hidden)]
+    pub fn new() -> Self {
         let state = Arc::new(WakerProxyState::default());
         let proxy = Waker::from(Arc::clone(&state));
         Self { proxy, state }
@@ -68,7 +73,8 @@ impl WakerProxy {
     /// still holding a matching waker proves nothing has woken since that waker
     /// was installed. Handling it anyway costs one branch and keeps the "no
     /// wake is lost" claim from resting on that invariant.
-    pub(crate) fn register(&self, current: &Waker) {
+    #[doc(hidden)]
+    pub fn register(&self, current: &Waker) {
         let mut replacement = None;
         loop {
             // Effects precede the guard, so a bookkeeping unwind still
@@ -108,8 +114,23 @@ impl WakerProxy {
         }
     }
 
-    pub(crate) fn waker(&self) -> &Waker {
+    #[doc(hidden)]
+    pub fn waker(&self) -> &Waker {
         &self.proxy
+    }
+
+    /// Retires the caller registration through a framework-selected effect.
+    ///
+    /// The function pointer is queued while the proxy mutex is held and is
+    /// invoked only after unlock. This is the cross-crate adapter seam used by
+    /// `shelterwood-runtime`: the runtime owns the detached-disposal venue,
+    /// while this runtime-neutral crate owns the slot that makes it impossible
+    /// to remove a caller waker without first choosing that post-unlock venue.
+    #[doc(hidden)]
+    pub fn retire_with(&self, effect: fn(Waker), panics: &mut PanicAccumulator) {
+        let mut effects = WakerEffects::default();
+        self.retire(WakerAction::Run(effect), &mut effects);
+        effects.flush(panics);
     }
 
     /// Moves the caller waker into an explicitly chosen post-unlock effect,

--- a/crates/shelterwood-runtime/src/lib.rs
+++ b/crates/shelterwood-runtime/src/lib.rs
@@ -12,6 +12,7 @@ mod sync;
 #[cfg(test)]
 mod test_support;
 mod timer;
+mod waker_proxy;
 
 pub use disposal::*;
 pub use mailbox::*;

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -667,19 +667,21 @@ fn poll_one_shot_with_proxy<T, R>(
 }
 
 impl<T> DisposingReceiver<T> {
-    fn inner_mut(&mut self) -> &mut OneShotReceiver<T> {
-        self.inner
-            .as_mut()
-            .expect("a live disposing receiver retains its channel")
-    }
-
     /// Retires a caller waker only after selecting its post-unlock venue.
     ///
     /// Ready results use contained inline retirement: a result may own a user
     /// value (or a panic payload that owns one), so a hostile waker destructor
     /// is subordinate to returning that result intact. Drop glue uses the
-    /// detached lane because caller-waker destruction may block as well as
-    /// panic, and a holder's dropping thread is not an acceptable venue.
+    /// detached lane. That venue is a per-seam adjudication, not a universal
+    /// rule: the mailbox reply receiver retires cancellation inline
+    /// (`shelterwood-mailbox`'s `DisposingReceiver`), accepting that a slow
+    /// caller-waker destructor stalls the abandoning holder alone. This
+    /// receiver backs the one-shot task and blocking-offload seams — and,
+    /// downstream, the public admission, removal, and system-join futures —
+    /// where cancellation is cold, so one disposal-lane submission per
+    /// abandoned pending receiver buys drop glue that cannot block or stall
+    /// the holder's thread. A hot cancellation path added here should
+    /// revisit the reply receiver's ruling rather than inherit this one.
     fn retire_caller_waker(&mut self, retirement: WakerRetirement, panics: &mut PanicAccumulator) {
         let caller_waker = self.caller_waker.take();
         if let Some(caller_waker) = &caller_waker {
@@ -712,6 +714,13 @@ impl<T> DisposingReceiver<T> {
         result
     }
 
+    /// Staged parity with the mailbox receiver's timeout arbitration: no
+    /// production path closes a runtime `DisposingReceiver` today. It matters
+    /// to the venue split anyway, because a receiver-initiated close is the
+    /// one ready edge no sender wake precedes — the proxy can still hold an
+    /// installed caller clone when inline retirement runs, which every
+    /// sender-side completion consumes through the wake first. The
+    /// ready-edge containment test below is that path's pin.
     pub fn close_and_poll_receive(&mut self, context: &mut Context<'_>) -> OneShotClose<T> {
         let result = poll_one_shot_with_proxy(
             self.inner
@@ -729,13 +738,6 @@ impl<T> DisposingReceiver<T> {
         }
         result
     }
-
-    pub fn close(&mut self) {
-        self.inner_mut().close();
-        let mut panics = PanicAccumulator::default();
-        self.retire_caller_waker(WakerRetirement::Inline, &mut panics);
-        discard_panic(panics.take());
-    }
 }
 
 impl<T> Drop for DisposingReceiver<T> {
@@ -748,8 +750,13 @@ impl<T> Drop for DisposingReceiver<T> {
         let mut panics = PanicAccumulator::default();
 
         // Recover and dispatch an unclaimed value before either receiver or
-        // caller-waker retirement can fail. The receiver holds only a proxy
-        // clone, so Tokio's close/drop work below is framework-owned traffic.
+        // caller-waker retirement can fail. The waker Tokio's close/drop work
+        // below destroys is only ever a framework proxy clone. If recovery
+        // itself unwinds, the value stays in the channel and `inner`'s own
+        // drop glue destroys it inline rather than through `dispose`:
+        // accepted, because reaching it requires a destructor that has
+        // already panicked, and the alternative is retrying a step that just
+        // failed.
         panics.run(|| value = inner.close_and_take());
         panics.run(|| {
             if let Some(value) = value {
@@ -1434,6 +1441,37 @@ mod tests {
             destructor_name.as_deref(),
             Some(DISPOSAL_THREAD),
             "drop glue must not destroy a caller waker on the holder's thread"
+        );
+    }
+
+    #[test]
+    fn receiver_close_ready_edge_contains_the_installed_caller_waker() {
+        let closing_thread = std::thread::current().id();
+        let (_sender, receiver) = oneshot::<u8>();
+        let mut receiver = DisposingReceiver::new(receiver);
+        let (dropped, observed_drop) = mpsc::channel();
+        let caller = ManuallyDrop::new(record_panicking_drop_waker(dropped));
+
+        assert!(matches!(
+            receiver.poll_receive(&mut Context::from_waker(&caller)),
+            Poll::Pending
+        ));
+        // A receiver-initiated close reaches the ready edge with the caller
+        // clone still installed: no sender wake preceded it to consume the
+        // slot. Retirement must destroy that hostile clone synchronously on
+        // this thread and contain its panic so the close outcome is handed
+        // back intact.
+        assert!(matches!(
+            receiver.close_and_poll_receive(&mut Context::from_waker(&caller)),
+            OneShotClose::Empty
+        ));
+
+        let (destructor_thread, _destructor_name) = observed_drop
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the ready edge retires the installed caller clone");
+        assert_eq!(
+            destructor_thread, closing_thread,
+            "ready-path retirement is synchronous on the closing thread"
         );
     }
 

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -11,7 +11,10 @@ use std::{
 
 use tokio::sync::{broadcast, oneshot};
 
-use super::{PanicAccumulator, dispose_detached};
+use super::{
+    PanicAccumulator, discard_panic, dispose_detached,
+    waker_proxy::{WakerProxy, WakerRetirement},
+};
 
 /// A caller-waker registry whose lock protects only inert storage changes.
 ///
@@ -624,44 +627,137 @@ impl<T> OneShotReceiver<T> {
 /// boundary types preserve the same constructor-only bound. Execution bounds
 /// belong on constructors and operational impls here.
 pub struct DisposingReceiver<T> {
-    inner: OneShotReceiver<T>,
+    inner: Option<OneShotReceiver<T>>,
     dispose: fn(T),
+    caller_waker: Option<WakerProxy>,
 }
 
 impl<T: Send + 'static> DisposingReceiver<T> {
     pub fn new(inner: OneShotReceiver<T>) -> Self {
         Self {
-            inner,
+            inner: Some(inner),
             dispose: dispose_detached::<T>,
+            caller_waker: None,
         }
     }
 }
 
-impl<T> DisposingReceiver<T> {
-    pub fn poll_receive(
-        &mut self,
-        context: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<T>> {
-        self.inner.poll_receive(context)
+fn poll_one_shot_with_proxy<T, R>(
+    inner: &mut OneShotReceiver<T>,
+    caller_waker: &mut Option<WakerProxy>,
+    context: &mut Context<'_>,
+    mut poll: impl FnMut(&mut OneShotReceiver<T>, &mut Context<'_>) -> R,
+    is_pending: impl Fn(&R) -> bool,
+) -> R {
+    if caller_waker.is_none() {
+        let mut probe = Context::from_waker(Waker::noop());
+        let result = poll(inner, &mut probe);
+        if !is_pending(&result) {
+            return result;
+        }
+        *caller_waker = Some(WakerProxy::new());
     }
 
-    pub fn close_and_poll_receive(
-        &mut self,
-        context: &mut std::task::Context<'_>,
-    ) -> OneShotClose<T> {
-        self.inner.close_and_poll_receive(context)
+    let caller_waker = caller_waker
+        .as_ref()
+        .expect("a parked disposing receiver retains its waker proxy");
+    caller_waker.register(context);
+    let mut proxy_context = Context::from_waker(caller_waker.waker());
+    poll(inner, &mut proxy_context)
+}
+
+impl<T> DisposingReceiver<T> {
+    fn inner_mut(&mut self) -> &mut OneShotReceiver<T> {
+        self.inner
+            .as_mut()
+            .expect("a live disposing receiver retains its channel")
+    }
+
+    /// Retires a caller waker only after selecting its post-unlock venue.
+    ///
+    /// Ready results use contained inline retirement: a result may own a user
+    /// value (or a panic payload that owns one), so a hostile waker destructor
+    /// is subordinate to returning that result intact. Drop glue uses the
+    /// detached lane because caller-waker destruction may block as well as
+    /// panic, and a holder's dropping thread is not an acceptable venue.
+    fn retire_caller_waker(&mut self, retirement: WakerRetirement, panics: &mut PanicAccumulator) {
+        let caller_waker = self.caller_waker.take();
+        if let Some(caller_waker) = &caller_waker {
+            caller_waker.retire(retirement, panics);
+        }
+        panics.run(|| drop(caller_waker));
+    }
+
+    pub fn poll_receive(&mut self, context: &mut Context<'_>) -> Poll<Option<T>> {
+        // In pinned Tokio 1.53.1, `Receiver::poll` obtains the result before
+        // clearing its `Inner`; the last `Inner::drop` then calls
+        // `rx_task.drop_task` while that result can own the delivered value.
+        // Probe with a framework waker, then leave only the stable proxy
+        // registered across a pending return so Tokio never destroys the raw
+        // caller waker at that delivery seam.
+        let result = poll_one_shot_with_proxy(
+            self.inner
+                .as_mut()
+                .expect("a live disposing receiver retains its channel"),
+            &mut self.caller_waker,
+            context,
+            OneShotReceiver::poll_receive,
+            Poll::is_pending,
+        );
+        if result.is_ready() {
+            let mut panics = PanicAccumulator::default();
+            self.retire_caller_waker(WakerRetirement::Inline, &mut panics);
+            discard_panic(panics.take());
+        }
+        result
+    }
+
+    pub fn close_and_poll_receive(&mut self, context: &mut Context<'_>) -> OneShotClose<T> {
+        let result = poll_one_shot_with_proxy(
+            self.inner
+                .as_mut()
+                .expect("a live disposing receiver retains its channel"),
+            &mut self.caller_waker,
+            context,
+            OneShotReceiver::close_and_poll_receive,
+            |result| matches!(result, OneShotClose::Pending),
+        );
+        if !matches!(result, OneShotClose::Pending) {
+            let mut panics = PanicAccumulator::default();
+            self.retire_caller_waker(WakerRetirement::Inline, &mut panics);
+            discard_panic(panics.take());
+        }
+        result
     }
 
     pub fn close(&mut self) {
-        self.inner.close();
+        self.inner_mut().close();
+        let mut panics = PanicAccumulator::default();
+        self.retire_caller_waker(WakerRetirement::Inline, &mut panics);
+        discard_panic(panics.take());
     }
 }
 
 impl<T> Drop for DisposingReceiver<T> {
     fn drop(&mut self) {
-        if let Some(value) = self.inner.close_and_take() {
-            (self.dispose)(value);
-        }
+        let mut inner = self
+            .inner
+            .take()
+            .expect("a live disposing receiver retains its channel");
+        let mut value = None;
+        let mut panics = PanicAccumulator::default();
+
+        // Recover and dispatch an unclaimed value before either receiver or
+        // caller-waker retirement can fail. The receiver holds only a proxy
+        // clone, so Tokio's close/drop work below is framework-owned traffic.
+        panics.run(|| value = inner.close_and_take());
+        panics.run(|| {
+            if let Some(value) = value {
+                (self.dispose)(value);
+            }
+        });
+        panics.run(|| drop(inner));
+        self.retire_caller_waker(WakerRetirement::Detached, &mut panics);
     }
 }
 
@@ -1030,14 +1126,17 @@ mod tests {
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
+            mpsc,
         },
         task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker},
+        thread::ThreadId,
         time::Duration,
     };
 
     use crate::{
-        BroadcastReceive, CompletionGatedLatch, JoinOutcome, Latch, OneShotClose, Signal, Timeout,
-        broadcast, join, oneshot, oneshot_sending_for_test, spawn, timeout, yield_now,
+        BroadcastReceive, CompletionGatedLatch, DisposingReceiver, JoinOutcome, Latch,
+        OneShotClose, Signal, Timeout, broadcast, join, oneshot, oneshot_sending_for_test, spawn,
+        test_support::DISPOSAL_THREAD, timeout, yield_now,
     };
 
     use super::{RegisteredWaker, WaiterRegistry};
@@ -1124,6 +1223,54 @@ mod tests {
         let raw = RawWaker::new(
             Arc::into_raw(Arc::new(LastWakerDropPanics { drops, message })).cast(),
             &LAST_DROP_PANICS_VTABLE,
+        );
+        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+        // ownership across clone, wake, and drop.
+        unsafe { Waker::from_raw(raw) }
+    }
+
+    struct RecordPanickingDrop(mpsc::Sender<(ThreadId, Option<String>)>);
+
+    unsafe fn clone_record_panicking_drop(data: *const ()) -> RawWaker {
+        // SAFETY: every pointer using this vtable came from an Arc of the
+        // matching type. ManuallyDrop preserves the represented reference;
+        // the returned raw waker owns only the new clone.
+        let probe = ManuallyDrop::new(unsafe { Arc::<RecordPanickingDrop>::from_raw(data.cast()) });
+        RawWaker::new(
+            Arc::into_raw(Arc::clone(&probe)).cast(),
+            &RECORD_PANICKING_DROP_VTABLE,
+        )
+    }
+
+    unsafe fn wake_record_panicking_drop(data: *const ()) {
+        // SAFETY: wake consumes the Arc reference represented by this waker.
+        drop(unsafe { Arc::<RecordPanickingDrop>::from_raw(data.cast()) });
+    }
+
+    unsafe fn wake_by_ref_record_panicking_drop(_data: *const ()) {}
+
+    unsafe fn drop_record_panicking_drop(data: *const ()) {
+        // SAFETY: drop consumes the Arc reference represented by this waker.
+        let probe = unsafe { Arc::<RecordPanickingDrop>::from_raw(data.cast()) };
+        let _ = probe.0.send((
+            std::thread::current().id(),
+            std::thread::current().name().map(str::to_owned),
+        ));
+        drop(probe);
+        panic!("injected disposing-receiver caller-waker drop panic");
+    }
+
+    static RECORD_PANICKING_DROP_VTABLE: RawWakerVTable = RawWakerVTable::new(
+        clone_record_panicking_drop,
+        wake_record_panicking_drop,
+        wake_by_ref_record_panicking_drop,
+        drop_record_panicking_drop,
+    );
+
+    fn record_panicking_drop_waker(dropped: mpsc::Sender<(ThreadId, Option<String>)>) -> Waker {
+        let raw = RawWaker::new(
+            Arc::into_raw(Arc::new(RecordPanickingDrop(dropped))).cast(),
+            &RECORD_PANICKING_DROP_VTABLE,
         );
         // SAFETY: `raw` owns one Arc reference and its vtable maintains that
         // ownership across clone, wake, and drop.
@@ -1263,6 +1410,31 @@ mod tests {
 
         assert_eq!(sending.publish(7_u8), Err(7));
         assert_eq!(receiver.try_receive(), None);
+    }
+
+    #[test]
+    fn dropping_disposing_receiver_detaches_caller_waker_retirement() {
+        let dropping_thread = std::thread::current().id();
+        let (_sender, receiver) = oneshot::<u8>();
+        let mut receiver = DisposingReceiver::new(receiver);
+        let (dropped, observed_drop) = mpsc::channel();
+        let caller = ManuallyDrop::new(record_panicking_drop_waker(dropped));
+
+        assert!(matches!(
+            receiver.poll_receive(&mut Context::from_waker(&caller)),
+            Poll::Pending
+        ));
+        drop(receiver);
+
+        let (destructor_thread, destructor_name) = observed_drop
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the caller waker reaches detached disposal");
+        assert_ne!(destructor_thread, dropping_thread);
+        assert_eq!(
+            destructor_name.as_deref(),
+            Some(DISPOSAL_THREAD),
+            "drop glue must not destroy a caller waker on the holder's thread"
+        );
     }
 
     #[test]

--- a/crates/shelterwood-runtime/src/waker_proxy.rs
+++ b/crates/shelterwood-runtime/src/waker_proxy.rs
@@ -1,0 +1,66 @@
+use std::task::{Context, Waker};
+
+use shelterwood_mailbox::WakerProxy as MailboxWakerProxy;
+
+use crate::{PanicAccumulator, discard_panic, dispose_detached};
+
+/// Where a caller waker removed from the stable proxy is destroyed.
+pub(crate) enum WakerRetirement {
+    /// Destroy synchronously, under a caller-owned panic boundary.
+    Inline,
+    /// Transfer destruction to the runtime's blocking disposal lane.
+    Detached,
+}
+
+/// Runtime-facing stable waker registered with an external primitive.
+///
+/// The runtime-neutral implementation lives beside the mailbox state machines,
+/// which already need the same lost-wake and post-unlock-effect guarantees.
+/// This wrapper supplies the runtime-owned retirement venues without exposing
+/// caller wakers as values across the crate boundary.
+pub(crate) struct WakerProxy(MailboxWakerProxy);
+
+impl WakerProxy {
+    pub(crate) fn new() -> Self {
+        Self(MailboxWakerProxy::new())
+    }
+
+    pub(crate) fn register(&self, context: &Context<'_>) {
+        self.0.register(context.waker());
+    }
+
+    pub(crate) fn waker(&self) -> &Waker {
+        self.0.waker()
+    }
+
+    /// Retires the stored caller waker through an explicit post-unlock venue.
+    pub(crate) fn retire(&self, retirement: WakerRetirement, panics: &mut PanicAccumulator) {
+        let effect = match retirement {
+            WakerRetirement::Inline => drop_waker,
+            WakerRetirement::Detached => dispose_waker,
+        };
+        self.0.retire_with(effect, panics);
+    }
+}
+
+impl Drop for WakerProxy {
+    /// Transfers any still-registered caller waker to detached disposal.
+    ///
+    /// Ordinary delivery retires inline before returning its value. Drop glue
+    /// has no such safe handoff point: the surrounding frame may itself be
+    /// unwinding or destroying user state, and a caller-waker destructor may
+    /// block as well as panic.
+    fn drop(&mut self) {
+        let mut panics = PanicAccumulator::default();
+        self.retire(WakerRetirement::Detached, &mut panics);
+        discard_panic(panics.take());
+    }
+}
+
+fn drop_waker(waker: Waker) {
+    drop(waker);
+}
+
+fn dispose_waker(waker: Waker) {
+    dispose_detached(waker);
+}

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -328,11 +328,12 @@ impl<T: Send + 'static> OneShotTaskRef<T> {
 mod tests {
     use std::{
         future::Future,
+        mem::ManuallyDrop,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
         },
-        task::{Context, Poll, Waker},
+        task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
     };
 
     use crate::{
@@ -451,6 +452,95 @@ mod tests {
         let (sender, receiver) = runtime::oneshot();
         let claim = OneShotTaskRef::new(receiver, TaskRef::new(std::sync::Arc::clone(&member)));
         (sender, claim, member)
+    }
+
+    unsafe fn clone_panicking_drop_waker(data: *const ()) -> RawWaker {
+        // SAFETY: every pointer using this vtable came from an Arc of the
+        // matching type. ManuallyDrop preserves the represented reference;
+        // the returned raw waker owns only the new clone.
+        let state = ManuallyDrop::new(unsafe { Arc::<()>::from_raw(data.cast()) });
+        RawWaker::new(
+            Arc::into_raw(Arc::clone(&state)).cast(),
+            &PANICKING_DROP_WAKER_VTABLE,
+        )
+    }
+
+    unsafe fn wake_panicking_drop_waker(data: *const ()) {
+        // SAFETY: wake consumes the Arc reference represented by this waker.
+        drop(unsafe { Arc::<()>::from_raw(data.cast()) });
+    }
+
+    unsafe fn wake_by_ref_panicking_drop_waker(_data: *const ()) {}
+
+    unsafe fn drop_panicking_drop_waker(data: *const ()) {
+        // SAFETY: drop consumes the Arc reference represented by this waker.
+        drop(unsafe { Arc::<()>::from_raw(data.cast()) });
+        panic!("injected one-shot completion caller-waker drop panic");
+    }
+
+    static PANICKING_DROP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+        clone_panicking_drop_waker,
+        wake_panicking_drop_waker,
+        wake_by_ref_panicking_drop_waker,
+        drop_panicking_drop_waker,
+    );
+
+    fn panicking_drop_waker() -> Waker {
+        let raw = RawWaker::new(
+            Arc::into_raw(Arc::new(())).cast(),
+            &PANICKING_DROP_WAKER_VTABLE,
+        );
+        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+        // ownership across clone, wake, and drop.
+        unsafe { Waker::from_raw(raw) }
+    }
+
+    struct PanickingCompletion;
+
+    impl Drop for PanickingCompletion {
+        fn drop(&mut self) {
+            panic!("injected one-shot completion value drop panic");
+        }
+    }
+
+    /// Exercises `OneShotTaskRef::wait` with the typed one-shot deliberately
+    /// held in its test-only `SENDING` window after terminal publication.
+    ///
+    /// Production ordering sends the value before publishing `Completed`, so
+    /// today's driver cannot expose this pending completion poll. The staged
+    /// boundary keeps `wait` hardened if that ordering grows another producer:
+    /// Tokio must see only the framework proxy, never the hostile caller waker
+    /// it otherwise destroys while its ready frame owns `PanickingCompletion`.
+    #[crate::runtime::test]
+    async fn staged_one_shot_wait_cannot_double_panic_at_completion_delivery() {
+        let mut identity = ScopeIdentity::new();
+        let id = ChildId::from("task");
+        let membership = identity.mint_membership(&id).expect("membership available");
+        let member = MemberCell::new(id, membership);
+        let (sending, receiver) = runtime::oneshot_sending_for_test();
+        let claim = OneShotTaskRef::new(receiver, TaskRef::new(Arc::clone(&member)));
+        member.terminalize(
+            Exit::completed(Cancellation::NotObserved),
+            crate::cells::StartupDisposition::Unchanged,
+        );
+
+        let hostile = ManuallyDrop::new(panicking_drop_waker());
+        let mut waiting = Box::pin(claim.wait());
+        assert!(matches!(
+            waiting.as_mut().poll(&mut Context::from_waker(&hostile)),
+            Poll::Pending
+        ));
+        sending
+            .publish(PanickingCompletion)
+            .unwrap_or_else(|_| panic!("the staged completion receiver remains live"));
+
+        let Poll::Ready(Ok(value)) = waiting.as_mut().poll(&mut Context::from_waker(&hostile))
+        else {
+            panic!("the staged typed completion is delivered")
+        };
+        // A passing receiver returns the value intact. Its destructor is the
+        // abort's second half, so intentionally leave it live.
+        std::mem::forget(value);
     }
 
     #[crate::runtime::test]

--- a/crates/shelterwood/tests/result_delivery_waker_proxy.rs
+++ b/crates/shelterwood/tests/result_delivery_waker_proxy.rs
@@ -1,0 +1,197 @@
+mod common;
+
+use std::{
+    future::Future,
+    mem::ManuallyDrop,
+    pin::Pin,
+    sync::{Arc, mpsc},
+    task::{Context as TaskContext, Poll, RawWaker, RawWakerVTable, Waker},
+    time::Instant,
+};
+
+use common::POLL_TIMEOUT;
+use shelterwood::{Actor, ActorOnceDef, Blocking, Context, ExitError, ExitResult, Tree};
+
+unsafe fn clone_panicking_drop_waker(data: *const ()) -> RawWaker {
+    // SAFETY: every pointer using this vtable came from an Arc of the
+    // matching type. ManuallyDrop preserves the reference represented by
+    // `data`; the returned raw waker owns only the new clone.
+    let state = ManuallyDrop::new(unsafe { Arc::<()>::from_raw(data.cast()) });
+    RawWaker::new(
+        Arc::into_raw(Arc::clone(&state)).cast(),
+        &PANICKING_DROP_WAKER_VTABLE,
+    )
+}
+
+unsafe fn wake_panicking_drop_waker(data: *const ()) {
+    // SAFETY: wake consumes the Arc reference represented by this raw waker.
+    drop(unsafe { Arc::<()>::from_raw(data.cast()) });
+}
+
+unsafe fn wake_by_ref_panicking_drop_waker(_data: *const ()) {}
+
+unsafe fn drop_panicking_drop_waker(data: *const ()) {
+    // SAFETY: drop consumes the Arc reference represented by this raw waker.
+    drop(unsafe { Arc::<()>::from_raw(data.cast()) });
+    panic!("injected result caller-waker drop panic");
+}
+
+static PANICKING_DROP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    clone_panicking_drop_waker,
+    wake_panicking_drop_waker,
+    wake_by_ref_panicking_drop_waker,
+    drop_panicking_drop_waker,
+);
+
+fn panicking_drop_waker() -> Waker {
+    let raw = RawWaker::new(
+        Arc::into_raw(Arc::new(())).cast(),
+        &PANICKING_DROP_WAKER_VTABLE,
+    );
+    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+    // ownership across clone, wake, and drop.
+    unsafe { Waker::from_raw(raw) }
+}
+
+struct DeliveredValue {
+    panic_on_drop: bool,
+}
+
+impl Drop for DeliveredValue {
+    fn drop(&mut self) {
+        if self.panic_on_drop {
+            panic!("injected delivered-value drop panic");
+        }
+    }
+}
+
+fn poll_until_ready<F: Future>(mut future: Pin<&mut F>, waker: &Waker) -> F::Output {
+    let deadline = Instant::now() + POLL_TIMEOUT;
+    loop {
+        if let Poll::Ready(output) = future.as_mut().poll(&mut TaskContext::from_waker(waker)) {
+            return output;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "result future becomes ready before the test deadline"
+        );
+        std::thread::yield_now();
+    }
+}
+
+enum BlockingMessage {
+    Start {
+        entered: mpsc::Sender<()>,
+        release: mpsc::Receiver<()>,
+        panic_on_drop: bool,
+    },
+}
+
+struct BlockingSource {
+    work: mpsc::Sender<Blocking<DeliveredValue>>,
+}
+
+impl Actor for BlockingSource {
+    type Msg = BlockingMessage;
+    type Args = mpsc::Sender<Blocking<DeliveredValue>>;
+
+    async fn init(work: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self { work })
+    }
+
+    async fn handle(
+        &mut self,
+        message: BlockingMessage,
+        context: &mut Context<'_, Self>,
+    ) -> ExitResult {
+        let BlockingMessage::Start {
+            entered,
+            release,
+            panic_on_drop,
+        } = message;
+        let work = context.run_blocking(move |_| {
+            let _ = entered.send(());
+            release
+                .recv_timeout(POLL_TIMEOUT)
+                .expect("the test releases the blocking operation");
+            DeliveredValue { panic_on_drop }
+        });
+        self.work
+            .send(work)
+            .unwrap_or_else(|_| panic!("the test retains the blocking future receiver"));
+        Ok(())
+    }
+}
+
+async fn drive_run_blocking_delivery(panic_on_drop: bool) {
+    let (work_tx, work_rx) = mpsc::channel();
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "blocking-result-waker",
+            ActorOnceDef::<BlockingSource>::new(work_tx),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    system.wait_started().await.expect("actor starts");
+    actor
+        .send(BlockingMessage::Start {
+            entered: entered_tx,
+            release: release_rx,
+            panic_on_drop,
+        })
+        .await
+        .expect("actor accepts the blocking request");
+
+    let mut work = Box::pin(
+        work_rx
+            .recv_timeout(POLL_TIMEOUT)
+            .expect("the actor returns the public blocking future"),
+    );
+    entered_rx
+        .recv_timeout(POLL_TIMEOUT)
+        .expect("the blocking operation starts");
+    let hostile = ManuallyDrop::new(panicking_drop_waker());
+    assert!(matches!(
+        work.as_mut().poll(&mut TaskContext::from_waker(&hostile)),
+        Poll::Pending
+    ));
+
+    release_tx
+        .send(())
+        .expect("the blocking operation retains its release lane");
+    let value = poll_until_ready(work.as_mut(), &hostile);
+    assert_eq!(value.panic_on_drop, panic_on_drop);
+    if panic_on_drop {
+        // Its destructor is the abort's second half. A passing implementation
+        // returns it intact, so this regression intentionally leaves it live.
+        std::mem::forget(value);
+    } else {
+        drop(value);
+    }
+    drop(work);
+
+    system
+        .shutdown(POLL_TIMEOUT)
+        .await
+        .expect("the actor stops");
+}
+
+/// Drives the public `Context::run_blocking` future after parking it with a
+/// caller waker whose drop vtable panics.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn successful_run_blocking_contains_completion_caller_waker_retirement() {
+    drive_run_blocking_delivery(false).await;
+}
+
+/// Combines the hostile registered-waker destructor with a blocking result
+/// whose destructor also panics. Before the proxy, Tokio 1.53.1 destroyed the
+/// raw caller waker while its ready frame owned this result, so unwinding that
+/// result aborted the process. Nextest's process-per-test isolation makes that
+/// SIGABRT a failure of this exact regression.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn successful_run_blocking_cannot_double_panic_with_hostile_waker_and_value_drops() {
+    drive_run_blocking_delivery(true).await;
+}


### PR DESCRIPTION
## Summary

- reuse the mailbox WakerProxy through a runtime adapter that selects inline or detached caller-waker retirement
- keep DisposingReceiver caller wakers out of Tokio's result-delivery frame, contain ready-path destructor panics, and detach cancellation/drop cleanup
- cover public Context::run_blocking delivery plus the OneShotTaskRef::wait completion boundary with hostile waker and hostile value regressions

## Ordering note

The current one-shot task driver sends the typed value before it publishes Completed, so the public end-to-end OneShotTaskRef::wait path does not currently expose a pending completion receiver. The staged ONESHOT_SENDING unit test exercises that shared pending-to-ready boundary without claiming the current driver ordering reproduces it, and hardens the receiver against future or test-only producers.

## Validation

- ./tools/dev cargo test -p shelterwood-mailbox waker_proxy
- ./tools/dev cargo test -p shelterwood-runtime sync::tests::dropping_disposing_receiver_detaches_caller_waker_retirement
- ./tools/dev cargo nextest run -p shelterwood --test result_delivery_waker_proxy
- staged OneShotTaskRef::wait regression selected through nextest
- ./tools/dev just ci

Mutation checks against clean origin/main fail at the intended receiver seams: the run_blocking tests produce the hostile-waker panic and SIGABRT pairing, and the staged OneShotTaskRef test SIGABRTs when Tokio drops the raw caller waker while owning the hostile completion value.

Closes #407
