### PR TITLE
Tighten observation cell invariants

### DIFF
--- a/crates/shelterwood/src/cells/gate.rs
+++ b/crates/shelterwood/src/cells/gate.rs
@@ -69,14 +69,18 @@ impl ObservationGate {
 /// from stranding already-committed wakes.
 pub(crate) struct ObservationTxn<'a> {
     guard: Option<MutexGuard<'a, ()>>,
+    #[cfg(debug_assertions)]
+    gate: Option<&'a ObservationGate>,
     effects: Vec<Box<dyn FnOnce()>>,
     snapshots: Vec<SnapshotPublication>,
 }
 
 impl<'a> ObservationTxn<'a> {
-    pub(super) fn new(guard: MutexGuard<'a, ()>) -> Self {
+    pub(super) fn new(gate: &'a ObservationGate, guard: MutexGuard<'a, ()>) -> Self {
         Self {
             guard: Some(guard),
+            #[cfg(debug_assertions)]
+            gate: Some(gate),
             effects: Vec::new(),
             snapshots: Vec::new(),
         }
@@ -86,9 +90,28 @@ impl<'a> ObservationTxn<'a> {
     pub(crate) fn detached() -> Self {
         Self {
             guard: None,
+            #[cfg(debug_assertions)]
+            gate: None,
             effects: Vec::new(),
             snapshots: Vec::new(),
         }
+    }
+
+    /// Checks that a locked cell writer received the transaction for its
+    /// current resident-tree gate.
+    ///
+    /// Unit tests for isolated hub mechanics use [`Self::detached`], which
+    /// deliberately carries no identity and therefore opts out.
+    pub(crate) fn debug_assert_gate(&self, gate: &ObservationGate) {
+        #[cfg(debug_assertions)]
+        if let Some(held) = self.gate {
+            debug_assert!(
+                held.shares_gate(gate),
+                "a locked observation writer requires its current tree gate"
+            );
+        }
+        #[cfg(not(debug_assertions))]
+        let _ = gate;
     }
 
     pub(crate) fn defer(&mut self, operation: impl FnOnce() + 'static) {
@@ -215,7 +238,7 @@ mod tests {
     fn observation_txn_commit_unlocks_before_effects_and_drains_once() {
         let gate = ObservationGate::new();
         let order = Arc::new(Mutex::new(Vec::new()));
-        let mut txn = ObservationTxn::new(gate.lock());
+        let mut txn = ObservationTxn::new(&gate, gate.lock());
         for value in [1, 2] {
             let gate = gate.clone();
             let order = Arc::clone(&order);
@@ -266,7 +289,7 @@ mod tests {
         );
 
         let payload = catch_unwind(AssertUnwindSafe(|| {
-            let mut txn = ObservationTxn::new(gate.lock());
+            let mut txn = ObservationTxn::new(&gate, gate.lock());
             txn.pulse(&hostile_sender);
             txn.pulse(&later_sender);
         }))
@@ -295,7 +318,7 @@ mod tests {
             let effects = Arc::clone(&effects);
             let gate = gate.clone();
             move || {
-                let mut txn = ObservationTxn::new(gate.lock());
+                let mut txn = ObservationTxn::new(&gate, gate.lock());
                 let first = Arc::clone(&effects);
                 let first_gate = gate.clone();
                 // An assertion here would be inert: `PanicAccumulator`

--- a/crates/shelterwood/src/cells/gate.rs
+++ b/crates/shelterwood/src/cells/gate.rs
@@ -77,6 +77,8 @@ pub(crate) struct ObservationTxn<'a> {
 
 impl<'a> ObservationTxn<'a> {
     pub(super) fn new(gate: &'a ObservationGate, guard: MutexGuard<'a, ()>) -> Self {
+        #[cfg(not(debug_assertions))]
+        let _ = gate;
         Self {
             guard: Some(guard),
             #[cfg(debug_assertions)]
@@ -102,16 +104,14 @@ impl<'a> ObservationTxn<'a> {
     ///
     /// Unit tests for isolated hub mechanics use [`Self::detached`], which
     /// deliberately carries no identity and therefore opts out.
+    #[cfg(debug_assertions)]
     pub(crate) fn debug_assert_gate(&self, gate: &ObservationGate) {
-        #[cfg(debug_assertions)]
         if let Some(held) = self.gate {
             debug_assert!(
                 held.shares_gate(gate),
                 "a locked observation writer requires its current tree gate"
             );
         }
-        #[cfg(not(debug_assertions))]
-        let _ = gate;
     }
 
     pub(crate) fn defer(&mut self, operation: impl FnOnce() + 'static) {

--- a/crates/shelterwood/src/cells/member.rs
+++ b/crates/shelterwood/src/cells/member.rs
@@ -644,13 +644,20 @@ impl MemberCell {
                     MemberMailbox::Terminal {
                         control, teardown, ..
                     } => {
+                        // Unreachable under the gate — `terminalize_locked`
+                        // only stores a teardown alongside a control, which the
+                        // arm above already rejects — and kept as total
+                        // defense against ever draining one twice.
                         if teardown.is_some() {
                             rejected = Some(mailbox);
                             None
                         } else {
-                            let teardown = mailbox.prepare_termination(txn);
+                            // The stored `teardown` field stays empty: the
+                            // drain below is the only reader this one can have,
+                            // and it owns it before the mailbox guard drops.
+                            let drained = mailbox.prepare_termination(txn);
                             *control = Some(mailbox);
-                            teardown
+                            drained
                         }
                     }
                 }
@@ -903,6 +910,11 @@ mod tests {
         );
     }
 
+    /// Pins the invariant the direct teardown drain has to keep, not the
+    /// rewrite itself: the losing `terminalize_locked` it replaced published
+    /// no record edge either, so no test can separate the two shapes. The
+    /// teardown half is pinned by
+    /// `attach_to_a_terminal_member_finishes_record_before_mailbox_wake`.
     #[test]
     fn attaching_to_a_terminal_member_does_not_republish_its_record() {
         let scope = isolated_scope("root", ScopeFlavor::Ordered);
@@ -922,7 +934,7 @@ mod tests {
                 .as_mut()
                 .poll(&mut Context::from_waker(Waker::noop()))
                 .is_pending(),
-            "terminal attachment drains teardown without a synthetic losing transition"
+            "attaching to an already-terminal member publishes no second record edge"
         );
     }
 

--- a/crates/shelterwood/src/cells/member.rs
+++ b/crates/shelterwood/src/cells/member.rs
@@ -820,6 +820,7 @@ mod tests {
     use super::*;
     use crate::cells::test_support::{ThreadProbe, isolated_scope};
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "a locked observation writer requires its current tree gate")]
     fn locked_member_writer_checks_transaction_gate_identity() {

--- a/crates/shelterwood/src/cells/member.rs
+++ b/crates/shelterwood/src/cells/member.rs
@@ -332,17 +332,6 @@ impl MemberCell {
         self.record.watcher()
     }
 
-    #[cfg(test)]
-    pub(crate) fn stage_terminal_before_mailbox(&self, exit: Exit) {
-        let mut mailbox = self.mailbox.lock().expect("member mailbox mutex poisoned");
-        assert!(matches!(*mailbox, MemberMailbox::Unattached));
-        *mailbox = MemberMailbox::Terminal {
-            control: None,
-            exit: RetainedExit::new(exit),
-            teardown: None,
-        };
-    }
-
     /// Reports terminality or drain-entry terminal-disposal intent.
     ///
     /// `Acquire` pairs with the `Release` store in
@@ -427,7 +416,7 @@ impl MemberCell {
             report_capture();
             let guard = gate.lock();
             if gate.shares_gate(&self.current_observation_gate()) {
-                let mut txn = ObservationTxn::new(guard);
+                let mut txn = ObservationTxn::new(&gate, guard);
                 return operation
                     .take()
                     .expect("member observation operation runs exactly once")(
@@ -548,6 +537,8 @@ impl MemberCell {
         txn: &mut ObservationTxn<'_>,
         update: impl FnOnce(&mut MemberRecord),
     ) {
+        #[cfg(debug_assertions)]
+        txn.debug_assert_gate(&self.current_observation_gate());
         // Refreshing here rather than in each writer keeps the guard-set
         // invariant on every record mutation, including the test-only escape
         // hatch that writes fields directly.
@@ -581,6 +572,8 @@ impl MemberCell {
         txn: &mut ObservationTxn<'_>,
         transition: MemberTransition,
     ) -> bool {
+        #[cfg(debug_assertions)]
+        txn.debug_assert_gate(&self.current_observation_gate());
         // `RestartScheduled` carries a user error by value. Retain it before
         // the watch lock and reducer validation so an unrelated panic can
         // unwind the raw transition as refcount traffic only.
@@ -634,7 +627,7 @@ impl MemberCell {
     pub(crate) fn attach_mailbox(&self, mailbox: Arc<dyn MailboxControl>) {
         self.with_observation_txn(|txn| {
             let mut rejected = None;
-            let terminal_exit = {
+            let terminal_teardown = {
                 let mut state = self.mailbox.lock().expect("member mailbox mutex poisoned");
                 match &mut *state {
                     MemberMailbox::Unattached => {
@@ -649,17 +642,15 @@ impl MemberCell {
                         None
                     }
                     MemberMailbox::Terminal {
-                        control,
-                        exit,
-                        teardown,
+                        control, teardown, ..
                     } => {
                         if teardown.is_some() {
                             rejected = Some(mailbox);
                             None
                         } else {
-                            *teardown = mailbox.prepare_termination(txn);
+                            let teardown = mailbox.prepare_termination(txn);
                             *control = Some(mailbox);
-                            Some(exit.as_exit().clone())
+                            teardown
                         }
                     }
                 }
@@ -673,8 +664,10 @@ impl MemberCell {
                 txn.defer(move || runtime::dispose_detached(rejected));
                 return;
             }
-            if let Some(terminal_exit) = terminal_exit {
-                self.terminalize_locked(terminal_exit, StartupDisposition::Unchanged, txn);
+            if let Some(teardown) = terminal_teardown {
+                txn.defer(move || {
+                    runtime::dispose_detached(teardown.finish());
+                });
             }
         });
     }
@@ -699,6 +692,8 @@ impl MemberCell {
         startup: StartupDisposition,
         txn: &mut ObservationTxn<'_>,
     ) -> Exit {
+        #[cfg(debug_assertions)]
+        txn.debug_assert_gate(&self.current_observation_gate());
         // A losing terminalizer's exit is destroyed here, and an
         // `ExitKind::Failed` payload owns a type-erased user error whose
         // destructor may block, panic, or re-enter observation. Hand it to the
@@ -826,6 +821,16 @@ mod tests {
     use crate::cells::test_support::{ThreadProbe, isolated_scope};
 
     #[test]
+    #[should_panic(expected = "a locked observation writer requires its current tree gate")]
+    fn locked_member_writer_checks_transaction_gate_identity() {
+        let scope = isolated_scope("root", ScopeFlavor::Ordered);
+        let wrong_gate = ObservationGate::new();
+        let mut txn = ObservationTxn::new(&wrong_gate, wrong_gate.lock());
+
+        scope.member.update_locked(&mut txn, |_| {});
+    }
+
+    #[test]
     fn illegal_restart_transition_is_rejected_in_every_build() {
         let scope = isolated_scope("root", ScopeFlavor::Ordered);
         let mut watcher = scope.member.record_watcher();
@@ -894,6 +899,29 @@ mod tests {
         assert!(
             scope.member.mailbox().is_some(),
             "the rejected attach did not poison the mailbox mutex"
+        );
+    }
+
+    #[test]
+    fn attaching_to_a_terminal_member_does_not_republish_its_record() {
+        let scope = isolated_scope("root", ScopeFlavor::Ordered);
+        scope.member.terminalize(
+            Exit::completed(Cancellation::NotObserved),
+            StartupDisposition::Unchanged,
+        );
+        let mut watcher = scope.member.record_watcher();
+        watcher.borrow_and_update_cloned();
+        let mailbox = MailboxCell::<u8>::new(scope.member.id().clone(), runtime::mailbox_runtime());
+
+        scope.member.attach_mailbox(mailbox);
+
+        let mut changed = Box::pin(watcher.changed());
+        assert!(
+            changed
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending(),
+            "terminal attachment drains teardown without a synthetic losing transition"
         );
     }
 

--- a/crates/shelterwood/src/cells/observe.rs
+++ b/crates/shelterwood/src/cells/observe.rs
@@ -17,13 +17,6 @@ use shelterwood_core::{
 
 use super::{ObservationTxn, RetainedExit};
 
-fn unwrap_or_clone<T: Clone>(shared: Arc<T>) -> T {
-    match Arc::try_unwrap(shared) {
-        Ok(value) => value,
-        Err(shared) => shared.as_ref().clone(),
-    }
-}
-
 /// Number of lifecycle events retained independently for each subscriber.
 pub(crate) const LIFECYCLE_EVENT_CAPACITY: usize = 128;
 
@@ -169,7 +162,7 @@ impl RetainedLifecycleEvent {
         // the guard allocation first matters: a broadcast receive is often the
         // last owner, and letting the arc drop the guards would route a live
         // user error through isolated disposal for nothing.
-        let guards = unwrap_or_clone(guards);
+        let guards = Arc::unwrap_or_clone(guards);
         for guard in guards {
             drop(guard.into_exit());
         }
@@ -419,7 +412,7 @@ impl RetainedScopeSnapshot {
     }
 
     pub(crate) fn into_parts(self) -> (Arc<ScopeSnapshot>, Vec<RetainedExit>) {
-        let exits = unwrap_or_clone(self.exits);
+        let exits = Arc::unwrap_or_clone(self.exits);
         (self.snapshot, exits)
     }
 }
@@ -523,6 +516,13 @@ struct SnapshotInstallPolicy {
     pulse: bool,
 }
 
+/// Installs one cut and returns the effects its caller owes after unlock.
+///
+/// A hub already closed by a committed transaction keeps the authoritative
+/// terminal projection `close` installed, so every branch below refuses it and
+/// hands the uninstalled cut back through the effect list. `closed` is
+/// therefore only ever written onto an *open* hub: a refresh that passes
+/// `false` re-asserts the flag it just read rather than clearing a closure.
 fn install_snapshot(
     sender: &runtime::WatchSender<SnapshotHubState>,
     mut snapshot: Option<RetainedScopeSnapshot>,

--- a/crates/shelterwood/src/cells/observe.rs
+++ b/crates/shelterwood/src/cells/observe.rs
@@ -15,7 +15,14 @@ use shelterwood_core::{
     policy::ScopeFlavor,
 };
 
-use crate::cells::RetainedExit;
+use super::{ObservationTxn, RetainedExit};
+
+fn unwrap_or_clone<T: Clone>(shared: Arc<T>) -> T {
+    match Arc::try_unwrap(shared) {
+        Ok(value) => value,
+        Err(shared) => shared.as_ref().clone(),
+    }
+}
 
 /// Number of lifecycle events retained independently for each subscriber.
 pub(crate) const LIFECYCLE_EVENT_CAPACITY: usize = 128;
@@ -162,10 +169,7 @@ impl RetainedLifecycleEvent {
         // the guard allocation first matters: a broadcast receive is often the
         // last owner, and letting the arc drop the guards would route a live
         // user error through isolated disposal for nothing.
-        let guards = match Arc::try_unwrap(guards) {
-            Ok(guards) => guards,
-            Err(shared) => shared.as_ref().clone(),
-        };
+        let guards = unwrap_or_clone(guards);
         for guard in guards {
             drop(guard.into_exit());
         }
@@ -415,10 +419,7 @@ impl RetainedScopeSnapshot {
     }
 
     pub(crate) fn into_parts(self) -> (Arc<ScopeSnapshot>, Vec<RetainedExit>) {
-        let exits = match Arc::try_unwrap(self.exits) {
-            Ok(exits) => exits,
-            Err(exits) => exits.as_ref().clone(),
-        };
+        let exits = unwrap_or_clone(self.exits);
         (self.snapshot, exits)
     }
 }
@@ -449,15 +450,8 @@ impl SnapshotReceiver {
     }
 
     /// Borrows the newest snapshot and terminal flag from one retained state.
-    // This method bridges the internal cell module to the façade's `ScopeRef`
-    // implementation. It remains callable on the façade-public
-    // receiver, but its signature is entirely supported façade data and grants
-    // no construction or implementation capability. Hiding it from generated
-    // docs is the explicit boundary ruling; the rustdoc-JSON walk deliberately
-    // does not grow a second hidden-item graph for this benign bridge.
     #[must_use]
-    #[doc(hidden)]
-    pub fn borrow_latest_and_closed(&self) -> (Arc<ScopeSnapshot>, bool) {
+    pub(crate) fn borrow_latest_and_closed(&self) -> (Arc<ScopeSnapshot>, bool) {
         let state = self.inner.borrow_cloned();
         (state.snapshot.public(), state.closed)
     }
@@ -511,6 +505,67 @@ struct SnapshotHubState {
     snapshot: RetainedScopeSnapshot,
     generation: PoisonedCounter,
     closed: bool,
+}
+
+impl SnapshotHubState {
+    fn new(snapshot: RetainedScopeSnapshot, closed: bool) -> Self {
+        Self {
+            snapshot,
+            generation: PoisonedCounter::new(),
+            closed,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SnapshotInstallPolicy {
+    mint_generation: bool,
+    pulse: bool,
+}
+
+fn install_snapshot(
+    sender: &runtime::WatchSender<SnapshotHubState>,
+    mut snapshot: Option<RetainedScopeSnapshot>,
+    closed: bool,
+    policy: SnapshotInstallPolicy,
+) -> Vec<Box<dyn FnOnce()>> {
+    let mut retired = None;
+    let mut modified = false;
+    let mut generation_exhausted = false;
+    if snapshot.is_some() {
+        sender.modify_silently(|state| {
+            if state.closed {
+                return;
+            }
+            retired = Some(std::mem::replace(
+                &mut state.snapshot,
+                snapshot
+                    .take()
+                    .expect("a snapshot is installed at most once"),
+            ));
+            if policy.mint_generation && state.generation.mint().is_none() {
+                generation_exhausted = true;
+            }
+            state.closed = closed;
+            modified = true;
+        });
+    }
+
+    let mut effects: Vec<Box<dyn FnOnce()>> = Vec::new();
+    if let Some(uninstalled) = snapshot {
+        effects.push(Box::new(move || drop(uninstalled)));
+    }
+    if let Some(retired) = retired {
+        effects.push(Box::new(move || drop(retired)));
+    }
+    if generation_exhausted {
+        effects.push(Box::new(|| panic!("snapshot generation space exhausted")));
+    }
+    if modified && policy.pulse {
+        let sender = sender.clone();
+        effects.push(Box::new(move || sender.pulse()));
+    }
+    effects
 }
 
 /// Deferred construction of one hub's transaction-final projection.
@@ -588,11 +643,10 @@ impl SnapshotPublication {
 
     pub(crate) fn coalesce(&mut self, newer: Self) -> SnapshotProjection {
         // `ObservationTxn::stage_snapshot` selects this publication with
-        // `same_hub`, so hub identity is structural. Closure is total: once
-        // staged, it wins over every later publication in the transaction.
-        if self.closed {
-            return newer.projection;
-        }
+        // `same_hub`, so hub identity is structural. `publish` and `close`
+        // both decline before staging once a close is present, making the
+        // transaction's `snapshot_hub_will_close` guard authoritative.
+        debug_assert!(!self.closed, "a staged close accepts no successor");
         self.published |= newer.published;
         self.closed = newer.closed;
         std::mem::replace(&mut self.projection, newer.projection)
@@ -608,45 +662,17 @@ impl SnapshotPublication {
     pub(crate) fn install(&mut self, effects: &mut Vec<Box<dyn FnOnce()>>) {
         // A hub closed by an earlier transaction keeps the authoritative
         // terminal projection `close` installed; this cut is never built.
-        let mut snapshot =
+        let snapshot =
             (!self.sender.read_with(|state| state.closed)).then(|| self.projection.build());
-        let mut retired = None;
-        let mut modified = false;
-        let mut generation_exhausted = false;
-        if snapshot.is_some() {
-            self.sender.modify_silently(|state| {
-                if state.closed {
-                    return;
-                }
-                retired = Some(std::mem::replace(
-                    &mut state.snapshot,
-                    snapshot
-                        .take()
-                        .expect("a staged snapshot is installed exactly once"),
-                ));
-                if self.published && state.generation.mint().is_none() {
-                    generation_exhausted = true;
-                }
-                state.closed = self.closed;
-                modified = true;
-            });
-        }
-        if let Some(uninstalled) = snapshot.take() {
-            // A prior committed close remains authoritative. The cut was
-            // already built, so retire its user-bearing snapshot after both
-            // the watch mutex and observation gate are released.
-            effects.push(Box::new(move || drop(uninstalled)));
-        }
-        if let Some(retired) = retired {
-            effects.push(Box::new(move || drop(retired)));
-        }
-        if generation_exhausted {
-            effects.push(Box::new(|| panic!("snapshot generation space exhausted")));
-        }
-        if modified {
-            let sender = self.sender.clone();
-            effects.push(Box::new(move || sender.pulse()));
-        }
+        effects.extend(install_snapshot(
+            &self.sender,
+            snapshot,
+            self.closed,
+            SnapshotInstallPolicy {
+                mint_generation: self.published,
+                pulse: true,
+            },
+        ));
     }
 }
 
@@ -667,51 +693,38 @@ impl SnapshotHub {
     pub(crate) fn subscribe(
         &self,
         initial: RetainedScopeSnapshot,
-        txn: &mut crate::cells::ObservationTxn<'_>,
+        txn: &mut ObservationTxn<'_>,
     ) -> SnapshotReceiver {
+        let mut initial = Some(initial);
         let mut initialized = false;
         let sender = self.sender.get_or_init(|| {
             initialized = true;
-            runtime::watch(SnapshotHubState {
-                snapshot: initial.clone(),
-                generation: PoisonedCounter::new(),
-                closed: false,
-            })
+            runtime::watch(SnapshotHubState::new(
+                initial
+                    .take()
+                    .expect("the initial snapshot is installed exactly once"),
+                false,
+            ))
             .0
         });
-        // Initialization consumed a clone, and a closed hub declines the
-        // install below. Whatever the caller's projection is not moved into is
-        // still a full retained cut, so it retires through the transaction
-        // rather than under the gate — and, on the closed branch, under the
-        // watch's own lock as well.
-        let mut uninstalled = Some(initial);
         if !initialized && sender.receiver_count() == 0 {
             // Publication is skipped while receiverless, so the first
             // subscriber after a quiet stretch installs current state itself.
             // A closed hub already holds the authoritative terminal
             // projection installed by `close`; leave it unchanged.
-            let mut retired = None;
-            let mut generation_exhausted = false;
-            sender.modify_silently(|state| {
-                if state.closed {
-                    return;
-                }
-                retired = Some(std::mem::replace(
-                    &mut state.snapshot,
-                    uninstalled
-                        .take()
-                        .expect("the caller's projection is installed at most once"),
-                ));
-                generation_exhausted = state.generation.mint().is_none();
-            });
-            if let Some(retired) = retired {
-                txn.defer(move || drop(retired));
-            }
-            if generation_exhausted {
-                txn.defer(|| panic!("snapshot generation space exhausted"));
+            for effect in install_snapshot(
+                sender,
+                initial.take(),
+                false,
+                SnapshotInstallPolicy {
+                    mint_generation: true,
+                    pulse: false,
+                },
+            ) {
+                txn.defer(effect);
             }
         }
-        if let Some(uninstalled) = uninstalled {
+        if let Some(uninstalled) = initial {
             txn.defer(move || drop(uninstalled));
         }
         let inner = sender.watcher();
@@ -728,7 +741,7 @@ impl SnapshotHub {
     /// retained watch state is the only hub-local source of terminality.
     pub(crate) fn publish(
         &self,
-        txn: &mut crate::cells::ObservationTxn<'_>,
+        txn: &mut ObservationTxn<'_>,
         snapshot: impl FnOnce() -> RetainedScopeSnapshot + 'static,
     ) {
         let Some(sender) = self.sender.get() else {
@@ -754,20 +767,19 @@ impl SnapshotHub {
     /// is no longer a separate closed flag for it to read.
     pub(crate) fn close(
         &self,
-        txn: &mut crate::cells::ObservationTxn<'_>,
+        txn: &mut ObservationTxn<'_>,
         final_snapshot: impl FnOnce() -> RetainedScopeSnapshot + 'static,
     ) {
         let mut final_snapshot = Some(final_snapshot);
         let mut initialized = false;
         let sender = self.sender.get_or_init(|| {
             initialized = true;
-            runtime::watch(SnapshotHubState {
-                snapshot: final_snapshot
+            runtime::watch(SnapshotHubState::new(
+                final_snapshot
                     .take()
                     .expect("final snapshot is built exactly once")(),
-                generation: PoisonedCounter::new(),
-                closed: true,
-            })
+                true,
+            ))
             .0
         });
         if initialized {
@@ -934,7 +946,7 @@ impl LifecycleHub {
     ///
     /// Requiring the transaction makes the signal snapshot and broadcast
     /// subscription atomic with publication by construction.
-    pub(crate) fn subscribe(&self, _txn: &mut crate::cells::ObservationTxn<'_>) -> LifecycleEvents {
+    pub(crate) fn subscribe(&self, _txn: &mut ObservationTxn<'_>) -> LifecycleEvents {
         let signal = self.signal.watcher();
         let seen_explicit_lag = signal.borrow_cloned().explicit_lag;
         LifecycleEvents {
@@ -952,7 +964,7 @@ impl LifecycleHub {
     /// Publishes while the containing scope's observation gate is held.
     pub(crate) fn publish(
         &self,
-        txn: &mut crate::cells::ObservationTxn<'_>,
+        txn: &mut ObservationTxn<'_>,
         event: impl Into<RetainedLifecycleEvent>,
     ) {
         let event = event.into();
@@ -985,7 +997,7 @@ impl LifecycleHub {
     }
 
     /// Publishes an explicit lag marker under the observation gate.
-    pub(crate) fn publish_lagged(&self, txn: &mut crate::cells::ObservationTxn<'_>, dropped: u64) {
+    pub(crate) fn publish_lagged(&self, txn: &mut ObservationTxn<'_>, dropped: u64) {
         let mut published = false;
         self.signal.modify_silently(|signal| {
             if signal.closed {
@@ -1000,7 +1012,7 @@ impl LifecycleHub {
     }
 
     /// Closes while the containing scope's observation gate is held.
-    pub(crate) fn close(&self, txn: &mut crate::cells::ObservationTxn<'_>) {
+    pub(crate) fn close(&self, txn: &mut ObservationTxn<'_>) {
         let mut modified = false;
         self.signal.modify_silently(|signal| {
             if !signal.closed {
@@ -1066,7 +1078,8 @@ mod tests {
     use shelterwood_core::{ScopeState, StopReason};
 
     use super::{
-        LIFECYCLE_EVENT_CAPACITY, LifecycleHub, LifecycleSeq, RetainedScopeSnapshot, SnapshotHub,
+        LIFECYCLE_EVENT_CAPACITY, LifecycleHub, LifecycleSeq, ObservationTxn,
+        RetainedScopeSnapshot, SnapshotHub,
     };
 
     fn snapshot(state: ScopeState) -> RetainedScopeSnapshot {
@@ -1087,7 +1100,7 @@ mod tests {
     #[test]
     fn snapshot_projection_is_skipped_without_subscribers() {
         let hub = SnapshotHub::default();
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         hub.publish(&mut txn, || {
             panic!("projection must be lazy when no receiver exists")
         });
@@ -1096,7 +1109,7 @@ mod tests {
     #[test]
     fn initial_snapshot_subscription_does_not_mint_a_generation() {
         let hub = SnapshotHub::default();
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let receiver = hub.subscribe(snapshot(ScopeState::Unstarted), &mut txn);
         drop(txn);
 
@@ -1112,7 +1125,7 @@ mod tests {
     #[test]
     fn receiverless_generation_exhaustion_is_deferred_until_commit() {
         let hub = SnapshotHub::default();
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let receiver = hub.subscribe(snapshot(ScopeState::Unstarted), &mut txn);
         drop(txn);
         drop(receiver);
@@ -1122,12 +1135,12 @@ mod tests {
             state.generation = PoisonedCounter::near_exhaustion();
         });
 
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let receiver = hub.subscribe(snapshot(ScopeState::Starting), &mut txn);
         drop(txn);
         drop(receiver);
 
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let receiver = hub.subscribe(snapshot(ScopeState::Running), &mut txn);
         assert_eq!(receiver.borrow_latest().state, ScopeState::Running);
         drop(receiver);
@@ -1140,7 +1153,7 @@ mod tests {
     #[test]
     fn staged_snapshot_is_installed_during_unwind() {
         let hub = SnapshotHub::default();
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let receiver = hub.subscribe(snapshot(ScopeState::Unstarted), &mut txn);
         drop(txn);
 
@@ -1151,7 +1164,7 @@ mod tests {
         let mut mid_txn = None;
         assert!(
             catch_unwind(AssertUnwindSafe(|| {
-                let mut txn = crate::cells::ObservationTxn::detached();
+                let mut txn = ObservationTxn::detached();
                 hub.publish(&mut txn, || snapshot(ScopeState::Running));
                 mid_txn = Some(receiver.borrow_latest().state.clone());
                 panic!("inject transaction unwind");
@@ -1170,7 +1183,7 @@ mod tests {
     fn panicking_snapshot_install_does_not_strand_later_cuts_or_effects() {
         let failing = SnapshotHub::default();
         let succeeding = SnapshotHub::default();
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let _failing_receiver = failing.subscribe(snapshot(ScopeState::Unstarted), &mut txn);
         let succeeding_receiver = succeeding.subscribe(snapshot(ScopeState::Unstarted), &mut txn);
         drop(txn);
@@ -1179,7 +1192,7 @@ mod tests {
         let payload = catch_unwind(AssertUnwindSafe({
             let effects = Arc::clone(&effects);
             move || {
-                let mut txn = crate::cells::ObservationTxn::detached();
+                let mut txn = ObservationTxn::detached();
                 failing.publish(&mut txn, || panic!("injected snapshot installation panic"));
                 succeeding.publish(&mut txn, || snapshot(ScopeState::Running));
                 txn.defer(move || {
@@ -1207,12 +1220,12 @@ mod tests {
     #[test]
     fn repeated_publication_builds_and_mints_once_per_transaction() {
         let hub = SnapshotHub::default();
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let receiver = hub.subscribe(snapshot(ScopeState::Unstarted), &mut txn);
         drop(txn);
 
         let builds = Arc::new(AtomicUsize::new(0));
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         for state in [
             ScopeState::Starting,
             ScopeState::Running,
@@ -1243,11 +1256,11 @@ mod tests {
     #[test]
     fn publication_after_staged_close_is_not_built() {
         let hub = SnapshotHub::default();
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let receiver = hub.subscribe(snapshot(ScopeState::Running), &mut txn);
         drop(txn);
 
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         hub.close(&mut txn, || {
             snapshot(ScopeState::Stopped {
                 reason: StopReason::Finished,
@@ -1280,11 +1293,11 @@ mod tests {
     #[crate::runtime::test]
     async fn snapshot_publication_before_close_is_drained() {
         let hub = SnapshotHub::default();
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let mut snapshots = hub.subscribe(snapshot(ScopeState::Unstarted), &mut txn);
         drop(txn);
 
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         hub.publish(&mut txn, || snapshot(ScopeState::Running));
         drop(txn);
 
@@ -1297,7 +1310,7 @@ mod tests {
             ScopeState::Running
         );
 
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         hub.publish(&mut txn, || {
             snapshot(ScopeState::Stopped {
                 reason: StopReason::Finished,
@@ -1321,13 +1334,13 @@ mod tests {
             }
         ));
         assert!(snapshots.changed().await.is_err());
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         hub.publish(&mut txn, || {
             panic!("publication after close must remain lazy")
         });
         drop(txn);
 
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let mut after_close = hub.subscribe(
             snapshot(ScopeState::Stopped {
                 reason: StopReason::Finished,
@@ -1347,7 +1360,7 @@ mod tests {
     #[crate::runtime::test]
     async fn receiverless_snapshot_close_installs_the_terminal_state() {
         let hub = SnapshotHub::default();
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         hub.close(&mut txn, || {
             snapshot(ScopeState::Stopped {
                 reason: StopReason::NeverStarted,
@@ -1355,7 +1368,7 @@ mod tests {
         });
         drop(txn);
 
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let mut receiver = hub.subscribe(snapshot(ScopeState::Running), &mut txn);
         drop(txn);
         assert!(matches!(
@@ -1370,12 +1383,12 @@ mod tests {
     #[crate::runtime::test]
     async fn initialized_receiverless_snapshot_close_refreshes_the_terminal_state() {
         let hub = SnapshotHub::default();
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let receiver = hub.subscribe(snapshot(ScopeState::Running), &mut txn);
         drop(txn);
         drop(receiver);
 
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         hub.close(&mut txn, || {
             snapshot(ScopeState::Stopped {
                 reason: StopReason::Finished,
@@ -1383,7 +1396,7 @@ mod tests {
         });
         drop(txn);
 
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let mut receiver = hub.subscribe(snapshot(ScopeState::Running), &mut txn);
         drop(txn);
         assert!(matches!(
@@ -1402,11 +1415,11 @@ mod tests {
         // reads, so closure must install the authoritative one regardless of
         // who is currently attached.
         let hub = SnapshotHub::default();
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let mut live = hub.subscribe(snapshot(ScopeState::Running), &mut txn);
         drop(txn);
 
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         hub.close(&mut txn, || {
             snapshot(ScopeState::Stopped {
                 reason: StopReason::Finished,
@@ -1417,7 +1430,7 @@ mod tests {
         assert!(live.changed().await.is_err());
         drop(live);
 
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let mut later = hub.subscribe(snapshot(ScopeState::Running), &mut txn);
         drop(txn);
         assert!(matches!(
@@ -1432,13 +1445,13 @@ mod tests {
     #[crate::runtime::test]
     async fn lifecycle_close_wakes_parked_receivers() {
         let hub = Arc::new(LifecycleHub::default());
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let mut events = hub.subscribe(&mut txn);
         drop(txn);
         let waiter = runtime::spawn(async move { events.recv().await });
         runtime::yield_now().await;
 
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         hub.close(&mut txn);
         drop(txn);
 
@@ -1453,7 +1466,7 @@ mod tests {
             .expect("membership available")
             .membership();
         let hub = LifecycleHub::default();
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let mut events = hub.subscribe(&mut txn);
         hub.close(&mut txn);
 
@@ -1492,14 +1505,14 @@ mod tests {
             },
         };
         let hub = LifecycleHub::default();
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let mut events = hub.subscribe(&mut txn);
         hub.publish_lagged(&mut txn, 1);
         hub.publish(&mut txn, event(1));
         drop(txn);
         assert_eq!(events.try_recv(), Ok(LifecycleItem::Lagged { dropped: 1 }));
 
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         for seq in 2..=(LIFECYCLE_EVENT_CAPACITY as u64 + 2) {
             hub.publish(&mut txn, event(seq));
         }
@@ -1518,6 +1531,42 @@ mod tests {
     }
 
     #[test]
+    fn explicit_lag_and_ring_overflow_fold_into_one_leading_marker() {
+        let mut identity = ScopeIdentity::new();
+        let membership = identity
+            .mint_membership(&ChildId::from("scope"))
+            .expect("membership available")
+            .membership();
+        let event = |seq| LifecycleEvent {
+            scope_path: Vec::new(),
+            scope: membership,
+            seq: LifecycleSeq::new(seq),
+            kind: LifecycleEventKind::ScopeState {
+                state: ScopeState::Running,
+            },
+        };
+        let hub = LifecycleHub::default();
+        let mut txn = ObservationTxn::detached();
+        let mut events = hub.subscribe(&mut txn);
+        hub.publish_lagged(&mut txn, 5);
+        for seq in 1..=(LIFECYCLE_EVENT_CAPACITY as u64 + 3) {
+            hub.publish(&mut txn, event(seq));
+        }
+        drop(txn);
+
+        assert_eq!(
+            events.try_recv(),
+            Ok(LifecycleItem::Lagged { dropped: 8 }),
+            "the explicit loss and three ring evictions form one leading marker"
+        );
+        assert_eq!(
+            events.try_recv(),
+            Ok(LifecycleItem::Event(event(4))),
+            "folding lag does not consume the retained suffix"
+        );
+    }
+
+    #[test]
     fn lifecycle_close_drains_the_queued_prefix_and_rejects_late_publication() {
         let mut identity = ScopeIdentity::new();
         let membership = identity
@@ -1533,7 +1582,7 @@ mod tests {
             },
         };
         let hub = LifecycleHub::default();
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let mut events = hub.subscribe(&mut txn);
         hub.publish_lagged(&mut txn, 2);
         hub.publish(&mut txn, event(1));
@@ -1545,7 +1594,7 @@ mod tests {
         assert_eq!(events.try_recv(), Ok(LifecycleItem::Lagged { dropped: 2 }));
         assert_eq!(events.try_recv(), Ok(LifecycleItem::Event(event(1))));
         assert_eq!(events.try_recv(), Err(LifecycleTryRecvError::Closed));
-        let mut txn = crate::cells::ObservationTxn::detached();
+        let mut txn = ObservationTxn::detached();
         let mut after_close = hub.subscribe(&mut txn);
         drop(txn);
         assert_eq!(

--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -2265,6 +2265,10 @@ mod tests {
     fn rejected_restart_publication_disposes_its_lifecycle_exit_off_thread() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
         let member = child_member(&root, "invalid");
+        // Residency is what puts the member on the root's observation gate, so
+        // a restart publication reaches it the way production does.
+        assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None)));
+        member.update(|record| record.stage = MemberStage::Reserved);
         let mut events = root.subscribe_lifecycle();
         let incarnation = member
             .take_incarnation_counter()

--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -2094,6 +2094,8 @@ mod tests {
     fn rejected_stage_transition_suppresses_its_lifecycle_publication() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
         let member = child_member(&root, "invalid");
+        assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None,)));
+        member.update(|record| record.stage = MemberStage::Reserved);
         let mut events = root.subscribe_lifecycle();
 
         assert!(

--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -2094,7 +2094,9 @@ mod tests {
     fn rejected_stage_transition_suppresses_its_lifecycle_publication() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
         let member = child_member(&root, "invalid");
-        assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None,)));
+        // Residency is what puts the member on the root's observation gate, so
+        // a projection transition reaches it the way production does.
+        assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None)));
         member.update(|record| record.stage = MemberStage::Reserved);
         let mut events = root.subscribe_lifecycle();
 

--- a/crates/shelterwood/src/cells/scope/projection.rs
+++ b/crates/shelterwood/src/cells/scope/projection.rs
@@ -82,9 +82,12 @@ impl ScopeCell {
     }
 
     pub(crate) fn subscribe_snapshots(&self) -> SnapshotReceiver {
+        // No gate-identity check here or in `subscribe_lifecycle`: both acquire
+        // the gate themselves, and `with_observation_gate` already retries
+        // until the guard it hands the closure is this scope's installed one.
+        // Only a `*_locked` writer that receives someone else's transaction has
+        // an identity left to verify.
         let (receiver, closed_consistent) = self.with_observation_gate(|wakes| {
-            #[cfg(debug_assertions)]
-            wakes.debug_assert_gate(&self.current_observation_gate());
             let receiver = self
                 .observation
                 .snapshots
@@ -102,8 +105,6 @@ impl ScopeCell {
 
     pub(crate) fn subscribe_lifecycle(&self) -> LifecycleEvents {
         let (events, closed_consistent) = self.with_observation_gate(|txn| {
-            #[cfg(debug_assertions)]
-            txn.debug_assert_gate(&self.current_observation_gate());
             let events = self.observation.lifecycle.subscribe(txn);
             let closed_consistent = !self.observation.closed.load(Ordering::Acquire)
                 || self.observation.lifecycle.is_closed();

--- a/crates/shelterwood/src/cells/scope/projection.rs
+++ b/crates/shelterwood/src/cells/scope/projection.rs
@@ -83,6 +83,8 @@ impl ScopeCell {
 
     pub(crate) fn subscribe_snapshots(&self) -> SnapshotReceiver {
         let (receiver, closed_consistent) = self.with_observation_gate(|wakes| {
+            #[cfg(debug_assertions)]
+            wakes.debug_assert_gate(&self.current_observation_gate());
             let receiver = self
                 .observation
                 .snapshots
@@ -100,6 +102,8 @@ impl ScopeCell {
 
     pub(crate) fn subscribe_lifecycle(&self) -> LifecycleEvents {
         let (events, closed_consistent) = self.with_observation_gate(|txn| {
+            #[cfg(debug_assertions)]
+            txn.debug_assert_gate(&self.current_observation_gate());
             let events = self.observation.lifecycle.subscribe(txn);
             let closed_consistent = !self.observation.closed.load(Ordering::Acquire)
                 || self.observation.lifecycle.is_closed();
@@ -238,6 +242,8 @@ impl ScopeCell {
         wakes: &mut ObservationTxn<'_>,
         ancestors: &[Arc<ScopeCell>],
     ) {
+        #[cfg(debug_assertions)]
+        wakes.debug_assert_gate(&self.current_observation_gate());
         // Each producer owns the scope it projects: the cut is built at
         // commit, once per hub, after every publication in this transaction
         // has been coalesced onto it.
@@ -246,6 +252,8 @@ impl ScopeCell {
             .snapshots
             .publish(wakes, move || scope.snapshot_locked());
         for ancestor in ancestors {
+            #[cfg(debug_assertions)]
+            wakes.debug_assert_gate(&ancestor.current_observation_gate());
             let scope = Arc::clone(ancestor);
             ancestor
                 .observation
@@ -260,6 +268,8 @@ impl ScopeCell {
     }
 
     pub(super) fn emit_locked(&self, wakes: &mut ObservationTxn<'_>, kind: LifecycleEventKind) {
+        #[cfg(debug_assertions)]
+        wakes.debug_assert_gate(&self.current_observation_gate());
         // Mint the retention guards before any fallible framework bookkeeping.
         // A sequence-exhaustion path can then defer a *guarded* edge instead
         // of destroying a raw `Exit` under the observation gate.
@@ -311,6 +321,8 @@ impl ScopeCell {
     }
 
     pub(super) fn close_observation_locked(&self, wakes: &mut ObservationTxn<'_>) {
+        #[cfg(debug_assertions)]
+        wakes.debug_assert_gate(&self.current_observation_gate());
         if self.observation.closed.load(Ordering::Acquire) {
             return;
         }

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -592,7 +592,7 @@ async fn removal_from_a_foreign_thread_reaches_the_driver() {
         .mint_membership(&child_id)
         .expect("membership available");
     let member = MemberCell::new(child_id.clone(), membership);
-    assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None,)));
+    assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None)));
     let slot = SlotCell::new(Arc::clone(&member), None);
     let key = ChildKey::fixture(1);
     let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -592,6 +592,7 @@ async fn removal_from_a_foreign_thread_reaches_the_driver() {
         .mint_membership(&child_id)
         .expect("membership available");
     let member = MemberCell::new(child_id.clone(), membership);
+    assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None,)));
     let slot = SlotCell::new(Arc::clone(&member), None);
     let key = ChildKey::fixture(1);
     let (events, mut event_receiver) = crate::runtime::unbounded_mpsc();

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -957,7 +957,7 @@ fn mailbox_wake_observes_terminal_record_and_reentrant_terminality_is_idempotent
 }
 
 #[test]
-fn attach_during_terminal_publication_finishes_record_before_mailbox_wake() {
+fn attach_to_a_terminal_member_finishes_record_before_mailbox_wake() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
     let member = MemberCell::new(
@@ -967,7 +967,7 @@ fn attach_during_terminal_publication_finishes_record_before_mailbox_wake() {
     let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     let first_exit = Exit::never_started();
-    member.stage_terminal_before_mailbox(first_exit.clone());
+    member.terminalize(first_exit.clone(), StartupDisposition::Unchanged);
     let probe = Arc::new(ObserveMemberOnMailboxWake {
         member: Arc::clone(&member),
         competing_exit: Exit::completed(Cancellation::NotObserved),


### PR DESCRIPTION
Closes #420.

## Summary

- drains an already-terminal member's newly attached mailbox teardown directly, without manufacturing a losing terminalization or cloning the winning exit
- gives `ObservationTxn` a debug-only gate identity and checks member writers plus snapshot/lifecycle publication boundaries against the current resident-tree gate
- makes the transaction-level `snapshot_hub_will_close` checks authoritative, and consolidates snapshot installation/retirement/generation/pulse choreography behind one policy-driven helper
- folds the duplicate retained-`Arc` extraction shape into one helper, uses sibling module paths throughout `observe.rs`, and reduces `SnapshotReceiver::borrow_latest_and_closed` to `pub(crate)`
- pins explicit lifecycle loss plus broadcast overflow into one leading saturated lag marker

## Issue dispositions

1. `attach_mailbox`: replaced the synthetic losing `terminalize_locked` call with direct post-unlock teardown finishing. `attaching_to_a_terminal_member_does_not_republish_its_record` pins the absence of the synthetic record edge, and the existing reentrant-wake test now uses a production-reachable already-terminal member.
2. close-wins: removed the unreachable `self.closed` coalesce branch. `publish` and `close` remain the authoritative pre-staging guards; `publication_after_staged_close_is_not_built` covers that route.
3. gate identity: `ObservationTxn` retains a debug-only reference to its acquired gate, while `detached()` opts out for isolated hub unit tests. `update_locked`, legal/rejected `transition_locked` calls, `terminalize_locked`, and every scope snapshot/lifecycle boundary assert shared identity. The new check also found two tests with impossible "resident on a foreign gate" fixtures; both now perform real admission first. The diagnostic method and its panic regression are themselves debug-only, keeping release builds warning- and dead-code-clean.
4. lifecycle lag: added `explicit_lag_and_ring_overflow_fold_into_one_leading_marker`, covering the `saturating_add` fold of explicit loss plus ring overflow and the retained suffix. The `pending` item fallback is deliberately retained as total defense: with Tokio 1.53.1 and the power-of-two capacity const assertion, `len() > capacity` must yield `Lagged`, so an `Item` there is not constructible through the pinned implementation.
5. handoff retry: current `main` already contains `adoption_retries_when_the_captured_child_gate_has_already_been_replaced`, which parks adoption on the old gate, replaces the installed gate, observes the second `GateCapture::Adoption`, and verifies successful admission. This PR keeps and runs that exact regression.
6. repeated choreography: `install_snapshot` owns closed-state refusal, displaced/uninstalled retirement, optional generation mint, deferred exhaustion panic, and optional pulse. Call sites declare transaction-install versus receiverless-refresh mint/pulse policy; `SnapshotHubState::new` unifies open/closed initialization. `unwrap_or_clone` removes the duplicate retained-`Arc` extraction.
7. fold scar: production and unit-test references in `observe.rs` now resolve through `super`/local imports rather than the façade path.
8. follow-up visibility: `borrow_latest_and_closed` is now `pub(crate)` and its obsolete doc-hidden boundary ruling is removed. The rustdoc JSON reachability gate reports clean.

## Validation

- `./tools/dev cargo test -p shelterwood --lib` (364 passed)
- `./tools/dev cargo check --workspace --release`
- `./tools/dev cargo test -p shelterwood --lib --release` (363 passed; the debug-only gate-identity regression is intentionally absent)
- `./tools/dev cargo +nightly clippy -p shelterwood --all-targets -- -D warnings`
- `./tools/dev just ci` (914 nextest tests; doctests, examples, rustdoc/API reachability, external consumer, and Nix formatting all pass)
