### PR TITLE
Add GitHub Pages docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Enable shared Nix cache
+        uses: cachix/cachix-action@v17
+        with:
+          name: ralexstokes
+          skipPush: true
+
+      - name: Build docs
+        run: |
+          ./tools/dev mdbook build book
+          ./tools/dev cargo doc --workspace --no-deps --all-features
+          echo '<meta http-equiv="refresh" content="0; url=shelterwood/index.html">' > target/doc/index.html
+
+          mkdir -p _site/api
+          cp -r book/book/. _site/
+          cp -r target/doc/. _site/api/
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - id: deploy
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- build the Shelterwood book and workspace rustdoc on pushes to `main`
- publish the book at the GitHub Pages root and rustdoc under `/api`
- deploy through GitHub Pages with serialized deployments and the required OIDC permissions

Modeled after the [kokage docs workflow](https://github.com/ralexstokes/kokage/blob/main/.github/workflows/docs.yml).

## Testing

- `./tools/dev mdbook build book`
- `./tools/dev cargo doc --workspace --no-deps --all-features`
- assembled the Pages artifact locally and verified the book root, `/api` redirect, and Shelterwood rustdoc entry point
