### PR TITLE
Retain exits through terminal disposal

### DIFF
--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -1344,26 +1344,29 @@ impl ScopeRuntime {
         member.set_terminal_disposal_pending(false);
         if self.supervisor.membership_status(key) == MembershipStatus::Removing {
             self.flush_supervisor_effects();
-            if terminalized {
-                // The retained member record outlives this early return.
-                drop(exit.into_exit());
+        } else {
+            if terminal.startup == StartupDisposition::Aborted
+                && !self.supervisor.lifecycle().is_draining()
+            {
+                self.fail_startup(key, &exit);
             }
-            return;
+            if self.children[key].options.retention == crate::Retention::Remove {
+                self.prune_terminal(key);
+            }
         }
-        if terminal.startup == StartupDisposition::Aborted
-            && !self.supervisor.lifecycle().is_draining()
-        {
-            self.fail_startup(key, &exit);
-        }
-        if self.children[key].options.retention == crate::Retention::Remove {
-            self.prune_terminal(key);
-        }
+        // Both routes above are fallible, so the guard is released once, here.
+        // A winning publication installed an equivalent retained copy in the
+        // terminal member record, which the `member` handle keeps alive past
+        // this statement, so surrendering the raw copy is refcount traffic.
+        //
+        // A losing publication is unreachable today: #458 established that by
+        // whole-workspace enumeration rather than by any local guard, so no
+        // test pins the other branch and a probe for it would be a
+        // strong-count race by construction. It is retained defensively — the
+        // guard simply falls out of scope, and `RetainedExit::drop` retires
+        // the user error through critical disposal at the cost of one extra
+        // blocking-pool job.
         if terminalized {
-            // The terminal member record owns an equivalent retained copy.
-            // Keep the guard through every later fallible operation above,
-            // then surrender it as raw refcount traffic. A losing publication
-            // leaves the guard intact so its drop retires the exit through
-            // critical disposal.
             drop(exit.into_exit());
         }
     }

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -733,7 +733,7 @@ impl ScopeRuntime {
             // Exhaustion is a terminal outcome, not an exceptional cleanup
             // path. Join retained-definition disposal before terminality,
             // retention, removal completion, or ordered-scope progression.
-            self.begin_terminal_disposal(key, exit, None, startup);
+            self.begin_terminal_disposal(key, RetainedExit::new(exit), None, startup);
             return;
         };
 
@@ -914,7 +914,12 @@ impl ScopeRuntime {
             // A never-ran child and a child stopped between restart
             // incarnations share the same post-disposal terminal route. Hard
             // shutdown still detaches disposal through `hard_forced` below.
-            self.begin_terminal_disposal(key, exit, None, StartupDisposition::NotAborted);
+            self.begin_terminal_disposal(
+                key,
+                RetainedExit::new(exit),
+                None,
+                StartupDisposition::NotAborted,
+            );
         }
     }
 
@@ -1108,7 +1113,7 @@ impl ScopeRuntime {
             membership_status,
         ) {
             ExitDispatch::Terminal => {
-                self.begin_terminal_disposal(key, exit.into_exit(), Some(incarnation), startup);
+                self.begin_terminal_disposal(key, exit, Some(incarnation), startup);
             }
             ExitDispatch::ScheduleRestart => {
                 let sample =
@@ -1220,14 +1225,15 @@ impl ScopeRuntime {
     pub(super) fn begin_terminal_disposal(
         &mut self,
         key: ChildKey,
-        exit: Exit,
+        exit: RetainedExit,
         exited_incarnation: Option<Incarnation>,
         startup: StartupDisposition,
     ) {
-        // Retain before every refusal and invariant verdict. A failed Exit can
-        // own hostile user error drop glue, so no path may unwind or return it
-        // directly on the driver thread.
-        let mut exit = Some(RetainedExit::new(exit));
+        // Keep the caller's guard through every refusal and invariant verdict.
+        // A failed Exit can own hostile user error drop glue, so no call-site
+        // argument window or local path may unwind or return it directly on
+        // the driver thread.
+        let mut exit = Some(exit);
         if !self.supervisor.contains(key)
             || self.supervisor.is_disposing(key)
             || self.supervisor.joined(key)
@@ -1322,8 +1328,12 @@ impl ScopeRuntime {
         } else {
             StartupDisposition::NotAborted
         };
-        let exit = exit.into_exit();
-        self.terminalize_child(key, exit.clone(), terminal.exited_incarnation, startup);
+        let terminalized = self.terminalize_child(
+            key,
+            exit.as_exit().clone(),
+            terminal.exited_incarnation,
+            startup,
+        );
         // Keep the marker installed until terminal publication has committed.
         // A concurrent shutdown sampler then sees either pending cleanup or a
         // terminal member, never the gap between those two representations.
@@ -1334,15 +1344,27 @@ impl ScopeRuntime {
         member.set_terminal_disposal_pending(false);
         if self.supervisor.membership_status(key) == MembershipStatus::Removing {
             self.flush_supervisor_effects();
+            if terminalized {
+                // The retained member record outlives this early return.
+                drop(exit.into_exit());
+            }
             return;
         }
         if terminal.startup == StartupDisposition::Aborted
             && !self.supervisor.lifecycle().is_draining()
         {
-            self.fail_startup(key, exit);
+            self.fail_startup(key, &exit);
         }
         if self.children[key].options.retention == crate::Retention::Remove {
             self.prune_terminal(key);
+        }
+        if terminalized {
+            // The terminal member record owns an equivalent retained copy.
+            // Keep the guard through every later fallible operation above,
+            // then surrender it as raw refcount traffic. A losing publication
+            // leaves the guard intact so its drop retires the exit through
+            // critical disposal.
+            drop(exit.into_exit());
         }
     }
 }

--- a/crates/shelterwood/src/driver/startup.rs
+++ b/crates/shelterwood/src/driver/startup.rs
@@ -114,17 +114,19 @@ impl ScopeRuntime {
         self.record_storage();
     }
 
-    pub(super) fn fail_startup(&mut self, key: ChildKey, exit: Exit) {
+    pub(super) fn fail_startup(&mut self, key: ChildKey, exit: &RetainedExit) {
         // Several initial children can fail in one arbitration batch. The
         // first failure owns the startup verdict and its sole lifecycle edge;
         // later exits are still terminalized, but cannot republish the scope
-        // transition or replace the authoritative cause.
+        // transition or replace the authoritative cause. Keep the caller's
+        // retained owner alive while this raw structured copy crosses the
+        // child lookup, reducer verdict and publication paths.
         let child = &self.children[key];
         let failure = StartupFailure {
             cause: StartupFailureCause::Child {
                 id: child.slot.member.id().clone(),
                 membership: child.slot.member.membership(),
-                exit,
+                exit: exit.as_exit().clone(),
             },
         };
         let Some(state) = supervisor_fail_startup(&mut self.supervisor) else {
@@ -139,7 +141,7 @@ impl ScopeRuntime {
                 {
                     self.begin_terminal_disposal(
                         later,
-                        Exit::never_started(),
+                        RetainedExit::new(Exit::never_started()),
                         None,
                         StartupDisposition::NotAborted,
                     );

--- a/crates/shelterwood/src/driver/tests/shutdown.rs
+++ b/crates/shelterwood/src/driver/tests/shutdown.rs
@@ -1,4 +1,5 @@
 use super::support::*;
+use crate::cells::RetainedExit;
 
 struct BlockingFactoryDrop(Arc<FactoryGate>);
 
@@ -294,9 +295,11 @@ async fn refused_terminal_disposal_retires_its_exit_off_the_driver() {
     let (error, disposed) = thread_reporting_error();
     let driver_thread = std::thread::current().id();
 
+    // The carrier makes retention structural; the destructor-thread probe
+    // still pins the refusal's disposal artifact to the blocking pool.
     scope.begin_terminal_disposal(
         ChildKey::fixture(999),
-        Exit::failed(error, Cancellation::NotObserved),
+        RetainedExit::new(Exit::failed(error, Cancellation::NotObserved)),
         None,
         StartupDisposition::NotAborted,
     );


### PR DESCRIPTION
Closes #458

## Summary
- carry RetainedExit across terminal-disposal entry, construction disposal, and startup arbitration
- release the carrier as raw refcount traffic only after terminal publication wins
- preserve the refused-disposal destructor-thread regression while adapting it to the structural carrier boundary

## Verification
- ./tools/dev cargo test -p shelterwood driver::tests::
- ./tools/dev just ci