### PR TITLE
Harden core waker and exit support

### DIFF
--- a/crates/shelterwood-core/src/exit.rs
+++ b/crates/shelterwood-core/src/exit.rs
@@ -565,19 +565,21 @@ impl PartialEq for Exit {
 impl Eq for Exit {}
 
 fn exit_kind_eq(left: &ExitKind, right: &ExitKind) -> bool {
-    match (left, right) {
-        (ExitKind::Completed, ExitKind::Completed)
-        | (ExitKind::NeverStarted, ExitKind::NeverStarted) => true,
-        (ExitKind::Failed(left), ExitKind::Failed(right)) => Arc::ptr_eq(&left.0, &right.0),
-        (ExitKind::Panicked { message: left }, ExitKind::Panicked { message: right }) => {
-            left == right
+    match left {
+        ExitKind::Completed => matches!(right, ExitKind::Completed),
+        ExitKind::Failed(left) => {
+            matches!(right, ExitKind::Failed(right) if Arc::ptr_eq(&left.0, &right.0))
         }
-        (
-            ExitKind::ReadinessTimedOut { deadline: left },
-            ExitKind::ReadinessTimedOut { deadline: right },
-        ) => left == right,
-        (ExitKind::Aborted { phase: left }, ExitKind::Aborted { phase: right }) => left == right,
-        _ => false,
+        ExitKind::Panicked { message: left } => {
+            matches!(right, ExitKind::Panicked { message: right } if left == right)
+        }
+        ExitKind::ReadinessTimedOut { deadline: left } => {
+            matches!(right, ExitKind::ReadinessTimedOut { deadline: right } if left == right)
+        }
+        ExitKind::Aborted { phase: left } => {
+            matches!(right, ExitKind::Aborted { phase: right } if left == right)
+        }
+        ExitKind::NeverStarted => matches!(right, ExitKind::NeverStarted),
     }
 }
 
@@ -998,6 +1000,7 @@ mod tests {
                 None,
                 Cancellation::NotObserved,
                 Exit::completed(Cancellation::NotObserved),
+                None,
             ),
             (
                 "cancellation overrides recorded completion",
@@ -1011,6 +1014,7 @@ mod tests {
                     },
                     Cancellation::Observed,
                 ),
+                Some(Exit::completed(Cancellation::Observed)),
             ),
             (
                 "recorded failure",
@@ -1019,6 +1023,7 @@ mod tests {
                 None,
                 Cancellation::NotObserved,
                 Exit::failed(failure.clone(), Cancellation::NotObserved),
+                None,
             ),
             (
                 "late cancellation preserves recorded failure",
@@ -1027,6 +1032,10 @@ mod tests {
                 Some(GracePhase::AfterGrace),
                 Cancellation::Observed,
                 Exit::failed(failure.clone(), Cancellation::Observed),
+                Some(Exit::aborted(
+                    GracePhase::AfterGrace,
+                    Cancellation::Observed,
+                )),
             ),
             (
                 "join panic overrides recorded failure",
@@ -1042,6 +1051,7 @@ mod tests {
                     },
                     Cancellation::NotObserved,
                 ),
+                Some(Exit::failed(failure.clone(), Cancellation::NotObserved)),
             ),
             (
                 "readiness timeout overrides cancellation",
@@ -1053,6 +1063,10 @@ mod tests {
                     ExitKind::ReadinessTimedOut { deadline },
                     Cancellation::Observed,
                 ),
+                Some(Exit::aborted(
+                    GracePhase::AfterGrace,
+                    Cancellation::Observed,
+                )),
             ),
             (
                 "join panic overrides recorded completion",
@@ -1068,6 +1082,7 @@ mod tests {
                     },
                     Cancellation::NotObserved,
                 ),
+                Some(Exit::completed(Cancellation::NotObserved)),
             ),
             (
                 "earlier recorded panic wins a tie",
@@ -1085,6 +1100,10 @@ mod tests {
                     },
                     Cancellation::Observed,
                 ),
+                Some(Exit::panicked(
+                    Some("drop panic".to_owned()),
+                    Cancellation::Observed,
+                )),
             ),
             (
                 "earlier recorded abort wins a tie",
@@ -1098,6 +1117,10 @@ mod tests {
                     },
                     Cancellation::Observed,
                 ),
+                Some(Exit::aborted(
+                    GracePhase::AfterGrace,
+                    Cancellation::Observed,
+                )),
             ),
             (
                 "cancelled join without a hard abort fails closed to within grace",
@@ -1111,6 +1134,7 @@ mod tests {
                     },
                     Cancellation::Observed,
                 ),
+                None,
             ),
             (
                 "hard abort phase is ignored when the join completed normally",
@@ -1119,6 +1143,7 @@ mod tests {
                 Some(GracePhase::AfterGrace),
                 Cancellation::Observed,
                 Exit::completed(Cancellation::Observed),
+                None,
             ),
             (
                 "join cancellation supplies a missing outcome",
@@ -1132,6 +1157,7 @@ mod tests {
                     },
                     Cancellation::Observed,
                 ),
+                None,
             ),
             (
                 "missing outcome fails closed",
@@ -1145,13 +1171,17 @@ mod tests {
                     },
                     Cancellation::NotObserved,
                 ),
+                None,
             ),
         ];
 
-        for (case, recorded, join, hard_abort_phase, cancellation, expected) in cases {
-            let (classified, _discarded) =
+        for (case, recorded, join, hard_abort_phase, cancellation, expected, expected_discarded) in
+            cases
+        {
+            let (classified, discarded) =
                 classify_exit(recorded, join, hard_abort_phase, cancellation);
             assert_eq!(classified, expected, "{case}");
+            assert_eq!(discarded, expected_discarded, "{case}: discarded exit");
         }
     }
 

--- a/crates/shelterwood-core/src/proxied_sleep.rs
+++ b/crates/shelterwood-core/src/proxied_sleep.rs
@@ -199,6 +199,7 @@ mod tests {
     struct WakerCounts {
         clones: AtomicUsize,
         drops: AtomicUsize,
+        wakes: AtomicUsize,
     }
 
     unsafe fn clone_counting(data: *const ()) -> RawWaker {
@@ -212,10 +213,16 @@ mod tests {
 
     unsafe fn wake_counting(data: *const ()) {
         // SAFETY: wake consumes the Arc reference represented by this waker.
-        drop(unsafe { Arc::<WakerCounts>::from_raw(data.cast()) });
+        let state = unsafe { Arc::<WakerCounts>::from_raw(data.cast()) };
+        state.wakes.fetch_add(1, Ordering::SeqCst);
     }
 
-    unsafe fn wake_by_ref_counting(_data: *const ()) {}
+    unsafe fn wake_by_ref_counting(data: *const ()) {
+        // SAFETY: wake_by_ref borrows the Arc reference represented by this
+        // waker, which ManuallyDrop preserves.
+        let state = ManuallyDrop::new(unsafe { Arc::<WakerCounts>::from_raw(data.cast()) });
+        state.wakes.fetch_add(1, Ordering::SeqCst);
+    }
 
     unsafe fn drop_counting(data: *const ()) {
         // SAFETY: drop consumes the Arc reference represented by this waker.
@@ -252,6 +259,28 @@ mod tests {
                 Poll::Pending
             } else {
                 Poll::Ready(())
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct WakeOnDropTimer {
+        registered: Option<Waker>,
+    }
+
+    impl Future for WakeOnDropTimer {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<()> {
+            self.registered = Some(context.waker().clone());
+            Poll::Pending
+        }
+    }
+
+    impl Drop for WakeOnDropTimer {
+        fn drop(&mut self) {
+            if let Some(registered) = &self.registered {
+                registered.wake_by_ref();
             }
         }
     }
@@ -349,5 +378,28 @@ mod tests {
             1,
             "repolling a cancelled timer never reaches the caller vtable"
         );
+    }
+
+    #[test]
+    fn retirement_empties_the_caller_slot_before_the_timer_is_cancelled() {
+        let state = Arc::new(WakerCounts::default());
+        let waker = ManuallyDrop::new(counting_waker(&state));
+        let mut context = Context::from_waker(&waker);
+        let raw: BoxedSleep = Box::pin(WakeOnDropTimer::default());
+        let mut timer = ProxiedSleep::new(raw, runtime());
+
+        assert!(Pin::new(&mut timer).poll(&mut context).is_pending());
+        assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+
+        timer.cancel_inline();
+
+        assert_eq!(
+            state.wakes.load(Ordering::SeqCst),
+            0,
+            "the timer's drop-time proxy wake cannot reach a retired caller"
+        );
+        assert_eq!(state.drops.load(Ordering::SeqCst), 1);
+        assert!(timer.timer.is_none());
+        assert!(!timer.timer_poll.is_parked());
     }
 }

--- a/crates/shelterwood-core/src/waker.rs
+++ b/crates/shelterwood-core/src/waker.rs
@@ -31,11 +31,9 @@ pub enum WakerAction {
     Run(fn(Waker)),
 }
 
-enum WakerEffect {
-    Wake(Waker),
-    DropInline(Waker),
-    Dispose(Arc<dyn MailboxRuntime>, Waker),
-    Run(fn(Waker), Waker),
+struct WakerEffect {
+    waker: Waker,
+    action: WakerAction,
 }
 
 /// Deferred waker effects, flushed only with no framework mutex held.
@@ -72,23 +70,18 @@ impl WakerEffects {
     }
 
     fn push(&mut self, waker: Waker, action: WakerAction) {
-        self.0.push(match action {
-            WakerAction::Wake => WakerEffect::Wake(waker),
-            WakerAction::DropInline => WakerEffect::DropInline(waker),
-            WakerAction::Dispose(runtime) => WakerEffect::Dispose(runtime, waker),
-            WakerAction::Run(effect) => WakerEffect::Run(effect, waker),
-        });
+        self.0.push(WakerEffect { waker, action });
     }
 
     pub fn flush(&mut self, panics: &mut PanicAccumulator) {
-        for effect in self.0.drain(..) {
-            match effect {
-                WakerEffect::Wake(waker) => panics.run(|| waker.wake()),
-                WakerEffect::DropInline(waker) => panics.run(|| drop(waker)),
-                WakerEffect::Dispose(runtime, waker) => {
+        for WakerEffect { waker, action } in self.0.drain(..) {
+            match action {
+                WakerAction::Wake => panics.run(|| waker.wake()),
+                WakerAction::DropInline => panics.run(|| drop(waker)),
+                WakerAction::Dispose(runtime) => {
                     panics.run(|| runtime.dispose(Box::new(waker)));
                 }
-                WakerEffect::Run(effect, waker) => panics.run(|| effect(waker)),
+                WakerAction::Run(effect) => panics.run(|| effect(waker)),
             }
         }
     }

--- a/crates/shelterwood-core/src/waker_proxy.rs
+++ b/crates/shelterwood-core/src/waker_proxy.rs
@@ -291,12 +291,12 @@ impl Wake for WakerProxyState {
             // empty slot can mean the wake landed in `register`'s clone
             // window; an occupied slot can hold the previous task's waker
             // after migration. This leaf state cannot distinguish either case
-            // from an ordinary wake of the current caller, so it conservatively
-            // leaves the flag set after delivering that wake too. The next
-            // registration installs and immediately wakes its fresh caller,
-            // costing one extra clone and spurious poll per delivered wake in
-            // exchange for making staleness indistinguishable from safety.
-            // See `WakerProxy::register`.
+            // from an ordinary wake of the caller polling now, so it leaves
+            // the flag set after delivering that wake too. The next
+            // registration therefore installs, reads the flag, and takes its
+            // fresh waker straight back out: one extra clone and one spurious
+            // poll per delivered wake, which the `Future` contract permits —
+            // a lost wake is not. See `WakerProxy::register`.
             registration.woken = true;
             registration.caller.take(WakerAction::Wake, &mut effects);
         }
@@ -631,6 +631,33 @@ mod tests {
             wakes.load(Ordering::SeqCst),
             1,
             "waking the previous caller does not discharge the wake for the current one"
+        );
+    }
+
+    #[test]
+    fn a_delivered_wake_leaves_its_record_set_for_the_next_registration() {
+        let proxy = WakerProxy::new();
+        let delivered = Arc::new(CountWake::default());
+        proxy.register(&Waker::from(Arc::clone(&delivered)));
+
+        // An ordinary delivered wake: the caller polling now is installed, so
+        // nothing raced the registration and nothing is stale.
+        proxy.waker().wake_by_ref();
+        assert_eq!(delivered.0.load(Ordering::SeqCst), 1);
+
+        let next = Arc::new(CountWake::default());
+        proxy.register(&Waker::from(Arc::clone(&next)));
+
+        // The record is nonetheless left set, because this leaf state cannot
+        // tell that delivery apart from the racing one
+        // `a_window_wake_consuming_the_previous_caller_still_reaches_the_new_one`
+        // covers. That indistinguishability is what forces the spurious wake
+        // onto the ordinary path too, so the common case is pinned beside the
+        // race rather than left to the comment.
+        assert_eq!(
+            next.0.load(Ordering::SeqCst),
+            1,
+            "a delivered wake still wakes the caller that registers after it"
         );
     }
 

--- a/crates/shelterwood-core/src/waker_proxy.rs
+++ b/crates/shelterwood-core/src/waker_proxy.rs
@@ -14,7 +14,10 @@ use crate::{
 /// The first poll uses a framework no-op waker, preserving the already-ready
 /// fast path without cloning a caller waker. A pending result installs the
 /// stable proxy, registers the real caller behind it, and immediately polls
-/// again so the external primitive never retains a raw caller waker.
+/// again so the external primitive never retains a raw caller waker. The
+/// target must expose readiness level-wise across that probe and re-poll: a
+/// wake delivered to the no-op probe is recovered only when the immediate
+/// re-poll observes the state change that prompted it.
 ///
 /// Ready retirement is uniform and part of every poll: a ready result may own
 /// a user value (or a panic payload that owns one), so the stored caller
@@ -100,21 +103,17 @@ impl ProxiedPoll {
     /// Retires the current caller registration into a mailbox effects sink.
     #[doc(hidden)]
     pub fn retire(&mut self, action: WakerAction, effects: &mut WakerEffects) {
-        let proxy = self.proxy.take();
-        if let Some(proxy) = &proxy {
+        if let Some(proxy) = self.proxy.take() {
             proxy.retire(action, effects);
         }
-        drop(proxy);
     }
 
     /// Retires the current caller registration through a cross-crate effect.
     #[doc(hidden)]
     pub fn retire_with(&mut self, effect: fn(Waker), panics: &mut PanicAccumulator) {
-        let proxy = self.proxy.take();
-        if let Some(proxy) = &proxy {
+        if let Some(proxy) = self.proxy.take() {
             proxy.retire_with(effect, panics);
         }
-        panics.run(|| drop(proxy));
     }
 }
 
@@ -288,10 +287,16 @@ impl Wake for WakerProxyState {
         let mut effects = WakerEffects::default();
         {
             let mut registration = self.caller.lock().expect("waker proxy mutex poisoned");
-            // Recorded whether or not a caller waker is installed: an empty
-            // slot means the wake landed in `register`'s clone window, and the
-            // flag is the only thing that will carry it to the caller polling
-            // now. See `WakerProxy::register`.
+            // Record every wake, whether or not a caller is installed. An
+            // empty slot can mean the wake landed in `register`'s clone
+            // window; an occupied slot can hold the previous task's waker
+            // after migration. This leaf state cannot distinguish either case
+            // from an ordinary wake of the current caller, so it conservatively
+            // leaves the flag set after delivering that wake too. The next
+            // registration installs and immediately wakes its fresh caller,
+            // costing one extra clone and spurious poll per delivered wake in
+            // exchange for making staleness indistinguishable from safety.
+            // See `WakerProxy::register`.
             registration.woken = true;
             registration.caller.take(WakerAction::Wake, &mut effects);
         }
@@ -306,11 +311,14 @@ mod tests {
             Arc, Weak,
             atomic::{AtomicBool, AtomicUsize, Ordering},
         },
-        task::{RawWaker, RawWakerVTable, Wake, Waker},
+        task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker},
     };
 
-    use super::{WakerProxy, WakerProxyState};
-    use crate::waker::{WakerAction, WakerEffects};
+    use super::{ProxiedPoll, WakerProxy, WakerProxyState};
+    use crate::{
+        panic::PanicAccumulator,
+        waker::{WakerAction, WakerEffects},
+    };
 
     #[derive(Default)]
     struct CountWake(AtomicUsize);
@@ -465,6 +473,98 @@ mod tests {
         unsafe { Waker::from_raw(raw) }
     }
 
+    #[derive(Default)]
+    struct PanickingDropWaker {
+        drops: AtomicUsize,
+    }
+
+    unsafe fn clone_panicking_drop(data: *const ()) -> RawWaker {
+        // SAFETY: every pointer using this vtable came from an Arc of the
+        // matching type. ManuallyDrop preserves the reference represented by
+        // `data`; the returned raw waker owns only the new clone.
+        let state = ManuallyDrop::new(unsafe { Arc::<PanickingDropWaker>::from_raw(data.cast()) });
+        RawWaker::new(
+            Arc::into_raw(Arc::clone(&state)).cast(),
+            &PANICKING_DROP_VTABLE,
+        )
+    }
+
+    unsafe fn wake_panicking_drop(data: *const ()) {
+        // SAFETY: wake consumes the Arc reference represented by this waker.
+        drop(unsafe { Arc::<PanickingDropWaker>::from_raw(data.cast()) });
+    }
+
+    unsafe fn wake_by_ref_panicking_drop(_data: *const ()) {}
+
+    unsafe fn drop_panicking_drop(data: *const ()) {
+        // SAFETY: drop consumes the Arc reference represented by this waker.
+        let state = unsafe { Arc::<PanickingDropWaker>::from_raw(data.cast()) };
+        let first_drop = state.drops.fetch_add(1, Ordering::SeqCst) == 0;
+        drop(state);
+        if first_drop {
+            panic!("hostile caller-waker destructor");
+        }
+    }
+
+    static PANICKING_DROP_VTABLE: RawWakerVTable = RawWakerVTable::new(
+        clone_panicking_drop,
+        wake_panicking_drop,
+        wake_by_ref_panicking_drop,
+        drop_panicking_drop,
+    );
+
+    fn panicking_drop_waker(state: &Arc<PanickingDropWaker>) -> Waker {
+        let raw = RawWaker::new(
+            Arc::into_raw(Arc::clone(state)).cast(),
+            &PANICKING_DROP_VTABLE,
+        );
+        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+        // ownership across clone, wake, and drop.
+        unsafe { Waker::from_raw(raw) }
+    }
+
+    struct ReadyPayload(Arc<AtomicUsize>);
+
+    impl Drop for ReadyPayload {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct PendingThenPayload {
+        polls: usize,
+        payload_drops: Arc<AtomicUsize>,
+    }
+
+    impl PendingThenPayload {
+        fn poll(&mut self, _context: &mut Context<'_>) -> Poll<ReadyPayload> {
+            self.polls += 1;
+            if self.polls < 3 {
+                Poll::Pending
+            } else {
+                Poll::Ready(ReadyPayload(Arc::clone(&self.payload_drops)))
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct AlwaysPending {
+        polls: usize,
+        registered: Option<Waker>,
+    }
+
+    impl AlwaysPending {
+        fn poll(&mut self, context: &mut Context<'_>) -> Poll<()> {
+            self.polls += 1;
+            self.registered = Some(context.waker().clone());
+            Poll::Pending
+        }
+    }
+
+    fn forward_wake(waker: Waker) {
+        waker.wake();
+    }
+
     #[test]
     fn registration_keeps_a_stable_proxy_identity_across_replacements() {
         let proxy = WakerProxy::new();
@@ -554,15 +654,20 @@ mod tests {
     }
 
     #[test]
-    fn registration_clones_the_caller_after_unlock() {
+    fn retire_with_runs_its_cross_crate_effect_after_unlock() {
         let proxy = WakerProxy::new();
-        let clones = Arc::new(AtomicUsize::new(0));
-        let caller = reentrant_clone_waker(Arc::downgrade(&proxy.state), Arc::clone(&clones));
-
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let caller = Waker::from(Arc::new(ReentrantWake {
+            proxy: Arc::downgrade(&proxy.state),
+            wakes: Arc::clone(&wakes),
+        }));
         proxy.register(&caller);
-        proxy.register(&caller);
 
-        assert_eq!(clones.load(Ordering::SeqCst), 1);
+        let mut panics = PanicAccumulator::default();
+        proxy.retire_with(forward_wake, &mut panics);
+
+        assert!(panics.take().is_none());
+        assert_eq!(wakes.load(Ordering::SeqCst), 1);
     }
 
     #[test]
@@ -599,5 +704,107 @@ mod tests {
         drop(caller);
 
         drop(proxy);
+    }
+
+    #[test]
+    fn ready_retirement_contains_a_hostile_waker_drop_and_returns_the_payload() {
+        let waker_state = Arc::new(PanickingDropWaker::default());
+        let mut caller = ManuallyDrop::new(panicking_drop_waker(&waker_state));
+        let mut context = Context::from_waker(&caller);
+        let payload_drops = Arc::new(AtomicUsize::new(0));
+        let mut target = PendingThenPayload {
+            polls: 0,
+            payload_drops: Arc::clone(&payload_drops),
+        };
+        let mut proxied = ProxiedPoll::new();
+
+        assert!(
+            proxied
+                .poll(
+                    &mut target,
+                    &mut context,
+                    PendingThenPayload::poll,
+                    Poll::is_pending
+                )
+                .is_pending()
+        );
+        let Poll::Ready(payload) = proxied.poll(
+            &mut target,
+            &mut context,
+            PendingThenPayload::poll,
+            Poll::is_pending,
+        ) else {
+            panic!("the third target poll is ready");
+        };
+
+        assert_eq!(
+            waker_state.drops.load(Ordering::SeqCst),
+            1,
+            "ready retirement ran and contained the hostile caller clone's destructor"
+        );
+        assert_eq!(payload_drops.load(Ordering::SeqCst), 0);
+        assert!(!proxied.is_parked());
+        drop(payload);
+        assert_eq!(
+            payload_drops.load(Ordering::SeqCst),
+            1,
+            "the ready payload survived retirement and reached the caller"
+        );
+
+        // The first (proxied) clone was the hostile drop. The original caller
+        // can now be reclaimed without raising a second panic.
+        drop(unsafe { ManuallyDrop::take(&mut caller) });
+    }
+
+    #[test]
+    fn polling_after_retirement_rearms_with_a_fresh_proxy() {
+        let wakes = Arc::new(CountWake::default());
+        let caller = Waker::from(Arc::clone(&wakes));
+        let mut context = Context::from_waker(&caller);
+        let mut target = AlwaysPending::default();
+        let mut proxied = ProxiedPoll::new();
+
+        assert!(
+            proxied
+                .poll(
+                    &mut target,
+                    &mut context,
+                    AlwaysPending::poll,
+                    Poll::is_pending
+                )
+                .is_pending()
+        );
+        let stale = target
+            .registered
+            .as_ref()
+            .expect("the pending target retains the first proxy")
+            .clone();
+
+        let mut effects = WakerEffects::default();
+        proxied.retire(WakerAction::DropInline, &mut effects);
+        drop(effects);
+        assert!(!proxied.is_parked());
+
+        assert!(
+            proxied
+                .poll(
+                    &mut target,
+                    &mut context,
+                    AlwaysPending::poll,
+                    Poll::is_pending
+                )
+                .is_pending()
+        );
+        let rearmed = target
+            .registered
+            .as_ref()
+            .expect("the pending target retains the replacement proxy");
+        assert!(!stale.will_wake(rearmed));
+        assert_eq!(target.polls, 4, "re-arming probes and then proxy-polls");
+
+        stale.wake_by_ref();
+        assert_eq!(wakes.0.load(Ordering::SeqCst), 0);
+        rearmed.wake_by_ref();
+        assert_eq!(wakes.0.load(Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
## Summary

- make `ExitKind` equality exhaustive on the left-hand variant and assert every discarded classification result in the precedence table
- represent deferred waker effects as one `{ waker, action }` pair and make the two `ProxiedPoll` retirement paths symmetric
- add core-level adversarial coverage for cross-crate callback retirement, ready-edge hostile destruction, retire/re-arm behavior, and timer teardown ordering
- document the level-wise probe requirement and the deliberately conservative wake-record behavior

## Issue dispositions

1. Replaced the wildcard equality arm with an exhaustive outer `ExitKind` match.
2. Removed the mirrored `WakerEffect` enum; queued effects now pair a `Waker` with its `WakerAction`.
3. Removed the byte-identical clone-vtable test and simplified both retirement methods to the same take-and-retire shape.
4. Added a reentrant `retire_with` test that proves the supplied function runs after the proxy leaf mutex is unlocked.
5. Added tests for contained panicking ready-edge destruction with payload preservation, fresh-proxy re-arming after retirement, and caller-slot-before-timer cancellation ordering.
6. Expanded the `ProxiedPoll` and `wake_by_ref` documentation to state the level-wise readiness requirement and ordinary-path recovery cost.
7. Extended every classification table row with its expected discarded exit.

## Validation

- `./tools/dev cargo test -p shelterwood-core`
- `./tools/dev just ci`

Closes #424
