### PR TITLE
docs: rustdoc pass — front page, error catalog, depth, carried backlog (#371 PR 2)

### DIFF
--- a/crates/shelterwood-core/src/exit.rs
+++ b/crates/shelterwood-core/src/exit.rs
@@ -121,6 +121,38 @@ pub type ExitResult = Result<(), ExitError>;
 ///
 /// This type deliberately does not implement [`std::error::Error`], allowing
 /// the blanket `From<E>` conversion without overlap.
+///
+/// There are two construction forms: [`ExitError::message`] wraps a plain
+/// displayable message, and the blanket [`From`] impl erases any
+/// `E: Error + Send + Sync + 'static`, which is what lets child code use `?`
+/// in a function returning [`ExitResult`]. Cloning is shallow: every clone
+/// shares one erased allocation, and that shared provenance is what
+/// [`Exit`]'s failed-payload equality compares.
+///
+/// Three accessors observe the payload: [`ExitError::as_error`] views the
+/// erased source error, while [`ExitError::intensity_trip`] and
+/// [`ExitError::startup_failure`] return the framework-authenticated
+/// structured payloads. The structured accessors answer `Some` only for
+/// errors the framework itself minted; converting an [`IntensityTrip`] or a
+/// [`StartupFailure`] through the blanket impl yields an ordinary
+/// application error for which both return `None`.
+///
+/// # Examples
+///
+/// ```
+/// # use shelterwood_core::ExitError;
+/// // From a displayable message.
+/// let error = ExitError::message("shard offline");
+/// assert_eq!(error.as_error().to_string(), "shard offline");
+///
+/// // From any std error via the blanket conversion.
+/// let error = ExitError::from(std::io::Error::other("disk full"));
+/// assert_eq!(error.as_error().to_string(), "disk full");
+///
+/// // User conversions never carry structured framework provenance.
+/// assert!(error.intensity_trip().is_none());
+/// assert!(error.startup_failure().is_none());
+/// ```
 #[derive(Clone)]
 pub struct ExitError(Arc<ExitErrorInner>);
 
@@ -414,6 +446,42 @@ pub enum GracePhase {
 /// publishes through snapshots and lifecycle events — compare equal,
 /// while two independently constructed errors with identical messages do
 /// not. Compare failure content through [`ExitError::as_error`] instead.
+///
+/// # Examples
+///
+/// Classification is an exhaustive match on [`Exit::kind`]; a
+/// [`ExitKind::Failed`] exit carries its application error in the variant
+/// payload:
+///
+/// ```
+/// # use shelterwood_core::{Cancellation, Exit, ExitError, ExitKind};
+/// fn describe(exit: &Exit) -> String {
+///     match exit.kind() {
+///         ExitKind::Completed => "completed".to_owned(),
+///         ExitKind::Failed(error) => {
+///             format!("failed: {}", error.as_error())
+///         }
+///         ExitKind::Panicked { message: Some(message) } => {
+///             format!("panicked: {message}")
+///         }
+///         ExitKind::Panicked { message: None } => "panicked".to_owned(),
+///         ExitKind::ReadinessTimedOut { deadline } => {
+///             format!("readiness deadline expired at {deadline:?}")
+///         }
+///         ExitKind::Aborted { phase } => format!("aborted: {phase:?}"),
+///         ExitKind::NeverStarted => "never started".to_owned(),
+///     }
+/// }
+///
+/// let failed =
+///     Exit::failed(ExitError::message("boom"), Cancellation::NotObserved);
+/// assert_eq!(describe(&failed), "failed: boom");
+/// assert!(failed.is_failure());
+///
+/// let completed = Exit::completed(Cancellation::Observed);
+/// assert_eq!(describe(&completed), "completed");
+/// assert!(!completed.is_failure());
+/// ```
 #[derive(Clone, Debug)]
 pub struct Exit {
     kind: ExitKind,

--- a/crates/shelterwood-core/src/exit.rs
+++ b/crates/shelterwood-core/src/exit.rs
@@ -26,6 +26,13 @@ pub enum StopReason {
     /// A nested scope could not complete startup.
     StartupFailed(StartupFailure),
     /// The membership terminalized without an incarnation.
+    ///
+    /// A *nested scope* that stops for this reason surfaces at its parent as
+    /// `ExitKind::Failed` carrying a message-only application error
+    /// ("nested scope never started") with no structured accessor — unlike
+    /// `IntensityTripped` and `StartupFailed`, whose projections stay
+    /// structured. A membership that never spawned surfaces as
+    /// `ExitKind::NeverStarted`.
     NeverStarted,
 }
 

--- a/crates/shelterwood-core/src/policy.rs
+++ b/crates/shelterwood-core/src/policy.rs
@@ -170,6 +170,9 @@ impl JitterSample {
     }
 
     /// Normalizes an integer ratio and clamps it into `[0, 1)`.
+    ///
+    /// A zero denominator — or any ratio that is not finite — maps to zero,
+    /// the bottom of the range, not the ceiling.
     #[must_use]
     pub fn from_u64_ratio(numerator: u64, denominator: u64) -> Self {
         Self::new(numerator as f64 / denominator as f64)
@@ -425,6 +428,8 @@ impl Backoff {
     /// Derives the delay for a one-origin restart attempt.
     ///
     /// Randomness is deliberately supplied as external, range-checked data.
+    /// `RestartAttempt::ZERO` is coerced to the first attempt and yields the
+    /// same delay as attempt 1.
     #[must_use]
     pub fn next_delay(self, attempt: RestartAttempt, jitter_sample: JitterSample) -> Duration {
         let attempt = attempt.get().max(1);

--- a/crates/shelterwood-core/src/policy.rs
+++ b/crates/shelterwood-core/src/policy.rs
@@ -118,6 +118,10 @@ pub struct NonZeroDuration(Duration);
 
 impl NonZeroDuration {
     /// Validates and constructs a non-zero duration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyError::ZeroDuration`] when `duration` is zero.
     pub fn new(duration: Duration) -> Result<Self, PolicyError> {
         if duration.is_zero() {
             Err(PolicyError::ZeroDuration)
@@ -185,6 +189,11 @@ pub struct BackoffFactor(f64);
 
 impl BackoffFactor {
     /// Validates and constructs a factor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyError::InvalidBackoffFactor`] when `value` is not
+    /// finite or is below `1.0`.
     pub fn new(value: f64) -> Result<Self, PolicyError> {
         let factor = Self(value);
         factor.validate()?;
@@ -255,6 +264,35 @@ impl std::hash::Hash for BackoffFactor {
 ///     max: Duration::from_secs(1),
 ///     jitter: Jitter::None,
 /// });
+/// ```
+///
+/// # Examples
+///
+/// Validated payloads come from [`Backoff::fixed`] and
+/// [`Backoff::exponential`]; [`Backoff::next_delay`] then derives each
+/// attempt's delay, clamped to the configured maximum:
+///
+/// ```
+/// # use std::time::Duration;
+/// # use shelterwood_core::{
+/// #     Backoff, BackoffFactor, Jitter, JitterSample, RestartAttempt,
+/// # };
+/// let backoff = Backoff::exponential(
+///     Duration::from_millis(10),
+///     BackoffFactor::new(2.0)?,
+///     Duration::from_millis(35),
+///     Jitter::None,
+/// )?;
+///
+/// let sample = JitterSample::new(0.0);
+/// let first = RestartAttempt::ZERO.bump();
+/// let second = first.bump();
+/// let third = second.bump();
+/// assert_eq!(backoff.next_delay(first, sample), Duration::from_millis(10));
+/// assert_eq!(backoff.next_delay(second, sample), Duration::from_millis(20));
+/// // The doubled third delay would exceed the maximum, so it clamps.
+/// assert_eq!(backoff.next_delay(third, sample), Duration::from_millis(35));
+/// # Ok::<(), shelterwood_core::PolicyError>(())
 /// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Backoff {
@@ -391,6 +429,10 @@ impl ExponentialBackoff {
 
 impl Backoff {
     /// Constructs a validated fixed backoff.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyError::ZeroDuration`] when `delay` is zero.
     pub fn fixed(delay: Duration, jitter: Jitter) -> Result<Self, PolicyError> {
         if delay.is_zero() {
             return Err(PolicyError::ZeroDuration);
@@ -400,8 +442,11 @@ impl Backoff {
 
     /// Constructs a validated exponential backoff.
     ///
-    /// Only [`PolicyError::ZeroDuration`] and
-    /// [`PolicyError::BackoffMaximumBeforeBase`] are reachable here: the
+    /// # Errors
+    ///
+    /// Returns [`PolicyError::ZeroDuration`] when `base` or `max` is zero,
+    /// and [`PolicyError::BackoffMaximumBeforeBase`] when `max` is shorter
+    /// than `base`. Only those two variants are reachable here: the
     /// multiplier carries its own invariant, so
     /// [`PolicyError::InvalidBackoffFactor`] is spent at
     /// [`BackoffFactor::new`] before this call can be written.
@@ -515,6 +560,37 @@ fn duration_from_nanos(nanos: f64) -> Duration {
 }
 
 /// Restart condition and delay policy for one child.
+///
+/// The [`Default`] policy restarts on failure with [`Backoff::Immediate`].
+///
+/// # Examples
+///
+/// Build a policy from validated parts and carry it as a scope default:
+///
+/// ```
+/// # use std::time::Duration;
+/// # use shelterwood_core::{
+/// #     Backoff, BackoffFactor, Jitter, RestartCondition, RestartPolicy,
+/// #     ScopeDefaults,
+/// # };
+/// let backoff = Backoff::exponential(
+///     Duration::from_millis(100),
+///     BackoffFactor::new(2.0)?,
+///     Duration::from_secs(5),
+///     Jitter::Equal,
+/// )?;
+/// let policy = RestartPolicy::new(RestartCondition::OnFailure, backoff);
+/// assert_eq!(policy.condition(), RestartCondition::OnFailure);
+/// assert_eq!(policy.backoff(), backoff);
+/// assert!(!policy.is_never());
+///
+/// let defaults = ScopeDefaults {
+///     child_restart: Some(policy),
+///     ..ScopeDefaults::default()
+/// };
+/// assert_eq!(defaults.child_restart, Some(policy));
+/// # Ok::<(), shelterwood_core::PolicyError>(())
+/// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct RestartPolicy {
     condition: RestartCondition,
@@ -583,6 +659,10 @@ impl Default for Shutdown {
 
 impl Shutdown {
     /// Constructs a graceful policy with a validated non-zero grace.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyError::ZeroDuration`] when `grace` is zero.
     pub fn graceful(grace: Duration) -> Result<Self, PolicyError> {
         Ok(Self::Graceful {
             grace: NonZeroDuration::new(grace)?,
@@ -615,6 +695,10 @@ pub enum ReadinessDeadline {
 
 impl ReadinessDeadline {
     /// Constructs a validated bounded deadline.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyError::ZeroDuration`] when `duration` is zero.
     pub fn bounded(duration: Duration) -> Result<Self, PolicyError> {
         Ok(Self::Bounded(NonZeroDuration::new(duration)?))
     }
@@ -648,6 +732,21 @@ impl ReadinessDeadline {
 /// let intensity = Intensity::new(1, Duration::from_secs(1)).unwrap();
 /// let _ = intensity.within;
 /// ```
+///
+/// # Examples
+///
+/// Every budget passes through the validating constructor — the [`Default`]
+/// budget of five restarts within thirty seconds included — and the
+/// accessors return what it accepted:
+///
+/// ```
+/// # use std::time::Duration;
+/// # use shelterwood_core::Intensity;
+/// let budget = Intensity::new(5, Duration::from_secs(30))?;
+/// assert_eq!(budget.max_restarts(), 5);
+/// assert_eq!(budget.within(), Duration::from_secs(30));
+/// # Ok::<(), shelterwood_core::PolicyError>(())
+/// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Intensity {
     // Maximum restart charges allowed inside the rolling window.
@@ -658,6 +757,12 @@ pub struct Intensity {
 
 impl Intensity {
     /// Constructs a validated intensity budget.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyError::ZeroDuration`] when `within` is zero. A
+    /// `max_restarts` of zero is a valid budget that admits no restart
+    /// charge: the first charge trips the scope.
     pub fn new(max_restarts: u64, within: Duration) -> Result<Self, PolicyError> {
         if within.is_zero() {
             return Err(PolicyError::ZeroDuration);
@@ -703,6 +808,10 @@ pub enum Mailbox {
 
 impl Mailbox {
     /// Constructs a FIFO mailbox with an explicit capacity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyError::ZeroCapacity`] when `capacity` is zero.
     pub fn queue(capacity: usize) -> Result<Self, PolicyError> {
         NonZeroUsize::new(capacity)
             .map(|capacity| Self::Queue(Some(capacity)))

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -374,6 +374,12 @@ pub enum Either<L, R> {
     Right(R),
 }
 
+/// Polls two futures and resolves with the first to become ready.
+///
+/// Ties are contractual, not incidental: when both are ready in the same
+/// poll, `Left` always wins. Callers order a "won" edge before a
+/// "closed"/"completed" edge on exactly this bias — a latch that fired and
+/// completed must still report the fired side.
 pub async fn select_two<A, B>(left: A, right: B) -> Either<A::Output, B::Output>
 where
     A: Future + Send,

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -289,6 +289,12 @@ const COMPLETION_GATE_CLOSED_FIRED: u8 = 3;
 /// gate and reports whether the signal won first, so a capability retained by
 /// another task cannot publish after completion or disappear between a sample
 /// and the completion notification.
+///
+/// The wake lags the state: both transitions publish their state CAS before
+/// firing the corresponding latch, so `is_fired`/`is_completed` can read
+/// true while the matching waiter's wake is still in flight. A waiter racing
+/// `fired()` against `completed()` must resolve the tie by state or by
+/// left-biased selection (`select_two`), never by wake arrival order.
 #[derive(Clone, Debug)]
 pub struct CompletionGatedLatch {
     state: Arc<AtomicU8>,

--- a/crates/shelterwood/Cargo.toml
+++ b/crates/shelterwood/Cargo.toml
@@ -13,6 +13,10 @@ repository = "https://github.com/ralexstokes/shelterwood"
 [lints]
 workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--generate-link-to-definition"]
+
 [dependencies]
 shelterwood-core.workspace = true
 shelterwood-runtime.workspace = true

--- a/crates/shelterwood/docs/errors.md
+++ b/crates/shelterwood/docs/errors.md
@@ -1,0 +1,82 @@
+# The error catalog
+
+Which error type means what, and what to match on. Messaging errors carry
+*identity evidence* — the incarnation observed or accepting — because the
+retry discipline consumes it; treat those tokens as part of the protocol,
+not diagnostic metadata.
+
+## One rule before the tables
+
+Every kind below answers one question: **was the request accepted?** A
+pre-acceptance failure is guaranteed-never-accepted, so retrying cannot
+duplicate an effect. A post-acceptance failure has an unknown outcome, so
+only application ground truth can license a resend. The
+[retry guide](crate::guides::retry_and_ordering) turns this into a recipe.
+
+## `SendError` (`send`, `try_send`, `send_timeout`)
+
+The failed message is recovered in the error's public `message` field, so
+a failed send loses nothing.
+
+| `SendErrorKind` | Returned by | Meaning | Accepted? |
+| --- | --- | --- | --- |
+| `NotRunning` | `try_send` only | Membership currently not accepting: a restart rebind window, or intake frozen at stop. | No — safe to retry or reroute. |
+| `Full` | `try_send` only | Queue mailbox at capacity (latest-value mailboxes accept by replacement instead). | No — apply backpressure. |
+| `Terminated` | all flavors | Membership is terminal. The only failure plain `send` can return: it waits through rebind windows and backpressure. | No — the handle is permanently dead; a same-id replacement needs a new handle. |
+| `TimedOut` | `send_timeout` only | Deadline hit; the message was withdrawn and recovered. | No — guaranteed-never-accepted. |
+
+`incarnation_observed` is pinned per kind: `Full` always names the bound
+incarnation; `NotRunning` names the stopping incarnation at an intake
+freeze and is `None` in a rebind window or pre-spawn; `Terminated` names
+the membership's final incarnation (`None` if none ever ran); `TimedOut`
+names the newest incarnation observed bound during the attempt.
+
+## `CallError` (`call`)
+
+One deadline covers message construction, mailbox acceptance, and the
+reply.
+
+| `CallErrorKind` | Meaning | Accepted? | Required action |
+| --- | --- | --- | --- |
+| `Terminated` | Membership terminal before acceptance. | No | Obtain the replacement's new handle deliberately. |
+| `AcceptanceTimedOut` | Deadline hit before acceptance; the request was withdrawn. | No | Retrying is safe within the operation's overall deadline. |
+| `ResponseTimedOut` | Deadline hit after acceptance; effect and reply unknown. | **Yes** | Do not resend blindly — reconcile against durable state first. |
+| `ReplyDropped` | The handler dropped the `Reply` unanswered (also what latest-value conflation of a call looks like). | **Yes** | Retry only an idempotent operation, under one overall deadline, after a superseding incarnation is running. |
+
+The post-acceptance kinds always carry the accepting incarnation in
+`incarnation_observed`; the retry-after-newer step of the retry guide is
+measured against exactly that token. A successful call resolves to
+`Replied`, which pairs the value with the accepting incarnation.
+
+## `ReplyError` (`ReplyReceiver::recv`)
+
+For a reply awaited separately from its send (`reply_channel`):
+`Dropped` means the capability was destroyed unanswered; `Timeout` means
+the receiver's own deadline elapsed. Acceptance evidence belongs to the
+accompanying send's result — the receiver's deadline bounds only the
+response wait.
+
+## The rest of the error surface, briefly
+
+- **Declaration and admission** — `ReserveError` (duplicate or in-removal
+  id, scope not admitting: `NotAdmittingCause`), `BuildError` (root
+  lowering), `PolicyError` (invalid policy data, rejected at
+  construction).
+- **Startup** — `StartupError` from `wait_started`; `StartOrShutdownError`
+  pairs the startup failure with any rollback timeout report;
+  `StartupFailure`/`StartupFailureCause` describe a nested scope's failed
+  start inside an `ExitError`.
+- **Exits** — `Exit` classifies one incarnation's end (`ExitKind`), with
+  `ExitError` carrying the application error and `StopReason` the
+  supervisor-side terminal reason. `ShutdownTimeout`/`ShutdownStraggler`
+  report children that exceeded a shutdown deadline.
+- **Observation** — `WaitError` for bounded child waits, `SnapshotClosed`
+  and `LifecycleTryRecvError` for closed or empty observation streams.
+- **In-actor operations** — `Rejected` when a stopping incarnation refuses
+  `continue_with`, timers, or offloads; `DeadlineElapsed` marks an
+  offload's expired deadline; `ExitResult` is what child code itself
+  returns.
+
+These inventories are exhaustive by design, so new behavior cannot hide
+behind wildcard arms: match exhaustively rather than with a catch-all, and
+the compiler will surface new variants as decisions rather than surprises.

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -87,6 +87,11 @@ macro_rules! context_common_forwarders {
 
         /// Starts blocking work tied to actor shutdown and returned-future drop.
         ///
+        /// Available from [`StopContext`] too — deliberately, unlike
+        /// continuations, timers, and offloads. Awaiting the returned
+        /// [`Blocking`] resumes a panic raised inside the closure at the
+        /// await point.
+        ///
         /// Cancellation is cooperative; a hard-aborted operation's OS thread
         /// detaches and may outlive this actor incarnation.
         /// A blocking-pool rejection during runtime teardown uses a detached
@@ -440,7 +445,9 @@ impl<'a, A: Actor> StopContext<'a, A> {
 ///
 /// This is the composition point for raw decorators around callback-oriented
 /// actors. It also encapsulates the callback loop's error-path resource
-/// teardown, so decorators need no framework-internal teardown operations.
+/// teardown, so decorators need no framework-internal teardown operations;
+/// the post-error context capabilities a resuming decorator may rely on are
+/// documented on this type's [`RawActor::run`] implementation below.
 /// Its declared readiness is read before [`RawActor::run`] is polled.
 ///
 /// Like every [`RawActor`], one `Handler` value owns exactly one call to

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -118,6 +118,11 @@ macro_rules! actor_context_forwarders {
         /// Absent from [`StopContext`]. Capture it during [`Actor::init`] or
         /// [`Actor::handle`] if [`Actor::on_stop`] needs the handle itself;
         /// for identity alone the stop context keeps `incarnation()`.
+        ///
+        /// Never `call` and await this handle from inside a handler — the
+        /// reply can be produced only by the actor loop that handler is
+        /// blocking. [`crate::guides::retry_and_ordering`] catalogs the
+        /// supported shapes.
         #[must_use]
         pub fn myself(&self) -> ActorRef<$actor::Msg> {
             self.raw.myself()
@@ -134,6 +139,128 @@ enum DeliveryStage {
 }
 
 /// Callback context used by both live and frozen-prefix handler deliveries.
+///
+/// One `Context` is lent to [`Actor::init`] and to each [`Actor::handle`]
+/// call; it is the whole capability surface a callback has. The capabilities
+/// group as:
+///
+/// - **Identity** — [`id`](Context::id),
+///   [`incarnation`](Context::incarnation), and [`scope`](Context::scope)
+///   name this child, this run of it, and its supervising scope.
+/// - **Self-handle** — [`myself`](Context::myself) returns the
+///   membership-addressed [`ActorRef`] other tasks use to reach this actor.
+/// - **Protocol steps** — [`continue_with`](Context::continue_with) queues an
+///   actor-local message ahead of external input, the shape for splitting
+///   one request into steps without a handler awaiting itself.
+/// - **Timers** — [`set_timeout`](Context::set_timeout) and
+///   [`set_interval`](Context::set_interval) arm keyed deliveries;
+///   [`clear_timer`](Context::clear_timer) retracts one.
+/// - **Offloads** — [`offload`](Context::offload) and
+///   [`offload_scoped`](Context::offload_scoped) start incarnation-owned
+///   async work whose completion re-enters [`Actor::handle`] as a message.
+/// - **Blocking work** — [`run_blocking`](Context::run_blocking) moves a
+///   closure to a blocking thread with shutdown-tied cancellation.
+/// - **Readiness** — [`mark_ready`](Context::mark_ready) releases the
+///   incarnation's readiness gate, the completing move under an effective
+///   [`Readiness::Manual`].
+/// - **Stop and shutdown** — [`stop`](Context::stop) requests a clean local
+///   stop, [`is_draining`](Context::is_draining) reports the delivery
+///   regime, [`shutdown_token`](Context::shutdown_token) and
+///   [`abort_token`](Context::abort_token) expose the cooperative and
+///   escalation cancellation tokens, and
+///   [`request_scope_shutdown`](Context::request_scope_shutdown) asks the
+///   supervising scope to shut down.
+/// - **Decoration** — [`for_actor`](Context::for_actor) re-projects the
+///   context for a same-message wrapped actor.
+///
+/// # Delivery regimes
+///
+/// A context serves two regimes. **Live** deliveries — `init` and every
+/// `handle` call before a stop — have the full surface. Once the incarnation
+/// is **stopping** — after [`stop`](Context::stop), once cooperative
+/// shutdown is requested, or while draining the frozen mailbox prefix under
+/// [`MailboxShutdown::Drain`] — every operation that would queue new work
+/// for this incarnation ([`continue_with`](Context::continue_with),
+/// [`set_timeout`](Context::set_timeout),
+/// [`set_interval`](Context::set_interval), [`offload`](Context::offload),
+/// and [`offload_scoped`](Context::offload_scoped)) returns [`Rejected`]
+/// carrying its inputs back, and during frozen-prefix drain
+/// [`clear_timer`](Context::clear_timer) is rejected as well.
+/// [`run_blocking`](Context::run_blocking) is deliberately not gated because
+/// teardown code may still need it, and [`mark_ready`](Context::mark_ready)
+/// and [`stop`](Context::stop) degrade to documented no-ops while draining
+/// rather than rejecting.
+///
+/// # Never call and await `myself()`
+///
+/// Awaiting `context.myself().call(...)` from a handler deadlocks: the reply
+/// can be produced only by the actor loop the handler itself is blocking.
+/// [`crate::guides::retry_and_ordering`] catalogs the supported shapes —
+/// continuations, offloads, and split reply channels.
+///
+/// # Examples
+///
+/// A handler splitting one request into protocol steps with
+/// [`continue_with`](Context::continue_with) instead of awaiting itself:
+///
+/// ```
+/// use shelterwood::{Actor, Context, ExitError, ExitResult, Reply};
+/// # use std::time::Duration;
+/// # use shelterwood::{ActorDef, Tree};
+///
+/// struct Pipeline {
+///     staged: Option<u64>,
+/// }
+///
+/// enum Msg {
+///     Begin(u64),
+///     Finish,
+///     Result(Reply<Option<u64>>),
+/// }
+///
+/// impl Actor for Pipeline {
+///     type Msg = Msg;
+///     type Args = ();
+///
+///     async fn init(_args: (), _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+///         Ok(Self { staged: None })
+///     }
+///
+///     async fn handle(&mut self, message: Msg, context: &mut Context<'_, Self>) -> ExitResult {
+///         match message {
+///             Msg::Begin(n) => {
+///                 self.staged = Some(n * 2);
+///                 // Queue the next protocol step; it is delivered ahead of
+///                 // external input instead of this handler awaiting itself.
+///                 if context.continue_with(Msg::Finish).is_err() {
+///                     // Stopping incarnation: the step will not run.
+///                     self.staged = None;
+///                 }
+///             }
+///             Msg::Finish => {
+///                 if let Some(n) = self.staged.as_mut() {
+///                     *n += 1;
+///                 }
+///             }
+///             Msg::Result(reply) => reply.send(self.staged),
+///         }
+///         Ok(())
+///     }
+/// }
+///
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let mut tree = Tree::new();
+/// # let pipeline = tree.add_actor("pipeline", ActorDef::<Pipeline>::cloned(()))?;
+/// # let system = tree.spawn()?;
+/// # system.wait_started().await?;
+/// pipeline.send(Msg::Begin(20)).await?;
+/// let replied = pipeline.call(Msg::Result, Duration::from_secs(1)).await?;
+/// assert_eq!(replied.value, Some(41));
+/// # system.shutdown(Duration::from_secs(5)).await?;
+/// # Ok(())
+/// # }
+/// ```
 pub struct Context<'a, A: Actor> {
     raw: &'a mut RawContext<A::Msg>,
     stage: DeliveryStage,
@@ -222,6 +349,10 @@ impl<'a, A: Actor> Context<'a, A> {
     }
 
     /// Queues an actor-local continuation ahead of external input.
+    ///
+    /// Returns [`Rejected`] carrying the message back once this incarnation
+    /// is stopping: after [`Context::stop`], once cooperative shutdown is
+    /// requested, or during frozen-prefix drain.
     pub fn continue_with(&mut self, message: A::Msg) -> Result<(), Rejected<A::Msg>> {
         if self.stage == DeliveryStage::DrainingFrozenPrefix {
             Err(Rejected::new(message))
@@ -231,6 +362,10 @@ impl<'a, A: Actor> Context<'a, A> {
     }
 
     /// Arms or replaces a one-shot keyed timer.
+    ///
+    /// Returns [`Rejected`] carrying the key and message back once this
+    /// incarnation is stopping: after [`Context::stop`], once cooperative
+    /// shutdown is requested, or during frozen-prefix drain.
     pub fn set_timeout<K>(
         &mut self,
         key: K,
@@ -248,6 +383,10 @@ impl<'a, A: Actor> Context<'a, A> {
     }
 
     /// Arms or replaces a keyed interval; a zero period clears the key.
+    ///
+    /// Returns [`Rejected`] carrying the key and message back once this
+    /// incarnation is stopping: after [`Context::stop`], once cooperative
+    /// shutdown is requested, or during frozen-prefix drain.
     pub fn set_interval<K>(
         &mut self,
         key: K,
@@ -266,6 +405,11 @@ impl<'a, A: Actor> Context<'a, A> {
     }
 
     /// Retracts a keyed timer or rejects the operation while draining.
+    ///
+    /// `Ok(true)` reports that a timer was armed for the key, including one
+    /// that had elapsed but was not yet delivered. [`Rejected`] is returned
+    /// only during frozen-prefix drain; unlike the queueing operations, a
+    /// retraction stays available to a live handler after [`Context::stop`].
     pub fn clear_timer<K>(&mut self, key: &K) -> Result<bool, Rejected<()>>
     where
         K: Hash + Eq + Send + 'static,
@@ -280,6 +424,10 @@ impl<'a, A: Actor> Context<'a, A> {
     /// Starts incarnation-owned async work with one total deadline budget.
     /// A zero budget never polls `work` and re-enters with
     /// [`DeadlineElapsed`].
+    ///
+    /// Returns [`Rejected`] handing the work and continuation back once this
+    /// incarnation is stopping: after [`Context::stop`], once cooperative
+    /// shutdown is requested, or during frozen-prefix drain.
     pub fn offload<F, T, C>(
         &mut self,
         work: F,
@@ -301,6 +449,10 @@ impl<'a, A: Actor> Context<'a, A> {
     /// Starts guarded incarnation-owned async work with one deadline budget.
     /// A zero budget never polls `work` and re-enters with
     /// [`DeadlineElapsed`].
+    ///
+    /// Returns [`Rejected`] handing the work and continuation back once this
+    /// incarnation is stopping: after [`Context::stop`], once cooperative
+    /// shutdown is requested, or during frozen-prefix drain.
     pub fn offload_scoped<F, T, C>(
         &mut self,
         work: F,
@@ -407,6 +559,14 @@ impl<A: Actor> Drop for Context<'_, A> {
 ///
 /// Capture [`Context::myself`] during [`Actor::init`] or [`Actor::handle`]
 /// only when teardown needs the handle itself.
+///
+/// What remains is the common surface: identity ([`StopContext::id`],
+/// [`StopContext::incarnation`], [`StopContext::scope`]), the
+/// [`shutdown`](StopContext::shutdown_token) and
+/// [`abort`](StopContext::abort_token) tokens,
+/// [`StopContext::request_scope_shutdown`], and
+/// [`StopContext::run_blocking`] — the one resource operation teardown code
+/// may still need.
 pub struct StopContext<'a, A: Actor> {
     raw: &'a mut RawContext<A::Msg>,
     actor: PhantomData<fn() -> A>,

--- a/crates/shelterwood/src/cells/observe.rs
+++ b/crates/shelterwood/src/cells/observe.rs
@@ -55,8 +55,16 @@ pub enum LifecycleItem {
     /// One ordered lifecycle edge.
     Event(LifecycleEvent),
     /// Older events were dropped from this subscriber's private queue.
+    ///
+    /// The marker *leads* its overflow episode: it arrives before the
+    /// retained events, which may be older than the aligned resync snapshot
+    /// and may themselves still be evicted by further overflow. Resynchronize
+    /// with the subscribe-then-[`snapshot`](crate::ScopeRef::snapshot)
+    /// protocol instead of reasoning about what follows the marker.
     Lagged {
-        /// Exact number of events dropped in this overflow episode.
+        /// Number of drops accounted when this marker was produced.
+        ///
+        /// A later marker may report further drops from the same episode.
         dropped: u64,
     },
 }
@@ -1020,6 +1028,11 @@ impl fmt::Debug for LifecycleHub {
 #[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum WaitError {
     /// The trailing deadline elapsed before a matching child appeared.
+    ///
+    /// Termination is observable once published: a bounded wait racing that
+    /// publication honestly reports `TimedOut` even though the child's end
+    /// may already have logically happened. The published stream is the
+    /// waiter's sole authority.
     #[error("child wait timed out")]
     TimedOut,
     /// The observed scope membership terminalized before a match.

--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -1534,6 +1534,12 @@ impl ScopeCell {
     /// streams; a subscriber attaching after the final event and before that
     /// closure therefore resolves by closure alone, as it already does on the
     /// stale-epoch path above.
+    ///
+    /// Reachability note: in production the upgrade arm's only visitor is
+    /// `ShutdownRequested` outranking an already-recorded weaker reason —
+    /// the SPEC §11 stop-precedence order stands. The synthetic lattice
+    /// tests below (and `begin_drain`'s twin in `shelterwood-core`) drive
+    /// the full precedence table directly.
     fn publish_stopped_locked(
         &self,
         wakes: &mut ObservationTxn<'_>,

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -618,6 +618,9 @@ fn spawn_child_tasks(launch: ChildTaskLaunch) -> runtime::AbortHandle {
     if watch_readiness {
         let ready_sender = events.clone();
         let ready_completion = ready.clone();
+        // The latch publishes state before wake, so a child that fired and
+        // completed may deliver both wakes together; select_two's left bias
+        // is what keeps the fired edge winning that tie.
         runtime::spawn(async move {
             if matches!(
                 runtime::select_two(ready.fired(), ready_completion.completed()).await,

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -1,6 +1,200 @@
 #![warn(missing_docs)]
 
 //! Structured supervision and actors for asynchronous Rust systems.
+//!
+//! A system is declared as a tree of actors, plain tasks, and nested scopes;
+//! the tree owns startup order, readiness, restart policy, bounded mailboxes,
+//! shutdown, and observation. Stable membership and incarnation identities
+//! make failure recovery explicit without a global registry.
+//!
+//! # Vocabulary
+//!
+//! - A **scope** is a supervising node. An ordered scope ([`Tree`],
+//!   [`Subtree`] declarations) has fixed membership: declaration order is
+//!   startup order and reverse shutdown order, and each child's readiness
+//!   gates the next. A **dynamic scope** ([`DynamicTree`],
+//!   [`DynamicScopeRef`]) starts members concurrently and admits and removes
+//!   them at runtime.
+//! - A **child** is one supervised member of a scope — a callback [`Actor`],
+//!   a [`RawActor`] owning its own receive loop, a plain task
+//!   ([`TaskDef`]/[`TaskOnceDef`]), or a nested subtree. Actors and tasks are
+//!   peers; nothing needs a mailbox merely to obtain supervision.
+//! - A **membership** ([`Membership`]) is a child's identity within its
+//!   scope: minted when the child is declared or admitted, stable across
+//!   restarts, and never reused by a same-id replacement. An [`Incarnation`]
+//!   identifies one run of a membership; restarts produce superseding
+//!   incarnations. Handles ([`ActorRef`], [`TaskRef`], [`ScopeRef`]) address
+//!   a membership and follow its restarts.
+//! - The [`System`] is the sole owning handle for a spawned root. It waits
+//!   for startup, drives bounded shutdown, and joins the root on return.
+//!
+//! # Quickstart
+//!
+//! A counter actor with a request/reply protocol, spawned under an ordered
+//! tree inside an ambient Tokio runtime:
+//!
+//! ```rust
+//! use std::time::Duration;
+//!
+//! use shelterwood::{Actor, ActorDef, Context, ExitError, ExitResult, Reply, Tree};
+//!
+//! struct Counter {
+//!     count: u64,
+//! }
+//!
+//! enum Msg {
+//!     Add(u64),
+//!     Total(Reply<u64>),
+//! }
+//!
+//! impl Actor for Counter {
+//!     type Msg = Msg;
+//!     type Args = ();
+//!
+//!     async fn init(_args: (), _context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+//!         Ok(Self { count: 0 })
+//!     }
+//!
+//!     async fn handle(&mut self, message: Msg, _context: &mut Context<'_, Self>) -> ExitResult {
+//!         match message {
+//!             Msg::Add(n) => self.count += n,
+//!             Msg::Total(reply) => reply.send(self.count),
+//!         }
+//!         Ok(())
+//!     }
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let mut tree = Tree::new();
+//!     let counter = tree.add_actor("counter", ActorDef::<Counter>::cloned(()))?;
+//!
+//!     let system = tree.spawn()?;
+//!     system.wait_started().await?;
+//!
+//!     counter.send(Msg::Add(2)).await?;
+//!     let replied = counter.call(Msg::Total, Duration::from_secs(1)).await?;
+//!     assert_eq!(replied.value, 2);
+//!
+//!     system.shutdown(Duration::from_secs(5)).await?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! # The API by area
+//!
+//! The exports are deliberately flat; this index is the grouping.
+//!
+//! ## Actors
+//!
+//! [`Actor`] is the callback contract (`init`/`handle`/`on_stop`), declared
+//! through [`ActorDef`] (restartable) or [`ActorOnceDef`] (one-shot).
+//! Callbacks receive a [`Context`]; teardown receives the narrowed
+//! [`StopContext`]. [`Handler`] is the raw-actor wrapper the callback loop
+//! rides on, public for decorator composition.
+//!
+//! ## Mailboxes and messaging
+//!
+//! [`ActorRef`] is the membership-addressed send handle: [`ActorRef::send`]
+//! (waits for acceptance), [`ActorRef::try_send`] (fail-fast),
+//! [`ActorRef::send_timeout`] (bounded wait, message recovered on expiry),
+//! and [`ActorRef::call`] (request/reply under one deadline, resolving to
+//! [`Replied`]). Reply capabilities are [`Reply`], [`ReplyReceiver`], and
+//! its [`ReplyReceive`] future; send/call futures are [`SendFuture`],
+//! [`SendTimeout`], and [`CallFuture`]. Failures are [`SendError`] /
+//! [`SendErrorKind`], [`CallError`] / [`CallErrorKind`], and [`ReplyError`]
+//! — the decision table lives in [`guides::errors`]. Mailbox declarations
+//! are [`Mailbox`] (bounded queue or latest-value) and [`MailboxShutdown`]
+//! (drain or discard the frozen prefix).
+//!
+//! ## Trees and slots
+//!
+//! [`Tree`] and [`DynamicTree`] declare a root; [`System`] owns it once
+//! spawned ([`StartOrShutdownError`] reports a rolled-back startup).
+//! Subtrees compose through [`SubtreeDef`], [`SubtreeOnceDef`], and the
+//! sealed [`Subtree`] dispatch trait. Slots ([`ActorSlot`], [`TaskSlot`],
+//! [`SubtreeSlot`], [`DynamicActorSlot`], [`DynamicTaskSlot`],
+//! [`DynamicSubtreeSlot`]) split reservation from definition so cyclically
+//! wired children can hold each other's handles before either is defined.
+//! Declaration failures surface as [`BuildError`].
+//!
+//! ## Scopes and admission
+//!
+//! [`ScopeRef`] addresses an ordered scope; [`DynamicScopeRef`] adds
+//! runtime admission and removal, whose outcomes are [`Admission`],
+//! [`Removal`], [`RemoveOutcome`], [`ReserveError`], and
+//! [`NotAdmittingCause`]. Scope-level state is [`ScopeState`] and
+//! [`MembershipStatus`].
+//!
+//! ## Tasks
+//!
+//! [`TaskDef`] declares a restartable supervised task and [`TaskOnceDef`] a
+//! one-shot with a typed completion claimed through [`OneShotTaskRef`].
+//! Tasks run with a [`TaskContext`] and are addressed by [`TaskRef`].
+//!
+//! ## Raw actors, offloads, and blocking work
+//!
+//! [`RawActor`] owns its receive loop directly, declared through [`RawDef`]
+//! or [`RawOnceDef`] and driven with a [`RawContext`]. Offload machinery is
+//! shared with callback actors: [`Guard`] (cancel-on-drop lease),
+//! [`Blocking`] (cooperative blocking work), [`DeadlineElapsed`], and
+//! [`Rejected`] (operation refused by a stopping incarnation).
+//!
+//! ## Policy
+//!
+//! Supervision policy is plain validated data: [`RestartPolicy`],
+//! [`RestartCondition`], [`Backoff`] ([`FixedBackoff`],
+//! [`ExponentialBackoff`], [`BackoffFactor`], [`Jitter`], [`JitterSample`]),
+//! [`Intensity`], [`Strategy`], [`Readiness`], [`ReadinessDeadline`],
+//! [`Shutdown`], [`Retention`], [`ScopeDefaults`], [`DefaultsInheritance`],
+//! [`ScopeFlavor`], and [`NonZeroDuration`], with counters
+//! [`RestartAttempt`], [`RestartCount`], and [`TotalRestarts`]. Invalid
+//! configuration is unrepresentable; construction fails with
+//! [`PolicyError`].
+//!
+//! ## Exits and errors
+//!
+//! [`Exit`] is the structured result of one incarnation (or a never-started
+//! membership): classification [`ExitKind`], application error
+//! [`ExitError`], and the [`ExitResult`] alias child code returns.
+//! Supervisor-side terminal reasons are [`StopReason`], [`Cancellation`],
+//! and [`GracePhase`]; startup failures are [`StartupError`],
+//! [`StartupFailure`], and [`StartupFailureCause`]; restart-budget trips
+//! are [`IntensityTrip`]; shutdown deadline reports are [`ShutdownTimeout`]
+//! and [`ShutdownStraggler`].
+//!
+//! ## Observation
+//!
+//! [`ScopeSnapshot`] and [`ChildSnapshot`] are authoritative recursive
+//! current state ([`ChildState`]), watched through [`SnapshotReceiver`]
+//! (closed: [`SnapshotClosed`], waits: [`WaitError`]). Lifecycle histories
+//! are [`LifecycleEvents`] streams of [`LifecycleItem`] /
+//! [`LifecycleEvent`] / [`LifecycleEventKind`] ordered by [`LifecycleSeq`]
+//! (non-blocking reads: [`LifecycleTryRecvError`]).
+//!
+//! ## Identity, timing, and cancellation
+//!
+//! [`ChildId`] names a child within one scope; [`Membership`] is the
+//! process-wide unique key; [`Incarnation`] orders restarts via
+//! `supersedes`. Deadline-bearing operations take a [`DeadlineBudget`];
+//! cooperative shutdown and abort surface as [`CancellationToken`]s.
+//!
+//! # Guides
+//!
+//! - [`guides::retry_and_ordering`] — calls, retries, and message ordering.
+//! - [`guides::shutdown_and_resources`] — shutdown and resource ownership.
+//! - [`guides::errors`] — the error catalog: which type means what and what
+//!   to match on.
+//!
+//! # Operational preconditions
+//!
+//! Supervision classifies panics only under `panic = "unwind"`; with
+//! `panic = "abort"` the process ends before a supervisor can observe the
+//! panic, and Rust's ordinary double-panic rule still aborts when a
+//! destructor panics during an unwind. Spawn systems inside a Tokio runtime
+//! with time enabled, and resolve [`System::shutdown`] (or let the dropped
+//! owner finish teardown) before destroying that runtime; destroying the
+//! runtime around a live system is outside the contract.
 
 #[macro_use]
 mod definition;
@@ -66,6 +260,9 @@ pub mod guides {
 
     #[doc = include_str!("../docs/shutdown-and-resources.md")]
     pub mod shutdown_and_resources {}
+
+    #[doc = include_str!("../docs/errors.md")]
+    pub mod errors {}
 }
 
 // Keep the repository-root narrative documents in the doctest compilation lane

--- a/crates/shelterwood/src/mailbox/errors.rs
+++ b/crates/shelterwood/src/mailbox/errors.rs
@@ -30,6 +30,9 @@ pub struct SendError<M> {
     pub kind: SendErrorKind,
 }
 
+// Manual impl so no `M: Debug` bound is demanded and no user payload leaks
+// into logs; the placeholder stands in for the recoverable message. Debug
+// output stays non-contractual either way.
 impl<M> fmt::Debug for SendError<M> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
@@ -124,6 +127,8 @@ pub struct Replied<T> {
     pub incarnation: Incarnation,
 }
 
+// Manual impl so no `T: Debug` bound is demanded and no user reply value
+// leaks into logs; Debug output stays non-contractual either way.
 impl<T> fmt::Debug for Replied<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter

--- a/crates/shelterwood/src/mailbox/futures.rs
+++ b/crates/shelterwood/src/mailbox/futures.rs
@@ -46,6 +46,74 @@ impl<T: Send + 'static> Future for ReplyReceive<T> {
     }
 }
 /// A cheap membership-addressed actor handle.
+///
+/// The handle addresses one [`Membership`] and follows every incarnation of
+/// it across restarts. It never retargets: after remove and re-add under the
+/// same child id, the replacement has a new membership and needs a new
+/// handle, while this one stays pinned to the removed membership and reports
+/// [`SendErrorKind::Terminated`]. Cloning is reference-count work; every
+/// clone addresses the same membership.
+///
+/// # Choosing a send flavor
+///
+/// - [`send`](Self::send) waits through rebind windows and backpressure and
+///   fails only when the membership is terminal
+///   ([`SendErrorKind::Terminated`]).
+/// - [`try_send`](Self::try_send) is fail-fast: it never parks and reports
+///   [`NotRunning`](SendErrorKind::NotRunning), [`Full`](SendErrorKind::Full),
+///   or [`Terminated`](SendErrorKind::Terminated) immediately.
+/// - [`send_timeout`](Self::send_timeout) bounds the wait and recovers the
+///   message on expiry; a [`TimedOut`](SendErrorKind::TimedOut) message is
+///   guaranteed never to have been accepted.
+/// - [`call`](Self::call) is request/reply under one deadline covering
+///   message construction, mailbox acceptance, and the reply.
+///
+/// Which failures prove the message was never accepted, and when a resend is
+/// safe, is the subject of [`crate::guides::errors`] and
+/// [`crate::guides::retry_and_ordering`].
+///
+/// # Examples
+///
+/// Send and call against a counter actor (the actor and system scaffolding
+/// are hidden; see the crate front page for the full form):
+///
+/// ```rust
+/// # use std::time::Duration;
+/// # use shelterwood::{Actor, ActorDef, Context, ExitError, ExitResult, Reply, Tree};
+/// # struct Counter {
+/// #     count: u64,
+/// # }
+/// enum Msg {
+///     Add(u64),
+///     Total(Reply<u64>),
+/// }
+/// # impl Actor for Counter {
+/// #     type Msg = Msg;
+/// #     type Args = ();
+/// #     async fn init(_args: (), _context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+/// #         Ok(Self { count: 0 })
+/// #     }
+/// #     async fn handle(&mut self, message: Msg, _context: &mut Context<'_, Self>) -> ExitResult {
+/// #         match message {
+/// #             Msg::Add(n) => self.count += n,
+/// #             Msg::Total(reply) => reply.send(self.count),
+/// #         }
+/// #         Ok(())
+/// #     }
+/// # }
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let mut tree = Tree::new();
+/// let counter = tree.add_actor("counter", ActorDef::<Counter>::cloned(()))?;
+/// # let system = tree.spawn()?;
+/// # system.wait_started().await?;
+/// counter.send(Msg::Add(2)).await?;
+/// let replied = counter.call(Msg::Total, Duration::from_secs(1)).await?;
+/// assert_eq!(replied.value, 2);
+/// # system.shutdown(Duration::from_secs(5)).await?;
+/// # Ok(())
+/// # }
+/// ```
 pub struct ActorRef<M> {
     member: Arc<dyn ActorIdentity>,
     mailbox: Arc<MailboxCell<M>>,
@@ -88,31 +156,73 @@ where
 impl<M: Send + 'static> ActorRef<M> {
     /// Sends with backpressure and transparently waits through rebind windows.
     ///
+    /// Acceptance resolves to the accepting [`Incarnation`]. The future is
+    /// lazy: constructing it submits nothing until it is first polled, and
+    /// dropping it before acceptance withdraws the message.
+    ///
     /// On a live latest-value mailbox, acceptance can replace the previous
     /// message. The displaced message is dropped inline on the task polling
     /// this send, after the new message's acceptance is visible; a panicking
     /// displaced-message destructor therefore resumes on that task.
+    ///
+    /// # Errors
+    ///
+    /// The only failure is [`SendErrorKind::Terminated`]: the membership is
+    /// terminal and can never accept again. Rebind windows and a full queue
+    /// are waited through, not reported. The unaccepted message is recovered
+    /// in the error's `message` field; see [`crate::guides::errors`].
     pub fn send(&self, message: M) -> SendFuture<M> {
         SendFuture::new(Arc::clone(&self.mailbox), message)
     }
 
     /// Attempts immediate acceptance without parking.
     ///
+    /// Success returns the accepting [`Incarnation`]. Every failure is
+    /// guaranteed-never-accepted and recovers the message in the error's
+    /// `message` field, so a fail-fast send loses nothing.
+    ///
     /// On a live latest-value mailbox, acceptance can replace the previous
     /// message. The displaced message is dropped inline on the calling task,
     /// after the new message's acceptance is visible; a panicking
     /// displaced-message destructor therefore resumes on that task.
+    ///
+    /// # Errors
+    ///
+    /// - [`SendErrorKind::NotRunning`] — the membership is not currently
+    ///   accepting: pre-spawn, a restart rebind window, or intake frozen at
+    ///   stop.
+    /// - [`SendErrorKind::Full`] — a queue mailbox is at capacity (a live
+    ///   latest-value mailbox accepts by replacement instead).
+    /// - [`SendErrorKind::Terminated`] — the membership is terminal.
+    ///
+    /// See [`crate::guides::errors`] for the per-kind identity evidence.
     pub fn try_send(&self, message: M) -> Result<Incarnation, SendError<M>> {
         self.mailbox.try_send(message)
     }
 
     /// Sends within one acceptance budget, recovering an unaccepted message.
     ///
+    /// The budget starts when the returned future is first polled and bounds
+    /// only acceptance. Within it the send behaves exactly like
+    /// [`send`](Self::send): rebind windows and backpressure are waited
+    /// through, and success resolves to the accepting [`Incarnation`].
+    ///
     /// Live latest-value displacement follows [`send`](Self::send): the
     /// displaced message is dropped inline on the task polling this send,
     /// after acceptance of the replacement is visible.
     /// A zero budget makes no acceptance attempt and returns the unaccepted
     /// message with [`SendErrorKind::TimedOut`].
+    ///
+    /// # Errors
+    ///
+    /// - [`SendErrorKind::TimedOut`] — the budget elapsed before acceptance;
+    ///   the message was withdrawn, guaranteed never to have been accepted.
+    /// - [`SendErrorKind::Terminated`] — the membership terminalized before
+    ///   acceptance.
+    ///
+    /// Both recover the message in the error's `message` field. `NotRunning`
+    /// and `Full` are waited through, never reported; see
+    /// [`crate::guides::errors`].
     pub fn send_timeout(&self, message: M, deadline: impl Into<DeadlineBudget>) -> SendTimeout<M> {
         let runtime = self.mailbox.runtime();
         SendTimeout {
@@ -121,6 +231,14 @@ impl<M: Send + 'static> ActorRef<M> {
     }
 
     /// Creates a reply capability using this actor handle's installed runtime.
+    ///
+    /// Use it to await a reply separately from its send: embed the [`Reply`]
+    /// in a message, submit it with any send flavor, and await the
+    /// [`ReplyReceiver`](crate::ReplyReceiver). This method is infallible.
+    /// Acceptance evidence belongs to the accompanying send's result; the
+    /// receiver's own deadline bounds only the response wait, whose failures
+    /// are [`ReplyError`]. [`call`](Self::call) packages the same pieces
+    /// under one deadline.
     #[must_use]
     pub fn reply_channel<T: Send + 'static>(&self) -> (Reply<T>, crate::ReplyReceiver<T>) {
         Reply::channel(self.runtime())
@@ -149,6 +267,21 @@ impl<M: Send + 'static> ActorRef<M> {
     /// through isolated disposal, as cancelling a parked [`send`](Self::send)
     /// does. A panicking waker destructor is contained there rather than
     /// resuming on the awaiting task.
+    ///
+    /// # Errors
+    ///
+    /// - [`CallErrorKind::Terminated`] — the membership terminalized before
+    ///   acceptance; the request was never accepted.
+    /// - [`CallErrorKind::AcceptanceTimedOut`] — the deadline elapsed before
+    ///   acceptance; the request was withdrawn, guaranteed never to have
+    ///   been accepted.
+    /// - [`CallErrorKind::ResponseTimedOut`] — the deadline elapsed after
+    ///   acceptance; the request's effect and reply are unknown.
+    /// - [`CallErrorKind::ReplyDropped`] — the request was accepted but its
+    ///   [`Reply`] was dropped unanswered.
+    ///
+    /// The per-kind retry discipline lives in
+    /// [`crate::guides::retry_and_ordering`].
     pub fn call<T: Send + 'static>(
         &self,
         make_msg: impl FnOnce(Reply<T>) -> M + Send + 'static,

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -522,6 +522,11 @@ pub(crate) struct ChildPlan {
 }
 
 impl ChildPlan {
+    /// Builds the plan and, as a deliberate side effect, publishes the
+    /// resolved options onto the slot's member cell. Options resolve exactly
+    /// once and must be resolved before the member's first snapshot
+    /// publication; routing every plan through this constructor is what
+    /// upholds that ordering.
     pub(crate) fn with_options(
         slot: Arc<SlotCell>,
         construction: Isolated<ChildConstruction>,

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -784,6 +784,13 @@ impl<M: Send + 'static> RawContext<M> {
 
     /// Starts blocking work with cancellation tied to shutdown and future drop.
     ///
+    /// Unlike `continue_with`, timers, and offloads, this operation has no
+    /// stopping gate: it deliberately keeps working from stop paths, because
+    /// it is the one resource operation teardown code may still need.
+    /// Awaiting the returned [`Blocking`] resumes a panic raised inside the
+    /// closure at the await point (distinct from the runtime-teardown
+    /// cancellation panic below).
+    ///
     /// Cancellation is cooperative. If this future is dropped or its actor is
     /// hard-aborted, the OS thread detaches and can outlive the incarnation.
     /// A blocking-pool rejection during runtime teardown uses a detached

--- a/crates/shelterwood/src/raw/offload.rs
+++ b/crates/shelterwood/src/raw/offload.rs
@@ -96,6 +96,9 @@ impl Drop for Guard {
 
 /// A blocking operation whose thread cooperatively observes actor cancellation.
 ///
+/// Awaiting it returns the closure's value; a panic raised inside the
+/// closure is resumed at the await point.
+///
 /// Cancellation cannot forcibly stop a blocking thread. Dropping this future
 /// or hard-aborting its actor detaches the thread after requesting cooperative
 /// cancellation; Shelterwood does not join it, and any later value or panic is

--- a/crates/shelterwood/src/tree/builders.rs
+++ b/crates/shelterwood/src/tree/builders.rs
@@ -81,6 +81,13 @@ macro_rules! impl_common_builder_surface {
 
         /// Reserves an actor membership and returns its pre-spawn handle slot.
         #[doc = $member_note]
+        ///
+        /// # Errors
+        ///
+        /// Fails with [`ReserveError::EmptyId`] or
+        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
+        /// [`ReserveError::IdentityExhausted`]; no other variant is
+        /// reachable from a pre-spawn builder.
         pub fn reserve_actor<M: Send + 'static>(
             &mut self,
             id: impl Into<ChildId>,
@@ -90,6 +97,13 @@ macro_rules! impl_common_builder_surface {
 
         /// Adds a restartable callback-oriented actor.
         #[doc = $member_note]
+        ///
+        /// # Errors
+        ///
+        /// Fails with [`ReserveError::EmptyId`] or
+        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
+        /// [`ReserveError::IdentityExhausted`]; no other variant is
+        /// reachable from a pre-spawn builder.
         pub fn add_actor<A: crate::Actor>(
             &mut self,
             id: impl Into<ChildId>,
@@ -100,6 +114,13 @@ macro_rules! impl_common_builder_surface {
 
         /// Adds a consuming one-shot callback-oriented actor.
         #[doc = $member_note]
+        ///
+        /// # Errors
+        ///
+        /// Fails with [`ReserveError::EmptyId`] or
+        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
+        /// [`ReserveError::IdentityExhausted`]; no other variant is
+        /// reachable from a pre-spawn builder.
         pub fn add_actor_once<A: crate::Actor>(
             &mut self,
             id: impl Into<ChildId>,
@@ -110,6 +131,13 @@ macro_rules! impl_common_builder_surface {
 
         /// Adds a restartable raw actor.
         #[doc = $member_note]
+        ///
+        /// # Errors
+        ///
+        /// Fails with [`ReserveError::EmptyId`] or
+        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
+        /// [`ReserveError::IdentityExhausted`]; no other variant is
+        /// reachable from a pre-spawn builder.
         pub fn add_raw<R: crate::RawActor>(
             &mut self,
             id: impl Into<ChildId>,
@@ -120,6 +148,13 @@ macro_rules! impl_common_builder_surface {
 
         /// Adds a consuming one-shot raw actor.
         #[doc = $member_note]
+        ///
+        /// # Errors
+        ///
+        /// Fails with [`ReserveError::EmptyId`] or
+        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
+        /// [`ReserveError::IdentityExhausted`]; no other variant is
+        /// reachable from a pre-spawn builder.
         pub fn add_raw_once<R: crate::RawActor>(
             &mut self,
             id: impl Into<ChildId>,
@@ -130,12 +165,26 @@ macro_rules! impl_common_builder_surface {
 
         /// Reserves a task membership and returns its pre-spawn handle slot.
         #[doc = $member_note]
+        ///
+        /// # Errors
+        ///
+        /// Fails with [`ReserveError::EmptyId`] or
+        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
+        /// [`ReserveError::IdentityExhausted`]; no other variant is
+        /// reachable from a pre-spawn builder.
         pub fn reserve_task(&mut self, id: impl Into<ChildId>) -> Result<TaskSlot, ReserveError> {
             reserve_static::<TaskKind>(&mut self.core, id).map(|core| TaskSlot { core })
         }
 
         /// Adds a restartable task.
         #[doc = $member_note]
+        ///
+        /// # Errors
+        ///
+        /// Fails with [`ReserveError::EmptyId`] or
+        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
+        /// [`ReserveError::IdentityExhausted`]; no other variant is
+        /// reachable from a pre-spawn builder.
         pub fn add_task(
             &mut self,
             id: impl Into<ChildId>,
@@ -146,6 +195,13 @@ macro_rules! impl_common_builder_surface {
 
         /// Adds a consuming one-shot task and its typed completion claim.
         #[doc = $member_note]
+        ///
+        /// # Errors
+        ///
+        /// Fails with [`ReserveError::EmptyId`] or
+        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
+        /// [`ReserveError::IdentityExhausted`]; no other variant is
+        /// reachable from a pre-spawn builder.
         pub fn add_task_once<T: Send + 'static>(
             &mut self,
             id: impl Into<ChildId>,
@@ -156,6 +212,13 @@ macro_rules! impl_common_builder_surface {
 
         /// Reserves a typed subtree membership.
         #[doc = $member_note]
+        ///
+        /// # Errors
+        ///
+        /// Fails with [`ReserveError::EmptyId`] or
+        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
+        /// [`ReserveError::IdentityExhausted`]; no other variant is
+        /// reachable from a pre-spawn builder.
         pub fn reserve_subtree<T: Subtree>(
             &mut self,
             id: impl Into<ChildId>,
@@ -165,6 +228,13 @@ macro_rules! impl_common_builder_surface {
 
         /// Adds a restartable subtree.
         #[doc = $member_note]
+        ///
+        /// # Errors
+        ///
+        /// Fails with [`ReserveError::EmptyId`] or
+        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
+        /// [`ReserveError::IdentityExhausted`]; no other variant is
+        /// reachable from a pre-spawn builder.
         pub fn add_subtree<T: Subtree>(
             &mut self,
             id: impl Into<ChildId>,
@@ -175,6 +245,13 @@ macro_rules! impl_common_builder_surface {
 
         /// Adds a consuming one-shot subtree.
         #[doc = $member_note]
+        ///
+        /// # Errors
+        ///
+        /// Fails with [`ReserveError::EmptyId`] or
+        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
+        /// [`ReserveError::IdentityExhausted`]; no other variant is
+        /// reachable from a pre-spawn builder.
         pub fn add_subtree_once<T: Subtree>(
             &mut self,
             id: impl Into<ChildId>,
@@ -186,6 +263,65 @@ macro_rules! impl_common_builder_surface {
 }
 
 /// A fixed-membership, readiness-ordered tree declaration.
+///
+/// Declaration order is the contract: children start in the order they were
+/// added, each child's readiness gates the start of the next, and shutdown
+/// stops them in reverse declaration order, one fully joined child at a
+/// time. Membership is fixed at [`Tree::spawn`] — an ordered scope neither
+/// admits nor removes children at runtime; declare a [`DynamicTree`] where
+/// that is needed.
+///
+/// Every `add_*` method returns the child's membership-addressed handle
+/// before anything runs. The `reserve_*` methods ([`Tree::reserve_actor`],
+/// [`Tree::reserve_task`], [`Tree::reserve_subtree`]) split reservation from
+/// definition so cyclically wired children can hold each other's handles
+/// before either is defined; every reservation must be defined before
+/// [`Tree::spawn`]. Nested composition goes through [`SubtreeDef`] and
+/// [`SubtreeOnceDef`], and [`Tree::spawn`] returns the owning [`System`].
+///
+/// # Examples
+///
+/// A task and an actor under one ordered tree. The task is declared first,
+/// so it starts first, its readiness gates the actor's start, and it stops
+/// last:
+///
+/// ```rust
+/// # use std::time::Duration;
+/// # use shelterwood::{Actor, ActorDef, Context, ExitError, ExitResult, TaskDef, Tree};
+/// # struct Greeter;
+/// # impl Actor for Greeter {
+/// #     type Msg = String;
+/// #     type Args = ();
+/// #     async fn init(_args: (), _context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+/// #         Ok(Self)
+/// #     }
+/// #     async fn handle(&mut self, name: String, _context: &mut Context<'_, Self>) -> ExitResult {
+/// #         println!("hello, {name}");
+/// #         Ok(())
+/// #     }
+/// # }
+/// # #[tokio::main(flavor = "current_thread")]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut tree = Tree::new();
+///
+/// tree.add_task(
+///     "ticker",
+///     TaskDef::new(|context| async move {
+///         context.shutdown_token().cancelled().await;
+///         Ok(())
+///     }),
+/// )?;
+/// let greeter = tree.add_actor("greeter", ActorDef::<Greeter>::cloned(()))?;
+///
+/// let system = tree.spawn()?;
+/// system.wait_started().await?;
+///
+/// greeter.send("world".to_string()).await?;
+///
+/// system.shutdown(Duration::from_secs(5)).await?;
+/// # Ok(())
+/// # }
+/// ```
 pub struct Tree {
     pub(super) core: BuilderCore,
 }
@@ -216,12 +352,38 @@ impl Tree {
     }
 
     /// Lowers and starts this tree synchronously.
+    ///
+    /// The returned [`System`] is the sole owner of the running root.
+    /// Startup proceeds asynchronously from here; await
+    /// [`System::wait_started`] for the outcome, or use
+    /// [`System::start_or_shutdown`] to roll a failed startup back.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BuildError::NoRuntime`] outside an ambient supported async
+    /// runtime, and [`BuildError::UnfilledReservations`] when any reserved
+    /// slot was left undefined.
     pub fn spawn(self) -> Result<System<ScopeRef>, BuildError> {
         spawn_builder(self.core, |scope| scope)
     }
 }
 
 /// A runtime-dynamic tree declaration.
+///
+/// A dynamic scope starts its declared children concurrently — no child's
+/// readiness gates a sibling's start — and shutdown runs every member's
+/// stop ladder together rather than in declaration order. Membership stays
+/// open after [`DynamicTree::spawn`]: the [`DynamicScopeRef`] returned by
+/// [`System::scope`] admits new members through its own `add_*` and
+/// `reserve_*` methods and removes existing ones through
+/// [`DynamicScopeRef::remove`] and its typed variants.
+///
+/// The builder surface here declares the scope's *initial* membership.
+/// [`System::wait_started`] aggregates readiness over those initial members
+/// only; children admitted later through the scope handle never join the
+/// aggregate. The same reservation/definition split as on [`Tree`] is
+/// available through [`DynamicTree::reserve_actor`],
+/// [`DynamicTree::reserve_task`], and [`DynamicTree::reserve_subtree`].
 pub struct DynamicTree {
     pub(super) core: BuilderCore,
 }
@@ -252,6 +414,16 @@ impl DynamicTree {
     }
 
     /// Lowers and starts this tree synchronously.
+    ///
+    /// The returned [`System`] is the sole owner of the running root, and
+    /// [`System::scope`] hands out the [`DynamicScopeRef`] used for runtime
+    /// admission and removal.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BuildError::NoRuntime`] outside an ambient supported async
+    /// runtime, and [`BuildError::UnfilledReservations`] when any reserved
+    /// slot was left undefined.
     pub fn spawn(self) -> Result<System<DynamicScopeRef>, BuildError> {
         spawn_builder(self.core, DynamicScopeRef)
     }

--- a/crates/shelterwood/src/tree/system.rs
+++ b/crates/shelterwood/src/tree/system.rs
@@ -163,6 +163,29 @@ impl Subtree for Tree {}
 impl Subtree for DynamicTree {}
 #[must_use = "dropping the sole system owner requests graceful shutdown"]
 /// The sole owning handle for a running root system.
+///
+/// [`Tree::spawn`] and [`DynamicTree::spawn`] return exactly one `System`;
+/// it is not cloneable, and non-owning handles come from [`System::scope`].
+/// The owner sequences the root lifecycle:
+///
+/// - [`System::wait_started`] reports the startup outcome but deliberately
+///   leaves the successfully started prefix running and supervised, so the
+///   caller decides what a partial start means.
+/// - [`System::start_or_shutdown`] is the rollback form: on startup failure
+///   it consumes the owner and drives full shutdown of the started prefix,
+///   preserving the original cause beside any rollback timeout report.
+/// - [`System::shutdown`] consumes the owner, bounds the cooperative
+///   teardown phase with its timeout, and joins the root driver before
+///   returning.
+/// - [`System::wait`] consumes the owner and resolves at natural or
+///   externally requested terminal state.
+///
+/// Dropping a `System` requests graceful shutdown, but only an awaited
+/// [`System::shutdown`] joins the root driver and returns straggler
+/// evidence ([`ShutdownTimeout`]); an embedding host should normally await
+/// it before tearing down the async runtime. The escalation ladder, what a
+/// completed shutdown does and does not guarantee, and runtime-lifetime
+/// obligations are documented in [`crate::guides::shutdown_and_resources`].
 pub struct System<R = ScopeRef> {
     pub(super) root: R,
     pub(super) run: crate::driver::SystemRun,
@@ -187,6 +210,20 @@ impl<R: Clone> System<R> {
 
 impl<R> System<R> {
     /// Waits until the declared tree is ready or startup terminally fails.
+    ///
+    /// Resolves `Ok` once every declared child is ready — gated one child at
+    /// a time in an ordered [`Tree`], concurrently and counting initial
+    /// members only in a [`DynamicTree`]. A startup failure is reported here
+    /// but deliberately leaves the successfully started prefix running and
+    /// supervised: the caller chooses between a host-specific response and
+    /// rollback. Use [`Self::start_or_shutdown`] when a failed startup
+    /// should tear the prefix down.
+    ///
+    /// # Errors
+    ///
+    /// Returns the [`StartupError`] recorded by the root startup barrier: a
+    /// terminal child failure during startup, a restart-intensity trip, or a
+    /// shutdown requested before startup completed.
     pub async fn wait_started(&self) -> Result<(), StartupError> {
         self.run.root.wait_started().await
     }
@@ -198,6 +235,12 @@ impl<R> System<R> {
     /// preserves both the original startup cause and any rollback timeout.
     /// A zero rollback budget requests cooperative cancellation and then
     /// enters the ordinary escalation tail without a cooperative wait.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StartOrShutdownError`] carrying the original
+    /// [`StartupError`] beside any [`ShutdownTimeout`] the rollback
+    /// produced; rollback never masks the startup cause.
     pub async fn start_or_shutdown(
         mut self,
         timeout: impl Into<DeadlineBudget>,
@@ -226,6 +269,15 @@ impl<R> System<R> {
     /// past hard abort independently of that fallback.
     /// A zero budget still requests cooperative cancellation, then skips its
     /// wait and enters the ordinary escalation tail immediately.
+    /// [`crate::guides::shutdown_and_resources`] documents the full
+    /// escalation ladder and the runtime-lifetime obligations around this
+    /// call.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ShutdownTimeout`] when cooperative teardown exceeded
+    /// `timeout` and stragglers were escalated; the root driver is joined
+    /// before the report returns.
     pub async fn shutdown(
         mut self,
         timeout: impl Into<DeadlineBudget>,


### PR DESCRIPTION
Second PR of the #371 pass: the rustdoc layer. Doc-only — the diff's sole non-comment source change is the new doc-only `guides::errors` module.

## Crate front page

`lib.rs` grows from one sentence to a real landing page: the model vocabulary (scope, child, membership, incarnation, system), a running quickstart doctest (counter actor, send + call, bounded shutdown), the area-organized index over the deliberately flat export surface (actors; mailboxes & messaging; trees & slots; scopes & admission; tasks; raw actors, offloads & blocking; policy; exits & errors; observation; identity, timing & cancellation), guide links, and the operational preconditions.

## Error catalog

New `guides::errors` page (`crates/shelterwood/docs/errors.md`): the user-facing half of SPEC B.3 — the accepted-or-not rule, the `SendErrorKind`/`CallErrorKind` tables with required actions, the per-kind `incarnation_observed` pinning, `ReplyError`, and a brief map of the remaining error families.

## Depth pass (coverage was already 100%; this is depth)

- **ActorRef** — the send-flavor decision, never-retargets identity, a running doctest, `# Errors` naming each method's exact reachable kinds.
- **Context** — capability families with links, the live-vs-stopping regimes and precisely which operations return `Rejected` (verified against the raw-context gating), the `myself()` deadlock rule, a running `continue_with` doctest; `StopContext`'s retained surface.
- **Tree/DynamicTree/System** — ordering contracts, reservation/definition split, running doctest, `# Errors` throughout, drop-vs-awaited shutdown.
- **Exit/ExitError** — exhaustive `ExitKind` classification doctest; construction forms, shallow-clone provenance, framework-minted-only structured accessors.
- **Policy** — `# Errors` with exact `PolicyError` variants on every fallible constructor; positive doctests beside the untouched compile_fail fences.

## Carried #192 backlog — triaged first, as the issue requires

Triage against current `main` struck 10 of 20 bullets as moot or already done (details in the tables below the fold of this PR's first commit message; headline strikes: `LifecycleChannels` and lineage-0 are gone, `send_modify` and `handle_removal` are structurally moot, disposal-isolation prose already exists, `UnfilledReservations` is flat now, the `_with` race hook is on the shipped path and cannot be cfg-gated). Every survivor got its sentence:

- `LifecycleItem::Lagged` marker-leads-episode semantics (spec B.4 alignment); `dropped` re-described as at-production count.
- `StopReason::NeverStarted`'s stringly nested projection asymmetry.
- `next_delay`'s ZERO-attempt coercion; `from_u64_ratio`'s non-finite→zero mapping.
- `WaitError::TimedOut`: termination is observable once published; a bounded wait racing publication honestly reports `TimedOut` (decided 2026-08-11).
- Stop-lattice upgrade-arm reachability note (`ShutdownRequested` is the only production visitor; SPEC §11 citation).
- `select_two`'s contractual left bias; `CompletionGatedLatch`'s wake-lags-state ordering + the consumer-side comment.
- `run_blocking`'s deliberate works-while-stopping asymmetry and closure-panic resumption (context + `Blocking` docs).
- `ChildPlan::with_options` publication side effect; `SendError`/`Replied` Debug-redaction intent comments (Debug output is non-contractual per the #116-round precedent, so no pinning test); `Handler`'s post-error cross-link.

Survivors that are *code* changes (raw.rs `continuation_needs_external` rename + predicate extraction, `Admission`'s `H: Unpin` relaxation) are deliberately excluded to keep this PR doc-only; they follow separately.

## Checklist items closed

- Confirmed empirically that doc-check's `RUSTDOCFLAGS="-D warnings"` already denies `rustdoc::broken_intra_doc_links` (a broken link failed the build during development), so no crate attribute is needed.
- Added `[package.metadata.docs.rs]` (all-features, link-to-definition).

## Verification

`just ci` green in the worktree. One unrelated failure encountered along the way — the load-sensitive `timer_waker_proxy` caller-clone-ordinal pins — is filed as #430 with repro evidence (0/55 failures on quiet `main`; the diff here is behaviorally inert).

Part of #371.