### PR TITLE
Make cancellation and handler test probes fail closed

### DIFF
--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -163,9 +163,14 @@ impl Signal {
         }
     }
 
+    /// The channel-wide waiter-registry length.
+    ///
+    /// This is deliberately not the endpoint count: `changed()` never clones
+    /// its receiver, so an endpoint probe cannot observe a registration a
+    /// cancelled wait failed to remove.
     #[cfg(test)]
     fn waiter_count(&self) -> usize {
-        self.inner.shared.waiter_count()
+        self.inner.shared.waiters.len()
     }
 }
 
@@ -759,11 +764,6 @@ struct WatchShared<T> {
 }
 
 impl<T> WatchShared<T> {
-    #[cfg(test)]
-    fn waiter_count(&self) -> usize {
-        self.waiters.len()
-    }
-
     /// Acquires the retained value, tolerating poisoning.
     ///
     /// `modify_silently` and `read_with` run a caller closure under this
@@ -1593,9 +1593,17 @@ mod tests {
             let mut changed = Box::pin(watcher.changed());
             let mut context = Context::from_waker(Waker::noop());
             assert!(changed.as_mut().poll(&mut context).is_pending());
-            assert_eq!(signal.waiter_count(), 1);
+            assert_eq!(
+                signal.waiter_count(),
+                1,
+                "a parked wait holds exactly one registration"
+            );
             drop(changed);
-            assert_eq!(signal.waiter_count(), 0);
+            assert_eq!(
+                signal.waiter_count(),
+                0,
+                "cancelling the wait removes its registration"
+            );
         }
     }
 
@@ -2051,18 +2059,34 @@ mod tests {
             let first_poll =
                 std::future::poll_fn(|context| Poll::Ready(fired.as_mut().poll(context))).await;
             assert!(first_poll.is_pending());
-            assert_eq!(latch.state.waiters.len(), 1);
+            assert_eq!(
+                latch.state.waiters.len(),
+                1,
+                "a parked wait holds exactly one registration"
+            );
             drop(fired);
-            assert_eq!(latch.state.waiters.len(), 0);
+            assert_eq!(
+                latch.state.waiters.len(),
+                0,
+                "cancelling the wait removes its registration"
+            );
         }
 
         let mut live_waiter = Box::pin(latch.fired());
         let first_poll =
             std::future::poll_fn(|context| Poll::Ready(live_waiter.as_mut().poll(context))).await;
         assert!(first_poll.is_pending());
-        assert_eq!(latch.state.waiters.len(), 1);
+        assert_eq!(
+            latch.state.waiters.len(),
+            1,
+            "the surviving wait is still registered"
+        );
         assert!(latch.fire());
-        assert_eq!(latch.state.waiters.len(), 0);
+        assert_eq!(
+            latch.state.waiters.len(),
+            0,
+            "the fire drains every registration before waking"
+        );
         assert!(matches!(
             timeout(Duration::from_secs(1), live_waiter).await,
             Timeout::Completed(())

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -164,8 +164,8 @@ impl Signal {
     }
 
     #[cfg(test)]
-    fn watcher_count(&self) -> usize {
-        self.inner.receiver_count()
+    fn waiter_count(&self) -> usize {
+        self.inner.shared.waiter_count()
     }
 }
 
@@ -759,6 +759,11 @@ struct WatchShared<T> {
 }
 
 impl<T> WatchShared<T> {
+    #[cfg(test)]
+    fn waiter_count(&self) -> usize {
+        self.waiters.len()
+    }
+
     /// Acquires the retained value, tolerating poisoning.
     ///
     /// `modify_silently` and `read_with` run a caller closure under this
@@ -1579,17 +1584,18 @@ mod tests {
     }
 
     #[test]
-    fn quiet_signal_wait_cancellation_keeps_one_watch_registration() {
+    fn quiet_signal_wait_cancellation_removes_waiter_registration() {
         let signal = Signal::default();
         let mut watcher = signal.watcher();
-        assert_eq!(signal.watcher_count(), 1);
+        assert_eq!(signal.waiter_count(), 0);
 
         for _ in 0..10_000 {
             let mut changed = Box::pin(watcher.changed());
             let mut context = Context::from_waker(Waker::noop());
             assert!(changed.as_mut().poll(&mut context).is_pending());
+            assert_eq!(signal.waiter_count(), 1);
             drop(changed);
-            assert_eq!(signal.watcher_count(), 1);
+            assert_eq!(signal.waiter_count(), 0);
         }
     }
 
@@ -2045,14 +2051,18 @@ mod tests {
             let first_poll =
                 std::future::poll_fn(|context| Poll::Ready(fired.as_mut().poll(context))).await;
             assert!(first_poll.is_pending());
+            assert_eq!(latch.state.waiters.len(), 1);
             drop(fired);
+            assert_eq!(latch.state.waiters.len(), 0);
         }
 
         let mut live_waiter = Box::pin(latch.fired());
         let first_poll =
             std::future::poll_fn(|context| Poll::Ready(live_waiter.as_mut().poll(context))).await;
         assert!(first_poll.is_pending());
+        assert_eq!(latch.state.waiters.len(), 1);
         assert!(latch.fire());
+        assert_eq!(latch.state.waiters.len(), 0);
         assert!(matches!(
             timeout(Duration::from_secs(1), live_waiter).await,
             Timeout::Completed(())

--- a/crates/shelterwood/tests/events.rs
+++ b/crates/shelterwood/tests/events.rs
@@ -9,7 +9,9 @@ use std::{
 };
 
 use crate::common::{ReleaseGate, assert_quiet};
-use shelterwood::{Actor, ActorOnceDef, Context, ExitError, ExitResult, Tree};
+use shelterwood::{Actor, ActorOnceDef, Context, ExitError, ExitResult, Rejected, Tree};
+
+type ClearTimerResults = Arc<Mutex<Vec<Result<bool, Rejected<()>>>>>;
 
 #[derive(Clone, Copy, Debug)]
 enum PriorityMessage {
@@ -509,15 +511,23 @@ enum RetractionMessage {
 
 struct RetractionActor {
     log: Arc<Mutex<Vec<&'static str>>>,
+    clear_timer_results: ClearTimerResults,
 }
 
 impl Actor for RetractionActor {
     type Msg = RetractionMessage;
-    type Args = (ReleaseGate, Arc<Mutex<Vec<&'static str>>>);
+    type Args = (
+        ReleaseGate,
+        Arc<Mutex<Vec<&'static str>>>,
+        ClearTimerResults,
+    );
 
     async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
         args.0.wait().await;
-        Ok(Self { log: args.1 })
+        Ok(Self {
+            log: args.1,
+            clear_timer_results: args.2,
+        })
     }
 
     async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
@@ -530,7 +540,11 @@ impl Actor for RetractionActor {
             }
             RetractionMessage::Cancel => {
                 self.log.lock().expect("log mutex poisoned").push("cancel");
-                assert_eq!(context.clear_timer(&"deadline"), Ok(true));
+                let result = context.clear_timer(&"deadline");
+                self.clear_timer_results
+                    .lock()
+                    .expect("clear-timer result mutex poisoned")
+                    .push(result);
                 context.stop();
             }
             RetractionMessage::Fired => {
@@ -546,11 +560,16 @@ impl Actor for RetractionActor {
 async fn mailbox_work_queued_at_fire_can_retract_an_elapsed_timer() {
     let gate = ReleaseGate::default();
     let log = Arc::new(Mutex::new(Vec::new()));
+    let clear_timer_results = Arc::new(Mutex::new(Vec::new()));
     let mut tree = Tree::new();
     let actor = tree
         .add_actor_once(
             "retraction",
-            ActorOnceDef::<RetractionActor>::new((gate.clone(), Arc::clone(&log))),
+            ActorOnceDef::<RetractionActor>::new((
+                gate.clone(),
+                Arc::clone(&log),
+                Arc::clone(&clear_timer_results),
+            )),
         )
         .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
@@ -565,6 +584,13 @@ async fn mailbox_work_queued_at_fire_can_retract_an_elapsed_timer() {
     gate.release();
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert_eq!(*log.lock().expect("log mutex poisoned"), ["arm", "cancel"]);
+    assert_eq!(
+        *clear_timer_results
+            .lock()
+            .expect("clear-timer result mutex poisoned"),
+        [Ok(true)],
+        "the elapsed-but-undelivered timer remains retractable"
+    );
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -823,17 +849,24 @@ struct IntervalActor {
     ticks: Arc<AtomicUsize>,
     armed: ReleaseGate,
     ticked: ReleaseGate,
+    clear_timer_results: ClearTimerResults,
 }
 
 impl Actor for IntervalActor {
     type Msg = IntervalMessage;
-    type Args = (Arc<AtomicUsize>, ReleaseGate, ReleaseGate);
+    type Args = (
+        Arc<AtomicUsize>,
+        ReleaseGate,
+        ReleaseGate,
+        ClearTimerResults,
+    );
 
     async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
         Ok(Self {
             ticks: args.0,
             armed: args.1,
             ticked: args.2,
+            clear_timer_results: args.3,
         })
     }
 
@@ -849,7 +882,11 @@ impl Actor for IntervalActor {
                 let prior = self.ticks.fetch_add(1, Ordering::SeqCst);
                 self.ticked.release();
                 if prior == 1 {
-                    assert_eq!(context.clear_timer(&"interval"), Ok(true));
+                    let result = context.clear_timer(&"interval");
+                    self.clear_timer_results
+                        .lock()
+                        .expect("clear-timer result mutex poisoned")
+                        .push(result);
                     context.stop();
                 }
             }
@@ -863,11 +900,17 @@ async fn intervals_start_after_one_period_and_skip_missed_ticks() {
     let ticks = Arc::new(AtomicUsize::new(0));
     let armed = ReleaseGate::default();
     let ticked = ReleaseGate::default();
+    let clear_timer_results = Arc::new(Mutex::new(Vec::new()));
     let mut tree = Tree::new();
     let actor = tree
         .add_actor_once(
             "interval",
-            ActorOnceDef::<IntervalActor>::new((Arc::clone(&ticks), armed.clone(), ticked.clone())),
+            ActorOnceDef::<IntervalActor>::new((
+                Arc::clone(&ticks),
+                armed.clone(),
+                ticked.clone(),
+                Arc::clone(&clear_timer_results),
+            )),
         )
         .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
@@ -882,6 +925,13 @@ async fn intervals_start_after_one_period_and_skip_missed_ticks() {
     tokio::time::advance(Duration::from_secs(1)).await;
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert_eq!(ticks.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        *clear_timer_results
+            .lock()
+            .expect("clear-timer result mutex poisoned"),
+        [Ok(true)],
+        "the interval is still armed when the actor stops it"
+    );
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -894,27 +944,29 @@ enum ClearedIntervalMessage {
 struct ClearedIntervalActor {
     ticks: Arc<AtomicUsize>,
     armed: ReleaseGate,
+    clear_timer_results: ClearTimerResults,
 }
 
 impl Actor for ClearedIntervalActor {
     type Msg = ClearedIntervalMessage;
-    type Args = (Arc<AtomicUsize>, ReleaseGate);
+    type Args = (Arc<AtomicUsize>, ReleaseGate, ClearTimerResults);
 
     async fn init(args: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
         Ok(Self {
             ticks: args.0,
             armed: args.1,
+            clear_timer_results: args.2,
         })
     }
 
     async fn handle(&mut self, message: Self::Msg, context: &mut Context<'_, Self>) -> ExitResult {
         match message {
             ClearedIntervalMessage::Arm => {
-                assert_eq!(
-                    context.clear_timer(&"interval"),
-                    Ok(false),
-                    "a never-armed key has nothing to retract"
-                );
+                let result = context.clear_timer(&"interval");
+                self.clear_timer_results
+                    .lock()
+                    .expect("clear-timer result mutex poisoned")
+                    .push(result);
                 context
                     .set_interval(
                         "interval",
@@ -929,11 +981,11 @@ impl Actor for ClearedIntervalActor {
                 context
                     .set_interval("interval", ClearedIntervalMessage::Tick, Duration::ZERO)
                     .expect("a zero period clears the key");
-                assert_eq!(
-                    context.clear_timer(&"interval"),
-                    Ok(false),
-                    "the zero-period arm already cleared the key"
-                );
+                let result = context.clear_timer(&"interval");
+                self.clear_timer_results
+                    .lock()
+                    .expect("clear-timer result mutex poisoned")
+                    .push(result);
                 // The probe fires long after every deadline the cleared
                 // interval would have had, so a surviving interval must
                 // deliver again before the probe stops the actor.
@@ -955,11 +1007,16 @@ impl Actor for ClearedIntervalActor {
 async fn a_zero_period_interval_arming_clears_the_key_and_stops_ticks() {
     let ticks = Arc::new(AtomicUsize::new(0));
     let armed = ReleaseGate::default();
+    let clear_timer_results = Arc::new(Mutex::new(Vec::new()));
     let mut tree = Tree::new();
     let actor = tree
         .add_actor_once(
             "cleared-interval",
-            ActorOnceDef::<ClearedIntervalActor>::new((Arc::clone(&ticks), armed.clone())),
+            ActorOnceDef::<ClearedIntervalActor>::new((
+                Arc::clone(&ticks),
+                armed.clone(),
+                Arc::clone(&clear_timer_results),
+            )),
         )
         .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
@@ -981,6 +1038,13 @@ async fn a_zero_period_interval_arming_clears_the_key_and_stops_ticks() {
         ticks.load(Ordering::SeqCst),
         1,
         "a cleared interval must never tick again"
+    );
+    assert_eq!(
+        *clear_timer_results
+            .lock()
+            .expect("clear-timer result mutex poisoned"),
+        [Ok(false), Ok(false)],
+        "both the never-armed key and zero-period-cleared key are absent"
     );
 }
 

--- a/crates/shelterwood/tests/raw.rs
+++ b/crates/shelterwood/tests/raw.rs
@@ -81,7 +81,9 @@ fn raw_readiness_override_rejects_after_init_eagerly() {
 
 static STATEFUL_READINESS_CALLS: AtomicUsize = AtomicUsize::new(0);
 
-struct StatefulReadiness;
+struct StatefulReadiness {
+    observed: Arc<Mutex<Option<Readiness>>>,
+}
 
 impl RawActor for StatefulReadiness {
     type Msg = ();
@@ -92,7 +94,10 @@ impl RawActor for StatefulReadiness {
     }
 
     async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
-        assert_eq!(context.readiness(), Readiness::Immediate);
+        *self
+            .observed
+            .lock()
+            .expect("readiness observation mutex poisoned") = Some(context.readiness());
         Ok(())
     }
 }
@@ -100,14 +105,27 @@ impl RawActor for StatefulReadiness {
 #[tokio::test]
 async fn raw_readiness_is_definition_metadata_evaluated_once() {
     STATEFUL_READINESS_CALLS.store(0, Ordering::SeqCst);
+    let observed = Arc::new(Mutex::new(None));
     let mut tree = Tree::new();
-    tree.add_raw_once("stateful-readiness", RawOnceDef::new(StatefulReadiness))
-        .expect("valid actor");
+    tree.add_raw_once(
+        "stateful-readiness",
+        RawOnceDef::new(StatefulReadiness {
+            observed: Arc::clone(&observed),
+        }),
+    )
+    .expect("valid actor");
     assert_eq!(STATEFUL_READINESS_CALLS.load(Ordering::SeqCst), 1);
 
     let system = tree.spawn().expect("runtime is available");
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
     assert_eq!(STATEFUL_READINESS_CALLS.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        *observed
+            .lock()
+            .expect("readiness observation mutex poisoned"),
+        Some(Readiness::Immediate),
+        "the raw context exposes the definition's resolved readiness"
+    );
 }
 
 static RESTARTING_READINESS_CALLS: AtomicUsize = AtomicUsize::new(0);


### PR DESCRIPTION
Closes #418.

## Summary

- replace the vacuous signal endpoint-count probe with the actual watch waiter-registry length, checking both registration and cancellation cleanup
- pin the same registration/removal lifecycle for cancelled latch waits
- publish timer-retraction results from actor handlers and assert them in the test body, including the interval sweep cases
- publish the raw context's resolved readiness from `run` and judge it after supervision completes

## Verification

- `./tools/dev cargo test -p shelterwood-runtime cancel`
- `./tools/dev cargo test -p shelterwood --test events`
- `./tools/dev cargo test -p shelterwood --test raw raw_readiness_is_definition_metadata_evaluated_once`
- `./tools/dev just ci` (911 nextest cases plus doctests, examples, docs, API reachability, external-consumer checks, and Nix formatting)

## Sweep disposition

The restartable raw-readiness assertion and the defaults/offload fixture-wiring assertions remain unchanged: as documented in #418, their existing body-side evidence already fails closed when the handler or fixture assertion panics.
