### PR TITLE
feat: add shelterwood::prelude with area bundles

### DIFF
--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -31,12 +31,14 @@
 //! # Quickstart
 //!
 //! A counter actor with a request/reply protocol, spawned under an ordered
-//! tree inside an ambient Tokio runtime:
+//! tree inside an ambient Tokio runtime. The opening glob is
+//! [`prelude`]; every name it brings in also lives at the crate root,
+//! which is where each one is documented.
 //!
 //! ```rust
 //! use std::time::Duration;
 //!
-//! use shelterwood::{Actor, ActorDef, Context, ExitError, ExitResult, Reply, Tree};
+//! use shelterwood::prelude::*;
 //!
 //! struct Counter {
 //!     count: u64,
@@ -80,6 +82,17 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! # Prelude
+//!
+//! [`prelude`] re-exports the names a program has to write down —
+//! [`Actor`], [`Context`], the handles, the tree types — so a file can
+//! open with one glob. Its submodules ([`prelude::policy`],
+//! [`prelude::observe`], [`prelude::errors`], [`prelude::raw`],
+//! [`prelude::wiring`]) bundle one area each. Neither ring adds surface:
+//! the crate root below is canonical and complete, and it is where every
+//! item is documented. See [`prelude`] for the admission rule, the
+//! [`Context`] name collision, and the standing glob caveat.
 //!
 //! # The API by area
 //!
@@ -250,6 +263,8 @@ pub use tree::{
     DynamicTree, Removal, StartOrShutdownError, Subtree, SubtreeDef, SubtreeOnceDef, SubtreeSlot,
     System, TaskSlot, Tree,
 };
+
+pub mod prelude;
 
 /// Long-form operational guides, rendered with the API reference.
 ///

--- a/crates/shelterwood/src/prelude.rs
+++ b/crates/shelterwood/src/prelude.rs
@@ -1,0 +1,159 @@
+//! The names a program writes down, importable as one glob.
+//!
+//! The crate root stays flat and canonical: every item lives there, and
+//! [`crate`] is where each one is documented. This module re-exports a
+//! subset of those root paths so a file that defines actors and tasks,
+//! declares a tree, sends and calls, and shuts down can open with a single
+//! `use`. Nothing is defined here, nothing is renamed, and nothing foreign
+//! is re-exported — the prelude is an index, not a second API.
+//!
+//! # Admission
+//!
+//! An item enters this module iff a program that defines actors and tasks,
+//! declares a tree, sends and calls, and shuts down *must write its name*
+//! — in an impl header, a struct field, or a function signature. Items that
+//! appear only in return position you match occasionally, or only when
+//! tuning behavior, live in a bundle instead. The criterion governs future
+//! additions as well as the current contents.
+//!
+//! # Three rings
+//!
+//! - **Ring 0** — `use shelterwood::prelude::*;`, the names above. This is
+//!   the ordinary opening line of a file that uses the framework.
+//! - **Ring 1** — `use shelterwood::prelude::policy::*;` and its siblings
+//!   ([`observe`], [`errors`], [`raw`], [`wiring`]): one area at a time,
+//!   for a file that tunes supervision, reads observation, matches the
+//!   error taxonomy, writes a raw receive loop, or wires slots.
+//! - **Ring 2** — `use shelterwood::{Admission, ReserveError};`, the flat
+//!   crate root, which is canonical and complete. Everything reachable
+//!   through ring 0 or ring 1 is reachable there under the same name, and
+//!   the root additionally carries what no ring exports.
+//!
+//! Runtime admission outcomes — [`crate::Admission`], [`crate::Removal`],
+//! [`crate::RemoveOutcome`], [`crate::ReserveError`], and
+//! [`crate::NotAdmittingCause`] — are deliberately ring 2 only. They are
+//! matched at a handful of call sites in programs that admit children at
+//! runtime, which is not the shape this module is sized for.
+//!
+//! # The `Context` collision
+//!
+//! [`Context`] is the actor callback context, and the name is contested.
+//! [`std::task::Context`] appears in any manual [`Future`]
+//! implementation, and `anyhow::Context` is an extension trait many
+//! programs import. Rust's glob rules make this quiet rather than loud: an
+//! explicit `use` shadows a glob-imported name without an error, so
+//! `use anyhow::Context;` beneath `use shelterwood::prelude::*;` silently
+//! retargets every bare `Context` in the file to the trait, and the actor
+//! callbacks then fail to compile against a signature that no longer names
+//! what it did.
+//!
+//! Import the trait for its methods only, or path-qualify the other side:
+//!
+//! ```ignore
+//! use shelterwood::prelude::*;
+//! use anyhow::Context as _; // methods available, name not bound
+//!
+//! fn poll_manually(context: &mut std::task::Context<'_>) { /* ... */ }
+//! ```
+//!
+//! There is no `ActorContext` alias. One name for one type is worth more
+//! than an escape hatch from a collision an explicit `use` already fixes.
+//!
+//! # The glob caveat
+//!
+//! Every glob prelude trades control for brevity: a name added here in a
+//! later release can collide with a name the importing crate defines
+//! itself. That is the standing cost of rings 0 and 1, accepted rather
+//! than engineered around. A crate that wants immunity imports from the
+//! root.
+//!
+//! # Composing upward
+//!
+//! Utility-tier crates (`specs/non-core.md` §27) depend only on the
+//! supported façade and re-export their items through preludes of their
+//! own. Those preludes are expected to glob `shelterwood::prelude::*` into
+//! themselves, so this module is the base of that stack and its admission
+//! rule is what keeps the stack's ground floor small.
+
+#[doc(no_inline)]
+pub use crate::{
+    Actor, ActorDef, ActorOnceDef, ActorRef, Context, DynamicScopeRef, DynamicTree, ExitError,
+    ExitResult, Replied, Reply, ScopeRef, StopContext, SubtreeDef, System, TaskContext, TaskDef,
+    TaskOnceDef, TaskRef, Tree,
+};
+
+/// Supervision policy: restart, backoff, readiness, shutdown, mailboxes.
+///
+/// Policy is plain validated data, built once when a tree is declared and
+/// not named again at runtime. Import this bundle in the file that
+/// declares the tree; a file that only implements [`Actor`] rarely needs
+/// it.
+pub mod policy {
+    #[doc(no_inline)]
+    pub use crate::{
+        Backoff, BackoffFactor, DefaultsInheritance, ExponentialBackoff, FixedBackoff, Intensity,
+        Jitter, JitterSample, Mailbox, MailboxShutdown, NonZeroDuration, PolicyError, Readiness,
+        ReadinessDeadline, RestartAttempt, RestartCondition, RestartCount, RestartPolicy,
+        Retention, ScopeDefaults, ScopeFlavor, Shutdown, Strategy, TotalRestarts,
+    };
+}
+
+/// Observation: current-state snapshots, lifecycle histories, identity.
+///
+/// The two observation surfaces are the authoritative recursive snapshot
+/// ([`crate::ScopeSnapshot`]) and the lifecycle history ([`crate::LifecycleEvents`]);
+/// the identities they report ([`crate::Membership`], [`crate::Incarnation`],
+/// [`crate::ChildId`]) come with them because a reader almost always keys on one.
+pub mod observe {
+    #[doc(no_inline)]
+    pub use crate::{
+        ChildId, ChildSnapshot, ChildState, Incarnation, LifecycleEvent, LifecycleEventKind,
+        LifecycleEvents, LifecycleItem, LifecycleSeq, LifecycleTryRecvError, Membership,
+        MembershipStatus, ScopeSnapshot, ScopeState, SnapshotClosed, SnapshotReceiver, WaitError,
+    };
+}
+
+/// The exit and error taxonomy, as a single import.
+///
+/// This bundle is congruent with the catalog in [`crate::guides::errors`]:
+/// the structured result of an incarnation, the supervisor-side terminal
+/// reasons, the startup and shutdown reports, and the failures returned by
+/// sending, calling, replying, spawning, declaring, and validating policy.
+/// Import it in the file that decides what a failure means.
+pub mod errors {
+    #[doc(no_inline)]
+    pub use crate::{
+        BuildError, CallError, CallErrorKind, Cancellation, Exit, ExitError, ExitKind, ExitResult,
+        GracePhase, IntensityTrip, PolicyError, ReplyError, SendError, SendErrorKind,
+        ShutdownStraggler, ShutdownTimeout, StartOrShutdownError, StartupError, StartupFailure,
+        StartupFailureCause, StopReason,
+    };
+}
+
+/// Raw actors, offloads, and blocking work.
+///
+/// A [`crate::RawActor`] owns its receive loop instead of returning to a callback
+/// dispatcher. The offload machinery in this bundle is shared with
+/// callback actors, so a file that leases work out without writing a raw
+/// loop still wants it.
+pub mod raw {
+    #[doc(no_inline)]
+    pub use crate::{
+        Blocking, DeadlineBudget, DeadlineElapsed, Guard, Handler, RawActor, RawContext, RawDef,
+        RawOnceDef, Rejected,
+    };
+}
+
+/// Slots, subtrees, and the errors declaration raises.
+///
+/// Slots split reservation from definition, which is what lets cyclically
+/// wired children hold each other's handles before either is defined.
+/// Subtree composition rides in the same file, and [`crate::BuildError`] is what
+/// both report.
+pub mod wiring {
+    #[doc(no_inline)]
+    pub use crate::{
+        ActorSlot, BuildError, DynamicActorSlot, DynamicSubtreeSlot, DynamicTaskSlot, Subtree,
+        SubtreeOnceDef, SubtreeSlot, TaskSlot,
+    };
+}

--- a/tools/api-reachability/src/main.rs
+++ b/tools/api-reachability/src/main.rs
@@ -27,16 +27,26 @@ fn main() -> Result<(), Box<dyn Error>> {
     let document: Value = serde_json::from_slice(&fs::read(&path)?)?;
     let leaks = find_leaks(&document)?;
 
-    if leaks.is_empty() {
-        println!("public API runtime reachability: clean");
-        return Ok(());
+    if !leaks.is_empty() {
+        eprintln!("runtime types are reachable from public Shelterwood items:");
+        for leak in leaks {
+            eprintln!("  {leak}");
+        }
+        return Err("public API runtime reachability check failed".into());
     }
+    println!("public API runtime reachability: clean");
 
-    eprintln!("runtime types are reachable from public Shelterwood items:");
-    for leak in leaks {
-        eprintln!("  {leak}");
+    let escapes = find_prelude_escapes(&document)?;
+    if !escapes.is_empty() {
+        eprintln!("prelude re-exports items the crate root does not export:");
+        for escape in escapes {
+            eprintln!("  {escape}");
+        }
+        return Err("prelude containment check failed".into());
     }
-    Err("public API runtime reachability check failed".into())
+    println!("prelude containment: clean");
+
+    Ok(())
 }
 
 fn find_leaks(document: &Value) -> Result<BTreeSet<String>, Box<dyn Error>> {
@@ -91,6 +101,117 @@ fn find_leaks(document: &Value) -> Result<BTreeSet<String>, Box<dyn Error>> {
     }
 
     Ok(leaks)
+}
+
+// The prelude adds no surface: it re-exports crate-root paths and nothing
+// else. That claim is checked structurally rather than by convention. Every
+// `use` under `shelterwood::prelude` must name an item the crate root already
+// re-exports, under the same name — so "prelude ⊆ public root" holds by
+// construction, and with it "the prelude exposes nothing doc(hidden)", which
+// the root's own boundary (tools/check-external-consumer.sh) already pins.
+// Globs, locally defined items, and a missing `prelude` module are all
+// failures: the last one keeps the check from passing vacuously.
+fn find_prelude_escapes(document: &Value) -> Result<BTreeSet<String>, Box<dyn Error>> {
+    let index = object_field(document, "index")?;
+    let root_id = document
+        .get("root")
+        .map(id_key)
+        .ok_or("rustdoc JSON has no field `root`")?;
+    let root_items =
+        module_items(index, &root_id).ok_or("rustdoc JSON field `root` does not name a module")?;
+
+    let mut root_exports: HashSet<(String, String)> = HashSet::new();
+    let mut prelude_id = None;
+    for item_id in root_items {
+        let Some(item) = index.get(&item_id) else {
+            continue;
+        };
+        if let Some(reexport) = item.pointer("/inner/use") {
+            if let (Some(name), Some(target)) = (use_name(reexport), use_target(reexport)) {
+                root_exports.insert((name, target));
+            }
+            continue;
+        }
+        if item.pointer("/inner/module").is_some()
+            && item.get("name").and_then(Value::as_str) == Some("prelude")
+        {
+            prelude_id = Some(item_id);
+        }
+    }
+
+    let prelude_id = prelude_id.ok_or("the façade document has no public `prelude` module")?;
+    if root_exports.is_empty() {
+        return Err("the façade document's crate root re-exports nothing".into());
+    }
+
+    let mut escapes = BTreeSet::new();
+    let mut queue = VecDeque::from([("prelude".to_owned(), prelude_id)]);
+    while let Some((module_path, module_id)) = queue.pop_front() {
+        let Some(items) = module_items(index, &module_id) else {
+            escapes.insert(format!("{module_path} is not a module in this document"));
+            continue;
+        };
+        for item_id in items {
+            let Some(item) = index.get(&item_id) else {
+                escapes.insert(format!("{module_path} holds an item the document omits"));
+                continue;
+            };
+            if let Some(reexport) = item.pointer("/inner/use") {
+                let name = use_name(reexport).unwrap_or_else(|| "<unnamed>".to_owned());
+                if reexport.get("is_glob").and_then(Value::as_bool) == Some(true) {
+                    escapes.insert(format!("{module_path} re-exports the glob `{name}::*`"));
+                    continue;
+                }
+                let Some(target) = use_target(reexport) else {
+                    escapes.insert(format!("{module_path}::{name} names no resolvable item"));
+                    continue;
+                };
+                if !root_exports.contains(&(name.clone(), target)) {
+                    escapes.insert(format!(
+                        "{module_path}::{name} is not `shelterwood::{name}`"
+                    ));
+                }
+                continue;
+            }
+            let name = item
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or("<unnamed>")
+                .to_owned();
+            if item.pointer("/inner/module").is_some() {
+                queue.push_back((format!("{module_path}::{name}"), item_id));
+                continue;
+            }
+            escapes.insert(format!(
+                "{module_path} defines `{name}` instead of re-exporting"
+            ));
+        }
+    }
+
+    Ok(escapes)
+}
+
+fn module_items(index: &serde_json::Map<String, Value>, id: &str) -> Option<Vec<String>> {
+    let items = index.get(id)?.pointer("/inner/module/items")?.as_array()?;
+    Some(items.iter().map(id_key).collect())
+}
+
+fn use_name(reexport: &Value) -> Option<String> {
+    reexport
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
+fn use_target(reexport: &Value) -> Option<String> {
+    reexport.get("id").filter(|id| !id.is_null()).map(id_key)
+}
+
+fn id_key(value: &Value) -> String {
+    match value {
+        Value::String(value) => value.clone(),
+        other => other.to_string(),
+    }
 }
 
 fn validate_format_version(document: &Value) -> Result<(), Box<dyn Error>> {
@@ -195,9 +316,176 @@ fn push_known(value: String, known_ids: &HashSet<String>, output: &mut Vec<Strin
 mod tests {
     use std::collections::BTreeSet;
 
-    use serde_json::json;
+    use serde_json::{Value, json};
 
-    use super::find_leaks;
+    use super::{find_leaks, find_prelude_escapes};
+
+    /// A crate root re-exporting `Actor` (id 10) and `Hidden` (id 11), plus a
+    /// `prelude` module (id 3) whose items the caller supplies.
+    fn document_with_prelude(prelude_items: Value, extra_index: Value) -> Value {
+        let mut document = json!({
+            "format_version": 61,
+            "root": 0,
+            "index": {
+                "0": {
+                    "id": 0,
+                    "name": "shelterwood",
+                    "inner": { "module": { "items": [1, 2, 3] } }
+                },
+                "1": {
+                    "id": 1,
+                    "name": null,
+                    "inner": { "use": { "source": "actor::Actor", "name": "Actor", "id": 10, "is_glob": false } }
+                },
+                "2": {
+                    "id": 2,
+                    "name": null,
+                    "inner": { "use": { "source": "cells::Hidden", "name": "Hidden", "id": 11, "is_glob": false } }
+                },
+                "3": {
+                    "id": 3,
+                    "name": "prelude",
+                    "inner": { "module": { "items": [] } }
+                }
+            },
+            "paths": {}
+        });
+        document["index"]["3"]["inner"]["module"]["items"] = prelude_items;
+        let index = document["index"]
+            .as_object_mut()
+            .expect("index is an object");
+        for (id, item) in extra_index.as_object().expect("extra index is an object") {
+            index.insert(id.clone(), item.clone());
+        }
+        document
+    }
+
+    #[test]
+    fn accepts_a_prelude_that_only_re_exports_crate_root_names() {
+        let document = document_with_prelude(
+            json!([20, 21]),
+            json!({
+                "20": {
+                    "id": 20,
+                    "name": null,
+                    "inner": { "use": { "source": "crate::Actor", "name": "Actor", "id": 10, "is_glob": false } }
+                },
+                "21": {
+                    "id": 21,
+                    "name": "errors",
+                    "inner": { "module": { "items": [22] } }
+                },
+                "22": {
+                    "id": 22,
+                    "name": null,
+                    "inner": { "use": { "source": "crate::Hidden", "name": "Hidden", "id": 11, "is_glob": false } }
+                }
+            }),
+        );
+
+        assert_eq!(
+            find_prelude_escapes(&document).expect("the fixture is a complete document"),
+            BTreeSet::new()
+        );
+    }
+
+    #[test]
+    fn rejects_a_prelude_re_export_the_crate_root_does_not_carry() {
+        let document = document_with_prelude(
+            json!([20]),
+            json!({
+                "20": {
+                    "id": 20,
+                    "name": null,
+                    "inner": { "use": { "source": "crate::cells::MemberCell", "name": "MemberCell", "id": 12, "is_glob": false } }
+                }
+            }),
+        );
+
+        assert_eq!(
+            find_prelude_escapes(&document).expect("the fixture is a complete document"),
+            BTreeSet::from(["prelude::MemberCell is not `shelterwood::MemberCell`".to_owned()])
+        );
+    }
+
+    /// A name the root also exports is still an escape when the prelude's
+    /// `use` resolves to a different item — the check pairs name with target.
+    #[test]
+    fn rejects_a_shadowing_re_export_that_reuses_a_root_name() {
+        let document = document_with_prelude(
+            json!([20]),
+            json!({
+                "20": {
+                    "id": 20,
+                    "name": null,
+                    "inner": { "use": { "source": "crate::raw::Actor", "name": "Actor", "id": 12, "is_glob": false } }
+                }
+            }),
+        );
+
+        assert_eq!(
+            find_prelude_escapes(&document).expect("the fixture is a complete document"),
+            BTreeSet::from(["prelude::Actor is not `shelterwood::Actor`".to_owned()])
+        );
+    }
+
+    #[test]
+    fn rejects_a_prelude_that_globs_an_internal_module() {
+        let document = document_with_prelude(
+            json!([20]),
+            json!({
+                "20": {
+                    "id": 20,
+                    "name": null,
+                    "inner": { "use": { "source": "crate::cells", "name": "cells", "id": 12, "is_glob": true } }
+                }
+            }),
+        );
+
+        assert_eq!(
+            find_prelude_escapes(&document).expect("the fixture is a complete document"),
+            BTreeSet::from(["prelude re-exports the glob `cells::*`".to_owned()])
+        );
+    }
+
+    #[test]
+    fn rejects_a_prelude_that_defines_its_own_item() {
+        let document = document_with_prelude(
+            json!([20]),
+            json!({
+                "20": {
+                    "id": 20,
+                    "name": "ActorContext",
+                    "inner": { "type_alias": {} }
+                }
+            }),
+        );
+
+        assert_eq!(
+            find_prelude_escapes(&document).expect("the fixture is a complete document"),
+            BTreeSet::from(["prelude defines `ActorContext` instead of re-exporting".to_owned()])
+        );
+    }
+
+    /// Fail closed: a document without the module means the walk found
+    /// nothing to check, which must not read as a pass.
+    #[test]
+    fn rejects_a_document_with_no_prelude_module() {
+        let document = json!({
+            "format_version": 61,
+            "root": 0,
+            "index": {
+                "0": { "id": 0, "name": "shelterwood", "inner": { "module": { "items": [] } } }
+            },
+            "paths": {}
+        });
+
+        let error = find_prelude_escapes(&document).expect_err("a missing prelude is an error");
+        assert_eq!(
+            error.to_string(),
+            "the façade document has no public `prelude` module"
+        );
+    }
 
     #[test]
     fn follows_public_type_ids_without_treating_every_number_as_an_id() {

--- a/tools/external-consumer/tests/default_features.rs
+++ b/tools/external-consumer/tests/default_features.rs
@@ -1,5 +1,7 @@
-use shelterwood::{ExitError, StopReason, TaskOnceDef, Tree};
+use shelterwood::prelude::{errors::StopReason, *};
 
+/// The prelude is reachable from outside the workspace and carries enough
+/// to declare, spawn, and join a system without naming a crate-root path.
 #[test]
 fn default_feature_consumer_runs_a_supervised_task_to_completion() {
     let runtime = tokio::runtime::Builder::new_current_thread()


### PR DESCRIPTION
## What

A `prelude` module in the `shelterwood` façade. All new surface lives under one `pub mod prelude` (`crates/shelterwood/src/prelude.rs`); the crate root's flat exports are unchanged and remain the canonical paths.

## Three rings

- **Ring 0** — `use shelterwood::prelude::*;`: `Actor`, `Context`, `StopContext`, `ActorDef`, `ActorOnceDef`, `ExitError`, `ExitResult`, `ActorRef`, `Reply`, `Replied`, `Tree`, `DynamicTree`, `System`, `SubtreeDef`, `TaskDef`, `TaskOnceDef`, `TaskRef`, `TaskContext`, `ScopeRef`, `DynamicScopeRef`.
- **Ring 1** — five bundles, each an explicit `pub use crate::{...}` list (never a glob of an internal module):
  - `prelude::policy` — restart, backoff, readiness, shutdown, mailbox and scope-defaults declarations plus `PolicyError` and the restart counters.
  - `prelude::observe` — snapshots, lifecycle histories, scope/membership state, and the identity triple.
  - `prelude::errors` — the exit/error taxonomy, congruent with the `guides::errors` catalog.
  - `prelude::raw` — `RawActor` and the offload machinery, including `DeadlineBudget`.
  - `prelude::wiring` — slots, subtree composition, `BuildError`.
- **Ring 2** — the flat crate root, canonical and complete.

Overlap between bundles is intentional (`ExitError`, `PolicyError`, `BuildError` appear twice); the same item reached through two globs does not conflict.

## Admission rule

Documented in the module docs as the governing criterion for future additions: an item enters the prelude iff a program that defines actors and tasks, declares a tree, sends and calls, and shuts down must write its name — in an impl header, a field, or a function signature. Items appearing only in return position you match occasionally, or only when tuning behavior, live in a bundle.

## The `Context` collision

The module docs call out that `std::task::Context` (manual `Future` impls) and `anyhow::Context` collide with the actor `Context`, and that Rust's glob rules make this quiet: an explicit `use` shadows a glob-imported name without an error. The documented fix is `use anyhow::Context as _;` or path-qualifying the other side. No `ActorContext` alias is added.

Also documented: the standing glob caveat (a name added later can collide with a downstream-defined name — accepted trade), and that utility-tier crates (`specs/non-core.md` §27) are expected to glob `shelterwood::prelude::*` into their own preludes, making this the base of that stack.

## Probe coverage

The existing external-consumer probe is a set of targeted compile-failure assertions, not a walk, so it does not cover the prelude automatically. The `runtime-api-check` lane's rustdoc-JSON walk (`tools/api-reachability`) does visit new public modules for *runtime-type leaks*, but that is a different property from prelude containment. So the walk is extended with a second check:

`find_prelude_escapes` locates the `prelude` module in the façade's rustdoc JSON and walks it and its submodules. Every `use` beneath it must name an item the crate root already re-exports **under the same name** — the check pairs name with resolved target id, so an aliased or shadowing re-export is caught too. Globs, locally defined items, and a `prelude` module missing from the document are all failures; the last one keeps the check from passing vacuously.

That gives "prelude ⊆ public root" by construction, and with it "the prelude exposes nothing `doc(hidden)`", since the root's own boundary is already pinned by `tools/check-external-consumer.sh`.

Mutation-checked against the real document — all three escape classes fail the lane:

```
prelude::wiring defines `ActorContext` instead of re-exporting
prelude::wiring re-exports the glob `cells::*`
prelude::wiring::SubtreeFuture is not `shelterwood::SubtreeFuture`
```

Six unit tests in the tool cover the same classes plus the fail-closed missing-module case.

## Acceptance test

The lib.rs Quickstart doctest now opens with `use shelterwood::prelude::*;` (keeping `use std::time::Duration;`), so it compiles from the ring-0 glob alone. `tools/external-consumer/tests/default_features.rs` imports through the prelude from outside the workspace, proving external reachability. A `# Prelude` section in the crate docs points at the module from the API-by-area index.

## Deliberate exclusions

- Admission outcomes (`Admission`, `Removal`, `RemoveOutcome`, `ReserveError`, `NotAdmittingCause`) stay ring 2; the module docs say so and why.
- No renamed aliases, no `prelude::v1`, nothing foreign re-exported (no `Duration`, nothing from tokio).

## Verification

`./tools/dev just ci` passes.
