### PR TITLE
Share raw-waker probes across tests

### DIFF
--- a/crates/shelterwood/src/driver/tests/system_join.rs
+++ b/crates/shelterwood/src/driver/tests/system_join.rs
@@ -1,62 +1,25 @@
 use std::{
     mem::ManuallyDrop,
     sync::Arc,
-    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+    task::{Context, Poll, Waker},
 };
 
 use super::support::*;
-use crate::{cells::RetainedStopReason, policy::ScopeFlavor};
+use crate::{cells::RetainedStopReason, policy::ScopeFlavor, test_support::probe_waker_with_wake};
 
 #[derive(Default)]
 struct HostileWakeState {
     woken: tokio::sync::Notify,
 }
 
-unsafe fn clone_hostile_waker(data: *const ()) -> RawWaker {
-    // SAFETY: every pointer using this vtable came from an Arc of the
-    // matching type. ManuallyDrop preserves the reference represented by
-    // `data`; the returned raw waker owns only the new clone.
-    let state = ManuallyDrop::new(unsafe { Arc::<HostileWakeState>::from_raw(data.cast()) });
-    RawWaker::new(
-        Arc::into_raw(Arc::clone(&state)).cast(),
-        &HOSTILE_WAKER_VTABLE,
-    )
-}
-
-unsafe fn wake_hostile_waker(data: *const ()) {
-    // SAFETY: wake consumes the Arc reference represented by this raw waker.
-    let state = unsafe { Arc::<HostileWakeState>::from_raw(data.cast()) };
-    state.woken.notify_one();
-}
-
-unsafe fn wake_by_ref_hostile_waker(data: *const ()) {
-    // SAFETY: ManuallyDrop preserves the reference represented by `data`.
-    let state = ManuallyDrop::new(unsafe { Arc::<HostileWakeState>::from_raw(data.cast()) });
-    state.woken.notify_one();
-}
-
-unsafe fn drop_hostile_waker(data: *const ()) {
-    // SAFETY: drop consumes the Arc reference represented by this raw waker.
-    drop(unsafe { Arc::<HostileWakeState>::from_raw(data.cast()) });
-    panic!("injected SystemRun join caller-waker drop panic");
-}
-
-static HOSTILE_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-    clone_hostile_waker,
-    wake_hostile_waker,
-    wake_by_ref_hostile_waker,
-    drop_hostile_waker,
-);
-
 fn hostile_waker() -> (ManuallyDrop<Waker>, Arc<HostileWakeState>) {
     let state = Arc::new(HostileWakeState::default());
-    let raw = RawWaker::new(
-        Arc::into_raw(Arc::clone(&state)).cast(),
-        &HOSTILE_WAKER_VTABLE,
+    let wake_state = Arc::clone(&state);
+    let waker = probe_waker_with_wake(
+        || {},
+        move || wake_state.woken.notify_one(),
+        || panic!("injected SystemRun join caller-waker drop panic"),
     );
-    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
-    // ownership across clone, wake, and drop.
-    let waker = unsafe { Waker::from_raw(raw) };
     (ManuallyDrop::new(waker), state)
 }
 

--- a/crates/shelterwood/src/lib.rs
+++ b/crates/shelterwood/src/lib.rs
@@ -226,6 +226,8 @@ mod raw;
 mod runtime;
 mod scope;
 mod task;
+#[cfg(test)]
+mod test_support;
 mod tree;
 
 pub use actor::{Actor, ActorDef, ActorOnceDef, Context, Handler, StopContext};

--- a/crates/shelterwood/src/mailbox.rs
+++ b/crates/shelterwood/src/mailbox.rs
@@ -24,8 +24,6 @@ mod errors;
 mod futures;
 mod reply;
 #[cfg(test)]
-mod test_support;
-#[cfg(test)]
 mod timer;
 pub(crate) use cell::*;
 pub use errors::*;

--- a/crates/shelterwood/src/mailbox/cell/tests.rs
+++ b/crates/shelterwood/src/mailbox/cell/tests.rs
@@ -15,9 +15,9 @@ use crate::{
     mailbox::{
         ActorIdentity, ActorRef, ChildId, Incarnation, MailboxControl, MailboxReceiver,
         SendErrorKind,
-        test_support::{mint_actor_incarnation, mint_actor_membership},
     },
     policy::{ResolvedDefaults, ResolvedMailbox},
+    test_support::{mint_actor_incarnation, mint_actor_membership},
 };
 
 use super::MailboxCell;

--- a/crates/shelterwood/src/mailbox/deadline.rs
+++ b/crates/shelterwood/src/mailbox/deadline.rs
@@ -251,7 +251,7 @@ mod tests {
         task::{Context, Poll, Wake, Waker},
     };
 
-    use crate::mailbox::test_support::probe_waker;
+    use crate::test_support::probe_waker;
 
     /// Stays pending on its first elapsed poll, modelling an atomic
     /// completion transition that won without publishing its payload yet.

--- a/crates/shelterwood/src/mailbox/futures.rs
+++ b/crates/shelterwood/src/mailbox/futures.rs
@@ -828,9 +828,9 @@ mod tests {
     use crate::{
         mailbox::{
             CallErrorKind, Incarnation, MailboxControl, MailboxEffectQueue, MailboxReceiver, Reply,
-            test_support::{mint_actor_incarnation, probe_waker},
         },
         policy::ResolvedMailbox,
+        test_support::{mint_actor_incarnation, probe_waker},
     };
 
     use super::{

--- a/crates/shelterwood/src/mailbox/reply.rs
+++ b/crates/shelterwood/src/mailbox/reply.rs
@@ -164,8 +164,8 @@ mod tests {
         time::Duration,
     };
 
-    use crate::mailbox::{
-        capability::{DisposingReceiver, OneShotClose, oneshot},
+    use crate::{
+        mailbox::capability::{DisposingReceiver, OneShotClose, oneshot},
         test_support::probe_waker,
     };
     use shelterwood_core::{

--- a/crates/shelterwood/src/mailbox/timer.rs
+++ b/crates/shelterwood/src/mailbox/timer.rs
@@ -17,7 +17,7 @@ mod tests {
 
     use shelterwood_core::{BoxedSleep, ProxiedSleep};
 
-    use crate::mailbox::test_support::probe_waker;
+    use crate::test_support::probe_waker;
 
     fn thread_drop_waker(sender: mpsc::Sender<ThreadId>) -> Waker {
         probe_waker(

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -332,7 +332,7 @@ mod tests {
             Arc,
             atomic::{AtomicUsize, Ordering},
         },
-        task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+        task::{Context, Poll, Waker},
     };
 
     use crate::{
@@ -340,6 +340,7 @@ mod tests {
         cells::MemberCell,
         identity::ScopeIdentity,
         runtime::{self, CompletionGatedLatch, Latch},
+        test_support::probe_waker,
     };
 
     use super::{OneShotTaskRef, TaskContext, TaskContextLatches, TaskOnceDef, TaskRef};
@@ -453,45 +454,11 @@ mod tests {
         (sender, claim, member)
     }
 
-    unsafe fn clone_panicking_drop_waker(data: *const ()) -> RawWaker {
-        // SAFETY: every pointer using this vtable came from an Arc of the
-        // matching type. ManuallyDrop preserves the represented reference;
-        // the returned raw waker owns only the new clone.
-        let state = ManuallyDrop::new(unsafe { Arc::<()>::from_raw(data.cast()) });
-        RawWaker::new(
-            Arc::into_raw(Arc::clone(&state)).cast(),
-            &PANICKING_DROP_WAKER_VTABLE,
-        )
-    }
-
-    unsafe fn wake_panicking_drop_waker(data: *const ()) {
-        // SAFETY: wake consumes the Arc reference represented by this waker.
-        drop(unsafe { Arc::<()>::from_raw(data.cast()) });
-    }
-
-    unsafe fn wake_by_ref_panicking_drop_waker(_data: *const ()) {}
-
-    unsafe fn drop_panicking_drop_waker(data: *const ()) {
-        // SAFETY: drop consumes the Arc reference represented by this waker.
-        drop(unsafe { Arc::<()>::from_raw(data.cast()) });
-        panic!("injected one-shot completion caller-waker drop panic");
-    }
-
-    static PANICKING_DROP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-        clone_panicking_drop_waker,
-        wake_panicking_drop_waker,
-        wake_by_ref_panicking_drop_waker,
-        drop_panicking_drop_waker,
-    );
-
     fn panicking_drop_waker() -> Waker {
-        let raw = RawWaker::new(
-            Arc::into_raw(Arc::new(())).cast(),
-            &PANICKING_DROP_WAKER_VTABLE,
-        );
-        // SAFETY: `raw` owns one Arc reference and its vtable maintains that
-        // ownership across clone, wake, and drop.
-        unsafe { Waker::from_raw(raw) }
+        probe_waker(
+            || {},
+            || panic!("injected one-shot completion caller-waker drop panic"),
+        )
     }
 
     struct PanickingCompletion;

--- a/crates/shelterwood/src/test_support.rs
+++ b/crates/shelterwood/src/test_support.rs
@@ -82,3 +82,94 @@ pub(crate) fn mint_actor_incarnation() -> Incarnation {
     let (_, mut incarnations) = mint_actor_membership();
     incarnations.mint().expect("incarnation available")
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+    };
+
+    use super::probe_waker_with_wake;
+
+    #[test]
+    fn probe_waker_routes_clone_wake_and_drop_without_leaking() {
+        let clones = Arc::new(AtomicUsize::new(0));
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let drops = Arc::new(AtomicUsize::new(0));
+        let retained = Arc::new(());
+
+        let clone_count = Arc::clone(&clones);
+        let clone_retained = Arc::clone(&retained);
+        let wake_count = Arc::clone(&wakes);
+        let wake_retained = Arc::clone(&retained);
+        let drop_count = Arc::clone(&drops);
+        let drop_retained = Arc::clone(&retained);
+        let waker = probe_waker_with_wake(
+            move || {
+                let _retained = &clone_retained;
+                clone_count.fetch_add(1, Ordering::SeqCst);
+            },
+            move || {
+                let _retained = &wake_retained;
+                wake_count.fetch_add(1, Ordering::SeqCst);
+            },
+            move || {
+                let _retained = &drop_retained;
+                drop_count.fetch_add(1, Ordering::SeqCst);
+            },
+        );
+
+        let by_ref = waker.clone();
+        by_ref.wake_by_ref();
+        drop(by_ref);
+        let consumed = waker.clone();
+        consumed.wake();
+        drop(waker);
+
+        assert_eq!(clones.load(Ordering::SeqCst), 2);
+        assert_eq!(wakes.load(Ordering::SeqCst), 2);
+        assert_eq!(drops.load(Ordering::SeqCst), 2);
+        assert_eq!(Arc::strong_count(&retained), 1);
+    }
+
+    #[test]
+    fn panicking_consuming_wake_still_retires_its_raw_reference() {
+        let first_wake = Arc::new(AtomicBool::new(true));
+        let drops = Arc::new(AtomicUsize::new(0));
+        let retained = Arc::new(());
+
+        let wake_once = Arc::clone(&first_wake);
+        let wake_retained = Arc::clone(&retained);
+        let drop_count = Arc::clone(&drops);
+        let drop_retained = Arc::clone(&retained);
+        let waker = probe_waker_with_wake(
+            || {},
+            move || {
+                let _retained = &wake_retained;
+                if wake_once.swap(false, Ordering::SeqCst) {
+                    panic!("injected wake panic");
+                }
+            },
+            move || {
+                let _retained = &drop_retained;
+                drop_count.fetch_add(1, Ordering::SeqCst);
+            },
+        );
+        let consumed = waker.clone();
+
+        let panic = catch_unwind(AssertUnwindSafe(|| consumed.wake()));
+        assert!(
+            panic.is_err(),
+            "the wake callback panic reaches the harness"
+        );
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+        drop(waker);
+
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        assert_eq!(Arc::strong_count(&retained), 1);
+    }
+}

--- a/crates/shelterwood/src/test_support.rs
+++ b/crates/shelterwood/src/test_support.rs
@@ -8,6 +8,7 @@ use shelterwood_core::{ChildId, Incarnation, IncarnationCounter, Membership, Sco
 
 struct WakerProbe {
     on_clone: Box<dyn Fn() + Send + Sync>,
+    on_wake: Box<dyn Fn() + Send + Sync>,
     on_drop: Box<dyn Fn() + Send + Sync>,
 }
 
@@ -22,10 +23,16 @@ unsafe fn clone_probe(data: *const ()) -> RawWaker {
 
 unsafe fn wake_probe(data: *const ()) {
     // SAFETY: wake consumes exactly the Arc reference represented by `data`.
-    drop(unsafe { Arc::<WakerProbe>::from_raw(data.cast()) });
+    let probe = unsafe { Arc::<WakerProbe>::from_raw(data.cast()) };
+    (probe.on_wake)();
 }
 
-unsafe fn wake_probe_by_ref(_data: *const ()) {}
+unsafe fn wake_probe_by_ref(data: *const ()) {
+    // SAFETY: `data` remains owned by the caller, so this temporary reference
+    // neither consumes nor clones its Arc reference.
+    let probe = unsafe { &*data.cast::<WakerProbe>() };
+    (probe.on_wake)();
+}
 
 unsafe fn drop_probe(data: *const ()) {
     // SAFETY: drop consumes exactly the Arc reference represented by `data`.
@@ -44,8 +51,18 @@ pub(crate) fn probe_waker(
     on_clone: impl Fn() + Send + Sync + 'static,
     on_drop: impl Fn() + Send + Sync + 'static,
 ) -> Waker {
+    probe_waker_with_wake(on_clone, || {}, on_drop)
+}
+
+/// Builds a test-only waker that additionally observes wake operations.
+pub(crate) fn probe_waker_with_wake(
+    on_clone: impl Fn() + Send + Sync + 'static,
+    on_wake: impl Fn() + Send + Sync + 'static,
+    on_drop: impl Fn() + Send + Sync + 'static,
+) -> Waker {
     let probe = Arc::new(WakerProbe {
         on_clone: Box::new(on_clone),
+        on_wake: Box::new(on_wake),
         on_drop: Box::new(on_drop),
     });
     let raw = RawWaker::new(Arc::into_raw(probe).cast(), &PROBE_VTABLE);

--- a/crates/shelterwood/tests/common/main.rs
+++ b/crates/shelterwood/tests/common/main.rs
@@ -1,9 +1,22 @@
 #[path = "mod.rs"]
 mod common;
 
-use std::{cell::Cell, future, task::Poll, time::Duration};
+use std::{
+    cell::Cell,
+    future,
+    panic::{AssertUnwindSafe, catch_unwind},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    task::{Poll, Waker},
+    time::Duration,
+};
 
-use common::{ConsumeCount, LiveFlag, ReleaseGate, assert_quiet, poll_once};
+use common::{
+    ConsumeCount, LiveFlag, ReleaseGate, assert_quiet, hostile_waker, poll_once,
+    probe_waker_with_wake,
+};
 
 #[tokio::test]
 async fn release_gate_stores_one_permit() {
@@ -93,4 +106,105 @@ async fn eventual_assertion_context_is_evaluated_only_on_failure() {
     .await;
 
     assert!(!evaluated.get());
+}
+
+/// The integration-side raw-waker probe is a hand-written vtable restated from
+/// the crate-internal twin, and every fixture built on it -- `hostile_waker`
+/// above all -- is consumed by abort-class regressions that assert only that
+/// the process survives. A probe that silently stopped invoking its callbacks
+/// would therefore leave those suites passing with nothing injected. These
+/// pins are what makes that drift loud.
+#[test]
+fn probe_waker_routes_clone_wake_and_drop_without_leaking() {
+    let clones = Arc::new(AtomicUsize::new(0));
+    let wakes = Arc::new(AtomicUsize::new(0));
+    let drops = Arc::new(AtomicUsize::new(0));
+    let retained = Arc::new(());
+
+    let clone_count = Arc::clone(&clones);
+    let clone_retained = Arc::clone(&retained);
+    let wake_count = Arc::clone(&wakes);
+    let wake_retained = Arc::clone(&retained);
+    let drop_count = Arc::clone(&drops);
+    let drop_retained = Arc::clone(&retained);
+    let waker = probe_waker_with_wake(
+        move || {
+            let _retained = &clone_retained;
+            clone_count.fetch_add(1, Ordering::SeqCst);
+        },
+        move || {
+            let _retained = &wake_retained;
+            wake_count.fetch_add(1, Ordering::SeqCst);
+        },
+        move || {
+            let _retained = &drop_retained;
+            drop_count.fetch_add(1, Ordering::SeqCst);
+        },
+    );
+
+    let by_ref = waker.clone();
+    by_ref.wake_by_ref();
+    drop(by_ref);
+    let consumed = waker.clone();
+    consumed.wake();
+    drop(waker);
+
+    assert_eq!(clones.load(Ordering::SeqCst), 2);
+    assert_eq!(wakes.load(Ordering::SeqCst), 2);
+    assert_eq!(drops.load(Ordering::SeqCst), 2);
+    assert_eq!(Arc::strong_count(&retained), 1);
+}
+
+#[test]
+fn panicking_consuming_wake_still_retires_its_raw_reference() {
+    let first_wake = Arc::new(AtomicBool::new(true));
+    let drops = Arc::new(AtomicUsize::new(0));
+    let retained = Arc::new(());
+
+    let wake_once = Arc::clone(&first_wake);
+    let wake_retained = Arc::clone(&retained);
+    let drop_count = Arc::clone(&drops);
+    let drop_retained = Arc::clone(&retained);
+    let waker = probe_waker_with_wake(
+        || {},
+        move || {
+            let _retained = &wake_retained;
+            if wake_once.swap(false, Ordering::SeqCst) {
+                panic!("injected wake panic");
+            }
+        },
+        move || {
+            let _retained = &drop_retained;
+            drop_count.fetch_add(1, Ordering::SeqCst);
+        },
+    );
+    let consumed = waker.clone();
+
+    let panic = catch_unwind(AssertUnwindSafe(|| consumed.wake()));
+    assert!(
+        panic.is_err(),
+        "the wake callback panic reaches the harness"
+    );
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+    drop(waker);
+
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    assert_eq!(Arc::strong_count(&retained), 1);
+}
+
+/// `hostile_waker`'s whole contract is the destructor it installs on every
+/// registration the framework clones. The suites that consume it judge the
+/// absence of an abort, so the injection itself is pinned here.
+#[test]
+fn hostile_waker_registrations_panic_with_their_named_payload() {
+    const INJECTED: &str = "injected fixture caller-waker drop panic";
+
+    let hostile = hostile_waker(INJECTED);
+    // `ManuallyDrop`'s own `Clone` would yield another leaked handle, so clone
+    // the `Waker` itself: only a real registration reaches the drop vtable.
+    let registration = Waker::clone(&hostile);
+
+    let payload = catch_unwind(AssertUnwindSafe(move || drop(registration)))
+        .expect_err("a cloned hostile registration panics when it is destroyed");
+    assert_eq!(payload.downcast_ref::<&str>(), Some(&INJECTED));
 }

--- a/crates/shelterwood/tests/common/mod.rs
+++ b/crates/shelterwood/tests/common/mod.rs
@@ -23,7 +23,7 @@ pub(crate) use timing::{
 };
 pub(crate) use waker::{
     LiveWakerCounter, OrdinalWakerState, counting_waker, hostile_waker, ordinal_drop_waker,
-    ordinal_waker,
+    ordinal_waker, probe_waker,
 };
 
 macro_rules! assert_eventually {

--- a/crates/shelterwood/tests/common/mod.rs
+++ b/crates/shelterwood/tests/common/mod.rs
@@ -23,7 +23,7 @@ pub(crate) use timing::{
 };
 pub(crate) use waker::{
     LiveWakerCounter, OrdinalWakerState, counting_waker, hostile_waker, ordinal_drop_waker,
-    ordinal_waker, probe_waker,
+    ordinal_waker, probe_waker, probe_waker_with_wake,
 };
 
 macro_rules! assert_eventually {

--- a/crates/shelterwood/tests/common/waker.rs
+++ b/crates/shelterwood/tests/common/waker.rs
@@ -7,6 +7,51 @@ use std::{
     task::{RawWaker, RawWakerVTable, Waker},
 };
 
+struct WakerProbe {
+    on_clone: Box<dyn Fn() + Send + Sync>,
+    on_drop: Box<dyn Fn() + Send + Sync>,
+}
+
+unsafe fn clone_probe(data: *const ()) -> RawWaker {
+    // SAFETY: `probe_waker` creates every pointer paired with this vtable from
+    // `Arc<WakerProbe>`. ManuallyDrop preserves the represented reference;
+    // the returned raw waker owns exactly the newly cloned reference.
+    let probe = ManuallyDrop::new(unsafe { Arc::<WakerProbe>::from_raw(data.cast()) });
+    (probe.on_clone)();
+    RawWaker::new(Arc::into_raw(Arc::clone(&probe)).cast(), &PROBE_VTABLE)
+}
+
+unsafe fn wake_probe(data: *const ()) {
+    // SAFETY: wake consumes exactly the Arc reference represented by `data`.
+    drop(unsafe { Arc::<WakerProbe>::from_raw(data.cast()) });
+}
+
+unsafe fn wake_probe_by_ref(_data: *const ()) {}
+
+unsafe fn drop_probe(data: *const ()) {
+    // SAFETY: drop consumes exactly the Arc reference represented by `data`.
+    let probe = unsafe { Arc::<WakerProbe>::from_raw(data.cast()) };
+    (probe.on_drop)();
+}
+
+static PROBE_VTABLE: RawWakerVTable =
+    RawWakerVTable::new(clone_probe, wake_probe, wake_probe_by_ref, drop_probe);
+
+/// Builds a shared integration-test waker whose clone and drop entries are observable.
+pub(crate) fn probe_waker(
+    on_clone: impl Fn() + Send + Sync + 'static,
+    on_drop: impl Fn() + Send + Sync + 'static,
+) -> Waker {
+    let probe = Arc::new(WakerProbe {
+        on_clone: Box::new(on_clone),
+        on_drop: Box::new(on_drop),
+    });
+    let raw = RawWaker::new(Arc::into_raw(probe).cast(), &PROBE_VTABLE);
+    // SAFETY: `raw` owns one Arc reference and `PROBE_VTABLE` preserves or
+    // consumes exactly one reference for each RawWaker operation.
+    unsafe { Waker::from_raw(raw) }
+}
+
 #[derive(Default)]
 pub(crate) struct LiveWakerCounter(AtomicUsize);
 
@@ -183,53 +228,11 @@ fn make_ordinal_waker(
     (unsafe { Waker::from_raw(raw) }, shared)
 }
 
-struct HostileWakerState {
-    drop_panic: &'static str,
-}
-
-unsafe fn clone_hostile_waker(data: *const ()) -> RawWaker {
-    // SAFETY: every pointer using this vtable came from an Arc of the
-    // matching type. ManuallyDrop preserves the reference represented by
-    // `data`; the returned raw waker owns only the new clone.
-    let state = ManuallyDrop::new(unsafe { Arc::<HostileWakerState>::from_raw(data.cast()) });
-    RawWaker::new(
-        Arc::into_raw(Arc::clone(&state)).cast(),
-        &HOSTILE_WAKER_VTABLE,
-    )
-}
-
-unsafe fn wake_hostile_waker(data: *const ()) {
-    // SAFETY: wake consumes the Arc reference represented by this raw waker.
-    drop(unsafe { Arc::<HostileWakerState>::from_raw(data.cast()) });
-}
-
-unsafe fn wake_by_ref_hostile_waker(_data: *const ()) {}
-
-unsafe fn drop_hostile_waker(data: *const ()) {
-    // SAFETY: drop consumes the Arc reference represented by this raw waker.
-    let state = unsafe { Arc::<HostileWakerState>::from_raw(data.cast()) };
-    let drop_panic = state.drop_panic;
-    drop(state);
-    std::panic::panic_any(drop_panic);
-}
-
-static HOSTILE_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-    clone_hostile_waker,
-    wake_hostile_waker,
-    wake_by_ref_hostile_waker,
-    drop_hostile_waker,
-);
-
 /// Creates a deliberately leaked caller waker whose cloned registrations
 /// panic when destroyed.
 pub(crate) fn hostile_waker(drop_panic: &'static str) -> ManuallyDrop<Waker> {
-    let state = Arc::new(HostileWakerState { drop_panic });
-    let raw = RawWaker::new(
-        Arc::into_raw(Arc::clone(&state)).cast(),
-        &HOSTILE_WAKER_VTABLE,
-    );
-    // SAFETY: `raw` owns one Arc reference and its vtable maintains that
-    // ownership across clone, wake, and drop.
-    let waker = unsafe { Waker::from_raw(raw) };
-    ManuallyDrop::new(waker)
+    ManuallyDrop::new(probe_waker(
+        || {},
+        move || std::panic::panic_any(drop_panic),
+    ))
 }

--- a/crates/shelterwood/tests/common/waker.rs
+++ b/crates/shelterwood/tests/common/waker.rs
@@ -9,6 +9,7 @@ use std::{
 
 struct WakerProbe {
     on_clone: Box<dyn Fn() + Send + Sync>,
+    on_wake: Box<dyn Fn() + Send + Sync>,
     on_drop: Box<dyn Fn() + Send + Sync>,
 }
 
@@ -23,10 +24,16 @@ unsafe fn clone_probe(data: *const ()) -> RawWaker {
 
 unsafe fn wake_probe(data: *const ()) {
     // SAFETY: wake consumes exactly the Arc reference represented by `data`.
-    drop(unsafe { Arc::<WakerProbe>::from_raw(data.cast()) });
+    let probe = unsafe { Arc::<WakerProbe>::from_raw(data.cast()) };
+    (probe.on_wake)();
 }
 
-unsafe fn wake_probe_by_ref(_data: *const ()) {}
+unsafe fn wake_probe_by_ref(data: *const ()) {
+    // SAFETY: `data` remains owned by the caller, so this temporary reference
+    // neither consumes nor clones its Arc reference.
+    let probe = unsafe { &*data.cast::<WakerProbe>() };
+    (probe.on_wake)();
+}
 
 unsafe fn drop_probe(data: *const ()) {
     // SAFETY: drop consumes exactly the Arc reference represented by `data`.
@@ -42,8 +49,18 @@ pub(crate) fn probe_waker(
     on_clone: impl Fn() + Send + Sync + 'static,
     on_drop: impl Fn() + Send + Sync + 'static,
 ) -> Waker {
+    probe_waker_with_wake(on_clone, || {}, on_drop)
+}
+
+/// Builds a shared integration-test waker that additionally observes wake operations.
+pub(crate) fn probe_waker_with_wake(
+    on_clone: impl Fn() + Send + Sync + 'static,
+    on_wake: impl Fn() + Send + Sync + 'static,
+    on_drop: impl Fn() + Send + Sync + 'static,
+) -> Waker {
     let probe = Arc::new(WakerProbe {
         on_clone: Box::new(on_clone),
+        on_wake: Box::new(on_wake),
         on_drop: Box::new(on_drop),
     });
     let raw = RawWaker::new(Arc::into_raw(probe).cast(), &PROBE_VTABLE);

--- a/crates/shelterwood/tests/mailbox_future_drop_containment.rs
+++ b/crates/shelterwood/tests/mailbox_future_drop_containment.rs
@@ -17,12 +17,15 @@ use std::{
     mem::ManuallyDrop,
     panic::{AssertUnwindSafe, catch_unwind},
     pin::Pin,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     task::{Context as TaskContext, Poll, Waker},
     time::Duration,
 };
 
-use common::{ordinal_drop_waker, probe_waker};
+use common::{ordinal_drop_waker, probe_waker_with_wake};
 use shelterwood::{Actor, ActorOnceDef, Context, ExitError, ExitResult, Reply, Tree};
 
 const OUTER_PANIC: &str = "injected outer panic";
@@ -53,11 +56,12 @@ impl Actor for HoldingActor {
 }
 
 fn panicking_drop_waker() -> Waker {
-    let first = Arc::new(std::sync::atomic::AtomicBool::new(false));
-    probe_waker(
+    let first = Arc::new(AtomicBool::new(false));
+    probe_waker_with_wake(
         || {},
+        || panic!("injected waker wake panic"),
         move || {
-            if !first.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            if !first.swap(true, Ordering::SeqCst) {
                 panic!("injected waker drop panic");
             }
         },

--- a/crates/shelterwood/tests/mailbox_future_drop_containment.rs
+++ b/crates/shelterwood/tests/mailbox_future_drop_containment.rs
@@ -17,15 +17,12 @@ use std::{
     mem::ManuallyDrop,
     panic::{AssertUnwindSafe, catch_unwind},
     pin::Pin,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-    task::{Context as TaskContext, Poll, RawWaker, RawWakerVTable, Waker},
+    sync::Arc,
+    task::{Context as TaskContext, Poll, Waker},
     time::Duration,
 };
 
-use common::ordinal_drop_waker;
+use common::{ordinal_drop_waker, probe_waker};
 use shelterwood::{Actor, ActorOnceDef, Context, ExitError, ExitResult, Reply, Tree};
 
 const OUTER_PANIC: &str = "injected outer panic";
@@ -55,52 +52,16 @@ impl Actor for HoldingActor {
     }
 }
 
-struct FirstWakerDropPanics(AtomicBool);
-
-unsafe fn clone_panicking_drop_waker(data: *const ()) -> RawWaker {
-    // SAFETY: every pointer using this vtable came from an Arc of the matching
-    // type. ManuallyDrop preserves the reference represented by data; the
-    // returned raw waker owns only the new clone.
-    let probe = ManuallyDrop::new(unsafe { Arc::<FirstWakerDropPanics>::from_raw(data.cast()) });
-    RawWaker::new(
-        Arc::into_raw(Arc::clone(&probe)).cast(),
-        &PANICKING_DROP_WAKER_VTABLE,
-    )
-}
-
-unsafe fn wake_panicking_drop_waker(data: *const ()) {
-    // SAFETY: wake consumes the reference represented by this raw waker.
-    drop(unsafe { Arc::<FirstWakerDropPanics>::from_raw(data.cast()) });
-    panic!("injected waker wake panic");
-}
-
-unsafe fn wake_by_ref_panicking_drop_waker(_data: *const ()) {
-    panic!("injected waker wake panic");
-}
-
-unsafe fn drop_panicking_drop_waker(data: *const ()) {
-    // SAFETY: drop consumes the reference represented by this raw waker.
-    let probe = unsafe { Arc::<FirstWakerDropPanics>::from_raw(data.cast()) };
-    if !probe.0.swap(true, Ordering::SeqCst) {
-        panic!("injected waker drop panic");
-    }
-}
-
-static PANICKING_DROP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-    clone_panicking_drop_waker,
-    wake_panicking_drop_waker,
-    wake_by_ref_panicking_drop_waker,
-    drop_panicking_drop_waker,
-);
-
 fn panicking_drop_waker() -> Waker {
-    let raw = RawWaker::new(
-        Arc::into_raw(Arc::new(FirstWakerDropPanics(AtomicBool::new(false)))).cast(),
-        &PANICKING_DROP_WAKER_VTABLE,
-    );
-    // SAFETY: raw owns one Arc reference and its vtable maintains that
-    // ownership across clone, wake, and drop.
-    unsafe { Waker::from_raw(raw) }
+    let first = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    probe_waker(
+        || {},
+        move || {
+            if !first.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                panic!("injected waker drop panic");
+            }
+        },
+    )
 }
 
 fn assert_pending_then_unwind<F: Future>(mut future: Pin<Box<F>>) {


### PR DESCRIPTION
Closes #456.

Moves the unit-test probe_waker scaffold to crate-level test support and migrates mailbox, task, and SystemRun join probes. Adds the integration-side twin, migrates the remaining mailbox-future scaffold and shared hostile-waker fixture, and retains the already-centralized specialized ordinal/counting integration helpers. The core/runtime tier remains deliberately unchanged per adjudication.

Fresh adversarial review restored the mailbox fixture's original panic contract for consuming and by-reference wakes and added direct coverage for clone, wake, wake-by-reference, drop, and panicking-wake ownership.

Verification: ./tools/dev just ci (956 tests plus docs, examples, API reachability, external consumer, and nixfmt).