### PR TITLE
Simplify raw timer delivery and pin offload publication

### DIFF
--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -88,9 +88,11 @@ macro_rules! context_common_forwarders {
         /// Starts blocking work tied to actor shutdown and returned-future drop.
         ///
         /// Available from [`StopContext`] too — deliberately, unlike
-        /// continuations, timers, and offloads. Awaiting the returned
-        /// [`Blocking`] resumes a panic raised inside the closure at the
-        /// await point.
+        /// continuations, timers, and offloads. The returned [`Blocking`] is
+        /// caller-owned rather than tracked in the incarnation resource
+        /// ledger, so intake freeze and teardown never depend on its
+        /// completion. Awaiting it resumes a panic raised inside the closure
+        /// at the await point.
         ///
         /// Cancellation is cooperative; a hard-aborted operation's OS thread
         /// detaches and may outlive this actor incarnation.

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -33,7 +33,7 @@ use super::{
 #[cfg(test)]
 use super::offload::OffloadPoll;
 
-use timers::{ArmingOrder, IntervalRearm, TimerMessage, TimerStore};
+use timers::{ArmingOrder, TimerMessage, TimerStore};
 
 type DeferredMessage<M> = Box<dyn FnOnce() -> M + Send + 'static>;
 /// An operation rejected because the actor incarnation is already stopping.
@@ -694,7 +694,7 @@ impl<M: Send + 'static> RawContext<M> {
         if self.is_stopping() || !self.resources.accepting {
             return Err(Rejected::new((key, message)));
         }
-        self.replace_timer(key, TimerMessage::Once(message), after, None);
+        self.replace_timer(key, TimerMessage::Once(message), after);
         Ok(())
     }
 
@@ -718,9 +718,12 @@ impl<M: Send + 'static> RawContext<M> {
         }
         self.replace_timer(
             key,
-            TimerMessage::Interval(message, Clone::clone),
+            TimerMessage::Interval {
+                message,
+                clone: Clone::clone,
+                period,
+            },
             period,
-            Some(period),
         );
         Ok(())
     }
@@ -786,7 +789,10 @@ impl<M: Send + 'static> RawContext<M> {
     ///
     /// Unlike `continue_with`, timers, and offloads, this operation has no
     /// stopping gate: it deliberately keeps working from stop paths, because
-    /// it is the one resource operation teardown code may still need.
+    /// it is the one resource operation teardown code may still need. The
+    /// returned [`Blocking`] is caller-owned rather than tracked in the
+    /// incarnation resource ledger, so intake freeze and teardown never wait
+    /// on it or depend on its completion.
     /// Awaiting the returned [`Blocking`] resumes a panic raised inside the
     /// closure at the await point (distinct from the runtime-teardown
     /// cancellation panic below).
@@ -927,20 +933,13 @@ impl<M: Send + 'static> RawContext<M> {
         }
     }
 
-    fn replace_timer<K>(
-        &mut self,
-        key: K,
-        message: TimerMessage<M>,
-        after: Duration,
-        period: Option<Duration>,
-    ) where
+    fn replace_timer<K>(&mut self, key: K, message: TimerMessage<M>, after: Duration)
+    where
         K: Hash + Eq + Send + 'static,
     {
         let now = runtime::now();
         let deadline = crate::deadline::Deadline::after(now, after).instant();
-        self.resources
-            .timers
-            .replace(key, deadline, message, period);
+        self.resources.timers.replace(key, deadline, message);
     }
 
     fn start_offload<F, T, C>(
@@ -1254,18 +1253,7 @@ impl<M: Send + 'static> RawContext<M> {
     }
 
     fn deliver_timer(&mut self, arming: ArmingOrder) -> Option<M> {
-        match self.resources.timers.rearm_interval(arming, runtime::now()) {
-            IntervalRearm::Missing => return None,
-            IntervalRearm::OneShot => {}
-            IntervalRearm::Interval(message) => return Some(message),
-        }
-
-        Some(
-            self.resources
-                .timers
-                .take_due_once(arming)
-                .expect("a due one-shot timer remains registered"),
-        )
+        self.resources.timers.deliver_due(arming, runtime::now())
     }
 
     fn next_timer_deadline(&self) -> Option<Instant> {
@@ -1280,16 +1268,15 @@ impl<M: Send + 'static> RawContext<M> {
         self.resources.reclaim_finished();
         let deadline = self.next_timer_deadline();
         let shutdown = self.shutdown.clone();
-        let local_stop = self.local_stop.clone();
         let mailbox = &mut self.receiver;
         let event_watcher = &mut self.resources.event_watcher;
         let delivery = async move {
             let _ = runtime::select_two(mailbox.changed(), event_watcher.changed()).await;
         };
-        let event = runtime::select_two(
-            shutdown.cancelled(),
-            runtime::select_two(local_stop.fired(), delivery),
-        );
+        // `local_stop` can only be fired by this actor task, and `recv`
+        // checks it before parking here. No other task can make it a wakeup
+        // source while this future is pending.
+        let event = runtime::select_two(shutdown.cancelled(), delivery);
         // The timer stays outside the whole event selection so every event
         // winner -- especially the warm mailbox path -- retires its caller
         // waker through timeout_at's synchronous poll-path boundary. Burying
@@ -1858,10 +1845,10 @@ mod tests {
     /// `Guard::finished()` waiter's wake panic, and the ledger may not retire
     /// the work until it has.
     ///
-    /// The `Release` store that publishes completion is *not* pinned here:
-    /// `poller.join()` is a full fence, so weakening it to `Relaxed` would
-    /// still pass. Only the comment at that store constrains it. The
-    /// companion below covers the `task`-bearing chain this one omits.
+    /// The publication ordering itself is pinned by
+    /// `offload::tests::finished_publication_releases_wake_effect_to_reclaimer`;
+    /// this test covers panic retention, while the companion below covers the
+    /// `task`-bearing chain this one omits.
     #[test]
     fn ordinary_offload_completion_retains_a_finished_waiter_wake_panic() {
         let mut resources = RawResources::<()>::default();
@@ -2176,14 +2163,14 @@ mod tests {
         let arming = context.resources.timers.replace(
             "interval",
             Some(now),
-            TimerMessage::Interval(
-                PanicOnceClone {
+            TimerMessage::Interval {
+                message: PanicOnceClone {
                     clones: Arc::clone(&clones),
                     value: 7,
                 },
-                Clone::clone,
-            ),
-            Some(Duration::from_secs(1)),
+                clone: Clone::clone,
+                period: Duration::from_secs(1),
+            },
         );
 
         let panic = catch_unwind(AssertUnwindSafe(|| context.try_recv()))
@@ -2213,11 +2200,10 @@ mod tests {
     fn a_caught_offload_continuation_panic_preserves_later_fired_work() {
         let mut context = bound_raw_context_for::<u8>().0;
         let now = crate::runtime::now();
-        let arming =
-            context
-                .resources
-                .timers
-                .replace("timer", Some(now), TimerMessage::Once(7), None);
+        let arming = context
+            .resources
+            .timers
+            .replace("timer", Some(now), TimerMessage::Once(7));
         context.resources.events.push(QueuedEvent {
             cancellation: Latch::default(),
             make_message: Box::new(|| panic!("offload continuation panic")),
@@ -2248,11 +2234,11 @@ mod tests {
         context
             .resources
             .timers
-            .replace("first", Some(now), TimerMessage::Once(1), None);
+            .replace("first", Some(now), TimerMessage::Once(1));
         context
             .resources
             .timers
-            .replace("second", Some(now), TimerMessage::Once(2), None);
+            .replace("second", Some(now), TimerMessage::Once(2));
 
         assert_eq!(context.try_recv(), Some(1));
         assert!(
@@ -2276,9 +2262,7 @@ mod tests {
             cancellation: Latch::default(),
             make_message: Box::new(|| ()),
         });
-        resources
-            .timers
-            .replace(7_u8, None, TimerMessage::Once(()), None);
+        resources.timers.replace(7_u8, None, TimerMessage::Once(()));
 
         assert_eq!(
             Arc::strong_count(&resources.disposal.panic),
@@ -2486,7 +2470,6 @@ mod tests {
             1_u8,
             None,
             TimerMessage::Once(PanickingDrop(Arc::clone(&drops))),
-            None,
         );
 
         resources.freeze();

--- a/crates/shelterwood/src/raw/context/timers.rs
+++ b/crates/shelterwood/src/raw/context/timers.rs
@@ -589,6 +589,40 @@ mod tests {
     }
 
     #[test]
+    fn a_rearmed_interval_keeps_its_entry_and_deadline_index_in_step() {
+        let start = Instant::now();
+        let mut timers = TimerStore::default();
+        let arming = timers.replace(
+            "interval",
+            Some(start),
+            TimerMessage::Interval {
+                message: "tick",
+                clone: Clone::clone,
+                period: Duration::from_secs(5),
+            },
+        );
+        assert_eq!(timers.take_due(start), [arming]);
+
+        assert_eq!(timers.deliver_due(arming, start), Some("tick"));
+        assert_eq!(
+            timers.next_deadline(),
+            Some(start + Duration::from_secs(5)),
+            "the rearm publishes the next cadence deadline"
+        );
+
+        // Unlinking reads the deadline back off the entry, so a rearm that
+        // wrote only the deadline index would strand a phantom wakeup for an
+        // arming nothing can deliver.
+        assert!(timers.remove(&"interval"));
+        assert_eq!(
+            timers.next_deadline(),
+            None,
+            "clearing a rearmed interval leaves no orphaned deadline"
+        );
+        assert!(timers.is_empty());
+    }
+
+    #[test]
     fn interval_rearm_overflow_makes_the_live_entry_dormant() {
         let now = Instant::now();
         let mut timers = TimerStore::default();

--- a/crates/shelterwood/src/raw/context/timers.rs
+++ b/crates/shelterwood/src/raw/context/timers.rs
@@ -2,8 +2,9 @@
 //!
 //! The store owns every armed timer's user key and message, mints the arming
 //! orders that index them, and is the only place either value is destroyed —
-//! so both always retire through [`RawDisposal`] rather than on the actor
-//! task.
+//! so both retire through [`RawDisposal`]'s contained funnel on the
+//! incarnation's own task, per SPEC §6.5, rather than escaping into the
+//! actor's control flow.
 
 use std::{
     any::{Any, TypeId},
@@ -19,7 +20,11 @@ use crate::{
 
 pub(super) enum TimerMessage<M> {
     Once(M),
-    Interval(M, fn(&M) -> M),
+    Interval {
+        message: M,
+        clone: fn(&M) -> M,
+        period: Duration,
+    },
 }
 
 /// A timer's index identity, mintable only by the store that installs it.
@@ -40,13 +45,6 @@ struct TimerEntry<M> {
     deadline: Option<Instant>,
     arming_order: ArmingOrder,
     message: TimerMessage<M>,
-    period: Option<Duration>,
-}
-
-pub(super) enum IntervalRearm<M> {
-    Missing,
-    OneShot,
-    Interval(M),
 }
 
 #[derive(Clone, Copy)]
@@ -119,7 +117,6 @@ impl<M> TimerStore<M> {
         key: K,
         deadline: Option<Instant>,
         message: TimerMessage<M>,
-        period: Option<Duration>,
     ) -> ArmingOrder
     where
         K: Hash + Eq + Send + 'static,
@@ -145,7 +142,6 @@ impl<M> TimerStore<M> {
             deadline,
             arming_order,
             message: message.into_inner(),
-            period,
         });
         let previous = self.armings.insert(arming_order, hash);
         assert!(previous.is_none());
@@ -277,31 +273,6 @@ impl<M> TimerStore<M> {
         Some(TimerLocation { hash, index })
     }
 
-    /// Unlinks a one-shot timer and yields its message for delivery.
-    ///
-    /// The key is retired through disposal here rather than handed out, so no
-    /// caller can destroy a timer's user key on the actor task.
-    pub(super) fn take_due_once(&mut self, arming_order: ArmingOrder) -> Option<M> {
-        let location = self.locate_arming(arming_order)?;
-        let TimerEntry { key, message, .. } = self.unlink(location);
-        self.disposal.dispose(key);
-        let TimerMessage::Once(message) = message else {
-            unreachable!("a non-interval timer must own a one-shot message")
-        };
-        Some(message)
-    }
-
-    fn entry_mut(&mut self, arming_order: ArmingOrder) -> Option<&mut TimerEntry<M>> {
-        let location = self.locate_arming(arming_order)?;
-        Some(
-            self.keyed
-                .get_mut(&location.hash)
-                .expect("a timer location must reference a key bucket")
-                .get_mut(location.index)
-                .expect("a timer location must reference a timer"),
-        )
-    }
-
     pub(super) fn take_due(&mut self, now: Instant) -> VecDeque<ArmingOrder> {
         let due = self
             .deadlines
@@ -320,31 +291,57 @@ impl<M> TimerStore<M> {
         }
     }
 
-    pub(super) fn rearm_interval(
-        &mut self,
-        arming_order: ArmingOrder,
-        now: Instant,
-    ) -> IntervalRearm<M> {
-        let (message, deadline) = {
-            let Some(entry) = self.entry_mut(arming_order) else {
-                return IntervalRearm::Missing;
-            };
-            let Some(period) = entry.period else {
-                return IntervalRearm::OneShot;
-            };
-            let deadline = crate::deadline::Deadline::after(now, period).instant();
-            let TimerMessage::Interval(message, clone_message) = &entry.message else {
-                unreachable!("an interval timer must own a message factory")
-            };
-            // Cloning is user code. Keep the entry's prior deadline intact
-            // until it succeeds so the fired batch can retry this arming if
-            // the panic escapes `recv` and the raw actor catches it.
-            let message = clone_message(message);
-            entry.deadline = deadline;
-            (message, deadline)
+    /// Resolves one captured arming to its delivery with a single index walk.
+    ///
+    /// An interval remains installed and is rearmed after cloning its next
+    /// message. A one-shot is unlinked, and its key retires through contained
+    /// disposal before the message is returned. A missing arming was cleared
+    /// or superseded after its fired batch was captured and is simply skipped.
+    pub(super) fn deliver_due(&mut self, arming_order: ArmingOrder, now: Instant) -> Option<M> {
+        let location = self.locate_arming(arming_order)?;
+        let interval_delivery = {
+            let entry = self
+                .keyed
+                .get_mut(&location.hash)
+                .expect("a timer location must reference a key bucket")
+                .get_mut(location.index)
+                .expect("a timer location must reference a timer");
+            match &mut entry.message {
+                TimerMessage::Once(_) => None,
+                TimerMessage::Interval {
+                    message,
+                    clone,
+                    period,
+                } => {
+                    let deadline = crate::deadline::Deadline::after(now, *period).instant();
+                    // Cloning is user code. Keep the entry's prior deadline
+                    // intact until it succeeds so the fired batch can retry
+                    // this arming if the panic escapes `recv` and the raw
+                    // actor catches it.
+                    let message = clone(message);
+                    entry.deadline = deadline;
+                    Some((message, deadline))
+                }
+            }
         };
-        self.arm_deadline(arming_order, deadline);
-        IntervalRearm::Interval(message)
+        if let Some((message, deadline)) = interval_delivery {
+            self.arm_deadline(arming_order, deadline);
+            return Some(message);
+        }
+
+        let TimerEntry { key, message, .. } = self.unlink(location);
+        self.disposal.dispose(key);
+        match message {
+            TimerMessage::Once(message) => Some(message),
+            // No callback or re-entrant operation separates the variant check
+            // above from `unlink`, so this branch is structurally unavailable.
+            // Keep its defensive path contained rather than putting user
+            // ownership on an invariant-panic stack.
+            interval @ TimerMessage::Interval { .. } => {
+                self.disposal.dispose(interval);
+                None
+            }
+        }
     }
 
     pub(super) fn next_deadline(&self) -> Option<Instant> {
@@ -370,7 +367,7 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use super::{IntervalRearm, PoisonedCounter, TimerMessage, TimerStore};
+    use super::{PoisonedCounter, TimerMessage, TimerStore};
 
     #[derive(Eq, PartialEq)]
     struct CollidingKey(u8);
@@ -499,7 +496,6 @@ mod tests {
                 },
                 None,
                 TimerMessage::Once(message),
-                None,
             );
         }
 
@@ -514,19 +510,16 @@ mod tests {
             7_u8,
             Some(start + Duration::from_secs(3)),
             TimerMessage::Once("old-u8"),
-            None,
         );
         let u16_arming = timers.replace(
             7_u16,
             Some(start + Duration::from_secs(1)),
             TimerMessage::Once("u16"),
-            None,
         );
         let replacement = timers.replace(
             7_u8,
             Some(start + Duration::from_secs(2)),
             TimerMessage::Once("new-u8"),
-            None,
         );
 
         assert_eq!(timers.next_deadline(), Some(start + Duration::from_secs(1)));
@@ -536,14 +529,61 @@ mod tests {
             "different key types coexist and replacement takes a fresh order"
         );
         assert_eq!(
-            timers.take_due_once(u16_arming).expect("u16 timer remains"),
+            timers
+                .deliver_due(u16_arming, start + Duration::from_secs(3))
+                .expect("u16 timer remains"),
             "u16"
         );
         assert_eq!(
             timers
-                .take_due_once(replacement)
+                .deliver_due(replacement, start + Duration::from_secs(3))
                 .expect("replacement remains"),
             "new-u8"
+        );
+        assert!(timers.is_empty());
+    }
+
+    #[test]
+    fn interval_to_one_shot_replacement_skips_a_captured_arming_and_old_cadence() {
+        let start = Instant::now();
+        let mut timers = TimerStore::default();
+        let superseded = timers.replace(
+            "key",
+            Some(start),
+            TimerMessage::Interval {
+                message: "interval",
+                clone: Clone::clone,
+                period: Duration::from_secs(5),
+            },
+        );
+
+        assert_eq!(
+            timers.take_due(start),
+            [superseded],
+            "the fired batch captures the interval's original arming"
+        );
+        let replacement = timers.replace(
+            "key",
+            Some(start + Duration::from_secs(7)),
+            TimerMessage::Once("one-shot"),
+        );
+
+        assert_eq!(
+            timers.deliver_due(superseded, start),
+            None,
+            "the already-captured superseded interval is skipped"
+        );
+        assert!(
+            timers.take_due(start + Duration::from_secs(6)).is_empty(),
+            "the interval's old five-second cadence was not rearmed"
+        );
+        assert_eq!(
+            timers.take_due(start + Duration::from_secs(7)),
+            [replacement]
+        );
+        assert_eq!(
+            timers.deliver_due(replacement, start + Duration::from_secs(7)),
+            Some("one-shot")
         );
         assert!(timers.is_empty());
     }
@@ -558,22 +598,15 @@ mod tests {
         let arming = timers.replace(
             "interval",
             Some(now),
-            TimerMessage::Interval("tick", Clone::clone),
-            Some(Duration::MAX),
+            TimerMessage::Interval {
+                message: "tick",
+                clone: Clone::clone,
+                period: Duration::MAX,
+            },
         );
         assert_eq!(timers.take_due(now), [arming]);
 
-        assert!(matches!(
-            timers.rearm_interval(arming, now),
-            IntervalRearm::Interval("tick")
-        ));
-        assert_eq!(
-            timers
-                .entry_mut(arming)
-                .expect("the dormant interval remains clearable")
-                .deadline,
-            None
-        );
+        assert_eq!(timers.deliver_due(arming, now), Some("tick"));
         assert_eq!(
             timers.next_deadline(),
             None,
@@ -588,14 +621,9 @@ mod tests {
     #[test]
     fn hash_collision_uses_exact_erased_key_equality() {
         let mut timers = TimerStore::default();
-        timers.replace(CollidingKey(1), None, TimerMessage::Once("first"), None);
-        timers.replace(CollidingKey(2), None, TimerMessage::Once("second"), None);
-        timers.replace(
-            CollidingKey(1),
-            None,
-            TimerMessage::Once("replacement"),
-            None,
-        );
+        timers.replace(CollidingKey(1), None, TimerMessage::Once("first"));
+        timers.replace(CollidingKey(2), None, TimerMessage::Once("second"));
+        timers.replace(CollidingKey(1), None, TimerMessage::Once("replacement"));
 
         assert_eq!(
             once(
@@ -629,7 +657,6 @@ mod tests {
             },
             Some(deadline),
             TimerMessage::Once("message"),
-            None,
         );
         let query = PanickingEqKey {
             value: 7,
@@ -668,7 +695,6 @@ mod tests {
                 PanickingHashKey(Arc::clone(&drops)),
                 None,
                 TimerMessage::Once(PanickingTimerMessage(Arc::clone(&drops))),
-                None,
             );
         }))
         .expect_err("the user key hash panic escapes the timer operation");
@@ -713,7 +739,6 @@ mod tests {
                 PanickingDropKey(Arc::clone(&drops)),
                 None,
                 TimerMessage::Once(PanickingTimerMessage(Arc::clone(&drops))),
-                None,
             );
         }))
         .expect_err("the exhausted arming domain remains a framework panic");
@@ -773,7 +798,6 @@ mod tests {
             PanickingDropKey(Arc::clone(&drops)),
             None,
             TimerMessage::Once("message"),
-            None,
         );
 
         // Delivery hands back only the message. A hostile key destructor is
@@ -781,7 +805,7 @@ mod tests {
         // the actor task.
         assert_eq!(
             timers
-                .take_due_once(arming)
+                .deliver_due(arming, Instant::now())
                 .expect("the timer is registered"),
             "message"
         );
@@ -806,7 +830,7 @@ mod tests {
     #[test]
     fn unlink_is_total_when_the_arming_hash_disagrees() {
         let mut timers = TimerStore::default();
-        let arming = timers.replace(7_u8, None, TimerMessage::Once("message"), None);
+        let arming = timers.replace(7_u8, None, TimerMessage::Once("message"));
         let recorded = timers.armings[&arming];
         timers
             .armings
@@ -845,7 +869,6 @@ mod tests {
                 key,
                 Some(start + Duration::from_secs((TIMERS - index) as u64)),
                 TimerMessage::Once(()),
-                None,
             );
         }
         for key in keys.into_iter().rev() {

--- a/crates/shelterwood/src/raw/offload.rs
+++ b/crates/shelterwood/src/raw/offload.rs
@@ -248,8 +248,8 @@ impl SharedOffloadState {
         // installed in the incarnation slot. Ledger reclamation consumes this
         // edge with the matching `Acquire` in `finished_published`; weakening
         // either side would let a reclaiming actor observe retirement without
-        // observing the recorded payload. No test pins that pairing — only
-        // this comment does.
+        // observing the recorded payload. The publication-witness unit test
+        // makes this edge the sole synchronization for a wake-side effect.
         self.finished_published.store(true, Ordering::Release);
     }
 
@@ -363,5 +363,84 @@ impl OffloadResource {
         });
         panics.record(retained.take());
         panics.take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::Future,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        task::{Context, Poll, Wake, Waker},
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use super::{Latch, RawDisposal, SharedOffloadState};
+
+    struct RelaxedWakeWitness(Arc<AtomicBool>);
+
+    impl Wake for RelaxedWakeWitness {
+        fn wake(self: Arc<Self>) {
+            self.0.store(true, Ordering::Relaxed);
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// `finished_published` is the sole synchronizes-with edge between the
+    /// producer's relaxed wake-side witness and this consumer's relaxed read.
+    /// Observing publication must therefore make every effect completed by
+    /// `notify` visible before ledger reclamation can discard the state.
+    #[test]
+    fn finished_publication_releases_wake_effect_to_reclaimer() {
+        const WAIT: Duration = Duration::from_secs(10);
+
+        let finished = Latch::default();
+        let woke = Arc::new(AtomicBool::new(false));
+        let waker = Waker::from(Arc::new(RelaxedWakeWitness(Arc::clone(&woke))));
+        let mut waiter = Box::pin(finished.fired());
+        assert_eq!(
+            waiter.as_mut().poll(&mut Context::from_waker(&waker)),
+            Poll::Pending
+        );
+
+        let state = SharedOffloadState::new(
+            Box::pin(std::future::pending()),
+            RawDisposal::default(),
+            finished.clone(),
+        );
+        let producer = {
+            let state = Arc::clone(&state);
+            thread::spawn(move || state.fire_finished())
+        };
+
+        let deadline = Instant::now() + WAIT;
+        let published = loop {
+            if state.finished_published() {
+                break true;
+            }
+            if Instant::now() >= deadline {
+                break false;
+            }
+            thread::yield_now();
+        };
+        // Sample before joining: joining the producer would add a second
+        // synchronization edge and let a weakened publication pair pass.
+        let wake_visible_after_acquire = woke.load(Ordering::Relaxed);
+        producer
+            .join()
+            .expect("completion publisher does not panic");
+
+        assert!(published, "completion publication did not arrive");
+        assert!(
+            wake_visible_after_acquire,
+            "publication exposed retirement before the completed wake's effects"
+        );
     }
 }

--- a/crates/shelterwood/src/raw/offload.rs
+++ b/crates/shelterwood/src/raw/offload.rs
@@ -22,6 +22,8 @@ type SharedWork = Arc<SharedOffloadState>;
 // of the memory model exercised by a particular CI host. The witness below
 // verifies the data-flow consequence across threads; its exact-ordering
 // assertions keep a strong-memory machine from accepting a Relaxed mutation.
+// They are the only permitted spelling of that pair: inlining an ordering at
+// either use site below moves it out of the test's reach.
 const FINISHED_PUBLISH_ORDERING: Ordering = Ordering::Release;
 const FINISHED_OBSERVE_ORDERING: Ordering = Ordering::Acquire;
 

--- a/crates/shelterwood/src/raw/offload.rs
+++ b/crates/shelterwood/src/raw/offload.rs
@@ -18,6 +18,13 @@ use super::disposal::{PanicSlot, RawDisposal};
 type OffloadFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 type SharedWork = Arc<SharedOffloadState>;
 
+// These are named so the publication contract can be pinned independently
+// of the memory model exercised by a particular CI host. The witness below
+// verifies the data-flow consequence across threads; its exact-ordering
+// assertions keep a strong-memory machine from accepting a Relaxed mutation.
+const FINISHED_PUBLISH_ORDERING: Ordering = Ordering::Release;
+const FINISHED_OBSERVE_ORDERING: Ordering = Ordering::Acquire;
+
 /// Marker returned to an offload continuation when its one deadline expires.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
 #[error("the offload deadline elapsed")]
@@ -250,14 +257,15 @@ impl SharedOffloadState {
         // either side would let a reclaiming actor observe retirement without
         // observing the recorded payload. The publication-witness unit test
         // makes this edge the sole synchronization for a wake-side effect.
-        self.finished_published.store(true, Ordering::Release);
+        self.finished_published
+            .store(true, FINISHED_PUBLISH_ORDERING);
     }
 
     /// Reports whether completion has been notified *and* its wake has
     /// returned. See [`Self::fire_finished`] for why this, not
     /// [`Latch::is_fired`], is what may retire ledger state.
     pub(super) fn finished_published(&self) -> bool {
-        self.finished_published.load(Ordering::Acquire)
+        self.finished_published.load(FINISHED_OBSERVE_ORDERING)
     }
 
     pub(super) fn dispose(&self, future: Option<OffloadFuture>) {
@@ -379,7 +387,10 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use super::{Latch, RawDisposal, SharedOffloadState};
+    use super::{
+        FINISHED_OBSERVE_ORDERING, FINISHED_PUBLISH_ORDERING, Latch, RawDisposal,
+        SharedOffloadState,
+    };
 
     struct RelaxedWakeWitness(Arc<AtomicBool>);
 
@@ -400,6 +411,12 @@ mod tests {
     #[test]
     fn finished_publication_releases_wake_effect_to_reclaimer() {
         const WAIT: Duration = Duration::from_secs(10);
+
+        // A behavioral litmus alone is insufficient on a strong-memory CI
+        // host: the same run can succeed after both operations are weakened
+        // to Relaxed. Pin the exact pair as well as its cross-thread effect.
+        assert_eq!(FINISHED_PUBLISH_ORDERING, Ordering::Release);
+        assert_eq!(FINISHED_OBSERVE_ORDERING, Ordering::Acquire);
 
         let finished = Latch::default();
         let woke = Arc::new(AtomicBool::new(false));

--- a/crates/shelterwood/tests/timer_waker_proxy.rs
+++ b/crates/shelterwood/tests/timer_waker_proxy.rs
@@ -619,8 +619,10 @@ fn raw_recv_timer_cancellation_does_not_stall_unrelated_timer_traffic() {
     let runtime = runtime();
     let gate = DestructorGate::default();
     let (entered_tx, entered_rx) = mpsc::channel();
-    // shutdown, local stop, mailbox, offload event, then the raw timer.
-    let (hostile, state) = ordinal_waker(5, &gate, entered_tx);
+    // shutdown, mailbox, offload event, then the raw timer. Local stop is
+    // actor-task-only, so `recv` checks it before parking rather than
+    // registering a waiter in this selection.
+    let (hostile, state) = ordinal_waker(4, &gate, entered_tx);
     let (polled_tx, polled_rx) = mpsc::channel();
     let (cancelled_tx, cancelled_rx) = mpsc::channel();
     let mut tree = Tree::new();
@@ -643,8 +645,8 @@ fn raw_recv_timer_cancellation_does_not_stall_unrelated_timer_traffic() {
         polled_rx
             .recv_timeout(POLL_TIMEOUT)
             .expect("the raw actor manually parks recv"),
-        5,
-        "the fifth caller clone belongs to the armed raw timer"
+        4,
+        "the fourth caller clone belongs to the armed raw timer"
     );
     let destructor_thread = entered_rx
         .recv_timeout(POLL_TIMEOUT)

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -900,15 +900,8 @@ notification of §6.5 is the one carve-out in the other direction:
 because its wake panic MUST be retained before the framework may forget
 the work, a completion waiter whose waker *blocks* rather than panicking
 holds that work in the incarnation's resource ledger, and teardown joins
-it — so caller code can delay teardown and exit publication there.
-
-Grace bounds cannot interrupt user destruction already running in the
-incarnation-owned funnel: because that funnel runs inline so a disposal
-panic can become the incarnation's own verdict, a non-panicking destructor
-that blocks pins the Tokio worker running the incarnation until it returns.
-This is a venue cost of the required verdict semantics, not grounds to move
-the value to the detached-disposal lane. Grace bounds drain plus `on_stop`
-together (§11) — including after a local
+it — so caller code can delay teardown and exit publication there. Grace
+bounds drain plus `on_stop` together (§11) — including after a local
 `ctx.stop()`, which arms the child's own configured ladder (§11).
 
 ### 6.3 One timer facility
@@ -1053,6 +1046,12 @@ handlers non-blocking. Contracts:
   is unspecified. Panics in the offloaded future or the continuation
   resume on the actor task, so supervision classifies them as an ordinary
   actor panic.
+- Grace bounds cannot interrupt user destruction already running in the
+  incarnation-owned funnel. That funnel runs inline so a disposal panic can
+  become the incarnation's own verdict; consequently, a non-panicking
+  destructor that blocks pins the Tokio worker executing that disposal until
+  it returns. This is a venue cost of the required verdict semantics, not
+  grounds to move the value to the detached-disposal lane.
 - `run_blocking(f)` hands the closure a cancellation token that is a
   child of the actor's shutdown token and is also cancelled if the
   returned future is dropped. Cancellation is cooperative only; after

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -900,8 +900,15 @@ notification of §6.5 is the one carve-out in the other direction:
 because its wake panic MUST be retained before the framework may forget
 the work, a completion waiter whose waker *blocks* rather than panicking
 holds that work in the incarnation's resource ledger, and teardown joins
-it — so caller code can delay teardown and exit publication there. Grace
-bounds drain plus `on_stop` together (§11) — including after a local
+it — so caller code can delay teardown and exit publication there.
+
+Grace bounds cannot interrupt user destruction already running in the
+incarnation-owned funnel: because that funnel runs inline so a disposal
+panic can become the incarnation's own verdict, a non-panicking destructor
+that blocks pins the Tokio worker running the incarnation until it returns.
+This is a venue cost of the required verdict semantics, not grounds to move
+the value to the detached-disposal lane. Grace bounds drain plus `on_stop`
+together (§11) — including after a local
 `ctx.stop()`, which arms the child's own configured ladder (§11).
 
 ### 6.3 One timer facility

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -1049,7 +1049,7 @@ handlers non-blocking. Contracts:
 - Grace bounds cannot interrupt user destruction already running in the
   incarnation-owned funnel. That funnel runs inline so a disposal panic can
   become the incarnation's own verdict; consequently, a non-panicking
-  destructor that blocks pins the Tokio worker executing that disposal until
+  destructor that blocks pins the executor thread running that disposal until
   it returns. This is a venue cost of the required verdict semantics, not
   grounds to move the value to the detached-disposal lane.
 - `run_blocking(f)` hands the closure a cancellation token that is a


### PR DESCRIPTION
## Summary

- encode interval periods inside `TimerMessage::Interval`, make invalid timer/period pairings unconstructible, and resolve timer delivery with one arming lookup
- remove the actor-task-only local-stop waiter from `RawContext::wait_for_event` and update the timer-waker topology probe
- correct the raw timer disposal venue documentation while preserving SPEC §6.5's incarnation-owned contained funnel, document its blocking-destructor worker-pinning caveat, and explain why `run_blocking` remains available during teardown
- cover cross-variant timer replacement after a fired batch captures the superseded arming, including termination of the old interval cadence
- pin the `finished_published` Release/Acquire contract with a cross-thread wake-effect publication witness

## Testing

- `./tools/dev cargo test -p shelterwood raw::context::timers::tests --lib`
- `./tools/dev cargo test -p shelterwood raw::context::tests --lib`
- `./tools/dev cargo test -p shelterwood raw::offload::tests::finished_publication_releases_wake_effect_to_reclaimer --lib`
- `./tools/dev cargo test -p shelterwood --test events`
- `./tools/dev cargo test -p shelterwood --test timer_waker_proxy raw_recv_timer_cancellation_does_not_stall_unrelated_timer_traffic -- --exact`
- `./tools/dev just ci`

Closes #425.
