### PR TITLE
docs(book): add a maintainer-facing internals part

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -15,7 +15,16 @@
 - [Identity, incarnations, and the retry discipline](identity-incarnations-retries.md)
 - [Embedding in a host](embedding.md)
 
----
+# For maintainers
+
+- [The shape of the implementation](internals-shape.md)
+- [The life of a message](internals-message.md)
+- [The life of a child](internals-child.md)
+- [Shutdown from the inside](internals-shutdown.md)
+- [Observation from the inside](internals-observation.md)
+- [Locks, effects, and disposal](internals-concurrency.md)
+
+# Appendices
 
 - [Glossary](appendix-glossary.md)
 - [Where the prose lives](appendix-where-prose-lives.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -18,6 +18,7 @@
 # For maintainers
 
 - [The shape of the implementation](internals-shape.md)
+- [The decision core and its effects](internals-reducer.md)
 - [The life of a message](internals-message.md)
 - [The life of a child](internals-child.md)
 - [Shutdown from the inside](internals-shutdown.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -21,9 +21,11 @@
 - [The decision core and its effects](internals-reducer.md)
 - [The life of a message](internals-message.md)
 - [The life of a child](internals-child.md)
+- [Time, timers, and offloads](internals-time.md)
 - [Shutdown from the inside](internals-shutdown.md)
 - [Observation from the inside](internals-observation.md)
 - [Locks, effects, and disposal](internals-concurrency.md)
+- [How it stays correct](internals-testing.md)
 
 # Appendices
 

--- a/book/src/appendix-where-prose-lives.md
+++ b/book/src/appendix-where-prose-lives.md
@@ -9,6 +9,7 @@ here rather than inventing a new one.
 | rustdoc (crate docs) | API users at the call site | Per-item contracts, `# Errors`/`# Examples`, the crate front page's map of the flat surface | Doctests compile and run in `cargo test --doc`; `-D warnings` denies broken intra-doc links |
 | rustdoc guide pages (`shelterwood::guides`) | API users reading across items | Cross-item contracts: retries and ordering, shutdown and resources, the error catalog | Rendered on docs.rs from `crates/shelterwood/docs/*.md`; their code fences are rustdoc doctests |
 | This book (`book/`) | Newcomers and evaluators | The narrative on-ramp, taught in dependency order | Code blocks are `{{#include}}`s of anchored regions from `examples/`; `mdbook build` in CI proves the anchors resolve |
+| This book, "For maintainers" part | Maintainers arriving at the internals | The descriptive map of the implementation: crate layering, module roles, and the central data flows | Quotes no code — names types, modules, and files; a PR that renames or moves one updates the map in the same change |
 | `crates/shelterwood/examples/` | Everyone above | The tested artifacts the book and README quote | Each ends in assertions; `just examples` runs all of them in CI |
 | `specs/SPEC.md` | Maintainers and reviewers | The normative contract the implementation is held to | Conformance obligations map to tests; adjudication protocol in the tracker |
 | `README.md` | The front door | Orientation and the quickstart quote | Quotes `examples/quickstart.rs`, which CI runs |
@@ -21,3 +22,8 @@ Two corollaries the pass that created this structure settled:
   (`include_str!`, `{{#include}}`), never duplicated.
 - **The book has no test lane.** Its code cannot drift because it is not
   authored in the book at all; the examples are the single tested source.
+
+One boundary the maintainer part observes: it is a *map*, not a second
+normative home. The contract stays in `specs/SPEC.md`, and the invariants
+a diff must uphold stay in `CLAUDE.md` and code comments; the part links
+into both rather than restating them as requirements.

--- a/book/src/internals-child.md
+++ b/book/src/internals-child.md
@@ -5,7 +5,8 @@ restart — the supervision loop that is the library's reason to exist. The
 through-line is SPEC §15.3's pure-decision-core rule: every decision on
 this path is made by a synchronous reducer in `shelterwood-core` fed with
 sampled events, and the driver shell merely executes the effects the
-reducer returns.
+reducer returns — the contract the
+[previous chapter](internals-reducer.md) maps.
 
 ## Declaration
 

--- a/book/src/internals-child.md
+++ b/book/src/internals-child.md
@@ -110,6 +110,44 @@ intensity budget instead, the scope enters drain with
 `StopReason::IntensityTripped`, which escalates to its parent as an
 ordinary child exit.
 
+## Runtime admission
+
+A dynamic scope admits children at runtime through the same machinery,
+with a control-plane protocol in front of it
+(`crates/shelterwood/src/driver/admission_control.rs`). The public
+surface on `DynamicScopeRef` — `add_actor`, `reserve_actor`, and their
+kind siblings — splits into a synchronous *reservation* that claims the
+child id immediately (so a handle can exist before admission resolves,
+and a duplicate id fails fast with a `ReserveError`) and an
+`Admission` future that resolves when the driver actually admits.
+
+The driver samples admission requests as its lowest-arbitration-class
+pending work. `handle_admission` first re-checks liveness — a draining
+scope, a failed startup, or a superseded scope incarnation rejects with
+the matching `NotAdmittingCause` — then builds the `ChildRuntime`
+*outside* the control-plane lock, because conversion can unwind while
+acquiring identity or configuring the mailbox, and driver teardown must
+still be able to close reservations. The install itself is one
+observation-gate transaction holding the dynamic-state mutex: the
+reservation is re-matched, arena insertion and entry promotion happen as
+a single transition (so an exact remover sees either the reservation or
+a resident, never an unindexed intermediate), and
+`admit_child_locked` pushes the incoming projection into residency
+*before* any remaining fallible step. If bookkeeping panics after that
+push, the graph is owned by residency and retires at scope clear as an
+*unannounced* resident — the same rule that keeps snapshots'
+`Added`/`Removed` pairing exact
+([Observation from the inside](internals-observation.md)). Every
+rejection path routes the definition or built child through detached
+disposal rather than dropping it in place.
+
+Admitting a *subtree* adds the gate handoff: the adoptee's observation
+gate is taken while the parent's is held, the one sanctioned doubled
+gate section and the deepest point of that exemption
+([Locks, effects, and disposal](internals-concurrency.md)). Removal —
+the other half of dynamic membership — is covered with the rest of
+teardown in [Shutdown from the inside](internals-shutdown.md).
+
 ## Terminal
 
 A terminal exit first retains the exit (`RetainedExit`) and hands the

--- a/book/src/internals-child.md
+++ b/book/src/internals-child.md
@@ -1,0 +1,124 @@
+# The life of a child
+
+This chapter follows a child from declaration through startup, exit, and
+restart — the supervision loop that is the library's reason to exist. The
+through-line is SPEC §15.3's pure-decision-core rule: every decision on
+this path is made by a synchronous reducer in `shelterwood-core` fed with
+sampled events, and the driver shell merely executes the effects the
+reducer returns.
+
+## Declaration
+
+`Tree` and `DynamicTree` (`crates/shelterwood/src/tree/builders.rs`) wrap
+a shared `BuilderCore` (`plan.rs`). Reserving or adding a child mints its
+`Membership` immediately from the parent's scope identity and creates a
+`SlotCell` — which is why cyclic wiring works: `ActorRef` handles exist
+at declaration time, before anything runs. Attaching an actor definition
+is also the moment its `MailboxCell<M>` is created and paired with the
+runtime capability object (`tree/slots.rs`).
+
+`Tree::spawn` first checks that a runtime is ambient (else
+`BuildError::NoRuntime`), then *lowers* the declaration:
+`BuilderCore::lower` resolves every slot's policy against scope defaults,
+rejects unfilled reservations, reconciles memberships when a subtree is
+adopted, and produces an owned `ScopePlan` of `ChildPlan`s. Both the
+builder and the plan carry a terminality obligation, so an abandoned plan
+terminalizes every never-started member rather than leaking them.
+
+## Startup
+
+`driver::spawn_system` spawns `run_scope` as the scope's driver task
+(plus a root-join watchdog) and hands back `System`. Inside, per child:
+
+1. `ChildRuntime::from_plan` arms a fail-closed `ChildTerminality`
+   obligation *before any fallible step*, takes the member's incarnation
+   counter, and — for actors — configures the mailbox to obtain the first
+   `MailboxBindToken` (a linear, non-clonable permission to bind exactly
+   one incarnation).
+2. The child is admitted into the core reducer's `SupervisorState`,
+   yielding a `ChildKey`, and the resident projection is installed into
+   the `ScopeCell`, publishing `Added` lifecycle edges.
+3. Settlement runs the reducer, which emits `StartChild` for the first
+   ordered child — or for every child of a dynamic scope at once.
+4. `spawn_child` (`driver/child.rs`) mints an `Incarnation`, builds the
+   body for the child's kind (raw actor, task, or nested scope), binds
+   the mailbox — which promotes anything parked during the rebind window
+   — publishes `Started`, and spawns up to four tasks: the body (wrapped
+   in panic capture, ending by recording its outcome), the exit joiner, a
+   readiness watcher, and a local-stop watcher.
+
+Readiness is a core state machine (`ReadinessGate`). A readiness signal
+becomes a `Ready` lifecycle edge and, in an ordered scope, advances the
+startup cursor so the reducer emits the next `StartChild`; the aggregate
+completion becomes the startup result `System::wait_started` observes on
+the scope record's watch channel. Readiness deadlines feed the driver's
+single deadline queue, and a timeout stops the child with a recorded
+readiness-timeout outcome.
+
+## Exit capture
+
+Exits follow SPEC §15.3's E1 rule — record, destroy, join, publish:
+
+- The body task owns a `ReportToken`, an obligation whose `Drop` records
+  the fallback outcome, so a killed task still reports. A normal return
+  records `Completed` or `Failed`; a panic is captured, the incarnation's
+  teardown runs in SPEC §6.5 order (freeze mailbox, freeze resources,
+  join offloads, drop context, drop actor state) with cleanup panics
+  subordinated to the primary, and the primary is resumed so the runtime
+  join observes it.
+- Recording wraps the outcome in `RetainedRecordedOutcome`: a `Failed`
+  outcome owns a type-erased user error, and retention keeps its eventual
+  destruction off framework-critical paths (see
+  [Locks, effects, and disposal](internals-concurrency.md)).
+- The joiner task awaits the runtime join, claims the report, and sends
+  `ChildEvent::Exited` — recorded outcome, join outcome, sampled
+  cancellation, readiness evidence — down the scope's primary event lane.
+
+## Classification and arbitration
+
+The driver loop collects its event lanes (child events, dynamic control,
+disposal completions) and stably sorts the batch by `ArbitrationClass` —
+shutdown outranks removal outranks exits outranks readiness, and so on —
+so one wake processes concurrent facts in a deterministic order.
+
+For an exit, `handle_exit` replays readiness ordering, closes the mailbox
+(keeping the next bind token for a restart and sending unread messages to
+detached disposal), then folds the recorded outcome with the join outcome
+through the retaining classifiers. Verdict precedence is total and
+table-driven — a panic outranks a readiness timeout outranks a failure
+outranks an abort outranks completion — with the one deliberate
+asymmetry that a recorded `Failed` survives a later abort while a
+recorded `Completed` does not. The result is the `Exit` observers see.
+
+The decision itself is `dispatch_exit` in core: given the exit, the
+child's restart policy, the scope mode, and the membership status, it
+returns `ScheduleRestart` or `Terminal`. A draining scope or a removing
+membership always forces `Terminal` — restart suppression is derived
+from state, never from a flag.
+
+## Restart
+
+`schedule_restart` (core) bumps the attempt counters, computes the
+backoff delay from validated policy data plus a pre-drawn jitter sample,
+charges the scope's intensity window, and returns a `RestartDecision`.
+The scope publishes `Exited` and `RestartScheduled` in one observation
+transaction and arms a restart deadline; when it fires, `spawn_child`
+runs again — a new `Incarnation`, the same `MailboxCell` re-bound with
+the recycled token, parked senders promoted. If the decision tripped the
+intensity budget instead, the scope enters drain with
+`StopReason::IntensityTripped`, which escalates to its parent as an
+ordinary child exit.
+
+## Terminal
+
+A terminal exit first retains the exit (`RetainedExit`) and hands the
+child's retained construction to the disposal lane; its completion comes
+back as a disposal event so destructor panics are folded into the
+verdict before terminalization. Terminalizing writes the member's
+terminal stage and last exit, and prepares mailbox termination: every
+parked sender wakes with `Terminated`, and unread payloads leave for
+detached disposal. A pre-ready failure becomes a startup failure — an
+ordered scope terminalizes its never-started suffix and a nested scope
+begins rollback — and the retention option then decides whether the
+terminal membership is pruned immediately or kept resident as a
+tombstone.

--- a/book/src/internals-concurrency.md
+++ b/book/src/internals-concurrency.md
@@ -1,0 +1,135 @@
+# Locks, effects, and disposal
+
+This is the chapter to read before touching any `.lock()` in the
+codebase. The governing invariant — stated normatively in `CLAUDE.md` and
+SPEC §15.4, explained here — is the **lock rule**: code holding a
+framework mutex may only manipulate plain framework-owned data. Wakes,
+drops of user values, formatting, user callbacks, and panic resumption
+happen after unlock.
+
+The reason is that the framework runs arbitrary user code at moments it
+does not choose: waker vtable functions, destructors of messages and
+actor state, `Debug` on user errors, `Hash`/`Eq` on timer keys. All of it
+is safe Rust that may panic, block, or re-enter — and under a framework
+mutex each of those becomes poisoning, an ABBA deadlock, or a
+double-panic abort during an unwind.
+
+## The lock order
+
+The documented order, outermost to innermost:
+
+```text
+observation gate  →  MemberCell::mailbox  →  MailboxCell::state
+                                          →  SendOperation::state
+```
+
+The `WakerProxy` mutex is a **leaf** at the far end: `wake_by_ref`
+acquires it from whatever thread drives an external primitive, so no
+framework lock may ever be taken under it. The one exception to "gate is
+outermost" is the parent-to-child gate handoff described in
+[Observation from the inside](internals-observation.md); admission is the
+deepest use of that doubled section, and anything new added there needs
+the same accounting `CLAUDE.md` records for it. Everything else — scope
+control state, dynamic-membership maps, plan definition state — is
+framework-owned data taken under the gate or standalone.
+
+## The effects shapes
+
+The rule is implemented, not remembered: the two transaction types make
+deferral structural, and a family of single-purpose carriers moves
+specific effects past specific unlocks.
+
+- **`ObservationTxn`** (`cells/gate.rs`) — the gate guard plus a deferred
+  effect list; commit drops the guard then flushes under a panic
+  accumulator, and `Drop` runs the same path during an unwind.
+- **`MailboxTxn`** (`mailbox/cell.rs`) — the mailbox state guard beside a
+  `MailboxEffects` sink collecting pulses, waker actions, displaced
+  payloads, and disposal requests. Its `Drop` empties the guard field
+  before Rust drops the sink, so field order alone guarantees the flush
+  runs with no mailbox mutex held, unwind included.
+- **`WakerSlot` / `WakerAction` / `WakerEffects`** — the waker half made
+  structural: slot storage is private to core's waker module, and no
+  operation returns or replaces a `Waker` without an effects sink.
+- **`Withdrawal`**, **`Termination`**, **`MailboxPayload`** — carriers
+  that hand a cancellation outcome, a terminating mailbox's waiters, or
+  a closed mailbox's unread contents out of the critical section as one
+  owned value, so the destination — not the transition — decides where
+  user values die.
+- **`PanicAccumulator`** (core, `panic.rs`) — keeps the first panic
+  payload while later cleanup steps still run, and resumes the preferred
+  panic only once everything has been released. During an existing unwind
+  it contains rather than resumes, which is what keeps a hostile
+  destructor an ordinary outcome instead of a process abort.
+
+What the rule does *not* forbid is as important as what it does:
+framework-owned counters and maps need no ceremony; *moving* a user value
+out under a lock is fine (the destination must be outside); and `Arc`
+traffic that provably cannot reach zero is refcount work. The full
+exemption catalog, with the audit history behind it, lives in
+`CLAUDE.md` — treat that as the checklist of record.
+
+## Disposal lanes
+
+A value that may block or panic on destruction is not merely dropped
+after unlock — it is handed to a lane in
+`crates/shelterwood-runtime/src/disposal.rs`:
+
+- **`dispose_detached`** — for values whose owner is *not* inside a
+  critical section but whose destructor may block: unread mailbox
+  payloads, construction closures, displaced resident graphs, rejected
+  admissions. Falls back from the blocking pool to a shared fallback
+  thread to, ultimately, inline destruction on the submitting thread.
+- **`dispose_critical`** — for values whose *last owner may be inside a
+  framework critical section*: the `RetainedExit` and
+  `RetainedRecordedOutcome` wrappers around failed exits. No path ever
+  destroys the value on the submitting thread; under exhausted thread
+  creation the accepted fail-safe is a queued job held for the life of
+  the process, which is the trade against destroying user state under a
+  lock.
+- **`dispose_then` / `dispose_all`** — classified destruction with a
+  completion, used where a destructor panic must be folded into a
+  verdict (terminal disposal of a child's construction).
+
+The `Retained*` family in `cells/retained.rs` is the bridge: a framework-
+retained copy of an `Exit` owns a type-erased user error, and its drop
+transfers destruction to the critical lane. Framework code folds exits
+through the `*_retaining` classifiers so the losing half of every verdict
+fold retires through the lane too; exits handed to *users* keep ordinary
+drop timing.
+
+## The waker proxy
+
+External primitives — the timer wheel, senders, any executor — must never
+hold a raw caller waker, because its `clone`/`wake`/`drop` run
+caller-owned code on the primitive's thread. `WakerProxy`
+(`crates/shelterwood-core/src/waker_proxy.rs`) registers a stable
+framework-owned waker with the primitive and keeps the caller's real
+waker in a slot behind the leaf mutex; every removal queues the resulting
+user-code effect for after unlock.
+
+The subtle part is the lost-wake handshake: cloning the caller's waker
+happens *between* two critical sections, and a wake landing in that
+window would find the previous poll's waker. So the proxy's `wake_by_ref`
+records a `woken` flag in the same critical section that takes the slot,
+and every registration reads-and-clears the flag after installing — a set
+flag takes the just-installed waker straight back out to be woken after
+unlock. The cost is a spurious re-poll, which `Future` permits; the
+alternative is a lost wake, which it does not.
+
+`ProxiedPoll` wraps the proxy in a probe/install/re-poll state machine:
+first poll with a noop waker (preserving the already-ready fast path with
+no allocation), install and register only if pending, and on the ready
+edge retire the stored caller waker synchronously with any panic
+contained and discarded. `ProxiedSleep` applies the same boundary to
+runtime timers, retiring slot-first then cancelling the wheel entry, with
+the poll path retiring inline and drop glue handing the waker to the
+disposal lane.
+
+## Reviewing a new lock
+
+The one-pass review from `CLAUDE.md` applies to every new critical
+section: name every value it can destroy, every callback it can invoke,
+and every panic it can raise. If any of those is user code, hand it to a
+transaction, an effects struct, or the caller. The shapes above exist so
+that the easy way to write the code is also the compliant one — reach for
+them before inventing a new deferral mechanism.

--- a/book/src/internals-message.md
+++ b/book/src/internals-message.md
@@ -1,0 +1,117 @@
+# The life of a message
+
+This chapter follows one message from a caller's `send` to the receiving
+actor's handler, naming every structure it passes through. The mailbox is
+the most concurrency-dense subsystem in the library, and almost every
+shape it uses exists to satisfy the lock discipline described in
+[Locks, effects, and disposal](internals-concurrency.md): no user code —
+wakers, destructors, message drops — ever runs under a mailbox mutex.
+
+## The handle
+
+`ActorRef<M>` (`crates/shelterwood/src/mailbox/futures.rs`) is the only
+send surface. It holds exactly two `Arc`s: a `dyn ActorIdentity` (the
+restart-stable membership identity, implemented by `MemberCell`) and the
+`MailboxCell<M>` itself. Equality and hashing go by membership, which is
+why a handle keeps working across restarts: it addresses the slot, not
+the incarnation. Handles are minted only through the crate-private
+`actor_ref_from_parts` seam — at declaration time in `tree/slots.rs`,
+from `RawContext::myself`, and at dynamic admission.
+
+Four send flavors sit on the handle: `send` (waits through backpressure
+and rebind windows), `try_send` (fails fast), `send_timeout` (a
+deadline around `send`), and `call` (send plus reply under one budget).
+
+## Submission
+
+`SendFuture` is lazy — nothing happens until first poll. That poll calls
+`MailboxCell::submit` (`mailbox/cell.rs`), which opens a `MailboxTxn`:
+the guard over the cell's state mutex paired with a `MailboxEffects`
+sink. Every wake, displaced payload, and disposal request the transition
+produces is queued into the sink and flushed only after the guard drops.
+
+`submit` branches on the mailbox's binding status:
+
+- **Bound with capacity** — the message is stamped with an
+  `AcceptedSequence` and pushed onto the queue (or, for a `latest()`
+  mailbox, swapped into the conflating slot, with the displaced envelope
+  routed to disposal through the effects sink). The caller gets the
+  accepting `Incarnation` back as evidence.
+- **Full, unbound, or frozen** — a `SendOperation` is created and parked
+  in the binding's waiter queue. Unbound covers the pre-spawn and restart
+  rebind windows; frozen means intake stopped at shutdown entry.
+- **Terminal** — the message comes back inside
+  `SendError { kind: Terminated, .. }`, never silently dropped.
+
+## Parking and backpressure
+
+A parked `SendFuture` polls its `SendOperation`, whose state holds the
+outcome slot and a `WakerSlot` for the caller's waker. Two details are
+worth knowing before touching this code:
+
+- Cloning a caller's waker runs caller-owned vtable code, so the
+  operation poll returns a `NeedsWakerClone` result rather than cloning
+  under its own lock; the clone happens outside, and repeat polls use
+  `WakerSlot::will_wake` (a pointer compare) to skip it.
+- When capacity frees up, `MailboxCell::receive` promotes waiters FIFO:
+  each promoted operation's message moves into the queue and its waker is
+  taken as a `Wake` action into the effects sink, to be woken after
+  unlock.
+
+Cancelling a parked send (`SendFuture::drop`) produces a `Withdrawal`: a
+single value carrying both the outcome and the deferred waker effects.
+Since no caller remains to receive them, the recovered message and the
+registered waker go to isolated disposal.
+
+## Waking the actor
+
+Every accepting or binding transition queues a pulse. After unlock, the
+flush pulses the cell's `MailboxSignal` — the capability object's change
+signal, a watch channel in the Tokio adapter. The receiving incarnation
+holds a `MailboxReceiver<M>` (the mailbox `Arc`, its incarnation, and a
+signal watcher); the pulse is what makes its pending `changed()` future
+ready.
+
+## The receive loop
+
+The loop every actor runs — raw or callback — lives in
+`RawContext::recv` (`crates/shelterwood/src/raw/context.rs`). Its wait is
+a nested two-way select over four sources: the shutdown latch, the
+local-stop latch, the mailbox/offload change signals, and the earliest
+keyed-timer deadline (kept outside the nested select and applied as a
+timeout around it).
+
+When something is ready, `next_ready` arbitrates fairly over one
+`ReadyBatch` with a fixed stage priority: a fairness continuation first,
+then mailbox messages up to the batch's accepted-sequence cutoff, then
+offload completions, then remaining continuations, then due timers. The
+cutoff matters: a batch reads only what was accepted when it was formed,
+so a fast sender cannot starve timers and offloads.
+
+During shutdown drain the selector is bypassed entirely: `try_recv`
+freezes intake and reads the frozen accepted prefix synchronously.
+
+## The handler layer
+
+Callback actors ride on `Handler<A>` (`crates/shelterwood/src/actor.rs`),
+which implements `RawActor` — the high-level loop is a client of the same
+raw surface a hand-written actor uses. `Handler::run` drives
+`A::init`, then loops `recv().await` into `A::handle`, and on loop exit
+either drains the frozen prefix through the same `handle` (mailbox policy
+`Drain`, with the context marked as delivering the frozen prefix) or
+returns immediately (`Discard`, the framework disposing the prefix),
+before running `A::on_stop`. A handler error freezes and joins the
+incarnation's resources before the exit propagates, so no offload
+outlives the incarnation that started it.
+
+## Request and reply
+
+`Reply<T>` wraps a one-shot sender minted from the mailbox's capability
+object. Its `send` consumes it; if the receiver is already gone, the
+value routes to isolated disposal rather than being dropped on the actor
+task. `ActorRef::call` builds the whole conversation under one deadline
+budget: constructing the message from the user's closure, waiting for
+acceptance, and waiting for the reply. Pre-acceptance timeouts withdraw
+the parked send and dispose both the recovered request and the registered
+waker; the error catalog (`CallErrorKind`) distinguishes acceptance
+timeout, response timeout, terminated membership, and a dropped reply.

--- a/book/src/internals-observation.md
+++ b/book/src/internals-observation.md
@@ -1,0 +1,81 @@
+# Observation from the inside
+
+The [observation chapter](observation.md) covers the two user-facing
+contracts: conflating snapshots and bounded lifecycle streams. Both are
+produced by one publication path on the `ScopeCell`, and the machinery
+underneath exists to make every published value a *consistent cut* of the
+resident tree — SPEC §14's central demand.
+
+## The gate
+
+The observation gate (`crates/shelterwood/src/cells/gate.rs`) is a shared
+mutex-of-unit: one critical section for one resident tree's entire
+observation projection. Tree membership is defined by gate *identity* —
+two cells are in the same tree iff they share the gate `Arc` — which is
+what lets a subtree be adopted by re-homing its gate pointer. That
+re-homing (`MemberCell::with_handoff_gate`) is the single sanctioned
+gate-under-gate acquisition: parent-to-child direction only, re-reading
+the installed pointer under the acquired guard so a concurrent handoff
+retries instead of deadlocking.
+
+The gate deliberately tolerates poisoning: a panic on an observation path
+must not permanently wedge later observation or a handoff.
+
+## The transaction
+
+Nothing mutates observation state with the bare guard. Every writer works
+through `ObservationTxn`: the guard plus a deferred-effect list. `defer`
+queues arbitrary post-unlock work, `pulse` queues a watch wake (the
+runtime invokes registered wakers synchronously, so a pulse under the
+gate would run user waker code inside the tree's critical section), and
+`stage_snapshot` queues a publication. `commit` installs staged snapshots
+*first*, then drops the guard, then runs the effect list under a panic
+accumulator — and the transaction's `Drop` runs the same path, so an
+unwind cannot strand already-committed wakes. The install-before-unlock
+order is load-bearing: released first, two transactions could interleave
+and install a stale cut over a newer one.
+
+Because every retained control-plane writer takes `&mut ObservationTxn`,
+an out-of-transaction mutation is unavailable by construction — the
+token *is* the rule.
+
+## Lifecycle events
+
+Lifecycle streams are per-subscriber bounded rings fed by the scope's
+`LifecycleHub`. The event kinds are the edges the model promises —
+`Added`, `Started`, `Ready`, `Exited`, `RestartScheduled`, `Removed`,
+`ScopeState` — each stamped with the emitting scope's membership and a
+monotone, membership-owned sequence number that is continuous across
+restarts and starts a fresh domain under a replacement membership.
+Overflow drops oldest events behind a *leading* `Lagged` marker, and the
+documented resync protocol is subscribe-then-snapshot; the ring capacity
+is deliberately not API.
+
+An `Exited` event carries a projection of the child's `Exit`. The
+retained wrapper stores the public event before its retention guards, so
+ring eviction drops the projection while a `RetainedExit` still protects
+the user error inside it — its eventual destruction goes through the
+critical disposal lane, never a subscriber's thread.
+
+## Snapshots
+
+A snapshot is computed on demand under the gate — never served from the
+last published value — and skips *unannounced* residents: a child pushed
+into residency before its first fallible admission step, whose admission
+then unwound, must not appear in a cut that never saw its `Added` edge.
+This keeps the `Added`/`Removed` pairing exact.
+
+Publication stages a **producer, not a value**. A compound transition
+touching many children would otherwise build a full recursive projection
+per stage and retain all but the last until commit; coalescing replaces
+the staged producer instead, so a superseded cut is never built and the
+survivor runs exactly once inside `commit`, with the gate still holding
+the tree still. The superseded producer's captured `Arc`s leave with the
+effect list, after unlock. Snapshot receivers conflate: a subscriber
+always reads the latest committed cut, and every retained value is a
+complete transaction.
+
+Publishing a scope's snapshot also publishes every ancestor's, walking
+the resident chain under the same transaction, which is what makes a
+recursive `System`-level snapshot agree with the scope-level one taken in
+the same commit.

--- a/book/src/internals-reducer.md
+++ b/book/src/internals-reducer.md
@@ -1,0 +1,120 @@
+# The decision core and its effects
+
+SPEC §15.3 mandates a pure decision core: `step(state, event) -> effects`,
+with no awaits, clock reads, channel operations, or spawns in any decision
+module. This chapter maps how that mandate is realized, because the later
+flow chapters lean on it constantly — "the reducer emits `StartChild`" is
+shorthand for the machinery described here.
+
+## A federation of machines
+
+There is no single monolithic reducer. The decision layer is a family of
+small pure machines in `shelterwood-core`, composed by the driver:
+
+- **`SupervisorState`** (`supervisor.rs`) owns *structure*: membership
+  records, startup gating, ordered-stop sequencing, and finish
+  derivation. Per child it holds only a `ChildState` — `Resident` or
+  `Removing`, each wrapping an incarnation state
+  (`Unstarted → Active → Stopping → Complete → RestartPending |
+  Disposing → Joined`) — plus its startup membership and a spawned-once
+  bit. It embeds a **`ScopeLifecycle`** (`engine.rs`) for the scope's own
+  Starting → Running → Draining → Stopped arc and the stop-reason
+  lattice.
+- Its siblings in `engine.rs` are consumed by the driver directly:
+  **`StopLadder`** (per-child stop escalation over time),
+  **`ReadinessGate`**, **`IntensityState`** with `schedule_restart`,
+  **`dispatch_exit`** (restart-vs-terminal), **`arbitrate`** (the
+  event-class ordering), and **`DeadlineQueue`**.
+
+The division of labor: the supervisor decides *that* a child starts or
+stops and in what order; the ladder decides *how a stop escalates* as
+time passes; `dispatch_exit` decides a child's fate; the driver owns
+every venue — tasks, mailboxes, deadlines, publication. The ordering
+obligations *between* machines (readiness replay before exit handling,
+force owning stop arbitration) live in driver code and the arbitration
+table; the exhaustive reachable-state exploration suite under
+`supervisor.rs` pins safety on the structural machine alone, and targeted
+tests carry the cross-machine progress properties.
+
+## The step contract
+
+The entry point is `step(&mut SupervisorState, Event, &mut Vec<Effect>)`.
+Three properties of that signature carry most of the design:
+
+**Events are sampled facts, not live handles.** `Event::Ready` carries
+the removal latch's value *at step entry* — the reducer never reads the
+latch itself. Clocks arrive as pre-computed deadlines, randomness as a
+pre-drawn jitter sample, exits as an already-classified verdict. The
+`Exit` payload never enters `SupervisorState` at all, which is why the
+state is plain `Clone + Debug` data holding no user values, and why every
+time-of-check question is confined to the one sampling pass at the top of
+the driver loop.
+
+**Effects are six plain-data commands** — `StartChild`, `StopChild`,
+`ForceChild`, `FinalizeRemoval`, `StartupCompleted`, `Finished` —
+appended to a caller-owned vector. They are `Eq` and `Debug`, so tests
+drive events in and assert effect sequences out with no runtime anywhere.
+
+**Every transition is total.** State changes go through an
+expected-states check (`transition_incarnation`), and a stale or
+out-of-order event is a silent no-op — SPEC §15.3's E4. That is what
+makes the driver's event lanes safe to arbitrate and replay without the
+reducer trusting their ordering. Missing keys fail *closed*: querying a
+reclaimed child answers `Removing`, the status in which nothing
+schedules.
+
+## The settle loop
+
+`Event::Settle` is level-triggered: it recomputes startup progress, the
+ordered-stop cursor, and the finish predicate from current state, rather
+than reacting to any particular edge. The driver runs it to a fixed
+point — reduce `Settle`, execute the emitted effects, repeat until a pass
+emits nothing (`settle_supervisor` in `driver.rs`). Effect execution is a
+trampoline: executing `StartChild` runs `spawn_child`, which feeds
+`Event::Spawned` back through the reducer, appending any new effects to
+the same vector for the next drain.
+
+Termination rests on a discipline the code names explicitly: **every
+emitted effect must be acknowledgeable** — SPEC §15.3's R5. The settle
+pass emits `StartChild` only for a child in exactly the states
+`Event::Spawned` accepts (`ChildRecord::startable`, documented as "this
+event's own acceptance set"). The failure mode this prevents is sharp:
+because settlement is level-triggered, an effect the shell would decline
+is not merely wasted — it is re-derived from unchanged state on every
+pass, forever, and the loop spins. The reducer therefore never asks for
+construction it could not observe the result of.
+
+On top of the level-triggered derivation sit edge latches for emissions
+that must happen once: completion is *derived* — `all_children_joined` is
+a fold over child states, deliberately not a counter that could drift —
+but *emitted* exactly once, guarded by `finish_emitted` (SPEC S5).
+
+## Two output channels
+
+Not every decision comes back as an `Effect`. `begin_drain`, `force`, and
+`fail_startup` return the state transition directly to the caller —
+`(startup_pending, ScopeState)` — instead of queueing it. The convention:
+an output that must *publish atomically* with the caller's already-open
+observation transaction (the `Draining` edge commits together with its
+terminal-disposal intents) rides the return value; a command the shell
+executes *afterwards* rides the vector. When adding a transition, decide
+which channel it belongs to by that coupling, not by convenience.
+
+## Removal, and purity under the lock rule
+
+Two smaller shapes are worth knowing before editing this code:
+
+- Removal is not a boolean beside the state. `ChildState::Removing`
+  wraps the incarnation state, and the only method across the boundary
+  goes one way — removal is monotone by construction, with no path back
+  to `Resident`. Two events split the sampling protocol:
+  `RemovalLatched` records the fact *and* queues the stop command;
+  `RemovalSampled` records the fact without replaying the command, for
+  the paths where the command was queued separately.
+- The purity mandate reaches into error handling. `admit` refuses an
+  impossible key-domain collision by returning `None` rather than
+  asserting, because admission callers can hold framework locks while
+  retaining a user construction — a pure reducer must never diagnose a
+  broken invariant by unwinding through them. The lock rule
+  ([Locks, effects, and disposal](internals-concurrency.md)) constrains
+  even what a pure function may do on input it believes unreachable.

--- a/book/src/internals-shape.md
+++ b/book/src/internals-shape.md
@@ -1,0 +1,148 @@
+# The shape of the implementation
+
+Everything before this point teaches the model to someone building *on*
+Shelterwood. This part is for someone changing Shelterwood itself: it maps
+how the library is constructed, where each responsibility lives, and how
+data flows through a running system. It is a map, not a contract — the
+normative statement of what the implementation must do is `specs/SPEC.md`
+(§15 in particular, which mandates the layering and lock discipline this
+part describes), and the invariants contributors must uphold in a diff live
+in `CLAUDE.md` beside the code. When an internal name in this part goes
+stale, the change that renamed it updates the map in the same PR.
+
+Unlike the rest of the book, these chapters quote no code. They name real
+types, modules, and files so you can jump straight to the source; depth
+lives in the source and its tests, not here.
+
+## Three crates and a tool
+
+The workspace has three implementation crates with a strict dependency
+direction, plus one checking tool:
+
+- **`shelterwood-core`** — runtime-independent supervision types,
+  capabilities, and state machines. Its only dependency is `thiserror`: no
+  async runtime, no adapter, nothing that can run user code behind its
+  back. This is where the pure decision machinery lives (`engine.rs`,
+  `supervisor.rs`, `exit.rs`, `policy.rs`), along with the identity types,
+  panic-capture facilities, and the doc-hidden seams the other crates
+  consume (`capability.rs`, `waker.rs`, `waker_proxy.rs`,
+  `proxied_sleep.rs`).
+- **`shelterwood-runtime`** — the Tokio adapter. It is the only crate in
+  the workspace that names Tokio as a normal dependency, and it pins the
+  exact release, because blocking-pool rejection ownership is verified
+  against that release. It provides spawning and joining (`spawn.rs`),
+  synchronization primitives (`sync.rs`), timers (`timer.rs`), and the
+  isolated-disposal lanes (`disposal.rs`).
+- **`shelterwood`** — the public façade, and the only crate with a public
+  API. All sixteen of its modules are private; the API is a flat set of
+  `pub use` lists on the crate root. Tokio appears only in its
+  dev-dependencies, for tests.
+
+Core is the leaf; the runtime adapter depends only on core; the façade
+depends on both. No edge points back toward the façade, and core never
+names the adapter. That graph — not convention — is what makes SPEC §1's
+"the public API is runtime-independent" principle structural.
+
+The fourth workspace member, `tools/api-reachability`, is part of the
+enforcement story described at the end of this chapter.
+
+## The capability seam
+
+The façade's mailboxes need runtime services — one-shot channels, change
+signals, timers, isolated disposal — without naming a runtime. The seam is
+`MailboxRuntime` in `crates/shelterwood-core/src/capability.rs`: a
+doc-hidden, type-erased trait whose five methods mint the sub-capabilities
+(`ErasedOneShotSender`/`ErasedOneShotReceiver`, `MailboxSignal` and its
+watcher, `dispose`, `now`/`sleep_until`).
+
+The adapter implements it once (`TokioMailboxRuntime` in
+`crates/shelterwood-runtime/src/mailbox.rs`) and exposes a single
+process-wide instance through `mailbox_runtime()`. The façade installs
+that object per mailbox at slot-attach time
+(`crates/shelterwood/src/tree/slots.rs`), and the same object then flows
+through reply channels and deadline futures, so virtual-time and disposal
+semantics cannot silently switch adapters mid-conversation. Type erasure
+is also why `ActorRef<M>` carries no runtime type parameter.
+
+Two one-line modules make the boundary auditable: the façade's
+`runtime.rs` (`pub(crate) use shelterwood_runtime::*` — "the only boundary
+between the library and its async runtime") and `engine.rs`
+(`pub use shelterwood_core::engine::*`). Every runtime touchpoint in the
+façade imports through the former, which makes "where do we touch Tokio?"
+a one-file question.
+
+## Inside the façade
+
+SPEC §15.1 mandates four layers; the façade's module tree realizes them,
+with one extra structural stratum (the cells) underneath the mutable
+shell:
+
+- **`tree/`** — declaration and ownership (the tree façade over L1).
+  `Tree` and `DynamicTree` wrap a shared `BuilderCore`; `tree/slots.rs`
+  holds the reserve-before-define slot machinery for cyclic wiring (and is
+  where mailboxes are minted); `tree/system.rs` holds `System`, the sole
+  owning handle. `plan.rs` lowers a declaration into an owned
+  `ScopePlan`/`ChildPlan` construction plan.
+- **`driver/`** — the mutable runtime shell (L1's executor). There is
+  deliberately no type named `Driver`: the shell is `run_scope` and its
+  helpers around `ScopeRuntime`, feeding sampled events into core's pure
+  reducers and executing the effects they return. Submodules split the
+  shell by concern: `child.rs` (one incarnation's spawn/join/disposal),
+  `events.rs` (event lanes and arbitration), `startup.rs`, `shutdown.rs`,
+  `removal.rs`, `admission_control.rs` (dynamic membership), and
+  `storage.rs` (fail-closed completion obligations).
+- **`cells/`** — restart-stable state, structurally *below* the driver.
+  `MemberCell` is the per-membership cell that survives restarts;
+  `ScopeCell` is the supervising node's stable state and the publication
+  point for observation; `cells/observe.rs` holds snapshots and lifecycle
+  streams (L4); `cells/gate.rs` holds the observation gate and its
+  transaction; `cells/retained.rs` holds the `RetainedExit` family that
+  keeps user errors off framework-critical destruction paths.
+- **`mailbox/`** — the mailbox kinds, the send flavors, and request/reply
+  (L2's delivery half). `mailbox/cell.rs` is the restart-stable
+  `MailboxCell<M>`; `mailbox/futures.rs` is the public send surface
+  (`ActorRef<M>` and its futures); the module root declares the
+  crate-private control traits a `MemberCell` uses to drive a mailbox it
+  cannot name generically (`MailboxControl`, `MailboxTermination`,
+  `ActorIdentity`, and friends).
+- **`raw/`** — loop-owning raw actors (L2's execution half): the
+  `RawActor` trait, the per-incarnation `RawContext<M>` with its keyed
+  timers, offloads, and panic containment.
+- **`actor.rs`** — the callback layer (L3): the `Actor` trait and the
+  `Handler<A>` wrapper, which is itself just a `RawActor` implementation —
+  the proof of SPEC §1 principle 5 that the high-level loop uses nothing a
+  hand-written raw actor cannot reach.
+
+The remaining top-level modules (`deadline.rs`, `exit.rs`, `identity.rs`,
+`policy.rs`, `scope.rs`, `task.rs`, `definition.rs`) are thin façade
+wrappers or handle types over the corresponding core machinery.
+
+## The boundary is machine-checked
+
+Three checks in the CI lane turn the crate boundaries from intent into
+enforcement:
+
+- **`tools/api-reachability`** walks the façade's rustdoc JSON: every
+  public item's signature graph is searched for references into
+  `tokio`, `tokio_util`, `fastrand`, or `shelterwood_runtime`. Its known
+  blind spot — rustdoc JSON cannot see through cross-crate re-exports
+  from core — is covered by the next check.
+- **`tools/check-core-manifest.sh`** pins `shelterwood-core`'s direct
+  normal dependencies to a literal allowlist (today: `thiserror`). A
+  doc-hidden core signature cannot name an adapter type its crate cannot
+  reach, which is what makes the reachability walk's blind spot safe.
+  Growing the list is a deliberate boundary decision, never a convenience.
+- **`tools/check-external-consumer.sh`** compiles a real external crate
+  against the façade, then runs negative compile probes that must fail
+  with specific diagnostics — including one proving that every private
+  installation seam (`MailboxRuntime`, `MailboxControl`, `WakerProxy`,
+  `MemberCell`, and the rest of the family) is unimportable from outside.
+
+Together they state one argument in three parts: no public item reachably
+names a runtime type; the one un-walkable residue is structurally safe
+because core has no runtime dependency; and an actual external consumer
+cannot import the seams anyway.
+
+The next chapters follow the two central data flows through this
+structure: [a message](internals-message.md) from `send` to handler, and
+[a child](internals-child.md) from declaration to restart.

--- a/book/src/internals-shape.md
+++ b/book/src/internals-shape.md
@@ -143,6 +143,7 @@ names a runtime type; the one un-walkable residue is structurally safe
 because core has no runtime dependency; and an actual external consumer
 cannot import the seams anyway.
 
-The next chapters follow the two central data flows through this
-structure: [a message](internals-message.md) from `send` to handler, and
-[a child](internals-child.md) from declaration to restart.
+The next chapter maps [the decision core](internals-reducer.md) that
+sits at the center of this structure; the two after it follow the central
+data flows through it: [a message](internals-message.md) from `send` to
+handler, and [a child](internals-child.md) from declaration to restart.

--- a/book/src/internals-shutdown.md
+++ b/book/src/internals-shutdown.md
@@ -1,0 +1,108 @@
+# Shutdown from the inside
+
+The [shutdown chapter](shutdown.md) teaches the user-facing contract: one
+escalation ladder, reverse order, a budget. This chapter maps how the
+implementation delivers it. Two ideas organize everything: shutdown
+*requests* are sampled latches, and the shutdown *budget* bounds
+cooperative teardown, never the framework's own bookkeeping.
+
+## Requests are latches
+
+Every entry point — `System::shutdown`, `ScopeRef::request_shutdown`, a
+child calling `request_scope_shutdown`, or dropping the sole `System`
+owner — converges on the same level-triggered, per-incarnation latch on
+the `ScopeCell`. Latching stores the request against the scope's current
+epoch, pulses the member record so the driver wakes, and returns. The
+driver samples the latch at the top of its loop pass, alongside force
+requests and ancestor latches, and the sampled facts are arbitrated with
+everything else that arrived in the same wake — which is how "force owns
+shutdown arbitration" holds: a readiness edge sampled in the same pass
+cannot publish `Running` after the stop boundary.
+
+The owner-drop path latches through a poison-tolerant variant, so a drop
+on an already-unwinding thread cannot abort the process.
+
+## The waiting side
+
+`shutdown_scope` (`crates/shelterwood/src/driver/shutdown.rs`) is what
+`System::shutdown` and `ScopeRef::shutdown_and_wait` await. Its sequence:
+return early if the scope is already settled; latch the request; wait for
+drain entry; then wait for settlement under the budget. A zero budget
+skips the wait but still delivers the cooperative request. When the
+budget elapses, it collects *stragglers* — the innermost incomplete
+members, by path — forces the scope, and then **keeps waiting to
+settlement**: the timeout bounds cooperation, not the call, so the error
+a caller gets (`ShutdownTimeout` with straggler paths) describes a tree
+that has nonetheless been fully torn down. `System::shutdown` then joins
+the driver task itself.
+
+## Drain entry
+
+Inside the driver, a sampled shutdown becomes `begin_drain`. The stop
+reason is first retained (it can carry a user error — a startup failure
+owns the triggering child's exit), then the core reducer enters drain:
+
+- an **ordered** scope initializes a reverse cursor at its last child and
+  stops one child at a time, advancing only past a joined child;
+- a **dynamic** scope emits a stop for every non-joined child at once,
+  with parallel grace clocks.
+
+One settlement pass runs before publication so the `Draining` edge
+carries the first stop's intent, and the state change plus any terminal
+disposal intents publish as a single observation commit. A force request
+(`force_all`) instead marks the hard-force fact and emits a force per
+child directly.
+
+## The drain lattice
+
+A scope can be asked to stop for several reasons before it finishes
+stopping — a shutdown request landing during an intensity trip, a startup
+failure during a drain. The stop reason is therefore a monotone verdict
+lattice, severity-ascending:
+
+`Finished < IntensityTripped < StartupFailed < ShutdownRequested <
+NeverStarted`
+
+Both consumers — the in-progress drain in core's `ScopeLifecycle` and the
+already-published `Stopped` projection on the `ScopeCell` — join new
+verdicts into the current one with strictly-greater-wins, so repeats are
+idempotent and a later, more severe fact upgrades the reason without
+repeating drain entry.
+
+## The per-child ladder
+
+Each stopping child gets a `StopLadder`
+(`crates/shelterwood-core/src/engine.rs`): a pure state machine
+`Idle → Cooperative → Escalated → Finished` whose `advance(now)` returns
+the next `StopAction` — cancel, escalate, framework-abort (for a nested
+scope's driver, with its own acknowledgement), or hard abort. The driver
+funnels every stop through `begin_stop_child`, which **freezes the
+mailbox unconditionally**, cancels the readiness deadline, installs the
+ladder, and pushes its deadlines into the scope's single deadline queue.
+Actions map onto latches and abort handles; `force(now)` only ever moves
+the current deadline earlier and never skips the tidy beat between
+escalation and abort. A grace expiry records `AfterGrace` on the exit; a
+declared `Abort` policy records `WithinGrace`.
+
+## Driver death discharges
+
+The driver task itself can be aborted — a parent's hard force, a host
+tearing down the runtime. `ScopeRuntime`'s drop epilogue is written for
+that case: per child it folds pending disposal, freezes and closes the
+mailbox, fires the shutdown and abort edges, aborts the task, and
+discharges the child's terminality obligation, publishing the coarse kill
+verdict. It then clears residency (publishing every `Removed` edge before
+the scope's final event) and unconditionally retires the epoch. Every
+step runs under a panic accumulator, so one hostile destructor cannot
+stop the discharge of the rest. The rule of thumb the code comments use:
+the epilogue *discharges* obligations, it never *absolves* them.
+
+## Removal
+
+Dynamic removal rides the same machinery with one extra care: committing
+a removal happens inside a single observation transaction that withdraws
+residency while the child's id remains claimed, so a concurrent
+reservation can never observe a reused-id overlap. During startup,
+releasing the removal response is deferred until startup has seen the
+shrunken initial set, which is what makes a returned `Removed` a safe
+signal to re-admit under the same id.

--- a/book/src/internals-testing.md
+++ b/book/src/internals-testing.md
@@ -1,0 +1,109 @@
+# How it stays correct
+
+The final question a maintainer needs answered is not how the machinery
+works but how a change to it is checked. The verification architecture
+follows the construction architecture: because the decision layer is
+pure, most properties are tested with no runtime at all, and each higher
+gear exists only for what the gear below cannot state.
+
+## The gear ladder
+
+SPEC §16 sets the posture: every conformance obligation must have direct
+test coverage, and where §15.3 is followed, prefer the lower gear —
+drive the decision state machines directly, events in, effects out — and
+reserve integration fixtures for the driver shell and end-to-end
+invariants. In practice the suite has three gears:
+
+1. **Pure-machine tests** in `shelterwood-core`, next to each machine:
+   effect-sequence assertions against `SupervisorState`, the ladder, the
+   readiness gate, the lattice.
+2. **The exploration walk** (below) for the properties that are about
+   the *whole state space* rather than a chosen schedule.
+3. **Integration suites** in `crates/shelterwood/tests/`, organized by
+   subsystem (`delivery.rs`, `rebind.rs`, `drain.rs`, `readiness.rs`,
+   `offloads.rs`, the waker-proxy files, …) over shared fixtures in
+   `tests/common/` — release gates, event recorders, timing helpers,
+   hostile wakers.
+
+## The exploration walk
+
+`crates/shelterwood-core/src/supervisor/tests/exploration.rs` walks the
+structural reducer exhaustively: once the child roster is fixed, the
+reducer is a finite transition system, so the entire reachable state
+space is expanded — every state against the *entire* event alphabet,
+including events it will reject — and visited once.
+
+Two design points make it trustworthy rather than merely impressive:
+
+- The visited-set fingerprint destructures `SupervisorState`
+  exhaustively, so **a new field cannot compile until it is classified**
+  into the fingerprint or given a by-construction reason to be excluded.
+  A field silently dropped from the fingerprint would prune states — the
+  successors only the discarded state had are never explored — and the
+  destructure turns that from a review obligation into a compile error.
+- Its claims are scoped honestly. The walk checks the
+  reducer-expressible subset of §15.3's invariants (R1–R6, E4, S3–S5).
+  The stop ladder, the sampled latches, driver death, the exit funnel,
+  and tree lowering are not stated over `SupervisorState`, so the walk
+  does not claim them — the engine and integration suites own those.
+
+The corollary the project learned early: an exhaustive walk sees
+*safety* (nothing bad is reachable); *progress* properties — something
+good eventually happens — still need targeted tests, and cross-machine
+composition lives in the integration gear.
+
+## Obligations, provocations, and acceptance scenarios
+
+SPEC §16's entries each name the adversarial situation they are about
+and, where non-obvious, how to construct it — parked sends on capacity-1
+mailboxes of never-receiving actors, drop-counting guards owned by
+construction args, hand-polled boxed futures proving `Pending` inside a
+rebind window, bounded negative assertions ("this event does *not*
+arrive within the window"). Those provocations are a floor, not a
+ceiling. Appendix C's acceptance scenarios get their own end-to-end
+files (`tests/acceptance_*.rs`).
+
+The hostile inputs are first-class fixtures: test-only `MailboxRuntime`
+implementations that panic in their pulse path, wakers that panic or
+re-enter, destructor-blocking actors. They exist because the lock rule's
+whole premise is that user code misbehaves at framework-chosen moments —
+so the suite supplies user code that does.
+
+## Time in tests
+
+Timing properties run under virtual time: the adapter's `test-util`
+feature exposes `advance`, and paused-clock tests step it explicitly.
+Where a real-clock bound survives, the suite's convention is that it is
+*diagnostic only* — a single generous poll timeout covering steps an
+idle machine reaches immediately, so the bound exists to fail with a
+message instead of hanging. The comment in the acceptance suite states
+the reasoning: a machine loaded enough to stretch one bound stretches
+them all, so a tighter bound anywhere only relocates a flake rather than
+removing it. A timing bound that *is* the property under test belongs
+under virtual time, never the wall clock.
+
+## Structural conventions
+
+A few conventions keep the suite honest as it grows:
+
+- **White-box pins live beside the type they pin** and move with it. A
+  test asserting an internal invariant (drop-field order, a lock-order
+  detail) sits in that module's tests, not in a far-away integration
+  file that a refactor would silently orphan.
+- **Process isolation is the harness's job.** nextest runs each test in
+  its own process, which is what lets abort-class tests — double-panic
+  and containment checks — be ordinary `#[test]`s instead of a bespoke
+  subprocess harness.
+- **Examples are tests.** Every example ends in assertions and runs in
+  CI (`just examples`), which is what lets the book quote them without
+  a test lane of its own.
+- **The seam is provably substitutable.** The capability interface has
+  working test implementations inside the façade's own tests; a change
+  that breaks substitutability breaks them first.
+
+The full check list is the `ci` recipe in the `justfile` — format, both
+clippy passes, nextest plus doctests, examples, rustdoc with denied
+warnings, the book build, the three boundary checks from
+[The shape of the implementation](internals-shape.md), and Nix
+formatting — mirroring the authoritative flake checks that
+`just ci-nix` runs clean.

--- a/book/src/internals-time.md
+++ b/book/src/internals-time.md
@@ -1,0 +1,92 @@
+# Time, timers, and offloads
+
+Time enters the library in exactly one way, and no decision module ever
+reads it. This chapter maps the clock's single entry point, the two timer
+subsystems built on it (the driver's deadline queue and the raw actor's
+keyed timer store), and offloads — the mechanism that lets an actor start
+concurrent work whose completion re-enters its own loop.
+
+## One clock
+
+The capability object installed per mailbox carries the clock: `now` and
+`sleep_until` on `MailboxRuntime`, implemented by the Tokio adapter over
+`tokio::time`. Because deadline futures and reply channels flow through
+the same object as the mailbox that minted them, virtual time in tests
+(the adapter's `advance`, under the `test-util` feature) reaches every
+timer in a system consistently — there is no second clock to drift.
+
+Decision modules never call it. `StopLadder::advance(now)` and
+`schedule_restart(..., now, jitter)` take the instant as an argument, and
+the reducer sees deadlines only as "this deadline fired" events. That is
+SPEC §15.3's rule, and it is why the stop ladder is a state machine
+rather than a sleeping task per child.
+
+## The driver's deadline queue
+
+Each scope driver owns one `DeadlineQueue`, multiplexing every timed
+obligation its children have: stop-ladder deadlines, restart backoff
+expirations, and readiness deadlines, each tagged with a `DeadlineKind`.
+The driver's select sleeps until the earliest entry; a firing becomes a
+sampled event, arbitrated alongside everything else that arrived in the
+same wake. One consequence worth internalizing: no child ever owns a
+timer task, so a scope with hundreds of stopping children still holds
+exactly one pending sleep.
+
+## The raw actor's keyed timers
+
+`set_timeout`/`set_interval`/`clear_timer` on the actor contexts are
+backed by the keyed timer store in
+`crates/shelterwood/src/raw/context/timers.rs`. Its ownership rule is
+the interesting part: the store owns every armed timer's *user key and
+message*, mints the `ArmingOrder` values that index them (mintable only
+by the store), and is the only place either value is destroyed — so both
+always retire through the raw incarnation's contained-disposal path
+rather than on the actor task, where a hostile `Drop`, `Hash`, or `Eq`
+would otherwise run at a moment the framework didn't choose.
+
+A requested delay that overflows the clock becomes a deadline of `None`
+— a timer that never fires, mirroring the offload path — never one that
+is "due now". The earliest due deadline is applied as a timeout *around*
+the receive loop's nested select rather than as an arm inside it, and
+due timers are the last stage of the fairness batch's arbitration
+([The life of a message](internals-message.md)), so a hot mailbox cannot
+indefinitely pre-empt them within a batch but timers also cannot starve
+message delivery.
+
+Mailbox-side deadlines — `send_timeout`, `call`, reply waits — use the
+`Deadlined` wrapper over `ProxiedSleep`, which is how a runtime timer
+wheel is prevented from ever holding a caller's raw waker
+([Locks, effects, and disposal](internals-concurrency.md)).
+
+## Offloads
+
+`offload` and `offload_scoped` (`crates/shelterwood/src/raw/offload.rs`
+and the context methods) start incarnation-owned async work with a
+continuation and a single `DeadlineBudget` covering the whole
+conversation. The mechanics:
+
+- The work runs as its own task; its completion is queued into the
+  incarnation's event queue and re-enters the actor loop as an ordinary
+  message via the continuation — which is why offload results obey the
+  same at-most-once, no-cross-incarnation rules as everything else.
+  Completion storage is unbounded but bounded in practice by one entry
+  per offload the actor itself started, and it drains in bounded
+  arbitration turns beside mailbox input.
+- `offload_scoped` returns a `Guard`: a cancel-on-drop lease with
+  explicit `cancel` and `detach`. Cancellation suppresses the
+  continuation, so no offload extends the incarnation that created it;
+  `offload` is simply the scoped form with the guard detached.
+- A zero budget never polls the work at all and queues the continuation
+  with `DeadlineElapsed` — the honest degenerate case rather than a
+  race.
+
+`run_blocking` is deliberately different. It has no stopping gate —
+teardown code may still need blocking work, so it keeps working from
+stop paths — and its cancellation is cooperative: dropping the returned
+`Blocking` future or hard-aborting the actor detaches the OS thread,
+which can outlive the incarnation. A closure panic resumes at the await
+point; an operation cancelled by runtime teardown before it ever ran
+panics with a distinct teardown diagnostic when awaited. The
+blocking-pool submission path underneath is the same one the disposal
+lanes use, and its rejection-ownership subtleties are why the workspace
+pins the exact Tokio release.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -17,5 +17,9 @@ catalog, and the operational guides live in the
 specification lives in the repository's `specs/SPEC.md`. The final appendix,
 [Where the prose lives](appendix-where-prose-lives.md), maps that division.
 
+A closing part, [For maintainers](internals-shape.md), turns inward: it
+maps how the implementation itself is constructed and how data flows
+through it, for readers changing Shelterwood rather than building on it.
+
 If you want to skip straight to code, [A first system](first-system.md) has
 you running in a page.


### PR DESCRIPTION
## What

Adds a closing **For maintainers** part to the book — nine chapters mapping how the library is constructed, how it works, and what the general data flows are:

1. **The shape of the implementation** — the three crates and their dependency direction, the `MailboxRuntime` capability seam, the façade's internal layering mapped onto SPEC §15.1, and the three boundary checks (`api-reachability`, `check-core-manifest.sh`, `check-external-consumer.sh`).
2. **The decision core and its effects** — the federation of pure machines, the `step(state, event, &mut Vec<Effect>)` contract (sampled events, plain-data effects, total transitions), the settle loop's acknowledgeable-effects fixed point (R5), the two output channels, and the removal/purity shapes.
3. **The life of a message** — `ActorRef` → `MailboxCell::submit` → parking/promotion → signal pulse → `RawContext::recv` fairness → `Handler<A>` → request/reply.
4. **The life of a child** — declaration/lowering → `ChildRuntime` spawn and readiness → exit capture → arbitration and `dispatch_exit` → restart or terminalization, plus the runtime-admission flow (reserve/admit split, one-transaction install, unannounced-resident rejection paths).
5. **Time, timers, and offloads** — the single clock entry point on the capability object, the driver's one `DeadlineQueue`, the keyed timer store's ownership rule, `Deadlined`/`ProxiedSleep`, and the offload vs `run_blocking` split.
6. **Shutdown from the inside** — the request latches, `shutdown_scope`'s budget semantics, drain entry, the stop-reason lattice, the per-child `StopLadder`, driver-death discharge, removal.
7. **Observation from the inside** — the gate, `ObservationTxn` commit ordering, lifecycle streams, snapshot producers and coalescing.
8. **Locks, effects, and disposal** — the lock rule and order, the effects shapes, the disposal lanes, the waker proxy and its lost-wake handshake, and the new-lock review pass.
9. **How it stays correct** — the test gear ladder (pure machines → exploration walk → integration), the exploration fingerprint's compile-checked exhaustiveness and honest claim scope (R1–R6, E4, S3–S5 only), SPEC §16 provocations and Appendix C acceptance files, virtual-time conventions, and the structural test conventions (white-box pins beside their type, nextest process isolation, examples-as-tests).

## Boundaries kept

- The part **quotes no code**, so it adds no include/test-lane surface; it names real types, modules, and files as jump targets.
- It is a *map*, not a second normative home: SPEC §15 and CLAUDE.md remain the contracts, and the "Where the prose lives" appendix now records the new home plus the drift rule (a PR renaming an internal named here updates the map in the same change).
- Deliberately excluded: a per-module API tour (rustdoc's job), restating the §15.3 invariant lists, and deep `raw/context.rs` internals beyond the flows (highest-churn file; prose there rots fastest).
- `SUMMARY.md` gains explicit part titles (`For maintainers`, `Appendices`); the introduction gains one pointer sentence.

## Verification

- `./tools/dev just book` builds clean; the rendered TOC shows both part titles and all nine chapters.
- Content was derived from a fresh source walk of `crates/` plus SPEC §15/§16 and CLAUDE.md, using current type/module names (`ScopeRuntime`, `MailboxTxn`, `RetainedExit`, `ProxiedPoll`, `SupervisorState`, `ArmingOrder`, …).