### PR TITLE
Document admission lock ordering and exit disposal venue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ result
 
 # mdbook build output
 /book/book/
+
+# Retired local review sketch; the durable conclusions live in tracked issues.
+/pi-sketch.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,10 +169,11 @@ the pattern; where releasing is impossible, `debug_assert!` instead, as
 `MailboxState::take_waiters` does). And a value that may block on destruction
 goes to `runtime::dispose_detached`, not merely past the unlock. That second
 convention is currently met for mailbox payloads, construction closures,
-blocking-offload captured state, displaced resident graphs and rejected
-admission projections. Raw incarnation-owned values — async offload futures,
-continuations, timers and completions — instead follow SPEC §6.5's on-task
-contained funnel because its disposal verdict is part of exit classification.
+blocking-offload captured state, displaced resident graphs, and rejected
+lifecycle events and admission projections. Raw incarnation-owned values —
+async offload futures, continuations, timers and completions — instead
+follow SPEC §6.5's on-task contained funnel, because a destructor panic
+there is cleanup evidence that exit classification must fold in.
 Framework-retained `Exit` copies meet it through `RetainedExit`,
 including driver completions and pending terminal disposal; exits handed to
 users keep ordinary drop timing. Its fail-safe under exhausted thread

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,8 @@ rests on:
   a drop. What must be outside the critical section is the *destination*:
   `MailboxTxn::finish`/`finish_returned` handing the value back only after
   releasing the guard, `withdraw`'s `Withdrawal` carrying its outcome and
-  post-unlock effects together, and `Acceptance`'s `#[must_use]` result all
-  encode that.
+  post-unlock effects together, and `MailboxTxn::take_payload`'s `#[must_use]`
+  carrier all encode that.
 - **`Arc` traffic that cannot reach zero.** Cloning an `Arc` under a lock is
   refcount work; dropping one is only refcount work while another owner is
   provable. Prefer restructuring over the proof — every violation the #235
@@ -142,6 +142,16 @@ rests on:
   stays inside the rule — the record is framework-owned data and the retained
   clone is provably non-last — but it is the deepest the exemption goes, so a
   new operation added to the doubled section needs the same accounting.
+  Dynamic admission has two further, narrowly accounted shapes around this
+  order. `DynamicControl::reserve` holds its state mutex while
+  `mint_reserved_slot` takes the child-identity mutex and adoption acquires the
+  new child's gate; both belong to a member minted inside that critical
+  section and are unpublished, hence uncontended. Admission install holds the
+  same state mutex inside the root gate while calling `admit_child_locked`, but
+  the reserved member was already adopted onto that root gate and the root
+  cannot be re-homed while its dynamic route is live, so the handoff check
+  short-circuits without a second gate acquisition. Changing either
+  publication or re-homing invariant requires re-deriving this exception.
   `WakerProxy`'s mutex (`crates/shelterwood-core/src/waker_proxy.rs`) sits at the
   other end of that order: it is a **leaf**. `wake_by_ref` acquires it from
   whatever thread drives the external primitive — the timer driver, a sender,
@@ -156,7 +166,11 @@ the pattern; where releasing is impossible, `debug_assert!` instead, as
 `MailboxState::take_waiters` does). And a value that may block on destruction
 goes to `runtime::dispose_detached`, not merely past the unlock. That second
 convention is currently met for mailbox payloads, construction closures,
-offloads, displaced resident graphs and rejected admission projections. Framework-retained `Exit` copies meet it through `RetainedExit`,
+blocking-offload captured state, displaced resident graphs and rejected
+admission projections. Raw incarnation-owned values — async offload futures,
+continuations, timers and completions — instead follow SPEC §6.5's on-task
+contained funnel because its disposal verdict is part of exit classification.
+Framework-retained `Exit` copies meet it through `RetainedExit`,
 including driver completions and pending terminal disposal; exits handed to
 users keep ordinary drop timing. Its fail-safe under exhausted thread
 creation is an unreclaimed queued job — memory held for the life of the
@@ -167,6 +181,15 @@ Reviewing a new `.lock()` is one pass: name every value the critical section
 can destroy, every callback it can invoke, and every panic it can raise. If
 any of those is user code, hand it to a transaction (`txn.defer`), an effects
 struct, or the caller.
+
+## Runtime naming
+
+Non-test façade code names only the runtime capability layer, never Tokio.
+After the crate fold, façade tests, doctests and examples may use the pinned
+Tokio dev-dependency when executor control or runnable example syntax is the
+subject; internal unit tests still prefer `crate::runtime` when it exposes the
+needed operation. This dev-only allowance does not widen the public API or the
+core crate's dependency boundary.
 
 ## Running anything
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,14 +144,17 @@ rests on:
   new operation added to the doubled section needs the same accounting.
   Dynamic admission has two further, narrowly accounted shapes around this
   order. `DynamicControl::reserve` holds its state mutex while
-  `mint_reserved_slot` takes the child-identity mutex and adoption acquires the
-  new child's gate; both belong to a member minted inside that critical
-  section and are unpublished, hence uncontended. Admission install holds the
-  same state mutex inside the root gate while calling `admit_child_locked`, but
-  the reserved member was already adopted onto that root gate and the root
-  cannot be re-homed while its dynamic route is live, so the handoff check
-  short-circuits without a second gate acquisition. Changing either
-  publication or re-homing invariant requires re-deriving this exception.
+  `mint_reserved_slot` briefly takes the already-published parent scope's
+  child-identity mutex, then adoption acquires the new child's gate. The
+  identity API releases its guard before returning and cannot call back into
+  dynamic control, so no reverse edge can be held; the child gate belongs to a
+  member minted inside the state critical section and remains unpublished,
+  hence uncontended. Admission install holds the same state mutex inside the
+  root gate while calling `admit_child_locked`, but the reserved member was
+  already adopted onto that root gate and the root cannot be re-homed while
+  its dynamic route is live, so the handoff check short-circuits without a
+  second gate acquisition. Changing either publication or re-homing invariant
+  requires re-deriving this exception.
   `WakerProxy`'s mutex (`crates/shelterwood-core/src/waker_proxy.rs`) sits at the
   other end of that order: it is a **leaf**. `wake_by_ref` acquires it from
   whatever thread drives the external primitive — the timer driver, a sender,
@@ -184,12 +187,13 @@ struct, or the caller.
 
 ## Runtime naming
 
-Non-test façade code names only the runtime capability layer, never Tokio.
-After the crate fold, façade tests, doctests and examples may use the pinned
-Tokio dev-dependency when executor control or runnable example syntax is the
-subject; internal unit tests still prefer `crate::runtime` when it exposes the
-needed operation. This dev-only allowance does not widen the public API or the
-core crate's dependency boundary.
+Non-test façade implementation imports and invokes only the runtime capability
+layer, never a concrete Tokio API. After the crate fold, façade tests, doctests
+and examples may use the pinned Tokio dev-dependency for executor control,
+test-only synchronization or runnable example syntax; internal unit tests
+still prefer `crate::runtime` when it exposes the behavior under test. This
+dev-only allowance does not widen the public API or the core crate's dependency
+boundary.
 
 ## Running anything
 

--- a/book/src/appendix-where-prose-lives.md
+++ b/book/src/appendix-where-prose-lives.md
@@ -12,7 +12,7 @@ here rather than inventing a new one.
 | `crates/shelterwood/examples/` | Everyone above | The tested artifacts the book and README quote | Each ends in assertions; `just examples` runs all of them in CI |
 | `specs/SPEC.md` | Maintainers and reviewers | The normative contract the implementation is held to | Conformance obligations map to tests; adjudication protocol in the tracker |
 | `README.md` | The front door | Orientation and the quickstart quote | Quotes `examples/quickstart.rs`, which CI runs |
-| `CLAUDE.md` / code comments | Contributors in the diff | Invariants the code cannot say itself | Reviewed beside the code they constrain |
+| `AGENTS.md` (`CLAUDE.md` symlinks to it) / code comments | Contributors in the diff | Invariants the code cannot say itself | Reviewed beside the code they constrain |
 
 Two corollaries the pass that created this structure settled:
 

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -770,6 +770,12 @@ impl ScopeRuntime {
         }
         let root = Arc::clone(&self.root);
         let installed = root.with_observation_gate(|txn| {
+            // The dynamic-state mutex rides inside the root gate here. Every
+            // reservation was adopted onto this same gate before publication,
+            // and a root with a live dynamic route cannot be re-homed. Thus
+            // `admit_child_locked`'s handoff check below short-circuits on gate
+            // identity: it never acquires a second gate under `state`. This is
+            // the install half of the admission exemption in AGENTS.md.
             let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
             let id = request.slot.member.id();
             let matches_reservation = state.entry(id).is_some_and(|entry| {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -770,8 +770,10 @@ impl ScopeRuntime {
         }
         let root = Arc::clone(&self.root);
         let installed = root.with_observation_gate(|txn| {
-            // The dynamic-state mutex rides inside the root gate here. Every
-            // reservation was adopted onto this same gate before publication,
+            // The dynamic-state mutex rides inside the root gate here. The
+            // route check above admitted only a request whose control is this
+            // driver's live one, so its reservation was minted against this
+            // very root and adopted onto this same gate before publication,
             // and a root with a live dynamic route cannot be re-homed. Thus
             // `admit_child_locked`'s handoff check below short-circuits on gate
             // identity: it never acquires a second gate under `state`. This is

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -290,13 +290,14 @@ impl DynamicControl {
             }
             return Err(ReserveError::DuplicateId(id));
         }
-        // This is the one admission-lane exception to the observation gate's
-        // usual outermost position. `mint_reserved_slot` creates both the
-        // member and its gate while `state` is held, so the child-identity
-        // mutex and the new gate are unpublished and uncontended here. The
-        // adoption below may therefore acquire only that fresh gate under the
-        // dynamic-state mutex; no other thread can hold it or acquire
-        // `state` from it. AGENTS.md records this lock-order exemption.
+        // This is the reservation half of the admission-lane lock-order
+        // exception. `mint_reserved_slot` briefly takes the already-published
+        // parent scope's child-identity mutex; that API releases its guard
+        // before returning and cannot call back into dynamic control, so it
+        // introduces no reverse edge. The member and its gate are then minted
+        // while `state` is held and remain unpublished until `state.insert`.
+        // Adoption below therefore acquires only that fresh, uncontended gate
+        // under the dynamic-state mutex. AGENTS.md records both edges.
         let slot = mint_reserved_slot(scope, &id, child_scope)?;
         scope.adopt_child_observation_gate(&slot.member, slot.scope.as_deref(), _txn);
         state.insert(id, DynamicEntry::reserved(Arc::clone(&slot)), _txn);

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -290,6 +290,13 @@ impl DynamicControl {
             }
             return Err(ReserveError::DuplicateId(id));
         }
+        // This is the one admission-lane exception to the observation gate's
+        // usual outermost position. `mint_reserved_slot` creates both the
+        // member and its gate while `state` is held, so the child-identity
+        // mutex and the new gate are unpublished and uncontended here. The
+        // adoption below may therefore acquire only that fresh gate under the
+        // dynamic-state mutex; no other thread can hold it or acquire
+        // `state` from it. AGENTS.md records this lock-order exemption.
         let slot = mint_reserved_slot(scope, &id, child_scope)?;
         scope.adopt_child_observation_gate(&slot.member, slot.scope.as_deref(), _txn);
         state.insert(id, DynamicEntry::reserved(Arc::clone(&slot)), _txn);

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -769,9 +769,10 @@ panics has its replacement discarded, never requeued. A panic payload
 cleanup panic — is still discarded inline, since it is already a spent
 diagnostic. Application errors carried by framework-retained failed exits and
 provisional failed outcomes likewise retire through critical isolated
-disposal after the framework releases its guard; if that lane cannot preserve
-the job, it retains the value for the process lifetime rather than destroy it
-in a critical section. Exits handed to users retain ordinary Rust drop timing.
+disposal, never inline on the framework stack that retires the carrier. If no
+worker can be started, the job stays queued for a later attempt — potentially
+for the process lifetime — rather than destroy the value in a critical
+section. Exits handed to users retain ordinary Rust drop timing.
 Incarnation-owned continuations, timer messages, and offload state instead
 follow §6.5 and §8's incarnation teardown and verdict rules. No single
 disposal-thread identity is promised.
@@ -3269,11 +3270,12 @@ fixtures for the driver shell and end-to-end invariants.
     be destroyed after the guard. The lock-held probe is the direct
     oracle: a payload destructor that asks whether the framework lock is
     held must answer no, on every path that retires one. What this item does
-    *not* assert is where the destructor then runs: §5.5 separately assigns
-    mailbox payloads and framework-retained failed-exit application errors to
-    isolated disposal while user-held `Exit` copies retain ordinary Rust drop
-    timing. Those venue rules are independent of this item's after-unlock
-    requirement.
+    *not* assert is one common destructor venue: §5.5 separately assigns
+    framework-initiated mailbox/reply disposal and framework-retained
+    failed-exit application errors to isolated lanes, while live `latest()`
+    displacement and user-held `Exit` copies retain their documented ordinary
+    Rust drop timing. Those venue rules are independent of this item's
+    after-unlock requirement.
 
 ---
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -2865,8 +2865,9 @@ Two conventions travel with the rule. Panicking while holding a mutex the
 implementation expects unpoisoned poisons it for every later caller —
 compute the verdict, release, *then* panic; where releasing is
 impossible, debug-assert instead. And a value that may block on
-destruction goes to detached disposal (§5.5's venue), not merely past the
-unlock.
+destruction goes to isolated disposal (§5.5's venue — the detached lane,
+or the critical lane when a critical section retires the carrier), not
+merely past the unlock.
 
 ### 15.5 Promises are owned completions
 
@@ -3269,13 +3270,13 @@ fixtures for the driver shell and end-to-end invariants.
     schedule, and retire the projection that carried it — every one must
     be destroyed after the guard. The lock-held probe is the direct
     oracle: a payload destructor that asks whether the framework lock is
-    held must answer no, on every path that retires one. What this item does
-    *not* assert is one common destructor venue: §5.5 separately assigns
-    framework-initiated mailbox/reply disposal and framework-retained
-    failed-exit application errors to isolated lanes, while live `latest()`
-    displacement and user-held `Exit` copies retain their documented ordinary
-    Rust drop timing. Those venue rules are independent of this item's
-    after-unlock requirement.
+    held must answer no, on every path that retires one. What this item
+    does *not* assert is where the destructor then runs: §5.5 separately
+    assigns framework-initiated mailbox/reply disposal and
+    framework-retained failed-exit application errors to isolated lanes,
+    while live `latest()` displacement and user-held `Exit` copies retain
+    their documented ordinary Rust drop timing. Those venue rules are
+    independent of this item's after-unlock requirement.
 
 ---
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -767,9 +767,14 @@ applies), and that destruction is terminal: a payload whose own destructor
 panics has its replacement discarded, never requeued. A panic payload
 *displaced* by one that outranks it — a rejected panic-slot record, a losing
 cleanup panic — is still discarded inline, since it is already a spent
-diagnostic. Incarnation-owned continuations, timer messages, and offload
-state instead follow §6.5 and §8's incarnation teardown and verdict rules. No
-single disposal-thread identity is promised.
+diagnostic. Application errors carried by framework-retained failed exits and
+provisional failed outcomes likewise retire through critical isolated
+disposal after the framework releases its guard; if that lane cannot preserve
+the job, it retains the value for the process lifetime rather than destroy it
+in a critical section. Exits handed to users retain ordinary Rust drop timing.
+Incarnation-owned continuations, timer messages, and offload state instead
+follow §6.5 and §8's incarnation teardown and verdict rules. No single
+disposal-thread identity is promised.
 
 (The synchronization discipline behind every mailbox transition — the
 effects sink paired with the state guard, and the structural waker slot —
@@ -3263,13 +3268,12 @@ fixtures for the driver shell and end-to-end invariants.
     schedule, and retire the projection that carried it — every one must
     be destroyed after the guard. The lock-held probe is the direct
     oracle: a payload destructor that asks whether the framework lock is
-    held must answer no, on every path that retires one. What this item
-    does *not* assert is where the destructor then runs: a mailbox
-    payload reaches isolated disposal, an `Exit`'s application error is
-    destroyed on the framework thread that released the guard. Moving the
-    second to isolated disposal is a separate rule about blocking
-    destructors on framework threads, outside this item, because the same
-    thread already destroys exits on paths that hold no lock at all.
+    held must answer no, on every path that retires one. What this item does
+    *not* assert is where the destructor then runs: §5.5 separately assigns
+    mailbox payloads and framework-retained failed-exit application errors to
+    isolated disposal while user-held `Exit` copies retain ordinary Rust drop
+    timing. Those venue rules are independent of this item's after-unlock
+    requirement.
 
 ---
 


### PR DESCRIPTION
Closes #427.

## What changed

- accounts for both admission-lane lock-order exceptions at the exact call sites and in `AGENTS.md`: reservation briefly nests the published parent child-identity mutex through a non-escaping API, then acquires only an unpublished fresh child gate under dynamic state; install proves the reserved slot already shares the root gate and therefore performs no nested gate acquisition
- replaces the deleted `Acceptance` reference with the live must-use `MailboxTxn::take_payload` carrier
- distinguishes blocking-offload captured state on the detached lane from raw incarnation-owned async offload/timer/continuation state on SPEC §6.5's on-task funnel
- makes the retained failed-exit application-error disposal venue normative in SPEC §5.5 and removes §16's stale framework-thread aside
- explicitly re-adjudicates Tokio naming after the fold: production façade implementation stays behind runtime capabilities; façade tests, doctests, and examples may use the pinned dev dependency
- ignores the retired root-level `pi-sketch.md` review artifact without deleting a contributor's local copy

## Dispositions of recorded micro items

- The doubled “the” in `flake.nix` was already removed on current `main`.
- The old README/docs `include_str!` link concern was made stale by the completed documentation split: the README is no longer included into crate rustdoc, and the remaining included guide links use rustdoc paths.

## Fresh adversarial review

The post-open review found and fixed three accuracy problems in the first draft:

- the parent scope's child-identity mutex is already published, not owned by the newly minted child; the lock proof now accounts for its non-escaping API separately from the fresh child gate
- critical exit disposal guarantees no inline destruction on the retiring framework stack, but does not promise that an isolated worker starts only after the submitting guard is released
- the Tokio policy now distinguishes implementation imports/calls from prose and explicitly covers test-only synchronization

## Verification

- `./tools/dev just ci`
- `git diff --check`

This remains a draft until the required fresh adversarial review is reported complete.
