### PR TITLE
Benchmark public mailbox operations

### DIFF
--- a/tools/benchmarks/Cargo.lock
+++ b/tools/benchmarks/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -189,6 +190,12 @@ name = "either"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -460,11 +467,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "shelterwood"
+version = "0.1.0"
+dependencies = [
+ "shelterwood-core",
+ "shelterwood-runtime",
+ "thiserror",
+]
+
+[[package]]
 name = "shelterwood-benchmarks"
 version = "0.0.0"
 dependencies = [
  "criterion",
+ "shelterwood",
  "shelterwood-core",
+ "tokio",
 ]
 
 [[package]]
@@ -472,6 +490,15 @@ name = "shelterwood-core"
 version = "0.1.0"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "shelterwood-runtime"
+version = "0.1.0"
+dependencies = [
+ "fastrand",
+ "shelterwood-core",
+ "tokio",
 ]
 
 [[package]]
@@ -536,6 +563,27 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/tools/benchmarks/Cargo.toml
+++ b/tools/benchmarks/Cargo.toml
@@ -13,6 +13,12 @@ publish = false
 name = "core"
 harness = false
 
+[[bench]]
+name = "mailbox"
+harness = false
+
 [dev-dependencies]
-criterion = "=0.8.2"
+criterion = { version = "=0.8.2", features = ["async_tokio"] }
+shelterwood = { path = "../../crates/shelterwood" }
 shelterwood-core = { path = "../../crates/shelterwood-core" }
+tokio = { version = "=1.53.1", features = ["rt", "rt-multi-thread", "time"] }

--- a/tools/benchmarks/README.md
+++ b/tools/benchmarks/README.md
@@ -23,6 +23,17 @@ Criterion accepts a name filter after `--`. For example:
   --manifest-path tools/benchmarks/Cargo.toml -- core/deadline
 ```
 
+The suites separate deterministic structural costs from executor-backed public
+operations:
+
+- `core` covers the supervision reducer and deadline queue.
+- `mailbox` covers batched send, fail-fast send, request/reply, and concurrent
+  producer tasks over both current-thread and four-worker Tokio runtimes.
+
+`concurrent_send_tasks` deliberately includes task spawn and join overhead. It
+represents the common application shape of short-lived producer tasks rather
+than claiming to isolate mailbox mutex contention alone.
+
 The core supervisor `startup` and `drain` cases apply one child's transition
 sequence and then settle before advancing to the next child. They deliberately
 stress incremental, level-triggered settlement; they do not model the driver's

--- a/tools/benchmarks/README.md
+++ b/tools/benchmarks/README.md
@@ -29,10 +29,35 @@ operations:
 - `core` covers the supervision reducer and deadline queue.
 - `mailbox` covers batched send, fail-fast send, request/reply, and concurrent
   producer tasks over both current-thread and four-worker Tokio runtimes.
+  Four details govern how to read it:
+  - The timed region of every batched send case ends at the last accepted
+    send. `Mailbox::Queue` is FIFO, so a reply barrier inside that region
+    would have to wait for the handler to run the whole batch, reporting
+    `enqueue + handler + wakeups + a round trip` under the name of a send and
+    burying the difference between two send APIs in the shared drain. The
+    barrier still runs once per iteration, between measurements, so every
+    iteration starts from an empty queue.
+  - Capacity selects which operation runs rather than tuning one operation,
+    so the arms are named for their regime. `send_buffered` holds the whole
+    batch and parks no sender; `send_backpressured` parks every send past its
+    capacity, so its timed region legitimately includes consumer scheduling.
+    The two are not comparable, and the backpressured arms are the noisy ones.
+  - `call` is measured whole. Boxing the message constructor, creating the
+    reply channel, and arming and retiring a real deadline wheel entry are
+    inside the timed region because the operation cannot be performed without
+    them; no deadline ever expires there.
+  - The group runs at a reduced sampling budget (20 samples, 0.5 s warm-up,
+    2 s measurement) with a 10% noise floor and a 1% significance level. That
+    keeps the 48-case suite near three minutes inside `just bench` and keeps
+    routine spread on the backpressured arms out of the change reports.
 
 `concurrent_send_tasks` deliberately includes task spawn and join overhead. It
 represents the common application shape of short-lived producer tasks rather
-than claiming to isolate mailbox mutex contention alone.
+than claiming to isolate mailbox mutex contention alone. Under the
+`current_thread` group there is no real contention to isolate: the producers
+interleave cooperatively on a single thread, and only the `multi_thread_4`
+group exercises parallel senders. Its mailbox capacity sits below the batch
+size in both groups, so it is a backpressured arm as well.
 
 The core supervisor `startup` and `drain` cases apply one child's transition
 sequence and then settle before advancing to the next child. They deliberately

--- a/tools/benchmarks/benches/mailbox.rs
+++ b/tools/benchmarks/benches/mailbox.rs
@@ -1,4 +1,26 @@
-use std::{hint::black_box, time::Duration};
+//! Public mailbox operation benchmarks.
+//!
+//! # Timing discipline
+//!
+//! `Mailbox::Queue` is FIFO (`shelterwood_core::policy::Mailbox::Queue`), so a
+//! reply barrier enqueued after a batch cannot be answered until the handler
+//! has run every message ahead of it. A barrier *inside* a timed region would
+//! therefore report `enqueue + handler + wakeups + a full round trip` under
+//! the name of a send, and the drain would dominate: the named operation is
+//! the smaller half of that sum, and two different send APIs become
+//! indistinguishable because they share the same drain.
+//!
+//! Every batched send case below is written with `iter_custom` so that the
+//! clock stops at the last accepted send and the barrier runs outside the
+//! measurement. The barrier still runs once per iteration -- it is what
+//! guarantees an empty queue at the next iteration's start, which the
+//! `try_send` occupancy invariant depends on.
+
+use std::{
+    future::Future,
+    hint::black_box,
+    time::{Duration, Instant},
+};
 
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use shelterwood::{
@@ -8,6 +30,28 @@ use tokio::runtime::{Builder, Runtime};
 
 const BATCH: usize = 256;
 const DEADLINE: Duration = Duration::from_secs(30);
+
+/// Sampling budget for the mailbox suite.
+///
+/// The suite is 48 benchmarks (3 payload sizes x 2 runtimes x 8 cases). At
+/// Criterion's defaults that is roughly seven minutes on top of the `core`
+/// suite, which is too long for `just bench` to stay an ordinary entry point.
+/// These settings keep the whole suite near three minutes; the suite is a
+/// coarse regression guardrail, not a publishable baseline.
+const SAMPLE_SIZE: usize = 20;
+const WARM_UP: Duration = Duration::from_millis(500);
+const MEASUREMENT: Duration = Duration::from_secs(2);
+
+/// Change-detection thresholds.
+///
+/// The backpressured arms are inherently noisy: their timed region contains
+/// consumer scheduling, so run-to-run spreads of tens of percent are normal
+/// on a shared machine. Criterion's defaults (`significance_level` 0.05,
+/// `noise_threshold` 0.01) would report most of that spread as a regression.
+/// A tighter significance level and a 10% noise floor keep the reports
+/// meaningful.
+const SIGNIFICANCE_LEVEL: f64 = 0.01;
+const NOISE_THRESHOLD: f64 = 0.10;
 
 enum Message<const N: usize> {
     Data([u8; N]),
@@ -89,6 +133,11 @@ fn stop(runtime: &Runtime, system: System) {
     });
 }
 
+/// Drains the mailbox and returns the handler's running count.
+///
+/// The barrier is a real `call`, so it costs a boxed constructor, a reply
+/// channel and one armed-and-retired deadline timer. It is never inside a
+/// timed region: it runs only between measured batches.
 async fn barrier<const N: usize>(actor: &ActorRef<Message<N>>) -> u64 {
     actor
         .call(Message::Barrier, DEADLINE)
@@ -97,56 +146,108 @@ async fn barrier<const N: usize>(actor: &ActorRef<Message<N>>) -> u64 {
         .value
 }
 
+/// Runs `iters` measured batches and returns only the batches' own time.
+///
+/// Each iteration builds its input, times `run`, and then drains the mailbox
+/// with an untimed barrier. The drain is what makes the *next* iteration
+/// start from an empty queue, so it cannot be hoisted out of the loop even
+/// though it is not measured.
+async fn timed_batches<const N: usize, I, S, R, F>(
+    iters: u64,
+    actor: &ActorRef<Message<N>>,
+    mut setup: S,
+    mut run: R,
+) -> Duration
+where
+    S: FnMut() -> I,
+    R: FnMut(I) -> F,
+    F: Future<Output = ()>,
+{
+    let mut elapsed = Duration::ZERO;
+    for _ in 0..iters {
+        let input = setup();
+        let started = Instant::now();
+        run(input).await;
+        elapsed += started.elapsed();
+        black_box(barrier(actor).await);
+    }
+    elapsed
+}
+
 fn bench_payload<const N: usize>(c: &mut Criterion, runtime_name: &str, runtime: &Runtime) {
     let mut group = c.benchmark_group(format!("mailbox/{runtime_name}/payload_{N}"));
     group.throughput(Throughput::Elements(BATCH as u64));
+    group.sample_size(SAMPLE_SIZE);
+    group.warm_up_time(WARM_UP);
+    group.measurement_time(MEASUREMENT);
+    group.significance_level(SIGNIFICANCE_LEVEL);
+    group.noise_threshold(NOISE_THRESHOLD);
 
+    // Capacity is not a tuning knob over one operation: it selects which
+    // operation is measured. Below `BATCH` the batch cannot fit, so sends
+    // past the capacity park until the consumer dequeues and are woken by it
+    // -- the timed region then legitimately contains consumer scheduling. At
+    // or above `BATCH` no send ever parks and the timed region is pure
+    // enqueue. The two regimes are named apart so a reader never compares
+    // them as one curve.
     for capacity in [1, 64, 1_024] {
+        let name = if capacity >= BATCH {
+            "send_buffered"
+        } else {
+            "send_backpressured"
+        };
         let (system, actor) = start::<N>(runtime, capacity);
-        group.bench_with_input(BenchmarkId::new("send", capacity), &capacity, |b, _| {
-            b.to_async(runtime).iter_batched(
-                payloads::<N>,
-                |messages| {
-                    let actor = &actor;
-                    async move {
-                        for payload in messages {
-                            actor
-                                .send(Message::Data(payload))
-                                .await
-                                .expect("the live benchmark actor accepts every message");
-                        }
-                        black_box(barrier(actor).await)
+        group.bench_with_input(BenchmarkId::new(name, capacity), &capacity, |b, _| {
+            b.to_async(runtime).iter_custom(|iters| {
+                let actor = &actor;
+                timed_batches(iters, actor, payloads::<N>, move |messages| async move {
+                    for payload in messages {
+                        actor
+                            .send(Message::Data(payload))
+                            .await
+                            .expect("the live benchmark actor accepts every message");
                     }
-                },
-                BatchSize::PerIteration,
-            );
+                })
+            });
         });
         stop(runtime, system);
     }
 
+    // `try_send` never returns `Full` here, and the headroom is exactly one
+    // slot. The chain: occupancy is the queue length checked at accept time
+    // (`shelterwood::mailbox::cell::accept_locked`), a slot is freed when the
+    // driver *dequeues* rather than when the handler finishes
+    // (`promote_waiter_queue` recomputes from the queue length), and
+    // `timed_batches`' barrier guarantees an empty queue at the start of
+    // every iteration. Peak occupancy is therefore `BATCH`, one below
+    // `try_capacity`. A restructure that stops draining between iterations
+    // invalidates this and must re-derive it.
     let try_capacity = BATCH + 1;
     let (system, actor) = start::<N>(runtime, try_capacity);
     group.bench_function("try_send", |b| {
-        b.to_async(runtime).iter_batched(
-            payloads::<N>,
-            |messages| {
-                let actor = &actor;
-                async move {
-                    for payload in messages {
-                        black_box(
-                            actor
-                                .try_send(Message::Data(payload))
-                                .expect("the benchmark batch fits without backpressure"),
-                        );
-                    }
-                    black_box(barrier(actor).await)
+        b.to_async(runtime).iter_custom(|iters| {
+            let actor = &actor;
+            timed_batches(iters, actor, payloads::<N>, move |messages| async move {
+                for payload in messages {
+                    black_box(
+                        actor
+                            .try_send(Message::Data(payload))
+                            .expect("the benchmark batch fits without backpressure"),
+                    );
                 }
-            },
-            BatchSize::PerIteration,
-        );
+            })
+        });
     });
     stop(runtime, system);
 
+    // `call` is measured whole, and the timed region necessarily includes
+    // everything the signature implies: the message value is built inside it
+    // (only the payload buffers are pre-built), `ActorRef::call` boxes the
+    // constructor, a reply channel is created, and a real wheel entry is
+    // armed and retired per call because the deadline is non-zero. For
+    // `payload_4096` the boxing alone is a 4 KiB allocation and memcpy per
+    // call. That is the cost of the operation, not harness overhead, but it
+    // is why `call` is not comparable to a `send` figure element for element.
     let (system, actor) = start::<N>(runtime, 64);
     group.bench_function("call", |b| {
         b.to_async(runtime).iter_batched(
@@ -170,17 +271,21 @@ fn bench_payload<const N: usize>(c: &mut Criterion, runtime_name: &str, runtime:
     });
     stop(runtime, system);
 
+    // Capacity 64 is below `BATCH`, so these arms are backpressured too: the
+    // timed region is spawn, send-with-parking, and join.
     for producers in [1, 4, 16] {
         let (system, actor) = start::<N>(runtime, 64);
         group.bench_with_input(
             BenchmarkId::new("concurrent_send_tasks", producers),
             &producers,
             |b, &producers| {
-                b.to_async(runtime).iter_batched(
-                    || partitioned_payloads::<N>(producers),
-                    |batches| {
-                        let actor = &actor;
-                        async move {
+                b.to_async(runtime).iter_custom(|iters| {
+                    let actor = &actor;
+                    timed_batches(
+                        iters,
+                        actor,
+                        || partitioned_payloads::<N>(producers),
+                        move |batches: Vec<Vec<[u8; N]>>| async move {
                             let mut tasks = Vec::with_capacity(producers);
                             for messages in batches {
                                 let actor = actor.clone();
@@ -196,11 +301,9 @@ fn bench_payload<const N: usize>(c: &mut Criterion, runtime_name: &str, runtime:
                             for task in tasks {
                                 task.await.expect("a benchmark producer does not panic");
                             }
-                            black_box(barrier(actor).await)
-                        }
-                    },
-                    BatchSize::PerIteration,
-                );
+                        },
+                    )
+                });
             },
         );
         stop(runtime, system);

--- a/tools/benchmarks/benches/mailbox.rs
+++ b/tools/benchmarks/benches/mailbox.rs
@@ -1,0 +1,234 @@
+use std::{hint::black_box, time::Duration};
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use shelterwood::{
+    Actor, ActorDef, ActorRef, Context, ExitError, ExitResult, Mailbox, Reply, System, Tree,
+};
+use tokio::runtime::{Builder, Runtime};
+
+const BATCH: usize = 256;
+const DEADLINE: Duration = Duration::from_secs(30);
+
+enum Message<const N: usize> {
+    Data([u8; N]),
+    Request([u8; N], Reply<u8>),
+    Barrier(Reply<u64>),
+}
+
+struct Sink<const N: usize> {
+    processed: u64,
+}
+
+impl<const N: usize> Actor for Sink<N> {
+    type Msg = Message<N>;
+    type Args = ();
+
+    async fn init(_args: (), _context: &mut Context<'_, Self>) -> Result<Self, ExitError> {
+        Ok(Self { processed: 0 })
+    }
+
+    async fn handle(
+        &mut self,
+        message: Message<N>,
+        _context: &mut Context<'_, Self>,
+    ) -> ExitResult {
+        match message {
+            Message::Data(payload) => {
+                black_box(payload);
+                self.processed = self.processed.wrapping_add(1);
+            }
+            Message::Request(payload, reply) => {
+                let value = payload.first().copied().unwrap_or_default();
+                black_box(payload);
+                self.processed = self.processed.wrapping_add(1);
+                reply.send(value);
+            }
+            Message::Barrier(reply) => reply.send(self.processed),
+        }
+        Ok(())
+    }
+}
+
+fn payloads<const N: usize>() -> Vec<[u8; N]> {
+    (0..BATCH).map(|index| [index as u8; N]).collect()
+}
+
+fn partitioned_payloads<const N: usize>(producers: usize) -> Vec<Vec<[u8; N]>> {
+    let mut batches: Vec<_> = (0..producers).map(|_| Vec::new()).collect();
+    for (index, payload) in payloads().into_iter().enumerate() {
+        batches[index % producers].push(payload);
+    }
+    batches
+}
+
+fn start<const N: usize>(runtime: &Runtime, capacity: usize) -> (System, ActorRef<Message<N>>) {
+    runtime.block_on(async {
+        let mut tree = Tree::new();
+        let actor = tree
+            .add_actor(
+                "sink",
+                ActorDef::<Sink<N>>::cloned(())
+                    .mailbox(Mailbox::queue(capacity).expect("benchmark capacities are non-zero")),
+            )
+            .expect("the benchmark tree is valid");
+        let system = tree.spawn().expect("the benchmark runtime is active");
+        system
+            .wait_started()
+            .await
+            .expect("the benchmark actor starts");
+        (system, actor)
+    })
+}
+
+fn stop(runtime: &Runtime, system: System) {
+    runtime.block_on(async {
+        system
+            .shutdown(DEADLINE)
+            .await
+            .expect("the benchmark actor shuts down within its generous bound");
+    });
+}
+
+async fn barrier<const N: usize>(actor: &ActorRef<Message<N>>) -> u64 {
+    actor
+        .call(Message::Barrier, DEADLINE)
+        .await
+        .expect("the benchmark barrier receives a reply")
+        .value
+}
+
+fn bench_payload<const N: usize>(c: &mut Criterion, runtime_name: &str, runtime: &Runtime) {
+    let mut group = c.benchmark_group(format!("mailbox/{runtime_name}/payload_{N}"));
+    group.throughput(Throughput::Elements(BATCH as u64));
+
+    for capacity in [1, 64, 1_024] {
+        let (system, actor) = start::<N>(runtime, capacity);
+        group.bench_with_input(BenchmarkId::new("send", capacity), &capacity, |b, _| {
+            b.to_async(runtime).iter_batched(
+                payloads::<N>,
+                |messages| {
+                    let actor = &actor;
+                    async move {
+                        for payload in messages {
+                            actor
+                                .send(Message::Data(payload))
+                                .await
+                                .expect("the live benchmark actor accepts every message");
+                        }
+                        black_box(barrier(actor).await)
+                    }
+                },
+                BatchSize::PerIteration,
+            );
+        });
+        stop(runtime, system);
+    }
+
+    let try_capacity = BATCH + 1;
+    let (system, actor) = start::<N>(runtime, try_capacity);
+    group.bench_function("try_send", |b| {
+        b.to_async(runtime).iter_batched(
+            payloads::<N>,
+            |messages| {
+                let actor = &actor;
+                async move {
+                    for payload in messages {
+                        black_box(
+                            actor
+                                .try_send(Message::Data(payload))
+                                .expect("the benchmark batch fits without backpressure"),
+                        );
+                    }
+                    black_box(barrier(actor).await)
+                }
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    stop(runtime, system);
+
+    let (system, actor) = start::<N>(runtime, 64);
+    group.bench_function("call", |b| {
+        b.to_async(runtime).iter_batched(
+            payloads::<N>,
+            |messages| {
+                let actor = &actor;
+                async move {
+                    let mut checksum = 0_u64;
+                    for payload in messages {
+                        let replied = actor
+                            .call(move |reply| Message::Request(payload, reply), DEADLINE)
+                            .await
+                            .expect("the benchmark request receives a reply");
+                        checksum = checksum.wrapping_add(u64::from(replied.value));
+                    }
+                    black_box(checksum)
+                }
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    stop(runtime, system);
+
+    for producers in [1, 4, 16] {
+        let (system, actor) = start::<N>(runtime, 64);
+        group.bench_with_input(
+            BenchmarkId::new("concurrent_send_tasks", producers),
+            &producers,
+            |b, &producers| {
+                b.to_async(runtime).iter_batched(
+                    || partitioned_payloads::<N>(producers),
+                    |batches| {
+                        let actor = &actor;
+                        async move {
+                            let mut tasks = Vec::with_capacity(producers);
+                            for messages in batches {
+                                let actor = actor.clone();
+                                tasks.push(tokio::spawn(async move {
+                                    for payload in messages {
+                                        actor
+                                            .send(Message::Data(payload))
+                                            .await
+                                            .expect("the live actor accepts every producer batch");
+                                    }
+                                }));
+                            }
+                            for task in tasks {
+                                task.await.expect("a benchmark producer does not panic");
+                            }
+                            black_box(barrier(actor).await)
+                        }
+                    },
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+        stop(runtime, system);
+    }
+
+    group.finish();
+}
+
+fn run_runtime(c: &mut Criterion, name: &str, runtime: Runtime) {
+    bench_payload::<0>(c, name, &runtime);
+    bench_payload::<64>(c, name, &runtime);
+    bench_payload::<4_096>(c, name, &runtime);
+}
+
+fn bench_mailbox(c: &mut Criterion) {
+    let current_thread = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("the current-thread benchmark runtime builds");
+    run_runtime(c, "current_thread", current_thread);
+
+    let multi_thread = Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("the multi-thread benchmark runtime builds");
+    run_runtime(c, "multi_thread_4", multi_thread);
+}
+
+criterion_group!(benches, bench_mailbox);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

- add batched public-API benchmarks for `send`, `try_send`, and `call`
- cover zero-byte, 64-byte, and 4 KiB payloads across bounded queue capacities
- name the send arms for their backpressure regime — `send_buffered` (capacity
  holds the batch, no sender parks) versus `send_backpressured` (capacity below
  the batch, so consumer scheduling is inside the timed region). Capacity picks
  which operation is measured; it is not a tuning knob over one operation.
- compare current-thread and four-worker Tokio runtimes
- exercise one, four, and sixteen short-lived producer tasks, with spawn/join
  cost explicit in the benchmark name and documentation
- stop the clock at the last accepted send. `Mailbox::Queue` is FIFO, so a
  reply barrier inside the timed region would wait for the handler to run the
  whole batch; the barrier instead drains the mailbox *between* iterations, and
  it still runs every iteration because that is what guarantees an empty queue
  at the next iteration's start.
- pre-build the payload buffers outside the timed region. The message value
  itself is necessarily constructed inside it, and `ActorRef::call` boxes its
  constructor — for `payload_4096` that is a 4 KiB allocation and memcpy per
  call. That is the operation's cost, not harness overhead, and the source says
  so at the call site.
- run the group at a coarse-guardrail sampling budget (20 samples, 0.5 s
  warm-up, 2 s measurement) with a 10% noise floor and a 1% significance level,
  keeping the 48-case suite under three minutes inside `just bench`

Stacked on #467.

## Validation

- `./tools/dev just ci`
- `./tools/dev just bench-check`
- `./tools/dev cargo bench --locked --manifest-path tools/benchmarks/Cargo.toml --bench mailbox -- --test`
- `./tools/dev nix build .#checks.x86_64-linux.benchmark-check --no-link --no-update-lock-file`
