### PR TITLE
Harden raw teardown result retention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,11 @@ rests on:
   `reconcile_recorded_outcomes_retaining` and
   `classify_disposal_panic_retaining`; the raw `shelterwood-core` folds hand
   both halves back and are for core's own tests.
+  `RetainedExitResult` closes the earlier raw-incarnation window: the completed
+  callback result stays in that carrier across the fallible teardown epilogue,
+  so an epilogue panic transfers a failed result to critical disposal instead
+  of destroying its application error during the unwind. The normal path takes
+  the result back before returning it to the driver.
   `ScopeCell::clear_residents_locked`, `prune_child_locked` and
   `admit_child_locked` route `Arc<MemberCell>`s through
   `runtime::dispose_detached` after unlock: the last member owner can also be

--- a/crates/shelterwood/src/cells/retained.rs
+++ b/crates/shelterwood/src/cells/retained.rs
@@ -5,7 +5,7 @@ use shelterwood_core::{
     Exit,
     engine::ScopeState,
     exit::{
-        Cancellation, ExitKind, GracePhase, JoinOutcome, RecordedOutcome, StartupError,
+        Cancellation, ExitKind, ExitResult, GracePhase, JoinOutcome, RecordedOutcome, StartupError,
         StartupFailure, StartupFailureCause, StopReason, classify_disposal_panic, classify_exit,
         reconcile_recorded_outcomes,
     },
@@ -171,6 +171,42 @@ impl Drop for RetainedRecordedOutcome {
         };
         if outcome.is_failed() {
             runtime::dispose_critical(outcome);
+        }
+    }
+}
+
+/// A completed incarnation result retained across a fallible teardown epilogue.
+///
+/// The failed variant owns a type-erased application error that no framework
+/// copy has reached yet: the first retention point downstream is
+/// [`RetainedRecordedOutcome`], one hop after the incarnation future returns.
+/// The raw epilogue runs several contained teardown steps while holding the
+/// completed result and then resumes any surviving panic, so the carrier is
+/// dropped during that unwind — and destroying a user error there is a second
+/// panic inside the first one's cleanup, which aborts the process.
+/// [`Self::into_result`] on the normal return path preserves ordinary
+/// downstream ownership.
+pub(crate) struct RetainedExitResult(Option<ExitResult>);
+
+impl RetainedExitResult {
+    pub(crate) fn new(result: ExitResult) -> Self {
+        Self(Some(result))
+    }
+
+    pub(crate) fn into_result(mut self) -> ExitResult {
+        self.0
+            .take()
+            .expect("retained exit result was already taken")
+    }
+}
+
+impl Drop for RetainedExitResult {
+    fn drop(&mut self) {
+        let Some(result) = self.0.take() else {
+            return;
+        };
+        if let Err(error) = result {
+            runtime::dispose_critical(error);
         }
     }
 }
@@ -392,6 +428,40 @@ mod tests {
                 .recv_timeout(TEST_WAIT)
                 .expect("recorded failure disposal completes"),
             retiring_thread
+        );
+    }
+
+    #[test]
+    fn retained_failed_exit_result_disposes_off_the_retiring_thread() {
+        let retiring_thread = std::thread::current().id();
+        let (dropped, observed) = mpsc::sync_channel(1);
+        let retained = RetainedExitResult::new(Err(ExitError::from(ThreadProbe(dropped))));
+
+        drop(retained);
+
+        assert_ne!(
+            observed
+                .recv_timeout(TEST_WAIT)
+                .expect("retained result disposal completes"),
+            retiring_thread,
+            "a teardown unwind must not run the application error's destructor inline"
+        );
+    }
+
+    #[test]
+    fn taken_exit_result_preserves_the_callers_drop_thread() {
+        let caller = std::thread::current().id();
+        let (dropped, observed) = mpsc::sync_channel(1);
+        let retained = RetainedExitResult::new(Err(ExitError::from(ThreadProbe(dropped))));
+
+        drop(retained.into_result());
+
+        assert_eq!(
+            observed
+                .recv_timeout(TEST_WAIT)
+                .expect("taken result destruction completes"),
+            caller,
+            "the normal return path keeps ordinary downstream drop timing"
         );
     }
 

--- a/crates/shelterwood/src/raw/definition.rs
+++ b/crates/shelterwood/src/raw/definition.rs
@@ -11,7 +11,7 @@ use crate::{
     mailbox::{MailboxCell, MailboxControl, MailboxEffectQueue, actor_ref_from_parts},
     policy::CommonOptions,
     runtime::{
-        CompletionGatedLatch, Isolated, Latch, PanicAccumulator, PanicPayload, UnwindPanics,
+        self, CompletionGatedLatch, Isolated, Latch, PanicAccumulator, PanicPayload, UnwindPanics,
         catch_panic, keep_first_panic, resume_preferred_panic,
         resume_preferred_panic_outside_unwind,
     },
@@ -170,6 +170,37 @@ impl<R: RawActor> RawOnceDef<R> {
 type RawFuture = Pin<Box<dyn Future<Output = ExitResult> + Send + 'static>>;
 type RawFactory = Arc<dyn Fn() -> Box<dyn ErasedRawInstance> + Send + Sync + 'static>;
 
+/// A completed raw outcome retained across the fallible teardown epilogue.
+///
+/// A failed result owns a type-erased application error. If teardown resumes a
+/// panic, the incarnation future drops this carrier during that unwind, so the
+/// error must not be destroyed on the same stack. The normal return path takes
+/// the result back and preserves ordinary downstream ownership.
+struct RetainedExitResult(Option<ExitResult>);
+
+impl RetainedExitResult {
+    fn new(result: ExitResult) -> Self {
+        Self(Some(result))
+    }
+
+    fn into_result(mut self) -> ExitResult {
+        self.0
+            .take()
+            .expect("retained exit result was already taken")
+    }
+}
+
+impl Drop for RetainedExitResult {
+    fn drop(&mut self) {
+        let Some(result) = self.0.take() else {
+            return;
+        };
+        if let Err(error) = result {
+            runtime::dispose_critical(error);
+        }
+    }
+}
+
 pub(crate) trait ErasedRawInstance: Send {
     fn run(self: Box<Self>, context: RawRunContext, readiness: Readiness) -> RawFuture;
 }
@@ -256,7 +287,7 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
                 CatchUnwindFuture::new(actor.run(raw)).await
             };
             let result = match outcome {
-                Ok(result) => Some(result),
+                Ok(result) => Some(RetainedExitResult::new(result)),
                 Err(payload) => {
                     // Keep the actor's diagnostic in the owned epilogue so a
                     // hard abort during async teardown cannot replace it with
@@ -294,7 +325,9 @@ impl<R: RawActor> ErasedRawInstance for RawInstance<R> {
                 primary: owner.take_primary_panic(),
                 cleanup: cleanup_panic,
             });
-            result.expect("an incarnation without a primary panic returns a result")
+            result
+                .expect("an incarnation without a primary panic returns a result")
+                .into_result()
         })
     }
 }

--- a/crates/shelterwood/src/raw/definition.rs
+++ b/crates/shelterwood/src/raw/definition.rs
@@ -6,12 +6,12 @@ use std::{fmt, future::Future, pin::Pin, sync::Arc};
 use crate::{
     ChildId, ExitResult, Incarnation, Mailbox, MailboxShutdown, PolicyError, Readiness,
     ReadinessDeadline, RestartPolicy, Retention, Shutdown,
-    cells::MemberCell,
+    cells::{MemberCell, RetainedExitResult},
     definition::DefinitionSource,
     mailbox::{MailboxCell, MailboxControl, MailboxEffectQueue, actor_ref_from_parts},
     policy::CommonOptions,
     runtime::{
-        self, CompletionGatedLatch, Isolated, Latch, PanicAccumulator, PanicPayload, UnwindPanics,
+        CompletionGatedLatch, Isolated, Latch, PanicAccumulator, PanicPayload, UnwindPanics,
         catch_panic, keep_first_panic, resume_preferred_panic,
         resume_preferred_panic_outside_unwind,
     },
@@ -169,37 +169,6 @@ impl<R: RawActor> RawOnceDef<R> {
 
 type RawFuture = Pin<Box<dyn Future<Output = ExitResult> + Send + 'static>>;
 type RawFactory = Arc<dyn Fn() -> Box<dyn ErasedRawInstance> + Send + Sync + 'static>;
-
-/// A completed raw outcome retained across the fallible teardown epilogue.
-///
-/// A failed result owns a type-erased application error. If teardown resumes a
-/// panic, the incarnation future drops this carrier during that unwind, so the
-/// error must not be destroyed on the same stack. The normal return path takes
-/// the result back and preserves ordinary downstream ownership.
-struct RetainedExitResult(Option<ExitResult>);
-
-impl RetainedExitResult {
-    fn new(result: ExitResult) -> Self {
-        Self(Some(result))
-    }
-
-    fn into_result(mut self) -> ExitResult {
-        self.0
-            .take()
-            .expect("retained exit result was already taken")
-    }
-}
-
-impl Drop for RetainedExitResult {
-    fn drop(&mut self) {
-        let Some(result) = self.0.take() else {
-            return;
-        };
-        if let Err(error) = result {
-            runtime::dispose_critical(error);
-        }
-    }
-}
 
 pub(crate) trait ErasedRawInstance: Send {
     fn run(self: Box<Self>, context: RawRunContext, readiness: Readiness) -> RawFuture;

--- a/crates/shelterwood/tests/raw_teardown_result_containment.rs
+++ b/crates/shelterwood/tests/raw_teardown_result_containment.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use std::{error::Error, fmt, sync::mpsc, time::Duration};
+use std::{error::Error, fmt, sync::mpsc, thread::ThreadId, time::Duration};
 
 use crate::common::next_exit_of;
 use shelterwood::{
@@ -9,9 +9,12 @@ use shelterwood::{
 };
 
 const ACTOR_DROP_PANIC: &str = "injected actor-state destructor panic";
+const PROBE_WAIT: Duration = Duration::from_secs(10);
+
+type ThreadProbe = mpsc::SyncSender<ThreadId>;
 
 #[derive(Debug)]
-struct HostileError(mpsc::SyncSender<std::thread::ThreadId>);
+struct HostileError(ThreadProbe);
 
 impl fmt::Display for HostileError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -28,9 +31,33 @@ impl Drop for HostileError {
     }
 }
 
+/// Asserts that the epilogue moved the application error off the very thread
+/// that ran teardown, rather than off whichever thread happens to host the
+/// test. The two coincide only under the default current-thread flavour, so
+/// comparing against the teardown thread keeps the probe honest if the actor
+/// is ever scheduled elsewhere.
+fn assert_disposed_off_the_teardown_thread(
+    teardown: &mpsc::Receiver<ThreadId>,
+    disposal: &mpsc::Receiver<ThreadId>,
+) {
+    let teardown_thread = teardown
+        .recv_timeout(PROBE_WAIT)
+        .expect("the actor's destructor runs during teardown");
+    let disposal_thread = disposal
+        .recv_timeout(PROBE_WAIT)
+        .expect("the hostile error is eventually disposed");
+    assert_ne!(
+        disposal_thread, teardown_thread,
+        "the teardown unwind must not destroy the application error inline"
+    );
+}
+
 /// Returns an application error, then panics from actor destruction while the
 /// raw incarnation epilogue still owns that result.
-struct RawReturnsHostileErrorThenPanicsOnDrop(Option<HostileError>);
+struct RawReturnsHostileErrorThenPanicsOnDrop {
+    error: Option<HostileError>,
+    teardown: ThreadProbe,
+}
 
 impl RawActor for RawReturnsHostileErrorThenPanicsOnDrop {
     type Msg = ();
@@ -38,28 +65,30 @@ impl RawActor for RawReturnsHostileErrorThenPanicsOnDrop {
     async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
         let _ = context.recv().await;
         Err(ExitError::from(
-            self.0.take().expect("hostile error is returned once"),
+            self.error.take().expect("hostile error is returned once"),
         ))
     }
 }
 
 impl Drop for RawReturnsHostileErrorThenPanicsOnDrop {
     fn drop(&mut self) {
+        let _ = self.teardown.send(std::thread::current().id());
         panic!("{ACTOR_DROP_PANIC}");
     }
 }
 
 #[tokio::test]
 async fn raw_error_is_retained_while_the_teardown_panic_unwinds() {
-    let actor_thread = std::thread::current().id();
     let (dropped, observed) = mpsc::sync_channel(1);
+    let (torn_down, teardown) = mpsc::sync_channel(1);
     let mut tree = Tree::new();
     let actor = tree
         .add_raw_once(
             "hostile-raw",
-            RawOnceDef::new(RawReturnsHostileErrorThenPanicsOnDrop(Some(HostileError(
-                dropped,
-            )))),
+            RawOnceDef::new(RawReturnsHostileErrorThenPanicsOnDrop {
+                error: Some(HostileError(dropped)),
+                teardown: torn_down,
+            }),
         )
         .expect("valid raw actor");
     let system = tree.spawn().expect("runtime is available");
@@ -74,49 +103,53 @@ async fn raw_error_is_retained_while_the_teardown_panic_unwinds() {
         ExitKind::Panicked { message } if message.as_deref() == Some(ACTOR_DROP_PANIC)
     ));
     assert_eq!(system.wait().await, StopReason::Finished);
-    assert_ne!(
-        observed
-            .recv_timeout(Duration::from_secs(10))
-            .expect("the hostile error is eventually disposed"),
-        actor_thread,
-        "the teardown unwind must not destroy the application error inline"
-    );
+    assert_disposed_off_the_teardown_thread(&teardown, &observed);
 }
 
 /// The supported callback-oriented actor surface reaches the same raw
 /// epilogue through `Handler<A>`.
-struct HandlerReturnsHostileError(Option<HostileError>);
+struct HandlerReturnsHostileError {
+    error: Option<HostileError>,
+    teardown: ThreadProbe,
+}
 
 impl Actor for HandlerReturnsHostileError {
     type Msg = ();
-    type Args = HostileError;
+    type Args = (HostileError, ThreadProbe);
 
-    async fn init(error: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
-        Ok(Self(Some(error)))
+    async fn init(
+        (error, teardown): Self::Args,
+        _: &mut Context<'_, Self>,
+    ) -> Result<Self, ExitError> {
+        Ok(Self {
+            error: Some(error),
+            teardown,
+        })
     }
 
     async fn handle(&mut self, (): Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
         Err(ExitError::from(
-            self.0.take().expect("hostile error is returned once"),
+            self.error.take().expect("hostile error is returned once"),
         ))
     }
 }
 
 impl Drop for HandlerReturnsHostileError {
     fn drop(&mut self) {
+        let _ = self.teardown.send(std::thread::current().id());
         panic!("{ACTOR_DROP_PANIC}");
     }
 }
 
 #[tokio::test]
 async fn handler_error_is_retained_while_the_teardown_panic_unwinds() {
-    let actor_thread = std::thread::current().id();
     let (dropped, observed) = mpsc::sync_channel(1);
+    let (torn_down, teardown) = mpsc::sync_channel(1);
     let mut tree = Tree::new();
     let actor = tree
         .add_actor_once(
             "hostile-handler",
-            ActorOnceDef::<HandlerReturnsHostileError>::new(HostileError(dropped)),
+            ActorOnceDef::<HandlerReturnsHostileError>::new((HostileError(dropped), torn_down)),
         )
         .expect("valid actor");
     let system = tree.spawn().expect("runtime is available");
@@ -131,11 +164,5 @@ async fn handler_error_is_retained_while_the_teardown_panic_unwinds() {
         ExitKind::Panicked { message } if message.as_deref() == Some(ACTOR_DROP_PANIC)
     ));
     assert_eq!(system.wait().await, StopReason::Finished);
-    assert_ne!(
-        observed
-            .recv_timeout(Duration::from_secs(10))
-            .expect("the hostile error is eventually disposed"),
-        actor_thread,
-        "the teardown unwind must not destroy the application error inline"
-    );
+    assert_disposed_off_the_teardown_thread(&teardown, &observed);
 }

--- a/crates/shelterwood/tests/raw_teardown_result_containment.rs
+++ b/crates/shelterwood/tests/raw_teardown_result_containment.rs
@@ -1,0 +1,141 @@
+mod common;
+
+use std::{error::Error, fmt, sync::mpsc, time::Duration};
+
+use crate::common::next_exit_of;
+use shelterwood::{
+    Actor, ActorOnceDef, Context, ExitError, ExitKind, ExitResult, RawActor, RawContext,
+    RawOnceDef, StopReason, Tree,
+};
+
+const ACTOR_DROP_PANIC: &str = "injected actor-state destructor panic";
+
+#[derive(Debug)]
+struct HostileError(mpsc::SyncSender<std::thread::ThreadId>);
+
+impl fmt::Display for HostileError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("hostile application error")
+    }
+}
+
+impl Error for HostileError {}
+
+impl Drop for HostileError {
+    fn drop(&mut self) {
+        let _ = self.0.send(std::thread::current().id());
+        panic!("injected application-error destructor panic");
+    }
+}
+
+/// Returns an application error, then panics from actor destruction while the
+/// raw incarnation epilogue still owns that result.
+struct RawReturnsHostileErrorThenPanicsOnDrop(Option<HostileError>);
+
+impl RawActor for RawReturnsHostileErrorThenPanicsOnDrop {
+    type Msg = ();
+
+    async fn run(&mut self, context: &mut RawContext<Self::Msg>) -> ExitResult {
+        let _ = context.recv().await;
+        Err(ExitError::from(
+            self.0.take().expect("hostile error is returned once"),
+        ))
+    }
+}
+
+impl Drop for RawReturnsHostileErrorThenPanicsOnDrop {
+    fn drop(&mut self) {
+        panic!("{ACTOR_DROP_PANIC}");
+    }
+}
+
+#[tokio::test]
+async fn raw_error_is_retained_while_the_teardown_panic_unwinds() {
+    let actor_thread = std::thread::current().id();
+    let (dropped, observed) = mpsc::sync_channel(1);
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_raw_once(
+            "hostile-raw",
+            RawOnceDef::new(RawReturnsHostileErrorThenPanicsOnDrop(Some(HostileError(
+                dropped,
+            )))),
+        )
+        .expect("valid raw actor");
+    let system = tree.spawn().expect("runtime is available");
+    let mut events = system.scope().subscribe_lifecycle();
+    system.wait_started().await.expect("raw actor starts");
+
+    actor.send(()).await.expect("trigger is accepted");
+
+    let exit = next_exit_of(&mut events, "hostile-raw").await;
+    assert!(matches!(
+        exit.kind(),
+        ExitKind::Panicked { message } if message.as_deref() == Some(ACTOR_DROP_PANIC)
+    ));
+    assert_eq!(system.wait().await, StopReason::Finished);
+    assert_ne!(
+        observed
+            .recv_timeout(Duration::from_secs(10))
+            .expect("the hostile error is eventually disposed"),
+        actor_thread,
+        "the teardown unwind must not destroy the application error inline"
+    );
+}
+
+/// The supported callback-oriented actor surface reaches the same raw
+/// epilogue through `Handler<A>`.
+struct HandlerReturnsHostileError(Option<HostileError>);
+
+impl Actor for HandlerReturnsHostileError {
+    type Msg = ();
+    type Args = HostileError;
+
+    async fn init(error: Self::Args, _: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self(Some(error)))
+    }
+
+    async fn handle(&mut self, (): Self::Msg, _: &mut Context<'_, Self>) -> ExitResult {
+        Err(ExitError::from(
+            self.0.take().expect("hostile error is returned once"),
+        ))
+    }
+}
+
+impl Drop for HandlerReturnsHostileError {
+    fn drop(&mut self) {
+        panic!("{ACTOR_DROP_PANIC}");
+    }
+}
+
+#[tokio::test]
+async fn handler_error_is_retained_while_the_teardown_panic_unwinds() {
+    let actor_thread = std::thread::current().id();
+    let (dropped, observed) = mpsc::sync_channel(1);
+    let mut tree = Tree::new();
+    let actor = tree
+        .add_actor_once(
+            "hostile-handler",
+            ActorOnceDef::<HandlerReturnsHostileError>::new(HostileError(dropped)),
+        )
+        .expect("valid actor");
+    let system = tree.spawn().expect("runtime is available");
+    let mut events = system.scope().subscribe_lifecycle();
+    system.wait_started().await.expect("handler actor starts");
+
+    actor.send(()).await.expect("trigger is accepted");
+
+    let exit = next_exit_of(&mut events, "hostile-handler").await;
+    assert!(matches!(
+        exit.kind(),
+        ExitKind::Panicked { message } if message.as_deref() == Some(ACTOR_DROP_PANIC)
+    ));
+    assert_eq!(system.wait().await, StopReason::Finished);
+    assert_ne!(
+        observed
+            .recv_timeout(Duration::from_secs(10))
+            .expect("the hostile error is eventually disposed"),
+        actor_thread,
+        "the teardown unwind must not destroy the application error inline"
+    );
+}


### PR DESCRIPTION
## Summary

- retain a completed raw `ExitResult` across the fallible incarnation teardown epilogue
- route a failed result to critical disposal when teardown unwinds, while preserving normal downstream ownership
- cover both `RawActor` and supported `Actor` paths with hostile-error/teardown-panic regressions
- record the new carrier in the lock-rule ownership accounting

## Testing

- `./tools/dev cargo test -p shelterwood --test raw_teardown_result_containment`
- `./tools/dev just ci`
- `./tools/dev just ci-nix`

Closes #432.