### PR TITLE
Bind provisional memberships to their child IDs

### DIFF
--- a/crates/shelterwood-core/src/identity.rs
+++ b/crates/shelterwood-core/src/identity.rs
@@ -306,6 +306,17 @@ pub struct IncarnationCounter {
 }
 
 /// Linear authority to reconcile one declaration-time membership.
+///
+/// The token carries the [`ChildId`] its lineage was minted for, and
+/// [`ScopeIdentity::adopt_or_mint_membership`] reads the id from it rather
+/// than from a second argument: donating a lineage to a *different* id is
+/// therefore unconstructible, not merely unused. Deliberately not `Clone` —
+/// one minted lineage may seed at most one stable id, so a copyable token
+/// would restore the cross-domain donation the binding removes. The
+/// remaining cross-*scope* half (two provisionals for one id, adopted into
+/// two stable scopes) cannot be closed by construction and rides on the
+/// framework-only ruling that keeps this whole minting family
+/// `#[doc(hidden)]`.
 #[derive(Debug)]
 #[doc(hidden)]
 pub struct ProvisionalMembership {
@@ -348,6 +359,14 @@ impl MintedMembership {
                 generations: PoisonedCounter::new(),
             },
         }
+    }
+
+    /// Returns the child id this lineage was minted for.
+    ///
+    /// Keeping the id inside the grant is what lets a member cell derive its
+    /// own id from its identity instead of accepting the two separately.
+    pub fn id(&self) -> &ChildId {
+        &self.provisional.id
     }
 
     #[cfg(any(test, feature = "test-util"))]
@@ -450,6 +469,9 @@ impl ScopeIdentity {
     /// successor. Terminalization evicts the lineage, so an ordinary later
     /// remove-and-re-add or post-restart rebuild donates a fresh, incomparable
     /// identity instead.
+    ///
+    /// The reconciled id comes from the [`ProvisionalMembership`] itself, so
+    /// the lineage can only ever be donated to the id it was minted for.
     pub fn adopt_or_mint_membership(
         &mut self,
         provisional: ProvisionalMembership,

--- a/crates/shelterwood-core/src/identity.rs
+++ b/crates/shelterwood-core/src/identity.rs
@@ -143,6 +143,7 @@ impl Fence {
 /// `u64::MAX` is poison and is never returned. Once the last usable value has
 /// been minted, no successor can be minted.
 #[derive(Clone, Debug)]
+#[doc(hidden)]
 pub struct PoisonedCounter {
     current: u64,
 }
@@ -204,6 +205,7 @@ impl Default for PoisonedCounter {
 
 /// A thread-safe [`PoisonedCounter`] with the same fail-closed domain.
 #[derive(Debug)]
+#[doc(hidden)]
 pub struct AtomicPoisonedCounter(AtomicU64);
 
 impl AtomicPoisonedCounter {
@@ -297,16 +299,26 @@ impl FenceCounter {
 
 /// A membership and the generation counter that can mint only its incarnations.
 #[derive(Debug)]
+#[doc(hidden)]
 pub struct IncarnationCounter {
     membership: Membership,
     generations: PoisonedCounter,
 }
 
+/// Linear authority to reconcile one declaration-time membership.
+#[derive(Debug)]
+#[doc(hidden)]
+pub struct ProvisionalMembership {
+    id: ChildId,
+    membership: Membership,
+}
+
 /// An inseparable identity grant: the counter for an incarnation lineage is
 /// allocated exactly once as its first membership method returns.
 #[derive(Debug)]
+#[doc(hidden)]
 pub struct MintedMembership {
-    membership: Membership,
+    provisional: ProvisionalMembership,
     incarnation_counter: IncarnationCounter,
 }
 
@@ -317,6 +329,7 @@ pub struct MintedMembership {
 /// reconciliation is never optional to consume.
 #[derive(Debug)]
 #[must_use]
+#[doc(hidden)]
 pub enum MembershipReconciliation {
     /// The stable scope adopted the provisional lineage unchanged.
     Adopted,
@@ -327,9 +340,9 @@ pub enum MembershipReconciliation {
 }
 
 impl MintedMembership {
-    fn new(membership: Membership) -> Self {
+    fn new(id: ChildId, membership: Membership) -> Self {
         Self {
-            membership,
+            provisional: ProvisionalMembership { id, membership },
             incarnation_counter: IncarnationCounter {
                 membership,
                 generations: PoisonedCounter::new(),
@@ -339,11 +352,19 @@ impl MintedMembership {
 
     #[cfg(any(test, feature = "test-util"))]
     pub fn membership(&self) -> Membership {
-        self.membership
+        self.provisional.membership
     }
 
     pub fn into_pair(self) -> (Membership, IncarnationCounter) {
-        (self.membership, self.incarnation_counter)
+        (self.provisional.membership, self.incarnation_counter)
+    }
+
+    pub fn into_provisional_parts(self) -> (Membership, ProvisionalMembership, IncarnationCounter) {
+        (
+            self.provisional.membership,
+            self.provisional,
+            self.incarnation_counter,
+        )
     }
 }
 
@@ -375,6 +396,7 @@ impl IncarnationCounter {
 
 /// The identity domain owned by one scope membership.
 #[derive(Debug)]
+#[doc(hidden)]
 pub struct ScopeIdentity {
     memberships: HashMap<ChildId, FenceCounter>,
 }
@@ -417,7 +439,7 @@ impl ScopeIdentity {
                 Some(membership)
             }
         }?;
-        Some(MintedMembership::new(membership))
+        Some(MintedMembership::new(id.clone(), membership))
     }
 
     /// Reconciles a declaration-time membership with this stable scope.
@@ -430,22 +452,23 @@ impl ScopeIdentity {
     /// identity instead.
     pub fn adopt_or_mint_membership(
         &mut self,
-        id: &ChildId,
-        provisional: Membership,
+        provisional: ProvisionalMembership,
     ) -> MembershipReconciliation {
-        match self.memberships.entry(id.clone()) {
+        let ProvisionalMembership { id, membership } = provisional;
+        match self.memberships.entry(id) {
             Entry::Occupied(mut entry) => {
                 let Some(membership) = entry.get_mut().mint().map(Membership) else {
                     return MembershipReconciliation::Exhausted;
                 };
-                MembershipReconciliation::Minted(MintedMembership::new(membership))
+                let id = entry.key().clone();
+                MembershipReconciliation::Minted(MintedMembership::new(id, membership))
             }
             Entry::Vacant(entry) => {
                 // Diagnostic-only under the cells child-identity mutex. A
                 // public Membership cannot contain the private poison value;
                 // insertion behavior therefore does not rely on this check.
-                debug_assert_ne!(provisional.0.generation, Generation::POISON);
-                entry.insert(FenceCounter::from_fence(provisional.0));
+                debug_assert_ne!(membership.0.generation, Generation::POISON);
+                entry.insert(FenceCounter::from_fence(membership.0));
                 MembershipReconciliation::Adopted
             }
         }
@@ -581,14 +604,14 @@ mod tests {
     fn adopted_membership_orders_a_direct_mint_and_later_rebuild() {
         let id = ChildId::from("worker");
         let mut declaration = ScopeIdentity::new();
-        let provisional = declaration
+        let (provisional_membership, provisional, _) = declaration
             .mint_membership(&id)
             .expect("provisional membership available")
-            .membership();
+            .into_provisional_parts();
 
         let mut stable = ScopeIdentity::new();
         assert!(matches!(
-            stable.adopt_or_mint_membership(&id, provisional),
+            stable.adopt_or_mint_membership(provisional),
             MembershipReconciliation::Adopted
         ));
         let direct = stable
@@ -597,22 +620,21 @@ mod tests {
             .membership();
 
         let mut rebuilt_declaration = ScopeIdentity::new();
-        let rebuilt = rebuilt_declaration
+        let (rebuilt_membership, rebuilt, _) = rebuilt_declaration
             .mint_membership(&id)
             .expect("rebuilt provisional membership available")
-            .membership();
-        let MembershipReconciliation::Minted(reconciled) =
-            stable.adopt_or_mint_membership(&id, rebuilt)
+            .into_provisional_parts();
+        let MembershipReconciliation::Minted(reconciled) = stable.adopt_or_mint_membership(rebuilt)
         else {
             panic!("an occupied stable identity mints a successor")
         };
         let reconciled = reconciled.membership();
 
-        assert!(direct.supersedes(provisional));
+        assert!(direct.supersedes(provisional_membership));
         assert!(reconciled.supersedes(direct));
         assert!(!direct.supersedes(reconciled));
-        assert!(!rebuilt.supersedes(reconciled));
-        assert!(!reconciled.supersedes(rebuilt));
+        assert!(!rebuilt_membership.supersedes(reconciled));
+        assert!(!reconciled.supersedes(rebuilt_membership));
     }
 
     #[test]
@@ -620,42 +642,41 @@ mod tests {
         let id = ChildId::from("worker");
         let other_id = ChildId::from("other");
         let mut first_builder = ScopeIdentity::new();
-        let first = first_builder
+        let (first_membership, first, _) = first_builder
             .mint_membership(&id)
             .expect("first provisional membership available")
-            .membership();
-        let other = first_builder
+            .into_provisional_parts();
+        let (other_membership, other, _) = first_builder
             .mint_membership(&other_id)
             .expect("other provisional membership available")
-            .membership();
+            .into_provisional_parts();
         let mut rebuilt_builder = ScopeIdentity::new();
-        let rebuilt = rebuilt_builder
+        let (rebuilt_membership, rebuilt, _) = rebuilt_builder
             .mint_membership(&id)
             .expect("rebuilt provisional membership available")
-            .membership();
+            .into_provisional_parts();
 
         let mut stable = ScopeIdentity::new();
         assert!(matches!(
-            stable.adopt_or_mint_membership(&id, first),
+            stable.adopt_or_mint_membership(first),
             MembershipReconciliation::Adopted
         ));
         assert!(matches!(
-            stable.adopt_or_mint_membership(&other_id, other),
+            stable.adopt_or_mint_membership(other),
             MembershipReconciliation::Adopted
         ));
-        let MembershipReconciliation::Minted(successor) =
-            stable.adopt_or_mint_membership(&id, rebuilt)
+        let MembershipReconciliation::Minted(successor) = stable.adopt_or_mint_membership(rebuilt)
         else {
             panic!("stable identity mints a rebuilt successor")
         };
         let successor = successor.membership();
 
-        assert!(successor.supersedes(first));
-        assert!(!first.supersedes(successor));
-        assert!(!successor.supersedes(rebuilt));
-        assert!(!rebuilt.supersedes(successor));
-        assert!(!successor.supersedes(other));
-        assert!(!other.supersedes(successor));
+        assert!(successor.supersedes(first_membership));
+        assert!(!first_membership.supersedes(successor));
+        assert!(!successor.supersedes(rebuilt_membership));
+        assert!(!rebuilt_membership.supersedes(successor));
+        assert!(!successor.supersedes(other_membership));
+        assert!(!other_membership.supersedes(successor));
     }
 
     #[test]
@@ -715,17 +736,21 @@ mod tests {
             .mint_membership(&id)
             .expect("last usable stable membership is minted");
         let mut builder = ScopeIdentity::new();
-        let provisional = builder
+        let (_, first_provisional, _) = builder
             .mint_membership(&id)
             .expect("provisional membership available")
-            .membership();
+            .into_provisional_parts();
+        let (_, second_provisional, _) = builder
+            .mint_membership(&id)
+            .expect("second provisional membership available")
+            .into_provisional_parts();
 
         assert!(matches!(
-            stable.adopt_or_mint_membership(&id, provisional),
+            stable.adopt_or_mint_membership(first_provisional),
             MembershipReconciliation::Exhausted
         ));
         assert!(matches!(
-            stable.adopt_or_mint_membership(&id, provisional),
+            stable.adopt_or_mint_membership(second_provisional),
             MembershipReconciliation::Exhausted
         ));
         assert!(

--- a/crates/shelterwood-core/tests/identity_authority.rs
+++ b/crates/shelterwood-core/tests/identity_authority.rs
@@ -1,0 +1,64 @@
+use std::hash::Hash;
+
+use shelterwood_core::{
+    ChildId, Incarnation, Membership, MembershipReconciliation, ProvisionalMembership,
+    ScopeIdentity,
+};
+
+macro_rules! assert_not_impl {
+    ($type:ty: $trait:path) => {
+        const _: fn() = || {
+            struct Check<T: ?Sized>(std::marker::PhantomData<T>);
+            trait AmbiguousIfImpl<A> {
+                fn check() {}
+            }
+            impl<T: ?Sized> AmbiguousIfImpl<()> for Check<T> {}
+            impl<T: ?Sized + $trait> AmbiguousIfImpl<u8> for Check<T> {}
+            let _ = <Check<$type> as AmbiguousIfImpl<_>>::check;
+        };
+    };
+}
+
+assert_not_impl!(ProvisionalMembership: Clone);
+
+fn assert_copy_identity<T: Copy + Eq + Hash + Send + Sync>() {}
+
+#[test]
+fn supported_identity_values_remain_plain_public_types() {
+    assert_copy_identity::<Membership>();
+    assert_copy_identity::<Incarnation>();
+    let id = ChildId::from("worker");
+    assert_eq!(id.as_str(), "worker");
+}
+
+#[test]
+fn provisional_membership_selects_its_minting_child_id() {
+    let worker_id = ChildId::from("worker");
+    let other_id = ChildId::from("other");
+    let mut declaration = ScopeIdentity::new();
+    let (declared, provisional, _) = declaration
+        .mint_membership(&worker_id)
+        .expect("declaration membership available")
+        .into_provisional_parts();
+
+    let mut stable = ScopeIdentity::new();
+    assert!(matches!(
+        stable.adopt_or_mint_membership(provisional),
+        MembershipReconciliation::Adopted
+    ));
+
+    let worker_successor = stable
+        .mint_membership(&worker_id)
+        .expect("adopted worker lineage remains mintable")
+        .into_pair()
+        .0;
+    let other = stable
+        .mint_membership(&other_id)
+        .expect("unrelated child identity remains mintable")
+        .into_pair()
+        .0;
+
+    assert!(worker_successor.supersedes(declared));
+    assert!(!other.supersedes(declared));
+    assert!(!declared.supersedes(other));
+}

--- a/crates/shelterwood-core/tests/identity_authority.rs
+++ b/crates/shelterwood-core/tests/identity_authority.rs
@@ -1,3 +1,12 @@
+//! What an out-of-crate consumer can reach in the identity module.
+//!
+//! `#[doc(hidden)]` on the minting-authority family is a *documentation*
+//! marker, not a visibility one, so nothing here can pin it — core has no
+//! public-surface audit lane (recorded on #436 as a deferred probe, not part
+//! of this fix). What this file does pin is the half that is mechanical: the
+//! three supported value types stay reachable and keyed, and the
+//! reconciliation token stays linear so a lineage cannot be donated twice.
+
 use std::hash::Hash;
 
 use shelterwood_core::{
@@ -19,6 +28,8 @@ macro_rules! assert_not_impl {
     };
 }
 
+// Copying the token would let one minted lineage seed two stable ids, which
+// is the cross-domain donation the id binding exists to remove.
 assert_not_impl!(ProvisionalMembership: Clone);
 
 fn assert_copy_identity<T: Copy + Eq + Hash + Send + Sync>() {}

--- a/crates/shelterwood/src/cells.rs
+++ b/crates/shelterwood/src/cells.rs
@@ -65,7 +65,6 @@ pub(crate) mod test_support {
         let id = ChildId::from(id);
         let mut identity = ScopeIdentity::new();
         let member = MemberCell::new(
-            id.clone(),
             identity
                 .mint_membership(&id)
                 .expect("scope membership is available"),
@@ -81,7 +80,6 @@ pub(crate) mod test_support {
     pub(super) fn child_member(parent: &ScopeCell, id: &str) -> Arc<MemberCell> {
         let id = ChildId::from(id);
         let member = MemberCell::new(
-            id.clone(),
             parent
                 .mint_membership(&id)
                 .expect("child membership is available"),

--- a/crates/shelterwood/src/cells/member.rs
+++ b/crates/shelterwood/src/cells/member.rs
@@ -14,7 +14,7 @@ use crate::{
 use shelterwood_core::{
     ChildId, Exit, ExitKind, Incarnation, Membership, RestartCount,
     engine::MembershipStatus,
-    identity::{IncarnationCounter, MintedMembership},
+    identity::{IncarnationCounter, MintedMembership, ProvisionalMembership},
     policy::ResolvedCommonOptions,
 };
 
@@ -176,6 +176,7 @@ pub(crate) struct MemberCell {
     id: ChildId,
     membership: Membership,
     rebased_membership: OnceLock<Membership>,
+    provisional_membership: Mutex<Option<ProvisionalMembership>>,
     incarnations: Mutex<Option<IncarnationCounter>>,
     pub(super) record: runtime::WatchSender<MemberRecord>,
     // Guards only a gate-pointer swap, so no torn state is possible; every
@@ -252,7 +253,7 @@ impl fmt::Debug for MemberMailbox {
 
 impl MemberCell {
     pub(crate) fn new(id: ChildId, identity: MintedMembership) -> Arc<Self> {
-        let (membership, incarnations) = identity.into_pair();
+        let (membership, provisional_membership, incarnations) = identity.into_provisional_parts();
         let (record, _) = runtime::watch(MemberRecord {
             stage: MemberStage::Reserved,
             incarnation: None,
@@ -268,6 +269,7 @@ impl MemberCell {
             id,
             membership,
             rebased_membership: OnceLock::new(),
+            provisional_membership: Mutex::new(Some(provisional_membership)),
             incarnations: Mutex::new(Some(incarnations)),
             record,
             observation_gate: RwLock::new(ObservationGate::new()),
@@ -286,6 +288,15 @@ impl MemberCell {
             .get()
             .copied()
             .unwrap_or(self.membership)
+    }
+
+    pub(crate) fn take_provisional_membership(&self) -> ProvisionalMembership {
+        let provisional = self
+            .provisional_membership
+            .lock()
+            .expect("provisional membership mutex poisoned")
+            .take();
+        provisional.expect("a declaration membership can be reconciled at most once")
     }
 
     pub(crate) fn rebase_membership(&self, identity: MintedMembership) {

--- a/crates/shelterwood/src/cells/member.rs
+++ b/crates/shelterwood/src/cells/member.rs
@@ -252,7 +252,12 @@ impl fmt::Debug for MemberMailbox {
 }
 
 impl MemberCell {
-    pub(crate) fn new(id: ChildId, identity: MintedMembership) -> Arc<Self> {
+    // The id is read from the grant rather than accepted beside it: the
+    // reconciliation token carries the id its lineage was minted for, so a
+    // member whose `id()` disagrees with the id its membership was minted
+    // under — and would therefore be adopted under — is unconstructible.
+    pub(crate) fn new(identity: MintedMembership) -> Arc<Self> {
+        let id = identity.id().clone();
         let (membership, provisional_membership, incarnations) = identity.into_provisional_parts();
         let (record, _) = runtime::watch(MemberRecord {
             stage: MemberStage::Reserved,
@@ -291,6 +296,9 @@ impl MemberCell {
     }
 
     pub(crate) fn take_provisional_membership(&self) -> ProvisionalMembership {
+        // Two statements, not one chain: the guard must be released before
+        // the verdict can panic, or the failing assertion would poison the
+        // mutex for every later caller.
         let provisional = self
             .provisional_membership
             .lock()
@@ -1000,7 +1008,6 @@ mod tests {
         let mut identity = ScopeIdentity::new();
         let id = ChildId::from("worker");
         let member = MemberCell::new(
-            id.clone(),
             identity
                 .mint_membership(&id)
                 .expect("membership is available"),
@@ -1035,7 +1042,6 @@ mod tests {
         let id = ChildId::from("worker");
         let mut identity = ScopeIdentity::new();
         let member = MemberCell::new(
-            id.clone(),
             identity
                 .mint_membership(&id)
                 .expect("membership is available"),

--- a/crates/shelterwood/src/cells/retained.rs
+++ b/crates/shelterwood/src/cells/retained.rs
@@ -490,7 +490,6 @@ mod tests {
         let id = ChildId::from("worker");
         let mut identity = ScopeIdentity::new();
         let member = MemberCell::new(
-            id.clone(),
             identity
                 .mint_membership(&id)
                 .expect("membership is available"),

--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -15,7 +15,10 @@ use shelterwood_core::{
     ChildId, Exit, Incarnation, Membership, TotalRestarts,
     engine::{Epoch, MembershipStatus, RequestTarget, ScopeEpochs, ScopeState},
     exit::{StartupError, StopReason, stop_reason_precedence},
-    identity::{AtomicPoisonedCounter, MembershipReconciliation, MintedMembership, ScopeIdentity},
+    identity::{
+        AtomicPoisonedCounter, MembershipReconciliation, MintedMembership, ProvisionalMembership,
+        ScopeIdentity,
+    },
     panic::{catch_panic, discard_panic},
     policy::ScopeFlavor,
 };
@@ -244,13 +247,12 @@ impl ScopeCell {
 
     pub(crate) fn adopt_or_mint_membership(
         &self,
-        id: &ChildId,
-        provisional: Membership,
+        provisional: ProvisionalMembership,
     ) -> MembershipReconciliation {
         self.child_identity
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .adopt_or_mint_membership(id, provisional)
+            .adopt_or_mint_membership(provisional)
     }
 
     pub(crate) fn evict_child_identity(&self, member: &MemberCell) {

--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -2684,7 +2684,6 @@ mod tests {
         let mut identity = ScopeIdentity::new();
         let root_id = ChildId::from("root");
         let root = MemberCell::new(
-            root_id.clone(),
             identity
                 .mint_membership(&root_id)
                 .expect("root membership is available"),
@@ -2692,7 +2691,6 @@ mod tests {
         let scope = ScopeCell::new(root, ScopeFlavor::Ordered, ScopeIdentity::new());
         let child_id = ChildId::from("worker");
         let child = MemberCell::new(
-            child_id.clone(),
             identity
                 .mint_membership(&child_id)
                 .expect("child membership is available"),
@@ -2745,7 +2743,6 @@ mod tests {
         let id = ChildId::from("root");
         let mut identity = ScopeIdentity::new();
         let member = MemberCell::new(
-            id.clone(),
             identity
                 .mint_membership(&id)
                 .expect("root membership is available"),
@@ -2819,7 +2816,6 @@ mod tests {
         let id = ChildId::from("root");
         let mut identity = ScopeIdentity::new();
         let member = MemberCell::new(
-            id.clone(),
             identity
                 .mint_membership(&id)
                 .expect("root membership is available"),
@@ -2857,7 +2853,6 @@ mod tests {
         let root_id = ChildId::from("root");
         let mut root_identity = ScopeIdentity::new();
         let root_member = MemberCell::new(
-            root_id.clone(),
             root_identity
                 .mint_membership(&root_id)
                 .expect("root membership is available"),
@@ -2868,7 +2863,6 @@ mod tests {
         let child_id = ChildId::from("child");
         let mut child_identity = ScopeIdentity::new();
         let child = MemberCell::new(
-            child_id.clone(),
             child_identity
                 .mint_membership(&child_id)
                 .expect("child membership is available"),

--- a/crates/shelterwood/src/cells/scope/projection.rs
+++ b/crates/shelterwood/src/cells/scope/projection.rs
@@ -397,7 +397,6 @@ mod tests {
         let id = ChildId::from("root");
         let mut identity = ScopeIdentity::new();
         let member = MemberCell::new(
-            id.clone(),
             identity
                 .mint_membership(&id)
                 .expect("root membership is available"),
@@ -435,7 +434,6 @@ mod tests {
         let id = ChildId::from("root");
         let mut identity = ScopeIdentity::new();
         let member = MemberCell::new(
-            id.clone(),
             identity
                 .mint_membership(&id)
                 .expect("root membership is available"),

--- a/crates/shelterwood/src/driver/tests/construction.rs
+++ b/crates/shelterwood/src/driver/tests/construction.rs
@@ -14,10 +14,7 @@ fn handle_identity_is_stable_across_membership_rebase() {
 
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
-    let member = MemberCell::new(
-        id.clone(),
-        identity.mint_membership(&id).expect("membership available"),
-    );
+    let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
     let mailbox: Arc<MailboxCell<u8>> =
         MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), mailbox);
@@ -53,10 +50,7 @@ fn handle_identity_is_stable_across_membership_rebase() {
 async fn attaching_after_terminality_closes_the_mailbox() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
-    let member = MemberCell::new(
-        id.clone(),
-        identity.mint_membership(&id).expect("membership available"),
-    );
+    let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
     let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     let mut parked = Box::pin(actor.send(1));

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -213,7 +213,6 @@ fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
     let mut identity = ScopeIdentity::new();
     let root_id = ChildId::from("root");
     let root_member = MemberCell::new(
-        root_id.clone(),
         identity
             .mint_membership(&root_id)
             .expect("root membership available"),
@@ -221,7 +220,6 @@ fn dynamic_close_holds_removal_completion_through_observation_cleanup() {
     let root = ScopeCell::new(root_member, ScopeFlavor::Dynamic, ScopeIdentity::new());
     let child_id = ChildId::from("worker");
     let member = MemberCell::new(
-        child_id.clone(),
         root.mint_membership(&child_id)
             .expect("child membership available"),
     );
@@ -368,7 +366,6 @@ fn dynamic_removal_waits_for_the_observation_gate_before_mutating_state() {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
     let child_id = ChildId::from("worker");
     let member = MemberCell::new(
-        child_id.clone(),
         root.mint_membership(&child_id)
             .expect("child membership available"),
     );
@@ -591,7 +588,7 @@ async fn removal_from_a_foreign_thread_reaches_the_driver() {
     let membership = root
         .mint_membership(&child_id)
         .expect("membership available");
-    let member = MemberCell::new(child_id.clone(), membership);
+    let member = MemberCell::new(membership);
     assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None)));
     let slot = SlotCell::new(Arc::clone(&member), None);
     let key = ChildKey::fixture(1);

--- a/crates/shelterwood/src/driver/tests/exhaustion.rs
+++ b/crates/shelterwood/src/driver/tests/exhaustion.rs
@@ -5,7 +5,6 @@ async fn reserve_error_identity_exhausted_maps_the_membership_domain() {
     let mut root_identity = ScopeIdentity::new();
     let root_id = ChildId::from("root");
     let root_member = MemberCell::new(
-        root_id.clone(),
         root_identity
             .mint_membership(&root_id)
             .expect("root membership available"),
@@ -110,7 +109,7 @@ fn member_transitions_own_their_complete_record_projection() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
     let membership = identity.mint_membership(&id).expect("membership available");
-    let member = MemberCell::new(id, membership);
+    let member = MemberCell::new(membership);
     let mut incarnations = member.take_incarnation_counter();
     let incarnation = incarnations.mint().expect("incarnation available");
 
@@ -166,7 +165,7 @@ fn incarnation_mint_exhaustion_has_no_terminal_side_effects() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
     let membership = identity.mint_membership(&id).expect("membership available");
-    let member = MemberCell::new(id, membership);
+    let member = MemberCell::new(membership);
     let previous = Exit::failed(
         ExitError::message("last completed incarnation"),
         Cancellation::NotObserved,
@@ -438,7 +437,7 @@ async fn nested_membership_exhaustion_is_structured_and_fail_closed() {
     let nested_membership = parent_identity
         .mint_membership(&nested_id)
         .expect("nested membership available");
-    let nested_member = MemberCell::new(nested_id, nested_membership);
+    let nested_member = MemberCell::new(nested_membership);
 
     let worker_id = ChildId::from("worker");
     let mut child_identity = ScopeIdentity::near_exhaustion(worker_id.clone(), 7);
@@ -508,7 +507,7 @@ async fn assert_pre_loop_stop_upgrades_a_nested_lowering_failure(source: PreLoop
     let nested_membership = parent_identity
         .mint_membership(&nested_id)
         .expect("nested membership available");
-    let nested_member = MemberCell::new(nested_id, nested_membership);
+    let nested_member = MemberCell::new(nested_membership);
 
     let worker_id = ChildId::from("worker");
     let mut child_identity = ScopeIdentity::near_exhaustion(worker_id.clone(), 7);
@@ -610,7 +609,7 @@ async fn scope_incarnation_exhaustion_closes_nested_observation() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("nested");
     let membership = identity.mint_membership(&id).expect("membership available");
-    let member = MemberCell::new(id, membership);
+    let member = MemberCell::new(membership);
     let scope = ScopeCell::new(
         Arc::clone(&member),
         ScopeFlavor::Ordered,
@@ -706,7 +705,7 @@ fn lifecycle_sequence_exhaustion_poison_is_never_minted_and_becomes_lag() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("scope");
     let membership = identity.mint_membership(&id).expect("membership available");
-    let member = MemberCell::new(id, membership);
+    let member = MemberCell::new(membership);
     let scope = ScopeCell::new(member, ScopeFlavor::Ordered, ScopeIdentity::new());
     scope.set_lifecycle_sequence(u64::MAX - 2);
     let mut events = scope.subscribe_lifecycle();

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -6,7 +6,6 @@ fn snapshot_rejects_a_resident_whose_options_were_never_resolved() {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
     let child_id = ChildId::from("worker");
     let member = MemberCell::new(
-        child_id.clone(),
         root.mint_membership(&child_id)
             .expect("child membership available"),
     );
@@ -555,7 +554,7 @@ async fn wait_for_child_reloads_after_its_predicate_closes_the_snapshot_stream()
     let membership = scope
         .mint_membership(&child_id)
         .expect("child membership is available");
-    let child = MemberCell::new(child_id, membership);
+    let child = MemberCell::new(membership);
     resolve_fixture_options(&child);
     let slot = SlotCell::new(Arc::clone(&child), None);
     assert!(scope.set_admitted_children(vec![resident_projection(&slot)]));
@@ -942,7 +941,6 @@ fn admitted_subtree_rehomes_existing_descendants_to_one_gate() {
     let leaf = isolated_scope("leaf", ScopeFlavor::Ordered);
     let raw_leaf_id = ChildId::from("raw-leaf");
     let raw_leaf = MemberCell::new(
-        raw_leaf_id.clone(),
         nested
             .mint_membership(&raw_leaf_id)
             .expect("raw leaf membership is available"),
@@ -1383,7 +1381,6 @@ fn a_losing_supervised_terminal_exit_is_a_complete_noop_outside_the_gate() {
     let root = isolated_scope("root", ScopeFlavor::Ordered);
     let child_id = ChildId::from("worker");
     let member = MemberCell::new(
-        child_id.clone(),
         root.mint_membership(&child_id)
             .expect("child membership available"),
     );
@@ -1423,7 +1420,6 @@ fn a_retired_snapshot_payload_is_destroyed_outside_the_gate() {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
     let child_id = ChildId::from("worker");
     let member = MemberCell::new(
-        child_id.clone(),
         root.mint_membership(&child_id)
             .expect("child membership available"),
     );
@@ -1522,7 +1518,6 @@ fn a_snapshot_retired_by_observation_closure_is_destroyed_outside_the_gate() {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
     let child_id = ChildId::from("worker");
     let member = MemberCell::new(
-        child_id.clone(),
         root.mint_membership(&child_id)
             .expect("child membership available"),
     );
@@ -1659,7 +1654,6 @@ fn residency_can_release_the_last_member_arc_with_a_failed_exit() {
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
     let child_id = ChildId::from("worker");
     let member = MemberCell::new(
-        child_id.clone(),
         root.mint_membership(&child_id)
             .expect("child membership available"),
     );

--- a/crates/shelterwood/src/driver/tests/support.rs
+++ b/crates/shelterwood/src/driver/tests/support.rs
@@ -566,7 +566,6 @@ pub(super) fn restarting_member_fixture() -> (Arc<ScopeCell>, Arc<MemberCell>, I
     let root = isolated_scope("root", ScopeFlavor::Dynamic);
     let child_id = ChildId::from("worker");
     let member = MemberCell::new(
-        child_id.clone(),
         root.mint_membership(&child_id)
             .expect("child membership available"),
     );

--- a/crates/shelterwood/src/driver/tests/terminalization.rs
+++ b/crates/shelterwood/src/driver/tests/terminalization.rs
@@ -541,10 +541,7 @@ fn stopped_publication_keeps_mailbox_panic_primary_and_finishes_observation() {
 fn panicking_mailbox_waker_cannot_skip_the_terminal_pulse() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
-    let member = MemberCell::new(
-        id.clone(),
-        identity.mint_membership(&id).expect("membership available"),
-    );
+    let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
     let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     member.attach_mailbox(mailbox);
@@ -595,10 +592,7 @@ fn panicking_mailbox_waker_cannot_skip_the_terminal_pulse() {
 fn mailbox_teardown_panic_precedes_a_terminal_pulse_panic() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
-    let member = MemberCell::new(
-        id.clone(),
-        identity.mint_membership(&id).expect("membership available"),
-    );
+    let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
     let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     member.attach_mailbox(mailbox);
@@ -751,10 +745,7 @@ async fn mailbox_waker_panic_is_contained_without_wedging_system_completion() {
 fn terminality_signal_follows_mailbox_termination() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
-    let member = MemberCell::new(
-        id.clone(),
-        identity.mint_membership(&id).expect("membership available"),
-    );
+    let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
     let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     member.attach_mailbox(mailbox);
@@ -783,10 +774,7 @@ fn supervised_terminality_pulse_follows_mailbox_termination() {
     let root = isolated_scope("root", ScopeFlavor::Ordered);
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
-    let member = MemberCell::new(
-        id.clone(),
-        identity.mint_membership(&id).expect("membership available"),
-    );
+    let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
     assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None)));
     let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
@@ -847,10 +835,7 @@ fn supervised_mailbox_teardown_panic_precedes_terminal_pulse_panic() {
     let root = isolated_scope("root", ScopeFlavor::Ordered);
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
-    let member = MemberCell::new(
-        id.clone(),
-        identity.mint_membership(&id).expect("membership available"),
-    );
+    let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
     assert!(root.admit_child(ResidentProjection::new(Arc::clone(&member), None)));
     let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
@@ -919,10 +904,7 @@ fn supervised_mailbox_teardown_panic_precedes_terminal_pulse_panic() {
 fn mailbox_wake_observes_terminal_record_and_reentrant_terminality_is_idempotent() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
-    let member = MemberCell::new(
-        id.clone(),
-        identity.mint_membership(&id).expect("membership available"),
-    );
+    let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
     let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     member.attach_mailbox(mailbox);
@@ -960,10 +942,7 @@ fn mailbox_wake_observes_terminal_record_and_reentrant_terminality_is_idempotent
 fn attach_to_a_terminal_member_finishes_record_before_mailbox_wake() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
-    let member = MemberCell::new(
-        id.clone(),
-        identity.mint_membership(&id).expect("membership available"),
-    );
+    let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
     let mailbox = MailboxCell::new(member.id().clone(), crate::runtime::mailbox_runtime());
     let actor = actor_ref_from_parts(Arc::clone(&member), Arc::clone(&mailbox));
     let first_exit = Exit::never_started();
@@ -1001,10 +980,7 @@ fn attach_to_a_terminal_member_finishes_record_before_mailbox_wake() {
 fn concurrent_terminalizers_return_after_one_consistent_record_is_visible() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
-    let member = MemberCell::new(
-        id.clone(),
-        identity.mint_membership(&id).expect("membership available"),
-    );
+    let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
     let start = Arc::new(Barrier::new(3));
     let workers = [
         Exit::never_started(),
@@ -1037,10 +1013,7 @@ fn concurrent_terminalizers_return_after_one_consistent_record_is_visible() {
 fn a_losing_terminalizer_does_not_reclassify_or_republish_startup() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("worker");
-    let member = MemberCell::new(
-        id.clone(),
-        identity.mint_membership(&id).expect("membership available"),
-    );
+    let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
     let winner = Exit::completed(Cancellation::NotObserved);
     member.terminalize(winner, StartupDisposition::NotAborted);
     let winning_record = member.record();
@@ -1075,10 +1048,7 @@ fn a_losing_terminalizer_does_not_reclassify_or_republish_startup() {
 fn terminal_startup_wake_follows_member_and_incarnation_publication() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("root");
-    let member = MemberCell::new(
-        id.clone(),
-        identity.mint_membership(&id).expect("membership available"),
-    );
+    let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
     let scope = ScopeCell::new(member, ScopeFlavor::Ordered, ScopeIdentity::new());
     let epoch = scope
         .begin_incarnation(ScopeState::Starting)
@@ -1120,10 +1090,7 @@ fn terminal_startup_wake_follows_member_and_incarnation_publication() {
 fn no_live_root_startup_wake_follows_member_publication() {
     let mut identity = ScopeIdentity::new();
     let id = ChildId::from("root");
-    let member = MemberCell::new(
-        id.clone(),
-        identity.mint_membership(&id).expect("membership available"),
-    );
+    let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
     let scope = ScopeCell::new(member, ScopeFlavor::Ordered, ScopeIdentity::new());
     let probe = Arc::new(ObserveScopeOnStartupWake {
         scope: Arc::clone(&scope),

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -398,7 +398,7 @@ impl BuilderCore {
             // not this builder's throwaway root.
             self.adopting_root = Some(Arc::clone(&root));
             for slot in &self.slots {
-                match root.adopt_or_mint_membership(slot.member.id(), slot.member.membership()) {
+                match root.adopt_or_mint_membership(slot.member.take_provisional_membership()) {
                     MembershipReconciliation::Adopted => {}
                     MembershipReconciliation::Minted(identity) => {
                         slot.member.rebase_membership(identity);

--- a/crates/shelterwood/src/plan.rs
+++ b/crates/shelterwood/src/plan.rs
@@ -41,8 +41,7 @@ fn mint_reserved_slot_inner(
     id: &ChildId,
     child_scope: Option<ScopeFlavor>,
 ) -> Option<Arc<SlotCell>> {
-    let membership = parent.mint_membership(id)?;
-    let member = MemberCell::new(id.clone(), membership);
+    let member = MemberCell::new(parent.mint_membership(id)?);
     let scope = child_scope.map(|flavor| {
         let identity = ScopeIdentity::new();
         ScopeCell::new(Arc::clone(&member), flavor, identity)
@@ -328,10 +327,11 @@ impl BuilderCore {
     pub(crate) fn new(flavor: ScopeFlavor) -> Self {
         let root_id = ChildId::from("$root");
         let mut root_identity = ScopeIdentity::new();
-        let membership = root_identity
-            .mint_membership(&root_id)
-            .expect("fresh scope identity must mint its root membership");
-        let member = MemberCell::new(root_id, membership);
+        let member = MemberCell::new(
+            root_identity
+                .mint_membership(&root_id)
+                .expect("fresh scope identity must mint its root membership"),
+        );
         let child_identity = ScopeIdentity::new();
         let root = ScopeCell::new(member, flavor, child_identity);
         Self {
@@ -914,10 +914,11 @@ mod tests {
         // preceding slot's lineage was already adopted.
         let root_id = ChildId::from("$root");
         let mut root_identity = ScopeIdentity::new();
-        let root_membership = root_identity
-            .mint_membership(&root_id)
-            .expect("fresh scope identity must mint its root membership");
-        let member = MemberCell::new(root_id, root_membership);
+        let member = MemberCell::new(
+            root_identity
+                .mint_membership(&root_id)
+                .expect("fresh scope identity must mint its root membership"),
+        );
         let exhausted_id = ChildId::from("exhausted");
         let mut child_identity = ScopeIdentity::near_exhaustion(exhausted_id.clone(), 7);
         let _ = child_identity

--- a/crates/shelterwood/src/raw/context.rs
+++ b/crates/shelterwood/src/raw/context.rs
@@ -1345,10 +1345,7 @@ mod tests {
     fn bound_raw_context_for<M: Send + 'static>() -> (RawContext<M>, ActorRef<M>, Latch) {
         let mut identity = ScopeIdentity::new();
         let id = ChildId::from("raw-actor");
-        let member = MemberCell::new(
-            id.clone(),
-            identity.mint_membership(&id).expect("membership available"),
-        );
+        let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
         let mailbox = MailboxCell::new(id.clone(), crate::runtime::mailbox_runtime());
         member.attach_mailbox(mailbox.clone());
         let mut effects = MailboxEffectQueue::default();
@@ -1366,7 +1363,6 @@ mod tests {
         let mut scope_identity = ScopeIdentity::new();
         let scope_id = ChildId::from("scope");
         let scope_member = MemberCell::new(
-            scope_id.clone(),
             scope_identity
                 .mint_membership(&scope_id)
                 .expect("membership available"),

--- a/crates/shelterwood/src/task.rs
+++ b/crates/shelterwood/src/task.rs
@@ -446,8 +446,7 @@ mod tests {
     ) {
         let mut identity = ScopeIdentity::new();
         let id = ChildId::from("task");
-        let membership = identity.mint_membership(&id).expect("membership available");
-        let member = MemberCell::new(id, membership);
+        let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
         let (sender, receiver) = runtime::oneshot();
         let claim = OneShotTaskRef::new(receiver, TaskRef::new(std::sync::Arc::clone(&member)));
         (sender, claim, member)
@@ -514,8 +513,7 @@ mod tests {
     async fn staged_one_shot_wait_cannot_double_panic_at_completion_delivery() {
         let mut identity = ScopeIdentity::new();
         let id = ChildId::from("task");
-        let membership = identity.mint_membership(&id).expect("membership available");
-        let member = MemberCell::new(id, membership);
+        let member = MemberCell::new(identity.mint_membership(&id).expect("membership available"));
         let (sending, receiver) = runtime::oneshot_sending_for_test();
         let claim = OneShotTaskRef::new(receiver, TaskRef::new(Arc::clone(&member)));
         member.terminalize(


### PR DESCRIPTION
## Summary

- hide the `shelterwood-core` membership-minting authority family from generated documentation while leaving `ChildId`, `Membership`, and `Incarnation` plainly public
- introduce a non-`Clone` `ProvisionalMembership` that carries its minting child ID and is consumed by stable-scope reconciliation
- retain and consume the provisional authority through the production declaration-lowering path
- cover the core API shape, embedded-ID reconciliation, and existing adoption/exhaustion behavior

## Testing

- `./tools/dev cargo test --locked -p shelterwood-core --test identity_authority`
- `./tools/dev cargo test --locked -p shelterwood-core identity::tests`
- `./tools/dev cargo test --locked -p shelterwood plan::tests::failed_override_lowering_evicts_adopted_lineages_from_the_override`
- `./tools/dev just ci`

Closes #436.
