### PR TITLE
Sever nested observation links on retirement

### DIFF
--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -2204,71 +2204,119 @@ mod tests {
         );
     }
 
+    /// The venues that withdraw a resident from its scope. Every one of them
+    /// severs, so each pin below runs against all three.
+    #[derive(Clone, Copy, Debug)]
+    enum Retirement {
+        Prune,
+        Clear,
+        Replace,
+    }
+
+    impl Retirement {
+        fn retire(self, root: &Arc<ScopeCell>, member: &MemberCell) {
+            match self {
+                Self::Prune => assert!(root.prune_child(member)),
+                Self::Clear => root.clear_residents(),
+                Self::Replace => assert!(root.set_admitted_children(Vec::new())),
+            }
+        }
+    }
+
     #[test]
-    fn clearing_unannounced_nested_resident_severs_its_parent_link() {
+    fn retiring_an_unannounced_nested_resident_severs_its_parent_link() {
+        for retirement in [Retirement::Prune, Retirement::Clear, Retirement::Replace] {
+            let root = isolated_scope("root", ScopeFlavor::Ordered);
+            let nested = child_scope(&root, "nested", ScopeFlavor::Dynamic);
+            let mut root_lifecycle = root.subscribe_lifecycle();
+            let mut nested_lifecycle = nested.subscribe_lifecycle();
+
+            // `set_parent` installs the back-link before this poisoned control
+            // lock unwinds the admission, leaving an unannounced resident behind.
+            let poisoned = Arc::clone(&nested);
+            assert!(
+                catch_unwind(AssertUnwindSafe(move || {
+                    let _control = poisoned.control.lock().expect("control starts healthy");
+                    panic!("inject admission bookkeeping panic");
+                }))
+                .is_err()
+            );
+            catch_unwind(AssertUnwindSafe(|| {
+                let _ = root.admit_child(ResidentProjection::new(
+                    Arc::clone(&nested.member),
+                    Some(Arc::clone(&nested)),
+                ));
+            }))
+            .expect_err("poisoned parent wiring unwinds admission");
+
+            assert!(Arc::ptr_eq(
+                &nested
+                    .parent()
+                    .expect("the failed admission installed its link"),
+                &root
+            ));
+            retirement.retire(&root, &nested.member);
+            assert!(
+                nested.parent().is_none(),
+                "{retirement:?} severs an unannounced resident's parent link"
+            );
+            assert_eq!(
+                root_lifecycle.try_recv(),
+                Err(LifecycleTryRecvError::Empty),
+                "the failed admission published neither membership edge"
+            );
+
+            nested.set_state(ScopeState::Stopped {
+                reason: StopReason::Finished,
+            });
+            assert!(matches!(
+                nested_lifecycle.try_recv(),
+                Ok(LifecycleItem::Event(_))
+            ));
+            assert_eq!(
+                root_lifecycle.try_recv(),
+                Err(LifecycleTryRecvError::Empty),
+                "post-retirement events stay local to the removed subtree ({retirement:?})"
+            );
+        }
+    }
+
+    /// Retirement severs; destroying a resident child does not.
+    ///
+    /// A refused duplicate admission temporarily owns a second `ResidentChild`
+    /// for an already-resident subtree and then disposes it, so a sever in
+    /// `Drop` would detach a subtree that is still resident under its original
+    /// parent. `rejected_nested_admission_preserves_original_parent_and_gate`
+    /// walks that refusal path, but it retires the duplicate through *detached*
+    /// disposal — the assertion outruns the drop, so only this synchronous
+    /// destruction pins the venue.
+    #[test]
+    fn destroying_a_resident_child_leaves_the_subtree_parent_link_installed() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
         let nested = child_scope(&root, "nested", ScopeFlavor::Dynamic);
-        let mut root_lifecycle = root.subscribe_lifecycle();
-        let mut nested_lifecycle = nested.subscribe_lifecycle();
+        assert!(root.admit_child(ResidentProjection::new(
+            Arc::clone(&nested.member),
+            Some(Arc::clone(&nested)),
+        )));
 
-        // `set_parent` installs the back-link before this poisoned control
-        // lock unwinds the admission, leaving an unannounced resident behind.
-        let poisoned = Arc::clone(&nested);
+        drop(ResidentChild::new(ResidentProjection::new(
+            Arc::clone(&nested.member),
+            Some(Arc::clone(&nested)),
+        )));
+
         assert!(
-            catch_unwind(AssertUnwindSafe(move || {
-                let _control = poisoned.control.lock().expect("control starts healthy");
-                panic!("inject admission bookkeeping panic");
-            }))
-            .is_err()
-        );
-        catch_unwind(AssertUnwindSafe(|| {
-            let _ = root.admit_child(ResidentProjection::new(
-                Arc::clone(&nested.member),
-                Some(Arc::clone(&nested)),
-            ));
-        }))
-        .expect_err("poisoned parent wiring unwinds admission");
-
-        assert!(Arc::ptr_eq(
-            &nested
-                .parent()
-                .expect("the failed admission installed its link"),
-            &root
-        ));
-        root.clear_residents();
-        assert!(
-            nested.parent().is_none(),
-            "retiring an unannounced resident severs its parent link"
-        );
-        assert_eq!(
-            root_lifecycle.try_recv(),
-            Err(LifecycleTryRecvError::Empty),
-            "the failed admission published neither membership edge"
-        );
-
-        nested.set_state(ScopeState::Stopped {
-            reason: StopReason::Finished,
-        });
-        assert!(matches!(
-            nested_lifecycle.try_recv(),
-            Ok(LifecycleItem::Event(_))
-        ));
-        assert_eq!(
-            root_lifecycle.try_recv(),
-            Err(LifecycleTryRecvError::Empty),
-            "post-retirement events stay local to the removed subtree"
+            Arc::ptr_eq(
+                &nested
+                    .parent()
+                    .expect("residency still owns the upward observation edge"),
+                &root
+            ),
+            "a duplicate resident's destruction must not sever the original"
         );
     }
 
     #[test]
     fn announced_nested_retirement_makes_removed_the_last_parent_event() {
-        #[derive(Clone, Copy, Debug)]
-        enum Retirement {
-            Prune,
-            Clear,
-            Replace,
-        }
-
         for retirement in [Retirement::Prune, Retirement::Clear, Retirement::Replace] {
             let root = isolated_scope("root", ScopeFlavor::Ordered);
             let nested = child_scope(&root, "nested", ScopeFlavor::Dynamic);
@@ -2291,11 +2339,7 @@ mod tests {
                 })) if added == membership
             ));
 
-            match retirement {
-                Retirement::Prune => assert!(root.prune_child(&nested.member)),
-                Retirement::Clear => root.clear_residents(),
-                Retirement::Replace => assert!(root.set_admitted_children(Vec::new())),
-            }
+            retirement.retire(&root, &nested.member);
             assert!(matches!(
                 root_lifecycle.try_recv(),
                 Ok(LifecycleItem::Event(LifecycleEvent {

--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -1817,7 +1817,7 @@ mod tests {
 
     use super::*;
     use crate::cells::{
-        LifecycleItem, LifecycleTryRecvError,
+        LifecycleEvent, LifecycleItem, LifecycleTryRecvError,
         test_support::{TEST_WAIT, ThreadProbe, child_member, child_scope, isolated_scope},
     };
 
@@ -2261,42 +2261,104 @@ mod tests {
     }
 
     #[test]
-    fn clearing_announced_nested_resident_makes_removed_the_last_parent_event() {
+    fn announced_nested_retirement_makes_removed_the_last_parent_event() {
+        #[derive(Clone, Copy, Debug)]
+        enum Retirement {
+            Prune,
+            Clear,
+            Replace,
+        }
+
+        for retirement in [Retirement::Prune, Retirement::Clear, Retirement::Replace] {
+            let root = isolated_scope("root", ScopeFlavor::Ordered);
+            let nested = child_scope(&root, "nested", ScopeFlavor::Dynamic);
+            let membership = nested.member.membership();
+            let mut root_lifecycle = root.subscribe_lifecycle();
+            let mut nested_lifecycle = nested.subscribe_lifecycle();
+
+            assert!(root.admit_child(ResidentProjection::new(
+                Arc::clone(&nested.member),
+                Some(Arc::clone(&nested)),
+            )));
+            assert!(matches!(
+                root_lifecycle.try_recv(),
+                Ok(LifecycleItem::Event(LifecycleEvent {
+                    kind: LifecycleEventKind::Added {
+                        membership: added,
+                        ..
+                    },
+                    ..
+                })) if added == membership
+            ));
+
+            match retirement {
+                Retirement::Prune => assert!(root.prune_child(&nested.member)),
+                Retirement::Clear => root.clear_residents(),
+                Retirement::Replace => assert!(root.set_admitted_children(Vec::new())),
+            }
+            assert!(matches!(
+                root_lifecycle.try_recv(),
+                Ok(LifecycleItem::Event(LifecycleEvent {
+                    kind: LifecycleEventKind::Removed {
+                        membership: removed,
+                        ..
+                    },
+                    ..
+                })) if removed == membership
+            ));
+            assert!(
+                nested.parent().is_none(),
+                "{retirement:?} withdraws the resident's upward observation edge"
+            );
+
+            nested.set_state(ScopeState::Stopped {
+                reason: StopReason::Finished,
+            });
+            assert!(matches!(
+                nested_lifecycle.try_recv(),
+                Ok(LifecycleItem::Event(LifecycleEvent {
+                    kind: LifecycleEventKind::ScopeState {
+                        state: ScopeState::Stopped {
+                            reason: StopReason::Finished,
+                        },
+                    },
+                    ..
+                }))
+            ));
+            assert_eq!(
+                root_lifecycle.try_recv(),
+                Err(LifecycleTryRecvError::Empty),
+                "Removed is the parent stream's final word about the subtree ({retirement:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn nested_retirement_tolerates_a_poisoned_parent_link() {
         let root = isolated_scope("root", ScopeFlavor::Ordered);
         let nested = child_scope(&root, "nested", ScopeFlavor::Dynamic);
-        let mut root_lifecycle = root.subscribe_lifecycle();
-        let mut nested_lifecycle = nested.subscribe_lifecycle();
-
         assert!(root.admit_child(ResidentProjection::new(
             Arc::clone(&nested.member),
             Some(Arc::clone(&nested)),
         )));
-        assert!(matches!(
-            root_lifecycle.try_recv(),
-            Ok(LifecycleItem::Event(_))
-        ));
 
-        root.clear_residents();
-        assert!(matches!(
-            root_lifecycle.try_recv(),
-            Ok(LifecycleItem::Event(_))
-        ));
+        let poisoned = Arc::clone(&nested);
         assert!(
-            nested.parent().is_none(),
-            "retiring the resident withdraws its upward observation edge"
+            catch_unwind(AssertUnwindSafe(move || {
+                let _parent = poisoned
+                    .observation
+                    .parent
+                    .lock()
+                    .expect("parent link starts healthy");
+                panic!("inject parent-link poison");
+            }))
+            .is_err()
         );
 
-        nested.set_state(ScopeState::Stopped {
-            reason: StopReason::Finished,
-        });
-        assert!(matches!(
-            nested_lifecycle.try_recv(),
-            Ok(LifecycleItem::Event(_))
-        ));
-        assert_eq!(
-            root_lifecycle.try_recv(),
-            Err(LifecycleTryRecvError::Empty),
-            "Removed is the parent stream's final word about the subtree"
+        root.clear_residents();
+        assert!(
+            nested.parent().is_none(),
+            "retirement recovers the parent link and severs it"
         );
     }
 

--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -99,6 +99,18 @@ impl ResidentChild {
             .as_ref()
             .expect("a resident child owns its projection until it is dropped")
     }
+
+    /// Withdraws the upward observation edge for the resident being retired.
+    ///
+    /// This is deliberately not part of `Drop`: a refused duplicate admission
+    /// temporarily owns a `ResidentChild`, but must not sever the subtree from
+    /// its original parent. Prune and displacement call this only after they
+    /// have selected their own resident for retirement.
+    fn sever_parent(&self) {
+        if let Some(scope) = &self.projection().scope {
+            scope.sever_parent();
+        }
+    }
 }
 
 impl Drop for ResidentChild {
@@ -411,6 +423,14 @@ impl ScopeCell {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .as_ref()
             .and_then(Weak::upgrade)
+    }
+
+    fn sever_parent(&self) {
+        *self
+            .observation
+            .parent
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
     }
 
     #[cfg(test)]
@@ -966,6 +986,11 @@ impl ScopeCell {
         let Some(resident) = resident else {
             return false;
         };
+        // Residency is the ownership edge for upward observation. Withdraw
+        // the nested scope's parent link in the same gate transaction that
+        // removes the resident, before publishing `Removed` or retiring its
+        // graph. An unannounced resident takes this path too.
+        resident.sever_parent();
         // Mirror the announcement: a resident an unwound admission installed
         // never published `Added`, and SPEC §3.2's pairing is both edges or
         // neither. It is still withdrawn and disposed.
@@ -1524,6 +1549,13 @@ impl ScopeCell {
             let mut children = self.current_children();
             std::mem::take(&mut *children)
         };
+        // Sever each nested observation edge before any `Removed` publication
+        // or detached graph retirement. The parent mutex contains only a
+        // framework-owned weak link, so this remains legal under the resident
+        // tree's observation gate.
+        for resident in &residents {
+            resident.sever_parent();
+        }
         // An unannounced resident is one an admission installed and then
         // unwound past. It never published `Added`, so SPEC §3.2's exact
         // pairing forbids publishing its `Removed`; it is still displaced and
@@ -2169,6 +2201,102 @@ mod tests {
                 .expect("scope clear disposes the lingering mailbox payload"),
             retiring_thread,
             "scope clear retains the detached disposal venue"
+        );
+    }
+
+    #[test]
+    fn clearing_unannounced_nested_resident_severs_its_parent_link() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let nested = child_scope(&root, "nested", ScopeFlavor::Dynamic);
+        let mut root_lifecycle = root.subscribe_lifecycle();
+        let mut nested_lifecycle = nested.subscribe_lifecycle();
+
+        // `set_parent` installs the back-link before this poisoned control
+        // lock unwinds the admission, leaving an unannounced resident behind.
+        let poisoned = Arc::clone(&nested);
+        assert!(
+            catch_unwind(AssertUnwindSafe(move || {
+                let _control = poisoned.control.lock().expect("control starts healthy");
+                panic!("inject admission bookkeeping panic");
+            }))
+            .is_err()
+        );
+        catch_unwind(AssertUnwindSafe(|| {
+            let _ = root.admit_child(ResidentProjection::new(
+                Arc::clone(&nested.member),
+                Some(Arc::clone(&nested)),
+            ));
+        }))
+        .expect_err("poisoned parent wiring unwinds admission");
+
+        assert!(Arc::ptr_eq(
+            &nested
+                .parent()
+                .expect("the failed admission installed its link"),
+            &root
+        ));
+        root.clear_residents();
+        assert!(
+            nested.parent().is_none(),
+            "retiring an unannounced resident severs its parent link"
+        );
+        assert_eq!(
+            root_lifecycle.try_recv(),
+            Err(LifecycleTryRecvError::Empty),
+            "the failed admission published neither membership edge"
+        );
+
+        nested.set_state(ScopeState::Stopped {
+            reason: StopReason::Finished,
+        });
+        assert!(matches!(
+            nested_lifecycle.try_recv(),
+            Ok(LifecycleItem::Event(_))
+        ));
+        assert_eq!(
+            root_lifecycle.try_recv(),
+            Err(LifecycleTryRecvError::Empty),
+            "post-retirement events stay local to the removed subtree"
+        );
+    }
+
+    #[test]
+    fn clearing_announced_nested_resident_makes_removed_the_last_parent_event() {
+        let root = isolated_scope("root", ScopeFlavor::Ordered);
+        let nested = child_scope(&root, "nested", ScopeFlavor::Dynamic);
+        let mut root_lifecycle = root.subscribe_lifecycle();
+        let mut nested_lifecycle = nested.subscribe_lifecycle();
+
+        assert!(root.admit_child(ResidentProjection::new(
+            Arc::clone(&nested.member),
+            Some(Arc::clone(&nested)),
+        )));
+        assert!(matches!(
+            root_lifecycle.try_recv(),
+            Ok(LifecycleItem::Event(_))
+        ));
+
+        root.clear_residents();
+        assert!(matches!(
+            root_lifecycle.try_recv(),
+            Ok(LifecycleItem::Event(_))
+        ));
+        assert!(
+            nested.parent().is_none(),
+            "retiring the resident withdraws its upward observation edge"
+        );
+
+        nested.set_state(ScopeState::Stopped {
+            reason: StopReason::Finished,
+        });
+        assert!(matches!(
+            nested_lifecycle.try_recv(),
+            Ok(LifecycleItem::Event(_))
+        ));
+        assert_eq!(
+            root_lifecycle.try_recv(),
+            Err(LifecycleTryRecvError::Empty),
+            "Removed is the parent stream's final word about the subtree"
         );
     }
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -3564,6 +3564,11 @@ Ordering and delivery contract:
   Forwarding preserves each origin scope's order and the causal edges — a
   child's `Added → Started/Ready/… → Removed` chain is never reordered,
   and a subtree child's own `Added` precedes any event from inside it.
+  Forwarding lasts only while the nested scope is resident: residency
+  withdrawal severs its parent link before publishing `Removed`, making
+  `Removed` the containing scope's last word about that subtree. Events the
+  removed subtree emits later remain on its own stream and do not reach the
+  former parent's stream.
 - Subscriptions and the snapshot watch are membership-owned, like the
   mailbox binding (§5.4): they ride the scope's own restarts, and they
   exist from cell creation (§3.2) — a subscription through a pre-spawn


### PR DESCRIPTION
Stack: 2 of 3 for #437, based on #473.

Summary:
- sever the parent back-link only after prune or displacement selects its resident for retirement
- cover announced and unannounced panic-resident retirement while preserving rejected duplicate parentage
- amend SPEC B.4 so Removed is the former parent stream final word about a subtree
- invert both verify-admission probes and prove later events remain on the removed subtree local stream
- pin prune, explicit clear, and residency-replacement retirement independently, including poisoned parent-link recovery

Verification:
- ./tools/dev just ci (959 tests plus doctests, examples, docs, API reachability, manifest and Nix formatting checks)
- mutation check: replacing the common sever with a no-op fails the announced, unannounced, and poison-tolerance regressions
- mutation check: omitting only the prune-path sever fails the prune retirement case while the prior 386-test library suite remained green

Closes #435