### PR TITLE
Harden send-path caller-waker unwind handling

### DIFF
--- a/crates/shelterwood/src/mailbox/cell.rs
+++ b/crates/shelterwood/src/mailbox/cell.rs
@@ -211,13 +211,17 @@ impl<M> SendOperation<M> {
         let result = loop {
             let mut state = self.state.lock().expect("send operation mutex poisoned");
             let result = match &mut state.outcome {
-                // The replacement was cloned outside this lock. Completion can
-                // win that window, leaving a caller waker which must be retired
-                // before a terminal message is moved into the return value. A
-                // hostile destructor is contained at this ready seam for the
-                // same reason as reply and timer retirement: after the handoff,
-                // unwinding would destroy a user value in the poll frame.
-                OperationOutcome::Accepted(_) | OperationOutcome::Terminated { .. }
+                // The replacement was cloned outside this lock. Every outcome
+                // but `Waiting` refuses it, so it must be retired before this
+                // frame either moves a terminal message into the return value
+                // or raises one of the defensive diagnostics below. Both would
+                // otherwise destroy the caller waker mid-unwind -- beside a
+                // user value in the first case, inside an existing panic in the
+                // second. A hostile destructor is contained at this ready seam
+                // for the same reason as reply and timer retirement.
+                OperationOutcome::Accepted(_)
+                | OperationOutcome::Terminated { .. }
+                | OperationOutcome::Withdrawn
                     if replacement.is_some() =>
                 {
                     None
@@ -256,14 +260,14 @@ impl<M> SendOperation<M> {
 
             // Stage the clone through the structural waker sink, then drain it
             // with no operation lock held and before re-reading the stable
-            // completing outcome. `flush` catches its vtable panic; taking and
+            // non-waiting outcome. `flush` catches its vtable panic; taking and
             // discarding the payload prevents `PanicAccumulator::drop` from
             // resuming it over the eventual by-value result.
             let mut staged = WakerSlot::default();
             staged.replace(
                 replacement
                     .take()
-                    .expect("a completing clone window retains its replacement waker"),
+                    .expect("a refused clone window retains its replacement waker"),
                 &mut effects,
             );
             staged.take(WakerAction::DropInline, &mut effects);

--- a/crates/shelterwood/src/mailbox/cell.rs
+++ b/crates/shelterwood/src/mailbox/cell.rs
@@ -202,22 +202,33 @@ impl<M> SendOperation<M> {
 
     pub(super) fn poll(
         &self,
-        replacement: Option<std::task::Waker>,
+        mut replacement: Option<std::task::Waker>,
         current: &std::task::Waker,
     ) -> OperationPoll<M> {
         // Effects precede the guard, so even an unwind drops the guard before
         // invoking a displaced RawWaker vtable.
         let mut effects = WakerEffects::default();
-        let result = {
+        let result = loop {
             let mut state = self.state.lock().expect("send operation mutex poisoned");
-            match &mut state.outcome {
+            let result = match &mut state.outcome {
+                // The replacement was cloned outside this lock. Completion can
+                // win that window, leaving a caller waker which must be retired
+                // before a terminal message is moved into the return value. A
+                // hostile destructor is contained at this ready seam for the
+                // same reason as reply and timer retirement: after the handoff,
+                // unwinding would destroy a user value in the poll frame.
+                OperationOutcome::Accepted(_) | OperationOutcome::Terminated { .. }
+                    if replacement.is_some() =>
+                {
+                    None
+                }
                 OperationOutcome::Accepted(incarnation) => {
-                    Ok(OperationPoll::Accepted(*incarnation))
+                    Some(Ok(OperationPoll::Accepted(*incarnation)))
                 }
                 OperationOutcome::Terminated {
                     message,
                     final_incarnation,
-                } => message.take().map_or_else(
+                } => Some(message.take().map_or_else(
                     || Err("a terminal operation retains its message until observed"),
                     |message| {
                         Ok(OperationPoll::Terminated {
@@ -225,19 +236,40 @@ impl<M> SendOperation<M> {
                             final_incarnation: *final_incarnation,
                         })
                     },
-                ),
+                )),
                 OperationOutcome::Waiting { .. } => {
-                    if let Some(replacement) = replacement {
+                    if let Some(replacement) = replacement.take() {
                         state.waker.replace(replacement, &mut effects);
-                        Ok(OperationPoll::Pending)
+                        Some(Ok(OperationPoll::Pending))
                     } else if state.waker.will_wake(current) {
-                        Ok(OperationPoll::Pending)
+                        Some(Ok(OperationPoll::Pending))
                     } else {
-                        Ok(OperationPoll::NeedsWakerClone)
+                        Some(Ok(OperationPoll::NeedsWakerClone))
                     }
                 }
-                OperationOutcome::Withdrawn => Err("a withdrawn send future was polled"),
+                OperationOutcome::Withdrawn => Some(Err("a withdrawn send future was polled")),
+            };
+            drop(state);
+            if let Some(result) = result {
+                break result;
             }
+
+            // Stage the clone through the structural waker sink, then drain it
+            // with no operation lock held and before re-reading the stable
+            // completing outcome. `flush` catches its vtable panic; taking and
+            // discarding the payload prevents `PanicAccumulator::drop` from
+            // resuming it over the eventual by-value result.
+            let mut staged = WakerSlot::default();
+            staged.replace(
+                replacement
+                    .take()
+                    .expect("a completing clone window retains its replacement waker"),
+                &mut effects,
+            );
+            staged.take(WakerAction::DropInline, &mut effects);
+            let mut panics = PanicAccumulator::default();
+            effects.flush(&mut panics);
+            crate::runtime::discard_panic(panics.take());
         };
         drop(effects);
         match result {
@@ -1377,6 +1409,18 @@ impl<M: Send + 'static> MailboxCell<M> {
             Ok(transition) => transition,
             Err(message) => {
                 transaction.finish(());
+                if std::thread::panicking() {
+                    // `withdraw` is reached from `SendFuture` drop glue. If a
+                    // concurrent poll already consumed a terminal message and
+                    // then unwound, repeating this invariant panic would abort
+                    // the process. Preserve the primary unwind and return an
+                    // empty carrier whose remaining effects still flush after
+                    // every framework guard has been released.
+                    return Withdrawal {
+                        outcome: None,
+                        _waker_effects: waker_effects,
+                    };
+                }
                 panic!("{message}");
             }
         };
@@ -1798,6 +1842,10 @@ impl<M> Withdrawal<M> {
         self.outcome
             .take()
             .expect("a withdrawal outcome is consumed exactly once")
+    }
+
+    pub(super) fn take_outcome_if_present(&mut self) -> Option<WithdrawalOutcome<M>> {
+        self.outcome.take()
     }
 
     pub(super) fn finish(self) {}

--- a/crates/shelterwood/src/mailbox/futures.rs
+++ b/crates/shelterwood/src/mailbox/futures.rs
@@ -1202,6 +1202,19 @@ mod tests {
         assert_eq!(first, incarnation);
     }
 
+    /// Reaches the operation a parked send registered, so a regression can
+    /// drive or observe it directly.
+    fn parked_operation<M: Send + 'static>(
+        send: &Pin<Box<SendFuture<M>>>,
+    ) -> Arc<SendOperation<M>> {
+        match &send.as_ref().get_ref().state {
+            SendFutureState::Parked(operation) => Arc::clone(operation),
+            SendFutureState::Immediate(_) | SendFutureState::Sent(_) | SendFutureState::Done => {
+                panic!("an unbound mailbox parks its send")
+            }
+        }
+    }
+
     #[test]
     fn replacing_a_send_waker_runs_its_vtable_outside_the_operation_lock() {
         let (_, actor) = actor();
@@ -1211,12 +1224,7 @@ mod tests {
                 .poll(&mut Context::from_waker(Waker::noop()))
                 .is_pending()
         );
-        let operation = match &send.as_ref().get_ref().state {
-            SendFutureState::Parked(operation) => operation.clone(),
-            SendFutureState::Immediate(_) | SendFutureState::Sent(_) | SendFutureState::Done => {
-                panic!("an unbound mailbox parks its send")
-            }
-        };
+        let operation = parked_operation(&send);
         let calls = Arc::new(WakerVtableCalls::default());
         let hostile = operation_lock_probe_waker(&operation, Arc::clone(&calls));
 
@@ -1617,12 +1625,7 @@ mod tests {
                 .poll(&mut Context::from_waker(Waker::noop()))
                 .is_pending()
         );
-        let operation = match &send.as_ref().get_ref().state {
-            SendFutureState::Parked(operation) => operation.clone(),
-            SendFutureState::Immediate(_) | SendFutureState::Sent(_) | SendFutureState::Done => {
-                panic!("an unbound mailbox parks its send")
-            }
-        };
+        let operation = parked_operation(&send);
         let mut effects = MailboxEffectQueue::default();
         let teardown = MailboxControl::prepare_termination(&*mailbox, &mut effects)
             .expect("the mailbox terminates once");
@@ -1653,12 +1656,7 @@ mod tests {
                 .poll(&mut Context::from_waker(Waker::noop()))
                 .is_pending()
         );
-        let operation = match &send.as_ref().get_ref().state {
-            SendFutureState::Parked(operation) => operation.clone(),
-            SendFutureState::Immediate(_) | SendFutureState::Sent(_) | SendFutureState::Done => {
-                panic!("an unbound mailbox parks its send")
-            }
-        };
+        let operation = parked_operation(&send);
         let calls = Arc::new(WakerVtableCalls::default());
         let hostile = operation_lock_probe_waker(&operation, Arc::clone(&calls));
 
@@ -1790,12 +1788,7 @@ mod tests {
                 .poll(&mut Context::from_waker(Waker::noop()))
                 .is_pending()
         );
-        let operation = match &send.as_ref().get_ref().state {
-            SendFutureState::Parked(operation) => Arc::clone(operation),
-            SendFutureState::Immediate(_) | SendFutureState::Sent(_) | SendFutureState::Done => {
-                panic!("an unbound mailbox parks its send")
-            }
-        };
+        let operation = parked_operation(&send);
         let teardown = prepare_termination(&mailbox).expect("the mailbox terminates once");
         drop(teardown.finish());
         let retained = {
@@ -1816,5 +1809,108 @@ mod tests {
             Some("primary unwind")
         );
         assert_eq!(retained, 7);
+    }
+
+    #[test]
+    fn retiring_a_clone_window_replacement_runs_outside_the_operation_lock() {
+        let (mailbox, actor): (Arc<MailboxCell<u8>>, ActorRef<u8>) = actor_for();
+        let mut send = Box::pin(actor.send(7));
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        let operation = parked_operation(&send);
+        let completing = Arc::new(Mutex::new(Some(Arc::clone(&mailbox))));
+        let unlocked = Arc::new(Mutex::new(None));
+        let hostile = ManuallyDrop::new(probe_waker(
+            {
+                let completing = Arc::clone(&completing);
+                move || {
+                    let mailbox = completing
+                        .lock()
+                        .expect("completion probe mutex")
+                        .take()
+                        .expect("the replacement waker is cloned once");
+                    let teardown = prepare_termination(&mailbox)
+                        .expect("the clone-window probe terminates once");
+                    drop(teardown.finish());
+                }
+            },
+            {
+                let unlocked = Arc::clone(&unlocked);
+                let operation = Arc::downgrade(&operation);
+                move || {
+                    // Publish the observation instead of asserting it: this
+                    // destructor runs inside the retirement's own containment,
+                    // which would swallow a panic raised here. The test body
+                    // below is the only place that can fail.
+                    let operation = operation
+                        .upgrade()
+                        .expect("the polled operation outlives its replacement waker");
+                    let observed = operation.state.try_lock().is_ok();
+                    *unlocked.lock().expect("lock observation mutex") = Some(observed);
+                }
+            },
+        ));
+
+        let Poll::Ready(Err(error)) = send.as_mut().poll(&mut Context::from_waker(&hostile)) else {
+            panic!("termination in the clone window returns the message")
+        };
+        assert_eq!(error.kind, crate::SendErrorKind::Terminated);
+        assert_eq!(
+            *unlocked.lock().expect("lock observation mutex"),
+            Some(true),
+            "a refused replacement waker retires with no operation lock held"
+        );
+    }
+
+    #[test]
+    fn a_withdrawn_clone_window_retires_its_replacement_before_the_diagnostic() {
+        let (_mailbox, actor): (Arc<MailboxCell<u8>>, ActorRef<u8>) = actor_for();
+        let mut send = Box::pin(actor.send(7));
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        let operation = parked_operation(&send);
+        let waker_thread = disposal_thread();
+        let hostile = ManuallyDrop::new(probe_waker(
+            {
+                let operation = Arc::downgrade(&operation);
+                move || {
+                    // Only the defensive diagnostic is reachable from a
+                    // withdrawn outcome, and the replacement must not ride its
+                    // unwind. No product path reaches this state -- the send
+                    // future's own state machine refuses a second poll -- so
+                    // the outcome is installed directly.
+                    let operation = operation
+                        .upgrade()
+                        .expect("the polled operation outlives its replacement waker");
+                    let mut state = operation.state.lock().expect("send operation mutex");
+                    state.outcome = OperationOutcome::Withdrawn;
+                }
+            },
+            {
+                let waker_thread = waker_thread.clone();
+                move || {
+                    record_disposal(&waker_thread);
+                    panic!("injected withdrawn-window waker drop panic");
+                }
+            },
+        ));
+        let polling_thread = std::thread::current().id();
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let mut send = send;
+            let _ = send.as_mut().poll(&mut Context::from_waker(&hostile));
+        }))
+        .expect_err("a withdrawn operation raises its defensive diagnostic");
+        assert_eq!(
+            panic.downcast_ref::<String>().map(String::as_str),
+            Some("a withdrawn send future was polled")
+        );
+        assert_eq!(await_disposal(&waker_thread), polling_thread);
     }
 }

--- a/crates/shelterwood/src/mailbox/futures.rs
+++ b/crates/shelterwood/src/mailbox/futures.rs
@@ -501,12 +501,14 @@ impl<M: Send + 'static> Drop for SendFuture<M> {
                 let mut withdrawal = self
                     .mailbox
                     .withdraw(&operation, WithdrawalDisposition::Isolated);
-                match withdrawal.take_outcome() {
-                    WithdrawalOutcome::Withdrawn { message, .. }
-                    | WithdrawalOutcome::Terminated { message, .. } => {
-                        self.mailbox.dispose(message);
+                if let Some(outcome) = withdrawal.take_outcome_if_present() {
+                    match outcome {
+                        WithdrawalOutcome::Withdrawn { message, .. }
+                        | WithdrawalOutcome::Terminated { message, .. } => {
+                            self.mailbox.dispose(message);
+                        }
+                        WithdrawalOutcome::Accepted(_) => {}
                     }
-                    WithdrawalOutcome::Accepted(_) => {}
                 }
                 // A RawWaker vtable is caller code and there is no caller left
                 // to surface a panic to. Destroying it inline would run a
@@ -540,10 +542,11 @@ impl<M: Send + 'static> fmt::Debug for SendTimeout<M> {
 /// Withdraws an unaccepted send and classifies its outcome under the
 /// caller's chosen waker disposition.
 ///
-/// The outcome is taken before `finish()` releases the registered waker, so
-/// under either disposition the recovered message already belongs to
-/// `result` and a hostile waker destructor can neither divert nor destroy
-/// it.
+/// The outcome is taken before `finish()` releases the registered waker. An
+/// inline release is a poll-path ready seam and `result` can own a recovered
+/// user message, so any waker-destructor panic is contained before the result
+/// is returned. Allowing it to unwind would destroy that message during
+/// cleanup and could turn a second hostile destructor into a process abort.
 fn withdraw_send_with<M: Send + 'static>(
     send: &mut SendFuture<M>,
     disposition: WithdrawalDisposition,
@@ -565,7 +568,8 @@ fn withdraw_send_with<M: Send + 'static>(
             kind: SendErrorKind::Terminated,
         }),
     };
-    withdrawal.finish();
+    let finish_panic = crate::runtime::catch_panic(|| withdrawal.finish()).err();
+    crate::runtime::discard_panic(finish_panic);
     result
 }
 
@@ -834,8 +838,12 @@ mod tests {
     };
 
     use super::{
-        super::cell::tests::{
-            actor, actor_for, actor_for_with_runtime, bind, close, configure, prepare_termination,
+        super::cell::{
+            OperationOutcome,
+            tests::{
+                actor, actor_for, actor_for_with_runtime, bind, close, configure,
+                prepare_termination,
+            },
         },
         ActorRef, DeadlineOperation, DeadlinePhase, MailboxCell, SendFuture, SendFutureState,
         SendOperation,
@@ -1322,6 +1330,15 @@ mod tests {
         }
     }
 
+    struct PanickingMessageDrop(DisposalThread);
+
+    impl Drop for PanickingMessageDrop {
+        fn drop(&mut self) {
+            record_disposal(&self.0);
+            panic!("injected message drop panic");
+        }
+    }
+
     struct CallMessage {
         _reply: crate::Reply<u8>,
         _payload: ThreadRecordingDrop,
@@ -1415,16 +1432,16 @@ mod tests {
     }
 
     #[crate::runtime::test(start_paused = true)]
-    async fn send_timeout_releases_its_waker_inline_after_recovering_the_message() {
-        let (_, actor): (
-            Arc<MailboxCell<ThreadRecordingDrop>>,
-            ActorRef<ThreadRecordingDrop>,
+    async fn send_timeout_contains_its_inline_waker_panic_before_returning_the_message() {
+        let (mailbox, actor): (
+            Arc<MailboxCell<PanickingMessageDrop>>,
+            ActorRef<PanickingMessageDrop>,
         ) = actor_for();
         let width = Duration::from_secs(1);
         let message_thread = disposal_thread();
         let waker_thread = disposal_thread();
         let mut send =
-            Box::pin(actor.send_timeout(ThreadRecordingDrop(message_thread.clone()), width));
+            Box::pin(actor.send_timeout(PanickingMessageDrop(message_thread.clone()), width));
         // Keep the caller-owned raw waker permanently inert: if an assertion
         // below fails, dropping it during that unwind would create a second
         // panic and abort the test process. Only its registered clone is the
@@ -1444,24 +1461,25 @@ mod tests {
         );
         crate::runtime::advance(width * 2).await;
         let polling_thread = std::thread::current().id();
-        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            send.deadlined.operation.poll_deadlined(
-                &mut context,
-                deadline,
-                DeadlinePhase::TimeoutArbitration,
-            )
-        }))
-        .expect_err("inline waker destruction surfaces its panic from the timeout poll");
-        assert_eq!(
-            panic.downcast_ref::<&'static str>().copied(),
-            Some("injected call waker drop panic")
-        );
+        let Poll::Ready(Err(error)) = send.deadlined.operation.poll_deadlined(
+            &mut context,
+            deadline,
+            DeadlinePhase::TimeoutArbitration,
+        ) else {
+            panic!("timeout arbitration returns the recovered message")
+        };
+        assert_eq!(error.kind, crate::SendErrorKind::TimedOut);
         assert_eq!(await_disposal(&waker_thread), polling_thread);
-        assert_eq!(
-            await_disposal(&message_thread),
-            polling_thread,
-            "the recovered message remains caller-owned when the waker drop unwinds"
+        assert!(
+            message_thread
+                .recorded
+                .lock()
+                .expect("message disposal recorder mutex")
+                .is_none(),
+            "the contained waker panic cannot destroy the returned message"
         );
+        mailbox.dispose(error);
+        assert_ne!(await_disposal(&message_thread), polling_thread);
     }
 
     #[test]
@@ -1594,5 +1612,145 @@ mod tests {
             "will_wake registers once and skips the vtable on every repoll"
         );
         assert_eq!(calls.drops.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn termination_in_the_waker_clone_window_contains_drop_before_returning_the_message() {
+        let (mailbox, actor): (
+            Arc<MailboxCell<PanickingMessageDrop>>,
+            ActorRef<PanickingMessageDrop>,
+        ) = actor_for();
+        let message_thread = disposal_thread();
+        let waker_thread = disposal_thread();
+        let mut send = Box::pin(actor.send(PanickingMessageDrop(message_thread.clone())));
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+
+        let completing = Arc::new(Mutex::new(Some(Arc::clone(&mailbox))));
+        let hostile = ManuallyDrop::new(probe_waker(
+            {
+                let completing = Arc::clone(&completing);
+                move || {
+                    let mailbox = completing
+                        .lock()
+                        .expect("completion probe mutex")
+                        .take()
+                        .expect("the replacement waker is cloned once");
+                    let teardown = prepare_termination(&mailbox)
+                        .expect("the clone-window probe terminates once");
+                    drop(teardown.finish());
+                }
+            },
+            {
+                let waker_thread = waker_thread.clone();
+                move || {
+                    record_disposal(&waker_thread);
+                    panic!("injected clone-window waker drop panic");
+                }
+            },
+        ));
+        let polling_thread = std::thread::current().id();
+
+        let Poll::Ready(Err(error)) = send.as_mut().poll(&mut Context::from_waker(&hostile)) else {
+            panic!("termination in the clone window returns the message")
+        };
+        assert_eq!(error.kind, crate::SendErrorKind::Terminated);
+        assert_eq!(await_disposal(&waker_thread), polling_thread);
+        assert!(
+            message_thread
+                .recorded
+                .lock()
+                .expect("message disposal recorder mutex")
+                .is_none(),
+            "the replacement retires before the terminal message is taken"
+        );
+        mailbox.dispose(error);
+        assert_ne!(await_disposal(&message_thread), polling_thread);
+    }
+
+    #[test]
+    fn acceptance_in_the_waker_clone_window_contains_replacement_drop() {
+        let (mailbox, actor): (Arc<MailboxCell<u8>>, ActorRef<u8>) = actor_for();
+        let mut send = Box::pin(actor.send(7));
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        let completing = Arc::new(Mutex::new(Some(Arc::clone(&mailbox))));
+        let waker_thread = disposal_thread();
+        let hostile = ManuallyDrop::new(probe_waker(
+            {
+                let completing = Arc::clone(&completing);
+                move || {
+                    let mailbox = completing
+                        .lock()
+                        .expect("completion probe mutex")
+                        .take()
+                        .expect("the replacement waker is cloned once");
+                    let token = configure(
+                        &mailbox,
+                        ResolvedMailbox::Queue(
+                            std::num::NonZeroUsize::new(1).expect("non-zero queue capacity"),
+                        ),
+                    );
+                    bind(&mailbox, token, mint_actor_incarnation());
+                }
+            },
+            {
+                let waker_thread = waker_thread.clone();
+                move || {
+                    record_disposal(&waker_thread);
+                    panic!("injected clone-window waker drop panic");
+                }
+            },
+        ));
+        let polling_thread = std::thread::current().id();
+
+        assert!(matches!(
+            send.as_mut().poll(&mut Context::from_waker(&hostile)),
+            Poll::Ready(Ok(_))
+        ));
+        assert_eq!(await_disposal(&waker_thread), polling_thread);
+    }
+
+    #[test]
+    fn terminal_message_invariant_is_contained_during_an_existing_unwind() {
+        let (mailbox, actor): (Arc<MailboxCell<u8>>, ActorRef<u8>) = actor_for();
+        let mut send = Box::pin(actor.send(7));
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        let operation = match &send.as_ref().get_ref().state {
+            SendFutureState::Parked(operation) => Arc::clone(operation),
+            SendFutureState::Immediate(_) | SendFutureState::Sent(_) | SendFutureState::Done => {
+                panic!("an unbound mailbox parks its send")
+            }
+        };
+        let teardown = prepare_termination(&mailbox).expect("the mailbox terminates once");
+        drop(teardown.finish());
+        let retained = {
+            let mut state = operation.state.lock().expect("send operation mutex");
+            let OperationOutcome::Terminated { message, .. } = &mut state.outcome else {
+                panic!("termination publishes a terminal operation")
+            };
+            message.take().expect("termination retains the message")
+        };
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let _send = send;
+            panic!("primary unwind");
+        }))
+        .expect_err("the primary panic survives send drop");
+        assert_eq!(
+            panic.downcast_ref::<&'static str>().copied(),
+            Some("primary unwind")
+        );
+        assert_eq!(retained, 7);
     }
 }

--- a/crates/shelterwood/src/mailbox/futures.rs
+++ b/crates/shelterwood/src/mailbox/futures.rs
@@ -568,8 +568,13 @@ fn withdraw_send_with<M: Send + 'static>(
             kind: SendErrorKind::Terminated,
         }),
     };
-    let finish_panic = crate::runtime::catch_panic(|| withdrawal.finish()).err();
-    crate::runtime::discard_panic(finish_panic);
+    match disposition {
+        WithdrawalDisposition::Inline => {
+            let finish_panic = crate::runtime::catch_panic(|| withdrawal.finish()).err();
+            crate::runtime::discard_panic(finish_panic);
+        }
+        WithdrawalDisposition::Isolated => withdrawal.finish(),
+    }
     result
 }
 
@@ -590,8 +595,9 @@ impl<M: Send + 'static> DeadlineOperation for SendFuture<M> {
         } else {
             // Unlike cancellation this is a normal return on the caller's
             // task. The recovered message goes back to that caller and the
-            // registered waker destructor stays inline, so its panic remains
-            // visible.
+            // registered waker destructor stays inline. Its panic is contained
+            // at this by-value handoff so it cannot destroy that message during
+            // cleanup.
             Poll::Ready(withdraw_send_with(self, WithdrawalDisposition::Inline))
         }
     }
@@ -839,7 +845,7 @@ mod tests {
 
     use super::{
         super::cell::{
-            OperationOutcome,
+            OperationOutcome, WithdrawalDisposition,
             tests::{
                 actor, actor_for, actor_for_with_runtime, bind, close, configure,
                 prepare_termination,
@@ -1339,6 +1345,40 @@ mod tests {
         }
     }
 
+    struct PanickingDisposeRuntime {
+        inner: Arc<dyn crate::mailbox::MailboxRuntime>,
+    }
+
+    impl crate::mailbox::MailboxRuntime for PanickingDisposeRuntime {
+        fn oneshot(
+            &self,
+        ) -> (
+            Box<dyn shelterwood_core::ErasedOneShotSender>,
+            Pin<Box<dyn shelterwood_core::ErasedOneShotReceiver>>,
+        ) {
+            self.inner.oneshot()
+        }
+
+        fn signal(&self) -> Arc<dyn crate::mailbox::MailboxSignal> {
+            self.inner.signal()
+        }
+
+        fn dispose(&self, _value: Box<dyn Send + 'static>) {
+            panic!("injected isolated disposal submission panic");
+        }
+
+        fn now(&self) -> std::time::Instant {
+            self.inner.now()
+        }
+
+        fn sleep_until(
+            &self,
+            deadline: Option<std::time::Instant>,
+        ) -> shelterwood_core::BoxedSleep {
+            self.inner.sleep_until(deadline)
+        }
+    }
+
     struct CallMessage {
         _reply: crate::Reply<u8>,
         _payload: ThreadRecordingDrop,
@@ -1480,6 +1520,30 @@ mod tests {
         );
         mailbox.dispose(error);
         assert_ne!(await_disposal(&message_thread), polling_thread);
+    }
+
+    #[test]
+    fn isolated_withdrawal_preserves_a_disposal_submission_diagnostic() {
+        let runtime = Arc::new(PanickingDisposeRuntime {
+            inner: crate::mailbox::capability::tests::runtime(),
+        });
+        let (_mailbox, actor): (Arc<MailboxCell<u8>>, ActorRef<u8>) =
+            actor_for_with_runtime(runtime);
+        let mut send = Box::pin(actor.send(7));
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            super::withdraw_send_with(send.as_mut().get_mut(), WithdrawalDisposition::Isolated)
+        }))
+        .expect_err("isolated disposal submission retains its diagnostic");
+        assert_eq!(
+            panic.downcast_ref::<&'static str>().copied(),
+            Some("injected isolated disposal submission panic")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #433.

## Summary

- contain inline withdrawal waker-destruction panics before returning a recovered send message
- retire a replacement caller waker that loses the send clone window before observing a completed operation or taking its terminal message
- contain the terminal-message invariant during an existing `SendFuture` unwind
- preserve isolated-withdrawal disposal diagnostics outside the adjudicated inline poll-path containment seam
- add safe regressions for timeout, termination, acceptance, the defensive invariant path, and diagnostic scope; no abort-class probes are retained

## Verification

- `./tools/dev cargo test -p shelterwood mailbox::futures::tests` (19 passed)
- `./tools/dev just ci` (958 nextest tests plus formatting, clippy, doctests, examples, docs, API checks, external consumer, and nixfmt)
