### PR TITLE
Benchmark lifecycle and observation costs

### DIFF
--- a/tools/benchmarks/Cargo.toml
+++ b/tools/benchmarks/Cargo.toml
@@ -17,8 +17,12 @@ harness = false
 name = "mailbox"
 harness = false
 
+[[bench]]
+name = "lifecycle"
+harness = false
+
 [dev-dependencies]
 criterion = { version = "=0.8.2", features = ["async_tokio"] }
 shelterwood = { path = "../../crates/shelterwood" }
 shelterwood-core = { path = "../../crates/shelterwood-core" }
-tokio = { version = "=1.53.1", features = ["rt", "rt-multi-thread", "time"] }
+tokio = { version = "=1.53.1", features = ["rt", "rt-multi-thread", "sync", "time"] }

--- a/tools/benchmarks/README.md
+++ b/tools/benchmarks/README.md
@@ -51,8 +51,8 @@ operations:
     keeps the 48-case suite near three minutes inside `just bench` and keeps
     routine spread on the backpressured arms out of the change reports.
 - `lifecycle` covers cold wide and deep trees, immediate restart cycles, and
-  dynamic admission/removal with no observer, a snapshot subscriber, a
-  lifecycle subscriber, or both.
+  dynamic admission/removal against a drained snapshot subscriber, a drained
+  lifecycle subscriber, both, or no subscriber at all.
 
 `concurrent_send_tasks` deliberately includes task spawn and join overhead. It
 represents the common application shape of short-lived producer tasks rather
@@ -68,10 +68,58 @@ stress incremental, level-triggered settlement; they do not model the driver's
 event-batch distribution. Use the lifecycle suite for end-to-end startup and
 shutdown costs.
 
-Cold lifecycle fixtures construct the declaration outside the timed region;
-`spawn`, recursive lowering, startup, shutdown, and joining are timed. Dynamic
-churn starts its root outside the timed region so it isolates live control-plane
-admission/removal and observation publication.
+Cold lifecycle fixtures build their top-level declaration outside the timed
+region; `spawn`, lowering, startup, shutdown, and joining are timed. The two
+sweeps differ in how much declaration survives into that region. `cold_width`
+builds all N `TaskDef`s in setup, so only lowering is timed. `cold_depth`
+builds only the outermost level eagerly: `SubtreeDef::factory` stores a
+closure that each nested incarnation invokes at construction, so a depth-32
+sample constructs 31 further trees and their definition `Arc`s inside the
+timed region. That is deliberate — a cold lifecycle is what the sweep measures
+— but the depth numbers include recursive declaration construction and the
+width numbers do not. `cold_depth/*/1` and `cold_width/*/1` build the
+identical one-task fixture on purpose: it is the shared intercept of both
+sweeps and a same-run check on host noise.
+
+`immediate_restarts` reports no element rate. Its timed region is a whole
+system lifecycle — `spawn`, `wait_started`, the restart cascade, `shutdown`,
+and the root driver join — so dividing by the restart count would attribute
+that fixed lifecycle cost to every restart. The sweep instead carries a
+zero-restart point; the marginal cost of one restart is the difference from
+that baseline divided by the restart count. The declared intensity budget
+carries head room over the exact number of charges the fixture provokes, so an
+unexpected charge cannot trip the scope and turn a slow sample into a panic.
+
+`dynamic_churn` starts its root outside the timed region, so it isolates live
+control-plane admission/removal and observation publication. Each cycle admits
+a task, waits for that incarnation's first poll, then removes it. The
+readiness rendezvous is inside the timed region and is there for determinism:
+removal latches immediately, so without it the removal races the driver's
+start transaction, the `Removing` mark suppresses the `Ready` edge, and the
+edge count per cycle varies between four and five — measured at 96 to 120
+edges per 24-cycle batch on a four-worker runtime, a 25% swing in the payload
+the arms are meant to hold constant. With the rendezvous every cycle emits
+exactly five edges (`Added`, `Started`, `Ready`, `Exited`, `Removed`) under
+both runtime configurations.
+
+The four `dynamic_churn` arms differ only in who is subscribed. Each
+subscribing arm parks a dedicated consumer task on its stream for the whole
+arm rather than draining inside the timed future, so publication has a real
+waiter to wake instead of an empty waiter list, and the lifecycle broadcast
+ring does not saturate: the arms measure the keeping-up-consumer regime, not a
+permanently lagged one. On the current-thread group that consumer is driven by
+the same `block_on` Criterion times, so its cost is attributed; on the
+multi-thread group it runs on another worker and only its wake and contention
+costs are. `none` is not an observer-free baseline for lifecycle work:
+snapshot publication skips a scope with no receivers, but lifecycle emission
+has no such gate — every edge mints retention guards, resolves ancestors,
+mints the sequence, builds the event, clones it per ancestor, takes the hub's
+signal mutex and the broadcast tail lock, and pulses the watch, whether or not
+anyone is subscribed. Only the ring write itself is skipped, and that is the
+channel's own zero-receiver check rather than a Shelterwood gate. The
+`lifecycle` arm's delta over `none` is therefore bounded below by that
+unconditional work and measures only the incremental cost of a subscribed,
+draining consumer — which on a keeping-up consumer is close to zero.
 
 That schedule is **quadratic** in the child count: it settles once per child,
 and every settle rescans the child table — `settle_finish` evaluates

--- a/tools/benchmarks/README.md
+++ b/tools/benchmarks/README.md
@@ -50,6 +50,9 @@ operations:
     2 s measurement) with a 10% noise floor and a 1% significance level. That
     keeps the 48-case suite near three minutes inside `just bench` and keeps
     routine spread on the backpressured arms out of the change reports.
+- `lifecycle` covers cold wide and deep trees, immediate restart cycles, and
+  dynamic admission/removal with no observer, a snapshot subscriber, a
+  lifecycle subscriber, or both.
 
 `concurrent_send_tasks` deliberately includes task spawn and join overhead. It
 represents the common application shape of short-lived producer tasks rather
@@ -62,8 +65,13 @@ size in both groups, so it is a backpressured arm as well.
 The core supervisor `startup` and `drain` cases apply one child's transition
 sequence and then settle before advancing to the next child. They deliberately
 stress incremental, level-triggered settlement; they do not model the driver's
-event-batch distribution. End-to-end lifecycle benchmarks build on this
-harness in the stacked series.
+event-batch distribution. Use the lifecycle suite for end-to-end startup and
+shutdown costs.
+
+Cold lifecycle fixtures construct the declaration outside the timed region;
+`spawn`, recursive lowering, startup, shutdown, and joining are timed. Dynamic
+churn starts its root outside the timed region so it isolates live control-plane
+admission/removal and observation publication.
 
 That schedule is **quadratic** in the child count: it settles once per child,
 and every settle rescans the child table — `settle_finish` evaluates

--- a/tools/benchmarks/benches/lifecycle.rs
+++ b/tools/benchmarks/benches/lifecycle.rs
@@ -9,21 +9,48 @@ use std::{
 
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use shelterwood::{
-    Backoff, DynamicScopeRef, DynamicTree, Intensity, LifecycleEvents, RemoveOutcome,
-    RestartCondition, RestartPolicy, ScopeRef, SnapshotReceiver, SubtreeDef, System, TaskDef, Tree,
+    Backoff, DynamicScopeRef, DynamicTree, Intensity, LifecycleEvents, LifecycleItem,
+    RemoveOutcome, RestartCondition, RestartPolicy, ScopeRef, SnapshotReceiver, SubtreeDef, System,
+    TaskDef, Tree,
 };
-use tokio::{runtime::Runtime, sync::Notify};
+use tokio::{runtime::Runtime, sync::Notify, task::JoinHandle};
 
 const DEADLINE: Duration = Duration::from_secs(30);
 const WIDTHS: [usize; 3] = [1, 16, 256];
 const DEPTHS: [usize; 3] = [1, 8, 32];
-const RESTARTS: [usize; 3] = [1, 8, 32];
+/// Restart counts, including a zero-restart baseline.
+///
+/// The timed region is a whole system lifecycle, so the marginal cost of one
+/// restart is only derivable by differencing against that baseline. See
+/// `bench_restarts` for why this group reports no element rate.
+const RESTARTS: [usize; 4] = [0, 1, 8, 32];
+/// Spare restart charges beyond the exact number the fixture provokes.
+///
+/// A budget of exactly `restarts` is correct at the boundary but has no
+/// tolerance: one extra charge from any source would trip the scope and turn
+/// a slow sample into a panic instead of a measurement.
+const RESTART_BUDGET_HEADROOM: u64 = 8;
 const CHURN_CYCLES: usize = 32;
 
 fn cooperative_task() -> TaskDef {
     TaskDef::new(|context| async move {
         context.shutdown_token().cancelled().await;
         Ok(())
+    })
+}
+
+/// A cooperative task that announces its first poll.
+///
+/// The dynamic churn loop uses the announcement to remove a child only after
+/// its incarnation has started, which pins the emitted lifecycle edge count.
+fn announcing_task(started: Arc<Notify>) -> TaskDef {
+    TaskDef::new(move |context| {
+        let started = Arc::clone(&started);
+        async move {
+            started.notify_one();
+            context.shutdown_token().cancelled().await;
+            Ok(())
+        }
     })
 }
 
@@ -45,6 +72,10 @@ fn wide_dynamic(width: usize) -> DynamicTree {
     tree
 }
 
+// Only the outermost level is built here. `SubtreeDef::factory` stores the
+// recursion, so every nested level is constructed lazily at its incarnation's
+// construction — inside the timed region. The README records that asymmetry
+// against the width sweep.
 fn deep_ordered(depth: usize) -> Tree {
     let mut tree = Tree::new();
     if depth == 1 {
@@ -146,8 +177,11 @@ fn restarting_tree(restarts: usize) -> (Tree, Arc<Notify>) {
     let stable = Arc::new(Notify::new());
     let mut tree = Tree::new();
     tree.intensity(
-        Intensity::new(restarts as u64, Duration::from_secs(30))
-            .expect("the benchmark intensity window is non-zero"),
+        Intensity::new(
+            restarts as u64 + RESTART_BUDGET_HEADROOM,
+            Duration::from_secs(30),
+        )
+        .expect("the benchmark intensity window is non-zero"),
     );
     tree.add_task(
         "worker",
@@ -179,8 +213,12 @@ fn restarting_tree(restarts: usize) -> (Tree, Arc<Notify>) {
 
 fn bench_restarts(c: &mut Criterion, runtime_name: &str, runtime: &Runtime) {
     let mut group = c.benchmark_group(format!("lifecycle/{runtime_name}/immediate_restarts"));
+    // Deliberately no `Throughput::Elements`. The timed region is a whole
+    // system lifecycle — spawn, startup, the restart cascade, shutdown, and
+    // the root driver join — so a per-restart rate would charge every restart
+    // with the fixed lifecycle cost. The `0` point makes the marginal restart
+    // cost derivable by differencing instead.
     for restarts in RESTARTS {
-        group.throughput(Throughput::Elements(restarts as u64));
         group.bench_with_input(
             BenchmarkId::from_parameter(restarts),
             &restarts,
@@ -207,37 +245,97 @@ fn bench_restarts(c: &mut Criterion, runtime_name: &str, runtime: &Runtime) {
     group.finish();
 }
 
-enum Observation {
-    None,
-    Snapshots(SnapshotReceiver),
-    Lifecycle(LifecycleEvents),
-    Both(SnapshotReceiver, LifecycleEvents),
+/// What one draining consumer task observed over an arm.
+#[derive(Default)]
+struct DrainCounts {
+    items: AtomicUsize,
+    lagged: AtomicUsize,
 }
 
-impl Observation {
-    fn subscribe(mode: &str, scope: &ScopeRef) -> Self {
+/// The consumers an observation arm parks on its streams.
+///
+/// The arms exist to price observation, so a subscriber that never consumes
+/// prices the wrong thing: `WatchSender::pulse` walks an empty waiter list and
+/// the lifecycle ring saturates into a permanently lagged regime. A consumer
+/// task parked on the stream for the whole arm, rather than a drain inside the
+/// timed future, is what keeps a waiter present at the instant of publication.
+struct Observers {
+    handles: Vec<JoinHandle<()>>,
+    snapshots: Option<Arc<DrainCounts>>,
+    lifecycle: Option<Arc<DrainCounts>>,
+}
+
+impl Observers {
+    fn spawn(mode: &str, runtime: &Runtime, scope: &ScopeRef) -> Self {
+        let mut observers = Self {
+            handles: Vec::new(),
+            snapshots: None,
+            lifecycle: None,
+        };
         match mode {
-            "none" => Self::None,
-            "snapshots" => Self::Snapshots(scope.subscribe_snapshots()),
-            "lifecycle" => Self::Lifecycle(scope.subscribe_lifecycle()),
-            "both" => Self::Both(scope.subscribe_snapshots(), scope.subscribe_lifecycle()),
+            "none" => {}
+            "snapshots" => observers.drain_snapshots(runtime, scope.subscribe_snapshots()),
+            "lifecycle" => observers.drain_lifecycle(runtime, scope.subscribe_lifecycle()),
+            "both" => {
+                observers.drain_snapshots(runtime, scope.subscribe_snapshots());
+                observers.drain_lifecycle(runtime, scope.subscribe_lifecycle());
+            }
             _ => unreachable!("the benchmark supplies a known observation mode"),
         }
+        observers
     }
 
-    fn retain(&self) {
-        match self {
-            Self::None => {}
-            Self::Snapshots(receiver) => {
-                black_box(receiver);
+    fn drain_snapshots(&mut self, runtime: &Runtime, mut receiver: SnapshotReceiver) {
+        let counts = Arc::new(DrainCounts::default());
+        self.snapshots = Some(Arc::clone(&counts));
+        self.handles.push(runtime.spawn(async move {
+            while let Ok(snapshot) = receiver.changed().await {
+                black_box(&snapshot);
+                counts.items.fetch_add(1, Ordering::Relaxed);
             }
-            Self::Lifecycle(events) => {
-                black_box(events);
+        }));
+    }
+
+    fn drain_lifecycle(&mut self, runtime: &Runtime, mut events: LifecycleEvents) {
+        let counts = Arc::new(DrainCounts::default());
+        self.lifecycle = Some(Arc::clone(&counts));
+        self.handles.push(runtime.spawn(async move {
+            while let Some(item) = events.recv().await {
+                match item {
+                    LifecycleItem::Event(event) => {
+                        black_box(&event);
+                        counts.items.fetch_add(1, Ordering::Relaxed);
+                    }
+                    LifecycleItem::Lagged { dropped } => {
+                        counts.lagged.fetch_add(dropped as usize, Ordering::Relaxed);
+                    }
+                }
             }
-            Self::Both(receiver, events) => {
-                black_box((receiver, events));
-            }
+        }));
+    }
+
+    /// Checks the consumers were load-bearing, then retires them.
+    fn finish(self, runtime: &Runtime, mode: &str) {
+        for (stream, counts) in [
+            ("snapshots", &self.snapshots),
+            ("lifecycle", &self.lifecycle),
+        ] {
+            let Some(counts) = counts else { continue };
+            assert!(
+                counts.items.load(Ordering::Relaxed) > 0,
+                "the {mode} arm's {stream} consumer observed nothing, so the arm did not \
+                 measure a woken subscriber",
+            );
+            // Lag is a regime change, not an error: record it so a run that
+            // silently fell into the lagged regime is still visible.
+            black_box(counts.lagged.load(Ordering::Relaxed));
         }
+        runtime.block_on(async move {
+            for handle in self.handles {
+                handle.abort();
+                let _ = handle.await;
+            }
+        });
     }
 }
 
@@ -270,21 +368,35 @@ fn bench_dynamic_churn(c: &mut Criterion, runtime_name: &str, runtime: &Runtime)
 
     for mode in ["none", "snapshots", "lifecycle", "both"] {
         let (system, scope) = start_dynamic(runtime);
-        let observation = Observation::subscribe(mode, scope.as_scope());
+        let observers = Observers::spawn(mode, runtime, scope.as_scope());
         group.bench_function(mode, |b| {
             b.to_async(runtime).iter(|| async {
                 for _ in 0..CHURN_CYCLES {
+                    let started = Arc::new(Notify::new());
                     let task = scope
-                        .add_task("worker", cooperative_task())
+                        .add_task("worker", announcing_task(Arc::clone(&started)))
                         .await
                         .expect("the dynamic benchmark admits its task");
+                    // Removal latches immediately, so without this rendezvous
+                    // it races the driver's start transaction and the
+                    // `Removing` mark suppresses the `Ready` edge. Waiting
+                    // pins every cycle at five edges under both runtime
+                    // configurations; see the README.
+                    started.notified().await;
                     let outcome = scope.remove_task(&task).await;
-                    black_box(outcome);
-                    debug_assert_eq!(outcome, RemoveOutcome::Removed);
+                    // Promoted from `debug_assert_eq!`: `cargo bench` builds
+                    // the release-derived `bench` profile, where a debug
+                    // assertion is compiled out and this loop would have no
+                    // correctness guard at all.
+                    assert_eq!(
+                        outcome,
+                        RemoveOutcome::Removed,
+                        "each churn cycle must remove the membership it admitted",
+                    );
                 }
             });
         });
-        observation.retain();
+        observers.finish(runtime, mode);
         stop_dynamic(runtime, system);
     }
     group.finish();

--- a/tools/benchmarks/benches/lifecycle.rs
+++ b/tools/benchmarks/benches/lifecycle.rs
@@ -1,0 +1,315 @@
+use std::{
+    hint::black_box,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use shelterwood::{
+    Backoff, DynamicScopeRef, DynamicTree, Intensity, LifecycleEvents, RemoveOutcome,
+    RestartCondition, RestartPolicy, ScopeRef, SnapshotReceiver, SubtreeDef, System, TaskDef, Tree,
+};
+use tokio::{runtime::Runtime, sync::Notify};
+
+const DEADLINE: Duration = Duration::from_secs(30);
+const WIDTHS: [usize; 3] = [1, 16, 256];
+const DEPTHS: [usize; 3] = [1, 8, 32];
+const RESTARTS: [usize; 3] = [1, 8, 32];
+const CHURN_CYCLES: usize = 32;
+
+fn cooperative_task() -> TaskDef {
+    TaskDef::new(|context| async move {
+        context.shutdown_token().cancelled().await;
+        Ok(())
+    })
+}
+
+fn wide_ordered(width: usize) -> Tree {
+    let mut tree = Tree::new();
+    for index in 0..width {
+        tree.add_task(format!("task-{index}"), cooperative_task())
+            .expect("benchmark child ids are unique");
+    }
+    tree
+}
+
+fn wide_dynamic(width: usize) -> DynamicTree {
+    let mut tree = DynamicTree::new();
+    for index in 0..width {
+        tree.add_task(format!("task-{index}"), cooperative_task())
+            .expect("benchmark child ids are unique");
+    }
+    tree
+}
+
+fn deep_ordered(depth: usize) -> Tree {
+    let mut tree = Tree::new();
+    if depth == 1 {
+        tree.add_task("leaf", cooperative_task())
+            .expect("the leaf declaration is valid");
+    } else {
+        tree.add_subtree(
+            "scope",
+            SubtreeDef::factory(move || deep_ordered(depth - 1)),
+        )
+        .expect("the nested declaration is valid");
+    }
+    tree
+}
+
+fn deep_dynamic(depth: usize) -> DynamicTree {
+    let mut tree = DynamicTree::new();
+    if depth == 1 {
+        tree.add_task("leaf", cooperative_task())
+            .expect("the leaf declaration is valid");
+    } else {
+        tree.add_subtree(
+            "scope",
+            SubtreeDef::factory(move || deep_dynamic(depth - 1)),
+        )
+        .expect("the nested declaration is valid");
+    }
+    tree
+}
+
+async fn ordered_lifecycle(tree: Tree) {
+    let system = tree.spawn().expect("the benchmark runtime is active");
+    system
+        .wait_started()
+        .await
+        .expect("the benchmark tree starts");
+    system
+        .shutdown(DEADLINE)
+        .await
+        .expect("the benchmark tree shuts down within its generous bound");
+}
+
+async fn dynamic_lifecycle(tree: DynamicTree) {
+    let system = tree.spawn().expect("the benchmark runtime is active");
+    system
+        .wait_started()
+        .await
+        .expect("the benchmark tree starts");
+    system
+        .shutdown(DEADLINE)
+        .await
+        .expect("the benchmark tree shuts down within its generous bound");
+}
+
+fn bench_cold_lifecycle(c: &mut Criterion, runtime_name: &str, runtime: &Runtime) {
+    let mut width_group = c.benchmark_group(format!("lifecycle/{runtime_name}/cold_width"));
+    for width in WIDTHS {
+        width_group.throughput(Throughput::Elements(width as u64));
+        width_group.bench_with_input(BenchmarkId::new("ordered", width), &width, |b, &width| {
+            b.to_async(runtime).iter_batched(
+                || wide_ordered(width),
+                ordered_lifecycle,
+                BatchSize::PerIteration,
+            );
+        });
+        width_group.bench_with_input(BenchmarkId::new("dynamic", width), &width, |b, &width| {
+            b.to_async(runtime).iter_batched(
+                || wide_dynamic(width),
+                dynamic_lifecycle,
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    width_group.finish();
+
+    let mut depth_group = c.benchmark_group(format!("lifecycle/{runtime_name}/cold_depth"));
+    for depth in DEPTHS {
+        depth_group.throughput(Throughput::Elements(depth as u64));
+        depth_group.bench_with_input(BenchmarkId::new("ordered", depth), &depth, |b, &depth| {
+            b.to_async(runtime).iter_batched(
+                || deep_ordered(depth),
+                ordered_lifecycle,
+                BatchSize::PerIteration,
+            );
+        });
+        depth_group.bench_with_input(BenchmarkId::new("dynamic", depth), &depth, |b, &depth| {
+            b.to_async(runtime).iter_batched(
+                || deep_dynamic(depth),
+                dynamic_lifecycle,
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    depth_group.finish();
+}
+
+fn restarting_tree(restarts: usize) -> (Tree, Arc<Notify>) {
+    let starts = Arc::new(AtomicUsize::new(0));
+    let stable = Arc::new(Notify::new());
+    let mut tree = Tree::new();
+    tree.intensity(
+        Intensity::new(restarts as u64, Duration::from_secs(30))
+            .expect("the benchmark intensity window is non-zero"),
+    );
+    tree.add_task(
+        "worker",
+        TaskDef::new({
+            let starts = Arc::clone(&starts);
+            let stable = Arc::clone(&stable);
+            move |context| {
+                let generation = starts.fetch_add(1, Ordering::Relaxed) + 1;
+                let stable = Arc::clone(&stable);
+                async move {
+                    if generation <= restarts {
+                        Ok(())
+                    } else {
+                        stable.notify_one();
+                        context.shutdown_token().cancelled().await;
+                        Ok(())
+                    }
+                }
+            }
+        })
+        .restart(RestartPolicy::new(
+            RestartCondition::Always,
+            Backoff::Immediate,
+        )),
+    )
+    .expect("the restart benchmark declaration is valid");
+    (tree, stable)
+}
+
+fn bench_restarts(c: &mut Criterion, runtime_name: &str, runtime: &Runtime) {
+    let mut group = c.benchmark_group(format!("lifecycle/{runtime_name}/immediate_restarts"));
+    for restarts in RESTARTS {
+        group.throughput(Throughput::Elements(restarts as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(restarts),
+            &restarts,
+            |b, &restarts| {
+                b.to_async(runtime).iter_batched(
+                    || restarting_tree(restarts),
+                    |(tree, stable)| async move {
+                        let system = tree.spawn().expect("the benchmark runtime is active");
+                        system
+                            .wait_started()
+                            .await
+                            .expect("the first incarnation becomes ready");
+                        stable.notified().await;
+                        system
+                            .shutdown(DEADLINE)
+                            .await
+                            .expect("the stable incarnation shuts down");
+                    },
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+enum Observation {
+    None,
+    Snapshots(SnapshotReceiver),
+    Lifecycle(LifecycleEvents),
+    Both(SnapshotReceiver, LifecycleEvents),
+}
+
+impl Observation {
+    fn subscribe(mode: &str, scope: &ScopeRef) -> Self {
+        match mode {
+            "none" => Self::None,
+            "snapshots" => Self::Snapshots(scope.subscribe_snapshots()),
+            "lifecycle" => Self::Lifecycle(scope.subscribe_lifecycle()),
+            "both" => Self::Both(scope.subscribe_snapshots(), scope.subscribe_lifecycle()),
+            _ => unreachable!("the benchmark supplies a known observation mode"),
+        }
+    }
+
+    fn retain(&self) {
+        match self {
+            Self::None => {}
+            Self::Snapshots(receiver) => {
+                black_box(receiver);
+            }
+            Self::Lifecycle(events) => {
+                black_box(events);
+            }
+            Self::Both(receiver, events) => {
+                black_box((receiver, events));
+            }
+        }
+    }
+}
+
+fn start_dynamic(runtime: &Runtime) -> (System<DynamicScopeRef>, DynamicScopeRef) {
+    runtime.block_on(async {
+        let system = DynamicTree::new()
+            .spawn()
+            .expect("the benchmark runtime is active");
+        system
+            .wait_started()
+            .await
+            .expect("the empty dynamic root starts");
+        let scope = system.scope();
+        (system, scope)
+    })
+}
+
+fn stop_dynamic(runtime: &Runtime, system: System<DynamicScopeRef>) {
+    runtime.block_on(async {
+        system
+            .shutdown(DEADLINE)
+            .await
+            .expect("the dynamic benchmark root shuts down");
+    });
+}
+
+fn bench_dynamic_churn(c: &mut Criterion, runtime_name: &str, runtime: &Runtime) {
+    let mut group = c.benchmark_group(format!("lifecycle/{runtime_name}/dynamic_churn"));
+    group.throughput(Throughput::Elements(CHURN_CYCLES as u64));
+
+    for mode in ["none", "snapshots", "lifecycle", "both"] {
+        let (system, scope) = start_dynamic(runtime);
+        let observation = Observation::subscribe(mode, scope.as_scope());
+        group.bench_function(mode, |b| {
+            b.to_async(runtime).iter(|| async {
+                for _ in 0..CHURN_CYCLES {
+                    let task = scope
+                        .add_task("worker", cooperative_task())
+                        .await
+                        .expect("the dynamic benchmark admits its task");
+                    let outcome = scope.remove_task(&task).await;
+                    black_box(outcome);
+                    debug_assert_eq!(outcome, RemoveOutcome::Removed);
+                }
+            });
+        });
+        observation.retain();
+        stop_dynamic(runtime, system);
+    }
+    group.finish();
+}
+
+fn run_runtime(c: &mut Criterion, name: &str, runtime: Runtime) {
+    bench_cold_lifecycle(c, name, &runtime);
+    bench_restarts(c, name, &runtime);
+    bench_dynamic_churn(c, name, &runtime);
+}
+
+fn bench_lifecycle(c: &mut Criterion) {
+    let current_thread = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("the current-thread benchmark runtime builds");
+    run_runtime(c, "current_thread", current_thread);
+
+    let multi_thread = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("the multi-thread benchmark runtime builds");
+    run_runtime(c, "multi_thread_4", multi_thread);
+}
+
+criterion_group!(benches, bench_lifecycle);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

- benchmark cold spawn/start/shutdown/join for ordered and dynamic trees from width 1 to 256
- benchmark recursively lowered tree depths from 1 to 32
- measure immediate-restart cycles from 0 to 32 before settling on a stable incarnation
- benchmark live dynamic add/remove churn with no subscriber, a drained snapshot subscriber, a drained lifecycle subscriber, and both
- cover current-thread and four-worker Tokio runtime configurations

What is timed, precisely:

- **Cold width.** All N `TaskDef`s are built in setup, so only `spawn`, lowering, startup, shutdown, and join are timed.
- **Cold depth.** Only the outermost level is built in setup. `SubtreeDef::factory` stores the recursion, so a depth-32 sample constructs 31 further trees and their definition `Arc`s *inside* the timed region. Deliberate for a cold-lifecycle sweep, but the depth and width numbers are not directly comparable on that axis.
- **Immediate restarts.** A whole system lifecycle, including `spawn`, `wait_started`, `shutdown`, and the root driver join. This group reports **no element rate**: dividing by the restart count would charge each restart with the fixed lifecycle cost. A zero-restart point is included so the marginal restart cost is derivable by differencing.
- **Dynamic churn.** The root is started outside the timed region. Each cycle admits a task, waits for that incarnation's first poll, then removes it. The rendezvous is inside the timed region and is there for determinism — without it the removal latch races the driver's start transaction, the `Removing` mark suppresses the `Ready` edge, and the emitted edge count varies between four and five per cycle on the multi-thread runtime.
- **Observation arms.** Each subscribing arm parks a dedicated consumer task on its stream for the whole arm, so publication has a real waiter to wake and the lifecycle broadcast ring does not saturate. The arms measure the keeping-up-consumer regime.

`none` is not an observation-free baseline for the lifecycle lane: snapshot publication skips a scope with no receivers, but lifecycle emission has no such gate. Filed as #477; it is a framework change and deliberately not made here.

Stacked on #470 (and #467).

## Validation

- `./tools/dev just ci`
- `./tools/dev just bench-check`
- `./tools/dev cargo bench --locked --manifest-path tools/benchmarks/Cargo.toml --bench lifecycle -- --test`
- `./tools/dev nix build .#checks.x86_64-linux.benchmark-check --no-link --no-update-lock-file`
