### PR TITLE
Harden core engine and supervisor coverage

### DIFF
--- a/crates/shelterwood-core/src/engine.rs
+++ b/crates/shelterwood-core/src/engine.rs
@@ -189,6 +189,15 @@ impl StopLadder {
                 } else {
                     grace
                 };
+                // Unlike an unrepresentable cooperative grace, an
+                // unrepresentable tidy beat has no force rescue: `force`
+                // only expedites `Cooperative`, and this ladder is already
+                // `Escalated`. The same applies to the framework tidy beat
+                // below once the ladder reaches `AbortingFramework`. This can
+                // park either phase only when `now` is within
+                // `Deadline::ARMING_HEADROOM` of `Instant`'s ceiling; accept
+                // that theoretical clock-boundary asymmetry rather than
+                // substituting an earlier public deadline.
                 self.deadline = Deadline::after(now, tidy_abort_beat(beat)).instant();
                 Some(StopAction::Escalate)
             }
@@ -255,22 +264,12 @@ pub fn dispatch_exit(
     // verdict — it "is never input to restart or intensity accounting".
     // Every supported producer terminalizes the membership directly and never
     // reaches dispatch, so arriving here is a framework bug. Fail before
-    // charging a restart for an incarnation that never ran.
-    //
-    // Failing closed is the lesser of two wrong outcomes, not a correct one:
-    // the sole dispatch caller holds a real incarnation, so a `Terminal`
-    // verdict here would publish a `NeverStarted` terminal paired with
-    // `last_incarnation: Some(..)`, which SPEC §B.3 excludes. `ExitDispatch`
-    // carries no incarnation, so the pairing is the caller's to choose and
-    // cannot be repaired from inside this function, so every profile stops
-    // before publishing an inconsistent terminal projection.
+    // charging a restart for an incarnation that never ran or publishing the
+    // inconsistent terminal projection that SPEC §B.3 excludes.
     assert!(
         !matches!(exit.kind(), ExitKind::NeverStarted),
         "NeverStarted is a membership outcome outside incarnation dispatch"
     );
-    if matches!(exit.kind(), ExitKind::NeverStarted) {
-        return ExitDispatch::Terminal;
-    }
     if scope == ScopeMode::Draining || membership == MembershipStatus::Removing {
         return ExitDispatch::Terminal;
     }
@@ -283,6 +282,10 @@ pub fn dispatch_exit(
 
 #[derive(Debug)]
 pub struct IntensityState {
+    // This is deliberately one entry per restart still inside the policy
+    // window. `Intensity::new(u64::MAX, Duration::MAX)` can therefore retain
+    // charges without bound; that degenerate configuration is accepted as
+    // operator self-harm rather than adding a second, lossy accounting mode.
     charges: VecDeque<Instant>,
     total_restarts: TotalRestarts,
 }
@@ -1670,6 +1673,21 @@ mod tests {
             Some(ReadinessEffect::Disarmed)
         );
         assert!(!unsignaled_exit.needs_signal_watch());
+
+        let mut unbounded = ReadinessGate::new();
+        unbounded.step(ReadinessEvent::Configure {
+            readiness: crate::Readiness::Manual,
+            deadline: None,
+        });
+        assert_eq!(
+            unbounded.step(ReadinessEvent::Deadline {
+                now: deadline,
+                signal_seen: false,
+            }),
+            None,
+            "a spurious deadline cannot resolve an unbounded readiness wait"
+        );
+        assert!(unbounded.needs_signal_watch());
 
         let mut timed_out = ReadinessGate::new();
         assert_eq!(

--- a/crates/shelterwood-core/src/engine.rs
+++ b/crates/shelterwood-core/src/engine.rs
@@ -194,10 +194,11 @@ impl StopLadder {
                 // only expedites `Cooperative`, and this ladder is already
                 // `Escalated`. The same applies to the framework tidy beat
                 // below once the ladder reaches `AbortingFramework`. This can
-                // park either phase only when `now` is within
-                // `Deadline::ARMING_HEADROOM` of `Instant`'s ceiling; accept
-                // that theoretical clock-boundary asymmetry rather than
-                // substituting an earlier public deadline.
+                // park either phase only when `now` is within the beat plus
+                // `Deadline::ARMING_HEADROOM` of `Instant`'s ceiling — the
+                // beat is capped at ten milliseconds, so just over a second;
+                // accept that theoretical clock-boundary asymmetry rather
+                // than substituting an earlier public deadline.
                 self.deadline = Deadline::after(now, tidy_abort_beat(beat)).instant();
                 Some(StopAction::Escalate)
             }
@@ -265,7 +266,8 @@ pub fn dispatch_exit(
     // Every supported producer terminalizes the membership directly and never
     // reaches dispatch, so arriving here is a framework bug. Fail before
     // charging a restart for an incarnation that never ran or publishing the
-    // inconsistent terminal projection that SPEC §B.3 excludes.
+    // inconsistent terminal projection that SPEC §B.4 excludes: a `Removed`
+    // edge pairs `last_incarnation: None` with never having started.
     assert!(
         !matches!(exit.kind(), ExitKind::NeverStarted),
         "NeverStarted is a membership outcome outside incarnation dispatch"

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -726,8 +726,14 @@ pub fn step(state: &mut SupervisorState, event: Event, effects: &mut Vec<Effect>
 
 /// Admits one membership and returns its never-reused registration key.
 ///
-/// Admission policy lives in the runtime facade. This structural operation
-/// rejects only a duplicate live membership or an exhausted key domain.
+/// Admission policy lives in the runtime facade. In particular, this pure
+/// reducer remains permissive while draining; the supported driver's
+/// `handle_admission` gate must reject the request before reaching here. The
+/// exploration walk is blind to that boundary by design because admission
+/// mints an unbounded sequence of keys, so the facade test
+/// `draining_scopes_reject_admission_and_treat_removal_as_absent` pins it.
+/// This structural operation rejects only a duplicate live membership or an
+/// exhausted key domain.
 pub fn admit(
     state: &mut SupervisorState,
     membership: Membership,
@@ -953,6 +959,32 @@ mod tests {
         state.check_invariants();
     }
 
+    /// A forced stop deliberately leaves the readiness gate armed, so its
+    /// final signal can arrive after structural state has entered `Stopping`.
+    /// Losing this permissive acceptance is a progress failure — aggregate
+    /// startup would remain pending — rather than a state the exploration
+    /// walk's safety assertions can distinguish.
+    #[test]
+    fn ready_during_stopping_releases_the_initial_readiness_gate() {
+        let membership = memberships(1)[0];
+        let mut state = SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::starting());
+        let child = admit(&mut state, membership, true);
+
+        for event in [
+            Event::Spawned { child },
+            Event::StopStarted { child },
+            Event::Ready {
+                child,
+                removal_latched: false,
+            },
+        ] {
+            step(&mut state, event, &mut Vec::new());
+        }
+
+        assert!(state.initial_ready(child));
+        state.check_invariants();
+    }
+
     /// R4 — dynamic startup emits one start per *unspawned* initial member.
     /// A member awaiting a restart deadline has spawned once already, and its
     /// re-construction belongs to the restart path rather than to settlement;
@@ -1123,6 +1155,32 @@ mod tests {
         assert_eq!(state.ordered_stop_waiting(), None);
         assert!(state.all_children_joined());
         state.check_invariants();
+    }
+
+    #[test]
+    fn draining_an_empty_roster_finishes_on_settlement() {
+        for flavor in [ScopeFlavor::Ordered, ScopeFlavor::Dynamic] {
+            let mut state = SupervisorState::new(flavor, ScopeLifecycle::running());
+            let mut effects = Vec::new();
+            assert_eq!(
+                super::begin_drain(&mut state, StopReason::ShutdownRequested, &mut effects),
+                Some((false, ScopeState::Draining))
+            );
+            assert!(effects.is_empty());
+
+            step(&mut state, Event::Settle, &mut effects);
+            assert_eq!(
+                effects,
+                [Effect::Finished {
+                    reason: StopReason::ShutdownRequested
+                }],
+                "{flavor:?} drain finishes through vacuous all-children-joined"
+            );
+            effects.clear();
+            step(&mut state, Event::Settle, &mut effects);
+            assert!(effects.is_empty(), "{flavor:?} finish is emitted once");
+            state.check_invariants();
+        }
     }
 
     #[test]

--- a/crates/shelterwood-core/src/supervisor.rs
+++ b/crates/shelterwood-core/src/supervisor.rs
@@ -970,16 +970,25 @@ mod tests {
         let mut state = SupervisorState::new(ScopeFlavor::Dynamic, ScopeLifecycle::starting());
         let child = admit(&mut state, membership, true);
 
-        for event in [
-            Event::Spawned { child },
-            Event::StopStarted { child },
+        step(&mut state, Event::Spawned { child }, &mut Vec::new());
+        step(&mut state, Event::StopStarted { child }, &mut Vec::new());
+        // Pin the precondition too: without it a `StopStarted` that stopped
+        // transitioning would leave this an ordinary `Active` readiness test
+        // still passing under its own name.
+        assert_eq!(
+            state.child_state(child),
+            Some(ChildState::Resident(IncarnationState::Stopping))
+        );
+        assert!(!state.initial_ready(child));
+
+        step(
+            &mut state,
             Event::Ready {
                 child,
                 removal_latched: false,
             },
-        ] {
-            step(&mut state, event, &mut Vec::new());
-        }
+            &mut Vec::new(),
+        );
 
         assert!(state.initial_ready(child));
         state.check_invariants();

--- a/crates/shelterwood-core/src/supervisor/tests/exploration.rs
+++ b/crates/shelterwood-core/src/supervisor/tests/exploration.rs
@@ -131,7 +131,10 @@ fn fingerprint(state: &SupervisorState, keys: &[ChildKey]) -> u64 {
 /// Admission is deliberately not in the alphabet. Every admission mints a
 /// fresh key, so an explorable `Admit` would make the state space infinite;
 /// fixing the roster up front keeps it finite while still covering the
-/// initial/runtime distinction R1 is stated over.
+/// initial/runtime distinction R1 is stated over. Consequently this walk is
+/// also blind by design to the runtime facade's admit-during-drain rejection;
+/// the facade's targeted admission tests are the verification boundary for
+/// that policy.
 type Roster = &'static [bool];
 
 /// Every event the walk offers in every state, including the ones the state
@@ -172,6 +175,27 @@ fn alphabet(keys: &[ChildKey]) -> Vec<Event> {
         Event::Force,
         Event::Settle,
     ]);
+    for event in &events {
+        // Exhaustive over `Event` without restating its construction: a new
+        // variant does not compile until this guard is updated alongside the
+        // canonical list above, preventing silent pruning from the walk.
+        match event {
+            Event::Spawned { .. }
+            | Event::Ready { .. }
+            | Event::IncarnationComplete { .. }
+            | Event::RestartPending { .. }
+            | Event::StopStarted { .. }
+            | Event::DisposalStarted { .. }
+            | Event::Terminalized { .. }
+            | Event::RemovalSampled { .. }
+            | Event::RemovalLatched { .. }
+            | Event::Reclaim { .. }
+            | Event::FailStartup
+            | Event::BeginDrain { .. }
+            | Event::Force
+            | Event::Settle => {}
+        }
+    }
     events
 }
 


### PR DESCRIPTION
Closes #423.

## Summary

- remove the unreachable `NeverStarted` fallback after `dispatch_exit`'s unconditional invariant assertion
- pin the progress-sensitive Ready-in-Stopping and empty-roster drain transitions with supervisor tests
- make the exploration event alphabet exhaustively matched so new event variants cannot be silently omitted
- pin the unbounded-readiness spurious-deadline no-op
- document the accepted stop-ladder clock-ceiling, admit-during-drain, and maximum-intensity configuration boundaries

## Issue disposition

1. **Dead `dispatch_exit` branch:** deleted the unreachable `NeverStarted -> Terminal` branch and trimmed the comment to describe the assert-only invariant. The existing panic test continues to pin the invariant.
2. **Ready accepted from Stopping:** added `ready_during_stopping_releases_the_initial_readiness_gate`, which drives `Spawned -> StopStarted -> Ready` and asserts that initial readiness is recorded.
3. **Exploration alphabet exhaustiveness:** added an exhaustive `Event` match beside the canonical alphabet construction. Adding an event variant now breaks this test module at compile time until the alphabet guard is consciously updated.
4. **Minor coverage:** added `draining_an_empty_roster_finishes_on_settlement` for both scope flavors, including exactly-once publication, and added the unbounded-wait spurious-deadline assertion to the readiness-gate test.
5. **Accepted asymmetries:** no behavioral changes. Inline comments now record that escalated/framework tidy-beat overflow has no force rescue near the clock ceiling; the supported facade, not the pure reducer or finite-state walk, owns admit-during-drain rejection; and `Intensity(max=u64::MAX, within=Duration::MAX)` can retain an unbounded charge window as degenerate configuration self-harm.

## Verification

- `./tools/dev cargo test -p shelterwood-core` (107 unit tests plus doctests)
- `./tools/dev cargo test -p shelterwood --test dynamic draining_scopes_reject_admission_and_treat_removal_as_absent -- --exact`
- `./tools/dev just ci` (nightly fmt/clippy, 913 nextest tests, doctests, examples, docs/book, API reachability, manifest/external-consumer checks, nixfmt)
