### PR TITLE
Fence root terminality on the driver join

### DIFF
--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -1025,6 +1025,7 @@ impl ScopeCell {
         self.finish_incarnation_with_terminal(epoch, RetainedStopReason::new(reason), None);
     }
 
+    #[cfg(test)]
     pub(crate) fn finish_root_incarnation(&self, epoch: Epoch, reason: StopReason, exit: Exit) {
         self.finish_incarnation_with_terminal(
             epoch,

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -200,9 +200,9 @@ fn monitor_root_driver(
 /// diagnostic; discard it rather than replacing a classified completion with
 /// a second monitor failure that could strand the root's finality fence.
 fn finish_monitored_root(root: &ScopeCell, reason: StopReason, exit: Exit) {
-    let mut panics = runtime::PanicAccumulator::default();
-    panics.run(|| root.finish_live_root_incarnation(reason, exit));
-    runtime::discard_panic(panics.take());
+    runtime::discard_panic(
+        runtime::catch_panic(|| root.finish_live_root_incarnation(reason, exit)).err(),
+    );
 }
 
 struct AncestorCommandLatches {

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -85,6 +85,10 @@ use admission_control::RemovalResponses;
 pub(crate) struct SystemRun {
     pub(crate) root: Arc<ScopeCell>,
     driver: Option<runtime::JoinHandle<RetainedStopReason>>,
+    // Taking the handle starts a cancellation-sensitive join. Keep its
+    // completion separate so dropping a cancelled consuming API still requests
+    // shutdown even though the in-flight future already moved the handle out.
+    driver_joined: bool,
 }
 
 fn resident_projection(slot: &SlotCell) -> ResidentProjection {
@@ -102,9 +106,8 @@ impl SystemRun {
     }
 
     pub(crate) async fn wait(&mut self) -> StopReason {
-        let reason = self.root.wait_stopped().await;
         self.join_driver().await;
-        reason
+        self.root.wait_stopped().await
     }
 
     async fn join_driver(&mut self) {
@@ -119,9 +122,9 @@ impl SystemRun {
         if let Err(exit) =
             classify_retained_root_driver_join(runtime::join_user_polled(driver).await)
         {
-            self.root
-                .finish_live_root_incarnation(StopReason::ShutdownRequested, exit);
+            finish_monitored_root(&self.root, StopReason::ShutdownRequested, exit);
         }
+        self.driver_joined = true;
     }
 }
 
@@ -143,7 +146,7 @@ fn classify_retained_root_driver_join(
 
 impl Drop for SystemRun {
     fn drop(&mut self) {
-        if self.driver.is_none() {
+        if self.driver_joined {
             return;
         }
         // After a clean shutdown the root epochs are `Idle`, not `Exhausted`,
@@ -165,6 +168,7 @@ pub(crate) fn spawn_system(plan: ScopePlan) -> SystemRun {
     SystemRun {
         root,
         driver: Some(lifecycle),
+        driver_joined: false,
     }
 }
 
@@ -174,13 +178,31 @@ fn monitor_root_driver(
 ) -> runtime::JoinHandle<RetainedStopReason> {
     runtime::spawn(async move {
         match classify_retained_root_driver_join(runtime::join(driver).await) {
-            Ok(reason) => reason,
+            Ok(reason) => {
+                let public_reason = reason.as_reason().clone();
+                let exit = stop_reason_root_exit(&public_reason);
+                finish_monitored_root(&monitor_root, public_reason, exit);
+                reason
+            }
             Err(exit) => {
-                monitor_root.finish_live_root_incarnation(StopReason::ShutdownRequested, exit);
+                finish_monitored_root(&monitor_root, StopReason::ShutdownRequested, exit);
                 RetainedStopReason::new(StopReason::ShutdownRequested)
             }
         }
     })
+}
+
+/// Publishes the join monitor's final root verdict without letting a hostile
+/// terminal observer kill the monitor itself.
+///
+/// The driver is already joined, so exit classification cannot change after
+/// this boundary. A panic from the terminal wake flush is consequently only a
+/// diagnostic; discard it rather than replacing a classified completion with
+/// a second monitor failure that could strand the root's finality fence.
+fn finish_monitored_root(root: &ScopeCell, reason: StopReason, exit: Exit) {
+    let mut panics = runtime::PanicAccumulator::default();
+    panics.run(|| root.finish_live_root_incarnation(reason, exit));
+    runtime::discard_panic(panics.take());
 }
 
 struct AncestorCommandLatches {
@@ -360,7 +382,6 @@ impl<T> IndexMut<ChildKey> for ChildResources<T> {
 
 struct ScopeCompletion {
     reason: RetainedStopReason,
-    root_exit: Option<RetainedExit>,
 }
 
 /// Runs the synchronous fail-closed scope epilogue.
@@ -454,14 +475,12 @@ impl Drop for ScopeRuntime {
             .map(|completion| completion.reason.as_reason().clone())
             .or_else(|| self.supervisor.lifecycle().draining_reason().cloned())
             .unwrap_or(StopReason::ShutdownRequested);
-        panics.run(|| {
-            if let Some(exit) = completion.and_then(|completion| completion.root_exit) {
-                self.root
-                    .finish_root_incarnation(self.epoch, reason, exit.into_exit());
-            } else {
-                self.root.finish_incarnation(self.epoch, reason);
-            }
-        });
+        // Root membership terminality is join-gated: the monitor owns it on
+        // both successful and failed driver joins. The scope epilogue only
+        // retires this incarnation and publishes its stopped projection, just
+        // as it already does while unwinding. That keeps `wait_stopped` behind
+        // the last point at which the join can change the final verdict.
+        panics.run(|| self.root.finish_incarnation(self.epoch, reason));
     }
 }
 
@@ -1150,13 +1169,8 @@ async fn wait_for_scope_wake(
             // receiver and any queued admission response wakers outside
             // ScopeRuntime's contained epilogue.
             let reason = StopReason::ShutdownRequested;
-            let root_exit = scope
-                .role
-                .is_root()
-                .then(|| RetainedExit::new(stop_reason_root_exit(&reason)));
             scope.completion = Some(ScopeCompletion {
                 reason: RetainedStopReason::new(reason.clone()),
-                root_exit,
             });
             return Some(reason);
         }
@@ -1453,16 +1467,12 @@ async fn run_scope_incarnation(
         // until the recomputation above establishes that order.
         scope.publish_startup_removals();
         if let Some(reason) = scope.finished.take() {
-            let root_exit = scope
-                .role
-                .is_root()
-                .then(|| RetainedExit::new(stop_reason_root_exit(&reason)));
             // ScopeRuntime's synchronous epilogue clears dynamic state,
             // discharges child obligations and residency, and only then
-            // publishes the scope's terminal state.
+            // publishes the stopped projection. For the root, the join
+            // monitor owns the later membership-terminal fence.
             scope.completion = Some(ScopeCompletion {
                 reason: RetainedStopReason::new(reason.clone()),
-                root_exit,
             });
             return reason;
         }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -176,20 +176,88 @@ fn monitor_root_driver(
     monitor_root: Arc<ScopeCell>,
     driver: runtime::JoinHandle<RetainedStopReason>,
 ) -> runtime::JoinHandle<RetainedStopReason> {
+    // Constructed before the future so it is an upvar of the `async move`
+    // block rather than a local of its body: an `async` block owns its
+    // captures from creation, so the fence retires even for a monitor task
+    // that is dropped without ever being polled.
+    let mut fence = MonitorFence::armed(monitor_root);
     runtime::spawn(async move {
         match classify_retained_root_driver_join(runtime::join(driver).await) {
             Ok(reason) => {
                 let public_reason = reason.as_reason().clone();
                 let exit = stop_reason_root_exit(&public_reason);
-                finish_monitored_root(&monitor_root, public_reason, exit);
+                fence.publish(public_reason, exit);
                 reason
             }
             Err(exit) => {
-                finish_monitored_root(&monitor_root, StopReason::ShutdownRequested, exit);
+                fence.publish(StopReason::ShutdownRequested, exit);
                 RetainedStopReason::new(StopReason::ShutdownRequested)
             }
         }
     })
+}
+
+/// The monitor body's root-terminality duty, held across the driver join.
+///
+/// Invariant: **the monitor future never completes or is dropped without root
+/// membership terminality having been published.** Since `ScopeRuntime::drop`
+/// deliberately leaves root terminality to this monitor, an unpublished fence
+/// would strand every retained `wait_stopped()` observer forever and leave the
+/// observation streams open — the guard is what makes that unrepresentable.
+///
+/// The only way to reach `drop` still armed is cancellation of the monitor
+/// task itself: dropping the monitor's `JoinHandle` merely detaches, and no
+/// framework path aborts it. Runtime teardown is the reachable case, where
+/// every spawned task future is dropped, polled or not. Cancellation is also why the fallback
+/// verdict is not speculative: the driver's own `JoinHandle` lives inside the
+/// dropped join future, so the driver's real outcome becomes unobservable to
+/// everyone at exactly this moment, and the one join anyone can still observe
+/// — the monitor handle — resolves `Cancelled`. Publishing that outcome's
+/// classification is therefore a statement about the join that did settle, and
+/// it is bit-for-bit the verdict `SystemRun::join_driver`'s self-heal computes
+/// for the same cancellation. Should both run, member terminalization is
+/// first-writer-wins and the record lattice treats an equal verdict as an
+/// idempotent repeat, so neither can outrank or race the other.
+///
+/// Teardown drops the two tasks in an unspecified order, so the fence can
+/// precede the driver's own epilogue and close observation ahead of its final
+/// `Removed` edges. That truncation is confined to a runtime that is going
+/// away underneath its subscribers, and it is strictly the better half of the
+/// trade against an observer that never resolves at all.
+///
+/// Publication goes through [`finish_monitored_root`], which contains any
+/// hostile terminal-wake panic: this `drop` runs in task drop glue on a
+/// teardown thread that may already be unwinding, where a second panic would
+/// abort the process. The cancellation exit owns no user error, so the guard
+/// adds no user-value destruction and no lock site of its own.
+struct MonitorFence {
+    root: Arc<ScopeCell>,
+    armed: bool,
+}
+
+impl MonitorFence {
+    fn armed(root: Arc<ScopeCell>) -> Self {
+        Self { root, armed: true }
+    }
+
+    fn publish(&mut self, reason: StopReason, exit: Exit) {
+        finish_monitored_root(&self.root, reason, exit);
+        self.armed = false;
+    }
+}
+
+impl Drop for MonitorFence {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // A cancelled join never classifies as a completed reason, so the
+        // `Ok` half is unreachable; matching rather than unwrapping keeps a
+        // panic out of drop glue regardless.
+        if let Err(exit) = classify_retained_root_driver_join(runtime::JoinOutcome::Cancelled) {
+            finish_monitored_root(&self.root, StopReason::ShutdownRequested, exit);
+        }
+    }
 }
 
 /// Publishes the join monitor's final root verdict without letting a hostile

--- a/crates/shelterwood/src/driver/tests/system_join.rs
+++ b/crates/shelterwood/src/driver/tests/system_join.rs
@@ -43,6 +43,7 @@ async fn system_run_wait_proxies_a_pending_driver_join_caller_waker() {
     let mut run = super::super::SystemRun {
         root,
         driver: Some(driver),
+        driver_joined: false,
     };
     let mut wait = Box::pin(run.wait());
     let (hostile, state) = hostile_waker();
@@ -60,6 +61,36 @@ async fn system_run_wait_proxies_a_pending_driver_join_caller_waker() {
         wait.as_mut().poll(&mut Context::from_waker(&hostile)),
         Poll::Ready(StopReason::NeverStarted)
     ));
+}
+
+#[crate::runtime::test]
+async fn system_run_wait_reloads_after_self_healing_a_cancelled_monitor() {
+    let root = isolated_scope("root", ScopeFlavor::Ordered);
+    let epoch = root
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    root.finish_root_incarnation(
+        epoch,
+        StopReason::Finished,
+        Exit::completed(Cancellation::NotObserved),
+    );
+
+    let driver = crate::runtime::spawn(future::pending::<RetainedStopReason>());
+    driver.abort_handle().abort();
+    let mut run = super::super::SystemRun {
+        root: Arc::clone(&root),
+        driver: Some(driver),
+        driver_joined: false,
+    };
+
+    assert_eq!(run.wait().await, StopReason::ShutdownRequested);
+    assert_eq!(
+        root.record().state,
+        ScopeState::Stopped {
+            reason: StopReason::ShutdownRequested
+        },
+        "wait reloads the record after its join fallback upgrades the verdict"
+    );
 }
 
 /// `SystemRun::shutdown` is the exact join seam reached by both public
@@ -82,6 +113,7 @@ async fn system_run_shutdown_proxies_a_pending_driver_join_caller_waker() {
     let mut run = super::super::SystemRun {
         root,
         driver: Some(driver),
+        driver_joined: false,
     };
     let mut shutdown = Box::pin(run.shutdown(crate::DeadlineBudget::ZERO));
     let (hostile, state) = hostile_waker();

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -73,6 +73,75 @@ enum TerminalStopPath {
 }
 
 #[crate::runtime::test]
+async fn successful_root_monitor_publishes_membership_terminality() {
+    let scope = isolated_scope("root", ScopeFlavor::Ordered);
+    let epoch = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    scope.finish_incarnation(epoch, StopReason::Finished);
+    assert!(
+        !matches!(scope.member.record().stage, MemberStage::Terminal(_)),
+        "the scope epilogue leaves root membership live until its join"
+    );
+
+    let driver = crate::runtime::spawn(async {
+        crate::cells::RetainedStopReason::new(StopReason::Finished)
+    });
+    let monitor = monitor_root_driver(Arc::clone(&scope), driver);
+    let joined = crate::runtime::join(monitor).await;
+
+    assert!(matches!(
+        joined,
+        crate::runtime::JoinOutcome::Ok { ref value }
+            if value.as_reason() == &StopReason::Finished
+    ));
+    assert!(matches!(
+        scope.member.record().stage,
+        MemberStage::Terminal(ref exit) if matches!(exit.kind(), ExitKind::Completed)
+    ));
+    assert_eq!(scope.wait_stopped().await, StopReason::Finished);
+}
+
+#[crate::runtime::test]
+async fn root_monitor_contains_a_terminal_wake_panic() {
+    const PANIC: &str = "hostile root terminal wake";
+
+    let scope = isolated_scope("root", ScopeFlavor::Ordered);
+    let epoch = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    scope.finish_incarnation(epoch, StopReason::Finished);
+
+    let mut stopped = Box::pin(scope.wait_stopped());
+    let hostile = Waker::from(Arc::new(PanicWake(PANIC)));
+    assert!(
+        stopped
+            .as_mut()
+            .poll(&mut Context::from_waker(&hostile))
+            .is_pending(),
+        "the hostile observer parks behind membership terminality"
+    );
+
+    let driver = crate::runtime::spawn(async {
+        crate::cells::RetainedStopReason::new(StopReason::Finished)
+    });
+    let monitor = monitor_root_driver(Arc::clone(&scope), driver);
+    let joined = crate::runtime::join(monitor).await;
+
+    assert!(matches!(
+        joined,
+        crate::runtime::JoinOutcome::Ok { ref value }
+            if value.as_reason() == &StopReason::Finished
+    ));
+    assert!(matches!(
+        stopped
+            .as_mut()
+            .poll(&mut Context::from_waker(Waker::noop())),
+        Poll::Ready(StopReason::Finished)
+    ));
+}
+
+#[crate::runtime::test]
 async fn terminal_stop_paths_share_one_complete_observation_transition() {
     for (path, reason) in [
         (TerminalStopPath::LiveEpoch, StopReason::ShutdownRequested),

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -142,6 +142,56 @@ async fn root_monitor_contains_a_terminal_wake_panic() {
 }
 
 #[crate::runtime::test]
+async fn panicked_root_monitor_publishes_its_exit_despite_a_terminal_wake_panic() {
+    const DRIVER_PANIC: &str = "panicked root driver";
+    const WAKE_PANIC: &str = "hostile root terminal wake";
+
+    let scope = isolated_scope("root", ScopeFlavor::Ordered);
+    let epoch = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    scope.finish_incarnation(epoch, StopReason::Finished);
+
+    let mut stopped = Box::pin(scope.wait_stopped());
+    let hostile = Waker::from(Arc::new(PanicWake(WAKE_PANIC)));
+    assert!(
+        stopped
+            .as_mut()
+            .poll(&mut Context::from_waker(&hostile))
+            .is_pending(),
+        "the hostile observer parks behind membership terminality"
+    );
+
+    let driver = crate::runtime::spawn(async {
+        panic!("{DRIVER_PANIC}");
+        #[allow(unreachable_code)]
+        crate::cells::RetainedStopReason::new(StopReason::Finished)
+    });
+    let monitor = monitor_root_driver(Arc::clone(&scope), driver);
+    let joined = crate::runtime::join(monitor).await;
+
+    assert!(matches!(
+        joined,
+        crate::runtime::JoinOutcome::Ok { ref value }
+            if value.as_reason() == &StopReason::ShutdownRequested
+    ));
+    assert!(matches!(
+        scope.member.record().stage,
+        MemberStage::Terminal(ref exit)
+            if matches!(
+                exit.kind(),
+                ExitKind::Panicked { message: Some(message) } if message == DRIVER_PANIC
+            ) && exit.cancellation() == Cancellation::NotObserved
+    ));
+    assert!(matches!(
+        stopped
+            .as_mut()
+            .poll(&mut Context::from_waker(Waker::noop())),
+        Poll::Ready(StopReason::ShutdownRequested)
+    ));
+}
+
+#[crate::runtime::test]
 async fn terminal_stop_paths_share_one_complete_observation_transition() {
     for (path, reason) in [
         (TerminalStopPath::LiveEpoch, StopReason::ShutdownRequested),

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -191,6 +191,77 @@ async fn panicked_root_monitor_publishes_its_exit_despite_a_terminal_wake_panic(
     ));
 }
 
+/// A cancelled monitor is the runtime-teardown venue: every spawned task
+/// future is dropped mid-await, so neither join arm runs. The monitor body's
+/// fence guard must still publish root terminality, or a retained
+/// `wait_stopped()` observer would park forever behind a membership that the
+/// deliberately terminality-free driver epilogue never terminalizes.
+#[crate::runtime::test]
+async fn cancelled_root_monitor_publishes_membership_terminality() {
+    let scope = isolated_scope("root", ScopeFlavor::Ordered);
+    let epoch = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    scope.finish_incarnation(epoch, StopReason::Finished);
+    assert!(
+        !matches!(scope.member.record().stage, MemberStage::Terminal(_)),
+        "the scope epilogue leaves root membership live until its join"
+    );
+
+    let driver = crate::runtime::spawn(future::pending::<crate::cells::RetainedStopReason>());
+    let monitor = monitor_root_driver(Arc::clone(&scope), driver);
+    // Let the monitor reach its parked driver join before cancelling, so the
+    // guard is exercised at the mid-await venue rather than before first poll.
+    crate::runtime::yield_now().await;
+    monitor.abort_handle().abort();
+
+    // `Cancelled` is reported only after the task future -- and with it the
+    // fence -- has been dropped, so the publication is already complete here.
+    assert!(matches!(
+        crate::runtime::join(monitor).await,
+        crate::runtime::JoinOutcome::Cancelled
+    ));
+    assert!(
+        matches!(
+            scope.member.record().stage,
+            MemberStage::Terminal(ref exit)
+                if matches!(
+                    exit.kind(),
+                    ExitKind::Aborted {
+                        phase: GracePhase::WithinGrace
+                    }
+                ) && exit.cancellation() == Cancellation::Observed
+        ),
+        "the fence publishes the cancelled join's own classification"
+    );
+    assert_eq!(scope.wait_stopped().await, StopReason::ShutdownRequested);
+}
+
+/// The same duty holds for a monitor task dropped before its first poll: the
+/// fence is an upvar of the `async move` block, not a local of its body.
+#[crate::runtime::test]
+async fn unpolled_root_monitor_publishes_membership_terminality() {
+    let scope = isolated_scope("root", ScopeFlavor::Ordered);
+    let epoch = scope
+        .begin_incarnation(ScopeState::Starting)
+        .expect("test scope epoch is available");
+    scope.finish_incarnation(epoch, StopReason::Finished);
+
+    let driver = crate::runtime::spawn(future::pending::<crate::cells::RetainedStopReason>());
+    let monitor = monitor_root_driver(Arc::clone(&scope), driver);
+    monitor.abort_handle().abort();
+
+    assert!(matches!(
+        crate::runtime::join(monitor).await,
+        crate::runtime::JoinOutcome::Cancelled
+    ));
+    assert!(matches!(
+        scope.member.record().stage,
+        MemberStage::Terminal(_)
+    ));
+    assert_eq!(scope.wait_stopped().await, StopReason::ShutdownRequested);
+}
+
 #[crate::runtime::test]
 async fn terminal_stop_paths_share_one_complete_observation_transition() {
     for (path, reason) in [

--- a/crates/shelterwood/tests/runtime_teardown_root_terminality.rs
+++ b/crates/shelterwood/tests/runtime_teardown_root_terminality.rs
@@ -1,0 +1,70 @@
+//! Regression coverage for the root terminality fence at its real venue.
+//!
+//! `ScopeRuntime::drop` deliberately leaves root membership terminality to the
+//! join monitor. Runtime teardown drops *both* tasks, so the monitor is
+//! dropped mid-join and neither of its arms runs; its fence guard is the only
+//! thing left to publish. Without it a `ScopeRef` that outlives the runtime
+//! parks on `wait_stopped()` forever and the observation streams never close.
+//!
+//! The test deliberately never calls `System::wait`: that would exercise
+//! `SystemRun`'s join-first self-heal instead of the guard.
+
+use std::{sync::mpsc, time::Duration};
+
+use shelterwood::{ExitError, StopReason, System, TaskOnceDef, Tree};
+
+/// Bounds the observer so a regression fails the run instead of hanging CI.
+const OBSERVER_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn gated_system() -> (tokio::sync::oneshot::Sender<()>, System) {
+    let (hold, gated) = tokio::sync::oneshot::channel::<()>();
+    let mut tree = Tree::new();
+    let (_task, _completion) = tree
+        .add_task_once(
+            "work",
+            TaskOnceDef::new(move |_| async move {
+                let _ = gated.await;
+                Ok::<(), ExitError>(())
+            }),
+        )
+        .expect("valid declaration");
+    (hold, tree.spawn().expect("runtime is available"))
+}
+
+#[test]
+fn runtime_teardown_terminalizes_the_root_for_an_outliving_observer() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("a dedicated runtime is available");
+
+    // The oneshot sender stays on the test thread, so the root's only child
+    // is still parked when the runtime goes away.
+    let (_hold, system) = runtime.block_on(async {
+        let (hold, system) = gated_system();
+        system.wait_started().await.expect("tree starts");
+        (hold, system)
+    });
+    let scope = system.scope();
+
+    // Runtime drop returns only once every task future has been dropped, so
+    // the monitor's fence has already run by the time this returns.
+    drop(runtime);
+
+    let (reasons, observed) = mpsc::channel();
+    let observer = std::thread::spawn(move || {
+        let waiter = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("the observer runtime is available");
+        let _ = reasons.send(waiter.block_on(scope.wait_stopped()));
+    });
+
+    assert_eq!(
+        observed.recv_timeout(OBSERVER_TIMEOUT),
+        Ok(StopReason::ShutdownRequested),
+        "a retained scope handle resolves after the runtime that ran the system"
+    );
+    observer.join().expect("the observer thread does not panic");
+    drop(system);
+}

--- a/crates/shelterwood/tests/system_wait_stale_reason.rs
+++ b/crates/shelterwood/tests/system_wait_stale_reason.rs
@@ -1,0 +1,118 @@
+//! Regression coverage for the root terminality fence.
+//!
+//! Adapted from the `verify-wait` repro at commit 3169ba6. The original
+//! reliably exposed a completed-drain window in which a hostile terminal
+//! observer killed the root driver after `Finished` was published but before
+//! the join monitor upgraded the final verdict. Root membership terminality is
+//! now owned by that monitor, so every `wait_stopped` observer remains behind
+//! the last possible classification point.
+
+use std::{
+    sync::Arc,
+    task::{Context, Poll, Wake, Waker},
+    time::Duration,
+};
+
+use shelterwood::{ExitError, ScopeRef, ScopeState, StopReason, System, TaskOnceDef, Tree};
+
+/// Panics during the root's terminal wake flush after giving well-behaved
+/// waiters on another worker time to run.
+struct TerminalPanicWake {
+    scope: ScopeRef,
+    seen: std::sync::Mutex<Vec<ScopeState>>,
+}
+
+impl Wake for TerminalPanicWake {
+    fn wake(self: Arc<Self>) {
+        self.wake_by_ref();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        let state = self.scope.snapshot().state.clone();
+        self.seen
+            .lock()
+            .expect("probe mutex poisoned")
+            .push(state.clone());
+        if matches!(state, ScopeState::Stopped { .. }) {
+            std::thread::sleep(Duration::from_millis(250));
+            panic!("hostile terminal observer wake");
+        }
+    }
+}
+
+fn gated_finishing_system() -> (tokio::sync::oneshot::Sender<()>, System) {
+    let (release, gated) = tokio::sync::oneshot::channel::<()>();
+    let mut tree = Tree::new();
+    let (_task, _completion) = tree
+        .add_task_once(
+            "work",
+            TaskOnceDef::new(move |_| async move {
+                let _ = gated.await;
+                Ok::<(), ExitError>(())
+            }),
+        )
+        .expect("valid declaration");
+    (release, tree.spawn().expect("runtime is available"))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn completed_drain_hostile_terminal_wake_preserves_the_final_reason() {
+    let (release, system) = gated_finishing_system();
+    system.wait_started().await.expect("tree starts");
+    let scope = system.scope();
+
+    let waiter = tokio::spawn(async move { system.wait().await });
+    for _ in 0..16 {
+        tokio::task::yield_now().await;
+    }
+
+    let mut observers = Vec::new();
+    for _ in 0..4 {
+        let observer = scope.clone();
+        observers.push(tokio::spawn(async move { observer.wait_stopped().await }));
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    let probe = Arc::new(TerminalPanicWake {
+        scope: scope.clone(),
+        seen: std::sync::Mutex::new(Vec::new()),
+    });
+    let hostile = Waker::from(Arc::clone(&probe));
+    let mut parked = Box::pin(scope.wait_stopped());
+    assert_eq!(
+        parked.as_mut().poll(&mut Context::from_waker(&hostile)),
+        Poll::Pending,
+        "the hostile observer parks on the live root"
+    );
+
+    release.send(()).expect("the gated task is still running");
+    let mut awaited = vec![waiter.await.expect("the waiting task does not panic")];
+    for observer in observers {
+        awaited.push(observer.await.expect("an observer task does not panic"));
+    }
+
+    let recorded = scope.snapshot().state.clone();
+    assert_eq!(
+        recorded,
+        ScopeState::Stopped {
+            reason: StopReason::ShutdownRequested
+        },
+        "the join monitor publishes the final classification after the driver wake panic"
+    );
+    assert_eq!(
+        probe.seen.lock().expect("probe mutex poisoned").as_slice(),
+        [ScopeState::Stopped {
+            reason: StopReason::Finished
+        }],
+        "the hostile observer kills the driver from its completed-drain publication"
+    );
+    for reason in awaited {
+        assert_eq!(
+            ScopeState::Stopped { reason },
+            recorded,
+            "every awaited reason agrees with the final record"
+        );
+    }
+}

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -3806,7 +3806,10 @@ no scope incarnation ever began, rather than giving a live scope
 incarnation's verdict. This lattice and its agreement guarantee apply within
 the scope plane: `wait_stopped()`, the final snapshot, and the stream's last
 `ScopeState` event always report the same, highest-precedence verdict. They do
-not require the membership plane's exit kind to match. In particular, a
+not require the membership plane's exit kind to match. Root membership
+terminality is join-gated: the driver epilogue retires its incarnation and
+publishes its stopped projection, while the join monitor terminalizes the
+membership only after the driver's final outcome is known. In particular, a
 nested scope body dropped before its first poll is the sanctioned
 cross-plane divergence: the scope projection is `Stopped { NeverStarted }`
 because no scope incarnation began, while the membership exit is

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -3816,8 +3816,12 @@ driver that dies mid-drain reports the join monitor's `ShutdownRequested`
 rather than the abandoned drain's `Finished`. Root membership terminality is
 join-gated so that verdict cannot be missed: the driver epilogue retires its
 incarnation and publishes its stopped projection, while the join monitor
-terminalizes the membership only after the driver's final outcome is known.
-`wait_stopped()` on the root therefore never resolves ahead of the join.
+terminalizes the membership only once that join has settled. Cancellation of
+the monitor — runtime teardown dropping it mid-join — is one such settling: it
+makes the driver's own outcome permanently unobservable, and the monitor
+publishes that cancellation's classification rather than leaving the
+membership live. `wait_stopped()` on the root therefore never resolves ahead
+of the join, and never fails to resolve.
 
 ```text
 ActorStats (II §22)

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -3806,17 +3806,18 @@ no scope incarnation ever began, rather than giving a live scope
 incarnation's verdict. This lattice and its agreement guarantee apply within
 the scope plane: `wait_stopped()`, the final snapshot, and the stream's last
 `ScopeState` event always report the same, highest-precedence verdict. They do
-not require the membership plane's exit kind to match. Root membership
-terminality is join-gated: the driver epilogue retires its incarnation and
-publishes its stopped projection, while the join monitor terminalizes the
-membership only after the driver's final outcome is known. In particular, a
+not require the membership plane's exit kind to match. In particular, a
 nested scope body dropped before its first poll is the sanctioned
 cross-plane divergence: the scope projection is `Stopped { NeverStarted }`
 because no scope incarnation began, while the membership exit is
 `Aborted { WithinGrace }` with `last_incarnation: Some(1)` because an
 incarnation was spawned on the membership plane and then aborted. A root
 driver that dies mid-drain reports the join monitor's `ShutdownRequested`
-rather than the abandoned drain's `Finished`.
+rather than the abandoned drain's `Finished`. Root membership terminality is
+join-gated so that verdict cannot be missed: the driver epilogue retires its
+incarnation and publishes its stopped projection, while the join monitor
+terminalizes the membership only after the driver's final outcome is known.
+`wait_stopped()` on the root therefore never resolves ahead of the join.
 
 ```text
 ActorStats (II §22)


### PR DESCRIPTION
Closes #434.\n\nMoves root terminal publication behind the driver join on both monitor outcomes, contains terminal-boundary wake diagnostics, and makes SystemRun wait join before reloading the final reason. This implements the adjudicated full terminality fence without weakening the final-verdict contract.\n\nVerification: focused driver and stale-reason regressions; ./tools/dev just ci (958 tests plus docs, examples, API reachability, external consumer, and nixfmt).