### PR TITLE
Clean up static builder API and test fixtures

### DIFF
--- a/crates/shelterwood/docs/errors.md
+++ b/crates/shelterwood/docs/errors.md
@@ -58,10 +58,12 @@ response wait.
 
 ## The rest of the error surface, briefly
 
-- **Declaration and admission** — `ReserveError` (duplicate or in-removal
-  id, scope not admitting: `NotAdmittingCause`), `BuildError` (root
-  lowering), `PolicyError` (invalid policy data, rejected at
-  construction).
+- **Declaration and admission** — `StaticReserveError` (empty or duplicate
+  id, identity exhaustion) for pre-spawn tree declarations; `ReserveError`
+  (those common id failures plus in-removal ids, unavailable runtime, and a
+  scope not admitting: `NotAdmittingCause`) for live dynamic admission;
+  `BuildError` (root lowering); `PolicyError` (invalid policy data, rejected
+  at construction).
 - **Startup** — `StartupError` from `wait_started`; `StartOrShutdownError`
   pairs the startup failure with any rollback timeout report;
   `StartupFailure`/`StartupFailureCause` describe a nested scope's failed

--- a/crates/shelterwood/src/actor.rs
+++ b/crates/shelterwood/src/actor.rs
@@ -280,10 +280,19 @@ impl<A: Actor> fmt::Debug for Context<'_, A> {
 }
 
 impl<'a, A: Actor> Context<'a, A> {
-    fn new(raw: &'a mut RawContext<A::Msg>, stage: DeliveryStage) -> Self {
+    fn new_live(raw: &'a mut RawContext<A::Msg>) -> Self {
         Self {
             raw,
-            stage,
+            stage: DeliveryStage::Live,
+            owns_init_boundary: false,
+            actor: PhantomData,
+        }
+    }
+
+    fn new_draining(raw: &'a mut RawContext<A::Msg>) -> Self {
+        Self {
+            raw,
+            stage: DeliveryStage::DrainingFrozenPrefix,
             owns_init_boundary: false,
             actor: PhantomData,
         }
@@ -697,7 +706,7 @@ impl<A: Actor> RawActor for Handler<A> {
 
         while let Some(message) = raw.recv().await {
             let handled = {
-                let mut context = Context::<A>::new(raw, DeliveryStage::Live);
+                let mut context = Context::<A>::new_live(raw);
                 actor.handle(message, &mut context).await
             };
             if let Err(error) = handled {
@@ -709,8 +718,7 @@ impl<A: Actor> RawActor for Handler<A> {
             MailboxShutdown::Drain => {
                 while let Some(message) = raw.try_recv() {
                     let handled = {
-                        let mut context =
-                            Context::<A>::new(raw, DeliveryStage::DrainingFrozenPrefix);
+                        let mut context = Context::<A>::new_draining(raw);
                         actor.handle(message, &mut context).await
                     };
                     if let Err(error) = handled {

--- a/crates/shelterwood/src/cells/admission.rs
+++ b/crates/shelterwood/src/cells/admission.rs
@@ -1,8 +1,25 @@
-//! Dynamic membership admission errors and removal outcomes.
+//! Static declaration and dynamic admission errors, plus removal outcomes.
 
 use std::fmt;
 
 use shelterwood_core::ChildId;
+
+/// A pre-spawn child declaration or reservation error.
+///
+/// Static builders cannot observe runtime admission state: only id validation,
+/// duplicate detection, and membership identity exhaustion are reachable.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum StaticReserveError {
+    /// The child id was empty.
+    #[error("child id must not be empty")]
+    EmptyId,
+    /// A declared membership already occupies the id.
+    #[error("child id `{0}` is already declared")]
+    DuplicateId(ChildId),
+    /// The scope can mint no further membership identities.
+    #[error("membership identity space is exhausted")]
+    IdentityExhausted,
+}
 
 /// A child reservation or dynamic admission error.
 #[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -488,7 +488,10 @@ async fn hard_force_preserves_the_first_terminal_observer_panic_across_its_fallb
         .await
         .dispatch(&mut scope);
     }
-    gate.wait_entered().await;
+    assert!(matches!(
+        crate::runtime::timeout(DRIVER_PROGRESS_WAIT, gate.wait_entered()).await,
+        crate::runtime::Timeout::Completed(())
+    ));
     let arrived_completion = crate::runtime::timeout(DRIVER_PROGRESS_WAIT, async {
         while scope.disposal_event_receiver.is_empty() {
             crate::runtime::yield_now().await;

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -123,7 +123,8 @@
 //! [`ScopeRef`] addresses an ordered scope; [`DynamicScopeRef`] adds
 //! runtime admission and removal, whose outcomes are [`Admission`],
 //! [`Removal`], [`RemoveOutcome`], [`ReserveError`], and
-//! [`NotAdmittingCause`]. Scope-level state is [`ScopeState`] and
+//! [`NotAdmittingCause`]. Pre-spawn declarations return
+//! [`StaticReserveError`]. Scope-level state is [`ScopeState`] and
 //! [`MembershipStatus`].
 //!
 //! ## Tasks
@@ -218,7 +219,8 @@ pub use actor::{Actor, ActorDef, ActorOnceDef, Context, Handler, StopContext};
 pub use cells::{
     CancellationToken, ChildSnapshot, ChildState, LifecycleEvent, LifecycleEventKind,
     LifecycleEvents, LifecycleItem, LifecycleSeq, LifecycleTryRecvError, NotAdmittingCause,
-    RemoveOutcome, ReserveError, ScopeSnapshot, SnapshotClosed, SnapshotReceiver, WaitError,
+    RemoveOutcome, ReserveError, ScopeSnapshot, SnapshotClosed, SnapshotReceiver,
+    StaticReserveError, WaitError,
 };
 pub use deadline::DeadlineBudget;
 pub use engine::{MembershipStatus, ScopeState};

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -349,10 +349,7 @@ impl BuilderCore {
         id: impl Into<ChildId>,
         scope: Option<ScopeFlavor>,
     ) -> Result<Arc<SlotCell>, StaticReserveError> {
-        let id = id.into();
-        if id.as_str().is_empty() {
-            return Err(StaticReserveError::EmptyId);
-        }
+        let id = non_empty_id(id).ok_or(StaticReserveError::EmptyId)?;
         if self.ids.contains(&id) {
             return Err(StaticReserveError::DuplicateId(id));
         }
@@ -581,13 +578,15 @@ impl ScopeConstruction {
     }
 }
 
-pub(crate) fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError> {
+/// The one place the id-emptiness rule lives; each reservation error type
+/// names its own `EmptyId` on top of it.
+pub(crate) fn non_empty_id(id: impl Into<ChildId>) -> Option<ChildId> {
     let id = id.into();
-    if id.as_str().is_empty() {
-        Err(ReserveError::EmptyId)
-    } else {
-        Ok(id)
-    }
+    (!id.as_str().is_empty()).then_some(id)
+}
+
+pub(crate) fn checked_id(id: impl Into<ChildId>) -> Result<ChildId, ReserveError> {
+    non_empty_id(id).ok_or(ReserveError::EmptyId)
 }
 
 #[cfg(test)]

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{
     ChildId, DefaultsInheritance, Exit, Intensity, Readiness, ScopeDefaults,
-    cells::{MemberCell, ObservationTxn, ReserveError, ScopeCell},
+    cells::{MemberCell, ObservationTxn, ReserveError, ScopeCell, StaticReserveError},
     definition::DefinitionSource,
     identity::{MembershipReconciliation, ScopeIdentity},
     policy::{CommonOptions, ResolvedCommonOptions, ResolvedDefaults, ScopeFlavor, resolve_common},
@@ -33,15 +33,21 @@ pub(crate) fn mint_reserved_slot(
     id: &ChildId,
     child_scope: Option<ScopeFlavor>,
 ) -> Result<Arc<SlotCell>, ReserveError> {
-    let membership = parent
-        .mint_membership(id)
-        .ok_or(ReserveError::IdentityExhausted)?;
+    mint_reserved_slot_inner(parent, id, child_scope).ok_or(ReserveError::IdentityExhausted)
+}
+
+fn mint_reserved_slot_inner(
+    parent: &ScopeCell,
+    id: &ChildId,
+    child_scope: Option<ScopeFlavor>,
+) -> Option<Arc<SlotCell>> {
+    let membership = parent.mint_membership(id)?;
     let member = MemberCell::new(id.clone(), membership);
     let scope = child_scope.map(|flavor| {
         let identity = ScopeIdentity::new();
         ScopeCell::new(Arc::clone(&member), flavor, identity)
     });
-    Ok(SlotCell::new(member, scope))
+    Some(SlotCell::new(member, scope))
 }
 
 /// Installs a valid option set for a manually constructed resident fixture,
@@ -342,12 +348,16 @@ impl BuilderCore {
         &mut self,
         id: impl Into<ChildId>,
         scope: Option<ScopeFlavor>,
-    ) -> Result<Arc<SlotCell>, ReserveError> {
-        let id = checked_id(id)?;
-        if self.ids.contains(&id) {
-            return Err(ReserveError::DuplicateId(id));
+    ) -> Result<Arc<SlotCell>, StaticReserveError> {
+        let id = id.into();
+        if id.as_str().is_empty() {
+            return Err(StaticReserveError::EmptyId);
         }
-        let slot = mint_reserved_slot(&self.root, &id, scope)?;
+        if self.ids.contains(&id) {
+            return Err(StaticReserveError::DuplicateId(id));
+        }
+        let slot = mint_reserved_slot_inner(&self.root, &id, scope)
+            .ok_or(StaticReserveError::IdentityExhausted)?;
         self.ids.insert(id);
         self.slots.push(Arc::clone(&slot));
         Ok(slot)

--- a/crates/shelterwood/src/tree/builders.rs
+++ b/crates/shelterwood/src/tree/builders.rs
@@ -2,7 +2,7 @@ use std::{fmt, sync::Arc};
 
 use crate::{
     ActorDef, ActorOnceDef, ActorRef, ChildId, Intensity, ScopeDefaults,
-    cells::ReserveError,
+    cells::StaticReserveError,
     plan::{BuilderCore, LowerError},
     policy::{ResolvedDefaults, ScopeFlavor},
     raw::{RawDef, RawOnceDef},
@@ -29,19 +29,20 @@ pub enum BuildError {
         paths: Vec<ChildId>,
     },
 }
+
 /// Routes a definition rejected before admission through isolated disposal.
 ///
 /// Builder and dynamic-add entry points wrap the definition before evaluating
 /// the caller's `Into<ChildId>` hook or raw readiness metadata. A failed
 /// reservation therefore arrives here already isolated, and dropping the
 /// wrapper cannot run a possibly blocking or panicking user destructor on the
-/// caller instead of producing an ordinary [`ReserveError`]. This guarantee
+/// caller instead of producing an ordinary reservation error. This guarantee
 /// covers the supplied definition only; Rust's ordinary unwind rules still
 /// govern every other caller-owned local.
-pub(super) fn dispose_rejected<D: Send + 'static>(
+pub(super) fn dispose_rejected<D: Send + 'static, E>(
     definition: runtime::Isolated<D>,
-    error: ReserveError,
-) -> ReserveError {
+    error: E,
+) -> E {
     drop(definition);
     error
 }
@@ -50,7 +51,7 @@ fn add_definition<D: Definition>(
     core: &mut BuilderCore,
     id: impl Into<ChildId>,
     definition: D,
-) -> Result<D::Handles, ReserveError> {
+) -> Result<D::Handles, StaticReserveError> {
     let mut definition = runtime::Isolated::new(definition);
     match reserve_static::<D::Kind>(core, id) {
         Ok(slot) => Ok(slot.define(definition.take().expect("isolated definition is available"))),
@@ -84,14 +85,13 @@ macro_rules! impl_common_builder_surface {
         ///
         /// # Errors
         ///
-        /// Fails with [`ReserveError::EmptyId`] or
-        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
-        /// [`ReserveError::IdentityExhausted`]; no other variant is
-        /// reachable from a pre-spawn builder.
+        /// Fails with [`StaticReserveError::EmptyId`] or
+        /// [`StaticReserveError::DuplicateId`] when the id is unusable, or
+        /// with [`StaticReserveError::IdentityExhausted`].
         pub fn reserve_actor<M: Send + 'static>(
             &mut self,
             id: impl Into<ChildId>,
-        ) -> Result<ActorSlot<M>, ReserveError> {
+        ) -> Result<ActorSlot<M>, StaticReserveError> {
             reserve_static::<ActorKind<M>>(&mut self.core, id).map(|core| ActorSlot { core })
         }
 
@@ -100,15 +100,14 @@ macro_rules! impl_common_builder_surface {
         ///
         /// # Errors
         ///
-        /// Fails with [`ReserveError::EmptyId`] or
-        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
-        /// [`ReserveError::IdentityExhausted`]; no other variant is
-        /// reachable from a pre-spawn builder.
+        /// Fails with [`StaticReserveError::EmptyId`] or
+        /// [`StaticReserveError::DuplicateId`] when the id is unusable, or
+        /// with [`StaticReserveError::IdentityExhausted`].
         pub fn add_actor<A: crate::Actor>(
             &mut self,
             id: impl Into<ChildId>,
             definition: ActorDef<A>,
-        ) -> Result<ActorRef<A::Msg>, ReserveError> {
+        ) -> Result<ActorRef<A::Msg>, StaticReserveError> {
             add_definition(&mut self.core, id, definition)
         }
 
@@ -117,15 +116,14 @@ macro_rules! impl_common_builder_surface {
         ///
         /// # Errors
         ///
-        /// Fails with [`ReserveError::EmptyId`] or
-        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
-        /// [`ReserveError::IdentityExhausted`]; no other variant is
-        /// reachable from a pre-spawn builder.
+        /// Fails with [`StaticReserveError::EmptyId`] or
+        /// [`StaticReserveError::DuplicateId`] when the id is unusable, or
+        /// with [`StaticReserveError::IdentityExhausted`].
         pub fn add_actor_once<A: crate::Actor>(
             &mut self,
             id: impl Into<ChildId>,
             definition: ActorOnceDef<A>,
-        ) -> Result<ActorRef<A::Msg>, ReserveError> {
+        ) -> Result<ActorRef<A::Msg>, StaticReserveError> {
             add_definition(&mut self.core, id, definition)
         }
 
@@ -134,15 +132,14 @@ macro_rules! impl_common_builder_surface {
         ///
         /// # Errors
         ///
-        /// Fails with [`ReserveError::EmptyId`] or
-        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
-        /// [`ReserveError::IdentityExhausted`]; no other variant is
-        /// reachable from a pre-spawn builder.
+        /// Fails with [`StaticReserveError::EmptyId`] or
+        /// [`StaticReserveError::DuplicateId`] when the id is unusable, or
+        /// with [`StaticReserveError::IdentityExhausted`].
         pub fn add_raw<R: crate::RawActor>(
             &mut self,
             id: impl Into<ChildId>,
             definition: RawDef<R>,
-        ) -> Result<ActorRef<R::Msg>, ReserveError> {
+        ) -> Result<ActorRef<R::Msg>, StaticReserveError> {
             add_definition(&mut self.core, id, definition)
         }
 
@@ -151,15 +148,14 @@ macro_rules! impl_common_builder_surface {
         ///
         /// # Errors
         ///
-        /// Fails with [`ReserveError::EmptyId`] or
-        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
-        /// [`ReserveError::IdentityExhausted`]; no other variant is
-        /// reachable from a pre-spawn builder.
+        /// Fails with [`StaticReserveError::EmptyId`] or
+        /// [`StaticReserveError::DuplicateId`] when the id is unusable, or
+        /// with [`StaticReserveError::IdentityExhausted`].
         pub fn add_raw_once<R: crate::RawActor>(
             &mut self,
             id: impl Into<ChildId>,
             definition: RawOnceDef<R>,
-        ) -> Result<ActorRef<R::Msg>, ReserveError> {
+        ) -> Result<ActorRef<R::Msg>, StaticReserveError> {
             add_definition(&mut self.core, id, definition)
         }
 
@@ -168,11 +164,13 @@ macro_rules! impl_common_builder_surface {
         ///
         /// # Errors
         ///
-        /// Fails with [`ReserveError::EmptyId`] or
-        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
-        /// [`ReserveError::IdentityExhausted`]; no other variant is
-        /// reachable from a pre-spawn builder.
-        pub fn reserve_task(&mut self, id: impl Into<ChildId>) -> Result<TaskSlot, ReserveError> {
+        /// Fails with [`StaticReserveError::EmptyId`] or
+        /// [`StaticReserveError::DuplicateId`] when the id is unusable, or
+        /// with [`StaticReserveError::IdentityExhausted`].
+        pub fn reserve_task(
+            &mut self,
+            id: impl Into<ChildId>,
+        ) -> Result<TaskSlot, StaticReserveError> {
             reserve_static::<TaskKind>(&mut self.core, id).map(|core| TaskSlot { core })
         }
 
@@ -181,15 +179,14 @@ macro_rules! impl_common_builder_surface {
         ///
         /// # Errors
         ///
-        /// Fails with [`ReserveError::EmptyId`] or
-        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
-        /// [`ReserveError::IdentityExhausted`]; no other variant is
-        /// reachable from a pre-spawn builder.
+        /// Fails with [`StaticReserveError::EmptyId`] or
+        /// [`StaticReserveError::DuplicateId`] when the id is unusable, or
+        /// with [`StaticReserveError::IdentityExhausted`].
         pub fn add_task(
             &mut self,
             id: impl Into<ChildId>,
             definition: TaskDef,
-        ) -> Result<TaskRef, ReserveError> {
+        ) -> Result<TaskRef, StaticReserveError> {
             add_definition(&mut self.core, id, definition)
         }
 
@@ -198,15 +195,14 @@ macro_rules! impl_common_builder_surface {
         ///
         /// # Errors
         ///
-        /// Fails with [`ReserveError::EmptyId`] or
-        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
-        /// [`ReserveError::IdentityExhausted`]; no other variant is
-        /// reachable from a pre-spawn builder.
+        /// Fails with [`StaticReserveError::EmptyId`] or
+        /// [`StaticReserveError::DuplicateId`] when the id is unusable, or
+        /// with [`StaticReserveError::IdentityExhausted`].
         pub fn add_task_once<T: Send + 'static>(
             &mut self,
             id: impl Into<ChildId>,
             definition: TaskOnceDef<T>,
-        ) -> Result<(TaskRef, OneShotTaskRef<T>), ReserveError> {
+        ) -> Result<(TaskRef, OneShotTaskRef<T>), StaticReserveError> {
             add_definition(&mut self.core, id, definition)
         }
 
@@ -215,14 +211,13 @@ macro_rules! impl_common_builder_surface {
         ///
         /// # Errors
         ///
-        /// Fails with [`ReserveError::EmptyId`] or
-        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
-        /// [`ReserveError::IdentityExhausted`]; no other variant is
-        /// reachable from a pre-spawn builder.
+        /// Fails with [`StaticReserveError::EmptyId`] or
+        /// [`StaticReserveError::DuplicateId`] when the id is unusable, or
+        /// with [`StaticReserveError::IdentityExhausted`].
         pub fn reserve_subtree<T: Subtree>(
             &mut self,
             id: impl Into<ChildId>,
-        ) -> Result<SubtreeSlot<T>, ReserveError> {
+        ) -> Result<SubtreeSlot<T>, StaticReserveError> {
             reserve_static::<SubtreeKind<T>>(&mut self.core, id).map(|core| SubtreeSlot { core })
         }
 
@@ -231,15 +226,14 @@ macro_rules! impl_common_builder_surface {
         ///
         /// # Errors
         ///
-        /// Fails with [`ReserveError::EmptyId`] or
-        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
-        /// [`ReserveError::IdentityExhausted`]; no other variant is
-        /// reachable from a pre-spawn builder.
+        /// Fails with [`StaticReserveError::EmptyId`] or
+        /// [`StaticReserveError::DuplicateId`] when the id is unusable, or
+        /// with [`StaticReserveError::IdentityExhausted`].
         pub fn add_subtree<T: Subtree>(
             &mut self,
             id: impl Into<ChildId>,
             definition: SubtreeDef<T>,
-        ) -> Result<T::Ref, ReserveError> {
+        ) -> Result<T::Ref, StaticReserveError> {
             add_definition(&mut self.core, id, definition)
         }
 
@@ -248,15 +242,14 @@ macro_rules! impl_common_builder_surface {
         ///
         /// # Errors
         ///
-        /// Fails with [`ReserveError::EmptyId`] or
-        /// [`ReserveError::DuplicateId`] when the id is unusable, or with
-        /// [`ReserveError::IdentityExhausted`]; no other variant is
-        /// reachable from a pre-spawn builder.
+        /// Fails with [`StaticReserveError::EmptyId`] or
+        /// [`StaticReserveError::DuplicateId`] when the id is unusable, or
+        /// with [`StaticReserveError::IdentityExhausted`].
         pub fn add_subtree_once<T: Subtree>(
             &mut self,
             id: impl Into<ChildId>,
             definition: SubtreeOnceDef<T>,
-        ) -> Result<T::Ref, ReserveError> {
+        ) -> Result<T::Ref, StaticReserveError> {
             add_definition(&mut self.core, id, definition)
         }
     };

--- a/crates/shelterwood/src/tree/slots.rs
+++ b/crates/shelterwood/src/tree/slots.rs
@@ -2,7 +2,7 @@ use std::{fmt, marker::PhantomData, sync::Arc};
 
 use crate::{
     ActorDef, ActorOnceDef, ActorRef, ChildId,
-    cells::ReserveError,
+    cells::{ReserveError, StaticReserveError},
     driver::DynamicReservation,
     mailbox::{MailboxCell, actor_ref_from_parts},
     plan::{BuilderCore, ChildConstruction, SlotCell},
@@ -161,7 +161,7 @@ impl<E: SlotEndpoint, K: SlotKind> SlotCore<E, K> {
 pub(super) fn reserve_static<K: SlotKind>(
     core: &mut BuilderCore,
     id: impl Into<ChildId>,
-) -> Result<SlotCore<StaticSlotEndpoint, K>, ReserveError> {
+) -> Result<SlotCore<StaticSlotEndpoint, K>, StaticReserveError> {
     core.reserve(id, K::SCOPE_FLAVOR)
         .map(|slot| SlotCore::new(StaticSlotEndpoint(slot)))
 }
@@ -335,6 +335,7 @@ macro_rules! impl_slot_debug {
         }
     };
 }
+
 /// An owned pre-spawn actor slot with a stable mailbox binding.
 pub struct ActorSlot<M> {
     pub(super) core: SlotCore<StaticSlotEndpoint, ActorKind<M>>,
@@ -415,6 +416,7 @@ impl TaskSlot {
         self.core.define(definition)
     }
 }
+
 /// A split dynamic actor reservation with a stable mailbox binding.
 pub struct DynamicActorSlot<M> {
     pub(super) core: SlotCore<DynamicSlotEndpoint, ActorKind<M>>,
@@ -514,6 +516,7 @@ impl<T: Subtree> DynamicSubtreeSlot<T> {
         self.core.define(definition)
     }
 }
+
 /// A typed pre-spawn subtree slot.
 pub struct SubtreeSlot<T: Subtree> {
     pub(super) core: SlotCore<StaticSlotEndpoint, SubtreeKind<T>>,

--- a/crates/shelterwood/src/tree/system.rs
+++ b/crates/shelterwood/src/tree/system.rs
@@ -21,6 +21,7 @@ pub struct StartOrShutdownError {
     /// Stragglers forced down after the rollback bound, if any.
     pub rollback_timeout: Option<ShutdownTimeout>,
 }
+
 /// A restartable subtree definition.
 pub struct SubtreeDef<T: Subtree> {
     factory: Arc<dyn Fn() -> BuilderCore + Send + Sync + 'static>,
@@ -117,6 +118,8 @@ impl<T: Subtree> SubtreeOnceDef<T> {
         }
     }
 }
+
+/// Private dispatch that seals subtree flavor conversion inside the façade.
 #[allow(private_interfaces)]
 pub(super) mod sealed {
     use super::{BuilderCore, DynamicScopeRef, ScopeFlavor, ScopeRef};
@@ -161,7 +164,7 @@ pub trait Subtree: sealed::Sealed + fmt::Debug + Send + 'static {}
 impl Subtree for Tree {}
 
 impl Subtree for DynamicTree {}
-#[must_use = "dropping the sole system owner requests graceful shutdown"]
+
 /// The sole owning handle for a running root system.
 ///
 /// [`Tree::spawn`] and [`DynamicTree::spawn`] return exactly one `System`;
@@ -186,6 +189,7 @@ impl Subtree for DynamicTree {}
 /// it before tearing down the async runtime. The escalation ladder, what a
 /// completed shutdown does and does not guarantee, and runtime-lifetime
 /// obligations are documented in [`crate::guides::shutdown_and_resources`].
+#[must_use = "dropping the sole system owner requests graceful shutdown"]
 pub struct System<R = ScopeRef> {
     pub(super) root: R,
     pub(super) run: crate::driver::SystemRun,

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -7,11 +7,11 @@ use shelterwood::{
     DynamicTree, ExitError, ExitResult, GracePhase, Guard, Handler, Incarnation, Intensity,
     LifecycleEvents, LifecycleTryRecvError, Mailbox, MailboxShutdown, Membership, MembershipStatus,
     NonZeroDuration, OneShotTaskRef, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
-    ReadinessDeadline, Removal, Reply, ReplyReceive, ReplyReceiver, RestartAttempt, RestartCount,
-    RestartPolicy, Retention, ScopeDefaults, ScopeRef, SendError, SendFuture, SendTimeout,
-    Shutdown, SnapshotClosed, SnapshotReceiver, StaticReserveError, StopContext, SubtreeDef,
-    SubtreeOnceDef, SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, TotalRestarts,
-    Tree, WaitError,
+    ReadinessDeadline, Removal, Reply, ReplyReceive, ReplyReceiver, ReserveError, RestartAttempt,
+    RestartCount, RestartPolicy, Retention, ScopeDefaults, ScopeRef, SendError, SendFuture,
+    SendTimeout, Shutdown, SnapshotClosed, SnapshotReceiver, StaticReserveError, StopContext,
+    SubtreeDef, SubtreeOnceDef, SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot,
+    TotalRestarts, Tree, WaitError,
 };
 
 fn assert_error<T: Error>() {}
@@ -206,6 +206,7 @@ impl Actor for ClonedActor {
 #[test]
 fn actor_types_obey_resource_and_payload_trait_contracts() {
     assert_error::<DeadlineElapsed>();
+    assert_error::<ReserveError>();
     assert_error::<StaticReserveError>();
     assert_raw::<Handler<OpaqueActor>>();
     assert_send_type::<Context<'static, OpaqueActor>>();
@@ -370,6 +371,14 @@ fn nominal_add_methods_preserve_the_parallel_typed_surface() {
 
     let _: fn(Tree) -> Result<System<ScopeRef>, BuildError> = Tree::spawn;
     let _: fn(DynamicTree) -> Result<System<DynamicScopeRef>, BuildError> = DynamicTree::spawn;
+
+    let _assert_live_dynamic_reservation_errors = |scope: &DynamicScopeRef| {
+        let _: Result<DynamicActorSlot<Cell<()>>, ReserveError> =
+            scope.reserve_actor("live-actor-slot");
+        let _: Result<DynamicTaskSlot, ReserveError> = scope.reserve_task("live-task-slot");
+        let _: Result<DynamicSubtreeSlot<Tree>, ReserveError> =
+            scope.reserve_subtree("live-subtree-slot");
+    };
 }
 
 #[test]

--- a/crates/shelterwood/tests/api_trait_conformance.rs
+++ b/crates/shelterwood/tests/api_trait_conformance.rs
@@ -7,9 +7,9 @@ use shelterwood::{
     DynamicTree, ExitError, ExitResult, GracePhase, Guard, Handler, Incarnation, Intensity,
     LifecycleEvents, LifecycleTryRecvError, Mailbox, MailboxShutdown, Membership, MembershipStatus,
     NonZeroDuration, OneShotTaskRef, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
-    ReadinessDeadline, Removal, Reply, ReplyReceive, ReplyReceiver, ReserveError, RestartAttempt,
-    RestartCount, RestartPolicy, Retention, ScopeDefaults, ScopeRef, SendError, SendFuture,
-    SendTimeout, Shutdown, SnapshotClosed, SnapshotReceiver, StopContext, SubtreeDef,
+    ReadinessDeadline, Removal, Reply, ReplyReceive, ReplyReceiver, RestartAttempt, RestartCount,
+    RestartPolicy, Retention, ScopeDefaults, ScopeRef, SendError, SendFuture, SendTimeout,
+    Shutdown, SnapshotClosed, SnapshotReceiver, StaticReserveError, StopContext, SubtreeDef,
     SubtreeOnceDef, SubtreeSlot, System, TaskDef, TaskOnceDef, TaskRef, TaskSlot, TotalRestarts,
     Tree, WaitError,
 };
@@ -206,6 +206,7 @@ impl Actor for ClonedActor {
 #[test]
 fn actor_types_obey_resource_and_payload_trait_contracts() {
     assert_error::<DeadlineElapsed>();
+    assert_error::<StaticReserveError>();
     assert_raw::<Handler<OpaqueActor>>();
     assert_send_type::<Context<'static, OpaqueActor>>();
     assert_send_type::<StopContext<'static, OpaqueActor>>();
@@ -300,69 +301,71 @@ fn nominal_add_methods_preserve_the_parallel_typed_surface() {
     let mut ordered = Tree::new();
     let _: &mut Tree = ordered.intensity(Intensity::default());
     let _: &mut Tree = ordered.defaults(ScopeDefaults::default());
-    let _: Result<ActorSlot<Cell<()>>, ReserveError> = ordered.reserve_actor("ordered-actor-slot");
-    let _: Result<ActorRef<()>, ReserveError> =
+    let _: Result<ActorSlot<Cell<()>>, StaticReserveError> =
+        ordered.reserve_actor("ordered-actor-slot");
+    let _: Result<ActorRef<()>, StaticReserveError> =
         ordered.add_actor("ordered-actor", ActorDef::<ClonedActor>::cloned(()));
-    let _: Result<ActorRef<()>, ReserveError> =
+    let _: Result<ActorRef<()>, StaticReserveError> =
         ordered.add_actor_once("ordered-actor-once", ActorOnceDef::<ClonedActor>::new(()));
-    let _: Result<ActorRef<Cell<()>>, ReserveError> = ordered.add_raw(
+    let _: Result<ActorRef<Cell<()>>, StaticReserveError> = ordered.add_raw(
         "ordered-raw",
         RawDef::<OpaqueRaw>::factory(|| OpaqueRaw {
             _not_sync: Cell::new(()),
         }),
     );
-    let _: Result<ActorRef<Cell<()>>, ReserveError> = ordered.add_raw_once(
+    let _: Result<ActorRef<Cell<()>>, StaticReserveError> = ordered.add_raw_once(
         "ordered-raw-once",
         RawOnceDef::new(OpaqueRaw {
             _not_sync: Cell::new(()),
         }),
     );
-    let _: Result<TaskSlot, ReserveError> = ordered.reserve_task("ordered-task-slot");
-    let _: Result<TaskRef, ReserveError> =
+    let _: Result<TaskSlot, StaticReserveError> = ordered.reserve_task("ordered-task-slot");
+    let _: Result<TaskRef, StaticReserveError> =
         ordered.add_task("ordered-task", TaskDef::new(|_| async { Ok(()) }));
-    let _: Result<(TaskRef, OneShotTaskRef<()>), ReserveError> = ordered.add_task_once(
+    let _: Result<(TaskRef, OneShotTaskRef<()>), StaticReserveError> = ordered.add_task_once(
         "ordered-task-once",
         TaskOnceDef::new(|_| async { Ok::<_, ExitError>(()) }),
     );
-    let _: Result<SubtreeSlot<Tree>, ReserveError> =
+    let _: Result<SubtreeSlot<Tree>, StaticReserveError> =
         ordered.reserve_subtree("ordered-subtree-slot");
-    let _: Result<ScopeRef, ReserveError> =
+    let _: Result<ScopeRef, StaticReserveError> =
         ordered.add_subtree("ordered-subtree", SubtreeDef::factory(Tree::new));
-    let _: Result<ScopeRef, ReserveError> =
+    let _: Result<ScopeRef, StaticReserveError> =
         ordered.add_subtree_once("ordered-subtree-once", SubtreeOnceDef::new(Tree::new()));
 
     let mut dynamic = DynamicTree::new();
     let _: &mut DynamicTree = dynamic.intensity(Intensity::default());
     let _: &mut DynamicTree = dynamic.defaults(ScopeDefaults::default());
-    let _: Result<ActorSlot<Cell<()>>, ReserveError> = dynamic.reserve_actor("dynamic-actor-slot");
-    let _: Result<ActorRef<()>, ReserveError> =
+    let _: Result<ActorSlot<Cell<()>>, StaticReserveError> =
+        dynamic.reserve_actor("dynamic-actor-slot");
+    let _: Result<ActorRef<()>, StaticReserveError> =
         dynamic.add_actor("dynamic-actor", ActorDef::<ClonedActor>::cloned(()));
-    let _: Result<ActorRef<()>, ReserveError> =
+    let _: Result<ActorRef<()>, StaticReserveError> =
         dynamic.add_actor_once("dynamic-actor-once", ActorOnceDef::<ClonedActor>::new(()));
-    let _: Result<ActorRef<Cell<()>>, ReserveError> = dynamic.add_raw(
+    let _: Result<ActorRef<Cell<()>>, StaticReserveError> = dynamic.add_raw(
         "dynamic-raw",
         RawDef::<OpaqueRaw>::factory(|| OpaqueRaw {
             _not_sync: Cell::new(()),
         }),
     );
-    let _: Result<ActorRef<Cell<()>>, ReserveError> = dynamic.add_raw_once(
+    let _: Result<ActorRef<Cell<()>>, StaticReserveError> = dynamic.add_raw_once(
         "dynamic-raw-once",
         RawOnceDef::new(OpaqueRaw {
             _not_sync: Cell::new(()),
         }),
     );
-    let _: Result<TaskSlot, ReserveError> = dynamic.reserve_task("dynamic-task-slot");
-    let _: Result<TaskRef, ReserveError> =
+    let _: Result<TaskSlot, StaticReserveError> = dynamic.reserve_task("dynamic-task-slot");
+    let _: Result<TaskRef, StaticReserveError> =
         dynamic.add_task("dynamic-task", TaskDef::new(|_| async { Ok(()) }));
-    let _: Result<(TaskRef, OneShotTaskRef<()>), ReserveError> = dynamic.add_task_once(
+    let _: Result<(TaskRef, OneShotTaskRef<()>), StaticReserveError> = dynamic.add_task_once(
         "dynamic-task-once",
         TaskOnceDef::new(|_| async { Ok::<_, ExitError>(()) }),
     );
-    let _: Result<SubtreeSlot<Tree>, ReserveError> =
+    let _: Result<SubtreeSlot<Tree>, StaticReserveError> =
         dynamic.reserve_subtree("dynamic-subtree-slot");
-    let _: Result<ScopeRef, ReserveError> =
+    let _: Result<ScopeRef, StaticReserveError> =
         dynamic.add_subtree("dynamic-subtree", SubtreeDef::factory(Tree::new));
-    let _: Result<ScopeRef, ReserveError> =
+    let _: Result<ScopeRef, StaticReserveError> =
         dynamic.add_subtree_once("dynamic-subtree-once", SubtreeOnceDef::new(Tree::new()));
 
     let _: fn(Tree) -> Result<System<ScopeRef>, BuildError> = Tree::spawn;

--- a/crates/shelterwood/tests/common/lifecycle.rs
+++ b/crates/shelterwood/tests/common/lifecycle.rs
@@ -1,4 +1,6 @@
-use shelterwood::{ExitKind, LifecycleEvent, LifecycleEventKind, LifecycleEvents, LifecycleItem};
+use shelterwood::{
+    Exit, ExitKind, LifecycleEvent, LifecycleEventKind, LifecycleEvents, LifecycleItem,
+};
 
 pub(crate) async fn next_item(events: &mut LifecycleEvents) -> LifecycleItem {
     tokio::time::timeout(super::POLL_TIMEOUT, events.recv())
@@ -21,6 +23,19 @@ pub(crate) async fn next_event(events: &mut LifecycleEvents) -> LifecycleEvent {
         LifecycleItem::Event(event) => event,
         LifecycleItem::Lagged { dropped } => {
             panic!("unexpected lifecycle lag marker dropping {dropped}")
+        }
+    }
+}
+
+/// Returns the next exit published for `id`, rejecting fixture lag.
+pub(crate) async fn next_exit_of(events: &mut LifecycleEvents, id: &str) -> Exit {
+    loop {
+        if let LifecycleEventKind::Exited {
+            id: exited, exit, ..
+        } = next_event(events).await.kind
+            && exited.as_str() == id
+        {
+            return exit;
         }
     }
 }

--- a/crates/shelterwood/tests/common/lifecycle.rs
+++ b/crates/shelterwood/tests/common/lifecycle.rs
@@ -28,6 +28,10 @@ pub(crate) async fn next_event(events: &mut LifecycleEvents) -> LifecycleEvent {
 }
 
 /// Returns the next exit published for `id`, rejecting fixture lag.
+///
+/// It stops at the *first* matching exit, so it judges one incarnation only.
+/// A fixture that restarts the child and means the final exit wants
+/// [`last_panic_message`]'s drain-to-closure shape instead.
 pub(crate) async fn next_exit_of(events: &mut LifecycleEvents, id: &str) -> Exit {
     loop {
         if let LifecycleEventKind::Exited {

--- a/crates/shelterwood/tests/common/mod.rs
+++ b/crates/shelterwood/tests/common/mod.rs
@@ -22,7 +22,8 @@ pub(crate) use timing::{
     poll_until_ready,
 };
 pub(crate) use waker::{
-    LiveWakerCounter, OrdinalWakerState, counting_waker, hostile_waker, ordinal_waker,
+    LiveWakerCounter, OrdinalWakerState, counting_waker, hostile_waker, ordinal_drop_waker,
+    ordinal_waker,
 };
 
 macro_rules! assert_eventually {

--- a/crates/shelterwood/tests/common/mod.rs
+++ b/crates/shelterwood/tests/common/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod waiting;
 mod waker;
 
 pub(crate) use gates::{DestructorBlocker, DestructorGate, ReleaseGate};
-pub(crate) use lifecycle::{last_panic_message, next_event, next_item};
+pub(crate) use lifecycle::{last_panic_message, next_event, next_exit_of, next_item};
 pub(crate) use ownership::{ConsumeCount, ConsumeGuard, LiveFlag, PanicOnDrop};
 pub(crate) use recorder::{GatedRecorder, MessageRecorder};
 pub(crate) use startup::startup_failed_child;
@@ -21,7 +21,9 @@ pub(crate) use timing::{
     POLL_TIMEOUT, advance_time, assert_eventually_predicate, assert_quiet, poll_once, poll_until,
     poll_until_ready,
 };
-pub(crate) use waker::hostile_waker;
+pub(crate) use waker::{
+    LiveWakerCounter, OrdinalWakerState, counting_waker, hostile_waker, ordinal_waker,
+};
 
 macro_rules! assert_eventually {
     ($predicate:expr $(,)?) => {

--- a/crates/shelterwood/tests/common/waker.rs
+++ b/crates/shelterwood/tests/common/waker.rs
@@ -1,8 +1,159 @@
 use std::{
     mem::ManuallyDrop,
-    sync::Arc,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
     task::{RawWaker, RawWakerVTable, Waker},
 };
+
+#[derive(Default)]
+pub(crate) struct LiveWakerCounter(AtomicUsize);
+
+impl LiveWakerCounter {
+    pub(crate) fn live(&self) -> usize {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+unsafe fn clone_counting_waker(data: *const ()) -> RawWaker {
+    // SAFETY: every pointer using this vtable came from an Arc of the
+    // matching type. ManuallyDrop preserves the reference represented by
+    // `data`; the returned raw waker owns only the new clone.
+    let state = ManuallyDrop::new(unsafe { Arc::<LiveWakerCounter>::from_raw(data.cast()) });
+    state.0.fetch_add(1, Ordering::SeqCst);
+    RawWaker::new(
+        Arc::into_raw(Arc::clone(&state)).cast(),
+        &COUNTING_WAKER_VTABLE,
+    )
+}
+
+unsafe fn wake_counting_waker(data: *const ()) {
+    // SAFETY: wake consumes the Arc reference represented by this raw waker.
+    let state = unsafe { Arc::<LiveWakerCounter>::from_raw(data.cast()) };
+    state.0.fetch_sub(1, Ordering::SeqCst);
+}
+
+unsafe fn wake_by_ref_counting_waker(_data: *const ()) {}
+
+unsafe fn drop_counting_waker(data: *const ()) {
+    // SAFETY: drop consumes the Arc reference represented by this raw waker.
+    let state = unsafe { Arc::<LiveWakerCounter>::from_raw(data.cast()) };
+    state.0.fetch_sub(1, Ordering::SeqCst);
+}
+
+static COUNTING_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    clone_counting_waker,
+    wake_counting_waker,
+    wake_by_ref_counting_waker,
+    drop_counting_waker,
+);
+
+pub(crate) fn counting_waker(counter: &Arc<LiveWakerCounter>) -> Waker {
+    // Include the caller-owned waker in the live count so every handle using
+    // this vtable has the same balanced clone/drop accounting.
+    counter.0.fetch_add(1, Ordering::SeqCst);
+    let raw = RawWaker::new(
+        Arc::into_raw(Arc::clone(counter)).cast(),
+        &COUNTING_WAKER_VTABLE,
+    );
+    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+    // ownership across clone, wake, and drop.
+    unsafe { Waker::from_raw(raw) }
+}
+
+struct OrdinalWaker {
+    ordinal: usize,
+    shared: Arc<OrdinalWakerState>,
+}
+
+pub(crate) struct OrdinalWakerState {
+    clones: AtomicUsize,
+    target: AtomicUsize,
+    action: Mutex<Option<Box<dyn FnOnce() + Send>>>,
+}
+
+impl OrdinalWakerState {
+    pub(crate) fn clones(&self) -> usize {
+        self.clones.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn target_latest_clone(&self, path: &str) {
+        let target = self.clones();
+        assert_ne!(target, 0, "{path} registers a caller waker");
+        self.target.store(target, Ordering::SeqCst);
+    }
+}
+
+unsafe fn clone_ordinal_waker(data: *const ()) -> RawWaker {
+    // SAFETY: every pointer using this vtable came from an Arc of the
+    // matching type. ManuallyDrop preserves the reference represented by
+    // `data`; the returned raw waker owns only the new clone.
+    let current = ManuallyDrop::new(unsafe { Arc::<OrdinalWaker>::from_raw(data.cast()) });
+    let ordinal = current.shared.clones.fetch_add(1, Ordering::SeqCst) + 1;
+    RawWaker::new(
+        Arc::into_raw(Arc::new(OrdinalWaker {
+            ordinal,
+            shared: Arc::clone(&current.shared),
+        }))
+        .cast(),
+        &ORDINAL_WAKER_VTABLE,
+    )
+}
+
+unsafe fn wake_ordinal_waker(data: *const ()) {
+    // SAFETY: wake consumes the Arc reference represented by this raw waker.
+    unsafe { retire_ordinal_waker(data) };
+}
+
+unsafe fn wake_by_ref_ordinal_waker(_data: *const ()) {}
+
+unsafe fn retire_ordinal_waker(data: *const ()) {
+    // SAFETY: retirement consumes the Arc reference represented by this raw
+    // waker.
+    let current = unsafe { Arc::<OrdinalWaker>::from_raw(data.cast()) };
+    if current.ordinal != current.shared.target.load(Ordering::SeqCst) {
+        return;
+    }
+    let action = current
+        .shared
+        .action
+        .lock()
+        .expect("ordinal waker mutex poisoned")
+        .take();
+    if let Some(action) = action {
+        action();
+    }
+}
+
+static ORDINAL_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    clone_ordinal_waker,
+    wake_ordinal_waker,
+    wake_by_ref_ordinal_waker,
+    retire_ordinal_waker,
+);
+
+pub(crate) fn ordinal_waker(
+    target: usize,
+    action: impl FnOnce() + Send + 'static,
+) -> (Waker, Arc<OrdinalWakerState>) {
+    let shared = Arc::new(OrdinalWakerState {
+        clones: AtomicUsize::new(0),
+        target: AtomicUsize::new(target),
+        action: Mutex::new(Some(Box::new(action))),
+    });
+    let raw = RawWaker::new(
+        Arc::into_raw(Arc::new(OrdinalWaker {
+            ordinal: 0,
+            shared: Arc::clone(&shared),
+        }))
+        .cast(),
+        &ORDINAL_WAKER_VTABLE,
+    );
+    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
+    // ownership across clone, wake, and drop.
+    (unsafe { Waker::from_raw(raw) }, shared)
+}
 
 struct HostileWakerState {
     drop_panic: &'static str,

--- a/crates/shelterwood/tests/common/waker.rs
+++ b/crates/shelterwood/tests/common/waker.rs
@@ -70,6 +70,7 @@ struct OrdinalWaker {
 pub(crate) struct OrdinalWakerState {
     clones: AtomicUsize,
     target: AtomicUsize,
+    action_on_wake: bool,
     action: Mutex<Option<Box<dyn FnOnce() + Send>>>,
 }
 
@@ -103,7 +104,10 @@ unsafe fn clone_ordinal_waker(data: *const ()) -> RawWaker {
 
 unsafe fn wake_ordinal_waker(data: *const ()) {
     // SAFETY: wake consumes the Arc reference represented by this raw waker.
-    unsafe { retire_ordinal_waker(data) };
+    let current = unsafe { Arc::<OrdinalWaker>::from_raw(data.cast()) };
+    if current.shared.action_on_wake {
+        run_ordinal_action(&current);
+    }
 }
 
 unsafe fn wake_by_ref_ordinal_waker(_data: *const ()) {}
@@ -112,6 +116,10 @@ unsafe fn retire_ordinal_waker(data: *const ()) {
     // SAFETY: retirement consumes the Arc reference represented by this raw
     // waker.
     let current = unsafe { Arc::<OrdinalWaker>::from_raw(data.cast()) };
+    run_ordinal_action(&current);
+}
+
+fn run_ordinal_action(current: &OrdinalWaker) {
     if current.ordinal != current.shared.target.load(Ordering::SeqCst) {
         return;
     }
@@ -133,13 +141,33 @@ static ORDINAL_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
     retire_ordinal_waker,
 );
 
+/// Creates an ordinal waker whose target action runs when the target is
+/// retired by either consuming `wake` or `drop`.
 pub(crate) fn ordinal_waker(
     target: usize,
+    action: impl FnOnce() + Send + 'static,
+) -> (Waker, Arc<OrdinalWakerState>) {
+    make_ordinal_waker(target, true, action)
+}
+
+/// Creates an ordinal waker whose target action runs only from the vtable's
+/// `drop` operation, not its consuming `wake` operation.
+pub(crate) fn ordinal_drop_waker(
+    target: usize,
+    action: impl FnOnce() + Send + 'static,
+) -> (Waker, Arc<OrdinalWakerState>) {
+    make_ordinal_waker(target, false, action)
+}
+
+fn make_ordinal_waker(
+    target: usize,
+    action_on_wake: bool,
     action: impl FnOnce() + Send + 'static,
 ) -> (Waker, Arc<OrdinalWakerState>) {
     let shared = Arc::new(OrdinalWakerState {
         clones: AtomicUsize::new(0),
         target: AtomicUsize::new(target),
+        action_on_wake,
         action: Mutex::new(Some(Box::new(action))),
     });
     let raw = RawWaker::new(

--- a/crates/shelterwood/tests/disposal.rs
+++ b/crates/shelterwood/tests/disposal.rs
@@ -17,13 +17,13 @@ use std::{
 
 use crate::common::{
     DestructorBlocker, DestructorGate, POLL_TIMEOUT, PanicOnDrop, ReleaseGate, advance_time,
-    assert_eventually, assert_quiet, next_event, policy::never, poll_once,
+    assert_eventually, assert_quiet, next_exit_of, policy::never, poll_once,
 };
 use shelterwood::{
     Backoff, CallErrorKind, Cancellation, ChildId, ChildState, DynamicTree, ExitError, ExitKind,
-    ExitResult, Jitter, LifecycleEventKind, Mailbox, RawActor, RawContext, RawDef, RawOnceDef,
-    Readiness, ReadinessDeadline, RemoveOutcome, Reply, ReserveError, RestartCondition,
-    RestartPolicy, ScopeState, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
+    ExitResult, Jitter, Mailbox, RawActor, RawContext, RawDef, RawOnceDef, Readiness,
+    ReadinessDeadline, RemoveOutcome, Reply, ReserveError, RestartCondition, RestartPolicy,
+    ScopeState, StaticReserveError, SubtreeOnceDef, TaskDef, TaskOnceDef, Tree,
 };
 
 struct DropProbe {
@@ -347,13 +347,7 @@ async fn panicking_unread_messages_are_all_disposed_without_reclassifying_the_ac
         "one payload panic must not strand the remaining unread messages"
     )
     .await;
-    let exit = loop {
-        if let LifecycleEventKind::Exited { id, exit, .. } = next_event(&mut lifecycle).await.kind
-            && id.as_str() == "unread"
-        {
-            break exit;
-        }
-    };
+    let exit = next_exit_of(&mut lifecycle, "unread").await;
     assert!(matches!(exit.kind(), ExitKind::Completed));
     assert_eq!(exit.cancellation(), Cancellation::Observed);
 }
@@ -1358,7 +1352,7 @@ async fn duplicate_id_rejection_disposes_blocking_definition_off_the_caller() {
             }),
         )
         .expect_err("duplicate id is rejected");
-    assert!(matches!(error, ReserveError::DuplicateId(id) if id.as_str() == "dup"));
+    assert!(matches!(error, StaticReserveError::DuplicateId(id) if id.as_str() == "dup"));
 
     wait_for_destructor(&gate).await;
     assert_disposed_off_current(
@@ -1497,7 +1491,7 @@ async fn duplicate_id_rejection_contains_definition_destructor_panic() {
             }),
         )
         .expect_err("duplicate id is rejected without unwinding the caller");
-    assert!(matches!(error, ReserveError::DuplicateId(id) if id.as_str() == "dup"));
+    assert!(matches!(error, StaticReserveError::DuplicateId(id) if id.as_str() == "dup"));
     assert_disposed_off_current(
         &mut drops,
         "rejected definition reports its disposal thread",
@@ -1901,13 +1895,7 @@ async fn blocking_offload_panic_remains_primary_over_factory_destructor_panic() 
     run.release();
     assert_eq!(system.wait().await, shelterwood::StopReason::Finished);
 
-    let exit = loop {
-        if let LifecycleEventKind::Exited { id, exit, .. } = next_event(&mut lifecycle).await.kind
-            && id.as_str() == "offload-precedence"
-        {
-            break exit;
-        }
-    };
+    let exit = next_exit_of(&mut lifecycle, "offload-precedence").await;
     assert!(matches!(
         exit.kind(),
         ExitKind::Panicked { message }

--- a/crates/shelterwood/tests/drain.rs
+++ b/crates/shelterwood/tests/drain.rs
@@ -8,11 +8,10 @@ use std::{
     time::Duration,
 };
 
-use crate::common::{ReleaseGate, assert_eventually, assert_quiet, next_event, poll_until};
+use crate::common::{ReleaseGate, assert_eventually, assert_quiet, next_exit_of, poll_until};
 use shelterwood::{
     Actor, ActorOnceDef, Cancellation, Context, Exit, ExitError, ExitKind, ExitResult, GracePhase,
-    LifecycleEventKind, LifecycleEvents, Mailbox, MailboxShutdown, SendErrorKind, Shutdown,
-    StopContext, Tree,
+    Mailbox, MailboxShutdown, SendErrorKind, Shutdown, StopContext, Tree,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -412,16 +411,6 @@ struct FaultOutcome {
     blocking_result: usize,
 }
 
-async fn exited_actor(events: &mut LifecycleEvents) -> Exit {
-    loop {
-        if let LifecycleEventKind::Exited { id, exit, .. } = next_event(events).await.kind
-            && id.as_str() == "actor"
-        {
-            return exit;
-        }
-    }
-}
-
 async fn run_fault_fixture(
     mode: FaultMode,
     mailbox_shutdown: MailboxShutdown,
@@ -499,7 +488,7 @@ async fn run_fault_fixture(
         .expect("shutdown task joins")
         .expect("the child policy bounds shutdown");
     let elapsed = tokio::time::Instant::now() - started_at;
-    let exit = exited_actor(&mut events).await;
+    let exit = next_exit_of(&mut events, "actor").await;
     let drained = drained.load(Ordering::SeqCst);
     // Tying the observation count to `drained` keeps an absent handler from
     // passing: a mode that never drains records nothing and expects nothing.

--- a/crates/shelterwood/tests/dynamic.rs
+++ b/crates/shelterwood/tests/dynamic.rs
@@ -47,9 +47,9 @@ async fn wait_for_id_release(scope: &DynamicScopeRef, id: &str) {
     .await;
 }
 
-struct DropProbe(Arc<AtomicBool>);
+struct FlagDropProbe(Arc<AtomicBool>);
 
-impl Drop for DropProbe {
+impl Drop for FlagDropProbe {
     fn drop(&mut self) {
         self.0.store(true, Ordering::SeqCst);
     }
@@ -700,7 +700,7 @@ async fn reserved_cell_removal_wins_a_queued_split_definition() {
     let task = slot.task_ref();
     let removed = scope.remove("reserved");
     let admission = slot.define(TaskDef::new({
-        let probe = DropProbe(Arc::clone(&factory_dropped));
+        let probe = FlagDropProbe(Arc::clone(&factory_dropped));
         move |context| {
             let _ = &probe;
             async move {
@@ -1067,7 +1067,7 @@ async fn removing_a_member_releases_its_factory_before_scope_shutdown() {
             "worker",
             TaskDef::new({
                 let started = Arc::clone(&started);
-                let probe = DropProbe(Arc::clone(&factory_dropped));
+                let probe = FlagDropProbe(Arc::clone(&factory_dropped));
                 move |context| {
                     let _ = &probe;
                     started.store(true, Ordering::SeqCst);
@@ -1656,7 +1656,7 @@ async fn removal_of_a_polled_split_definition_keeps_the_scope_admitting() {
     let slot = scope.reserve_task("worker").expect("reservation succeeds");
     let task = slot.task_ref();
     let mut admission = Box::pin(slot.define(TaskDef::new({
-        let probe = DropProbe(Arc::clone(&factory_dropped));
+        let probe = FlagDropProbe(Arc::clone(&factory_dropped));
         move |context| {
             let _ = &probe;
             async move {

--- a/crates/shelterwood/tests/mailbox_future_drop_containment.rs
+++ b/crates/shelterwood/tests/mailbox_future_drop_containment.rs
@@ -10,6 +10,8 @@
 //! runner (`cargo test`) an abort would instead take the whole binary down --
 //! still a loud failure, but an unattributed one.
 
+mod common;
+
 use std::{
     future::Future,
     mem::ManuallyDrop,
@@ -17,12 +19,13 @@ use std::{
     pin::Pin,
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, Ordering},
     },
     task::{Context as TaskContext, Poll, RawWaker, RawWakerVTable, Waker},
     time::Duration,
 };
 
+use common::ordinal_waker;
 use shelterwood::{Actor, ActorOnceDef, Context, ExitError, ExitResult, Reply, Tree};
 
 const OUTER_PANIC: &str = "injected outer panic";
@@ -161,46 +164,7 @@ async fn recv_drop_contains_receiver_waker_during_unwind() {
     assert_pending_then_unwind(Box::pin(receiver.recv(Duration::MAX)));
 }
 
-/// Numbers the caller-waker clones a single poll hands out so the regression
-/// can aim at one of them. `Deadlined::poll` registers the operation's clone
-/// first and the timer proxy's stored caller second. The timer itself sees
-/// only the stable framework-owned proxy, so it does not mint another clone
-/// through this hostile vtable.
-///
-/// This counter is process-global but only this vtable bumps it, and only the
-/// one test below installs this vtable, so the ordinals stay dense under any
-/// runner.
-static CLONES_MINTED: AtomicUsize = AtomicUsize::new(0);
 const TIMER_CALLER_WAKER_ORDINAL: usize = 2;
-
-unsafe fn clone_ordinal_waker(_data: *const ()) -> RawWaker {
-    let ordinal = CLONES_MINTED.fetch_add(1, Ordering::SeqCst) + 1;
-    RawWaker::new(std::ptr::without_provenance(ordinal), &ORDINAL_WAKER_VTABLE)
-}
-
-unsafe fn wake_ordinal_waker(_data: *const ()) {}
-
-unsafe fn wake_by_ref_ordinal_waker(_data: *const ()) {}
-
-unsafe fn drop_ordinal_waker(data: *const ()) {
-    if data.addr() == TIMER_CALLER_WAKER_ORDINAL {
-        panic!("injected timer-proxy caller-waker drop panic");
-    }
-}
-
-static ORDINAL_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-    clone_ordinal_waker,
-    wake_ordinal_waker,
-    wake_by_ref_ordinal_waker,
-    drop_ordinal_waker,
-);
-
-fn ordinal_waker() -> Waker {
-    // SAFETY: the vtable never dereferences its data pointer -- it carries a
-    // clone ordinal, not an address -- so every operation on it is a no-op, a
-    // counter bump, or a panic.
-    unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &ORDINAL_WAKER_VTABLE)) }
-}
 
 /// Stands in for a user reply whose destructor is hostile. Only the abort
 /// half of the regression destroys one; the success path forgets it.
@@ -231,7 +195,13 @@ async fn recv_ready_after_parking_contains_the_retired_timer_waker() {
     let mut future = Box::pin(receiver.recv(Duration::from_secs(30)));
     // The caller-owned waker is deliberately leaked. Only the clones the
     // public future registers are under test.
-    let hostile = ManuallyDrop::new(ordinal_waker());
+    // `Deadlined::poll` registers the operation's clone first and the timer
+    // proxy's stored caller second. The timer itself sees only the stable
+    // framework-owned proxy, so it does not mint another hostile clone.
+    let (hostile, state) = ordinal_waker(TIMER_CALLER_WAKER_ORDINAL, || {
+        panic!("injected timer-proxy caller-waker drop panic")
+    });
+    let hostile = ManuallyDrop::new(hostile);
 
     // Parking registers one clone in the reply channel and one behind the
     // timer proxy; only the proxy-owned caller clone's destructor is hostile.
@@ -241,7 +211,7 @@ async fn recv_ready_after_parking_contains_the_retired_timer_waker() {
     ));
 
     assert_eq!(
-        CLONES_MINTED.load(Ordering::SeqCst),
+        state.clones(),
         TIMER_CALLER_WAKER_ORDINAL,
         "parking must register exactly the operation and timer-proxy caller clones"
     );

--- a/crates/shelterwood/tests/mailbox_future_drop_containment.rs
+++ b/crates/shelterwood/tests/mailbox_future_drop_containment.rs
@@ -25,7 +25,7 @@ use std::{
     time::Duration,
 };
 
-use common::ordinal_waker;
+use common::ordinal_drop_waker;
 use shelterwood::{Actor, ActorOnceDef, Context, ExitError, ExitResult, Reply, Tree};
 
 const OUTER_PANIC: &str = "injected outer panic";
@@ -198,7 +198,7 @@ async fn recv_ready_after_parking_contains_the_retired_timer_waker() {
     // `Deadlined::poll` registers the operation's clone first and the timer
     // proxy's stored caller second. The timer itself sees only the stable
     // framework-owned proxy, so it does not mint another hostile clone.
-    let (hostile, state) = ordinal_waker(TIMER_CALLER_WAKER_ORDINAL, || {
+    let (hostile, state) = ordinal_drop_waker(TIMER_CALLER_WAKER_ORDINAL, || {
         panic!("injected timer-proxy caller-waker drop panic")
     });
     let hostile = ManuallyDrop::new(hostile);

--- a/crates/shelterwood/tests/offloads.rs
+++ b/crates/shelterwood/tests/offloads.rs
@@ -12,12 +12,12 @@ use std::{
 
 use crate::common::{
     POLL_TIMEOUT, PanicOnDrop, ReleaseGate, assert_eventually, assert_quiet, last_panic_message,
-    next_event,
+    next_exit_of,
 };
 use shelterwood::{
     Actor, ActorDef, ActorOnceDef, Context, DeadlineElapsed, ExitError, ExitKind, ExitResult,
-    Guard, Handler, LifecycleEventKind, Mailbox, MailboxShutdown, RawActor, RawContext, RawOnceDef,
-    Readiness, Shutdown, StartupError, StartupFailureCause, StopContext, Tree,
+    Guard, Handler, Mailbox, MailboxShutdown, RawActor, RawContext, RawOnceDef, Readiness,
+    Shutdown, StartupError, StartupFailureCause, StopContext, Tree,
 };
 
 enum ZeroMessage {
@@ -1039,18 +1039,7 @@ async fn cancellation_destructor_panic_wakes_an_otherwise_idle_actor() {
 
     guard.cancel();
 
-    let exit = tokio::time::timeout(POLL_TIMEOUT, async {
-        loop {
-            let event = next_event(&mut events).await;
-            if let LifecycleEventKind::Exited { id, exit, .. } = event.kind
-                && id.as_str() == "idle-offload"
-            {
-                break exit;
-            }
-        }
-    })
-    .await
-    .expect("the retained panic wakes the idle actor");
+    let exit = next_exit_of(&mut events, "idle-offload").await;
     let ExitKind::Panicked { message } = exit.kind() else {
         panic!("expected destructor panic, got {:?}", exit.kind());
     };
@@ -1362,18 +1351,7 @@ async fn hostile_finished_waker_cannot_strand_later_offload_or_exit_publication(
     let mut events = system.scope().subscribe_lifecycle();
 
     actor.send(()).await.expect("actor is live");
-    let exit = tokio::time::timeout(POLL_TIMEOUT, async {
-        loop {
-            let event = next_event(&mut events).await;
-            if let LifecycleEventKind::Exited { id, exit, .. } = event.kind
-                && id.as_str() == "hostile-finished"
-            {
-                break exit;
-            }
-        }
-    })
-    .await
-    .expect("the incarnation publishes its exit without parent shutdown");
+    let exit = next_exit_of(&mut events, "hostile-finished").await;
 
     let ExitKind::Panicked { message } = exit.kind() else {
         panic!("expected hostile-waker panic exit, got {:?}", exit.kind());

--- a/crates/shelterwood/tests/reply_waker_containment.rs
+++ b/crates/shelterwood/tests/reply_waker_containment.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::{
     future::Future,
     sync::Arc,
@@ -5,9 +7,9 @@ use std::{
     time::Duration,
 };
 
+use crate::common::next_exit_of;
 use shelterwood::{
-    Actor, ActorOnceDef, Context, ExitError, ExitKind, ExitResult, LifecycleEventKind,
-    LifecycleItem, Reply, StopReason, Tree,
+    Actor, ActorOnceDef, Context, ExitError, ExitKind, ExitResult, Reply, StopReason, Tree,
 };
 
 const HANDLER_PANIC: &str = "injected reply-owning handler panic";
@@ -83,25 +85,7 @@ async fn unanswered_reply_drop_during_handler_panic_contains_hostile_waker() {
         .await
         .expect("crashing message is accepted");
 
-    let exit = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            match events.recv().await {
-                Some(LifecycleItem::Event(event)) => {
-                    if let LifecycleEventKind::Exited { id, exit, .. } = event.kind
-                        && id.as_str() == "panicking-reply-owner"
-                    {
-                        return exit;
-                    }
-                }
-                Some(LifecycleItem::Lagged { dropped }) => {
-                    panic!("unexpected lifecycle lag marker dropping {dropped}");
-                }
-                None => panic!("lifecycle stream closed before the actor exit"),
-            }
-        }
-    })
-    .await
-    .expect("the actor publishes its contained exit");
+    let exit = next_exit_of(&mut events, "panicking-reply-owner").await;
     assert!(matches!(
         exit.kind(),
         ExitKind::Panicked { message: Some(message) } if message == HANDLER_PANIC

--- a/crates/shelterwood/tests/tasks.rs
+++ b/crates/shelterwood/tests/tasks.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use crate::common::{LiveFlag, assert_eventually};
 use shelterwood::{
     BuildError, Cancellation, DynamicTree, Exit, ExitError, ExitKind, GracePhase, PolicyError,
-    Readiness, ReadinessDeadline, RemoveOutcome, ReserveError, Shutdown, StopReason, TaskDef,
-    TaskOnceDef, Tree,
+    Readiness, ReadinessDeadline, RemoveOutcome, ReserveError, Shutdown, StaticReserveError,
+    StopReason, TaskDef, TaskOnceDef, Tree,
 };
 
 #[test]
@@ -51,12 +51,12 @@ fn declaration_errors_are_eager_and_root_lowering_is_the_only_other_build_error(
     let mut tree = Tree::new();
     assert!(matches!(
         tree.reserve_task(""),
-        Err(shelterwood::ReserveError::EmptyId)
+        Err(StaticReserveError::EmptyId)
     ));
     let slot = tree.reserve_task("duplicate").expect("first id is free");
     assert!(matches!(
         tree.reserve_task("duplicate"),
-        Err(shelterwood::ReserveError::DuplicateId(ref id)) if id.as_str() == "duplicate"
+        Err(StaticReserveError::DuplicateId(ref id)) if id.as_str() == "duplicate"
     ));
     let task = slot.task_ref();
     drop(slot);

--- a/crates/shelterwood/tests/timer_waker_proxy.rs
+++ b/crates/shelterwood/tests/timer_waker_proxy.rs
@@ -34,9 +34,18 @@ impl Actor for IdleActor {
     }
 }
 
+/// The ordinal `Deadlined::poll` hands the timer proxy's stored caller waker.
+/// The operation registers its own clone first, so the timer's is second; the
+/// timer itself only ever sees the stable framework-owned proxy and mints no
+/// further clone through this vtable.
+const TIMER_CALLER_WAKER_ORDINAL: usize = 2;
+
+/// A caller waker whose timer-proxy clone blocks when the framework retires
+/// it. Naming the ordinal rather than blocking on whichever clone retires
+/// first keeps the fixture aimed at the timer seam the tests below describe.
 fn blocking_drop_waker(gate: &DestructorGate, entered: mpsc::Sender<ThreadId>) -> Waker {
     let blocker = gate.blocker();
-    action_ordinal_drop_waker(1, move || {
+    action_ordinal_drop_waker(TIMER_CALLER_WAKER_ORDINAL, move || {
         let _ = entered.send(thread::current().id());
         drop(blocker);
     })

--- a/crates/shelterwood/tests/timer_waker_proxy.rs
+++ b/crates/shelterwood/tests/timer_waker_proxy.rs
@@ -12,7 +12,7 @@ use std::{
 
 use common::{
     DestructorGate, LiveWakerCounter, OrdinalWakerState, POLL_TIMEOUT, counting_waker,
-    ordinal_waker as action_ordinal_waker,
+    ordinal_drop_waker as action_ordinal_drop_waker, ordinal_waker as action_ordinal_waker,
 };
 use shelterwood::{
     Actor, ActorOnceDef, Context, DynamicTree, ExitError, ExitResult, RawActor, RawContext,
@@ -35,7 +35,12 @@ impl Actor for IdleActor {
 }
 
 fn blocking_drop_waker(gate: &DestructorGate, entered: mpsc::Sender<ThreadId>) -> Waker {
-    ordinal_waker(1, gate, entered).0
+    let blocker = gate.blocker();
+    action_ordinal_drop_waker(1, move || {
+        let _ = entered.send(thread::current().id());
+        drop(blocker);
+    })
+    .0
 }
 
 fn ordinal_waker(

--- a/crates/shelterwood/tests/timer_waker_proxy.rs
+++ b/crates/shelterwood/tests/timer_waker_proxy.rs
@@ -4,17 +4,16 @@ use std::{
     future::Future,
     mem::ManuallyDrop,
     pin::Pin,
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
-        mpsc,
-    },
-    task::{Context as TaskContext, Poll, RawWaker, RawWakerVTable, Waker},
+    sync::{Arc, mpsc},
+    task::{Context as TaskContext, Poll, Waker},
     thread::{self, ThreadId},
     time::{Duration, Instant},
 };
 
-use common::{DestructorBlocker, DestructorGate, POLL_TIMEOUT};
+use common::{
+    DestructorGate, LiveWakerCounter, OrdinalWakerState, POLL_TIMEOUT, counting_waker,
+    ordinal_waker as action_ordinal_waker,
+};
 use shelterwood::{
     Actor, ActorOnceDef, Context, DynamicTree, ExitError, ExitResult, RawActor, RawContext,
     RawOnceDef, ScopeRef, Shutdown, TaskDef, Tree,
@@ -35,208 +34,20 @@ impl Actor for IdleActor {
     }
 }
 
-struct BlockingDropWaker {
-    blocked: AtomicBool,
-    blocker: Mutex<Option<DestructorBlocker>>,
-    entered: mpsc::Sender<ThreadId>,
-}
-
-unsafe fn clone_blocking_drop_waker(data: *const ()) -> RawWaker {
-    // SAFETY: every pointer using this vtable came from an Arc of the
-    // matching type. ManuallyDrop preserves the reference represented by
-    // `data`; the returned raw waker owns only the new clone.
-    let state = ManuallyDrop::new(unsafe { Arc::<BlockingDropWaker>::from_raw(data.cast()) });
-    RawWaker::new(
-        Arc::into_raw(Arc::clone(&state)).cast(),
-        &BLOCKING_DROP_WAKER_VTABLE,
-    )
-}
-
-unsafe fn wake_blocking_drop_waker(data: *const ()) {
-    // SAFETY: wake consumes the Arc reference represented by this raw waker.
-    drop(unsafe { Arc::<BlockingDropWaker>::from_raw(data.cast()) });
-}
-
-unsafe fn wake_by_ref_blocking_drop_waker(_data: *const ()) {}
-
-unsafe fn drop_blocking_drop_waker(data: *const ()) {
-    // SAFETY: drop consumes the Arc reference represented by this raw waker.
-    let state = unsafe { Arc::<BlockingDropWaker>::from_raw(data.cast()) };
-    if !state.blocked.swap(true, Ordering::SeqCst) {
-        let blocker = state
-            .blocker
-            .lock()
-            .expect("blocking waker mutex poisoned")
-            .take()
-            .expect("the first framework clone owns the blocker");
-        let _ = state.entered.send(thread::current().id());
-        drop(blocker);
-    }
-}
-
-static BLOCKING_DROP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-    clone_blocking_drop_waker,
-    wake_blocking_drop_waker,
-    wake_by_ref_blocking_drop_waker,
-    drop_blocking_drop_waker,
-);
-
 fn blocking_drop_waker(gate: &DestructorGate, entered: mpsc::Sender<ThreadId>) -> Waker {
-    let raw = RawWaker::new(
-        Arc::into_raw(Arc::new(BlockingDropWaker {
-            blocked: AtomicBool::new(false),
-            blocker: Mutex::new(Some(gate.blocker())),
-            entered,
-        }))
-        .cast(),
-        &BLOCKING_DROP_WAKER_VTABLE,
-    );
-    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
-    // ownership across clone, wake, and drop.
-    unsafe { Waker::from_raw(raw) }
+    ordinal_waker(1, gate, entered).0
 }
-
-#[derive(Default)]
-struct LiveWakerCounter(AtomicUsize);
-
-unsafe fn clone_counting_waker(data: *const ()) -> RawWaker {
-    // SAFETY: every pointer using this vtable came from an Arc of the
-    // matching type. ManuallyDrop preserves the reference represented by
-    // `data`; the returned raw waker owns only the new clone.
-    let state = ManuallyDrop::new(unsafe { Arc::<LiveWakerCounter>::from_raw(data.cast()) });
-    state.0.fetch_add(1, Ordering::SeqCst);
-    RawWaker::new(
-        Arc::into_raw(Arc::clone(&state)).cast(),
-        &COUNTING_WAKER_VTABLE,
-    )
-}
-
-unsafe fn wake_counting_waker(data: *const ()) {
-    // SAFETY: wake consumes the Arc reference represented by this raw waker.
-    let state = unsafe { Arc::<LiveWakerCounter>::from_raw(data.cast()) };
-    state.0.fetch_sub(1, Ordering::SeqCst);
-}
-
-unsafe fn wake_by_ref_counting_waker(_data: *const ()) {}
-
-unsafe fn drop_counting_waker(data: *const ()) {
-    // SAFETY: drop consumes the Arc reference represented by this raw waker.
-    let state = unsafe { Arc::<LiveWakerCounter>::from_raw(data.cast()) };
-    state.0.fetch_sub(1, Ordering::SeqCst);
-}
-
-static COUNTING_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-    clone_counting_waker,
-    wake_counting_waker,
-    wake_by_ref_counting_waker,
-    drop_counting_waker,
-);
-
-fn counting_waker(counter: &Arc<LiveWakerCounter>) -> Waker {
-    // Include the caller-owned waker in the live count so every handle using
-    // this vtable has the same balanced clone/drop accounting.
-    counter.0.fetch_add(1, Ordering::SeqCst);
-    let raw = RawWaker::new(
-        Arc::into_raw(Arc::clone(counter)).cast(),
-        &COUNTING_WAKER_VTABLE,
-    );
-    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
-    // ownership across clone, wake, and drop.
-    unsafe { Waker::from_raw(raw) }
-}
-
-struct OrdinalWaker {
-    ordinal: usize,
-    shared: Arc<OrdinalWakerState>,
-}
-
-struct OrdinalWakerState {
-    clones: AtomicUsize,
-    target: AtomicUsize,
-    blocked: AtomicBool,
-    blocker: Mutex<Option<DestructorBlocker>>,
-    entered: mpsc::Sender<ThreadId>,
-}
-
-unsafe fn clone_ordinal_waker(data: *const ()) -> RawWaker {
-    // SAFETY: every pointer using this vtable came from an Arc of the
-    // matching type. ManuallyDrop preserves the reference represented by
-    // `data`; the returned raw waker owns only the new clone.
-    let current = ManuallyDrop::new(unsafe { Arc::<OrdinalWaker>::from_raw(data.cast()) });
-    let ordinal = current.shared.clones.fetch_add(1, Ordering::SeqCst) + 1;
-    RawWaker::new(
-        Arc::into_raw(Arc::new(OrdinalWaker {
-            ordinal,
-            shared: Arc::clone(&current.shared),
-        }))
-        .cast(),
-        &ORDINAL_WAKER_VTABLE,
-    )
-}
-
-unsafe fn wake_ordinal_waker(data: *const ()) {
-    // SAFETY: wake consumes the Arc reference represented by this raw waker.
-    unsafe { drop_ordinal_waker(data) };
-}
-
-unsafe fn wake_by_ref_ordinal_waker(_data: *const ()) {}
-
-unsafe fn drop_ordinal_waker(data: *const ()) {
-    // SAFETY: drop consumes the Arc reference represented by this raw waker.
-    let current = unsafe { Arc::<OrdinalWaker>::from_raw(data.cast()) };
-    if current.ordinal == current.shared.target.load(Ordering::SeqCst)
-        && !current.shared.blocked.swap(true, Ordering::SeqCst)
-    {
-        let blocker = current
-            .shared
-            .blocker
-            .lock()
-            .expect("ordinal waker mutex poisoned")
-            .take()
-            .expect("the targeted framework clone owns the blocker");
-        let _ = current.shared.entered.send(thread::current().id());
-        drop(blocker);
-    }
-}
-
-static ORDINAL_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-    clone_ordinal_waker,
-    wake_ordinal_waker,
-    wake_by_ref_ordinal_waker,
-    drop_ordinal_waker,
-);
 
 fn ordinal_waker(
     target: usize,
     gate: &DestructorGate,
     entered: mpsc::Sender<ThreadId>,
 ) -> (Waker, Arc<OrdinalWakerState>) {
-    let shared = Arc::new(OrdinalWakerState {
-        clones: AtomicUsize::new(0),
-        target: AtomicUsize::new(target),
-        blocked: AtomicBool::new(false),
-        blocker: Mutex::new(Some(gate.blocker())),
-        entered,
-    });
-    let raw = RawWaker::new(
-        Arc::into_raw(Arc::new(OrdinalWaker {
-            ordinal: 0,
-            shared: Arc::clone(&shared),
-        }))
-        .cast(),
-        &ORDINAL_WAKER_VTABLE,
-    );
-    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
-    // ownership across clone, wake, and drop.
-    (unsafe { Waker::from_raw(raw) }, shared)
-}
-
-impl OrdinalWakerState {
-    fn target_latest_clone(&self, path: &str) {
-        let target = self.clones.load(Ordering::SeqCst);
-        assert_ne!(target, 0, "{path} registers a caller waker");
-        self.target.store(target, Ordering::SeqCst);
-    }
+    let blocker = gate.blocker();
+    action_ordinal_waker(target, move || {
+        let _ = entered.send(thread::current().id());
+        drop(blocker);
+    })
 }
 
 fn poll_until_registered<F>(runtime: &tokio::runtime::Runtime, future: Pin<&mut F>, path: &str)
@@ -261,7 +72,7 @@ where
         // The caller owns one live handle. Two additional handles prove the
         // operation and timer are both parked; repeatedly replacing one
         // registration can no longer satisfy the preparation condition.
-        if counter.0.load(Ordering::SeqCst) >= 3 {
+        if counter.live() >= 3 {
             return;
         }
         assert!(
@@ -607,7 +418,7 @@ impl RawActor for RawRecvTimerProbe {
                 .poll(&mut TaskContext::from_waker(&hostile))
                 .is_pending()
         );
-        let _ = self.polled.send(self.clones.clones.load(Ordering::SeqCst));
+        let _ = self.polled.send(self.clones.clones());
         drop(receive);
         let _ = self.cancelled.send(thread::current().id());
         Ok(())

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -1573,16 +1573,19 @@ The shape is content-normative (Appendix B's latitude on exact names
 applies):
 
 ```rust
-// On ordered tree builders and on DynamicScopeRef alike — reservation is
-// synchronous on both flavors, and is where the id errors reject (rules
-// below). Receivers differ by flavor: `&mut self` on builders (plain
-// owned values, §12 — exclusive access is free), `&self` on
-// `DynamicScopeRef` (a cheap-`Clone` shared handle, B.10 — `&mut`
-// would be bypassable by cloning and is not pretended); `add_*`
-// follows the same split:
-fn reserve_actor<M: Send + 'static>(&mut self, id: …) -> Result<ActorSlot<M>, ReserveError>;
-fn reserve_task(&mut self, id: …) -> Result<TaskSlot, ReserveError>;
-fn reserve_subtree<T: Subtree>(&mut self, id: …) -> Result<SubtreeSlot<T>, ReserveError>;
+// Reservation is synchronous on both flavors and is where id errors reject
+// (rules below). Pre-spawn builders take `&mut self` (plain owned values,
+// §12 — exclusive access is free) and return the three-variant
+// `StaticReserveError`; `DynamicScopeRef` takes `&self` (a cheap-`Clone`
+// shared handle, B.10 — `&mut` would be bypassable by cloning and is not
+// pretended) and returns `ReserveError`. `add_*` follows the same split:
+fn reserve_actor<M: Send + 'static>(&mut self, id: …) -> Result<ActorSlot<M>, StaticReserveError>;
+fn reserve_task(&mut self, id: …) -> Result<TaskSlot, StaticReserveError>;
+fn reserve_subtree<T: Subtree>(&mut self, id: …) -> Result<SubtreeSlot<T>, StaticReserveError>;
+
+fn reserve_actor<M: Send + 'static>(&self, id: …) -> Result<DynamicActorSlot<M>, ReserveError>;
+fn reserve_task(&self, id: …) -> Result<DynamicTaskSlot, ReserveError>;
+fn reserve_subtree<T: Subtree>(&self, id: …) -> Result<DynamicSubtreeSlot<T>, ReserveError>;
 
 // Slots are owned and non-`Clone`. Handles are available immediately —
 // before define, before spawn (§3.2):
@@ -3847,7 +3850,10 @@ observes `NotAdmitting(Terminal)` and a latched removal observes
 Debug builds MAY instead assert and panic at that boundary to expose the
 internal regression instead of returning an outcome.
 
-The public `ReserveError` is exhaustive and includes `NoRuntime`: it
+The public `StaticReserveError` is exhaustive and contains exactly
+`EmptyId`, `DuplicateId`, and `IdentityExhausted`: pre-spawn builders
+cannot observe runtime or admission state. The public dynamic
+`ReserveError` is exhaustive and includes `NoRuntime`: it
 names the absent ambient runtime at dynamic reservation or first poll,
 with the cleanup and precedence pinned in §9. Dynamic `add_*` fails with
 exactly the union of its two halves (§9): `EmptyId`, `NoRuntime`,

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -3878,8 +3878,9 @@ Defines add no definition-validation errors: validation is spent eagerly
 at spec construction (§10.3), on both flavors. A dynamic define still
 crosses §9's admission boundary, so it can return `NoRuntime` at first
 poll or `NotAdmitting`; declaration builders share the reserve id errors
-(`EmptyId`, `DuplicateId`), require no runtime for reservation or
-define, and their defines cannot fail (§9).
+(`EmptyId`, `DuplicateId`, `IdentityExhausted`) through
+`StaticReserveError`, require no runtime for reservation or define, and
+their defines cannot fail (§9).
 
 `BuildError` (spawn-time, §12) is enumerated and exhaustive pre-release:
 `NoRuntime` (no ambient async runtime reachable through the private

--- a/tools/check-external-consumer.sh
+++ b/tools/check-external-consumer.sh
@@ -56,6 +56,8 @@ for seam in \
     ErasedOneShotSender \
     MailboxCell \
     MailboxControl \
+    MailboxEffectQueue \
+    MailboxEffectSink \
     MailboxRuntime \
     MailboxSignal \
     MailboxSignalWatcher \

--- a/tools/external-consumer/src/main.rs
+++ b/tools/external-consumer/src/main.rs
@@ -11,9 +11,10 @@ fn accepts_supported_token(_: &CancellationToken) {}
 #[cfg(feature = "installable-seams")]
 use shelterwood::{
     ActorIdentity, DynamicRoute, ErasedOneShotClose, ErasedOneShotReceiver, ErasedOneShotSender,
-    MailboxCell, MailboxControl, MailboxRuntime, MailboxSignal, MailboxSignalWatcher,
-    MailboxTermination, MemberCell, ParentCancellationToken, ProxiedPoll, ProxiedSleep, ScopeCell,
-    WakerAction, WakerEffects, WakerProxy, WakerSlot, actor_ref_from_parts,
+    MailboxCell, MailboxControl, MailboxEffectQueue, MailboxEffectSink, MailboxRuntime,
+    MailboxSignal, MailboxSignalWatcher, MailboxTermination, MemberCell, ParentCancellationToken,
+    ProxiedPoll, ProxiedSleep, ScopeCell, WakerAction, WakerEffects, WakerProxy, WakerSlot,
+    actor_ref_from_parts,
 };
 
 fn main() {


### PR DESCRIPTION
Closes #428.

## What changed

- Split pre-spawn declaration failures into the exhaustive three-variant `StaticReserveError` (`EmptyId`, `DuplicateId`, `IdentityExhausted`). `Tree` and `DynamicTree` builders now expose only those reachable outcomes; live `DynamicScopeRef` reservation and admission keep the broader `ReserveError`. Updated API conformance coverage, error docs, crate docs, and SPEC §9/§12 accordingly.
- Added `common::next_exit_of` and migrated every current simple “scan until this child id exits” fixture (seven sites across drain, disposal, offloads, and reply-waker containment). The remaining `Exited` matches intentionally stay local because they judge ordering with `Started`/`RestartScheduled`/`Removed`, match membership or incarnation rather than id, count multiple children, or drain a complete stream; routing those through an exit-only helper would discard evidence the tests assert.
- Consolidated the counting and ordinal hostile raw-waker families in `tests/common/waker.rs`. Timer cancellation supplies its blocking action to shared ordinal fixtures, while mailbox completion supplies its panic action; explicit wake-or-drop and drop-only modes preserve each original vtable's exact semantics while removing both duplicated ordinal vtables and the timer-local counting/blocking families.
- Renamed the unrelated dynamic fixture to `FlagDropProbe`, and bounded the lone shutdown `wait_entered` outlier with `DRIVER_PROGRESS_WAIT`.
- Replaced `Context::new(raw, stage)` with dedicated live and frozen-prefix constructors, leaving initialization constructible only through `new_initializing` and its owned initialization boundary.
- Kept `Context::clear_timer -> Result<bool, Rejected<()>>`: the unit payload is intentionally empty, but the rejected result preserves the same diagnosable frozen-prefix refusal as the other context operations.
- Normalized the item spacing and doc/attribute placement identified in the issue.
- Extended the external-consumer installable-seam probe to cover the private `MailboxEffectQueue` and `MailboxEffectSink` names called out in the tracking follow-up.

## Adversarial review

A fresh reviewer found and fixed three issues before readiness:

- The first shared ordinal fixture made the mailbox test's drop-only panic run from consuming `wake` too. The fixture now has explicit modes: timer ordinal actions retain wake-or-drop behavior, while the blocking-drop and mailbox-destructor probes remain drop-only.
- The SPEC's summary paragraph still listed only two static reserve failures. It now names all three `StaticReserveError` variants.
- Replacing static builder signatures had removed `ReserveError` from the API conformance test. The test now pins both error types and explicitly checks the live `DynamicScopeRef` reservation signatures remain `ReserveError`.

The reviewer also mutation-tested the mailbox fixture: temporarily resuming the captured ready-edge waker panic produced the intended SIGABRT double-panic failure, while the restored production boundary passes.

## Verification

- `./tools/dev cargo test -p shelterwood --test timer_waker_proxy` (5 passed)
- `./tools/dev cargo test -p shelterwood --test mailbox_future_drop_containment` (5 passed)
- `./tools/dev cargo test -p shelterwood --test api_trait_conformance` (7 passed)
- affected lifecycle suites: reply-waker containment (1), drain (8), disposal (41), offloads (32), all passed
- focused static-builder and shutdown regressions passed
- initial implementation and post-review `./tools/dev just ci` runs passed: nightly fmt/clippy, 911 nextest tests, doctests, every example, rustdoc/mdBook, API reachability, core manifest, external consumer (including both new seam probes), and Nix formatting
