### PR TITLE
Harden runtime completion and teardown seams

### DIFF
--- a/crates/shelterwood-runtime/src/mailbox.rs
+++ b/crates/shelterwood-runtime/src/mailbox.rs
@@ -133,6 +133,8 @@ mod tests {
 
     use shelterwood_core::{ErasedOneShotClose, ErasedOneShotReceiver, ErasedValue};
 
+    use crate::sync::ONESHOT_REPOLL_PANIC;
+
     use super::{TokioOneShotReceiver, mailbox_runtime};
 
     struct CountWake(Arc<AtomicUsize>);
@@ -222,8 +224,6 @@ mod tests {
 
     #[test]
     fn adapter_oneshot_rejects_poll_after_close_and_take_with_framework_diagnostic() {
-        const REPOLL: &str = "shelterwood one-shot receiver polled after completion";
-
         let runtime = mailbox_runtime();
         let (sender, mut receiver) = runtime.oneshot();
         sender
@@ -245,7 +245,7 @@ mod tests {
         .expect_err("an erased receiver cannot poll after terminal take");
         assert_eq!(
             payload.downcast_ref::<&'static str>().copied(),
-            Some(REPOLL)
+            Some(ONESHOT_REPOLL_PANIC)
         );
     }
 

--- a/crates/shelterwood-runtime/src/mailbox.rs
+++ b/crates/shelterwood-runtime/src/mailbox.rs
@@ -120,6 +120,7 @@ impl MailboxSignalWatcher for TokioSignalWatcher {
 #[cfg(test)]
 mod tests {
     use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -216,6 +217,35 @@ mod tests {
         assert_eq!(
             *value.downcast::<u8>().expect("value type is preserved"),
             11
+        );
+    }
+
+    #[test]
+    fn adapter_oneshot_rejects_poll_after_close_and_take_with_framework_diagnostic() {
+        const REPOLL: &str = "shelterwood one-shot receiver polled after completion";
+
+        let runtime = mailbox_runtime();
+        let (sender, mut receiver) = runtime.oneshot();
+        sender
+            .send(Box::new(12_u8))
+            .unwrap_or_else(|_| panic!("the adapter receiver is live"));
+        let value = receiver
+            .as_mut()
+            .close_and_take()
+            .expect("close-and-take recovers the published erased value");
+        assert_eq!(
+            *value.downcast::<u8>().expect("value type is preserved"),
+            12
+        );
+
+        let mut context = Context::from_waker(Waker::noop());
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            let _ = receiver.as_mut().poll_receive(&mut context);
+        }))
+        .expect_err("an erased receiver cannot poll after terminal take");
+        assert_eq!(
+            payload.downcast_ref::<&'static str>().copied(),
+            Some(REPOLL)
         );
     }
 

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -698,14 +698,6 @@ mod tests {
         }
     }
 
-    struct ActorDropNotice(mpsc::Sender<()>);
-
-    impl Drop for ActorDropNotice {
-        fn drop(&mut self) {
-            let _ = self.0.send(());
-        }
-    }
-
     struct PanicWake(Arc<AtomicUsize>);
 
     impl Wake for PanicWake {
@@ -830,7 +822,7 @@ mod tests {
         let (started, started_rx) = tokio::sync::oneshot::channel();
         let (dropped, dropped_rx) = mpsc::channel();
         let work = super::spawn_actor_work(async move {
-            let _notice = ActorDropNotice(dropped);
+            let _notice = RecordingDrop(dropped);
             let _ = started.send(());
             std::future::pending::<()>().await;
         });
@@ -841,7 +833,7 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {
                 match dropped_rx.try_recv() {
-                    Ok(()) => break,
+                    Ok(_) => break,
                     Err(mpsc::TryRecvError::Empty) => tokio::task::yield_now().await,
                     Err(mpsc::TryRecvError::Disconnected) => {
                         panic!("the aborted actor work did not drop its task state")
@@ -884,7 +876,7 @@ mod tests {
     #[test]
     fn blocking_job_recovers_poison_for_pending_checks_and_drop() {
         let (captured_dropped, captured_dropped_rx) = mpsc::channel();
-        let captured = ActorDropNotice(captured_dropped);
+        let captured = RecordingDrop(captured_dropped);
         let (completion, _receiver) = super::oneshot();
         let job = super::BlockingJob::new(move || drop(captured), completion);
         let injected = panic::catch_unwind(panic::AssertUnwindSafe(|| {

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -3,7 +3,7 @@ use std::{
     future::{Future, poll_fn},
     ops::RangeBounds,
     panic::resume_unwind,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, MutexGuard, PoisonError},
     task::Poll,
 };
 
@@ -233,6 +233,16 @@ where
             pending: Mutex::new(Some((operation, completion))),
         })
     }
+
+    /// Recovers the pending slot even after an injected or future panic.
+    ///
+    /// `Drop` can run during an unrelated unwind, so poisoning must not turn
+    /// its capture-disposal fallback into a double panic. The mutex protects
+    /// only an ownership move; recovery never observes a partially-mutated
+    /// user value.
+    fn lock_pending(&self) -> MutexGuard<'_, Option<(F, BlockingCompletion<T>)>> {
+        self.pending.lock().unwrap_or_else(PoisonError::into_inner)
+    }
 }
 
 impl<F, T> BlockingPoolJob for BlockingJob<F, T>
@@ -241,12 +251,7 @@ where
     T: Send + 'static,
 {
     fn run(&self) {
-        let Some((operation, completion)) = self
-            .pending
-            .lock()
-            .expect("blocking job mutex poisoned")
-            .take()
-        else {
+        let Some((operation, completion)) = self.lock_pending().take() else {
             return;
         };
         let outcome = catch_panic(operation);
@@ -269,10 +274,7 @@ where
     }
 
     fn is_pending(&self) -> bool {
-        self.pending
-            .lock()
-            .expect("blocking job mutex poisoned")
-            .is_some()
+        self.lock_pending().is_some()
     }
 }
 
@@ -282,12 +284,7 @@ where
     T: Send + 'static,
 {
     fn drop(&mut self) {
-        let Some((operation, completion)) = self
-            .pending
-            .lock()
-            .expect("blocking job mutex poisoned")
-            .take()
-        else {
+        let Some((operation, completion)) = self.lock_pending().take() else {
             return;
         };
         // A cancelled or unstartable job must wake its waiter, but a hostile
@@ -701,6 +698,14 @@ mod tests {
         }
     }
 
+    struct ActorDropNotice(mpsc::Sender<()>);
+
+    impl Drop for ActorDropNotice {
+        fn drop(&mut self) {
+            let _ = self.0.send(());
+        }
+    }
+
     struct PanicWake(Arc<AtomicUsize>);
 
     impl Wake for PanicWake {
@@ -818,6 +823,81 @@ mod tests {
         // ownership across clone, wake, and drop.
         let waker = unsafe { Waker::from_raw(raw) };
         (ManuallyDrop::new(waker), state, observed_drop)
+    }
+
+    #[tokio::test]
+    async fn dropping_actor_work_aborts_its_task() {
+        let (started, started_rx) = tokio::sync::oneshot::channel();
+        let (dropped, dropped_rx) = mpsc::channel();
+        let work = super::spawn_actor_work(async move {
+            let _notice = ActorDropNotice(dropped);
+            let _ = started.send(());
+            std::future::pending::<()>().await;
+        });
+        started_rx.await.expect("the actor work starts");
+
+        drop(work);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                match dropped_rx.try_recv() {
+                    Ok(()) => break,
+                    Err(mpsc::TryRecvError::Empty) => tokio::task::yield_now().await,
+                    Err(mpsc::TryRecvError::Disconnected) => {
+                        panic!("the aborted actor work did not drop its task state")
+                    }
+                }
+            }
+        })
+        .await
+        .expect("actor-work drop cancellation completes");
+    }
+
+    #[tokio::test]
+    async fn actor_work_abort_is_idempotent_and_join_reports_cancelled() {
+        let work = super::spawn_actor_work(std::future::pending::<()>());
+        work.abort();
+        work.abort();
+
+        assert!(matches!(work.join().await, super::JoinOutcome::Cancelled));
+    }
+
+    #[test]
+    fn unbounded_sender_returns_the_value_after_receiver_close() {
+        let (sender, receiver) = super::unbounded_mpsc();
+        drop(receiver);
+
+        assert_eq!(
+            sender.send(String::from("returned")),
+            Err(String::from("returned"))
+        );
+    }
+
+    #[test]
+    fn jitter_rng_respects_requested_bounds() {
+        let mut rng = super::JitterRng::new();
+        for _ in 0..128 {
+            assert!((7..11).contains(&rng.sample(7..11)));
+        }
+    }
+
+    #[test]
+    fn blocking_job_recovers_poison_for_pending_checks_and_drop() {
+        let (completion, _receiver) = super::oneshot();
+        let job = super::BlockingJob::new(|| (), completion);
+        let injected = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            let _guard = job.pending.lock().expect("fresh blocking-job mutex");
+            panic!("inject blocking-job mutex poison");
+        }));
+        assert!(injected.is_err());
+        assert!(
+            job.is_pending(),
+            "poison recovery preserves the pending job"
+        );
+        assert!(
+            panic::catch_unwind(panic::AssertUnwindSafe(|| drop(job))).is_ok(),
+            "blocking-job drop stays panic-free after poison"
+        );
     }
 
     #[tokio::test]

--- a/crates/shelterwood-runtime/src/spawn.rs
+++ b/crates/shelterwood-runtime/src/spawn.rs
@@ -883,8 +883,10 @@ mod tests {
 
     #[test]
     fn blocking_job_recovers_poison_for_pending_checks_and_drop() {
+        let (captured_dropped, captured_dropped_rx) = mpsc::channel();
+        let captured = ActorDropNotice(captured_dropped);
         let (completion, _receiver) = super::oneshot();
-        let job = super::BlockingJob::new(|| (), completion);
+        let job = super::BlockingJob::new(move || drop(captured), completion);
         let injected = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             let _guard = job.pending.lock().expect("fresh blocking-job mutex");
             panic!("inject blocking-job mutex poison");
@@ -898,6 +900,9 @@ mod tests {
             panic::catch_unwind(panic::AssertUnwindSafe(|| drop(job))).is_ok(),
             "blocking-job drop stays panic-free after poison"
         );
+        captured_dropped_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("poison recovery still retires the captured operation");
     }
 
     #[tokio::test]

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -386,6 +386,8 @@ const ONESHOT_SENDING: u8 = 1;
 const ONESHOT_SENT: u8 = 2;
 const ONESHOT_SENDER_CLOSED: u8 = 3;
 const ONESHOT_RECEIVER_CLOSED: u8 = 4;
+#[cfg(test)]
+const ONESHOT_REPOLL_PANIC: &str = "shelterwood one-shot receiver polled after completion";
 
 /// Sending half of a runtime-backed single-delivery channel.
 pub struct OneShotSender<T> {
@@ -397,7 +399,7 @@ pub struct OneShotSender<T> {
 pub struct OneShotReceiver<T> {
     channel: oneshot::Receiver<T>,
     state: Arc<AtomicU8>,
-    delivered: bool,
+    completed: bool,
 }
 
 /// Outcome after atomically closing a single-delivery receive side.
@@ -423,7 +425,7 @@ pub fn oneshot<T>() -> (OneShotSender<T>, OneShotReceiver<T>) {
         OneShotReceiver {
             channel: channel_receiver,
             state,
-            delivered: false,
+            completed: false,
         },
     )
 }
@@ -451,7 +453,7 @@ pub fn oneshot_sending_for_test<T>() -> (OneShotSending<T>, OneShotReceiver<T>) 
         OneShotReceiver {
             channel: receiver,
             state,
-            delivered: false,
+            completed: false,
         },
     )
 }
@@ -549,9 +551,9 @@ impl<T> Drop for OneShotSender<T> {
 }
 
 impl<T> OneShotReceiver<T> {
-    fn assert_not_delivered(&self) {
+    fn assert_not_completed(&self) {
         assert!(
-            !self.delivered,
+            !self.completed,
             "shelterwood one-shot receiver polled after completion"
         );
     }
@@ -560,10 +562,10 @@ impl<T> OneShotReceiver<T> {
         &mut self,
         context: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<T>> {
-        self.assert_not_delivered();
+        self.assert_not_completed();
         let result = Pin::new(&mut self.channel).poll(context).map(Result::ok);
         if result.is_ready() {
-            self.delivered = true;
+            self.completed = true;
         }
         result
     }
@@ -578,7 +580,7 @@ impl<T> OneShotReceiver<T> {
         &mut self,
         context: &mut std::task::Context<'_>,
     ) -> OneShotClose<T> {
-        self.assert_not_delivered();
+        self.assert_not_completed();
         let result = match self.state.compare_exchange(
             ONESHOT_OPEN,
             ONESHOT_RECEIVER_CLOSED,
@@ -601,7 +603,7 @@ impl<T> OneShotReceiver<T> {
             Err(other) => unreachable!("unknown one-shot transition state {other}"),
         };
         if !matches!(&result, OneShotClose::Pending) {
-            self.delivered = true;
+            self.completed = true;
         }
         result
     }
@@ -623,17 +625,42 @@ impl<T> OneShotReceiver<T> {
     /// disposal instead of destroying it in their own drop glue.
     pub fn close_and_take(&mut self) -> Option<T> {
         self.close();
-        self.channel.try_recv().ok()
+        let value = self.channel.try_recv().ok();
+        // Closing makes every outcome terminal, including the staged-send
+        // window where publication has not yet observed the receiver close.
+        // Record that edge so an erased receiver cannot later re-enter
+        // Tokio's completed receiver poll.
+        self.completed = true;
+        value
     }
 
     pub async fn receive(self) -> Option<T> {
+        self.assert_not_completed();
         self.channel.await.ok()
     }
 
     #[cfg(any(test, feature = "test-util"))]
     pub fn try_receive(&mut self) -> Option<T> {
-        self.channel.try_recv().ok()
+        match self.channel.try_recv() {
+            Ok(value) => {
+                self.completed = true;
+                Some(value)
+            }
+            Err(oneshot::error::TryRecvError::Closed) => {
+                self.completed = true;
+                None
+            }
+            Err(oneshot::error::TryRecvError::Empty) => None,
+        }
     }
+}
+
+mod framework_plain {
+    pub trait Sealed {}
+
+    impl Sealed for () {}
+
+    impl<T: Sealed, E: Sealed> Sealed for Result<T, E> {}
 }
 
 /// Marker for framework-owned response values whose destructor runs no user
@@ -647,22 +674,21 @@ impl<T> OneShotReceiver<T> {
 /// own user data — an `Exit`, a message, a type-erased error — must go
 /// through [`DisposingReceiver::new`] instead.
 ///
-/// # Safety
+/// This trait is sealed: response types owned by another crate must use
+/// [`DisposingReceiver::new`], even when that crate currently knows their
+/// variants are plain. That keeps the authority to select inline destruction
+/// in the same runtime crate that owns the disposal implementation.
 ///
-/// Every value of the implementing type must be plain framework-owned data:
-/// dropping it must not invoke user code, block, panic, or re-enter the
-/// framework. The trait is unsafe because its intentional implementations
-/// live on both sides of the runtime/façade crate boundary, which rules out a
-/// private Rust sealing trait; a foreign implementation must therefore make
-/// the same safety claim explicitly.
+/// ```compile_fail
+/// struct ForeignResponse;
+/// impl shelterwood_runtime::FrameworkPlain for ForeignResponse {}
+/// ```
 #[doc(hidden)]
-pub unsafe trait FrameworkPlain: Send + 'static {}
+pub trait FrameworkPlain: framework_plain::Sealed + Send + 'static {}
 
-// SAFETY: `()` has no drop glue.
-unsafe impl FrameworkPlain for () {}
+impl FrameworkPlain for () {}
 
-// SAFETY: both possible payloads satisfy the same no-user-code drop contract.
-unsafe impl<T: FrameworkPlain, E: FrameworkPlain> FrameworkPlain for Result<T, E> {}
+impl<T: FrameworkPlain, E: FrameworkPlain> FrameworkPlain for Result<T, E> {}
 
 /// One-shot receive state that keeps user value destruction off framework and
 /// holder drop glue.
@@ -1143,6 +1169,7 @@ impl<T> fmt::Debug for BroadcastReceiver<T> {
 #[cfg(test)]
 mod tests {
     use std::{
+        cell::Cell,
         future::Future,
         mem::ManuallyDrop,
         panic::{AssertUnwindSafe, catch_unwind},
@@ -1162,21 +1189,24 @@ mod tests {
         test_support::DISPOSAL_THREAD, timeout, yield_now,
     };
 
-    use super::{RegisteredWaker, WaiterRegistry};
+    use super::{ONESHOT_REPOLL_PANIC, RegisteredWaker, WaiterRegistry};
 
     struct CountWake(Arc<AtomicUsize>);
 
     struct DebugProbe(Arc<AtomicUsize>);
 
-    struct FrameworkDropProbe(mpsc::Sender<ThreadId>);
+    thread_local! {
+        static FRAMEWORK_DROP_OBSERVED: Cell<bool> = const { Cell::new(false) };
+    }
 
-    // SAFETY: this test-only probe performs one nonblocking channel send on
-    // drop and cannot reach application code or framework locks.
-    unsafe impl super::FrameworkPlain for FrameworkDropProbe {}
+    struct FrameworkDropProbe;
+
+    impl super::framework_plain::Sealed for FrameworkDropProbe {}
+    impl super::FrameworkPlain for FrameworkDropProbe {}
 
     impl Drop for FrameworkDropProbe {
         fn drop(&mut self) {
-            let _ = self.0.send(std::thread::current().id());
+            FRAMEWORK_DROP_OBSERVED.set(true);
         }
     }
 
@@ -1420,8 +1450,6 @@ mod tests {
 
     #[test]
     fn oneshot_repoll_uses_a_framework_owned_diagnostic() {
-        const REPOLL: &str = "shelterwood one-shot receiver polled after completion";
-
         let mut context = Context::from_waker(Waker::noop());
         let (sender, mut receiver) = oneshot();
         sender.send(1_u8).expect("receiver is live");
@@ -1433,7 +1461,14 @@ mod tests {
             let _ = receiver.poll_receive(&mut context);
         }))
         .expect_err("a completed one-shot cannot be polled twice");
-        assert_panic_message(&*payload, REPOLL);
+        assert_panic_message(&*payload, ONESHOT_REPOLL_PANIC);
+
+        let mut receive = Box::pin(receiver.receive());
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            let _ = receive.as_mut().poll(&mut context);
+        }))
+        .expect_err("receive cannot re-poll an already delivered receiver");
+        assert_panic_message(&*payload, ONESHOT_REPOLL_PANIC);
 
         let (sender, receiver) = oneshot();
         sender.send(2_u8).expect("receiver is live");
@@ -1446,7 +1481,7 @@ mod tests {
             let _ = receiver.poll_receive(&mut context);
         }))
         .expect_err("a completed disposing receiver cannot be polled twice");
-        assert_panic_message(&*payload, REPOLL);
+        assert_panic_message(&*payload, ONESHOT_REPOLL_PANIC);
 
         let (sender, mut receiver) = oneshot();
         sender.send(3_u8).expect("receiver is live");
@@ -1458,7 +1493,33 @@ mod tests {
             let _ = receiver.close_and_poll_receive(&mut context);
         }))
         .expect_err("a completed close poll cannot be repeated");
-        assert_panic_message(&*payload, REPOLL);
+        assert_panic_message(&*payload, ONESHOT_REPOLL_PANIC);
+
+        let (sender, mut receiver) = oneshot();
+        sender.send(4_u8).expect("receiver is live");
+        assert_eq!(receiver.close_and_take(), Some(4));
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            let _ = receiver.poll_receive(&mut context);
+        }))
+        .expect_err("close-and-take terminality prevents a later poll");
+        assert_panic_message(&*payload, ONESHOT_REPOLL_PANIC);
+
+        let (sender, mut receiver) = oneshot();
+        sender.send(5_u8).expect("receiver is live");
+        assert_eq!(receiver.try_receive(), Some(5));
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            let _ = receiver.close_and_poll_receive(&mut context);
+        }))
+        .expect_err("try-receive terminality prevents a later close poll");
+        assert_panic_message(&*payload, ONESHOT_REPOLL_PANIC);
+
+        let (sender, mut receiver) = oneshot::<u8>();
+        receiver.close();
+        drop(sender);
+        assert!(matches!(
+            receiver.poll_receive(&mut context),
+            Poll::Ready(None)
+        ));
     }
 
     #[test]
@@ -1492,19 +1553,15 @@ mod tests {
 
     #[test]
     fn framework_disposing_receiver_drops_abandoned_values_inline() {
-        let dropping_thread = std::thread::current().id();
-        let (dropped, observed_drop) = mpsc::channel();
+        FRAMEWORK_DROP_OBSERVED.set(false);
         let (sender, receiver) = oneshot();
-        assert!(sender.send(FrameworkDropProbe(dropped)).is_ok());
+        assert!(sender.send(FrameworkDropProbe).is_ok());
 
         drop(DisposingReceiver::new_framework(receiver));
 
-        assert_eq!(
-            observed_drop
-                .recv_timeout(Duration::from_secs(1))
-                .expect("the abandoned framework value is destroyed"),
-            dropping_thread,
-            "plain framework responses do not use the blocking disposal lane"
+        assert!(
+            FRAMEWORK_DROP_OBSERVED.replace(false),
+            "the plain framework response is destroyed synchronously on this thread"
         );
     }
 
@@ -1572,6 +1629,11 @@ mod tests {
 
         assert_eq!(sending.publish(7_u8), Err(7));
         assert_eq!(receiver.try_receive(), None);
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            let _ = receiver.poll_receive(&mut Context::from_waker(Waker::noop()));
+        }))
+        .expect_err("close-and-take completes the staged-send receiver");
+        assert_panic_message(&*payload, ONESHOT_REPOLL_PANIC);
     }
 
     #[test]

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -19,6 +19,10 @@ use super::{PanicAccumulator, dispose_detached, waker_proxy::ProxiedPoll};
 /// draining only move wakers out; their vtables run after unlock, one behind
 /// each accumulator boundary. The opaque identity is retained by its waiter,
 /// so its `Arc` traffic under the lock cannot destroy even framework data.
+/// Cancellation destroys a removed caller-waker clone inline on the thread
+/// dropping `LatchWait` or `WatchWait`: unlike the external-primitive proxy
+/// family, the registry owns the waker directly and has no foreign drop seam
+/// that requires detached retirement.
 #[derive(Default)]
 struct WaiterRegistry {
     waiters: Mutex<Vec<RegisteredWaker>>,
@@ -393,6 +397,7 @@ pub struct OneShotSender<T> {
 pub struct OneShotReceiver<T> {
     channel: oneshot::Receiver<T>,
     state: Arc<AtomicU8>,
+    delivered: bool,
 }
 
 /// Outcome after atomically closing a single-delivery receive side.
@@ -418,6 +423,7 @@ pub fn oneshot<T>() -> (OneShotSender<T>, OneShotReceiver<T>) {
         OneShotReceiver {
             channel: channel_receiver,
             state,
+            delivered: false,
         },
     )
 }
@@ -445,6 +451,7 @@ pub fn oneshot_sending_for_test<T>() -> (OneShotSending<T>, OneShotReceiver<T>) 
         OneShotReceiver {
             channel: receiver,
             state,
+            delivered: false,
         },
     )
 }
@@ -542,11 +549,23 @@ impl<T> Drop for OneShotSender<T> {
 }
 
 impl<T> OneShotReceiver<T> {
+    fn assert_not_delivered(&self) {
+        assert!(
+            !self.delivered,
+            "shelterwood one-shot receiver polled after completion"
+        );
+    }
+
     pub fn poll_receive(
         &mut self,
         context: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<T>> {
-        Pin::new(&mut self.channel).poll(context).map(Result::ok)
+        self.assert_not_delivered();
+        let result = Pin::new(&mut self.channel).poll(context).map(Result::ok);
+        if result.is_ready() {
+            self.delivered = true;
+        }
+        result
     }
 
     /// Closes the receive side unless send or sender-drop won first.
@@ -559,7 +578,8 @@ impl<T> OneShotReceiver<T> {
         &mut self,
         context: &mut std::task::Context<'_>,
     ) -> OneShotClose<T> {
-        match self.state.compare_exchange(
+        self.assert_not_delivered();
+        let result = match self.state.compare_exchange(
             ONESHOT_OPEN,
             ONESHOT_RECEIVER_CLOSED,
             Ordering::AcqRel,
@@ -579,7 +599,11 @@ impl<T> OneShotReceiver<T> {
             }
             Err(ONESHOT_RECEIVER_CLOSED) => OneShotClose::Empty,
             Err(other) => unreachable!("unknown one-shot transition state {other}"),
+        };
+        if !matches!(&result, OneShotClose::Pending) {
+            self.delivered = true;
         }
+        result
     }
 
     pub fn close(&mut self) {
@@ -622,12 +646,23 @@ impl<T> OneShotReceiver<T> {
 /// only for plain framework enums and their compositions; a type that can
 /// own user data — an `Exit`, a message, a type-erased error — must go
 /// through [`DisposingReceiver::new`] instead.
+///
+/// # Safety
+///
+/// Every value of the implementing type must be plain framework-owned data:
+/// dropping it must not invoke user code, block, panic, or re-enter the
+/// framework. The trait is unsafe because its intentional implementations
+/// live on both sides of the runtime/façade crate boundary, which rules out a
+/// private Rust sealing trait; a foreign implementation must therefore make
+/// the same safety claim explicitly.
 #[doc(hidden)]
-pub trait FrameworkPlain: Send + 'static {}
+pub unsafe trait FrameworkPlain: Send + 'static {}
 
-impl FrameworkPlain for () {}
+// SAFETY: `()` has no drop glue.
+unsafe impl FrameworkPlain for () {}
 
-impl<T: FrameworkPlain, E: FrameworkPlain> FrameworkPlain for Result<T, E> {}
+// SAFETY: both possible payloads satisfy the same no-user-code drop contract.
+unsafe impl<T: FrameworkPlain, E: FrameworkPlain> FrameworkPlain for Result<T, E> {}
 
 /// One-shot receive state that keeps user value destruction off framework and
 /// holder drop glue.
@@ -860,7 +895,10 @@ impl<T> WatchSender<T> {
     ///
     /// This is only for compound publication that must finish another
     /// synchronous state transition before receivers are notified. The caller
-    /// must follow a successful logical mutation with [`Self::pulse`].
+    /// must follow a successful logical mutation with [`Self::pulse`]. The
+    /// closure runs under the watch value mutex and therefore may only move
+    /// plain framework-owned data: it must not call user code, drop user
+    /// values, block, panic, or re-enter the framework.
     pub fn modify_silently(&self, update: impl FnOnce(&mut T)) {
         let mut value = self.shared.value();
         update(&mut value);
@@ -868,8 +906,9 @@ impl<T> WatchSender<T> {
 
     /// Reads a projection of the retained value without cloning it.
     ///
-    /// `project` runs under the watch's value guard, so it must stay cheap and
-    /// must not touch the same channel.
+    /// `project` runs under the watch's value guard, so it may only inspect
+    /// plain framework-owned data. It must not call user code, drop user
+    /// values, block, panic, re-enter the framework, or touch this channel.
     pub fn read_with<R>(&self, project: impl FnOnce(&T) -> R) -> R {
         let value = self.shared.value();
         project(&value)
@@ -1131,7 +1170,9 @@ mod tests {
 
     struct FrameworkDropProbe(mpsc::Sender<ThreadId>);
 
-    impl super::FrameworkPlain for FrameworkDropProbe {}
+    // SAFETY: this test-only probe performs one nonblocking channel send on
+    // drop and cannot reach application code or framework locks.
+    unsafe impl super::FrameworkPlain for FrameworkDropProbe {}
 
     impl Drop for FrameworkDropProbe {
         fn drop(&mut self) {
@@ -1375,6 +1416,49 @@ mod tests {
             OneShotClose::Empty
         ));
         assert_eq!(sender.send(1), Err(1));
+    }
+
+    #[test]
+    fn oneshot_repoll_uses_a_framework_owned_diagnostic() {
+        const REPOLL: &str = "shelterwood one-shot receiver polled after completion";
+
+        let mut context = Context::from_waker(Waker::noop());
+        let (sender, mut receiver) = oneshot();
+        sender.send(1_u8).expect("receiver is live");
+        assert!(matches!(
+            receiver.poll_receive(&mut context),
+            Poll::Ready(Some(1))
+        ));
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            let _ = receiver.poll_receive(&mut context);
+        }))
+        .expect_err("a completed one-shot cannot be polled twice");
+        assert_panic_message(&*payload, REPOLL);
+
+        let (sender, receiver) = oneshot();
+        sender.send(2_u8).expect("receiver is live");
+        let mut receiver = DisposingReceiver::new(receiver);
+        assert!(matches!(
+            receiver.poll_receive(&mut context),
+            Poll::Ready(Some(2))
+        ));
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            let _ = receiver.poll_receive(&mut context);
+        }))
+        .expect_err("a completed disposing receiver cannot be polled twice");
+        assert_panic_message(&*payload, REPOLL);
+
+        let (sender, mut receiver) = oneshot();
+        sender.send(3_u8).expect("receiver is live");
+        assert!(matches!(
+            receiver.close_and_poll_receive(&mut context),
+            OneShotClose::Value(3)
+        ));
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            let _ = receiver.close_and_poll_receive(&mut context);
+        }))
+        .expect_err("a completed close poll cannot be repeated");
+        assert_panic_message(&*payload, REPOLL);
     }
 
     #[test]

--- a/crates/shelterwood-runtime/src/sync.rs
+++ b/crates/shelterwood-runtime/src/sync.rs
@@ -22,7 +22,10 @@ use super::{PanicAccumulator, dispose_detached, waker_proxy::ProxiedPoll};
 /// Cancellation destroys a removed caller-waker clone inline on the thread
 /// dropping `LatchWait` or `WatchWait`: unlike the external-primitive proxy
 /// family, the registry owns the waker directly and has no foreign drop seam
-/// that requires detached retirement.
+/// that requires detached retirement. That inherits the reply receiver's
+/// ruling rather than the proxy wrapper's — a slow caller-waker destructor
+/// stalls the abandoning waiter alone, and a hostile one is contained by the
+/// accumulator above.
 #[derive(Default)]
 struct WaiterRegistry {
     waiters: Mutex<Vec<RegisteredWaker>>,
@@ -387,7 +390,8 @@ const ONESHOT_SENT: u8 = 2;
 const ONESHOT_SENDER_CLOSED: u8 = 3;
 const ONESHOT_RECEIVER_CLOSED: u8 = 4;
 #[cfg(test)]
-const ONESHOT_REPOLL_PANIC: &str = "shelterwood one-shot receiver polled after completion";
+pub(crate) const ONESHOT_REPOLL_PANIC: &str =
+    "shelterwood one-shot receiver polled after completion";
 
 /// Sending half of a runtime-backed single-delivery channel.
 pub struct OneShotSender<T> {
@@ -399,6 +403,14 @@ pub struct OneShotSender<T> {
 pub struct OneShotReceiver<T> {
     channel: oneshot::Receiver<T>,
     state: Arc<AtomicU8>,
+    /// Whether a receive edge has already consumed Tokio's receiver.
+    ///
+    /// In the pinned Tokio 1.53.1, `Receiver::poll` clears its `Inner` once it
+    /// yields `Ready`, and `try_recv` clears it on every outcome but `Empty`;
+    /// a later `poll` then panics with a message naming neither Shelterwood
+    /// nor this seam. Every terminal edge here records that instead, so the
+    /// re-poll diagnostic is framework-owned. A bare [`Self::close`] is not
+    /// terminal — Tokio keeps the receiver pollable — so it does not set this.
     completed: bool,
 }
 
@@ -576,6 +588,10 @@ impl<T> OneShotReceiver<T> {
     /// close, which Tokio's post-close `try_recv` result alone cannot do. A
     /// send that wins but is preempted before publishing returns `Pending`;
     /// the channel poll in that branch registers the wake for its completion.
+    ///
+    /// Every outcome but `Pending` is terminal for this receiver: the close
+    /// has been arbitrated, so a later receive edge is a caller bug and gets
+    /// the framework diagnostic rather than a fresh arbitration.
     pub fn close_and_poll_receive(
         &mut self,
         context: &mut std::task::Context<'_>,
@@ -1513,6 +1529,19 @@ mod tests {
         .expect_err("try-receive terminality prevents a later close poll");
         assert_panic_message(&*payload, ONESHOT_REPOLL_PANIC);
 
+        // Tokio's `try_recv` consumes its receiver on every outcome but
+        // `Empty`, so an empty sender-closed take is terminal too.
+        let (sender, mut receiver) = oneshot::<u8>();
+        drop(sender);
+        assert_eq!(receiver.try_receive(), None);
+        let payload = catch_unwind(AssertUnwindSafe(|| {
+            let _ = receiver.poll_receive(&mut context);
+        }))
+        .expect_err("an exhausted try-receive prevents a later poll");
+        assert_panic_message(&*payload, ONESHOT_REPOLL_PANIC);
+
+        // A bare close is not a receive edge: the receiver stays pollable and
+        // reports the sender-closed result.
         let (sender, mut receiver) = oneshot::<u8>();
         receiver.close();
         drop(sender);

--- a/crates/shelterwood-runtime/src/test_support.rs
+++ b/crates/shelterwood-runtime/src/test_support.rs
@@ -121,6 +121,12 @@ pub(crate) fn assert_blocking_pool_outcomes<
 /// Submits `task` behind an occupied blocking worker, starts runtime teardown,
 /// then frees the worker so Tokio rejects nested blocking submissions in
 /// `task` synchronously.
+///
+/// This fixture intentionally pins Tokio 1.53.1's shutdown behavior: a queued
+/// blocking task runs while `shutdown_background` drains the pool. The
+/// workspace's exact Tokio pin makes that a supported test premise. An upgrade
+/// that starts discarding queued tasks must update this helper to fail before
+/// its bounded receives, and re-audit every rejection-path test that uses it.
 pub(crate) fn submit_during_blocking_pool_shutdown(task: impl FnOnce() + Send + 'static) {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .max_blocking_threads(1)

--- a/crates/shelterwood/src/cells/admission.rs
+++ b/crates/shelterwood/src/cells/admission.rs
@@ -63,18 +63,6 @@ pub enum RemoveOutcome {
     AlreadyAbsent,
 }
 
-// The admission and removal response receivers drop these inline when a
-// caller abandons them (`DisposingReceiver::new_framework`); the marker is
-// the claim that no variant can ever own a user destructor. A variant that
-// grows one must lose the marker and move its receivers back to the
-// disposal-lane constructor.
-// SAFETY: every variant owns only framework enums and `ChildId`; none can
-// invoke user code or block on drop. A user-owned field must remove this impl.
-unsafe impl crate::runtime::FrameworkPlain for ReserveError {}
-
-// SAFETY: this fieldless framework enum has no drop glue.
-unsafe impl crate::runtime::FrameworkPlain for RemoveOutcome {}
-
 #[cfg(test)]
 mod tests {
     use super::{NotAdmittingCause, ReserveError};

--- a/crates/shelterwood/src/cells/admission.rs
+++ b/crates/shelterwood/src/cells/admission.rs
@@ -68,9 +68,12 @@ pub enum RemoveOutcome {
 // the claim that no variant can ever own a user destructor. A variant that
 // grows one must lose the marker and move its receivers back to the
 // disposal-lane constructor.
-impl crate::runtime::FrameworkPlain for ReserveError {}
+// SAFETY: every variant owns only framework enums and `ChildId`; none can
+// invoke user code or block on drop. A user-owned field must remove this impl.
+unsafe impl crate::runtime::FrameworkPlain for ReserveError {}
 
-impl crate::runtime::FrameworkPlain for RemoveOutcome {}
+// SAFETY: this fieldless framework enum has no drop glue.
+unsafe impl crate::runtime::FrameworkPlain for RemoveOutcome {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/shelterwood/src/tree/admission.rs
+++ b/crates/shelterwood/src/tree/admission.rs
@@ -53,7 +53,10 @@ impl<H> PendingAdmission<H> {
             Arc::clone(&self.reservation.slot),
             self.fused_cancel.clone(),
         )?;
-        let mut response = crate::runtime::DisposingReceiver::new_framework(response);
+        // The runtime's inline-disposal marker is deliberately sealed in its
+        // own crate. Cross-crate response types take the detached lane even
+        // when their current variants are plain framework data.
+        let mut response = crate::runtime::DisposingReceiver::new(response);
         Ok(Box::pin(async move {
             poll_fn(|context| response.poll_receive(context))
                 .await
@@ -243,7 +246,9 @@ impl fmt::Debug for Removal {
 
 impl Removal {
     pub(super) fn new(response: crate::driver::RemovalResponse) -> Self {
-        let mut response = crate::runtime::DisposingReceiver::new_framework(response);
+        // Keep cross-crate response destruction on the detached lane; only
+        // runtime-owned sealed types may select inline disposal.
+        let mut response = crate::runtime::DisposingReceiver::new(response);
         Self {
             inner: Box::pin(async move {
                 poll_fn(|context| response.poll_receive(context))


### PR DESCRIPTION
Closes #426.

## What changed

1. `OneShotReceiver` now records every terminal receive edge and rejects later polls with a Shelterwood-owned diagnostic instead of leaking Tokio's opaque `called after complete` panic. The state covers direct polling, `close_and_poll_receive`, `close_and_take`, test-only `try_receive`, consuming `receive`, `DisposingReceiver`, staged publication, and the erased mailbox adapter.
2. `BlockingJob` centralizes poison-tolerant pending-state recovery for `run`, the acceptance sample, and—critically—`Drop`. A poison regression proves teardown remains panic-free and actually retires the captured operation.
3. `WaiterRegistry` now records why latch/watch cancellation retires registered caller-waker clones inline, distinct from external-primitive proxy retirement.
4. `ActorWork` has direct abort-on-drop and idempotent-abort/join-cancelled tests. The adjacent unbounded sender return path and `JitterRng` bounds also receive direct pins.
5. `submit_during_blocking_pool_shutdown` now names the Tokio 1.53.1 queued-task premise, its exact-version support, and the required upgrade re-audit/failure behavior.
6. The optional `spawn_blocking_fallback_with` match remains explicit: its two arms document different ownership evidence (the handle is detached on success; the consumed closure leaves the authoritative job for disposal on error), so collapsing it would erase the reason the helper exists.

## Follow-up findings from #429

- `FrameworkPlain` is now genuinely sealed with a private supertrait, and a compile-fail doctest pins that foreign response types cannot select inline destruction. Because the intentional admission/removal response types live in the separate façade crate, those cold cancellation paths now use the existing detached-disposal constructor rather than weakening the seal with a public unsafe opt-in.
- `modify_silently` and `read_with` explicitly state that their closures run under the watch value mutex and may only manipulate plain framework-owned data—no user code, user-value drops, blocking, panics, or re-entry.

## Adversarial review follow-up

The fresh review replaced the original unsafe-public marker design with actual sealing, extended one-shot completion tracking across the take/consume/erased paths, and strengthened poison recovery coverage to observe captured-operation retirement.

## Verification

- `./tools/dev cargo test -p shelterwood-runtime` (80 unit tests plus sealing doctest)
- `./tools/dev cargo test -p shelterwood` (full façade unit, integration, and doc suites)
- `./tools/dev just ci` (918 nextest tests plus formatting, clippy, docs, examples, reachability, external-consumer, and Nix checks)
- `git diff --check`

Kept as a draft until the tracking workflow marks the reviewed PR ready.
