### PR TITLE
docs: examples/ — nine asserting smoke tests, wired into CI (#371 PR 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,32 +23,59 @@ the current checkout, including when invoked from a worktree:
 ./tools/dev just ci-nix
 ```
 
-A task-first application needs no actor merely to obtain supervision:
+A counter actor with a request/reply protocol, spawned under an ordered
+tree — quoted from [`examples/quickstart.rs`](crates/shelterwood/examples/quickstart.rs),
+which CI compiles and runs:
 
 ```rust
-use std::time::Duration;
+struct Counter {
+    count: u64,
+}
 
-use shelterwood::{ExitError, TaskOnceDef, Tree};
+enum Msg {
+    Add(u64),
+    Total(Reply<u64>),
+}
+
+impl Actor for Counter {
+    type Msg = Msg;
+    type Args = ();
+
+    async fn init(_args: (), _context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self { count: 0 })
+    }
+
+    async fn handle(&mut self, message: Msg, _context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            Msg::Add(n) => self.count += n,
+            Msg::Total(reply) => reply.send(self.count),
+        }
+        Ok(())
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut tree = Tree::new();
-    let (_worker, _completion) = tree.add_task_once(
-        "worker",
-        TaskOnceDef::new(|context| async move {
-            context.shutdown_token().cancelled().await;
-            Ok::<_, ExitError>(())
-        }),
-    )?;
+    let counter = tree.add_actor("counter", ActorDef::<Counter>::cloned(()))?;
 
     let system = tree.spawn()?;
     system.wait_started().await?;
 
-    // The owner drives bounded teardown and waits for every child to join.
+    counter.send(Msg::Add(2)).await?;
+    let replied = counter.call(Msg::Total, Duration::from_secs(1)).await?;
+    assert_eq!(replied.value, 2);
+
     system.shutdown(Duration::from_secs(5)).await?;
     Ok(())
 }
 ```
+
+The remaining runnable behaviors live in
+[`crates/shelterwood/examples/`](crates/shelterwood/examples/) — request/reply,
+supervision and restart, ordered startup, dynamic scopes, graceful shutdown,
+observation, cyclic wiring, and host embedding — each an asserting smoke test
+run by CI (`just examples`).
 
 Use `Tree` when declaration order should also be startup order and reverse
 shutdown order. Use `DynamicTree` for concurrently started membership that can

--- a/crates/shelterwood/examples/cyclic_wiring.rs
+++ b/crates/shelterwood/examples/cyclic_wiring.rs
@@ -1,0 +1,109 @@
+//! Cyclic wiring: reserving slots splits handle creation from definition, so
+//! two actors can hold each other's `ActorRef` before either is defined. A
+//! one-round ping-pong proves the cycle carries traffic both ways.
+
+use std::time::Duration;
+
+use shelterwood::{Actor, ActorOnceDef, ActorRef, Context, ExitError, ExitResult, Tree};
+use tokio::sync::mpsc;
+
+// ANCHOR: cyclic_wiring
+// ANCHOR: actors
+enum PingMsg {
+    Kick,
+    Pong,
+}
+
+enum PongMsg {
+    Ping,
+}
+
+struct Pinger {
+    peer: ActorRef<PongMsg>,
+    done: mpsc::UnboundedSender<()>,
+}
+
+impl Actor for Pinger {
+    type Msg = PingMsg;
+    type Args = (ActorRef<PongMsg>, mpsc::UnboundedSender<()>);
+
+    async fn init(
+        (peer, done): Self::Args,
+        _context: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        Ok(Self { peer, done })
+    }
+
+    async fn handle(&mut self, message: PingMsg, _context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            PingMsg::Kick => {
+                self.peer
+                    .send(PongMsg::Ping)
+                    .await
+                    .map_err(|_| ExitError::message("ponger is unavailable"))?;
+                Ok(())
+            }
+            PingMsg::Pong => {
+                let _ = self.done.send(());
+                Ok(())
+            }
+        }
+    }
+}
+
+struct Ponger {
+    peer: ActorRef<PingMsg>,
+}
+
+impl Actor for Ponger {
+    type Msg = PongMsg;
+    type Args = ActorRef<PingMsg>;
+
+    async fn init(peer: Self::Args, _context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self { peer })
+    }
+
+    async fn handle(&mut self, message: PongMsg, _context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            PongMsg::Ping => {
+                self.peer
+                    .send(PingMsg::Pong)
+                    .await
+                    .map_err(|_| ExitError::message("pinger is unavailable"))?;
+                Ok(())
+            }
+        }
+    }
+}
+// ANCHOR_END: actors
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel();
+
+    // ANCHOR: reserve
+    let mut tree = Tree::new();
+    let pinger_slot = tree.reserve_actor::<PingMsg>("pinger")?;
+    let ponger_slot = tree.reserve_actor::<PongMsg>("ponger")?;
+
+    // Both handles exist before either definition, so each definition can
+    // capture the other's.
+    let pinger = pinger_slot.actor_ref();
+    let ponger = ponger_slot.actor_ref();
+
+    let _ = pinger_slot.define_once(ActorOnceDef::<Pinger>::new((ponger, done_tx)));
+    let _ = ponger_slot.define_once(ActorOnceDef::<Ponger>::new(pinger.clone()));
+    // ANCHOR_END: reserve
+
+    let system = tree.spawn()?;
+    system.wait_started().await?;
+
+    pinger.send(PingMsg::Kick).await?;
+    let completed = tokio::time::timeout(Duration::from_secs(5), done_rx.recv()).await?;
+    assert_eq!(completed, Some(()));
+
+    system.shutdown(Duration::from_secs(5)).await?;
+    println!("ping-pong round trip completed through cyclically wired actors");
+    Ok(())
+}
+// ANCHOR_END: cyclic_wiring

--- a/crates/shelterwood/examples/dynamic_scope.rs
+++ b/crates/shelterwood/examples/dynamic_scope.rs
@@ -1,0 +1,69 @@
+//! Runtime admission and planned removal under a dynamic scope: admit an
+//! actor through the `DynamicScopeRef`, exercise it, then remove exactly the
+//! retained membership.
+
+use std::time::Duration;
+
+use shelterwood::{
+    Actor, ActorDef, Context, DynamicTree, ExitError, ExitResult, RemoveOutcome, Reply,
+};
+
+// ANCHOR: actor
+struct Counter {
+    count: u64,
+}
+
+enum Msg {
+    Add(u64),
+    Total(Reply<u64>),
+}
+
+impl Actor for Counter {
+    type Msg = Msg;
+    type Args = ();
+
+    async fn init(_args: (), _context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self { count: 0 })
+    }
+
+    async fn handle(&mut self, message: Msg, _context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            Msg::Add(n) => self.count += n,
+            Msg::Total(reply) => reply.send(self.count),
+        }
+        Ok(())
+    }
+}
+// ANCHOR_END: actor
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // ANCHOR: dynamic_scope
+    let system = DynamicTree::new().spawn()?;
+    system.wait_started().await?;
+    let scope = system.scope();
+
+    // ANCHOR: admit
+    let counter = scope
+        .add_actor("counter", ActorDef::<Counter>::cloned(()))
+        .await?;
+    // ANCHOR_END: admit
+
+    counter.send(Msg::Add(3)).await?;
+    let replied = counter.call(Msg::Total, Duration::from_secs(1)).await?;
+    assert_eq!(replied.value, 3);
+
+    // ANCHOR: remove
+    // Planned removal: keep the exact handle returned by admission and remove
+    // that membership. A same-id successor admitted later is a distinct
+    // membership this removal could never touch.
+    let outcome = scope.remove_actor(&counter).await;
+    assert_eq!(outcome, RemoveOutcome::Removed);
+    // ANCHOR_END: remove
+    assert!(scope.as_scope().snapshot().child("counter").is_none());
+
+    system.shutdown(Duration::from_secs(5)).await?;
+    // ANCHOR_END: dynamic_scope
+    println!("admitted, exercised, and removed a runtime member");
+    Ok(())
+}

--- a/crates/shelterwood/examples/embedding.rs
+++ b/crates/shelterwood/examples/embedding.rs
@@ -1,0 +1,59 @@
+//! Host-owned `main`: the host opens process-lifetime state, then runs two
+//! complete build/spawn/`start_or_shutdown`/operate/`shutdown` cycles over
+//! fresh trees sharing that state.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use shelterwood::{PolicyError, Readiness, TaskDef, Tree};
+
+// ANCHOR: service
+fn service(database: Arc<AtomicU64>) -> Result<TaskDef, PolicyError> {
+    TaskDef::new(move |context| {
+        let database = Arc::clone(&database);
+        async move {
+            database.fetch_add(1, Ordering::SeqCst);
+            // Manual readiness publishes that the resource is usable, not
+            // merely that the future was spawned.
+            context.mark_ready();
+            context.shutdown_token().cancelled().await;
+            Ok(())
+        }
+    })
+    .readiness(Readiness::Manual)
+}
+// ANCHOR_END: service
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // ANCHOR: embedding
+    // Durable host state is what crosses cycles; each tree receives a handle.
+    let database = Arc::new(AtomicU64::new(0));
+
+    for cycle in 1..=2u64 {
+        // Builders and `System` are single-use: each cycle constructs afresh.
+        let mut tree = Tree::new();
+        tree.add_task("service", service(Arc::clone(&database))?)?;
+
+        let system = tree.spawn()?;
+        // A ready owner on success; on failure the started prefix is rolled
+        // back and the startup error returned instead.
+        let system = system.start_or_shutdown(Duration::from_secs(5)).await?;
+
+        // Operate: readiness gated on the increment, so it is visible here.
+        assert_eq!(database.load(Ordering::SeqCst), cycle);
+
+        // Explicit shutdown joins the root driver before host resources close.
+        system.shutdown(Duration::from_secs(5)).await?;
+    }
+
+    assert_eq!(database.load(Ordering::SeqCst), 2);
+    // ANCHOR_END: embedding
+    println!("two host-owned cycles ran over shared state");
+    Ok(())
+}

--- a/crates/shelterwood/examples/graceful_shutdown.rs
+++ b/crates/shelterwood/examples/graceful_shutdown.rs
@@ -1,0 +1,86 @@
+//! Bounded shutdown of a resource-owning actor and a cooperative task:
+//! the frozen mailbox prefix drains under `MailboxShutdown::Drain`, then
+//! `on_stop` returns the resource, then the task observes its shutdown
+//! token — all inside one `System::shutdown` budget.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use shelterwood::{
+    Actor, ActorDef, Context, ExitError, ExitResult, MailboxShutdown, StopContext, TaskDef, Tree,
+};
+
+// ANCHOR: graceful_shutdown
+// ANCHOR: actor
+struct Store {
+    handled: Arc<AtomicU64>,
+    closed: Arc<AtomicBool>,
+}
+
+impl Actor for Store {
+    type Msg = u64;
+    type Args = (Arc<AtomicU64>, Arc<AtomicBool>);
+
+    async fn init(
+        (handled, closed): Self::Args,
+        _context: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        Ok(Self { handled, closed })
+    }
+
+    async fn handle(&mut self, value: u64, _context: &mut Context<'_, Self>) -> ExitResult {
+        self.handled.fetch_add(value, Ordering::SeqCst);
+        Ok(())
+    }
+
+    // Best-effort resource return: runs after the drained prefix, within
+    // the same grace budget.
+    async fn on_stop(&mut self, _context: &mut StopContext<'_, Self>) {
+        self.closed.store(true, Ordering::SeqCst);
+    }
+}
+// ANCHOR_END: actor
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let handled = Arc::new(AtomicU64::new(0));
+    let closed = Arc::new(AtomicBool::new(false));
+
+    // ANCHOR: declare
+    let mut tree = Tree::new();
+    tree.add_task(
+        "worker",
+        TaskDef::new(|context| async move {
+            context.shutdown_token().cancelled().await;
+            Ok(())
+        }),
+    )?;
+    let store = tree.add_actor(
+        "store",
+        ActorDef::<Store>::cloned((Arc::clone(&handled), Arc::clone(&closed)))
+            .mailbox_shutdown(MailboxShutdown::Drain),
+    )?;
+    // ANCHOR_END: declare
+
+    let system = tree.spawn()?;
+    system.wait_started().await?;
+
+    // ANCHOR: shutdown
+    // Accepted before shutdown, so `Drain` guarantees delivery ahead of
+    // `on_stop` even if teardown wins the race to freeze intake.
+    store.send(7).await?;
+
+    system.shutdown(Duration::from_secs(5)).await?;
+
+    assert_eq!(handled.load(Ordering::SeqCst), 7);
+    assert!(closed.load(Ordering::SeqCst));
+    // ANCHOR_END: shutdown
+    println!("drained; resource closed");
+    Ok(())
+}
+// ANCHOR_END: graceful_shutdown

--- a/crates/shelterwood/examples/observation.rs
+++ b/crates/shelterwood/examples/observation.rs
@@ -1,0 +1,86 @@
+//! The subscribe-then-snapshot catch-up protocol: subscribe to lifecycle
+//! events first, read `snapshot()` as ground truth, then apply later events
+//! as deltas using the watermark rule.
+
+use std::time::Duration;
+
+use shelterwood::{
+    ChildState, DynamicTree, LifecycleEventKind, LifecycleItem, RemoveOutcome, TaskDef,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let system = DynamicTree::new().spawn()?;
+    system.wait_started().await?;
+    let scope = system.scope();
+
+    // ANCHOR: observation
+    // ANCHOR: subscribe_then_snapshot
+    // Subscribe first: subscriptions begin "now" and never replay history.
+    let mut events = scope.as_scope().subscribe_lifecycle();
+    // Read the snapshot after subscribing and treat it as ground truth.
+    let ground_truth = scope.as_scope().snapshot();
+    assert!(ground_truth.child("worker").is_none());
+    // ANCHOR_END: subscribe_then_snapshot
+
+    let worker = scope
+        .add_task(
+            "worker",
+            TaskDef::new(|context| async move {
+                context.shutdown_token().cancelled().await;
+                Ok(())
+            }),
+        )
+        .await?;
+
+    // ANCHOR: watermark
+    let added = loop {
+        let item = tokio::time::timeout(Duration::from_secs(10), events.recv())
+            .await?
+            .expect("the stream stays open while the scope handle lives");
+        let LifecycleItem::Event(event) = item else {
+            // On `Lagged`, restart the protocol from a fresh snapshot.
+            unreachable!("this small fixture cannot overflow its buffer");
+        };
+        // The watermark rule: an event with `seq <= watermark` is already
+        // reflected by the ground-truth snapshot and must be discarded.
+        let watermark = if event.scope == scope.as_scope().membership() {
+            Some(ground_truth.lifecycle_seq)
+        } else {
+            ground_truth.watermark(event.scope)
+        };
+        if watermark.is_some_and(|watermark| event.seq <= watermark) {
+            continue;
+        }
+        if let LifecycleEventKind::Added { membership, .. } = event.kind
+            && membership == worker.membership()
+        {
+            break event;
+        }
+    };
+    assert!(
+        added.seq > ground_truth.lifecycle_seq,
+        "the admission edge postdates the ground-truth snapshot"
+    );
+    // ANCHOR_END: watermark
+
+    // ANCHOR: wait_for_child
+    // Predicates accept every state at or beyond the desired edge — watches
+    // conflate intermediate committed states — under a finite budget.
+    let child = scope
+        .as_scope()
+        .wait_for_child(
+            "worker",
+            |child| matches!(child.state, ChildState::Running) || child.state.is_terminal(),
+            Duration::from_secs(10),
+        )
+        .await?;
+    assert_eq!(child.membership, worker.membership());
+    // ANCHOR_END: wait_for_child
+    // ANCHOR_END: observation
+
+    assert_eq!(scope.remove_task(&worker).await, RemoveOutcome::Removed);
+    system.shutdown(Duration::from_secs(5)).await?;
+    println!("observed the admission through catch-up and a bounded wait");
+    Ok(())
+}

--- a/crates/shelterwood/examples/ordered_startup.rs
+++ b/crates/shelterwood/examples/ordered_startup.rs
@@ -1,0 +1,68 @@
+//! Ordered startup: in an ordered tree each child's readiness gates the next
+//! declared child's start, and shutdown stops one fully joined child at a
+//! time in reverse declaration order.
+
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use shelterwood::{PolicyError, Readiness, TaskDef, Tree};
+
+type Log = Arc<Mutex<Vec<String>>>;
+
+// ANCHOR: ordered_startup
+// ANCHOR: worker
+fn worker(name: &'static str, log: Log) -> Result<TaskDef, PolicyError> {
+    TaskDef::new(move |context| {
+        let log = Arc::clone(&log);
+        async move {
+            log.lock()
+                .expect("the log mutex is never poisoned")
+                .push(format!("start:{name}"));
+            // Manual readiness: the next declared child starts only after
+            // this signal.
+            context.mark_ready();
+            context.shutdown_token().cancelled().await;
+            log.lock()
+                .expect("the log mutex is never poisoned")
+                .push(format!("stop:{name}"));
+            Ok(())
+        }
+    })
+    .readiness(Readiness::Manual)
+}
+// ANCHOR_END: worker
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let log = Log::default();
+
+    let mut tree = Tree::new();
+    for name in ["first", "second", "third"] {
+        tree.add_task(name, worker(name, Arc::clone(&log))?)?;
+    }
+
+    let system = tree.spawn()?;
+    system.wait_started().await?;
+    assert_eq!(
+        *log.lock().expect("the log mutex is never poisoned"),
+        ["start:first", "start:second", "start:third"],
+    );
+
+    system.shutdown(Duration::from_secs(5)).await?;
+    assert_eq!(
+        *log.lock().expect("the log mutex is never poisoned"),
+        [
+            "start:first",
+            "start:second",
+            "start:third",
+            "stop:third",
+            "stop:second",
+            "stop:first",
+        ],
+    );
+    println!("startup followed declaration order; shutdown reversed it");
+    Ok(())
+}
+// ANCHOR_END: ordered_startup

--- a/crates/shelterwood/examples/quickstart.rs
+++ b/crates/shelterwood/examples/quickstart.rs
@@ -1,0 +1,55 @@
+//! The front-page quickstart: a counter actor with a request/reply
+//! protocol, spawned under an ordered tree inside an ambient Tokio runtime.
+
+use std::time::Duration;
+
+use shelterwood::{Actor, ActorDef, Context, ExitError, ExitResult, Reply, Tree};
+
+// ANCHOR: quickstart
+// ANCHOR: actor
+struct Counter {
+    count: u64,
+}
+
+enum Msg {
+    Add(u64),
+    Total(Reply<u64>),
+}
+
+impl Actor for Counter {
+    type Msg = Msg;
+    type Args = ();
+
+    async fn init(_args: (), _context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self { count: 0 })
+    }
+
+    async fn handle(&mut self, message: Msg, _context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            Msg::Add(n) => self.count += n,
+            Msg::Total(reply) => reply.send(self.count),
+        }
+        Ok(())
+    }
+}
+// ANCHOR_END: actor
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // ANCHOR: run
+    let mut tree = Tree::new();
+    let counter = tree.add_actor("counter", ActorDef::<Counter>::cloned(()))?;
+
+    let system = tree.spawn()?;
+    system.wait_started().await?;
+
+    counter.send(Msg::Add(2)).await?;
+    let replied = counter.call(Msg::Total, Duration::from_secs(1)).await?;
+    assert_eq!(replied.value, 2);
+
+    system.shutdown(Duration::from_secs(5)).await?;
+    // ANCHOR_END: run
+    println!("counter total: {}", replied.value);
+    Ok(())
+}
+// ANCHOR_END: quickstart

--- a/crates/shelterwood/examples/request_reply.rs
+++ b/crates/shelterwood/examples/request_reply.rs
@@ -1,0 +1,71 @@
+//! Request/reply two ways: a split reply channel awaited separately from
+//! its send, and the packaged `call` that bundles the same pieces under one
+//! deadline. Both results carry the accepting incarnation as identity
+//! evidence.
+
+use std::time::Duration;
+
+use shelterwood::{Actor, ActorDef, Context, ExitError, ExitResult, Reply, Tree};
+
+// ANCHOR: request_reply
+// ANCHOR: actor
+struct Counter {
+    count: u64,
+}
+
+enum Msg {
+    Add(u64),
+    Total(Reply<u64>),
+}
+
+impl Actor for Counter {
+    type Msg = Msg;
+    type Args = ();
+
+    async fn init(_args: (), _context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self { count: 0 })
+    }
+
+    async fn handle(&mut self, message: Msg, _context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            Msg::Add(n) => self.count += n,
+            Msg::Total(reply) => reply.send(self.count),
+        }
+        Ok(())
+    }
+}
+// ANCHOR_END: actor
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tree = Tree::new();
+    let counter = tree.add_actor("counter", ActorDef::<Counter>::cloned(()))?;
+
+    let system = tree.spawn()?;
+    system.wait_started().await?;
+
+    counter.send(Msg::Add(40)).await?;
+
+    // ANCHOR: split_reply
+    // Split the pieces of a call: embed the `Reply` in a message, submit it
+    // fail-fast, and await the receiver under a response-only deadline.
+    // Acceptance evidence belongs to the send's own result.
+    let (reply, receiver) = counter.reply_channel();
+    let accepted = counter.try_send(Msg::Total(reply))?;
+    let total = receiver.recv(Duration::from_secs(1)).await?;
+    assert_eq!(total, 40);
+    // ANCHOR_END: split_reply
+
+    // ANCHOR: call
+    // `call` packages construction, acceptance, and response under one
+    // deadline, resolving to the value plus the accepting incarnation.
+    let replied = counter.call(Msg::Total, Duration::from_secs(1)).await?;
+    assert_eq!(replied.value, 40);
+    assert_eq!(replied.incarnation, accepted);
+    // ANCHOR_END: call
+
+    system.shutdown(Duration::from_secs(5)).await?;
+    println!("split reply and call both saw: {total}");
+    Ok(())
+}
+// ANCHOR_END: request_reply

--- a/crates/shelterwood/examples/supervision_restart.rs
+++ b/crates/shelterwood/examples/supervision_restart.rs
@@ -1,0 +1,91 @@
+//! Supervised restart: an actor that fails on demand is restarted by policy,
+//! and the same handle keeps answering across the superseding incarnation.
+
+use std::time::Duration;
+
+use shelterwood::{
+    Actor, ActorDef, Backoff, Context, ExitError, ExitResult, Jitter, Reply, RestartCondition,
+    RestartPolicy, Tree,
+};
+
+// ANCHOR: supervision_restart
+// ANCHOR: actor
+struct Worker;
+
+enum Msg {
+    Crash,
+    Greet(Reply<&'static str>),
+}
+
+impl Actor for Worker {
+    type Msg = Msg;
+    type Args = ();
+
+    async fn init(_args: (), _context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self)
+    }
+
+    async fn handle(&mut self, message: Msg, _context: &mut Context<'_, Self>) -> ExitResult {
+        match message {
+            Msg::Crash => Err(ExitError::message("crashed on request")),
+            Msg::Greet(reply) => {
+                reply.send("hello");
+                Ok(())
+            }
+        }
+    }
+}
+// ANCHOR_END: actor
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // ANCHOR: policy
+    let mut tree = Tree::new();
+    let worker = tree.add_actor(
+        "worker",
+        ActorDef::<Worker>::cloned(()).restart(RestartPolicy::new(
+            RestartCondition::OnFailure,
+            Backoff::fixed(Duration::from_millis(10), Jitter::None)?,
+        )),
+    )?;
+
+    let system = tree.spawn()?;
+    system.wait_started().await?;
+    // ANCHOR_END: policy
+
+    // ANCHOR: restart_wait
+    let scope = system.scope();
+    let before = scope
+        .child("worker")
+        .and_then(|child| child.incarnation)
+        .expect("a started child has a live incarnation");
+
+    worker.send(Msg::Crash).await?;
+
+    // Snapshot watches conflate, so accept any incarnation at or past the
+    // restart edge rather than expecting exactly the next generation.
+    let restarted = scope
+        .wait_for_child(
+            "worker",
+            |child| {
+                child
+                    .incarnation
+                    .is_some_and(|incarnation| incarnation.supersedes(before))
+            },
+            Duration::from_secs(10),
+        )
+        .await?;
+    let after = restarted
+        .incarnation
+        .expect("the predicate matched a live incarnation");
+    assert!(after.supersedes(before));
+
+    let replied = worker.call(Msg::Greet, Duration::from_secs(1)).await?;
+    assert_eq!(replied.value, "hello");
+    // ANCHOR_END: restart_wait
+
+    system.shutdown(Duration::from_secs(5)).await?;
+    println!("worker restarted after failure and answered again");
+    Ok(())
+}
+// ANCHOR_END: supervision_restart

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -272,9 +272,6 @@ pub mod guides {
 // never resolve them.
 #[cfg(doctest)]
 mod repository_docs {
-    #[doc = include_str!("../../../README.md")]
-    mod readme {}
-
     #[doc = include_str!("../../../docs/embedding.md")]
     mod embedding {}
 

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,23 @@
             }
           );
 
+          # Examples are asserting smoke tests; running them is the check.
+          # Keep the list in sync with the justfile's `examples` recipe.
+          examples-run = craneLibNightly.mkCargoDerivation (
+            commonArgs
+            // {
+              cargoArtifacts = cargoArtifactsNightly;
+              buildPhaseCargoCommand = ''
+                for example in quickstart request_reply supervision_restart \
+                  ordered_startup dynamic_scope graceful_shutdown observation \
+                  cyclic_wiring embedding; do
+                  cargo run --locked -p shelterwood --example "$example"
+                done
+              '';
+              doInstallCargoArtifacts = false;
+            }
+          );
+
           api-enforcement = craneLibNightly.mkCargoDerivation (
             commonArgs
             // {

--- a/justfile
+++ b/justfile
@@ -37,6 +37,20 @@ runtime-api-check:
     cargo run --locked -p shelterwood-api-reachability -- target/doc/shelterwood.json
     ./tools/check-core-manifest.sh
 
+# Examples are smoke tests: each ends in assertions and a nonzero exit fails
+# the recipe. Keep the list in sync with crates/shelterwood/examples/ and the
+# flake's examples-run check.
+examples:
+    cargo run --locked -p shelterwood --example quickstart
+    cargo run --locked -p shelterwood --example request_reply
+    cargo run --locked -p shelterwood --example supervision_restart
+    cargo run --locked -p shelterwood --example ordered_startup
+    cargo run --locked -p shelterwood --example dynamic_scope
+    cargo run --locked -p shelterwood --example graceful_shutdown
+    cargo run --locked -p shelterwood --example observation
+    cargo run --locked -p shelterwood --example cyclic_wiring
+    cargo run --locked -p shelterwood --example embedding
+
 external-consumer-check:
     ./tools/check-external-consumer.sh
 
@@ -45,7 +59,7 @@ nixfmt-check:
 
 # Fast local CI mirror — reuses the local cargo cache and incremental builds.
 # The clean Nix lane retains the explicit all-target build for non-test codegen coverage.
-ci: fmt lint lint-default test doc-check runtime-api-check external-consumer-check nixfmt-check
+ci: fmt lint lint-default test examples doc-check runtime-api-check external-consumer-check nixfmt-check
 
 # Full clean Nix CI lane; use before pushing or when touching Nix files.
 ci-nix:


### PR DESCRIPTION
Third PR of the #371 pass: the tested artifacts everything else quotes.

## What's here

One file per behavior in `crates/shelterwood/examples/`, each an asserting smoke test (not a demo) that terminates in seconds:

- `quickstart` — the front-page counter (byte-close to the lib.rs doctest); `request_reply` — split `reply_channel` + plain `call`, asserting the accepting-incarnation identity evidence; `graceful_shutdown` — `MailboxShutdown::Drain` contract + `on_stop` + a token-parked task under one bounded `shutdown`.
- `supervision_restart` — OnFailure restart proven by `supersedes` under an at-or-past `wait_for_child` predicate (never expects exactly +1); `ordered_startup` — `Readiness::Manual` gating proves declaration order = start order and reverse-order joined stops; `cyclic_wiring` — `reserve_actor` slots hand out both handles before either child is defined.
- `dynamic_scope` — runtime admission, exercise, and the planned-removal protocol (`RemoveOutcome::Removed`, gone from the snapshot); `observation` — the subscribe-then-snapshot catch-up protocol with the watermark rule, exactly as the observation guide teaches; `embedding` — host-owned main, two complete build/`start_or_shutdown`/operate/`shutdown` cycles over shared host state (condensed from the sidecar acceptance test).

Every file carries `// ANCHOR:` regions for the mdbook `{{#include}}`s (PR 4) and README quoting.

## Wiring

- `just examples` runs all nine; wired into `ci`. Matching `examples-run` check added to `flake.nix` extraChecks (justfile/flake sync rule observed).
- README's code sample is now a quote of `examples/quickstart.rs` — the tested artifact — and the README doctest lane in `lib.rs` is removed, completing that PR 1 checklist item.

## The runtime decision the issue flags

Examples name Tokio (`#[tokio::main]`). That matches current practice everywhere the repo shows runnable code — README, the crate front page, the acceptance tests — and tokio is the declared dev-dependency runtime. If the pending spec-prose adjudication about de-naming Tokio lands differently, the examples are one mechanical sweep.

## Verification

`just ci` green in the worktree, including the new `examples` recipe (all nine run and assert). Each example was also re-run repeatedly by its author agent with no flakes; clippy `--all-targets -D warnings` and nightly fmt cover the new files.

Part of #371. Contains no source changes outside `examples/`, the README, the doctest-lane removal in `lib.rs`, and the CI wiring.

Note: this branch was cut from the #431 branch pre-merge, so the PR shows only the examples commits once GitHub resolves the merged ancestors.