### PR TITLE
Proxy remaining public caller-waker handoffs

### DIFF
--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -684,13 +684,13 @@ mod tests {
         mem::ManuallyDrop,
         panic,
         sync::{
-            Arc,
+            Arc, Mutex,
             atomic::{AtomicBool, AtomicUsize, Ordering},
             mpsc,
         },
         task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker},
         thread,
-        time::Duration,
+        time::{Duration, Instant},
     };
 
     use super::BlockingPoolJob;
@@ -721,32 +721,63 @@ mod tests {
         }
     }
 
-    #[derive(Default)]
-    struct JoinWakeState(AtomicBool);
+    struct JoinWakeState {
+        woken: AtomicBool,
+        dropped: mpsc::Sender<crate::test_support::ThreadDescription>,
+        clone_action: Mutex<Option<CloneJoinAction>>,
+    }
+
+    struct CloneJoinAction {
+        release: tokio::sync::oneshot::Sender<()>,
+        finished: super::AbortHandle,
+    }
 
     unsafe fn clone_join_waker(data: *const ()) -> RawWaker {
         // SAFETY: every pointer using this vtable came from an Arc of the
         // matching type. ManuallyDrop preserves the reference represented by
         // `data`; the returned raw waker owns only the new clone.
         let state = ManuallyDrop::new(unsafe { Arc::<JoinWakeState>::from_raw(data.cast()) });
+        let action = state
+            .clone_action
+            .lock()
+            .expect("join clone-action mutex is not poisoned")
+            .take();
+        if let Some(CloneJoinAction { release, finished }) = action {
+            release
+                .send(())
+                .expect("the join task still awaits its release");
+            let deadline = Instant::now() + Duration::from_secs(1);
+            while !finished.0.is_finished() {
+                assert!(
+                    Instant::now() < deadline,
+                    "the released join task completes while its no-op waker is parked"
+                );
+                thread::yield_now();
+            }
+        }
         RawWaker::new(Arc::into_raw(Arc::clone(&state)).cast(), &JOIN_WAKER_VTABLE)
     }
 
     unsafe fn wake_join_waker(data: *const ()) {
         // SAFETY: wake consumes the Arc reference represented by this waker.
         let state = unsafe { Arc::<JoinWakeState>::from_raw(data.cast()) };
-        state.0.store(true, Ordering::SeqCst);
+        state.woken.store(true, Ordering::SeqCst);
     }
 
     unsafe fn wake_by_ref_join_waker(data: *const ()) {
         // SAFETY: ManuallyDrop preserves the reference represented by `data`.
         let state = ManuallyDrop::new(unsafe { Arc::<JoinWakeState>::from_raw(data.cast()) });
-        state.0.store(true, Ordering::SeqCst);
+        state.woken.store(true, Ordering::SeqCst);
     }
 
     unsafe fn drop_join_waker(data: *const ()) {
         // SAFETY: drop consumes the Arc reference represented by this waker.
-        drop(unsafe { Arc::<JoinWakeState>::from_raw(data.cast()) });
+        let state = unsafe { Arc::<JoinWakeState>::from_raw(data.cast()) };
+        let current = thread::current();
+        let _ = state
+            .dropped
+            .send((current.id(), current.name().map(str::to_owned)));
+        drop(state);
         panic!("hostile public-join waker destructor");
     }
 
@@ -757,13 +788,43 @@ mod tests {
         drop_join_waker,
     );
 
-    fn panicking_drop_join_waker() -> (ManuallyDrop<Waker>, Arc<JoinWakeState>) {
-        let state = Arc::new(JoinWakeState::default());
+    unsafe fn panic_clone_join_waker(_data: *const ()) -> RawWaker {
+        panic!("an already-ready join must not clone its caller waker")
+    }
+
+    unsafe fn no_op_join_waker(_data: *const ()) {}
+
+    static PANIC_CLONE_JOIN_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+        panic_clone_join_waker,
+        no_op_join_waker,
+        no_op_join_waker,
+        no_op_join_waker,
+    );
+
+    fn panic_clone_join_waker_value() -> Waker {
+        let raw = RawWaker::new(std::ptr::null(), &PANIC_CLONE_JOIN_WAKER_VTABLE);
+        // SAFETY: the vtable never dereferences or owns its null data pointer.
+        unsafe { Waker::from_raw(raw) }
+    }
+
+    fn panicking_drop_join_waker(
+        clone_action: Option<CloneJoinAction>,
+    ) -> (
+        ManuallyDrop<Waker>,
+        Arc<JoinWakeState>,
+        mpsc::Receiver<crate::test_support::ThreadDescription>,
+    ) {
+        let (dropped, observed_drop) = mpsc::channel();
+        let state = Arc::new(JoinWakeState {
+            woken: AtomicBool::new(false),
+            dropped,
+            clone_action: Mutex::new(clone_action),
+        });
         let raw = RawWaker::new(Arc::into_raw(Arc::clone(&state)).cast(), &JOIN_WAKER_VTABLE);
         // SAFETY: `raw` owns one Arc reference and its vtable maintains that
         // ownership across clone, wake, and drop.
         let waker = unsafe { Waker::from_raw(raw) };
-        (ManuallyDrop::new(waker), state)
+        (ManuallyDrop::new(waker), state, observed_drop)
     }
 
     #[tokio::test]
@@ -973,32 +1034,34 @@ mod tests {
     /// failure rather than taking the whole suite with it.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn user_polled_join_separates_hostile_waker_and_panic_payload_destruction() {
+        let polling_thread = thread::current().id();
         let (release, released) = tokio::sync::oneshot::channel();
         let (payload_dropped, payload_dropped_rx) = mpsc::channel();
         let handle = super::spawn(async move {
             let _ = released.await;
             panic::panic_any(PanickingDrop(payload_dropped));
         });
+        let finished = handle.abort_handle();
         let mut join = Box::pin(super::join_user_polled(handle));
-        let (hostile, state) = panicking_drop_join_waker();
+        let (hostile, _state, observed_waker_drop) =
+            panicking_drop_join_waker(Some(CloneJoinAction { release, finished }));
 
-        assert!(matches!(
-            join.as_mut().poll(&mut Context::from_waker(&hostile)),
-            Poll::Pending
-        ));
-        release.send(()).expect("the panicking task is still live");
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while !state.0.load(Ordering::SeqCst) {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("the completed task wakes its public join waiter");
-
+        // The first no-op probe parks Pending. Cloning the caller waker then
+        // releases the task and waits until Tokio marks it complete, so the
+        // second probe in the same poll returns Ready while the caller waker
+        // is still installed in the framework proxy. This pins the narrow
+        // ready-retirement path rather than relying on a scheduler race.
         assert!(matches!(
             join.as_mut().poll(&mut Context::from_waker(&hostile)),
             Poll::Ready(super::JoinOutcome::Panic { message: None })
         ));
+        let (waker_drop_thread, _) = observed_waker_drop
+            .recv_timeout(Duration::from_secs(1))
+            .expect("ready joins retire the caller waker before returning");
+        assert_eq!(
+            waker_drop_thread, polling_thread,
+            "ready joins retire the caller waker synchronously before handle teardown"
+        );
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {
                 match payload_dropped_rx.try_recv() {
@@ -1012,6 +1075,73 @@ mod tests {
         })
         .await
         .expect("the hostile panic payload reaches detached disposal");
+    }
+
+    #[tokio::test]
+    async fn already_ready_user_polled_join_never_clones_the_caller_waker() {
+        let handle = super::spawn(async { 17_u8 });
+        let finished = handle.abort_handle();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !finished.0.is_finished() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the ready task completes before its first join poll");
+
+        let mut join = Box::pin(super::join_user_polled(handle));
+        let caller = panic_clone_join_waker_value();
+        assert!(matches!(
+            join.as_mut().poll(&mut Context::from_waker(&caller)),
+            Poll::Ready(super::JoinOutcome::Ok { value: 17 })
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_polled_join_preserves_runtime_cancellation() {
+        let (runtime, handle) = super::DedicatedRuntime::spawn(std::future::pending::<()>());
+        let mut join = Box::pin(super::join_user_polled(handle));
+        assert!(matches!(
+            join.as_mut().poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Pending
+        ));
+
+        runtime.shutdown().await;
+
+        assert!(matches!(
+            join.as_mut().poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Ready(super::JoinOutcome::Cancelled)
+        ));
+    }
+
+    /// Cancelling a pending public join has no ready-result handoff point.
+    /// Its caller waker may block on destruction, so the future's drop glue
+    /// must transfer retirement to the detached disposal lane instead of
+    /// running it on the holder's thread.
+    #[tokio::test]
+    async fn dropping_pending_user_polled_join_detaches_caller_waker_retirement() {
+        let dropping_thread = thread::current().id();
+        let handle = super::spawn(std::future::pending::<()>());
+        let abort = handle.abort_handle();
+        let mut join = Box::pin(super::join_user_polled(handle));
+        let (hostile, _state, observed_drop) = panicking_drop_join_waker(None);
+
+        assert!(matches!(
+            join.as_mut().poll(&mut Context::from_waker(&hostile)),
+            Poll::Pending
+        ));
+        drop(join);
+
+        let (destructor_thread, destructor_name) = observed_drop
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the pending join caller waker reaches detached disposal");
+        assert_ne!(destructor_thread, dropping_thread);
+        assert!(
+            destructor_name.as_deref() == Some(DISPOSAL_THREAD)
+                || destructor_name.as_deref() == Some("tokio-rt-worker"),
+            "pending join drop uses either Tokio's blocking pool or the fallback disposal lane"
+        );
+        abort.abort();
     }
 
     #[test]

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -409,6 +409,13 @@ where
     }
 }
 
+/// Joins a task polled only from framework-task venues.
+///
+/// The waker parked raw in Tokio's join trailer here is the polling
+/// executor's own, so its destruction stays framework traffic. A future that
+/// a public API caller polls supplies that caller's waker instead and must
+/// join through [`join_user_polled`] — reaching for this helper from a public
+/// seam is exactly the class #409 closed.
 pub async fn join<T>(handle: JoinHandle<T>) -> JoinOutcome<T> {
     let JoinHandle { inner } = handle;
     classify_join_result(inner.await)

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -13,6 +13,7 @@ use shelterwood_core::exit::JoinOutcome;
 use super::{
     DisposingReceiver, OneShotReceiver, OneShotSender, PanicPayload, catch_panic, discard_panic,
     dispose_detached, oneshot, sleep_until_std,
+    waker_proxy::{WakerProxy, WakerRetirement},
 };
 
 const BLOCKING_FALLBACK_THREAD: &str = "shelterwood-blocking";
@@ -410,7 +411,71 @@ where
 
 pub async fn join<T>(handle: JoinHandle<T>) -> JoinOutcome<T> {
     let JoinHandle { inner } = handle;
-    match inner.await {
+    classify_join_result(inner.await)
+}
+
+/// Joins a task from a future polled directly by a public API caller.
+///
+/// Tokio retains the polling task's raw waker in the join trailer. In pinned
+/// Tokio 1.53.1 that waker survives task completion until the `JoinHandle` is
+/// dropped, when the awaiting frame can already own a `JoinError::Panic` and
+/// its opaque panic payload. Park only a stable framework proxy in Tokio,
+/// retire the real caller waker synchronously and with containment before the
+/// ready result crosses this boundary, then let the handle destroy the proxy.
+///
+/// The ordinary [`join`] remains the lower-cost path for framework-task
+/// venues, whose executor wakers are not supplied by a public caller.
+pub async fn join_user_polled<T>(handle: JoinHandle<T>) -> JoinOutcome<T> {
+    let JoinHandle { inner } = handle;
+    classify_join_result(poll_join_user_waker(inner).await)
+}
+
+async fn poll_join_user_waker<T>(mut inner: task::JoinHandle<T>) -> Result<T, task::JoinError> {
+    let mut caller_waker = None;
+    let result = poll_fn(|context| {
+        if caller_waker.is_none() {
+            // Preserve the already-ready fast path: a framework no-op probe
+            // avoids cloning a caller waker that Tokio never needs to park.
+            let mut probe = std::task::Context::from_waker(std::task::Waker::noop());
+            let result = std::pin::Pin::new(&mut inner).poll(&mut probe);
+            if result.is_ready() {
+                return result;
+            }
+            caller_waker = Some(WakerProxy::new());
+        }
+
+        let proxy = caller_waker
+            .as_ref()
+            .expect("a pending public join retains its waker proxy");
+        proxy.register(context);
+        let mut proxy_context = std::task::Context::from_waker(proxy.waker());
+        let result = std::pin::Pin::new(&mut inner).poll(&mut proxy_context);
+        if result.is_ready() {
+            retire_join_caller_waker(&mut caller_waker);
+        }
+        result
+    })
+    .await;
+
+    // `result` can own Tokio's opaque panic payload. The real caller waker was
+    // already retired above, so dropping the completed handle dispatches only
+    // framework proxy vtables while that payload is live.
+    drop(inner);
+    result
+}
+
+fn retire_join_caller_waker(caller_waker: &mut Option<WakerProxy>) {
+    let caller_waker = caller_waker.take();
+    let mut panics = super::PanicAccumulator::default();
+    if let Some(caller_waker) = &caller_waker {
+        caller_waker.retire(WakerRetirement::Inline, &mut panics);
+    }
+    panics.run(|| drop(caller_waker));
+    discard_panic(panics.take());
+}
+
+fn classify_join_result<T>(result: Result<T, task::JoinError>) -> JoinOutcome<T> {
+    match result {
         Ok(value) => JoinOutcome::Ok { value },
         Err(error) if error.is_panic() => JoinOutcome::Panic {
             message: contain_panic_payload(error.into_panic()),
@@ -616,13 +681,14 @@ impl Default for JitterRng {
 #[cfg(test)]
 mod tests {
     use std::{
+        mem::ManuallyDrop,
         panic,
         sync::{
             Arc,
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
             mpsc,
         },
-        task::{Context, Poll, Wake, Waker},
+        task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker},
         thread,
         time::Duration,
     };
@@ -653,6 +719,51 @@ mod tests {
             self.0.fetch_add(1, Ordering::SeqCst);
             panic!("hostile blocking-result waker");
         }
+    }
+
+    #[derive(Default)]
+    struct JoinWakeState(AtomicBool);
+
+    unsafe fn clone_join_waker(data: *const ()) -> RawWaker {
+        // SAFETY: every pointer using this vtable came from an Arc of the
+        // matching type. ManuallyDrop preserves the reference represented by
+        // `data`; the returned raw waker owns only the new clone.
+        let state = ManuallyDrop::new(unsafe { Arc::<JoinWakeState>::from_raw(data.cast()) });
+        RawWaker::new(Arc::into_raw(Arc::clone(&state)).cast(), &JOIN_WAKER_VTABLE)
+    }
+
+    unsafe fn wake_join_waker(data: *const ()) {
+        // SAFETY: wake consumes the Arc reference represented by this waker.
+        let state = unsafe { Arc::<JoinWakeState>::from_raw(data.cast()) };
+        state.0.store(true, Ordering::SeqCst);
+    }
+
+    unsafe fn wake_by_ref_join_waker(data: *const ()) {
+        // SAFETY: ManuallyDrop preserves the reference represented by `data`.
+        let state = ManuallyDrop::new(unsafe { Arc::<JoinWakeState>::from_raw(data.cast()) });
+        state.0.store(true, Ordering::SeqCst);
+    }
+
+    unsafe fn drop_join_waker(data: *const ()) {
+        // SAFETY: drop consumes the Arc reference represented by this waker.
+        drop(unsafe { Arc::<JoinWakeState>::from_raw(data.cast()) });
+        panic!("hostile public-join waker destructor");
+    }
+
+    static JOIN_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+        clone_join_waker,
+        wake_join_waker,
+        wake_by_ref_join_waker,
+        drop_join_waker,
+    );
+
+    fn panicking_drop_join_waker() -> (ManuallyDrop<Waker>, Arc<JoinWakeState>) {
+        let state = Arc::new(JoinWakeState::default());
+        let raw = RawWaker::new(Arc::into_raw(Arc::clone(&state)).cast(), &JOIN_WAKER_VTABLE);
+        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+        // ownership across clone, wake, and drop.
+        let waker = unsafe { Waker::from_raw(raw) };
+        (ManuallyDrop::new(waker), state)
     }
 
     #[tokio::test]
@@ -852,6 +963,55 @@ mod tests {
                 message: Some(message)
             } if message == "blocking work panic"
         ));
+    }
+
+    /// Tokio's ready join result can own the task's opaque panic payload while
+    /// dropping the caller waker retained in the handle trailer. Combining a
+    /// panicking payload destructor with a panicking waker destructor used to
+    /// make that geometry abort the process. This test intentionally installs
+    /// both; nextest's process isolation turns a regression into this test's
+    /// failure rather than taking the whole suite with it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_polled_join_separates_hostile_waker_and_panic_payload_destruction() {
+        let (release, released) = tokio::sync::oneshot::channel();
+        let (payload_dropped, payload_dropped_rx) = mpsc::channel();
+        let handle = super::spawn(async move {
+            let _ = released.await;
+            panic::panic_any(PanickingDrop(payload_dropped));
+        });
+        let mut join = Box::pin(super::join_user_polled(handle));
+        let (hostile, state) = panicking_drop_join_waker();
+
+        assert!(matches!(
+            join.as_mut().poll(&mut Context::from_waker(&hostile)),
+            Poll::Pending
+        ));
+        release.send(()).expect("the panicking task is still live");
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !state.0.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the completed task wakes its public join waiter");
+
+        assert!(matches!(
+            join.as_mut().poll(&mut Context::from_waker(&hostile)),
+            Poll::Ready(super::JoinOutcome::Panic { message: None })
+        ));
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                match payload_dropped_rx.try_recv() {
+                    Ok(()) => break,
+                    Err(mpsc::TryRecvError::Empty) => tokio::task::yield_now().await,
+                    Err(mpsc::TryRecvError::Disconnected) => {
+                        panic!("the hostile panic payload was not destroyed")
+                    }
+                }
+            }
+        })
+        .await
+        .expect("the hostile panic payload reaches detached disposal");
     }
 
     #[test]

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -112,7 +112,14 @@ impl SystemRun {
         let Some(driver) = self.driver.take() else {
             return;
         };
-        if let Err(exit) = classify_retained_root_driver_join(runtime::join(driver).await) {
+        // This is the sole production join polled directly by a public API
+        // caller: `System::wait`, `System::shutdown`, and startup rollback all
+        // converge here. The other joins are framework-task venues -- the
+        // root monitor below, child monitors, and raw offload reclamation --
+        // and therefore keep the ordinary runtime join path.
+        if let Err(exit) =
+            classify_retained_root_driver_join(runtime::join_user_polled(driver).await)
+        {
             self.root
                 .finish_live_root_incarnation(StopReason::ShutdownRequested, exit);
         }

--- a/crates/shelterwood/src/driver/tests.rs
+++ b/crates/shelterwood/src/driver/tests.rs
@@ -9,6 +9,7 @@ mod retained_outcomes;
 mod shutdown;
 mod startup;
 mod support;
+mod system_join;
 mod terminalization;
 
 pub(crate) use dynamic::exercise_queued_fused_drop_before_exit_dispatch;

--- a/crates/shelterwood/src/driver/tests/system_join.rs
+++ b/crates/shelterwood/src/driver/tests/system_join.rs
@@ -1,0 +1,100 @@
+use std::{
+    mem::ManuallyDrop,
+    sync::Arc,
+    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+};
+
+use super::support::*;
+use crate::{cells::RetainedStopReason, policy::ScopeFlavor};
+
+#[derive(Default)]
+struct HostileWakeState {
+    woken: tokio::sync::Notify,
+}
+
+unsafe fn clone_hostile_waker(data: *const ()) -> RawWaker {
+    // SAFETY: every pointer using this vtable came from an Arc of the
+    // matching type. ManuallyDrop preserves the reference represented by
+    // `data`; the returned raw waker owns only the new clone.
+    let state = ManuallyDrop::new(unsafe { Arc::<HostileWakeState>::from_raw(data.cast()) });
+    RawWaker::new(
+        Arc::into_raw(Arc::clone(&state)).cast(),
+        &HOSTILE_WAKER_VTABLE,
+    )
+}
+
+unsafe fn wake_hostile_waker(data: *const ()) {
+    // SAFETY: wake consumes the Arc reference represented by this raw waker.
+    let state = unsafe { Arc::<HostileWakeState>::from_raw(data.cast()) };
+    state.woken.notify_one();
+}
+
+unsafe fn wake_by_ref_hostile_waker(data: *const ()) {
+    // SAFETY: ManuallyDrop preserves the reference represented by `data`.
+    let state = ManuallyDrop::new(unsafe { Arc::<HostileWakeState>::from_raw(data.cast()) });
+    state.woken.notify_one();
+}
+
+unsafe fn drop_hostile_waker(data: *const ()) {
+    // SAFETY: drop consumes the Arc reference represented by this raw waker.
+    drop(unsafe { Arc::<HostileWakeState>::from_raw(data.cast()) });
+    panic!("injected SystemRun join caller-waker drop panic");
+}
+
+static HOSTILE_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    clone_hostile_waker,
+    wake_hostile_waker,
+    wake_by_ref_hostile_waker,
+    drop_hostile_waker,
+);
+
+fn hostile_waker() -> (ManuallyDrop<Waker>, Arc<HostileWakeState>) {
+    let state = Arc::new(HostileWakeState::default());
+    let raw = RawWaker::new(
+        Arc::into_raw(Arc::clone(&state)).cast(),
+        &HOSTILE_WAKER_VTABLE,
+    );
+    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+    // ownership across clone, wake, and drop.
+    let waker = unsafe { Waker::from_raw(raw) };
+    (ManuallyDrop::new(waker), state)
+}
+
+/// `SystemRun::wait` is the exact common seam reached by public
+/// `System::wait`, `System::shutdown`, and startup rollback after their
+/// operation-specific waits. Publish terminal scope state up front and hold a
+/// synthetic driver behind a latch, so the first poll reaches a provably
+/// pending driver join without relying on the scheduler interval between the
+/// real driver's terminal publication and completion.
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+async fn system_run_wait_proxies_a_pending_driver_join_caller_waker() {
+    let root = isolated_scope("root", ScopeFlavor::Ordered);
+    root.terminalize_never_started();
+
+    let release = Latch::default();
+    let driver_release = release.clone();
+    let driver = crate::runtime::spawn(async move {
+        driver_release.fired().await;
+        RetainedStopReason::new(StopReason::NeverStarted)
+    });
+    let mut run = super::super::SystemRun {
+        root,
+        driver: Some(driver),
+    };
+    let mut wait = Box::pin(run.wait());
+    let (hostile, state) = hostile_waker();
+
+    assert!(matches!(
+        wait.as_mut().poll(&mut Context::from_waker(&hostile)),
+        Poll::Pending
+    ));
+    assert!(release.fire(), "the synthetic driver is released once");
+    assert!(matches!(
+        crate::runtime::timeout(DRIVER_PROGRESS_WAIT, state.woken.notified()).await,
+        crate::runtime::Timeout::Completed(())
+    ));
+    assert!(matches!(
+        wait.as_mut().poll(&mut Context::from_waker(&hostile)),
+        Poll::Ready(StopReason::NeverStarted)
+    ));
+}

--- a/crates/shelterwood/src/tree/admission.rs
+++ b/crates/shelterwood/src/tree/admission.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt,
-    future::Future,
+    future::{Future, poll_fn},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -53,15 +53,18 @@ impl<H> PendingAdmission<H> {
             Arc::clone(&self.reservation.slot),
             self.fused_cancel.clone(),
         )?;
+        let mut response = crate::runtime::DisposingReceiver::new(response);
         Ok(Box::pin(async move {
-            response.receive().await.unwrap_or_else(|| {
-                // The driver's admission `Obligation` publishes an outcome on
-                // every path, including its drop fallback. Treat a missing
-                // response as the scope having gone terminal so a caller is
-                // never stranded, but fail loudly: silence here would mask
-                // an obligation regression.
-                panic!("admission response obligation must complete");
-            })
+            poll_fn(|context| response.poll_receive(context))
+                .await
+                .unwrap_or_else(|| {
+                    // The driver's admission `Obligation` publishes an outcome on
+                    // every path, including its drop fallback. Treat a missing
+                    // response as the scope having gone terminal so a caller is
+                    // never stranded, but fail loudly: silence here would mask
+                    // an obligation regression.
+                    panic!("admission response obligation must complete");
+                })
         }))
     }
 
@@ -234,16 +237,19 @@ impl fmt::Debug for Removal {
 
 impl Removal {
     pub(super) fn new(response: crate::driver::RemovalResponse) -> Self {
+        let mut response = crate::runtime::DisposingReceiver::new(response);
         Self {
             inner: Box::pin(async move {
-                response.receive().await.unwrap_or_else(|| {
-                    // The driver's removal `Obligation` publishes `Removed`
-                    // on every destruction path. A missing response therefore
-                    // means the terminal route vanished after removal latched:
-                    // preserve the removal goal, but flag the invariant break
-                    // just as admission does above.
-                    panic!("removal response obligation must complete");
-                })
+                poll_fn(|context| response.poll_receive(context))
+                    .await
+                    .unwrap_or_else(|| {
+                        // The driver's removal `Obligation` publishes `Removed`
+                        // on every destruction path. A missing response therefore
+                        // means the terminal route vanished after removal latched:
+                        // preserve the removal goal, but flag the invariant break
+                        // just as admission does above.
+                        panic!("removal response obligation must complete");
+                    })
             }),
         }
     }

--- a/crates/shelterwood/tests/admission_removal_waker_proxy.rs
+++ b/crates/shelterwood/tests/admission_removal_waker_proxy.rs
@@ -1,3 +1,11 @@
+//! Public-path pins that `Admission` and `Removal` never park the caller's
+//! raw waker in Tokio's one-shot: reverting either to the raw receive makes
+//! its fixture fail at hostile caller-waker destruction. On the fixed path
+//! response publication consumes the installed clone through the proxy wake,
+//! so the hostile drop vtable never fires here — contained ready-path
+//! destruction and the detached cancellation venue are pinned by
+//! `shelterwood-runtime`'s `sync` unit tests instead.
+
 mod common;
 
 use std::{
@@ -57,7 +65,7 @@ fn panicking_drop_waker() -> Waker {
 /// deterministic: no driver task can publish the response during that poll.
 /// The later Running projection is downstream of response publication.
 #[tokio::test]
-async fn successful_admission_contains_waker_retirement_and_returns_the_exact_handle() {
+async fn successful_admission_never_parks_its_caller_waker_and_returns_the_exact_handle() {
     let system = DynamicTree::new().spawn().expect("runtime is available");
     system.wait_started().await.expect("dynamic root starts");
     let scope = system.scope();
@@ -95,9 +103,10 @@ async fn successful_admission_contains_waker_retirement_and_returns_the_exact_ha
 /// Exact-handle removal is latched synchronously, so its first manual poll is
 /// pending before the current-thread driver can run. Once the Removed edge is
 /// visible, response publication follows in the same driver turn. The stale
-/// exact handle must still resolve AlreadyAbsent after the hostile retirement.
+/// exact handle must still resolve AlreadyAbsent with the hostile caller
+/// waker kept out of the one-shot.
 #[tokio::test]
-async fn exact_removal_contains_waker_retirement_and_preserves_its_outcomes() {
+async fn exact_removal_never_parks_its_caller_waker_and_preserves_its_outcomes() {
     let system = DynamicTree::new().spawn().expect("runtime is available");
     system.wait_started().await.expect("dynamic root starts");
     let scope = system.scope();

--- a/crates/shelterwood/tests/admission_removal_waker_proxy.rs
+++ b/crates/shelterwood/tests/admission_removal_waker_proxy.rs
@@ -1,0 +1,145 @@
+mod common;
+
+use std::{
+    future::Future,
+    mem::ManuallyDrop,
+    sync::Arc,
+    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+    time::Duration,
+};
+
+use common::{assert_eventually, waiting::task as waiting_task};
+use shelterwood::{ChildState, DynamicTree, RemoveOutcome};
+
+unsafe fn clone_panicking_drop_waker(data: *const ()) -> RawWaker {
+    // SAFETY: every pointer using this vtable came from an Arc of the
+    // matching type. ManuallyDrop preserves the reference represented by
+    // `data`; the returned raw waker owns only the new clone.
+    let state = ManuallyDrop::new(unsafe { Arc::<()>::from_raw(data.cast()) });
+    RawWaker::new(
+        Arc::into_raw(Arc::clone(&state)).cast(),
+        &PANICKING_DROP_WAKER_VTABLE,
+    )
+}
+
+unsafe fn wake_panicking_drop_waker(data: *const ()) {
+    // SAFETY: wake consumes the Arc reference represented by this raw waker.
+    drop(unsafe { Arc::<()>::from_raw(data.cast()) });
+}
+
+unsafe fn wake_by_ref_panicking_drop_waker(_data: *const ()) {}
+
+unsafe fn drop_panicking_drop_waker(data: *const ()) {
+    // SAFETY: drop consumes the Arc reference represented by this raw waker.
+    drop(unsafe { Arc::<()>::from_raw(data.cast()) });
+    panic!("injected admission/removal caller-waker drop panic");
+}
+
+static PANICKING_DROP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    clone_panicking_drop_waker,
+    wake_panicking_drop_waker,
+    wake_by_ref_panicking_drop_waker,
+    drop_panicking_drop_waker,
+);
+
+fn panicking_drop_waker() -> Waker {
+    let raw = RawWaker::new(
+        Arc::into_raw(Arc::new(())).cast(),
+        &PANICKING_DROP_WAKER_VTABLE,
+    );
+    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+    // ownership across clone, wake, and drop.
+    unsafe { Waker::from_raw(raw) }
+}
+
+/// Admission does not enqueue its driver request until first poll. A
+/// current-thread runtime therefore makes the pending registration
+/// deterministic: no driver task can publish the response during that poll.
+/// The later Running projection is downstream of response publication.
+#[tokio::test]
+async fn successful_admission_contains_waker_retirement_and_returns_the_exact_handle() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+    let slot = scope.reserve_task("proxied-admission").expect("id is free");
+    let expected = slot.task_ref();
+    let mut admission = Box::pin(slot.define(waiting_task()));
+    let hostile = ManuallyDrop::new(panicking_drop_waker());
+
+    assert!(matches!(
+        admission.as_mut().poll(&mut Context::from_waker(&hostile)),
+        Poll::Pending
+    ));
+    assert_eventually!(
+        || scope
+            .as_scope()
+            .child("proxied-admission")
+            .is_some_and(|child| matches!(child.state, ChildState::Running)),
+        "the driver did not start the admitted task"
+    )
+    .await;
+
+    let Poll::Ready(Ok(admitted)) = admission.as_mut().poll(&mut Context::from_waker(&hostile))
+    else {
+        panic!("the published admission response is ready")
+    };
+    assert_eq!(admitted, expected, "admission returns its reserved handle");
+
+    assert_eq!(scope.remove_task(&admitted).await, RemoveOutcome::Removed);
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root stops");
+}
+
+/// Exact-handle removal is latched synchronously, so its first manual poll is
+/// pending before the current-thread driver can run. Once the Removed edge is
+/// visible, response publication follows in the same driver turn. The stale
+/// exact handle must still resolve AlreadyAbsent after the hostile retirement.
+#[tokio::test]
+async fn exact_removal_contains_waker_retirement_and_preserves_its_outcomes() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("dynamic root starts");
+    let scope = system.scope();
+    let task = scope
+        .add_task("proxied-removal", waiting_task())
+        .await
+        .expect("task is admitted");
+    let mut removal = Box::pin(scope.remove_task(&task));
+    let hostile = ManuallyDrop::new(panicking_drop_waker());
+
+    assert!(matches!(
+        removal.as_mut().poll(&mut Context::from_waker(&hostile)),
+        Poll::Pending
+    ));
+    assert_eventually!(
+        || scope.as_scope().child("proxied-removal").is_none(),
+        "the driver did not publish the Removed edge"
+    )
+    .await;
+    tokio::task::yield_now().await;
+
+    assert!(matches!(
+        removal.as_mut().poll(&mut Context::from_waker(&hostile)),
+        Poll::Ready(RemoveOutcome::Removed)
+    ));
+    let replacement = scope
+        .add_task("proxied-removal", waiting_task())
+        .await
+        .expect("the removed id is reusable");
+    assert_eq!(
+        scope.remove_task(&task).await,
+        RemoveOutcome::AlreadyAbsent,
+        "a stale exact handle cannot remove a successor"
+    );
+    assert_eq!(
+        scope.remove_task(&replacement).await,
+        RemoveOutcome::Removed,
+        "the exact successor handle remains authoritative"
+    );
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("dynamic root stops");
+}

--- a/crates/shelterwood/tests/system_join_waker_proxy.rs
+++ b/crates/shelterwood/tests/system_join_waker_proxy.rs
@@ -17,22 +17,28 @@ use shelterwood::{
 #[derive(Default)]
 struct BlockingWakeState {
     started: tokio::sync::Notify,
-    release: Mutex<(usize, bool)>,
+    release: Mutex<WakeRelease>,
     released: Condvar,
+}
+
+#[derive(Default)]
+struct WakeRelease {
+    started: usize,
+    released: usize,
+    shutdown: bool,
 }
 
 impl BlockingWakeState {
     fn run(&self) {
-        self.started.notify_one();
         let mut release = self.release.lock().expect("release mutex is not poisoned");
-        while release.0 == 0 && !release.1 {
+        release.started += 1;
+        let sequence = release.started;
+        self.started.notify_one();
+        while release.released < sequence && !release.shutdown {
             release = self
                 .released
                 .wait(release)
                 .expect("release mutex is not poisoned");
-        }
-        if !release.1 {
-            release.0 -= 1;
         }
     }
 }
@@ -56,9 +62,28 @@ impl WakeController {
     }
 
     async fn wait_until_wake_is_blocked(&self) {
-        tokio::time::timeout(POLL_TIMEOUT, self.0.started.notified())
-            .await
-            .expect("the system future is woken before the progress bound");
+        tokio::time::timeout(POLL_TIMEOUT, async {
+            loop {
+                // Register before sampling the counter so a wake starting
+                // between those operations leaves either a visible counter
+                // edge or a stored notification permit.
+                let started = self.0.started.notified();
+                {
+                    let release = self
+                        .0
+                        .release
+                        .lock()
+                        .expect("release mutex is not poisoned");
+                    assert!(!release.shutdown, "the wake gate remains live");
+                    if release.started > release.released {
+                        return;
+                    }
+                }
+                started.await;
+            }
+        })
+        .await
+        .expect("the system future is woken before the progress bound");
     }
 
     fn release_one(&self) {
@@ -67,8 +92,28 @@ impl WakeController {
             .release
             .lock()
             .expect("release mutex is not poisoned");
-        release.0 += 1;
-        self.0.released.notify_one();
+        assert!(
+            release.released < release.started,
+            "a blocked wake exists before it is released"
+        );
+        release.released += 1;
+        // Every waiter rechecks its own sequence, so only the earliest
+        // unreleased wake can leave even though all are notified.
+        self.0.released.notify_all();
+    }
+
+    fn release_all_started(&self) {
+        let mut release = self
+            .0
+            .release
+            .lock()
+            .expect("release mutex is not poisoned");
+        assert!(
+            release.released < release.started,
+            "a blocked wake exists before the blocked prefix is released"
+        );
+        release.released = release.started;
+        self.0.released.notify_all();
     }
 }
 
@@ -79,7 +124,7 @@ impl Drop for WakeController {
             .release
             .lock()
             .unwrap_or_else(|error| error.into_inner());
-        release.1 = true;
+        release.shutdown = true;
         self.0.released.notify_all();
     }
 }
@@ -145,8 +190,11 @@ fn hostile_waker() -> (ManuallyDrop<Waker>, Arc<HostileWakeState>) {
 
 /// Drives a public system future to the narrow interval after its root scope
 /// has published Stopped but before its root driver can return. The benign
-/// waker is deliberately blocked inside that terminal publication, making the
-/// following poll deterministically reach the still-pending Tokio join handle.
+/// waker is deliberately blocked inside that terminal publication. Wake calls
+/// are released strictly in arrival order, and each poll happens before the
+/// corresponding state sample. If that poll crosses into the join while
+/// Stopped is being published, the hostile replacement is therefore installed
+/// before the blocked publisher is released.
 async fn park_hostile_waker_in_driver_join<F: Future>(
     mut future: Pin<&mut F>,
     scope: &ScopeRef,
@@ -155,6 +203,10 @@ async fn park_hostile_waker_in_driver_join<F: Future>(
 ) -> (ManuallyDrop<Waker>, Arc<HostileWakeState>) {
     for _ in 0..16 {
         controller.wait_until_wake_is_blocked().await;
+        assert!(matches!(
+            future.as_mut().poll(&mut Context::from_waker(benign)),
+            Poll::Pending
+        ));
         if matches!(scope.snapshot().state, ScopeState::Stopped { .. }) {
             let (hostile, state) = hostile_waker();
             assert!(matches!(
@@ -164,10 +216,6 @@ async fn park_hostile_waker_in_driver_join<F: Future>(
             return (hostile, state);
         }
 
-        assert!(matches!(
-            future.as_mut().poll(&mut Context::from_waker(benign)),
-            Poll::Pending
-        ));
         controller.release_one();
     }
     panic!("the system did not publish its terminal scope state");
@@ -200,7 +248,7 @@ async fn system_wait_contains_join_waker_retirement() {
 
     let (hostile, state) =
         park_hostile_waker_in_driver_join(wait.as_mut(), &scope, &controller, &benign).await;
-    controller.release_one();
+    controller.release_all_started();
     wait_for_join_wake(&state).await;
     assert!(matches!(
         wait.as_mut().poll(&mut Context::from_waker(&hostile)),
@@ -226,7 +274,7 @@ async fn system_shutdown_contains_join_waker_retirement() {
 
     let (hostile, state) =
         park_hostile_waker_in_driver_join(shutdown.as_mut(), &scope, &controller, &benign).await;
-    controller.release_one();
+    controller.release_all_started();
     wait_for_join_wake(&state).await;
     assert!(matches!(
         shutdown.as_mut().poll(&mut Context::from_waker(&hostile)),
@@ -259,7 +307,7 @@ async fn start_or_shutdown_contains_join_waker_retirement() {
 
     let (hostile, state) =
         park_hostile_waker_in_driver_join(rollback.as_mut(), &scope, &controller, &benign).await;
-    controller.release_one();
+    controller.release_all_started();
     wait_for_join_wake(&state).await;
     let Poll::Ready(Err(error)) = rollback.as_mut().poll(&mut Context::from_waker(&hostile)) else {
         panic!("startup failure is returned after rollback")

--- a/crates/shelterwood/tests/system_join_waker_proxy.rs
+++ b/crates/shelterwood/tests/system_join_waker_proxy.rs
@@ -10,9 +10,7 @@ use std::{
 };
 
 use common::{POLL_TIMEOUT, policy::never, waiting};
-use shelterwood::{
-    ExitError, Readiness, ScopeRef, ScopeState, StartupError, StopReason, TaskDef, Tree,
-};
+use shelterwood::{ExitError, Readiness, ScopeRef, ScopeState, StartupError, TaskDef, Tree};
 
 #[derive(Default)]
 struct BlockingWakeState {
@@ -225,36 +223,6 @@ async fn wait_for_join_wake(state: &HostileWakeState) {
     tokio::time::timeout(POLL_TIMEOUT, state.woken.notified())
         .await
         .expect("the joined root driver wakes its public waiter");
-}
-
-/// `System::wait` reaches the shared `join_driver` seam after the natural
-/// terminal wait. A hostile caller-waker destructor must be contained before
-/// the joined output is handed back.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn system_wait_contains_join_waker_retirement() {
-    let system = waiting::tree().spawn().expect("runtime is available");
-    system.wait_started().await.expect("root starts");
-    let scope = system.scope();
-    let (controller, benign) = WakeController::new();
-    let mut wait = Box::pin(system.wait());
-    assert!(matches!(
-        wait.as_mut().poll(&mut Context::from_waker(&benign)),
-        Poll::Pending
-    ));
-    // Request from a foreign thread because this test intentionally blocks
-    // the registered waker inside the synchronous request publication.
-    let shutdown_scope = scope.clone();
-    let requester = std::thread::spawn(move || shutdown_scope.request_shutdown());
-
-    let (hostile, state) =
-        park_hostile_waker_in_driver_join(wait.as_mut(), &scope, &controller, &benign).await;
-    controller.release_all_started();
-    wait_for_join_wake(&state).await;
-    assert!(matches!(
-        wait.as_mut().poll(&mut Context::from_waker(&hostile)),
-        Poll::Ready(StopReason::ShutdownRequested)
-    ));
-    requester.join().expect("shutdown requester returns");
 }
 
 /// `System::shutdown` performs the same root-driver join after its bounded

--- a/crates/shelterwood/tests/system_join_waker_proxy.rs
+++ b/crates/shelterwood/tests/system_join_waker_proxy.rs
@@ -1,3 +1,11 @@
+//! Public-path pins that a system join never parks the caller's raw waker in
+//! Tokio's join trailer: reverting `join_driver` to the raw `runtime::join`
+//! makes each fixture fail at hostile caller-waker destruction. On the fixed
+//! path every driver completion consumes the installed clone through the
+//! proxy wake, so the hostile drop vtable never fires here — contained
+//! ready-path destruction and the detached cancellation venue are pinned by
+//! `shelterwood-runtime`'s `spawn` unit tests instead.
+
 mod common;
 
 use std::{
@@ -229,7 +237,7 @@ async fn wait_for_join_wake(state: &HostileWakeState) {
 /// shutdown wait, so it must carry the proxy even though the public output is
 /// the timeout verdict rather than the root stop reason.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn system_shutdown_contains_join_waker_retirement() {
+async fn system_shutdown_never_parks_its_caller_waker_in_the_driver_join() {
     let system = waiting::tree().spawn().expect("runtime is available");
     system.wait_started().await.expect("root starts");
     let scope = system.scope();
@@ -252,9 +260,9 @@ async fn system_shutdown_contains_join_waker_retirement() {
 
 /// Startup rollback consumes the same system owner and reaches the same join
 /// seam only after preserving the startup error. This pins both pieces: proxy
-/// retirement cannot replace the error, and rollback remains successful.
+/// proxied join cannot displace the error, and rollback remains successful.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn start_or_shutdown_contains_join_waker_retirement() {
+async fn start_or_shutdown_never_parks_its_caller_waker_in_the_driver_join() {
     let mut tree = Tree::new();
     tree.add_task(
         "failure",

--- a/crates/shelterwood/tests/system_join_waker_proxy.rs
+++ b/crates/shelterwood/tests/system_join_waker_proxy.rs
@@ -1,0 +1,269 @@
+mod common;
+
+use std::{
+    future::Future,
+    mem::ManuallyDrop,
+    pin::Pin,
+    sync::{Arc, Condvar, Mutex},
+    task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker},
+    time::Duration,
+};
+
+use common::{POLL_TIMEOUT, policy::never, waiting};
+use shelterwood::{
+    ExitError, Readiness, ScopeRef, ScopeState, StartupError, StopReason, TaskDef, Tree,
+};
+
+#[derive(Default)]
+struct BlockingWakeState {
+    started: tokio::sync::Notify,
+    release: Mutex<(usize, bool)>,
+    released: Condvar,
+}
+
+impl BlockingWakeState {
+    fn run(&self) {
+        self.started.notify_one();
+        let mut release = self.release.lock().expect("release mutex is not poisoned");
+        while release.0 == 0 && !release.1 {
+            release = self
+                .released
+                .wait(release)
+                .expect("release mutex is not poisoned");
+        }
+        if !release.1 {
+            release.0 -= 1;
+        }
+    }
+}
+
+impl Wake for BlockingWakeState {
+    fn wake(self: Arc<Self>) {
+        self.run();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.run();
+    }
+}
+
+struct WakeController(Arc<BlockingWakeState>);
+
+impl WakeController {
+    fn new() -> (Self, Waker) {
+        let state = Arc::new(BlockingWakeState::default());
+        (Self(Arc::clone(&state)), Waker::from(state))
+    }
+
+    async fn wait_until_wake_is_blocked(&self) {
+        tokio::time::timeout(POLL_TIMEOUT, self.0.started.notified())
+            .await
+            .expect("the system future is woken before the progress bound");
+    }
+
+    fn release_one(&self) {
+        let mut release = self
+            .0
+            .release
+            .lock()
+            .expect("release mutex is not poisoned");
+        release.0 += 1;
+        self.0.released.notify_one();
+    }
+}
+
+impl Drop for WakeController {
+    fn drop(&mut self) {
+        let mut release = self
+            .0
+            .release
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        release.1 = true;
+        self.0.released.notify_all();
+    }
+}
+
+#[derive(Default)]
+struct HostileWakeState {
+    woken: tokio::sync::Notify,
+}
+
+impl HostileWakeState {
+    fn wake(&self) {
+        self.woken.notify_one();
+    }
+}
+
+unsafe fn clone_hostile_waker(data: *const ()) -> RawWaker {
+    // SAFETY: every pointer using this vtable came from an Arc of the
+    // matching type. ManuallyDrop preserves the reference represented by
+    // `data`; the returned raw waker owns only the new clone.
+    let state = ManuallyDrop::new(unsafe { Arc::<HostileWakeState>::from_raw(data.cast()) });
+    RawWaker::new(
+        Arc::into_raw(Arc::clone(&state)).cast(),
+        &HOSTILE_WAKER_VTABLE,
+    )
+}
+
+unsafe fn wake_hostile_waker(data: *const ()) {
+    // SAFETY: wake consumes the Arc reference represented by this raw waker.
+    let state = unsafe { Arc::<HostileWakeState>::from_raw(data.cast()) };
+    state.wake();
+}
+
+unsafe fn wake_by_ref_hostile_waker(data: *const ()) {
+    // SAFETY: ManuallyDrop preserves the reference represented by `data`.
+    let state = ManuallyDrop::new(unsafe { Arc::<HostileWakeState>::from_raw(data.cast()) });
+    state.wake();
+}
+
+unsafe fn drop_hostile_waker(data: *const ()) {
+    // SAFETY: drop consumes the Arc reference represented by this raw waker.
+    drop(unsafe { Arc::<HostileWakeState>::from_raw(data.cast()) });
+    panic!("injected system-join caller-waker drop panic");
+}
+
+static HOSTILE_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    clone_hostile_waker,
+    wake_hostile_waker,
+    wake_by_ref_hostile_waker,
+    drop_hostile_waker,
+);
+
+fn hostile_waker() -> (ManuallyDrop<Waker>, Arc<HostileWakeState>) {
+    let state = Arc::new(HostileWakeState::default());
+    let raw = RawWaker::new(
+        Arc::into_raw(Arc::clone(&state)).cast(),
+        &HOSTILE_WAKER_VTABLE,
+    );
+    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+    // ownership across clone, wake, and drop.
+    let waker = unsafe { Waker::from_raw(raw) };
+    (ManuallyDrop::new(waker), state)
+}
+
+/// Drives a public system future to the narrow interval after its root scope
+/// has published Stopped but before its root driver can return. The benign
+/// waker is deliberately blocked inside that terminal publication, making the
+/// following poll deterministically reach the still-pending Tokio join handle.
+async fn park_hostile_waker_in_driver_join<F: Future>(
+    mut future: Pin<&mut F>,
+    scope: &ScopeRef,
+    controller: &WakeController,
+    benign: &Waker,
+) -> (ManuallyDrop<Waker>, Arc<HostileWakeState>) {
+    for _ in 0..16 {
+        controller.wait_until_wake_is_blocked().await;
+        if matches!(scope.snapshot().state, ScopeState::Stopped { .. }) {
+            let (hostile, state) = hostile_waker();
+            assert!(matches!(
+                future.as_mut().poll(&mut Context::from_waker(&hostile)),
+                Poll::Pending
+            ));
+            return (hostile, state);
+        }
+
+        assert!(matches!(
+            future.as_mut().poll(&mut Context::from_waker(benign)),
+            Poll::Pending
+        ));
+        controller.release_one();
+    }
+    panic!("the system did not publish its terminal scope state");
+}
+
+async fn wait_for_join_wake(state: &HostileWakeState) {
+    tokio::time::timeout(POLL_TIMEOUT, state.woken.notified())
+        .await
+        .expect("the joined root driver wakes its public waiter");
+}
+
+/// `System::wait` reaches the shared `join_driver` seam after the natural
+/// terminal wait. A hostile caller-waker destructor must be contained before
+/// the joined output is handed back.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn system_wait_contains_join_waker_retirement() {
+    let system = waiting::tree().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+    let (controller, benign) = WakeController::new();
+    let mut wait = Box::pin(system.wait());
+    assert!(matches!(
+        wait.as_mut().poll(&mut Context::from_waker(&benign)),
+        Poll::Pending
+    ));
+    // Request from a foreign thread because this test intentionally blocks
+    // the registered waker inside the synchronous request publication.
+    let shutdown_scope = scope.clone();
+    let requester = std::thread::spawn(move || shutdown_scope.request_shutdown());
+
+    let (hostile, state) =
+        park_hostile_waker_in_driver_join(wait.as_mut(), &scope, &controller, &benign).await;
+    controller.release_one();
+    wait_for_join_wake(&state).await;
+    assert!(matches!(
+        wait.as_mut().poll(&mut Context::from_waker(&hostile)),
+        Poll::Ready(StopReason::ShutdownRequested)
+    ));
+    requester.join().expect("shutdown requester returns");
+}
+
+/// `System::shutdown` performs the same root-driver join after its bounded
+/// shutdown wait, so it must carry the proxy even though the public output is
+/// the timeout verdict rather than the root stop reason.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn system_shutdown_contains_join_waker_retirement() {
+    let system = waiting::tree().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+    let (controller, benign) = WakeController::new();
+    let mut shutdown = Box::pin(system.shutdown(Duration::from_secs(1)));
+    assert!(matches!(
+        shutdown.as_mut().poll(&mut Context::from_waker(&benign)),
+        Poll::Pending
+    ));
+
+    let (hostile, state) =
+        park_hostile_waker_in_driver_join(shutdown.as_mut(), &scope, &controller, &benign).await;
+    controller.release_one();
+    wait_for_join_wake(&state).await;
+    assert!(matches!(
+        shutdown.as_mut().poll(&mut Context::from_waker(&hostile)),
+        Poll::Ready(Ok(()))
+    ));
+}
+
+/// Startup rollback consumes the same system owner and reaches the same join
+/// seam only after preserving the startup error. This pins both pieces: proxy
+/// retirement cannot replace the error, and rollback remains successful.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn start_or_shutdown_contains_join_waker_retirement() {
+    let mut tree = Tree::new();
+    tree.add_task(
+        "failure",
+        TaskDef::new(|_| async { Err(ExitError::message("startup failure")) })
+            .restart(never())
+            .readiness(Readiness::Manual)
+            .expect("manual readiness is supported"),
+    )
+    .expect("valid failing task");
+    let system = tree.spawn().expect("runtime is available");
+    let scope = system.scope();
+    let (controller, benign) = WakeController::new();
+    let mut rollback = Box::pin(system.start_or_shutdown(Duration::from_secs(1)));
+    assert!(matches!(
+        rollback.as_mut().poll(&mut Context::from_waker(&benign)),
+        Poll::Pending
+    ));
+
+    let (hostile, state) =
+        park_hostile_waker_in_driver_join(rollback.as_mut(), &scope, &controller, &benign).await;
+    controller.release_one();
+    wait_for_join_wake(&state).await;
+    let Poll::Ready(Err(error)) = rollback.as_mut().poll(&mut Context::from_waker(&hostile)) else {
+        panic!("startup failure is returned after rollback")
+    };
+    assert!(matches!(error.startup, StartupError::StartupFailed(_)));
+    assert!(error.rollback_timeout.is_none());
+}


### PR DESCRIPTION
Depends on #411 and is intentionally based on `agent/issue-407-offload-waker-proxy`. After #411 lands, this PR can be retargeted to `main` without changing its #409-only commits.

## Summary

- add a public-polling join wrapper that probes Tokio with a noop waker, parks only a stable framework proxy, and retires the caller waker before a ready join result crosses the boundary
- route the common `SystemRun::join_driver` seam used by `System::wait`, `System::shutdown`, and `start_or_shutdown` through that wrapper
- route public `Admission` and exact `Removal` one-shot receivers through #411's proxied `runtime::DisposingReceiver`
- add adversarial public-path regressions plus a scheduler-independent `SystemRun::wait` seam fixture for hostile caller-waker destruction, including a `JoinError::Panic` whose panic payload also panics on drop

## Handoff audit

The remaining supported public-user-polled sites are covered here:

- `SystemRun::join_driver`, shared by system wait, shutdown, and startup rollback
- `Admission`
- `Removal`

Related venues are accounted for as follows:

- `OneShotTaskRef::wait` and blocking one-shot receipt are covered by the #411 dependency
- mailbox reply futures are already covered by #405
- `monitor_root_driver`, child-driver monitoring, and raw offload joins are framework-task venues; they do not park caller-supplied public wakers and continue using the raw runtime join helper

The join ready path retires the caller waker first, then drops the Tokio handle while the returned result may own a panic payload. `PanicAccumulator` contains hostile retirement/destruction so the `JoinError::Panic` geometry cannot turn a second panic during unwind into an abort. Cancelling a still-pending public join instead transfers caller-waker destruction to detached disposal, keeping potentially blocking drop glue off the future holder's thread.

## Validation

- `./tools/dev cargo test -p shelterwood-runtime` — 68 passed
- `./tools/dev cargo test -p shelterwood --test result_delivery_waker_proxy --test admission_removal_waker_proxy --test system_join_waker_proxy` — 2 + 2 + 2 passed
- deterministic `SystemRun::wait` pending-join fixture — passed; terminal scope state is prepublished and a latch holds the synthetic driver incomplete, avoiding dependence on the real driver's terminal-publication/completion scheduler interval
- System join stress — 100/100 consecutive rounds passed (200 public shutdown/rollback executions plus 100 deterministic wait-seam executions)
- `./tools/dev cargo test -p shelterwood tree::admission::tests` — 5 passed
- mutation checks: removing the already-ready noop probe trips the caller-clone regression; removing synchronous ready retirement trips the narrow payload+waker ordering regression; making pending-drop retirement inline trips the detached-venue regression; reverting `join_driver` to raw `runtime::join` makes the deterministic `SystemRun::wait` seam fail at hostile waker drop; reverting Admission/Removal to raw receive makes both public one-shot regressions fail
- `./tools/dev just ci` — green, including 899/899 nextest tests, formatting, clippy, docs/doctests, public API reachability, packaging, and external-consumer checks

Closes #409
