### PR TITLE
Make admission announcement target its residency slot

### DIFF
--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -945,13 +945,6 @@ impl ScopeCell {
         terminalized.expect("a supervised terminal child must remain in parent residency")
     }
 
-    /// Installs residency without announcing it, as an admission that
-    /// unwound between its residency push and its `Added` publication does.
-    #[cfg(test)]
-    fn push_unannounced_resident_for_test(&self, child: ResidentProjection) {
-        self.current_children().push(ResidentChild::new(child));
-    }
-
     #[cfg(test)]
     pub(crate) fn prune_child(&self, member: &MemberCell) -> bool {
         self.with_observation_gate(|wakes| self.prune_child_locked(member, wakes))
@@ -2312,8 +2305,9 @@ mod tests {
         let mut lifecycle = root.subscribe_lifecycle();
 
         // Install residency exactly as an admission that unwound before its
-        // `Added` publication leaves it.
-        root.push_unannounced_resident_for_test(ResidentProjection::new(Arc::clone(&member), None));
+        // `Added` publication leaves it: the production push, with its slot
+        // dropped instead of announced.
+        drop(root.push_unannounced(ResidentProjection::new(Arc::clone(&member), None)));
         assert_eq!(root.resident_projections().len(), 1);
         assert!(root.snapshot().children.is_empty());
 

--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -101,6 +101,41 @@ impl ResidentChild {
     }
 }
 
+/// The exact residency slot installed by one in-flight admission.
+///
+/// The observation gate prevents a production admission from interleaving a
+/// second residency mutation, but the slot still carries its own index and
+/// membership. That makes the later announcement structurally address the
+/// resident whose `Added` edge is about to be published instead of relying on
+/// whichever child happens to be last.
+#[must_use = "an installed resident slot must be announced or withdrawn"]
+struct ResidentSlot<'a> {
+    children: &'a Mutex<Vec<ResidentChild>>,
+    index: usize,
+    membership: Membership,
+}
+
+impl ResidentSlot<'_> {
+    /// Marks this admission's exact resident as announced.
+    ///
+    /// The token and everything inspected under the residency mutex are plain
+    /// framework-owned data, so this adds no effect to the doubled observation
+    /// gate section's lock-rule accounting.
+    fn announce(self) -> bool {
+        let mut children = self
+            .children
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        children
+            .get_mut(self.index)
+            .filter(|resident| resident.projection().member.membership() == self.membership)
+            .is_some_and(|resident| {
+                resident.announced = true;
+                true
+            })
+    }
+}
+
 impl Drop for ResidentChild {
     fn drop(&mut self) {
         let Some(projection) = self.projection.take() else {
@@ -332,6 +367,18 @@ impl ScopeCell {
             .current_children
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn push_unannounced(&self, child: ResidentProjection) -> ResidentSlot<'_> {
+        let membership = child.member.membership();
+        let mut children = self.current_children();
+        let index = children.len();
+        children.push(ResidentChild::new(child));
+        ResidentSlot {
+            children: &self.observation.current_children,
+            index,
+            membership,
+        }
     }
 
     fn parent(&self) -> Option<Arc<ScopeCell>> {
@@ -1380,12 +1427,7 @@ impl ScopeCell {
         // what makes a lingering half-wired resident invisible rather than a
         // membership with only half its edges.
         let projection = child.clone();
-        let residency_index = {
-            let mut children = self.current_children();
-            let index = children.len();
-            children.push(ResidentChild::new(child));
-            index
-        };
+        let resident_slot = self.push_unannounced(child);
         let gate = self.current_observation_gate();
         let admitted = if let Some(scope) = &projection.scope {
             let admitted = scope.admit_observation_gate(self, &gate, txn);
@@ -1448,16 +1490,7 @@ impl ScopeCell {
         // missing or mismatched index prevents a different resident from being
         // paired with this Added edge and diagnoses the same no-interleaving
         // invariant as the refusal pop above.
-        let announced_is_admission = {
-            let mut children = self.current_children();
-            children
-                .get_mut(residency_index)
-                .filter(|resident| resident.projection().member.membership() == membership)
-                .is_some_and(|resident| {
-                    resident.announced = true;
-                    true
-                })
-        };
+        let announced_is_admission = resident_slot.announce();
         if !announced_is_admission {
             // Residency no longer holds this admission, so the lookup clone
             // can be the last member/mailbox owner. Move it into the
@@ -2125,6 +2158,27 @@ mod tests {
                 .expect("scope clear disposes the lingering mailbox payload"),
             retiring_thread,
             "scope clear retains the detached disposal venue"
+        );
+    }
+
+    #[test]
+    fn resident_slot_announces_its_index_when_a_later_resident_exists() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let first = child_member(&root, "first");
+        let second = child_member(&root, "second");
+
+        let first_slot = root.push_unannounced(ResidentProjection::new(first, None));
+        let _second_slot = root.push_unannounced(ResidentProjection::new(second, None));
+
+        assert!(
+            first_slot.announce(),
+            "the slot still addresses the resident installed before the later push"
+        );
+        let children = root.current_children();
+        assert!(children[0].announced, "the indexed resident is announced");
+        assert!(
+            !children[1].announced,
+            "announcing an earlier slot cannot mark the last resident"
         );
     }
 

--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -2182,6 +2182,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn resident_slot_refuses_a_different_membership_at_its_index() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let first = child_member(&root, "first");
+        let second = child_member(&root, "second");
+
+        let first_slot = root.push_unannounced(ResidentProjection::new(first, None));
+        let _second_slot = root.push_unannounced(ResidentProjection::new(second, None));
+        root.current_children().swap(0, 1);
+
+        assert!(
+            !first_slot.announce(),
+            "an index that now names another membership is not this admission's slot"
+        );
+        assert!(
+            root.current_children()
+                .iter()
+                .all(|resident| !resident.announced),
+            "a mismatched slot cannot announce either resident"
+        );
+    }
+
     /// Withdrawal mirrors announcement at both removal sites, not just the
     /// one `panicked_resident_admission_lingers_until_scope_clear` drives.
     #[test]

--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -101,16 +101,31 @@ impl ResidentChild {
     }
 }
 
+impl Drop for ResidentChild {
+    fn drop(&mut self) {
+        let Some(projection) = self.projection.take() else {
+            return;
+        };
+        discard_panic(catch_panic(|| drop(projection)).err());
+    }
+}
+
 /// The exact residency slot installed by one in-flight admission.
 ///
 /// The observation gate prevents a production admission from interleaving a
 /// second residency mutation, but the slot still carries its own index and
-/// membership. That makes the later announcement structurally address the
-/// resident whose `Added` edge is about to be published instead of relying on
-/// whichever child happens to be last.
-#[must_use = "an installed resident slot must be announced or withdrawn"]
+/// membership. That makes both of admission's later residency edits —
+/// announcement on success, withdrawal on refusal — structurally address the
+/// resident this admission installed instead of relying on whichever child
+/// happens to be last.
+///
+/// Dropping the token unconsumed is the containment path, not a leak: an
+/// unwind between the push and either edit deliberately leaves the resident
+/// installed and unannounced, so scope clear retires its possibly-last mailbox
+/// owner through detached disposal instead of unwinding it under the gate.
+#[must_use = "an installed resident slot is announced on success and withdrawn on refusal"]
 struct ResidentSlot<'a> {
-    children: &'a Mutex<Vec<ResidentChild>>,
+    scope: &'a ScopeCell,
     index: usize,
     membership: Membership,
 }
@@ -118,14 +133,12 @@ struct ResidentSlot<'a> {
 impl ResidentSlot<'_> {
     /// Marks this admission's exact resident as announced.
     ///
-    /// The token and everything inspected under the residency mutex are plain
-    /// framework-owned data, so this adds no effect to the doubled observation
-    /// gate section's lock-rule accounting.
+    /// Returns whether the slot still holds it. The token and everything
+    /// inspected under the residency mutex are plain framework-owned data, so
+    /// this adds no effect to the doubled observation gate section's lock-rule
+    /// accounting.
     fn announce(self) -> bool {
-        let mut children = self
-            .children
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut children = self.scope.current_children();
         children
             .get_mut(self.index)
             .filter(|resident| resident.projection().member.membership() == self.membership)
@@ -134,14 +147,22 @@ impl ResidentSlot<'_> {
                 true
             })
     }
-}
 
-impl Drop for ResidentChild {
-    fn drop(&mut self) {
-        let Some(projection) = self.projection.take() else {
-            return;
-        };
-        discard_panic(catch_panic(|| drop(projection)).err());
+    /// Removes this admission's resident again, publishing neither edge.
+    ///
+    /// Returns the displaced resident together with whether the slot still
+    /// held this admission's own. Popping is the diagnostic: no other
+    /// residency mutation may interleave under the observation gate, so the
+    /// entry this slot installed must still be the final one. A displaced
+    /// resident can own the last handle to a mailbox holding unread user
+    /// messages, so it is handed back by value for the caller to retire after
+    /// unlock rather than dropped here.
+    #[must_use = "a displaced resident retires after unlock, and the verdict is a diagnostic"]
+    fn withdraw(self) -> (Option<ResidentChild>, bool) {
+        let mut children = self.scope.current_children();
+        let is_admission = children.len() == self.index + 1
+            && children[self.index].projection().member.membership() == self.membership;
+        (children.pop(), is_admission)
     }
 }
 
@@ -375,7 +396,7 @@ impl ScopeCell {
         let index = children.len();
         children.push(ResidentChild::new(child));
         ResidentSlot {
-            children: &self.observation.current_children,
+            scope: self,
             index,
             membership,
         }
@@ -1464,14 +1485,11 @@ impl ScopeCell {
             )
         };
         if !admitted {
-            // No other residency mutation can interleave under the gate, so
-            // the entry pushed above is still the last one. Refusal removes
-            // it without emitting either half of the Added/Removed pair and
-            // retires its potentially last mailbox owner after unlock.
-            let rejected = self.current_children().pop();
-            let rejected_is_admission = rejected.as_ref().is_some_and(|rejected| {
-                rejected.projection().member.membership() == projection.member.membership()
-            });
+            // Refusal withdraws through the same token the announcement below
+            // consumes: it removes the entry pushed above without emitting
+            // either half of the Added/Removed pair and retires its
+            // potentially last mailbox owner after unlock.
+            let (rejected, rejected_is_admission) = resident_slot.withdraw();
             // Move both the resident and this function's lookup clone into
             // the effect before diagnosing the structural pop-last
             // invariant. If that diagnostic ever fires, neither possibly-last
@@ -1489,7 +1507,7 @@ impl ScopeCell {
         // walks residency and skips whatever is still unannounced. Refusing a
         // missing or mismatched index prevents a different resident from being
         // paired with this Added edge and diagnoses the same no-interleaving
-        // invariant as the refusal pop above.
+        // invariant as the refusal withdrawal above.
         let announced_is_admission = resident_slot.announce();
         if !announced_is_admission {
             // Residency no longer holds this admission, so the lookup clone
@@ -2201,6 +2219,87 @@ mod tests {
                 .iter()
                 .all(|resident| !resident.announced),
             "a mismatched slot cannot announce either resident"
+        );
+    }
+
+    #[test]
+    fn resident_slot_withdraws_the_resident_it_installed() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let only = child_member(&root, "only");
+        let membership = only.membership();
+
+        let slot = root.push_unannounced(ResidentProjection::new(only, None));
+        let (rejected, is_admission) = slot.withdraw();
+
+        assert!(
+            is_admission,
+            "the slot still holds this admission's resident"
+        );
+        assert_eq!(
+            rejected
+                .expect("withdrawal hands the displaced resident back")
+                .projection()
+                .member
+                .membership(),
+            membership,
+            "withdrawal returns the resident the slot installed"
+        );
+        assert!(
+            root.current_children().is_empty(),
+            "withdrawal leaves no residency entry behind"
+        );
+    }
+
+    #[test]
+    fn resident_slot_withdrawal_refuses_an_interposed_resident() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let first = child_member(&root, "first");
+        let second = child_member(&root, "second");
+        let second_membership = second.membership();
+
+        let first_slot = root.push_unannounced(ResidentProjection::new(first, None));
+        let _second_slot = root.push_unannounced(ResidentProjection::new(second, None));
+        let (rejected, is_admission) = first_slot.withdraw();
+
+        assert!(
+            !is_admission,
+            "a slot that is no longer the final entry is not this admission's resident"
+        );
+        assert_eq!(
+            rejected
+                .expect("withdrawal still displaces the final resident")
+                .projection()
+                .member
+                .membership(),
+            second_membership,
+            "withdrawal displaces the last entry so residency cannot grow past a refusal"
+        );
+    }
+
+    #[test]
+    fn resident_slot_withdrawal_refuses_a_different_membership_at_its_index() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let first = child_member(&root, "first");
+        let second = child_member(&root, "second");
+        let first_membership = first.membership();
+
+        let _first_slot = root.push_unannounced(ResidentProjection::new(first, None));
+        let second_slot = root.push_unannounced(ResidentProjection::new(second, None));
+        root.current_children().swap(0, 1);
+        let (rejected, is_admission) = second_slot.withdraw();
+
+        assert!(
+            !is_admission,
+            "a final index that now names another membership is not this admission's slot"
+        );
+        assert_eq!(
+            rejected
+                .expect("withdrawal still displaces the final resident")
+                .projection()
+                .member
+                .membership(),
+            first_membership,
+            "the displaced resident is whichever entry the swap left last"
         );
     }
 


### PR DESCRIPTION
Stack: 1 of 3 for #437. This PR intentionally leaves #437 open; the driver-side ledger in PR3 completes the signed-off design.

Summary:
- replace the raw residency index convention with a must-use ResidentSlot returned by push_unannounced
- make announce consume that exact index-and-membership token
- preserve residency-first unwind containment and the real rejected_is_admission diagnostic
- add interposed-resident and membership-mismatch regression tests

Verification:
- ./tools/dev just ci (956 tests plus doctests, examples, docs, API reachability, manifest and Nix formatting checks)
- mutation check: changing ResidentSlot::announce back to last_mut makes resident_slot_announces_its_index_when_a_later_resident_exists fail
- mutation check: removing the membership guard makes resident_slot_refuses_a_different_membership_at_its_index fail
