### PR TITLE
Make retained-exit surrender transactional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,11 +18,14 @@ Two types implement the rule and are the shapes to reach for:
 
 - **`ObservationTxn`** (`crates/shelterwood/src/cells/gate.rs`) holds the
   observation-gate guard plus a deferred-effect list. `defer`/`pulse` queue
-  work; `commit` drops the guard *then* runs the queue through a
-  `PanicAccumulator`. Its `Drop` runs the same path during an unwind, so a
-  poisoned transaction cannot strand already-committed wakes. Every retained
-  control-plane writer takes the token, which makes an out-of-transaction
-  mutation unavailable by construction.
+  work; `surrender` queues framework-internal `RetainedExit` raw drops at the
+  front, so they run after unlock but before an ordinary effect can hand their
+  co-owner to concurrent disposal. `commit` drops the guard *then* runs the
+  queue through a `PanicAccumulator`. Its `Drop` runs the same path during an
+  unwind, so a poisoned transaction cannot strand already-committed wakes.
+  Every retained control-plane writer takes the token, which makes both an
+  out-of-transaction mutation and a post-commit surrender unavailable by
+  construction.
 - **`MailboxTxn`** (`crates/shelterwood/src/mailbox/cell.rs`) is the same idea for
   every mutable mailbox transition. It owns the state guard beside a
   `MailboxEffects` sink that collects signal pulses, waker wake/drop actions,
@@ -68,6 +71,11 @@ rests on:
   `reconcile_recorded_outcomes_retaining` and
   `classify_disposal_panic_retaining`; the raw `shelterwood-core` folds hand
   both halves back and are for core's own tests.
+  `RetainedExit::into_user_owned` is deliberately narrower than surrender: it
+  appears only at the three genuine public-ownership handoffs
+  (`RetainedStopReason::into_public`, `RetainedLifecycleEvent::into_public`,
+  and the root completion handoff in `driver.rs`). Framework-internal raw
+  refcount drops go through `ObservationTxn::surrender` instead.
   `RetainedExitResult` closes the earlier raw-incarnation window: the completed
   callback result stays in that carrier across the fallible teardown epilogue,
   so an epilogue panic transfers a failed result to critical disposal instead

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,11 +71,15 @@ rests on:
   `reconcile_recorded_outcomes_retaining` and
   `classify_disposal_panic_retaining`; the raw `shelterwood-core` folds hand
   both halves back and are for core's own tests.
-  `RetainedExit::into_user_owned` is deliberately narrower than surrender: it
-  appears only at the three genuine public-ownership handoffs
-  (`RetainedStopReason::into_public`, `RetainedLifecycleEvent::into_public`,
-  and the root completion handoff in `driver.rs`). Framework-internal raw
-  refcount drops go through `ObservationTxn::surrender` instead.
+  `RetainedExit::into_user_owned` is deliberately narrower than surrender, and
+  `pub(in crate::cells)` is what keeps it narrow: no driver-layer caller can
+  extract a raw `Exit` from a carrier at all, so a carrier crossing a driver
+  seam stays a carrier. Its two remaining users are
+  `RetainedLifecycleEvent::into_public`, the one genuine hand-off to a
+  user-owned value, and `RetainedStopReason::into_public`, whose two call
+  sites release a framework copy beside an installed co-owner and therefore
+  still rest on the older conventional proof. Every other framework-internal
+  raw refcount drop goes through `ObservationTxn::surrender`.
   `RetainedExitResult` closes the earlier raw-incarnation window: the completed
   callback result stays in that carrier across the fallible teardown epilogue,
   so an epilogue panic transfers a failed result to critical disposal instead

--- a/crates/shelterwood/src/cells/gate.rs
+++ b/crates/shelterwood/src/cells/gate.rs
@@ -330,6 +330,57 @@ mod tests {
     }
 
     #[test]
+    fn observation_txn_unwind_drains_panicking_surrender_prefix_after_unlock() {
+        let gate = ObservationGate::new();
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let payload = catch_unwind(AssertUnwindSafe({
+            let observed = Arc::clone(&observed);
+            let gate = gate.clone();
+            move || {
+                let mut txn = ObservationTxn::new(&gate, gate.lock());
+                let ordinary = Arc::clone(&observed);
+                let ordinary_gate = gate.clone();
+                txn.defer(move || {
+                    ordinary
+                        .lock()
+                        .expect("probe mutex remains healthy")
+                        .push((3, ordinary_gate.is_held()));
+                });
+
+                let first = Arc::clone(&observed);
+                let first_gate = gate.clone();
+                txn.defer_surrender(move || {
+                    first
+                        .lock()
+                        .expect("probe mutex remains healthy")
+                        .push((1, first_gate.is_held()));
+                    std::panic::panic_any("hostile surrender effect");
+                });
+
+                let second = Arc::clone(&observed);
+                let second_gate = gate.clone();
+                txn.defer_surrender(move || {
+                    second
+                        .lock()
+                        .expect("probe mutex remains healthy")
+                        .push((2, second_gate.is_held()));
+                });
+
+                std::panic::panic_any("primary panic");
+            }
+        }))
+        .expect_err("the original unwind reaches its boundary");
+
+        assert_eq!(payload.downcast_ref::<&str>(), Some(&"primary panic"));
+        assert_eq!(
+            *observed.lock().expect("probe mutex remains healthy"),
+            [(1, false), (2, false), (3, false)],
+            "surrender effects stay ahead of the ordinary suffix, all run after unlock, and a \
+             hostile surrender cannot strand later effects during unwind"
+        );
+    }
+
+    #[test]
     fn observation_txn_drop_runs_later_pulses_after_a_hostile_waker() {
         let gate = ObservationGate::new();
         let (hostile_sender, mut hostile_receiver) = runtime::watch(());

--- a/crates/shelterwood/src/cells/gate.rs
+++ b/crates/shelterwood/src/cells/gate.rs
@@ -208,6 +208,7 @@ impl MailboxEffectSink for ObservationTxn<'_> {
 #[cfg(test)]
 mod tests {
     use std::{
+        fmt,
         future::Future,
         panic::{AssertUnwindSafe, catch_unwind},
         sync::{
@@ -264,6 +265,33 @@ mod tests {
     impl Drop for DropSignal {
         fn drop(&mut self) {
             let _ = self.0.send(());
+        }
+    }
+
+    /// A user error payload that reports whether the gate was held when its
+    /// destructor ran.
+    struct GatePresenceProbe {
+        gate: ObservationGate,
+        observed: mpsc::SyncSender<bool>,
+    }
+
+    impl fmt::Debug for GatePresenceProbe {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("GatePresenceProbe")
+        }
+    }
+
+    impl fmt::Display for GatePresenceProbe {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("gate presence probe")
+        }
+    }
+
+    impl std::error::Error for GatePresenceProbe {}
+
+    impl Drop for GatePresenceProbe {
+        fn drop(&mut self) {
+            let _ = self.observed.send(self.gate.is_held());
         }
     }
 
@@ -326,6 +354,40 @@ mod tests {
                 .expect("the failed payload is eventually destroyed"),
             retiring_thread,
             "surrender must precede a queued owner's concurrent disposal"
+        );
+    }
+
+    /// Production surrenders always have a co-owner, so their raw release is
+    /// refcount traffic and the venue is invisible. This one is deliberately
+    /// the sole owner: its destructor then runs at the exact moment the
+    /// surrender releases the raw exit, which is the only way to pin that the
+    /// release is queued rather than performed at the call site.
+    #[test]
+    fn observation_txn_surrender_releases_the_raw_exit_after_unlock() {
+        let gate = ObservationGate::new();
+        let (released, observed) = mpsc::sync_channel(1);
+        let retained = RetainedExit::new(Exit::failed(
+            ExitError::from(GatePresenceProbe {
+                gate: gate.clone(),
+                observed: released,
+            }),
+            Cancellation::NotObserved,
+        ));
+        let mut txn = ObservationTxn::new(&gate, gate.lock());
+
+        txn.surrender([retained]);
+        assert!(
+            observed.try_recv().is_err(),
+            "a surrender under the gate queues the release rather than running it"
+        );
+
+        drop(txn);
+
+        assert!(
+            !observed
+                .recv_timeout(TEST_WAIT)
+                .expect("the surrendered exit is released"),
+            "surrender must release its raw exit only after the gate is unlocked"
         );
     }
 

--- a/crates/shelterwood/src/cells/gate.rs
+++ b/crates/shelterwood/src/cells/gate.rs
@@ -72,6 +72,7 @@ pub(crate) struct ObservationTxn<'a> {
     #[cfg(debug_assertions)]
     gate: Option<&'a ObservationGate>,
     effects: Vec<Box<dyn FnOnce()>>,
+    surrender_effects: usize,
     snapshots: Vec<SnapshotPublication>,
 }
 
@@ -84,6 +85,7 @@ impl<'a> ObservationTxn<'a> {
             #[cfg(debug_assertions)]
             gate: Some(gate),
             effects: Vec::new(),
+            surrender_effects: 0,
             snapshots: Vec::new(),
         }
     }
@@ -95,6 +97,7 @@ impl<'a> ObservationTxn<'a> {
             #[cfg(debug_assertions)]
             gate: None,
             effects: Vec::new(),
+            surrender_effects: 0,
             snapshots: Vec::new(),
         }
     }
@@ -116,6 +119,18 @@ impl<'a> ObservationTxn<'a> {
 
     pub(crate) fn defer(&mut self, operation: impl FnOnce() + 'static) {
         self.effects.push(Box::new(operation));
+    }
+
+    /// Places a structural surrender ahead of ordinary deferred effects.
+    ///
+    /// [`crate::cells::RetainedExit`] owns the public entry point because it
+    /// alone may extract the guarded raw exit. Keeping surrender effects at
+    /// the front is load-bearing: a later ordinary effect may hand the
+    /// surrender's co-owner to a concurrent disposal worker.
+    pub(super) fn defer_surrender(&mut self, operation: impl FnOnce() + 'static) {
+        self.effects
+            .insert(self.surrender_effects, Box::new(operation));
+        self.surrender_effects += 1;
     }
 
     /// Defers a watch-channel wake. The driver reaches its own senders
@@ -161,8 +176,8 @@ impl<'a> ObservationTxn<'a> {
         // invariant assertions inside the accumulator. A broken installation
         // must not strand the remaining committed cuts or their queued effects,
         // and its panic resumes only after the guard is gone.
-        for mut publication in self.snapshots.drain(..) {
-            panics.run(|| publication.install(&mut self.effects));
+        for mut publication in std::mem::take(&mut self.snapshots) {
+            panics.run(|| publication.install(self));
             // The projection captures its publishing scope. Transfer the
             // whole attempted publication to the post-unlock list whether
             // installation succeeded or panicked.
@@ -174,6 +189,7 @@ impl<'a> ObservationTxn<'a> {
             // observation edges from notifying their waiters.
             panics.run(effect);
         }
+        self.surrender_effects = 0;
     }
 }
 
@@ -197,11 +213,20 @@ mod tests {
         sync::{
             Arc, Mutex,
             atomic::{AtomicBool, AtomicUsize, Ordering},
+            mpsc,
         },
         task::{Context, Wake, Waker},
     };
 
-    use crate::runtime;
+    use shelterwood_core::{Cancellation, Exit, ExitError};
+
+    use crate::{
+        cells::{
+            RetainedExit,
+            test_support::{TEST_WAIT, ThreadProbe},
+        },
+        runtime,
+    };
 
     use super::*;
 
@@ -234,6 +259,14 @@ mod tests {
         }
     }
 
+    struct DropSignal(mpsc::SyncSender<()>);
+
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            let _ = self.0.send(());
+        }
+    }
+
     #[test]
     fn observation_txn_commit_unlocks_before_effects_and_drains_once() {
         let gate = ObservationGate::new();
@@ -258,6 +291,41 @@ mod tests {
             *order.lock().expect("probe mutex remains healthy"),
             [1, 2],
             "a second commit from Drop is a no-op"
+        );
+    }
+
+    #[test]
+    fn observation_txn_surrenders_before_ordinary_deferred_disposal() {
+        let gate = ObservationGate::new();
+        let retiring_thread = std::thread::current().id();
+        let (payload_dropped, payload_observed) = mpsc::sync_channel(1);
+        let exit = Exit::failed(
+            ExitError::from(ThreadProbe(payload_dropped)),
+            Cancellation::NotObserved,
+        );
+        let retained = RetainedExit::new(exit.clone());
+        let (owner_dropped, owner_observed) = mpsc::sync_channel(1);
+        let mut txn = ObservationTxn::new(&gate, gate.lock());
+
+        // Queue the owner first on purpose. A surrender appended behind this
+        // effect would let its disposal worker release the raw owner before
+        // the guard, making the transaction thread run the final destructor.
+        txn.defer(move || {
+            runtime::dispose_detached((exit, DropSignal(owner_dropped)));
+            owner_observed
+                .recv_timeout(TEST_WAIT)
+                .expect("the queued raw owner is disposed");
+        });
+        txn.surrender([retained]);
+
+        drop(txn);
+
+        assert_ne!(
+            payload_observed
+                .recv_timeout(TEST_WAIT)
+                .expect("the failed payload is eventually destroyed"),
+            retiring_thread,
+            "surrender must precede a queued owner's concurrent disposal"
         );
     }
 

--- a/crates/shelterwood/src/cells/member.rs
+++ b/crates/shelterwood/src/cells/member.rs
@@ -113,7 +113,7 @@ impl MemberRecord {
     /// drop inside the watch mutation is refcount work, and the retired guard
     /// set transfers any failed payload to isolated disposal once its last
     /// record clone dies.
-    pub(super) fn refresh_retained_exits(&mut self) {
+    pub(super) fn refresh_retained_exits(&mut self, surrendered: &mut Vec<RetainedExit>) {
         let mut retained = Vec::new();
         if let MemberStage::Terminal(exit) = &self.stage {
             RetainedExit::retain_exit(&mut retained, exit);
@@ -121,7 +121,7 @@ impl MemberRecord {
         if let Some(exit) = &self.last_exit {
             RetainedExit::retain_exit(&mut retained, exit);
         }
-        RetainedExit::install(&mut self.retained_exits, retained);
+        RetainedExit::install(&mut self.retained_exits, retained, surrendered);
     }
 
     /// Applies one driver-requested transition.
@@ -561,10 +561,12 @@ impl MemberCell {
         // Refreshing here rather than in each writer keeps the guard-set
         // invariant on every record mutation, including the test-only escape
         // hatch that writes fields directly.
+        let mut surrendered = Vec::new();
         self.record.modify_silently(|record| {
             update(record);
-            record.refresh_retained_exits();
+            record.refresh_retained_exits(&mut surrendered);
         });
+        txn.surrender(surrendered);
         txn.pulse(&self.record);
     }
 
@@ -606,26 +608,28 @@ impl MemberCell {
             | MemberTransition::Stopping => None,
         };
         let mut rejected = None;
+        let mut surrendered = Vec::new();
         self.record
             .modify_silently(|record| match record.apply_transition(transition) {
-                Ok(()) => record.refresh_retained_exits(),
+                Ok(()) => record.refresh_retained_exits(&mut surrendered),
                 Err(transition) => rejected = Some(transition),
             });
         if let Some(rejected) = rejected {
             // Rejection leaves this cell exactly as it was. The rejected event
             // may own a failed exit, so retire it with the transaction rather
             // than under the observation gate or watch lock.
-            txn.defer(move || runtime::dispose_detached(rejected));
             if let Some(retained_exit) = retained_exit {
                 // The deferred transition proves this clone cannot be last.
-                drop(retained_exit.into_exit());
+                txn.surrender([retained_exit]);
             }
+            txn.defer(move || runtime::dispose_detached(rejected));
             return false;
         }
+        txn.surrender(surrendered);
         txn.pulse(&self.record);
         if let Some(retained_exit) = retained_exit {
             // The record now owns an equivalent retained copy.
-            drop(retained_exit.into_exit());
+            txn.surrender([retained_exit]);
         }
         true
     }
@@ -764,6 +768,7 @@ impl MemberCell {
             txn.defer(move || drop(losing_exit));
         }
         let mut published = false;
+        let mut surrendered = Vec::new();
         self.record.modify_silently(|record| {
             if !matches!(record.stage, MemberStage::Terminal(_)) {
                 match startup {
@@ -780,8 +785,9 @@ impl MemberCell {
             // The guard set displaced above still covers whatever this
             // mutation overwrote, so refreshing after the writes is what
             // keeps the inline drops refcount-only.
-            record.refresh_retained_exits();
+            record.refresh_retained_exits(&mut surrendered);
         });
+        txn.surrender(surrendered);
         // Store before discharge so reentrant mailbox wakers observe the
         // winning exit. Notification-driven readers still see
         // discharge-before-pulse; tree-scoped publication defers both until

--- a/crates/shelterwood/src/cells/observe.rs
+++ b/crates/shelterwood/src/cells/observe.rs
@@ -164,7 +164,7 @@ impl RetainedLifecycleEvent {
         // user error through isolated disposal for nothing.
         let guards = Arc::unwrap_or_clone(guards);
         for guard in guards {
-            drop(guard.into_exit());
+            drop(guard.into_user_owned());
         }
         event
     }
@@ -400,14 +400,13 @@ impl RetainedScopeSnapshot {
         Arc::clone(&self.snapshot)
     }
 
-    pub(crate) fn into_public(self) -> Arc<ScopeSnapshot> {
+    pub(crate) fn into_public(self, txn: &mut ObservationTxn<'_>) -> Arc<ScopeSnapshot> {
         let (snapshot, exits) = self.into_parts();
         // The public projection owns a raw clone corresponding to every
-        // guard, so releasing these copies inline is provably refcount-only.
-        // The caller's eventual last drop keeps ordinary user semantics.
-        for exit in exits {
-            drop(exit.into_exit());
-        }
+        // guard. The transaction surrenders those framework-internal copies
+        // after unlock; the caller's eventual last drop keeps ordinary user
+        // semantics.
+        txn.surrender(exits);
         snapshot
     }
 
@@ -581,19 +580,25 @@ fn install_snapshot(
 ///
 /// The producer is `FnMut` rather than `FnOnce` so that running it does not
 /// also destroy it: it captures an `Arc<ScopeCell>` whose release belongs
-/// after the gate is unlocked, like every other user-bearing drop. The
-/// transaction hands the whole spent publication to its effect list after
-/// each attempted install, including one that trips an invariant.
-pub(crate) struct SnapshotProjection(Box<dyn FnMut() -> Option<RetainedScopeSnapshot>>);
+/// after the gate is unlocked, like every other user-bearing drop. Its
+/// argument collects deduplicated retained-exit guards for structural
+/// surrender by the installing transaction. The transaction hands the whole
+/// spent publication to its effect list after each attempted install,
+/// including one that trips an invariant.
+type SnapshotProducer = dyn FnMut(&mut Vec<RetainedExit>) -> Option<RetainedScopeSnapshot>;
+
+pub(crate) struct SnapshotProjection(Box<SnapshotProducer>);
 
 impl SnapshotProjection {
-    fn new(build: impl FnOnce() -> RetainedScopeSnapshot + 'static) -> Self {
+    fn new(build: impl FnOnce(&mut Vec<RetainedExit>) -> RetainedScopeSnapshot + 'static) -> Self {
         let mut build = Some(build);
-        Self(Box::new(move || build.take().map(|build| build())))
+        Self(Box::new(move |surrendered| {
+            build.take().map(|build| build(surrendered))
+        }))
     }
 
-    fn build(&mut self) -> RetainedScopeSnapshot {
-        (self.0)().expect("a staged projection is built exactly once")
+    fn build(&mut self, surrendered: &mut Vec<RetainedExit>) -> RetainedScopeSnapshot {
+        (self.0)(surrendered).expect("a staged projection is built exactly once")
     }
 }
 
@@ -659,12 +664,14 @@ impl SnapshotPublication {
     /// displaces, and the generation-exhaustion panic. The producer runs
     /// before the watch's own lock is taken, so building a cut — which walks
     /// the resident tree — never nests that tree's locks inside the watch.
-    pub(crate) fn install(&mut self, effects: &mut Vec<Box<dyn FnOnce()>>) {
+    pub(crate) fn install(&mut self, txn: &mut ObservationTxn<'_>) {
         // A hub closed by an earlier transaction keeps the authoritative
         // terminal projection `close` installed; this cut is never built.
-        let snapshot =
-            (!self.sender.read_with(|state| state.closed)).then(|| self.projection.build());
-        effects.extend(install_snapshot(
+        let mut surrendered = Vec::new();
+        let snapshot = (!self.sender.read_with(|state| state.closed))
+            .then(|| self.projection.build(&mut surrendered));
+        txn.surrender(surrendered);
+        for effect in install_snapshot(
             &self.sender,
             snapshot,
             self.closed,
@@ -672,7 +679,9 @@ impl SnapshotPublication {
                 mint_generation: self.published,
                 pulse: true,
             },
-        ));
+        ) {
+            txn.defer(effect);
+        }
     }
 }
 
@@ -742,7 +751,7 @@ impl SnapshotHub {
     pub(crate) fn publish(
         &self,
         txn: &mut ObservationTxn<'_>,
-        snapshot: impl FnOnce() -> RetainedScopeSnapshot + 'static,
+        snapshot: impl FnOnce(&mut Vec<RetainedExit>) -> RetainedScopeSnapshot + 'static,
     ) {
         let Some(sender) = self.sender.get() else {
             return;
@@ -768,20 +777,24 @@ impl SnapshotHub {
     pub(crate) fn close(
         &self,
         txn: &mut ObservationTxn<'_>,
-        final_snapshot: impl FnOnce() -> RetainedScopeSnapshot + 'static,
+        final_snapshot: impl FnOnce(&mut Vec<RetainedExit>) -> RetainedScopeSnapshot + 'static,
     ) {
         let mut final_snapshot = Some(final_snapshot);
         let mut initialized = false;
+        let mut surrendered = Vec::new();
         let sender = self.sender.get_or_init(|| {
             initialized = true;
             runtime::watch(SnapshotHubState::new(
                 final_snapshot
                     .take()
-                    .expect("final snapshot is built exactly once")(),
+                    .expect("final snapshot is built exactly once")(
+                    &mut surrendered
+                ),
                 true,
             ))
             .0
         });
+        txn.surrender(surrendered);
         if initialized {
             return;
         }
@@ -799,10 +812,10 @@ impl SnapshotHub {
         // this final one.
         txn.stage_snapshot(SnapshotPublication::closed(
             sender.clone(),
-            SnapshotProjection::new(move || {
+            SnapshotProjection::new(move |surrendered| {
                 final_snapshot
                     .take()
-                    .expect("final snapshot is built exactly once")()
+                    .expect("final snapshot is built exactly once")(surrendered)
             }),
         ));
     }
@@ -1101,7 +1114,7 @@ mod tests {
     fn snapshot_projection_is_skipped_without_subscribers() {
         let hub = SnapshotHub::default();
         let mut txn = ObservationTxn::detached();
-        hub.publish(&mut txn, || {
+        hub.publish(&mut txn, |_| {
             panic!("projection must be lazy when no receiver exists")
         });
     }
@@ -1165,7 +1178,7 @@ mod tests {
         assert!(
             catch_unwind(AssertUnwindSafe(|| {
                 let mut txn = ObservationTxn::detached();
-                hub.publish(&mut txn, || snapshot(ScopeState::Running));
+                hub.publish(&mut txn, |_| snapshot(ScopeState::Running));
                 mid_txn = Some(receiver.borrow_latest().state.clone());
                 panic!("inject transaction unwind");
             }))
@@ -1193,8 +1206,8 @@ mod tests {
             let effects = Arc::clone(&effects);
             move || {
                 let mut txn = ObservationTxn::detached();
-                failing.publish(&mut txn, || panic!("injected snapshot installation panic"));
-                succeeding.publish(&mut txn, || snapshot(ScopeState::Running));
+                failing.publish(&mut txn, |_| panic!("injected snapshot installation panic"));
+                succeeding.publish(&mut txn, |_| snapshot(ScopeState::Running));
                 txn.defer(move || {
                     effects.fetch_add(1, Ordering::SeqCst);
                 });
@@ -1232,7 +1245,7 @@ mod tests {
             ScopeState::Draining,
         ] {
             let builds = Arc::clone(&builds);
-            hub.publish(&mut txn, move || {
+            hub.publish(&mut txn, move |_| {
                 builds.fetch_add(1, Ordering::Relaxed);
                 snapshot(state)
             });
@@ -1261,7 +1274,7 @@ mod tests {
         drop(txn);
 
         let mut txn = ObservationTxn::detached();
-        hub.close(&mut txn, || {
+        hub.close(&mut txn, |_| {
             snapshot(ScopeState::Stopped {
                 reason: StopReason::Finished,
             })
@@ -1271,7 +1284,7 @@ mod tests {
             "the close is still staged, so the publication below is declined \
              by the transaction rather than by an installed terminal state"
         );
-        hub.publish(&mut txn, || {
+        hub.publish(&mut txn, |_| {
             panic!("publication after a staged close must remain lazy")
         });
         drop(txn);
@@ -1298,7 +1311,7 @@ mod tests {
         drop(txn);
 
         let mut txn = ObservationTxn::detached();
-        hub.publish(&mut txn, || snapshot(ScopeState::Running));
+        hub.publish(&mut txn, |_| snapshot(ScopeState::Running));
         drop(txn);
 
         assert_eq!(
@@ -1311,12 +1324,12 @@ mod tests {
         );
 
         let mut txn = ObservationTxn::detached();
-        hub.publish(&mut txn, || {
+        hub.publish(&mut txn, |_| {
             snapshot(ScopeState::Stopped {
                 reason: StopReason::Finished,
             })
         });
-        hub.close(&mut txn, || {
+        hub.close(&mut txn, |_| {
             snapshot(ScopeState::Stopped {
                 reason: StopReason::Finished,
             })
@@ -1335,7 +1348,7 @@ mod tests {
         ));
         assert!(snapshots.changed().await.is_err());
         let mut txn = ObservationTxn::detached();
-        hub.publish(&mut txn, || {
+        hub.publish(&mut txn, |_| {
             panic!("publication after close must remain lazy")
         });
         drop(txn);
@@ -1361,7 +1374,7 @@ mod tests {
     async fn receiverless_snapshot_close_installs_the_terminal_state() {
         let hub = SnapshotHub::default();
         let mut txn = ObservationTxn::detached();
-        hub.close(&mut txn, || {
+        hub.close(&mut txn, |_| {
             snapshot(ScopeState::Stopped {
                 reason: StopReason::NeverStarted,
             })
@@ -1389,7 +1402,7 @@ mod tests {
         drop(receiver);
 
         let mut txn = ObservationTxn::detached();
-        hub.close(&mut txn, || {
+        hub.close(&mut txn, |_| {
             snapshot(ScopeState::Stopped {
                 reason: StopReason::Finished,
             })
@@ -1420,7 +1433,7 @@ mod tests {
         drop(txn);
 
         let mut txn = ObservationTxn::detached();
-        hub.close(&mut txn, || {
+        hub.close(&mut txn, |_| {
             snapshot(ScopeState::Stopped {
                 reason: StopReason::Finished,
             })

--- a/crates/shelterwood/src/cells/retained.rs
+++ b/crates/shelterwood/src/cells/retained.rs
@@ -34,7 +34,10 @@ impl RetainedExit {
     /// Framework-internal copies must instead go through
     /// [`ObservationTxn::surrender`], which makes their pre-commit co-owner
     /// proof structural and releases them only after the observation gate.
-    pub(crate) fn into_user_owned(mut self) -> Exit {
+    /// `pub(in crate::cells)` is what keeps that structural: no driver-layer
+    /// caller can reach the raw exit at all, so a framework carrier crossing
+    /// a driver seam has to stay a carrier.
+    pub(super) fn into_user_owned(mut self) -> Exit {
         self.0.take().expect("retained exit was already taken")
     }
 

--- a/crates/shelterwood/src/cells/retained.rs
+++ b/crates/shelterwood/src/cells/retained.rs
@@ -1,6 +1,6 @@
 use std::{fmt, sync::Arc};
 
-use crate::runtime;
+use crate::{cells::ObservationTxn, runtime};
 use shelterwood_core::{
     Exit,
     engine::ScopeState,
@@ -29,7 +29,12 @@ impl RetainedExit {
         self.0.as_ref().expect("retained exit was already taken")
     }
 
-    pub(crate) fn into_exit(mut self) -> Exit {
+    /// Hands the raw exit to a public/user-owned value.
+    ///
+    /// Framework-internal copies must instead go through
+    /// [`ObservationTxn::surrender`], which makes their pre-commit co-owner
+    /// proof structural and releases them only after the observation gate.
+    pub(crate) fn into_user_owned(mut self) -> Exit {
         self.0.take().expect("retained exit was already taken")
     }
 
@@ -63,11 +68,12 @@ impl RetainedExit {
         }
     }
 
-    pub(crate) fn retain_owned(exits: &mut Vec<Self>, exit: Self) {
+    pub(crate) fn retain_owned(exits: &mut Vec<Self>, exit: Self, surrendered: &mut Vec<Self>) {
         if exits.iter().any(|retained| retained == &exit) {
             // An existing retained copy keeps the raw clone alive while it is
-            // released. Avoid submitting a duplicate disposal job.
-            drop(exit.into_exit());
+            // released. Hand the duplicate to the surrounding observation
+            // transaction rather than submitting a duplicate disposal job.
+            surrendered.push(exit);
         } else {
             exits.push(exit);
         }
@@ -81,18 +87,40 @@ impl RetainedExit {
     /// released as refcount traffic, because an equal retained copy — for
     /// `ExitKind::Failed`, equality is `Arc::ptr_eq` — proves the payload
     /// stays owned.
-    pub(super) fn install(guards: &mut Arc<Vec<Self>>, incoming: Vec<Self>) {
+    pub(super) fn install(
+        guards: &mut Arc<Vec<Self>>,
+        incoming: Vec<Self>,
+        surrendered: &mut Vec<Self>,
+    ) {
         if incoming.len() == guards.len()
             && incoming
                 .iter()
                 .all(|incoming| guards.iter().any(|current| current == incoming))
         {
-            for exit in incoming {
-                drop(exit.into_exit());
-            }
+            surrendered.extend(incoming);
             return;
         }
         *guards = Arc::new(incoming);
+    }
+}
+
+impl ObservationTxn<'_> {
+    /// Surrenders framework-internal retained copies as raw refcount traffic.
+    ///
+    /// Accepting the transaction token makes the co-owner proof structural:
+    /// every caller queues the surrender before commit. Surrenders flush first
+    /// after unlock, while record owners still exist and before an ordinary
+    /// deferred effect can hand a queued co-owner to concurrent disposal.
+    pub(crate) fn surrender(&mut self, exits: impl IntoIterator<Item = RetainedExit>) {
+        let exits: Vec<_> = exits.into_iter().collect();
+        if exits.is_empty() {
+            return;
+        }
+        self.defer_surrender(move || {
+            for mut exit in exits {
+                drop(exit.0.take().expect("retained exit was already taken"));
+            }
+        });
     }
 }
 
@@ -250,10 +278,11 @@ pub(crate) fn classify_exit_retaining(
 /// the application error whenever one was recorded, because
 /// `Failed` ranks below `Panicked`.
 pub(crate) fn classify_disposal_panic_retaining(
-    exit: RetainedExit,
+    mut exit: RetainedExit,
     message: Option<String>,
 ) -> RetainedExit {
-    let (selected, discarded) = classify_disposal_panic(exit.into_exit(), message);
+    let exit = exit.0.take().expect("retained exit was already taken");
+    let (selected, discarded) = classify_disposal_panic(exit, message);
     drop(RetainedExit::new(discarded));
     RetainedExit::new(selected)
 }
@@ -291,7 +320,7 @@ impl RetainedStopReason {
             .take()
             .expect("retained stop reason was already taken");
         for exit in std::mem::take(&mut self.retained_exits) {
-            drop(exit.into_exit());
+            drop(exit.into_user_owned());
         }
         reason
     }
@@ -320,7 +349,15 @@ mod tests {
         let mut guards = Arc::new(vec![RetainedExit::new(exit.clone())]);
         let original = Arc::clone(&guards);
 
-        RetainedExit::install(&mut guards, vec![RetainedExit::new(exit.clone())]);
+        let mut txn = ObservationTxn::detached();
+        let mut surrendered = Vec::new();
+        RetainedExit::install(
+            &mut guards,
+            vec![RetainedExit::new(exit.clone())],
+            &mut surrendered,
+        );
+        txn.surrender(surrendered);
+        drop(txn);
 
         assert!(
             Arc::ptr_eq(&guards, &original),
@@ -352,12 +389,15 @@ mod tests {
         ))]);
         let original = Arc::downgrade(&guards);
 
+        let mut surrendered = Vec::new();
         RetainedExit::install(
             &mut guards,
             vec![RetainedExit::new(Exit::completed(
                 Cancellation::NotObserved,
             ))],
+            &mut surrendered,
         );
+        assert!(surrendered.is_empty());
 
         assert!(
             original.upgrade().is_none(),
@@ -394,7 +434,7 @@ mod tests {
     }
 
     #[test]
-    fn retained_exit_conversion_preserves_the_callers_drop_thread() {
+    fn retained_exit_user_handoff_preserves_the_callers_drop_thread() {
         let caller = std::thread::current().id();
         let (dropped, observed) = mpsc::sync_channel(1);
         let retained = RetainedExit::new(Exit::failed(
@@ -402,7 +442,7 @@ mod tests {
             Cancellation::NotObserved,
         ));
 
-        drop(retained.into_exit());
+        drop(retained.into_user_owned());
 
         assert_eq!(
             observed

--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -627,7 +627,6 @@ impl ScopeCell {
         }
         let mut state = Some(state);
         let mut startup = startup;
-        let mut startup_installed = false;
         let published = self.with_observation_gate(|txn| {
             if !terminal_disposals.iter().all(|member| {
                 self.current_observation_gate()
@@ -635,13 +634,12 @@ impl ScopeCell {
             }) {
                 return false;
             }
-            if let Some(startup) = startup.take() {
-                startup_installed = self.set_startup_locked(startup, txn);
-                if startup_installed {
-                    // The record now owns the diagnostic guards' raw peer.
-                    // Queue their surrender before this transaction commits.
-                    txn.surrender(std::mem::take(&mut retained_startup));
-                }
+            if let Some(startup) = startup.take()
+                && self.set_startup_locked(startup, txn)
+            {
+                // The record now owns the diagnostic guards' raw peer.
+                // Queue their surrender before this transaction commits.
+                txn.surrender(std::mem::take(&mut retained_startup));
             }
             self.set_state_locked(
                 state
@@ -656,13 +654,12 @@ impl ScopeCell {
             published,
             "a drain entry may mark only a resident member on its observation gate"
         );
-        if !startup_installed {
-            // A record that already held a startup result rejected this one,
-            // and the rejected raw result retired through the transaction's
-            // own guards — into isolated disposal, which is still running.
-            // These guards therefore retire through critical disposal too.
-            drop(retained_startup);
-        }
+        // Empty once the transaction surrendered them above. Otherwise a
+        // record that already held a startup result rejected this one, and the
+        // rejected raw result retired through the transaction's own guards —
+        // into isolated disposal, which is still running. These guards
+        // therefore retire through critical disposal too.
+        drop(retained_startup);
     }
 
     fn set_state_locked(
@@ -1031,13 +1028,19 @@ impl ScopeCell {
         self.finish_incarnation_with_terminal(epoch, RetainedStopReason::new(reason), None);
     }
 
+    /// Takes the terminal exit as a carrier so a root completion never
+    /// extracts a raw `Exit` between framework layers. Wrapping before the
+    /// stop reason keeps a failed payload guarded across every step of this
+    /// call, including the reason's own retention walk.
     #[cfg(test)]
-    pub(crate) fn finish_root_incarnation(&self, epoch: Epoch, reason: StopReason, exit: Exit) {
-        self.finish_incarnation_with_terminal(
-            epoch,
-            RetainedStopReason::new(reason),
-            Some(RetainedExit::new(exit)),
-        );
+    pub(crate) fn finish_root_incarnation(
+        &self,
+        epoch: Epoch,
+        reason: StopReason,
+        exit: impl Into<RetainedExit>,
+    ) {
+        let exit = exit.into();
+        self.finish_incarnation_with_terminal(epoch, RetainedStopReason::new(reason), Some(exit));
     }
 
     fn finish_incarnation_with_terminal(

--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -637,6 +637,11 @@ impl ScopeCell {
             }
             if let Some(startup) = startup.take() {
                 startup_installed = self.set_startup_locked(startup, txn);
+                if startup_installed {
+                    // The record now owns the diagnostic guards' raw peer.
+                    // Queue their surrender before this transaction commits.
+                    txn.surrender(std::mem::take(&mut retained_startup));
+                }
             }
             self.set_state_locked(
                 state
@@ -651,18 +656,11 @@ impl ScopeCell {
             published,
             "a drain entry may mark only a resident member on its observation gate"
         );
-        if startup_installed {
-            // The record installed its own retained copy, so the diagnostic
-            // guards are surrendered as raw refcount traffic.
-            for exit in retained_startup {
-                drop(exit.into_exit());
-            }
-        } else {
+        if !startup_installed {
             // A record that already held a startup result rejected this one,
             // and the rejected raw result retired through the transaction's
             // own guards — into isolated disposal, which is still running.
-            // Surrendering these guards raw would race that job for the last
-            // owner, so they retire the same way instead.
+            // These guards therefore retire through critical disposal too.
             drop(retained_startup);
         }
     }
@@ -689,10 +687,12 @@ impl ScopeCell {
         {
             route.close_admission(txn);
         }
+        let mut surrendered = Vec::new();
         self.observation.record.modify_silently(|record| {
             record.state = state.clone();
-            record.refresh_retained_exits();
+            record.refresh_retained_exits(&mut surrendered);
         });
+        txn.surrender(surrendered);
         txn.pulse(&self.observation.record);
         txn.pulse(&self.member.record);
         self.emit_locked(txn, LifecycleEventKind::ScopeState { state });
@@ -769,15 +769,21 @@ impl ScopeCell {
         &self,
         member: &MemberCell,
         total_restarts: TotalRestarts,
+        exit_guard: RetainedExit,
         transition: MemberTransition,
         exited: LifecycleEventKind,
         scheduled: LifecycleEventKind,
     ) -> bool {
         self.with_observation_gate(|wakes| {
             if !member.transition_locked(wakes, transition) {
+                wakes.defer(move || drop(exit_guard));
                 wakes.defer(move || runtime::dispose_detached((exited, scheduled)));
                 return false;
             }
+            // The member record now owns the exit used by both public edges.
+            // Surrender while its transaction is still open; the prioritized
+            // effect runs before any queued owner can enter disposal.
+            wakes.surrender([exit_guard]);
             self.observation.record.modify_silently(|scope| {
                 scope.total_restarts = total_restarts;
             });
@@ -791,14 +797,14 @@ impl ScopeCell {
     pub(crate) fn terminalize_child(
         &self,
         member: &MemberCell,
-        exit: Exit,
+        exit: impl Into<RetainedExit>,
         exited_incarnation: Option<Incarnation>,
         startup: StartupDisposition,
     ) -> bool {
         // Keep a retained owner across the residency assertion and every
         // fallible cell lookup. If an invariant fails, the raw argument can
         // unwind under the gate only as refcount traffic.
-        let exit = RetainedExit::new(exit);
+        let exit = exit.into();
         let terminalized = self.with_observation_gate(move |wakes| {
             let record = member.record();
             if matches!(record.stage, MemberStage::Terminal(_)) {
@@ -835,7 +841,7 @@ impl ScopeCell {
             let terminal_exit = member.terminalize_locked(exit.as_exit().clone(), startup, wakes);
             // The terminal member record now owns the equivalent retained
             // copy, so surrender this transient guard as refcount traffic.
-            drop(exit.into_exit());
+            wakes.surrender([exit]);
             self.evict_child_identity(member);
             if record.last_incarnation.is_none()
                 && let Some(scope) = &nested
@@ -950,22 +956,20 @@ impl ScopeCell {
         RetainedExit::retain_startup_result(&mut retained, &startup);
         let mut incoming = Some((startup, retained));
         let mut published = false;
+        let mut surrendered = Vec::new();
         self.observation.record.modify_silently(|record| {
             if record.startup.is_none() {
                 let (startup, retained) = incoming
                     .take()
                     .expect("startup result is installed at most once");
                 record.startup = Some(startup);
-                record.refresh_retained_exits();
-                // The record now owns an equivalent retained copy. Convert
-                // these transient guards back to raw refcount traffic rather
-                // than submitting duplicate disposal jobs under the gate.
-                for exit in retained {
-                    drop(exit.into_exit());
-                }
+                record.refresh_retained_exits(&mut surrendered);
+                // The record now owns an equivalent retained copy.
+                surrendered.extend(retained);
                 published = true;
             }
         });
+        txn.surrender(surrendered);
         // Tuple field order is intentional: a rejected raw startup result is
         // released while its retained guards still exist, then those guards
         // transfer failed destruction to isolated disposal.
@@ -999,12 +1003,14 @@ impl ScopeCell {
             // pairing is what lets `settled` treat terminal membership
             // plus a settled projection as final without stranding a scope
             // that still owns a live incarnation.
+            let mut surrendered = Vec::new();
             self.observation.record.modify_silently(|record| {
                 record.total_restarts = TotalRestarts::ZERO;
                 record.startup = None;
                 record.state = state.clone();
-                record.refresh_retained_exits();
+                record.refresh_retained_exits(&mut surrendered);
             });
+            wakes.surrender(surrendered);
             // Hold epoch ownership through its observation projection. A
             // stale finish and a newer begin can no longer cross these two
             // state planes in opposite orders.
@@ -1055,7 +1061,7 @@ impl ScopeCell {
                         StartupDisposition::Unchanged,
                         wakes,
                     );
-                    drop(exit.into_exit());
+                    wakes.surrender([exit]);
                     wakes.pulse(&self.member.record);
                     wakes.pulse(&self.observation.record);
                     self.close_observation_locked(wakes);
@@ -1096,7 +1102,7 @@ impl ScopeCell {
             }
             drop(reason.into_public());
             if let Some(exit) = terminal_exit.take() {
-                drop(exit.into_exit());
+                wakes.surrender([exit]);
             }
         });
     }
@@ -1122,7 +1128,7 @@ impl ScopeCell {
                 );
                 self.close_observation_locked(wakes);
                 drop(reason.into_public());
-                drop(exit.into_exit());
+                wakes.surrender([exit]);
             });
         }
     }
@@ -1614,6 +1620,7 @@ impl ScopeCell {
         let mut transient_retained = Vec::new();
         RetainedExit::retain_scope_state(&mut transient_retained, &state);
         let mut published = false;
+        let mut surrendered = Vec::new();
         self.observation.record.modify_silently(|record| {
             if let ScopeState::Stopped { reason: recorded } = &record.state
                 && incoming <= stop_reason_precedence(recorded)
@@ -1624,9 +1631,10 @@ impl ScopeCell {
                 record.startup = Some(Err(StartupError::ShutdownRequested));
             }
             record.state = state.clone();
-            record.refresh_retained_exits();
+            record.refresh_retained_exits(&mut surrendered);
             published = true;
         });
+        wakes.surrender(surrendered);
         if let Some(exit) = terminal_exit {
             self.member
                 .terminalize_locked(exit, StartupDisposition::Unchanged, wakes);
@@ -1639,9 +1647,7 @@ impl ScopeCell {
             // The record and lifecycle event now retain the raw projection.
             // Surrender the transient guards without scheduling duplicate
             // disposal jobs.
-            for exit in transient_retained {
-                drop(exit.into_exit());
-            }
+            wakes.surrender(transient_retained);
             wakes.pulse(&self.observation.record);
             self.emit_locked(wakes, LifecycleEventKind::ScopeState { state });
         } else {
@@ -2279,11 +2285,16 @@ mod tests {
             .expect("incarnation available");
         let (dropped, observed) = mpsc::sync_channel(1);
         let retiring_thread = std::thread::current().id();
+        let exit = Exit::failed(
+            ExitError::from(ThreadProbe(dropped)),
+            Cancellation::NotObserved,
+        );
 
         assert!(
             !root.publish_child_restart(
                 &member,
                 TotalRestarts::ZERO,
+                RetainedExit::new(exit.clone()),
                 MemberTransition::RestartScheduled {
                     exit: Exit::completed(Cancellation::NotObserved),
                     restart_count: RestartCount::ZERO.bump(),
@@ -2293,10 +2304,7 @@ mod tests {
                     id: member.id().clone(),
                     membership: member.membership(),
                     incarnation,
-                    exit: Exit::failed(
-                        ExitError::from(ThreadProbe(dropped)),
-                        Cancellation::NotObserved,
-                    ),
+                    exit,
                 },
                 LifecycleEventKind::RestartScheduled {
                     id: member.id().clone(),

--- a/crates/shelterwood/src/cells/scope/projection.rs
+++ b/crates/shelterwood/src/cells/scope/projection.rs
@@ -35,13 +35,13 @@ pub(crate) struct ScopeRecord {
 }
 
 impl ScopeRecord {
-    pub(super) fn refresh_retained_exits(&mut self) {
+    pub(super) fn refresh_retained_exits(&mut self, surrendered: &mut Vec<RetainedExit>) {
         let mut retained = Vec::new();
         RetainedExit::retain_scope_state(&mut retained, &self.state);
         if let Some(startup) = &self.startup {
             RetainedExit::retain_startup_result(&mut retained, startup);
         }
-        RetainedExit::install(&mut self.retained_exits, retained);
+        RetainedExit::install(&mut self.retained_exits, retained, surrendered);
     }
 }
 
@@ -78,7 +78,12 @@ impl ScopeCell {
     }
 
     pub(crate) fn snapshot(&self) -> Arc<ScopeSnapshot> {
-        self.with_observation_gate(|_| self.snapshot_locked().into_public())
+        self.with_observation_gate(|txn| {
+            let mut surrendered = Vec::new();
+            let snapshot = self.snapshot_locked(&mut surrendered);
+            txn.surrender(surrendered);
+            snapshot.into_public(txn)
+        })
     }
 
     pub(crate) fn subscribe_snapshots(&self) -> SnapshotReceiver {
@@ -88,10 +93,10 @@ impl ScopeCell {
         // Only a `*_locked` writer that receives someone else's transaction has
         // an identity left to verify.
         let (receiver, closed_consistent) = self.with_observation_gate(|wakes| {
-            let receiver = self
-                .observation
-                .snapshots
-                .subscribe(self.snapshot_locked(), wakes);
+            let mut surrendered = Vec::new();
+            let initial = self.snapshot_locked(&mut surrendered);
+            wakes.surrender(surrendered);
+            let receiver = self.observation.snapshots.subscribe(initial, wakes);
             let closed_consistent = !self.observation.closed.load(Ordering::Acquire)
                 || receiver.borrow_latest_and_closed().1;
             (receiver, closed_consistent)
@@ -117,7 +122,7 @@ impl ScopeCell {
         events
     }
 
-    fn snapshot_locked(&self) -> RetainedScopeSnapshot {
+    fn snapshot_locked(&self, surrendered: &mut Vec<RetainedExit>) -> RetainedScopeSnapshot {
         let record = self.record();
         let config = *self
             .observation
@@ -135,10 +140,10 @@ impl ScopeCell {
         // terminality lookup and straggler collection still see it: it is
         // owned residency, just not yet public.
         for resident in children.iter().filter(|resident| resident.announced) {
-            let (child, exits) = self.child_snapshot_locked(resident.projection());
+            let (child, exits) = self.child_snapshot_locked(resident.projection(), surrendered);
             projected.push(child);
             for exit in exits {
-                RetainedExit::retain_owned(&mut retained_exits, exit);
+                RetainedExit::retain_owned(&mut retained_exits, exit, surrendered);
             }
         }
         let snapshot = Arc::new(ScopeSnapshot {
@@ -158,6 +163,7 @@ impl ScopeCell {
     fn child_snapshot_locked(
         &self,
         child: &ResidentProjection,
+        surrendered: &mut Vec<RetainedExit>,
     ) -> (ChildSnapshot, Vec<RetainedExit>) {
         let MemberRecord {
             stage,
@@ -179,11 +185,13 @@ impl ScopeCell {
         let nested = child
             .scope
             .as_ref()
-            .and_then(|scope| (incarnation.is_some() || terminal).then(|| scope.snapshot_locked()))
+            .and_then(|scope| {
+                (incarnation.is_some() || terminal).then(|| scope.snapshot_locked(surrendered))
+            })
             .map(|nested| {
                 let (snapshot, exits) = nested.into_parts();
                 for exit in exits {
-                    RetainedExit::retain_owned(&mut retained_exits, exit);
+                    RetainedExit::retain_owned(&mut retained_exits, exit, surrendered);
                 }
                 snapshot
             });
@@ -251,7 +259,7 @@ impl ScopeCell {
         let scope = self.owned();
         self.observation
             .snapshots
-            .publish(wakes, move || scope.snapshot_locked());
+            .publish(wakes, move |surrendered| scope.snapshot_locked(surrendered));
         for ancestor in ancestors {
             #[cfg(debug_assertions)]
             wakes.debug_assert_gate(&ancestor.current_observation_gate());
@@ -259,7 +267,7 @@ impl ScopeCell {
             ancestor
                 .observation
                 .snapshots
-                .publish(wakes, move || scope.snapshot_locked());
+                .publish(wakes, move |surrendered| scope.snapshot_locked(surrendered));
         }
     }
 
@@ -332,7 +340,7 @@ impl ScopeCell {
         let scope = self.owned();
         self.observation
             .snapshots
-            .close(wakes, move || scope.snapshot_locked());
+            .close(wakes, move |surrendered| scope.snapshot_locked(surrendered));
         self.observation.lifecycle.close(wakes);
         // Both hub closures are idempotent. Set the aggregate marker last so
         // an unexpected panic leaves the operation retryable.
@@ -416,10 +424,13 @@ mod tests {
             let probe = Arc::clone(&under_gate);
             let gate = gate.clone();
             let cell = Arc::clone(&scope);
-            scope.observation.snapshots.publish(txn, move || {
-                probe.store(gate.is_held(), Ordering::Relaxed);
-                cell.snapshot_locked()
-            });
+            scope
+                .observation
+                .snapshots
+                .publish(txn, move |surrendered| {
+                    probe.store(gate.is_held(), Ordering::Relaxed);
+                    cell.snapshot_locked(surrendered)
+                });
         });
 
         assert!(

--- a/crates/shelterwood/src/driver/child.rs
+++ b/crates/shelterwood/src/driver/child.rs
@@ -234,7 +234,7 @@ impl ChildRuntime {
     pub(super) fn terminalize(
         &mut self,
         root: &ScopeCell,
-        exit: Exit,
+        exit: RetainedExit,
         exited_incarnation: Option<Incarnation>,
         startup: StartupDisposition,
     ) -> bool {
@@ -653,14 +653,14 @@ impl ScopeRuntime {
     pub(super) fn terminalize_child(
         &mut self,
         key: ChildKey,
-        exit: Exit,
+        exit: impl Into<RetainedExit>,
         exited_incarnation: Option<Incarnation>,
         startup: StartupDisposition,
     ) -> bool {
         // Protect the raw user error before every resource lookup and reducer
         // invariant. A malformed key may still be diagnosed, but it cannot
         // unwind the Exit payload on the driver stack.
-        let mut exit = Some(RetainedExit::new(exit));
+        let mut exit = Some(exit.into());
         // Production terminal publication follows joined construction
         // disposal.  A few structural test/fallback paths synthesize that
         // already-joined boundary directly, so normalize them through the
@@ -676,8 +676,7 @@ impl ScopeRuntime {
             .terminalize(
                 &self.root,
                 exit.take()
-                    .expect("terminal publication consumes its retained exit once")
-                    .into_exit(),
+                    .expect("terminal publication consumes its retained exit once"),
                 exited_incarnation,
                 startup,
             );
@@ -1134,11 +1133,13 @@ impl ScopeRuntime {
                 // would restart the child with neither `Exited` nor
                 // `RestartScheduled` published — see the partial-effect note
                 // on issue #392.
+                let raw_exit = exit.as_exit().clone();
                 let published = self.root.publish_child_restart(
                     &child.slot.member,
                     decision.total_restarts(),
+                    exit,
                     MemberTransition::RestartScheduled {
-                        exit: exit.as_exit().clone(),
+                        exit: raw_exit.clone(),
                         restart_count: decision.restart_count(),
                         // Publish the derived schedule even when intensity prevents spawning it.
                         // `None` means the exact clock point cannot be represented and armed; no
@@ -1149,7 +1150,7 @@ impl ScopeRuntime {
                         id: child.slot.member.id().clone(),
                         membership: child.slot.member.membership(),
                         incarnation,
-                        exit: exit.as_exit().clone(),
+                        exit: raw_exit,
                     },
                     LifecycleEventKind::RestartScheduled {
                         id: child.slot.member.id().clone(),
@@ -1162,10 +1163,6 @@ impl ScopeRuntime {
                     published,
                     "a restart is scheduled from an active incarnation's exit"
                 );
-                // Successful publication installed retained copies in the
-                // member record and lifecycle event. Releasing the local raw
-                // copy is therefore provably refcount traffic.
-                drop(exit.into_exit());
                 let trip = decision.intensity_trip();
                 if trip.is_none()
                     && let Some(restart_at) = decision.restart_at()
@@ -1328,12 +1325,11 @@ impl ScopeRuntime {
         } else {
             StartupDisposition::NotAborted
         };
-        let terminalized = self.terminalize_child(
-            key,
-            exit.as_exit().clone(),
-            terminal.exited_incarnation,
-            startup,
-        );
+        // Hand the publication seam a guarded clone rather than a raw one, so
+        // no window between here and the cell layer's own retention holds the
+        // user error unguarded. The cell layer surrenders its copy inside the
+        // publishing transaction.
+        self.terminalize_child(key, exit.clone(), terminal.exited_incarnation, startup);
         // Keep the marker installed until terminal publication has committed.
         // A concurrent shutdown sampler then sees either pending cleanup or a
         // terminal member, never the gap between those two representations.
@@ -1354,21 +1350,16 @@ impl ScopeRuntime {
                 self.prune_terminal(key);
             }
         }
-        // Both routes above are fallible, so the guard is released once, here.
-        // A winning publication installed an equivalent retained copy in the
-        // terminal member record, which the `member` handle keeps alive past
-        // this statement, so surrendering the raw copy is refcount traffic.
-        //
-        // A losing publication is unreachable today: #458 established that by
-        // whole-workspace enumeration rather than by any local guard, so no
-        // test pins the other branch and a probe for it would be a
-        // strong-count race by construction. It is retained defensively — the
-        // guard simply falls out of scope, and `RetainedExit::drop` retires
-        // the user error through critical disposal at the cost of one extra
-        // blocking-pool job.
-        if terminalized {
-            drop(exit.into_exit());
-        }
+        // Both routes above are fallible, so the guard retires once, here, by
+        // falling out of scope whichever route ran. Issue #455 removed the
+        // escape hatch that let a driver-layer caller surrender a guard on a
+        // conventional co-owner proof, and the driver owns no observation
+        // transaction to surrender into, so `RetainedExit::drop` is the venue:
+        // it retires a failed user error through critical disposal at the cost
+        // of one blocking-pool job. The copy that retires as refcount traffic
+        // is the clone handed to `terminalize_child` above, surrendered inside
+        // the publishing transaction where the terminal member record is its
+        // structural co-owner.
     }
 }
 


### PR DESCRIPTION
Closes #455.

## Summary

- Add `ObservationTxn::surrender`, the only framework-internal raw-release path for `RetainedExit`. It queues retained guards into the transaction's deferred-effect list, releases the observation gate first, and prioritizes surrenders ahead of ordinary effects that can hand a co-owner to concurrent disposal.
- Rename the former general `RetainedExit::into_exit` escape hatch to `into_user_owned` and leave it at only the three adjudicated production handoffs: `RetainedStopReason::into_public`, `RetainedLifecycleEvent::into_public`, and the root completion handoff in `driver.rs`.
- Propagate surrender collection through member/scope guard refresh, recursive snapshot construction and commit-time snapshot producers, so deduplicated guards cannot be released outside an open observation transaction.
- Carry `RetainedExit` itself through the driver terminal-disposal and terminal-publication seams. The newer restart-publication path now moves its guard into the cell transaction instead of surrendering after that transaction returns.
- Document the structural rule in `AGENTS.md` and add mutation-sensitive tests for concurrent-owner ordering plus prioritized surrender draining after unlock during unwind and a hostile surrender effect.

## Call-site audit

All 21 former `into_exit()` sites (the adjudicated 19 plus two later driver additions) were classified and migrated:

- **4 genuine user-owned handoffs:** 3 production sites use `into_user_owned`; the fourth is their drop-timing unit test.
- **13 framework-internal raw releases:** record/snapshot deduplication, direct snapshots, member transitions, scope startup/state/terminal publication, and restart publication now route through `ObservationTxn::surrender`.
- **3 framework carrier transfers:** driver terminalization, terminal-disposal entry, and post-disposal routing keep `RetainedExit` intact rather than extracting a raw `Exit` between framework layers.
- **1 retained fold:** disposal-panic classification extracts privately inside `cells::retained` and immediately re-wraps the selected/discarded halves; it is neither a surrender nor a user handoff.

`rg` now finds no `into_exit()` call or definition. `into_user_owned()` has exactly the three production handoffs named by the adjudication plus its unit test.

## Verification

- `./tools/dev cargo test --locked -p shelterwood --lib observation_txn_`
- `./tools/dev just ci` (956 nextest tests plus formatting, clippy, doctests, examples, docs, API reachability, manifest, external-consumer, and Nix formatting checks)

Fresh adversarial review added the unwind/panic-continuation regression in c26070c and found no remaining raw-conversion or lock-order defect.
