### PR TITLE
Harden driver exit and fail-closed paths

### DIFF
--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -698,20 +698,21 @@ impl ScopeRuntime {
             request.complete(Err(ReserveError::NotAdmitting(NotAdmittingCause::Terminal)));
             return;
         };
-        if self
+        let lifecycle = self.supervisor.lifecycle();
+        let not_admitting = if lifecycle.is_draining() {
+            Some(NotAdmittingCause::Draining)
+        } else if lifecycle.startup_failed() {
+            Some(NotAdmittingCause::StartupFailed)
+        } else if self
             .dynamic
             .as_ref()
             .is_none_or(|current| !Arc::ptr_eq(current, &control))
-            || self.supervisor.lifecycle().is_draining()
-            || self.supervisor.lifecycle().startup_failed()
         {
-            let cause = if self.supervisor.lifecycle().is_draining() {
-                NotAdmittingCause::Draining
-            } else if self.supervisor.lifecycle().startup_failed() {
-                NotAdmittingCause::StartupFailed
-            } else {
-                NotAdmittingCause::NoLiveIncarnation
-            };
+            Some(NotAdmittingCause::NoLiveIncarnation)
+        } else {
+            None
+        };
+        if let Some(cause) = not_admitting {
             let (definition, removed) = self.root.with_observation_gate(|txn| {
                 cancel_dynamic_reservation_parts(&self.root, &control, &request.slot, txn)
             });
@@ -1083,6 +1084,86 @@ async fn run_scope(plan: ScopePlan, role: ScopeRole) -> RetainedStopReason {
     RetainedStopReason::new(run_scope_incarnation(plan, role, epoch).await)
 }
 
+async fn wait_for_scope_wake(
+    scope: &mut ScopeRuntime,
+    signal: &mut runtime::WatchReceiver<crate::cells::MemberRecord>,
+    event_receiver: &mut runtime::UnboundedMpscReceiver<DriverEvent>,
+    dynamic_event_receiver: Option<&mut runtime::UnboundedMpscReceiver<DriverEvent>>,
+    pending: &mut Vec<(ArbitrationClass, Pending)>,
+) -> Option<StopReason> {
+    let ancestor_shutdown = scope
+        .role
+        .ancestor()
+        .filter(|_| !scope.ancestor_shutdown_seen)
+        .map(|latches| latches.framework_shutdown.clone());
+    let ancestor_abort = scope
+        .role
+        .ancestor()
+        .filter(|_| !scope.ancestor_abort_seen)
+        .map(|latches| latches.abort.clone());
+    let ancestor_command = async move {
+        let shutdown = async move {
+            if let Some(shutdown) = ancestor_shutdown {
+                shutdown.fired().await;
+            } else {
+                std::future::pending::<()>().await;
+            }
+        };
+        let abort = async move {
+            if let Some(abort) = ancestor_abort {
+                abort.fired().await;
+            } else {
+                std::future::pending::<()>().await;
+            }
+        };
+        let _ = runtime::select_two(shutdown, abort).await;
+    };
+    match runtime::wait_scope(
+        runtime::ScopeWait {
+            signal: signal.changed(),
+            parent_shutdown: ancestor_command,
+        },
+        event_receiver,
+        dynamic_event_receiver,
+        scope.deadlines.next_deadline(),
+    )
+    .await
+    {
+        runtime::ScopeWake::Signal | runtime::ScopeWake::ParentShutdown => {}
+        runtime::ScopeWake::Message(None) | runtime::ScopeWake::ControlMessage(None) => {
+            // Every lane sender is retained by the scope runtime or one of its
+            // registered children until the driver loop exits. A closed
+            // receiver would otherwise make this select arm permanently ready
+            // and spin. Fail closed by returning a retained shutdown
+            // completion: a framework panic here would unwind the other
+            // receiver and any queued admission response wakers outside
+            // ScopeRuntime's contained epilogue.
+            let reason = StopReason::ShutdownRequested;
+            let root_exit = scope
+                .role
+                .is_root()
+                .then(|| RetainedExit::new(stop_reason_root_exit(&reason)));
+            scope.completion = Some(ScopeCompletion {
+                reason: RetainedStopReason::new(reason.clone()),
+                root_exit,
+            });
+            return Some(reason);
+        }
+        runtime::ScopeWake::Deadline => {
+            // A producer becoming ready at the same instant owns the tie over
+            // its deadline. Give tasks woken by that clock edge one turn to
+            // publish their retained readiness latch before collecting due
+            // registrations.
+            runtime::yield_now().await;
+        }
+        runtime::ScopeWake::Message(Some(event))
+        | runtime::ScopeWake::ControlMessage(Some(event)) => {
+            retain_woken_event(event, pending);
+        }
+    }
+    None
+}
+
 async fn run_scope_incarnation(
     mut plan: ScopePlan,
     role: ScopeRole,
@@ -1261,75 +1342,16 @@ async fn run_scope_incarnation(
         }
 
         if pending.is_empty() {
-            let ancestor_shutdown = scope
-                .role
-                .ancestor()
-                .filter(|_| !scope.ancestor_shutdown_seen)
-                .map(|latches| latches.framework_shutdown.clone());
-            let ancestor_abort = scope
-                .role
-                .ancestor()
-                .filter(|_| !scope.ancestor_abort_seen)
-                .map(|latches| latches.abort.clone());
-            let ancestor_command = async move {
-                let shutdown = async move {
-                    if let Some(shutdown) = ancestor_shutdown {
-                        shutdown.fired().await;
-                    } else {
-                        std::future::pending::<()>().await;
-                    }
-                };
-                let abort = async move {
-                    if let Some(abort) = ancestor_abort {
-                        abort.fired().await;
-                    } else {
-                        std::future::pending::<()>().await;
-                    }
-                };
-                let _ = runtime::select_two(shutdown, abort).await;
-            };
-            match runtime::wait_scope(
-                runtime::ScopeWait {
-                    signal: signal.changed(),
-                    parent_shutdown: ancestor_command,
-                },
+            if let Some(reason) = wait_for_scope_wake(
+                &mut scope,
+                &mut signal,
                 &mut event_receiver,
                 dynamic_event_receiver.as_mut(),
-                scope.deadlines.next_deadline(),
+                &mut pending,
             )
             .await
             {
-                runtime::ScopeWake::Signal | runtime::ScopeWake::ParentShutdown => {}
-                runtime::ScopeWake::Message(None) | runtime::ScopeWake::ControlMessage(None) => {
-                    // Every lane sender is retained by the scope runtime or
-                    // one of its registered children until this loop exits.
-                    // A closed receiver would otherwise make this select arm
-                    // permanently ready and spin. Fail closed by returning a
-                    // retained shutdown completion: a framework panic here
-                    // would unwind the other receiver and any queued admission
-                    // response wakers outside ScopeRuntime's contained epilogue.
-                    let reason = StopReason::ShutdownRequested;
-                    let root_exit = scope
-                        .role
-                        .is_root()
-                        .then(|| RetainedExit::new(stop_reason_root_exit(&reason)));
-                    scope.completion = Some(ScopeCompletion {
-                        reason: RetainedStopReason::new(reason.clone()),
-                        root_exit,
-                    });
-                    return reason;
-                }
-                runtime::ScopeWake::Deadline => {
-                    // A producer becoming ready at the same instant owns the
-                    // tie over its deadline. Give tasks woken by that clock
-                    // edge one turn to publish their retained readiness
-                    // latch before collecting due registrations.
-                    runtime::yield_now().await;
-                }
-                runtime::ScopeWake::Message(Some(event))
-                | runtime::ScopeWake::ControlMessage(Some(event)) => {
-                    retain_woken_event(event, &mut pending);
-                }
+                return reason;
             }
             // Every wake re-enters the collection site above. Nothing is
             // dispatched from this arm.
@@ -1346,6 +1368,12 @@ async fn run_scope_incarnation(
                 Pending::Shutdown => {
                     if let ScopeRole::Nested(nested) = &scope.role {
                         nested.child_shutdown.fire();
+                        // The ancestor arm's sole action is the same
+                        // `begin_drain(ShutdownRequested)` call immediately
+                        // below, so consuming its observation here suppresses
+                        // only a duplicate idempotent transition. Construction
+                        // suppression still reads the ancestor latch itself
+                        // rather than this consumption flag.
                         scope.ancestor_shutdown_seen = true;
                     }
                     scope.begin_drain(StopReason::ShutdownRequested);

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -1084,6 +1084,9 @@ async fn run_scope(plan: ScopePlan, role: ScopeRole) -> RetainedStopReason {
     RetainedStopReason::new(run_scope_incarnation(plan, role, epoch).await)
 }
 
+/// Blocks the driver loop until one lane wakes it, returning `Some` only when
+/// the wake staged a scope completion the loop must return.
+#[must_use = "a staged fail-closed completion must end the driver loop"]
 async fn wait_for_scope_wake(
     scope: &mut ScopeRuntime,
     signal: &mut runtime::WatchReceiver<crate::cells::MemberRecord>,

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -178,13 +178,15 @@ impl DynamicEntry {
 
 pub(super) struct DynamicState {
     accepting: bool,
-    #[cfg(not(test))]
     entries: HashMap<ChildId, DynamicEntry>,
-    #[cfg(test)]
-    pub(super) entries: HashMap<ChildId, DynamicEntry>,
 }
 
 impl DynamicState {
+    #[cfg(test)]
+    pub(super) fn entries_mut(&mut self) -> &mut HashMap<ChildId, DynamicEntry> {
+        &mut self.entries
+    }
+
     pub(super) fn entry(&self, id: &ChildId) -> Option<&DynamicEntry> {
         self.entries.get(id)
     }

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -1063,7 +1063,12 @@ impl ScopeRuntime {
             }
         }
         let recorded = reconcile_recorded_outcomes_retaining(recorded, active.forced_outcome);
-        let exit = classify_exit_retaining(recorded, join, active.hard_abort_phase, cancellation);
+        let exit = RetainedExit::new(classify_exit_retaining(
+            recorded,
+            join,
+            active.hard_abort_phase,
+            cancellation,
+        ));
         child.restarts.settle_if_stable(
             IncarnationRun {
                 started_at: active.started_at,
@@ -1096,9 +1101,14 @@ impl ScopeRuntime {
         } else {
             ScopeMode::Running
         };
-        match dispatch_exit(&exit, child.options.restart, mode, membership_status) {
+        match dispatch_exit(
+            exit.as_exit(),
+            child.options.restart,
+            mode,
+            membership_status,
+        ) {
             ExitDispatch::Terminal => {
-                self.begin_terminal_disposal(key, exit, Some(incarnation), startup);
+                self.begin_terminal_disposal(key, exit.into_exit(), Some(incarnation), startup);
             }
             ExitDispatch::ScheduleRestart => {
                 let sample =
@@ -1123,7 +1133,7 @@ impl ScopeRuntime {
                     &child.slot.member,
                     decision.total_restarts(),
                     MemberTransition::RestartScheduled {
-                        exit: exit.clone(),
+                        exit: exit.as_exit().clone(),
                         restart_count: decision.restart_count(),
                         // Publish the derived schedule even when intensity prevents spawning it.
                         // `None` means the exact clock point cannot be represented and armed; no
@@ -1134,7 +1144,7 @@ impl ScopeRuntime {
                         id: child.slot.member.id().clone(),
                         membership: child.slot.member.membership(),
                         incarnation,
-                        exit: exit.clone(),
+                        exit: exit.as_exit().clone(),
                     },
                     LifecycleEventKind::RestartScheduled {
                         id: child.slot.member.id().clone(),
@@ -1147,6 +1157,10 @@ impl ScopeRuntime {
                     published,
                     "a restart is scheduled from an active incarnation's exit"
                 );
+                // Successful publication installed retained copies in the
+                // member record and lifecycle event. Releasing the local raw
+                // copy is therefore provably refcount traffic.
+                drop(exit.into_exit());
                 let trip = decision.intensity_trip();
                 if trip.is_none()
                     && let Some(restart_at) = decision.restart_at()

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -51,7 +51,7 @@ async fn refused_dynamic_admission_panics_after_control_plane_unlock() {
             .state
             .lock()
             .expect("dynamic-state mutex remains healthy")
-            .entries
+            .entries_mut()
             .get(member.id())
             .is_some_and(|entry| !entry.is_reserved()),
         "the fixture reaches the committing admission site after entry promotion"
@@ -236,7 +236,7 @@ fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
         .state
         .lock()
         .expect("dynamic-state mutex poisoned")
-        .entries
+        .entries_mut()
         .insert(
             ChildId::from("worker"),
             DynamicEntry::removing(slot, ChildKey::fixture(1), responses),
@@ -381,7 +381,7 @@ fn dynamic_removal_waits_for_the_observation_gate_before_mutating_state() {
         .state
         .lock()
         .expect("dynamic-state mutex poisoned")
-        .entries
+        .entries_mut()
         .insert(child_id.clone(), DynamicEntry::resident(slot, key, None));
     root.set_dynamic_route(Some(control.clone()));
 
@@ -402,12 +402,12 @@ fn dynamic_removal_waits_for_the_observation_gate_before_mutating_state() {
             .expect("removal reports its gate capture within the bound"),
         GateCapture::Observation
     );
-    let state = control
+    let mut state = control
         .state
         .try_lock()
         .expect("a removal waiting on observation has not acquired or mutated dynamic state");
     let entry = state
-        .entries
+        .entries_mut()
         .get(&child_id)
         .expect("the removal keeps its resident registration");
     assert!(!entry.is_removing());
@@ -464,7 +464,7 @@ async fn final_removal_holds_the_id_until_removed_publication_commits() {
                 .state
                 .lock()
                 .expect("dynamic-state mutex remains available")
-                .entries
+                .entries_mut()
                 .contains_key(member.id()),
             "the old id remains claimed until residency withdrawal can commit"
         );
@@ -478,7 +478,7 @@ async fn final_removal_holds_the_id_until_removed_publication_commits() {
             .state
             .lock()
             .expect("dynamic-state mutex remains healthy")
-            .entries
+            .entries_mut()
             .contains_key(member.id()),
         "id release follows the Removed publication"
     );
@@ -600,7 +600,7 @@ async fn removal_from_a_foreign_thread_reaches_the_driver() {
         .state
         .lock()
         .expect("dynamic-state mutex poisoned")
-        .entries
+        .entries_mut()
         .insert(
             child_id,
             DynamicEntry::resident(Arc::clone(&slot), key, Some(Latch::default())),
@@ -685,7 +685,7 @@ async fn admission_conversion_panic_does_not_poison_dynamic_cleanup() {
             .state
             .lock()
             .expect("dynamic-state mutex remains healthy")
-            .entries
+            .entries_mut()
             .is_empty(),
         "cleanup discharges the stranded reservation"
     );
@@ -778,7 +778,7 @@ async fn annulment_before_admission_owns_never_started_terminality() {
             .state
             .lock()
             .expect("dynamic-state mutex remains healthy")
-            .entries
+            .entries_mut()
             .is_empty()
     );
     assert_eq!(
@@ -848,7 +848,7 @@ async fn annulment_after_promotion_is_inert_and_supervision_owns_the_exit() {
             .state
             .lock()
             .expect("dynamic-state mutex remains healthy")
-            .entries
+            .entries_mut()
             .get(member.id())
             .is_some_and(|entry| !entry.is_reserved()),
         "the resident registration survives the inert annul"
@@ -981,7 +981,7 @@ async fn annulment_racing_admission_resolves_to_one_terminalization_owner() {
                         .state
                         .lock()
                         .expect("dynamic-state mutex remains healthy")
-                        .entries
+                        .entries_mut()
                         .get(member.id())
                         .is_some_and(|entry| !entry.is_reserved())
                 );
@@ -998,7 +998,7 @@ async fn annulment_racing_admission_resolves_to_one_terminalization_owner() {
                         .state
                         .lock()
                         .expect("dynamic-state mutex remains healthy")
-                        .entries
+                        .entries_mut()
                         .is_empty()
                 );
             }
@@ -1068,7 +1068,7 @@ async fn fused_cancellation_overtaking_admission_rejects_before_conversion() {
             .state
             .lock()
             .expect("dynamic-state mutex remains healthy")
-            .entries
+            .entries_mut()
             .is_empty()
     );
     assert!(matches!(member.record().stage, MemberStage::Terminal(_)));
@@ -1155,7 +1155,7 @@ async fn fused_cancellation_during_conversion_is_rejected_by_the_under_lock_rech
             .state
             .lock()
             .expect("dynamic-state mutex remains healthy")
-            .entries
+            .entries_mut()
             .is_empty()
     );
     assert!(matches!(member.record().stage, MemberStage::Terminal(_)));
@@ -1208,7 +1208,7 @@ async fn exercise_coalesced_removal(source: RemovalSource) {
         .state
         .lock()
         .expect("dynamic-state mutex poisoned")
-        .entries
+        .entries_mut()
         .get(member.id())
         .and_then(DynamicEntry::key)
         .expect("the admission installs its child key");
@@ -1318,7 +1318,7 @@ async fn exercise_coalesced_removal(source: RemovalSource) {
             .state
             .lock()
             .expect("dynamic-state mutex poisoned")
-            .entries
+            .entries_mut()
             .contains_key(member.id())
     );
     if let Some(response) = removal_response {
@@ -1433,7 +1433,7 @@ pub(crate) async fn exercise_queued_fused_drop_before_exit_dispatch<A>(
             .state
             .lock()
             .expect("dynamic-state mutex poisoned")
-            .entries
+            .entries_mut()
             .get(member.id())
             .is_some_and(|entry| entry.is_removing() && entry.matches_key(key)),
         "fused drop marks the indexed membership removing before its queued edge advances"

--- a/crates/shelterwood/src/driver/tests/events.rs
+++ b/crates/shelterwood/src/driver/tests/events.rs
@@ -11,6 +11,80 @@ fn disposed_child(pending: &Pending) -> ChildKey {
     }
 }
 
+async fn assert_closed_lane_fails_closed(closed_control: bool) {
+    let flavor = if closed_control {
+        ScopeFlavor::Dynamic
+    } else {
+        ScopeFlavor::Ordered
+    };
+    let root = isolated_scope("root", flavor);
+    let epoch = ScopeEpochGuard::begin(&root).expect("test scope epoch is available");
+    root.member
+        .update(|record| record.stage = MemberStage::Running);
+    root.set_state_and_startup(ScopeState::Running, Ok(()));
+
+    let (events, mut primary_receiver) = crate::runtime::unbounded_mpsc();
+    let (dynamic, mut dynamic_receiver) = if closed_control {
+        let (dynamic_events, dynamic_receiver) = crate::runtime::unbounded_mpsc();
+        (
+            Some(DynamicControl::new(dynamic_events)),
+            Some(dynamic_receiver),
+        )
+    } else {
+        (None, None)
+    };
+    let mut scope = ScopeRuntimeBuilder::new(Arc::clone(&root), epoch, events)
+        .with_lifecycle(ScopeLifecycle::running())
+        .with_dynamic(dynamic)
+        .build();
+    let (dead_sender, dead_receiver) = crate::runtime::unbounded_mpsc();
+    drop(dead_receiver);
+    if closed_control {
+        let replacement = DynamicControl::new(dead_sender);
+        root.set_dynamic_route(Some(replacement.clone()));
+        scope.dynamic = Some(replacement);
+    } else {
+        drop(std::mem::replace(&mut scope.events, dead_sender));
+    }
+
+    let mut signal = root.signal().watcher();
+    let mut pending = Vec::new();
+    let reason = wait_for_scope_wake(
+        &mut scope,
+        &mut signal,
+        &mut primary_receiver,
+        dynamic_receiver.as_mut(),
+        &mut pending,
+    )
+    .await;
+
+    assert_eq!(reason, Some(StopReason::ShutdownRequested));
+    assert!(pending.is_empty());
+    assert!(matches!(
+        scope
+            .completion
+            .as_ref()
+            .map(|completion| completion.reason.as_reason()),
+        Some(StopReason::ShutdownRequested)
+    ));
+    drop(scope);
+    assert!(matches!(
+        root.snapshot().state,
+        ScopeState::Stopped {
+            reason: StopReason::ShutdownRequested
+        }
+    ));
+}
+
+/// Sender retention makes both closed-lane wakes unreachable in production,
+/// but if that wiring invariant regresses the driver must take the contained
+/// shutdown epilogue instead of panicking or spinning on an always-ready lane.
+#[crate::runtime::test]
+async fn closed_event_lanes_publish_a_retained_shutdown_completion() {
+    assert_closed_lane_fails_closed(false).await;
+    assert_closed_lane_fails_closed(true).await;
+}
+
 /// Pins the post-blocking-wake gap: removal is queued on the control lane
 /// before readiness reaches the primary lane, but the biased wait returns the
 /// primary head. Retaining that head and re-entering the common collection

--- a/crates/shelterwood/src/driver/tests/retained_outcomes.rs
+++ b/crates/shelterwood/src/driver/tests/retained_outcomes.rs
@@ -211,3 +211,83 @@ async fn handle_exit_retains_the_selected_failure_across_dispatch_panics() {
 
     control.state.clear_poison();
 }
+
+/// The other consumption point of the same window. Restart dispatch clones
+/// through the retained carrier and asserts that publication landed, so the
+/// selected failure must still be retained when that invariant fails — the
+/// local raw copy is released only once the member record owns an equivalent
+/// one.
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_refused_restart_publication_retains_the_selected_failure() {
+    let mut tree = Tree::new();
+    tree.add_task(
+        "worker",
+        TaskDef::new(|_| future::pending::<crate::ExitResult>()).restart(RestartPolicy::new(
+            RestartCondition::Always,
+            Backoff::Immediate,
+        )),
+    )
+    .expect("valid task");
+    let fixture = OrderedScopeFixture::new(tree);
+    let root = Arc::clone(&fixture.root);
+    root.member
+        .update(|record| record.stage = MemberStage::Running);
+    root.set_state_and_startup(ScopeState::Running, Ok(()));
+    let key = fixture.children.keys().next().expect("one child plan");
+    let (mut scope, mut event_receiver) = fixture.with_lifecycle(ScopeLifecycle::running()).build();
+
+    scope.spawn_child(key);
+    let active = scope.children[key]
+        .active
+        .as_ref()
+        .expect("worker is active");
+    let incarnation = active.incarnation;
+    active.abort_handle.abort();
+    let _joined = recv_child_exit(
+        &mut event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "the aborted fixture task to join",
+    )
+    .await;
+
+    // Corrupt only the projection source stage. `RestartScheduled` is legal
+    // from `Starting`, `Running` and `Stopping`, so an `Admitted` source makes
+    // the cell reducer refuse and reaches the driver's publication invariant
+    // exactly.
+    let member = Arc::clone(&scope.children[key].slot.member);
+    member.update(|record| record.stage = MemberStage::Admitted);
+
+    let (recorded, observed) = thread_reporting_error();
+    // Sample after the last await: the dispatch below runs inline on whichever
+    // worker this multi-thread test task currently occupies.
+    let driver_thread = std::thread::current().id();
+    let refusal = catch_unwind(AssertUnwindSafe(|| {
+        scope.handle_exit(
+            key,
+            incarnation,
+            Some(RetainedRecordedOutcome::new(RecordedOutcome::returned(
+                Err(recorded),
+            ))),
+            crate::runtime::JoinOutcome::Ok { value: () },
+            Cancellation::NotObserved,
+            false,
+        );
+    }))
+    .expect_err("a refused restart publication remains a framework invariant");
+    assert_eq!(
+        refusal.downcast_ref::<&'static str>().copied(),
+        Some("a restart is scheduled from an active incarnation's exit"),
+        "the framework invariant is the primary failure"
+    );
+    assert_ne!(
+        observed
+            .recv_timeout(DRIVER_PROGRESS_WAIT)
+            .expect("the retained selected failure is disposed"),
+        driver_thread,
+        "a refused restart publication must not destroy the user error on the driver"
+    );
+
+    // Restore the source stage so ScopeRuntime's normal fail-closed epilogue
+    // can discharge this deliberately corrupted fixture.
+    member.update(|record| record.stage = MemberStage::Running);
+}

--- a/crates/shelterwood/src/driver/tests/retained_outcomes.rs
+++ b/crates/shelterwood/src/driver/tests/retained_outcomes.rs
@@ -131,3 +131,83 @@ async fn a_join_panic_disposes_the_recorded_application_failure_off_the_driver()
         "the losing application error must not be destroyed on the driver"
     );
 }
+
+/// The selected failure must stay behind `RetainedExit` after classification,
+/// not only while the losing half of the fold is discarded. Poisoning the
+/// dynamic membership mutex injects the first fallible operation in that
+/// window and proves unwind drop glue transfers the selected user error to
+/// critical disposal instead of destroying it on the driver thread.
+#[crate::runtime::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_exit_retains_the_selected_failure_across_dispatch_panics() {
+    let (mut scope, mut event_receiver, mut dynamic_events, control) = running_dynamic_fixture();
+    let root = Arc::clone(&scope.root);
+    let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
+        .expect("running dynamic scope reserves the child");
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new(|_| future::pending()).erase(),
+    ));
+    let (mut response, request) = begin_admission(&reservation, &mut dynamic_events, None).await;
+    scope.handle_admission(request);
+    assert!(matches!(response.try_receive(), Some(Ok(()))));
+
+    let (key, incarnation) = scope
+        .children
+        .iter()
+        .find_map(|(key, child)| {
+            child
+                .active
+                .as_ref()
+                .map(|active| (key, active.incarnation))
+        })
+        .expect("admission starts one child incarnation");
+    scope.children[key]
+        .active
+        .as_ref()
+        .expect("the child remains active")
+        .abort_handle
+        .abort();
+    let _joined = recv_child_exit(
+        &mut event_receiver,
+        DRIVER_PROGRESS_WAIT,
+        "the aborted fixture task to join",
+    )
+    .await;
+
+    assert!(
+        catch_unwind(AssertUnwindSafe(|| {
+            let _state = control
+                .state
+                .lock()
+                .expect("dynamic-state mutex starts healthy");
+            panic!("inject membership dispatch panic");
+        }))
+        .is_err()
+    );
+    let (recorded, observed) = thread_reporting_error();
+    let driver_thread = std::thread::current().id();
+    assert!(
+        catch_unwind(AssertUnwindSafe(|| {
+            scope.handle_exit(
+                key,
+                incarnation,
+                Some(RetainedRecordedOutcome::new(RecordedOutcome::returned(
+                    Err(recorded),
+                ))),
+                crate::runtime::JoinOutcome::Ok { value: () },
+                Cancellation::NotObserved,
+                false,
+            );
+        }))
+        .is_err(),
+        "the poisoned membership lock injects a post-classification panic"
+    );
+    assert_ne!(
+        observed
+            .recv_timeout(DRIVER_PROGRESS_WAIT)
+            .expect("the retained selected failure is disposed"),
+        driver_thread,
+        "post-classification unwind must not destroy the user error on the driver"
+    );
+
+    control.state.clear_poison();
+}

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -137,6 +137,7 @@ pub(super) use super::super::{
     discharge_child_terminality, events::collect_driver_events, monitor_root_driver,
     nested_scope_start, report_slot, reserve_dynamic, resident_projection, restart_shutdown_work,
     run_nested_factory, run_nested_tree, run_scope, run_scope_incarnation, storage::Obligation,
+    wait_for_scope_wake,
 };
 
 pub(super) async fn begin_admission(
@@ -191,7 +192,7 @@ pub(super) fn insert_dynamic_fixture(
         {
             let mut dynamic = control.state.lock().expect("dynamic-state mutex poisoned");
             let entry = dynamic
-                .entries
+                .entries_mut()
                 .get_mut(reservation.slot.member.id())
                 .expect("the fixture reservation remains registered");
             entry.promote(key, None, txn);


### PR DESCRIPTION
## Summary

- keep the selected child `Exit` in `RetainedExit` from classification until terminal disposal or successful restart publication
- derive dynamic-admission rejection cause once, document the nested self-shutdown consumption flag, and replace `DynamicState.entries`' test-only visibility split with `entries_mut()`
- exercise the real driver wake path after both primary and control sender-retention invariants are deliberately broken

## Issue dispositions

1. `handle_exit` now wraps the classified result immediately. Terminal dispatch unwraps only into `begin_terminal_disposal`, whose first operation re-retains it. Restart dispatch clones through the retained carrier, asserts successful publication, and releases the local raw copy only after the member record and lifecycle event own retained copies. `handle_exit_retains_the_selected_failure_across_dispatch_panics` poisons dynamic membership dispatch after classification and verifies the selected application error is destroyed off the driver thread.
2. The nested `Pending::Shutdown` assignment now documents both dependencies: the ancestor arm would only repeat the same idempotent `begin_drain(ShutdownRequested)`, while construction suppression samples the ancestor latch directly.
3. `handle_admission` samples the lifecycle once and produces one `Option<NotAdmittingCause>` before the rejection branch, preserving the existing Draining > StartupFailed > NoLiveIncarnation precedence.
4. `DynamicState.entries` has one declaration. Unit fixtures use a `#[cfg(test)] entries_mut()` accessor.
5. `closed_event_lanes_publish_a_retained_shutdown_completion` uses a hand-built `ScopeRuntime`, removes the actual retained sender for each lane in turn, and verifies a retained `ShutdownRequested` completion reaches the contained scope epilogue. The promote/admit invariant was already covered on current `main` by `refused_dynamic_admission_panics_after_control_plane_unlock`; this PR preserves that evidence while moving its state inspection through `entries_mut()`. That test verifies the framework diagnostic remains primary over a hostile response waker, both control-plane locks are released, and the lost response completes fail-closed.

## Validation

- `./tools/dev cargo test -p shelterwood --lib driver::tests` (162 passed)
- `./tools/dev just ci` (913 tests plus doctests, examples, rustdoc/API reachability, external consumer, and Nix formatting)

Closes #422
