### PR TITLE
Harden mailbox transitions and disposal coverage

### DIFF
--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -167,7 +167,9 @@ pub(crate) trait MailboxTermination: Send {
 pub(crate) trait MailboxControl: fmt::Debug + Send + Sync {
     /// Installs the declaration-time mailbox policy before the first bind.
     /// Reconfiguration may only repeat the same resolved policy; a mismatch
-    /// panics after the mailbox lock has been released.
+    /// panics after the mailbox lock has been released. Tokens returned by
+    /// repeated compatible configuration share one one-shot permit, so only
+    /// the first token presented can bind; later aliases are rejected.
     fn configure(
         &self,
         mailbox: ResolvedMailbox,

--- a/crates/shelterwood/src/mailbox/cell.rs
+++ b/crates/shelterwood/src/mailbox/cell.rs
@@ -319,16 +319,23 @@ impl<M> MailboxState<M> {
                 return waiters.park(operation);
             }
             MailboxBinding::Bound(BoundState::Available(incarnation)) => {
-                let Some(ResolvedMailbox::Queue(capacity)) = self.kind else {
-                    unreachable!("only a capacity-bound queue can park while bound")
-                };
                 // Diagnostic-only under the mailbox mutex: `Available` parks
                 // only after the accepting transition filled this configured
-                // queue, or after that transition's own incarnation-mismatch
-                // fallback, which has already recorded its invariant panic on
-                // the effects sink. The Full transition remains total without
-                // this check, and no test expects the diagnostic panic.
-                debug_assert_eq!(self.queue.len(), capacity.get());
+                // queue, so a latest mailbox never arrives here -- its
+                // incarnation mismatch now leaves through its own non-parking
+                // transition instead. Releasing the guard to raise the verdict
+                // is impossible mid-transition and an always-on panic would
+                // poison the mailbox for every later caller, so record it and
+                // keep the transition total: parking preserves the operation's
+                // user message under either mailbox kind. No test expects this
+                // diagnostic.
+                debug_assert!(
+                    matches!(
+                        self.kind,
+                        Some(ResolvedMailbox::Queue(capacity)) if self.queue.len() == capacity.get()
+                    ),
+                    "only a filled capacity-bound queue can park while bound"
+                );
                 let incarnation = *incarnation;
                 let mut waiters = WaiterQueue::default();
                 if !waiters.park(operation) {
@@ -579,15 +586,28 @@ impl<M> Default for MailboxEffectPayload<M> {
 
 impl<M> MailboxEffectPayload<M> {
     fn is_empty(&self) -> bool {
-        // `isolate_displaced` only selects how a nonempty displaced set is
-        // flushed; by itself it represents no work.
-        !self.pulse
-            && self.displaced.is_empty()
-            && self.wakers.is_empty()
-            && self.returned.is_none()
-            && !self.accepted_sequence_exhausted
-            && self.rejected_bindings.is_empty()
-            && self.invariant_panic.is_none()
+        // Destructured rather than field-accessed: a new effect field is then
+        // a compile error here instead of an effect silently discarded
+        // whenever it is the only one this transition set.
+        let Self {
+            pulse,
+            displaced,
+            // `isolate_displaced` only selects how a nonempty displaced set is
+            // flushed; by itself it represents no work.
+            isolate_displaced: _,
+            wakers,
+            returned,
+            accepted_sequence_exhausted,
+            rejected_bindings,
+            invariant_panic,
+        } = self;
+        !pulse
+            && displaced.is_empty()
+            && wakers.is_empty()
+            && returned.is_none()
+            && !accepted_sequence_exhausted
+            && rejected_bindings.is_empty()
+            && invariant_panic.is_none()
     }
 }
 
@@ -736,6 +756,11 @@ impl<M: Send + 'static> MailboxEffectBatch<M> {
         }
         payload.wakers.flush(&mut panics);
         if !payload.isolate_displaced {
+            // A live latest transition displaces at most the one value it
+            // replaced, so per-element containment here is totality for a
+            // future multi-displacement caller rather than a tested behavior;
+            // `bind`, the only caller that can accumulate several, isolates
+            // them into a `MailboxPayload` above instead.
             for envelope in payload.displaced.drain(..) {
                 panics.run(|| drop(envelope));
             }
@@ -1748,7 +1773,7 @@ pub(super) enum WithdrawalDisposition {
 }
 
 impl WithdrawalDisposition {
-    fn action(&self, runtime: &Arc<dyn MailboxRuntime>) -> WakerAction {
+    fn action(self, runtime: &Arc<dyn MailboxRuntime>) -> WakerAction {
         match self {
             Self::Inline => WakerAction::DropInline,
             Self::Isolated => WakerAction::Dispose(Arc::clone(runtime)),

--- a/crates/shelterwood/src/mailbox/cell.rs
+++ b/crates/shelterwood/src/mailbox/cell.rs
@@ -1,8 +1,7 @@
 use std::{
     collections::{BTreeMap, VecDeque},
     fmt,
-    num::NonZeroUsize,
-    ops::Deref,
+    ops::{Deref, DerefMut},
     sync::{
         Arc, Mutex, MutexGuard,
         atomic::{AtomicBool, Ordering},
@@ -75,12 +74,6 @@ impl ReceiveMode {
             Self::LiveThrough(limit) => sequence <= limit,
         }
     }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum MailboxKind {
-    Queue(NonZeroUsize),
-    Latest,
 }
 
 pub(super) struct Envelope<M> {
@@ -264,7 +257,7 @@ impl<M> SendOperation<M> {
 }
 
 pub(super) struct MailboxState<M> {
-    kind: Option<MailboxKind>,
+    kind: Option<ResolvedMailbox>,
     bind_permit: Arc<AtomicBool>,
     binding: MailboxBinding<M>,
     last_bound: Option<Incarnation>,
@@ -326,7 +319,7 @@ impl<M> MailboxState<M> {
                 return waiters.park(operation);
             }
             MailboxBinding::Bound(BoundState::Available(incarnation)) => {
-                let Some(MailboxKind::Queue(capacity)) = self.kind else {
+                let Some(ResolvedMailbox::Queue(capacity)) = self.kind else {
                     unreachable!("only a capacity-bound queue can park while bound")
                 };
                 // Diagnostic-only under the mailbox mutex: `Available` parks
@@ -380,13 +373,13 @@ impl<M> MailboxState<M> {
     /// Dequeues the next envelope this receive mode is willing to observe.
     fn take_next(&mut self, mode: ReceiveMode) -> Option<Envelope<M>> {
         match self.kind {
-            Some(MailboxKind::Queue(_)) => self
+            Some(ResolvedMailbox::Queue(_)) => self
                 .queue
                 .front()
                 .is_some_and(|item| mode.accepts(item.accepted_sequence))
                 .then(|| self.queue.pop_front())
                 .flatten(),
-            Some(MailboxKind::Latest) => self
+            Some(ResolvedMailbox::Latest) => self
                 .latest
                 .as_ref()
                 .is_some_and(|item| mode.accepts(item.accepted_sequence))
@@ -442,6 +435,7 @@ pub(super) enum Submission<M> {
 
 enum SubmitTransition<M> {
     Complete(Submission<M>),
+    IncarnationMismatch(M),
     WaiterIdentityExhausted(Arc<SendOperation<M>>),
     AcceptedSequenceExhausted(M),
 }
@@ -449,11 +443,13 @@ enum SubmitTransition<M> {
 enum AcceptTransition<M> {
     Accepted(Incarnation),
     Full(M),
+    IncarnationMismatch(M),
     Exhausted(M),
 }
 
 enum TrySendTransition<M> {
     Complete(Result<Incarnation, SendError<M>>),
+    IncarnationMismatch(M),
     AcceptedSequenceExhausted(M),
 }
 
@@ -551,6 +547,50 @@ impl<M> WaiterQueue<M> {
     }
 }
 
+/// The complete movable effect state for one mailbox transition.
+///
+/// `MailboxEffects` owns this value and moves it wholesale into the eventual
+/// batch, so adding an effect cannot require restating its field at that seam.
+struct MailboxEffectPayload<M> {
+    pulse: bool,
+    displaced: Vec<Envelope<M>>,
+    isolate_displaced: bool,
+    wakers: WakerEffects,
+    returned: Option<M>,
+    accepted_sequence_exhausted: bool,
+    rejected_bindings: Vec<MailboxBinding<M>>,
+    invariant_panic: Option<&'static str>,
+}
+
+impl<M> Default for MailboxEffectPayload<M> {
+    fn default() -> Self {
+        Self {
+            pulse: false,
+            displaced: Vec::new(),
+            isolate_displaced: false,
+            wakers: WakerEffects::default(),
+            returned: None,
+            accepted_sequence_exhausted: false,
+            rejected_bindings: Vec::new(),
+            invariant_panic: None,
+        }
+    }
+}
+
+impl<M> MailboxEffectPayload<M> {
+    fn is_empty(&self) -> bool {
+        // `isolate_displaced` only selects how a nonempty displaced set is
+        // flushed; by itself it represents no work.
+        !self.pulse
+            && self.displaced.is_empty()
+            && self.wakers.is_empty()
+            && self.returned.is_none()
+            && !self.accepted_sequence_exhausted
+            && self.rejected_bindings.is_empty()
+            && self.invariant_panic.is_none()
+    }
+}
+
 /// User-controlled effects produced while reducing one mailbox transition.
 ///
 /// `MailboxTxn` owns this sink beside the guard and drops the guard first.
@@ -563,14 +603,7 @@ impl<M> WaiterQueue<M> {
 struct MailboxEffects<'a, 's, M: Send + 'static> {
     cell: &'a MailboxCell<M>,
     external: Option<&'s mut dyn MailboxEffectSink>,
-    pulse: bool,
-    displaced: Vec<Envelope<M>>,
-    isolate_displaced: bool,
-    wakers: WakerEffects,
-    returned: Option<M>,
-    accepted_sequence_exhausted: bool,
-    rejected_bindings: Vec<MailboxBinding<M>>,
-    invariant_panic: Option<&'static str>,
+    payload: MailboxEffectPayload<M>,
 }
 
 impl<'a, 's, M: Send + 'static> MailboxEffects<'a, 's, M> {
@@ -589,49 +622,42 @@ impl<'a, 's, M: Send + 'static> MailboxEffects<'a, 's, M> {
         Self {
             cell,
             external,
-            pulse: false,
-            displaced: Vec::new(),
-            isolate_displaced: false,
-            wakers: WakerEffects::default(),
-            returned: None,
-            accepted_sequence_exhausted: false,
-            rejected_bindings: Vec::new(),
-            invariant_panic: None,
+            payload: MailboxEffectPayload::default(),
         }
     }
 
     fn pulse(&mut self) {
-        self.pulse = true;
+        self.payload.pulse = true;
     }
 
     fn isolate_displaced(&mut self) {
-        self.isolate_displaced = true;
+        self.payload.isolate_displaced = true;
+    }
+}
+
+impl<M: Send + 'static> Deref for MailboxEffects<'_, '_, M> {
+    type Target = MailboxEffectPayload<M>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.payload
+    }
+}
+
+impl<M: Send + 'static> DerefMut for MailboxEffects<'_, '_, M> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.payload
     }
 }
 
 impl<M: Send + 'static> Drop for MailboxEffects<'_, '_, M> {
     fn drop(&mut self) {
-        if !self.pulse
-            && self.displaced.is_empty()
-            && self.wakers.is_empty()
-            && self.returned.is_none()
-            && !self.accepted_sequence_exhausted
-            && self.rejected_bindings.is_empty()
-            && self.invariant_panic.is_none()
-        {
+        if self.payload.is_empty() {
             return;
         }
         let batch = MailboxEffectBatch {
             changed: Arc::clone(&self.cell.changed),
             runtime: Arc::clone(&self.cell.runtime),
-            pulse: self.pulse,
-            displaced: std::mem::take(&mut self.displaced),
-            isolate_displaced: self.isolate_displaced,
-            wakers: std::mem::take(&mut self.wakers),
-            returned: self.returned.take(),
-            accepted_sequence_exhausted: self.accepted_sequence_exhausted,
-            rejected_bindings: std::mem::take(&mut self.rejected_bindings),
-            invariant_panic: self.invariant_panic.take(),
+            payload: std::mem::take(&mut self.payload),
         };
         if let Some(external) = self.external.take() {
             external.defer_mailbox_effect(Box::new(move || {
@@ -646,14 +672,7 @@ impl<M: Send + 'static> Drop for MailboxEffects<'_, '_, M> {
 struct MailboxEffectBatch<M> {
     changed: Arc<dyn MailboxSignal>,
     runtime: Arc<dyn MailboxRuntime>,
-    pulse: bool,
-    displaced: Vec<Envelope<M>>,
-    isolate_displaced: bool,
-    wakers: WakerEffects,
-    returned: Option<M>,
-    accepted_sequence_exhausted: bool,
-    rejected_bindings: Vec<MailboxBinding<M>>,
-    invariant_panic: Option<&'static str>,
+    payload: MailboxEffectPayload<M>,
 }
 
 /// A received message remains isolated until every post-unlock effect has
@@ -684,42 +703,47 @@ impl<M: Send + 'static> Drop for ReturnedMessage<M> {
 }
 
 impl<M: Send + 'static> MailboxEffectBatch<M> {
-    fn flush(mut self) {
+    fn flush(self) {
+        let Self {
+            changed,
+            runtime,
+            mut payload,
+        } = self;
         let mut panics = PanicAccumulator::default();
-        if let Some(message) = self.invariant_panic {
+        if let Some(message) = payload.invariant_panic {
             panics.run(|| panic!("{message}"));
         }
-        for rejected in self.rejected_bindings.drain(..) {
+        for rejected in payload.rejected_bindings.drain(..) {
             // A rejected binding can own parked user messages. Submit every
             // binding separately so neither this caller nor a sibling job's
             // unwind destroys it inline.
-            panics.run(|| dispose_value(self.runtime.as_ref(), rejected));
+            panics.run(|| dispose_value(runtime.as_ref(), rejected));
         }
-        if self.pulse {
-            panics.run(|| self.changed.pulse());
+        if payload.pulse {
+            panics.run(|| changed.pulse());
         }
         // Submit displaced latest-value payloads to isolated disposal before
         // waking accepted senders: a woken sender may run immediately and must
         // not race ahead of disposal submission.
-        if self.isolate_displaced && !self.displaced.is_empty() {
-            let isolated = std::mem::take(&mut self.displaced);
+        if payload.isolate_displaced && !payload.displaced.is_empty() {
+            let isolated = std::mem::take(&mut payload.displaced);
             panics.run(|| {
                 dispose_value(
-                    self.runtime.as_ref(),
+                    runtime.as_ref(),
                     MailboxPayload::unread(isolated.into(), None),
                 );
             });
         }
-        self.wakers.flush(&mut panics);
-        if !self.isolate_displaced {
-            for envelope in self.displaced.drain(..) {
+        payload.wakers.flush(&mut panics);
+        if !payload.isolate_displaced {
+            for envelope in payload.displaced.drain(..) {
                 panics.run(|| drop(envelope));
             }
         }
-        if let Some(returned) = self.returned.take() {
+        if let Some(returned) = payload.returned.take() {
             panics.run(|| drop(returned));
         }
-        if self.accepted_sequence_exhausted {
+        if payload.accepted_sequence_exhausted {
             panics.run(|| panic!("mailbox accepted-sequence space exhausted"));
         }
     }
@@ -772,7 +796,7 @@ impl<'a, 's, M: Send + 'static> MailboxTxn<'a, 's, M> {
         self.parts().0
     }
 
-    fn configure_kind(&mut self, kind: MailboxKind) -> Option<MailboxKind> {
+    fn configure_kind(&mut self, kind: ResolvedMailbox) -> Option<ResolvedMailbox> {
         let state = self.state_mut();
         match state.kind {
             Some(existing) => (existing != kind).then_some(existing),
@@ -1087,6 +1111,9 @@ impl<M: Send + 'static> MailboxCell<M> {
                             SubmitTransition::WaiterIdentityExhausted(operation)
                         }
                     }
+                    AcceptTransition::IncarnationMismatch(message) => {
+                        SubmitTransition::IncarnationMismatch(message)
+                    }
                     AcceptTransition::Exhausted(message) => {
                         SubmitTransition::AcceptedSequenceExhausted(message)
                     }
@@ -1106,6 +1133,9 @@ impl<M: Send + 'static> MailboxCell<M> {
         };
         match transaction.finish(transition) {
             SubmitTransition::Complete(submission) => submission,
+            SubmitTransition::IncarnationMismatch(message) => {
+                reject_incarnation_mismatch(&self.runtime, message)
+            }
             SubmitTransition::WaiterIdentityExhausted(operation) => {
                 dispose(&self.runtime, operation);
                 panic!("mailbox waiter identity space exhausted");
@@ -1157,6 +1187,9 @@ impl<M: Send + 'static> MailboxCell<M> {
                             kind: SendErrorKind::Full,
                         }))
                     }
+                    AcceptTransition::IncarnationMismatch(message) => {
+                        TrySendTransition::IncarnationMismatch(message)
+                    }
                     AcceptTransition::Exhausted(message) => {
                         TrySendTransition::AcceptedSequenceExhausted(message)
                     }
@@ -1165,6 +1198,9 @@ impl<M: Send + 'static> MailboxCell<M> {
         };
         match transaction.finish(transition) {
             TrySendTransition::Complete(result) => result,
+            TrySendTransition::IncarnationMismatch(message) => {
+                reject_incarnation_mismatch(&self.runtime, message)
+            }
             TrySendTransition::AcceptedSequenceExhausted(message) => {
                 dispose(&self.runtime, message);
                 panic!("mailbox accepted-sequence space exhausted");
@@ -1265,15 +1301,9 @@ impl<M: Send + 'static> MailboxCell<M> {
                         // (including zero-duration) deadline poll.
                         let observed = (*newest_observed).or(current_observation);
                         state.outcome = OperationOutcome::Withdrawn;
-                        state.waker.take(
-                            match disposition {
-                                WithdrawalDisposition::Inline => WakerAction::DropInline,
-                                WithdrawalDisposition::Isolated => {
-                                    WakerAction::Dispose(Arc::clone(&self.runtime))
-                                }
-                            },
-                            &mut waker_effects,
-                        );
+                        state
+                            .waker
+                            .take(disposition.action(&self.runtime), &mut waker_effects);
                         Ok((
                             WithdrawalOutcome::Withdrawn { message, observed },
                             state.registration.take(),
@@ -1287,15 +1317,9 @@ impl<M: Send + 'static> MailboxCell<M> {
                     // that published this outcome. Keep a future regression
                     // total by transferring any leftover waker to the same
                     // post-unlock effect set as an ordinary withdrawal.
-                    state.waker.take(
-                        match disposition {
-                            WithdrawalDisposition::Inline => WakerAction::DropInline,
-                            WithdrawalDisposition::Isolated => {
-                                WakerAction::Dispose(Arc::clone(&self.runtime))
-                            }
-                        },
-                        &mut waker_effects,
-                    );
+                    state
+                        .waker
+                        .take(disposition.action(&self.runtime), &mut waker_effects);
                     Ok((
                         WithdrawalOutcome::Accepted(incarnation),
                         state.registration.take(),
@@ -1311,15 +1335,9 @@ impl<M: Send + 'static> MailboxCell<M> {
                         // publishing. Transfer a leftover instead of letting a
                         // diagnostic unwind this by-value message under the
                         // operation mutex.
-                        state.waker.take(
-                            match disposition {
-                                WithdrawalDisposition::Inline => WakerAction::DropInline,
-                                WithdrawalDisposition::Isolated => {
-                                    WakerAction::Dispose(Arc::clone(&self.runtime))
-                                }
-                            },
-                            &mut waker_effects,
-                        );
+                        state
+                            .waker
+                            .take(disposition.action(&self.runtime), &mut waker_effects);
                         Ok((
                             WithdrawalOutcome::Terminated { message, observed },
                             state.registration.take(),
@@ -1405,17 +1423,13 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         mailbox: ResolvedMailbox,
         effects: &mut dyn MailboxEffectSink,
     ) -> MailboxBindToken {
-        let kind = match mailbox {
-            ResolvedMailbox::Queue(capacity) => MailboxKind::Queue(capacity),
-            ResolvedMailbox::Latest => MailboxKind::Latest,
-        };
         let mut transaction = MailboxTxn::deferred(self, effects);
-        let mismatch = transaction.configure_kind(kind);
+        let mismatch = transaction.configure_kind(mailbox);
         let token = MailboxBindToken::new(Arc::clone(&transaction.bind_permit));
         transaction.finish(());
         if let Some(existing) = mismatch {
             panic!(
-                "mailbox configuration changed from {existing:?} to {kind:?} after initialization"
+                "mailbox configuration changed from {existing:?} to {mailbox:?} after initialization"
             );
         }
         token
@@ -1484,13 +1498,12 @@ impl<M: Send + 'static> MailboxControl for MailboxCell<M> {
         } else if waiters.is_empty() {
             transaction.bind_available(incarnation);
         } else {
-            let MailboxKind::Queue(capacity) = kind else {
+            let ResolvedMailbox::Queue(_) = kind else {
                 unreachable!("a latest mailbox finishes all waiting submissions")
             };
             // Promotion leaves waiters only after filling a configured queue.
             // Binding Full is the total fallback too: diagnosing here would
             // unwind the waiter queue's user messages under the mailbox mutex.
-            let _ = capacity;
             transaction.bind_full(incarnation, waiters);
         }
         transaction.effects.pulse();
@@ -1571,6 +1584,14 @@ fn mint_accepted_sequence(accepted: &AtomicPoisonedCounter) -> Option<AcceptedSe
         .map(AcceptedSequence)
 }
 
+fn reject_incarnation_mismatch<M: Send + 'static>(
+    runtime: &Arc<dyn MailboxRuntime>,
+    message: M,
+) -> ! {
+    dispose(runtime, message);
+    panic!("an accepting transition observes its own binding's incarnation");
+}
+
 fn accept_locked<M>(
     state: &mut MailboxState<M>,
     incarnation: Incarnation,
@@ -1585,14 +1606,13 @@ where
         MailboxBinding::Bound(BoundState::Available(current)) => {
             // `incarnation` was read from this same binding by the surrounding
             // transaction, so a mismatch is a framework invariant failure.
-            // Keep it total -- the by-value user message returns through the
-            // caller's post-unlock path rather than being destroyed under the
-            // mailbox mutex -- and raise the diagnostic through the same
-            // effects sink, which flushes it after unlock.
+            // Keep it total: a dedicated transition carries the by-value user
+            // message through the caller's post-unlock disposal path before
+            // the diagnostic is raised. In particular, it must not share the
+            // ordinary Full transition, whose submit caller parks a queue
+            // waiter and is structurally invalid for a Latest mailbox.
             if *current != incarnation {
-                effects.invariant_panic =
-                    Some("an accepting transition observes its own binding's incarnation");
-                return AcceptTransition::Full(message);
+                return AcceptTransition::IncarnationMismatch(message);
             }
         }
         MailboxBinding::Bound(BoundState::Full { .. }) => {
@@ -1605,24 +1625,24 @@ where
         }
     }
     let kind = match state.kind {
-        Some(MailboxKind::Queue(capacity)) if state.queue.len() < capacity.get() => {
-            MailboxKind::Queue(capacity)
+        Some(ResolvedMailbox::Queue(capacity)) if state.queue.len() < capacity.get() => {
+            ResolvedMailbox::Queue(capacity)
         }
-        Some(MailboxKind::Latest) => MailboxKind::Latest,
-        Some(MailboxKind::Queue(_)) => return AcceptTransition::Full(message),
+        Some(ResolvedMailbox::Latest) => ResolvedMailbox::Latest,
+        Some(ResolvedMailbox::Queue(_)) => return AcceptTransition::Full(message),
         None => unreachable!("a bound mailbox is always configured"),
     };
     let Some(accepted_sequence) = mint_accepted_sequence(accepted) else {
         return AcceptTransition::Exhausted(message);
     };
     match kind {
-        MailboxKind::Queue(_) => {
+        ResolvedMailbox::Queue(_) => {
             state.queue.push_back(Envelope {
                 message,
                 accepted_sequence,
             });
         }
-        MailboxKind::Latest => {
+        ResolvedMailbox::Latest => {
             let displaced = state.latest.replace(Envelope {
                 message,
                 accepted_sequence,
@@ -1661,13 +1681,20 @@ fn promote_waiters<M: Send + 'static>(
         accepted_sequence,
         effects,
     );
+    // Bind-time exhaustion freezes because no live incarnation has yet been
+    // published. A receive is different: it has already removed an accepted
+    // envelope from this live incarnation, and freezing here would make
+    // `LiveThrough` stop observing the remaining accepted envelopes. Leave a
+    // nonempty waiter queue Full instead. Exhaustion is a fatal diagnostic;
+    // if execution nevertheless continues, each later receive that opens
+    // capacity may re-observe and re-report the poisoned sequence counter.
     if waiters.is_empty() {
         state.binding = MailboxBinding::Bound(BoundState::Available(incarnation));
     }
 }
 
 fn promote_waiter_queue<M: Send + 'static>(
-    kind: MailboxKind,
+    kind: ResolvedMailbox,
     incarnation: Incarnation,
     waiters: &mut WaiterQueue<M>,
     queue: &mut VecDeque<Envelope<M>>,
@@ -1676,8 +1703,8 @@ fn promote_waiter_queue<M: Send + 'static>(
     effects: &mut MailboxEffects<'_, '_, M>,
 ) {
     let available = match kind {
-        MailboxKind::Queue(capacity) => capacity.get().saturating_sub(queue.len()),
-        MailboxKind::Latest => usize::MAX,
+        ResolvedMailbox::Queue(capacity) => capacity.get().saturating_sub(queue.len()),
+        ResolvedMailbox::Latest => usize::MAX,
     };
     let mut accepted = 0usize;
     while accepted < available {
@@ -1697,11 +1724,11 @@ fn promote_waiter_queue<M: Send + 'static>(
             continue;
         };
         match kind {
-            MailboxKind::Queue(_) => queue.push_back(Envelope {
+            ResolvedMailbox::Queue(_) => queue.push_back(Envelope {
                 message,
                 accepted_sequence,
             }),
-            MailboxKind::Latest => {
+            ResolvedMailbox::Latest => {
                 if let Some(displaced) = latest.replace(Envelope {
                     message,
                     accepted_sequence,
@@ -1718,6 +1745,15 @@ fn promote_waiter_queue<M: Send + 'static>(
 pub(super) enum WithdrawalDisposition {
     Inline,
     Isolated,
+}
+
+impl WithdrawalDisposition {
+    fn action(&self, runtime: &Arc<dyn MailboxRuntime>) -> WakerAction {
+        match self {
+            Self::Inline => WakerAction::DropInline,
+            Self::Isolated => WakerAction::Dispose(Arc::clone(runtime)),
+        }
+    }
 }
 
 pub(super) struct Withdrawal<M> {

--- a/crates/shelterwood/src/mailbox/cell/tests.rs
+++ b/crates/shelterwood/src/mailbox/cell/tests.rs
@@ -56,6 +56,26 @@ struct LatestDisplacementMessage {
     displaced: Option<mpsc::Sender<(bool, Option<u8>)>>,
 }
 
+struct PanickingDisplacementMessage {
+    value: u8,
+    mailbox: Weak<MailboxCell<PanickingDisplacementMessage>>,
+    displaced: Option<mpsc::Sender<bool>>,
+}
+
+impl Drop for PanickingDisplacementMessage {
+    fn drop(&mut self) {
+        let Some(displaced) = self.displaced.take() else {
+            return;
+        };
+        let unlocked = self
+            .mailbox
+            .upgrade()
+            .is_none_or(|mailbox| mailbox.state.try_lock().is_ok());
+        let _ = displaced.send(unlocked);
+        panic!("injected displaced-message destructor panic");
+    }
+}
+
 impl Drop for LatestDisplacementMessage {
     fn drop(&mut self) {
         let Some(displaced) = self.displaced.take() else {
@@ -527,7 +547,7 @@ fn accepted_sequence_boundary_is_inclusive_and_live_only_refuses_frozen_input() 
     assert_eq!(
         receiver.try_recv(),
         Some(3),
-        "IncludeFrozen drains the same payload LiveOnly refuses"
+        "Drain receives the same frozen payload LiveThrough refuses"
     );
 
     let (latest_mailbox, latest_actor) = actor();
@@ -965,6 +985,102 @@ fn live_latest_displacement_drops_after_unlock_and_replacement_visibility() {
 }
 
 #[test]
+fn latest_displacement_contains_a_panicking_payload_destructor() {
+    let mailbox = MailboxCell::new(
+        ChildId::from("actor"),
+        crate::mailbox::capability::tests::runtime(),
+    );
+    let token = configure(&mailbox, ResolvedMailbox::Latest);
+    let incarnation = mint_actor_incarnation();
+    bind(&mailbox, token, incarnation);
+    let weak = Arc::downgrade(&mailbox);
+    let (displaced, observed) = mpsc::channel();
+
+    assert!(matches!(
+        mailbox.submit(PanickingDisplacementMessage {
+            value: 1,
+            mailbox: Weak::clone(&weak),
+            displaced: Some(displaced),
+        }),
+        super::Submission::Accepted(bound) if bound == incarnation
+    ));
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        let _ = mailbox.submit(PanickingDisplacementMessage {
+            value: 2,
+            mailbox: weak,
+            displaced: None,
+        });
+    }));
+    assert!(
+        panic.is_err(),
+        "the hostile destructor panic reaches the caller"
+    );
+    assert!(
+        observed
+            .recv_timeout(Duration::from_secs(5))
+            .expect("the displaced payload reports its drop context"),
+        "the displaced payload is destroyed after mailbox unlock"
+    );
+
+    let receiver = MailboxReceiver::new(Arc::clone(&mailbox), incarnation);
+    let replacement = receiver
+        .try_recv()
+        .expect("the replacement remains readable after displacement panics");
+    assert_eq!(replacement.value, 2);
+}
+
+#[test]
+fn latest_incarnation_mismatch_uses_the_nonparking_post_unlock_path() {
+    let mailbox = MailboxCell::new(
+        ChildId::from("actor"),
+        crate::mailbox::capability::tests::runtime(),
+    );
+    let token = configure(&mailbox, ResolvedMailbox::Latest);
+    let (bound, mismatched) = two_incarnations();
+    bind(&mailbox, token, bound);
+    let (dropped, observed) = mpsc::channel();
+
+    let mut transaction = super::MailboxTxn::new(&mailbox);
+    let transition = {
+        let (state, effects) = transaction.parts();
+        super::accept_locked(
+            state,
+            mismatched,
+            ThreadRecordingMessage(Some(dropped)),
+            &mailbox.accepted,
+            effects,
+        )
+    };
+    let transition = transaction.finish(transition);
+    let super::AcceptTransition::IncarnationMismatch(message) = transition else {
+        panic!("a Latest mismatch must not use the queue-only Full transition");
+    };
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        super::reject_incarnation_mismatch(&mailbox.runtime, message);
+    }))
+    .expect_err("the invariant diagnostic reaches the caller");
+    assert_eq!(
+        panic.downcast_ref::<&'static str>().copied(),
+        Some("an accepting transition observes its own binding's incarnation")
+    );
+    let destructor_thread = observed
+        .recv_timeout(Duration::from_secs(5))
+        .expect("the rejected message reaches detached disposal");
+    assert_ne!(
+        destructor_thread,
+        std::thread::current().id(),
+        "the rejected user message is isolated before the diagnostic"
+    );
+    drop(
+        mailbox
+            .state
+            .lock()
+            .expect("the mismatch diagnostic does not poison the mailbox"),
+    );
+}
+
+#[test]
 fn bind_observes_waiters_that_remain_parked_beyond_capacity() {
     let (mailbox, _) = actor();
     let token = configure(
@@ -1108,10 +1224,118 @@ fn configuration_mismatch_panics_after_releasing_the_mailbox_lock() {
             .lock()
             .expect("configuration panic occurs after unlocking")
             .kind,
-        Some(super::MailboxKind::Queue(
+        Some(ResolvedMailbox::Queue(
             std::num::NonZeroUsize::new(1).expect("non-zero queue capacity")
         ))
     );
+}
+
+#[test]
+fn bind_after_terminal_is_silently_ignored() {
+    let (mailbox, _) = actor();
+    let token = configure(&mailbox, ResolvedDefaults::default().mailbox());
+    let teardown = prepare_termination(&mailbox).expect("the mailbox terminalizes");
+
+    bind(&mailbox, token, mint_actor_incarnation());
+    assert!(matches!(
+        mailbox.state.lock().expect("mailbox state").binding,
+        super::MailboxBinding::Terminal(None)
+    ));
+    drop(teardown.finish());
+}
+
+#[test]
+fn bind_requires_prior_configuration_without_poisoning_the_mailbox() {
+    let (mailbox, _) = actor();
+    let token = {
+        let state = mailbox.state.lock().expect("mailbox state");
+        crate::mailbox::MailboxBindToken::new(Arc::clone(&state.bind_permit))
+    };
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        bind(&mailbox, token, mint_actor_incarnation());
+    }))
+    .expect_err("an unconfigured mailbox rejects bind");
+    assert_eq!(
+        panic.downcast_ref::<&'static str>().copied(),
+        Some("mailbox must be configured before its first bind")
+    );
+    drop(
+        mailbox
+            .state
+            .lock()
+            .expect("the configuration guard panics after unlock"),
+    );
+}
+
+#[test]
+fn bind_requires_the_prior_incarnation_to_close() {
+    let (mailbox, _) = actor();
+    let token = configure(&mailbox, ResolvedDefaults::default().mailbox());
+    let first = mint_actor_incarnation();
+    bind(&mailbox, token, first);
+    let (foreign, _) = actor();
+    let foreign_token = configure(&foreign, ResolvedDefaults::default().mailbox());
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        bind(&mailbox, foreign_token, mint_actor_incarnation());
+    }))
+    .expect_err("a live incarnation rejects rebinding");
+    assert_eq!(
+        panic.downcast_ref::<&'static str>().copied(),
+        Some("mailbox must close the prior incarnation before rebinding")
+    );
+    assert_eq!(
+        mailbox
+            .state
+            .lock()
+            .expect("the prior-close guard panics after unlock")
+            .status(),
+        super::BindingStatus::Bound(first)
+    );
+}
+
+#[test]
+fn bind_rejects_a_foreign_token_without_consuming_the_valid_one() {
+    let (mailbox, _) = actor();
+    let valid = configure(&mailbox, ResolvedDefaults::default().mailbox());
+    let (foreign, _) = actor();
+    let foreign_token = configure(&foreign, ResolvedDefaults::default().mailbox());
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        bind(&mailbox, foreign_token, mint_actor_incarnation());
+    }))
+    .expect_err("a foreign token cannot bind the mailbox");
+    assert_eq!(
+        panic.downcast_ref::<&'static str>().copied(),
+        Some("mailbox bind token is foreign or was already consumed")
+    );
+
+    bind(&mailbox, valid, mint_actor_incarnation());
+}
+
+#[test]
+fn repeated_configuration_tokens_share_one_consumable_permit() {
+    let (mailbox, _) = actor();
+    let policy = ResolvedDefaults::default().mailbox();
+    let first_token = configure(&mailbox, policy);
+    let alias = configure(&mailbox, policy);
+    let first = mint_actor_incarnation();
+    bind(&mailbox, first_token, first);
+    let closed = close(&mailbox, first).expect("the first incarnation closes");
+    let (next_token, payload) = closed.into_parts();
+    drop(payload);
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        bind(&mailbox, alias, mint_actor_incarnation());
+    }))
+    .expect_err("the alias cannot bind after the shared permit was consumed");
+    assert_eq!(
+        panic.downcast_ref::<&'static str>().copied(),
+        Some("mailbox bind token is foreign or was already consumed")
+    );
+
+    bind(&mailbox, next_token, mint_actor_incarnation());
 }
 
 #[test]
@@ -1540,7 +1764,7 @@ fn accepted_sequence_exhaustion_poison_is_never_minted() {
 }
 
 #[test]
-fn waiter_identity_exhaustion_drops_the_message_after_unlock() {
+fn waiter_identity_exhaustion_disposes_the_message_on_the_detached_lane() {
     let mailbox = MailboxCell::new(
         ChildId::from("actor"),
         crate::mailbox::capability::tests::runtime(),
@@ -1550,33 +1774,28 @@ fn waiter_identity_exhaustion_drops_the_message_after_unlock() {
             ids: crate::identity::PoisonedCounter::near_exhaustion(),
             ..super::WaiterQueue::default()
         });
-    let weak = Arc::downgrade(&mailbox);
     assert!(matches!(
-        mailbox.submit(LockCheckingMessage {
-            mailbox: Weak::clone(&weak),
-            dropped: None,
-        }),
+        mailbox.submit(ThreadRecordingMessage(None)),
         super::Submission::Parked(_)
     ));
     let (dropped, observed) = mpsc::channel();
+    let caller = std::thread::current().id();
 
     let panic = catch_unwind(AssertUnwindSafe(|| {
-        let _ = mailbox.submit(LockCheckingMessage {
-            mailbox: weak,
-            dropped: Some(dropped),
-        });
+        let _ = mailbox.submit(ThreadRecordingMessage(Some(dropped)));
     }));
     assert!(panic.is_err(), "exhaustion is reported to the caller");
-    assert!(
+    assert_ne!(
         observed
             .recv_timeout(Duration::from_secs(5))
             .expect("isolated message destructor reports"),
-        "the exhausted message is destroyed outside the mailbox mutex"
+        caller,
+        "the exhausted message is destroyed on the detached disposal lane"
     );
 }
 
 #[test]
-fn accepted_sequence_exhaustion_drops_the_message_after_unlock() {
+fn accepted_sequence_exhaustion_disposes_the_message_on_the_detached_lane() {
     let mut mailbox = MailboxCell::new(
         ChildId::from("actor"),
         crate::mailbox::capability::tests::runtime(),
@@ -1586,28 +1805,23 @@ fn accepted_sequence_exhaustion_drops_the_message_after_unlock() {
         .accepted = crate::identity::AtomicPoisonedCounter::near_exhaustion();
     let token = configure(&mailbox, ResolvedMailbox::Latest);
     bind(&mailbox, token, mint_actor_incarnation());
-    let weak = Arc::downgrade(&mailbox);
     assert!(matches!(
-        mailbox.submit(LockCheckingMessage {
-            mailbox: Weak::clone(&weak),
-            dropped: None,
-        }),
+        mailbox.submit(ThreadRecordingMessage(None)),
         super::Submission::Accepted(_)
     ));
     let (dropped, observed) = mpsc::channel();
+    let caller = std::thread::current().id();
 
     let panic = catch_unwind(AssertUnwindSafe(|| {
-        let _ = mailbox.submit(LockCheckingMessage {
-            mailbox: weak,
-            dropped: Some(dropped),
-        });
+        let _ = mailbox.submit(ThreadRecordingMessage(Some(dropped)));
     }));
     assert!(panic.is_err(), "exhaustion is reported to the caller");
-    assert!(
+    assert_ne!(
         observed
             .recv_timeout(Duration::from_secs(5))
             .expect("isolated message destructor reports"),
-        "the exhausted message is destroyed outside the mailbox mutex"
+        caller,
+        "the exhausted message is destroyed on the detached disposal lane"
     );
 }
 
@@ -1729,21 +1943,13 @@ fn bind_sequence_exhaustion_retains_parked_senders_after_unlock() {
         .expect("mailbox is uniquely owned")
         .accepted = crate::identity::AtomicPoisonedCounter::near_exhaustion();
     let token = configure(&mailbox, ResolvedMailbox::Latest);
-    let weak = Arc::downgrade(&mailbox);
-    let first = match mailbox.submit(LockCheckingMessage {
-        mailbox: Weak::clone(&weak),
-        dropped: None,
-    }) {
+    let first = match mailbox.submit(1_u8) {
         super::Submission::Parked(operation) => operation,
         super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
             panic!("an unbound mailbox parks its send")
         }
     };
-    let (dropped, observed) = mpsc::channel();
-    let second = match mailbox.submit(LockCheckingMessage {
-        mailbox: weak,
-        dropped: Some(dropped),
-    }) {
+    let second = match mailbox.submit(2_u8) {
         super::Submission::Parked(operation) => operation,
         super::Submission::Accepted(_) | super::Submission::Terminated { .. } => {
             panic!("an unbound mailbox parks its send")
@@ -1778,11 +1984,5 @@ fn bind_sequence_exhaustion_retains_parked_senders_after_unlock() {
         "the unpromotable sender still owns its message"
     );
     withdrawal.finish();
-    assert!(
-        observed
-            .recv_timeout(Duration::from_secs(5))
-            .expect("the parked message destructor reports"),
-        "the parked message is destroyed outside the mailbox mutex"
-    );
     drop(first);
 }

--- a/crates/shelterwood/src/mailbox/deadline.rs
+++ b/crates/shelterwood/src/mailbox/deadline.rs
@@ -244,13 +244,14 @@ impl<F> Drop for Deadlined<F> {
 mod tests {
     use std::{
         future::Future,
-        mem::ManuallyDrop,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
         },
-        task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker},
+        task::{Context, Poll, Wake, Waker},
     };
+
+    use crate::mailbox::test_support::probe_waker;
 
     /// Stays pending on its first elapsed poll, modelling an atomic
     /// completion transition that won without publishing its payload yet.
@@ -327,39 +328,14 @@ mod tests {
     #[derive(Default)]
     struct CloneCounter(AtomicUsize);
 
-    unsafe fn clone_counting_waker(data: *const ()) -> RawWaker {
-        // SAFETY: every pointer using this vtable came from an Arc of the
-        // matching type. ManuallyDrop preserves the reference represented by
-        // `data`; the returned raw waker owns only the new clone.
-        let probe = ManuallyDrop::new(unsafe { Arc::<CloneCounter>::from_raw(data.cast()) });
-        probe.0.fetch_add(1, Ordering::SeqCst);
-        RawWaker::new(Arc::into_raw(Arc::clone(&probe)).cast(), &COUNTING_VTABLE)
-    }
-
-    unsafe fn wake_counting_waker(data: *const ()) {
-        // SAFETY: wake consumes the Arc reference represented by this waker.
-        drop(unsafe { Arc::<CloneCounter>::from_raw(data.cast()) });
-    }
-
-    unsafe fn wake_by_ref_counting_waker(_data: *const ()) {}
-
-    unsafe fn drop_counting_waker(data: *const ()) {
-        // SAFETY: drop consumes the Arc reference represented by this waker.
-        drop(unsafe { Arc::<CloneCounter>::from_raw(data.cast()) });
-    }
-
-    static COUNTING_VTABLE: RawWakerVTable = RawWakerVTable::new(
-        clone_counting_waker,
-        wake_counting_waker,
-        wake_by_ref_counting_waker,
-        drop_counting_waker,
-    );
-
     fn counting_waker(counter: &Arc<CloneCounter>) -> Waker {
-        let raw = RawWaker::new(Arc::into_raw(Arc::clone(counter)).cast(), &COUNTING_VTABLE);
-        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
-        // ownership across clone, wake, and drop.
-        unsafe { Waker::from_raw(raw) }
+        let counter = Arc::clone(counter);
+        probe_waker(
+            move || {
+                counter.0.fetch_add(1, Ordering::SeqCst);
+            },
+            || {},
+        )
     }
 
     impl super::DeadlineOperation for PendingOnFirstExpiry {

--- a/crates/shelterwood/src/mailbox/futures.rs
+++ b/crates/shelterwood/src/mailbox/futures.rs
@@ -818,7 +818,7 @@ mod tests {
             atomic::{AtomicUsize, Ordering},
             mpsc,
         },
-        task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker},
+        task::{Context, Poll, Wake, Waker},
         thread::ThreadId,
         time::Duration,
     };
@@ -828,7 +828,7 @@ mod tests {
     use crate::{
         mailbox::{
             CallErrorKind, Incarnation, MailboxControl, MailboxEffectQueue, MailboxReceiver, Reply,
-            test_support::mint_actor_incarnation,
+            test_support::{mint_actor_incarnation, probe_waker},
         },
         policy::ResolvedMailbox,
     };
@@ -1143,39 +1143,6 @@ mod tests {
         }
     }
 
-    unsafe fn clone_operation_lock_probe(data: *const ()) -> RawWaker {
-        // SAFETY: every pointer using this vtable was produced by
-        // `Arc::into_raw` for an `OperationLockProbe`. `ManuallyDrop` preserves
-        // the reference represented by `data`; the returned raw waker owns the
-        // newly cloned reference.
-        let probe = ManuallyDrop::new(unsafe { Arc::<OperationLockProbe>::from_raw(data.cast()) });
-        probe.assert_operation_unlocked("clone");
-        probe.calls.clones.fetch_add(1, Ordering::SeqCst);
-        let cloned = Arc::clone(&probe);
-        RawWaker::new(Arc::into_raw(cloned).cast(), &OPERATION_LOCK_PROBE_VTABLE)
-    }
-
-    unsafe fn wake_operation_lock_probe(data: *const ()) {
-        // SAFETY: `wake` consumes the raw-waker reference represented by data.
-        drop(unsafe { Arc::<OperationLockProbe>::from_raw(data.cast()) });
-    }
-
-    unsafe fn wake_operation_lock_probe_by_ref(_data: *const ()) {}
-
-    unsafe fn drop_operation_lock_probe(data: *const ()) {
-        // SAFETY: `drop` consumes the raw-waker reference represented by data.
-        let probe = unsafe { Arc::<OperationLockProbe>::from_raw(data.cast()) };
-        probe.assert_operation_unlocked("drop");
-        probe.calls.drops.fetch_add(1, Ordering::SeqCst);
-    }
-
-    static OPERATION_LOCK_PROBE_VTABLE: RawWakerVTable = RawWakerVTable::new(
-        clone_operation_lock_probe,
-        wake_operation_lock_probe,
-        wake_operation_lock_probe_by_ref,
-        drop_operation_lock_probe,
-    );
-
     fn operation_lock_probe_waker(
         operation: &Arc<SendOperation<u8>>,
         calls: Arc<WakerVtableCalls>,
@@ -1184,10 +1151,17 @@ mod tests {
             operation: Arc::downgrade(operation),
             calls,
         });
-        let raw = RawWaker::new(Arc::into_raw(probe).cast(), &OPERATION_LOCK_PROBE_VTABLE);
-        // SAFETY: `raw` owns one `OperationLockProbe` reference and its vtable
-        // maintains that reference count for every clone, wake, and drop.
-        unsafe { Waker::from_raw(raw) }
+        let clone_probe = Arc::clone(&probe);
+        probe_waker(
+            move || {
+                clone_probe.assert_operation_unlocked("clone");
+                clone_probe.calls.clones.fetch_add(1, Ordering::SeqCst);
+            },
+            move || {
+                probe.assert_operation_unlocked("drop");
+                probe.calls.drops.fetch_add(1, Ordering::SeqCst);
+            },
+        )
     }
 
     #[test]
@@ -1353,49 +1327,14 @@ mod tests {
         _payload: ThreadRecordingDrop,
     }
 
-    struct EveryWakerDropPanics(DisposalThread);
-
-    unsafe fn clone_panicking_drop_waker(data: *const ()) -> RawWaker {
-        // SAFETY: every pointer using this vtable came from an Arc of the
-        // matching type. ManuallyDrop preserves the reference represented by
-        // `data`; the returned raw waker owns only the new clone.
-        let probe =
-            ManuallyDrop::new(unsafe { Arc::<EveryWakerDropPanics>::from_raw(data.cast()) });
-        RawWaker::new(
-            Arc::into_raw(Arc::clone(&probe)).cast(),
-            &PANICKING_DROP_WAKER_VTABLE,
-        )
-    }
-
-    unsafe fn wake_panicking_drop_waker(data: *const ()) {
-        // SAFETY: wake consumes the reference represented by this raw waker.
-        drop(unsafe { Arc::<EveryWakerDropPanics>::from_raw(data.cast()) });
-    }
-
-    unsafe fn wake_by_ref_panicking_drop_waker(_data: *const ()) {}
-
-    unsafe fn drop_panicking_drop_waker(data: *const ()) {
-        // SAFETY: drop consumes the reference represented by this raw waker.
-        let probe = unsafe { Arc::<EveryWakerDropPanics>::from_raw(data.cast()) };
-        record_disposal(&probe.0);
-        panic!("injected call waker drop panic");
-    }
-
-    static PANICKING_DROP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-        clone_panicking_drop_waker,
-        wake_panicking_drop_waker,
-        wake_by_ref_panicking_drop_waker,
-        drop_panicking_drop_waker,
-    );
-
     fn panicking_drop_waker(recorder: DisposalThread) -> Waker {
-        let raw = RawWaker::new(
-            Arc::into_raw(Arc::new(EveryWakerDropPanics(recorder))).cast(),
-            &PANICKING_DROP_WAKER_VTABLE,
-        );
-        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
-        // ownership across clone, wake, and drop.
-        unsafe { Waker::from_raw(raw) }
+        probe_waker(
+            || {},
+            move || {
+                record_disposal(&recorder);
+                panic!("injected call waker drop panic");
+            },
+        )
     }
 
     /// Parks `send` behind a hostile waker and releases the caller's own

--- a/crates/shelterwood/src/mailbox/reply.rs
+++ b/crates/shelterwood/src/mailbox/reply.rs
@@ -160,11 +160,14 @@ mod tests {
             Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
         },
-        task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker},
+        task::{Context, Poll, Wake, Waker},
         time::Duration,
     };
 
-    use crate::mailbox::capability::{DisposingReceiver, OneShotClose, oneshot};
+    use crate::mailbox::{
+        capability::{DisposingReceiver, OneShotClose, oneshot},
+        test_support::probe_waker,
+    };
     use shelterwood_core::{
         ErasedOneShotClose, ErasedOneShotReceiver, ErasedOneShotSender, ErasedValue,
     };
@@ -218,51 +221,14 @@ mod tests {
         }
     }
 
-    struct DropCounter {
-        drops: Arc<AtomicUsize>,
-        hostile: bool,
-    }
-
-    unsafe fn clone_counted_drop_waker(data: *const ()) -> RawWaker {
-        // SAFETY: every pointer using this vtable came from an Arc of the
-        // matching type. ManuallyDrop preserves the represented reference;
-        // the returned raw waker owns only the new clone.
-        let state = ManuallyDrop::new(unsafe { Arc::<DropCounter>::from_raw(data.cast()) });
-        RawWaker::new(
-            Arc::into_raw(Arc::clone(&state)).cast(),
-            &COUNTED_DROP_WAKER_VTABLE,
-        )
-    }
-
-    unsafe fn wake_counted_drop_waker(data: *const ()) {
-        // SAFETY: wake consumes the Arc reference represented by this waker.
-        drop(unsafe { Arc::<DropCounter>::from_raw(data.cast()) });
-    }
-
-    unsafe fn wake_by_ref_counted_drop_waker(_data: *const ()) {}
-
-    unsafe fn drop_counted_drop_waker(data: *const ()) {
-        // SAFETY: drop consumes the Arc reference represented by this waker.
-        let state = unsafe { Arc::<DropCounter>::from_raw(data.cast()) };
-        state.drops.fetch_add(1, Ordering::SeqCst);
-        assert!(!state.hostile, "injected reply caller-waker drop panic");
-    }
-
-    static COUNTED_DROP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-        clone_counted_drop_waker,
-        wake_counted_drop_waker,
-        wake_by_ref_counted_drop_waker,
-        drop_counted_drop_waker,
-    );
-
     fn drop_waker(drops: Arc<AtomicUsize>, hostile: bool) -> Waker {
-        let raw = RawWaker::new(
-            Arc::into_raw(Arc::new(DropCounter { drops, hostile })).cast(),
-            &COUNTED_DROP_WAKER_VTABLE,
-        );
-        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
-        // ownership across clone, wake, and drop.
-        unsafe { Waker::from_raw(raw) }
+        probe_waker(
+            || {},
+            move || {
+                drops.fetch_add(1, Ordering::SeqCst);
+                assert!(!hostile, "injected reply caller-waker drop panic");
+            },
+        )
     }
 
     fn counted_drop_waker(drops: Arc<AtomicUsize>) -> Waker {

--- a/crates/shelterwood/src/mailbox/test_support.rs
+++ b/crates/shelterwood/src/mailbox/test_support.rs
@@ -1,4 +1,58 @@
+use std::{
+    mem::ManuallyDrop,
+    sync::Arc,
+    task::{RawWaker, RawWakerVTable, Waker},
+};
+
 use shelterwood_core::{ChildId, Incarnation, IncarnationCounter, Membership, ScopeIdentity};
+
+struct WakerProbe {
+    on_clone: Box<dyn Fn() + Send + Sync>,
+    on_drop: Box<dyn Fn() + Send + Sync>,
+}
+
+unsafe fn clone_probe(data: *const ()) -> RawWaker {
+    // SAFETY: `probe_waker` creates every pointer paired with this vtable from
+    // `Arc<WakerProbe>`. ManuallyDrop preserves the reference represented by
+    // `data`; the returned raw waker owns exactly the newly cloned reference.
+    let probe = ManuallyDrop::new(unsafe { Arc::<WakerProbe>::from_raw(data.cast()) });
+    (probe.on_clone)();
+    RawWaker::new(Arc::into_raw(Arc::clone(&probe)).cast(), &PROBE_VTABLE)
+}
+
+unsafe fn wake_probe(data: *const ()) {
+    // SAFETY: wake consumes exactly the Arc reference represented by `data`.
+    drop(unsafe { Arc::<WakerProbe>::from_raw(data.cast()) });
+}
+
+unsafe fn wake_probe_by_ref(_data: *const ()) {}
+
+unsafe fn drop_probe(data: *const ()) {
+    // SAFETY: drop consumes exactly the Arc reference represented by `data`.
+    let probe = unsafe { Arc::<WakerProbe>::from_raw(data.cast()) };
+    (probe.on_drop)();
+}
+
+static PROBE_VTABLE: RawWakerVTable =
+    RawWakerVTable::new(clone_probe, wake_probe, wake_probe_by_ref, drop_probe);
+
+/// Builds a test-only waker whose clone and drop vtable entries are observable.
+///
+/// The shared raw-waker ownership implementation lives here so individual
+/// regressions only supply the behavior they need to observe.
+pub(crate) fn probe_waker(
+    on_clone: impl Fn() + Send + Sync + 'static,
+    on_drop: impl Fn() + Send + Sync + 'static,
+) -> Waker {
+    let probe = Arc::new(WakerProbe {
+        on_clone: Box::new(on_clone),
+        on_drop: Box::new(on_drop),
+    });
+    let raw = RawWaker::new(Arc::into_raw(probe).cast(), &PROBE_VTABLE);
+    // SAFETY: `raw` owns one Arc reference and `PROBE_VTABLE` preserves or
+    // consumes exactly one reference for each RawWaker operation.
+    unsafe { Waker::from_raw(raw) }
+}
 
 pub(crate) fn mint_actor_membership() -> (Membership, IncarnationCounter) {
     ScopeIdentity::new()

--- a/crates/shelterwood/src/mailbox/timer.rs
+++ b/crates/shelterwood/src/mailbox/timer.rs
@@ -5,60 +5,27 @@
 //! reachable. This module keeps only the test that needs the real runtime's
 //! disposal lane, so core itself retains no dev-dependencies.
 
-#[cfg(test)]
 mod tests {
     use std::{
         future::Future,
         mem::ManuallyDrop,
-        sync::{Arc, mpsc},
-        task::{Context, RawWaker, RawWakerVTable, Waker},
+        sync::mpsc,
+        task::{Context, Waker},
         thread::{self, ThreadId},
         time::Duration,
     };
 
     use shelterwood_core::{BoxedSleep, ProxiedSleep};
 
-    struct ThreadDrop(mpsc::Sender<ThreadId>);
-
-    unsafe fn clone_thread_drop(data: *const ()) -> RawWaker {
-        // SAFETY: every pointer using this vtable came from an Arc of the
-        // matching type. ManuallyDrop preserves the reference represented by
-        // `data`; the returned raw waker owns only the new clone.
-        let state = ManuallyDrop::new(unsafe { Arc::<ThreadDrop>::from_raw(data.cast()) });
-        RawWaker::new(
-            Arc::into_raw(Arc::clone(&state)).cast(),
-            &THREAD_DROP_VTABLE,
-        )
-    }
-
-    unsafe fn wake_thread_drop(data: *const ()) {
-        // SAFETY: wake consumes the Arc reference represented by this waker.
-        drop(unsafe { Arc::<ThreadDrop>::from_raw(data.cast()) });
-    }
-
-    unsafe fn wake_by_ref_thread_drop(_data: *const ()) {}
-
-    unsafe fn drop_thread_drop(data: *const ()) {
-        // SAFETY: drop consumes the Arc reference represented by this waker.
-        let state = unsafe { Arc::<ThreadDrop>::from_raw(data.cast()) };
-        let _ = state.0.send(thread::current().id());
-    }
-
-    static THREAD_DROP_VTABLE: RawWakerVTable = RawWakerVTable::new(
-        clone_thread_drop,
-        wake_thread_drop,
-        wake_by_ref_thread_drop,
-        drop_thread_drop,
-    );
+    use crate::mailbox::test_support::probe_waker;
 
     fn thread_drop_waker(sender: mpsc::Sender<ThreadId>) -> Waker {
-        let raw = RawWaker::new(
-            Arc::into_raw(Arc::new(ThreadDrop(sender))).cast(),
-            &THREAD_DROP_VTABLE,
-        );
-        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
-        // ownership across clone, wake, and drop.
-        unsafe { Waker::from_raw(raw) }
+        probe_waker(
+            || {},
+            move || {
+                let _ = sender.send(thread::current().id());
+            },
+        )
     }
 
     #[crate::runtime::test]


### PR DESCRIPTION
Closes #421.

## Summary

- make the accepting-incarnation mismatch a dedicated non-parking transition, with rejected user payload disposal completed before the post-unlock diagnostic
- move all mailbox effect state through one `MailboxEffectPayload`, store `ResolvedMailbox` directly, and centralize withdrawal-disposition-to-waker-action mapping
- cover every `MailboxControl::bind` guard and document/test repeated compatible configuration: returned tokens alias one one-shot permit, so only the first can bind
- pin waiter-id and accepted-sequence exhaustion to the detached disposal venue; remove the assertion that only observed the test's own inline withdrawal
- document why receive-time promotion exhaustion intentionally leaves the live mailbox full instead of freezing it
- remove the remaining small scars: redundant queue binding, duplicate timer test gate, stale receive-mode assertion names, and five duplicated raw-waker scaffolds
- add direct `Mailbox::Latest` coverage proving a panicking displaced-payload destructor runs after unlock, remains contained, and does not lose the replacement

## Validation

- `./tools/dev cargo test -p shelterwood mailbox::cell::tests`
- `./tools/dev cargo test -p shelterwood mailbox::`
- `./tools/dev just ci`
