### PR TITLE
Make dynamic admission installs unwind-safe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,8 +170,9 @@ rests on:
   root gate while calling `admit_child_locked`, but the reserved member was
   already adopted onto that root gate and the root cannot be re-homed while
   its dynamic route is live, so the handoff check short-circuits without a
-  second gate acquisition. Changing either publication or re-homing invariant
-  requires re-deriving this exception.
+  second gate acquisition. `AdmissionInstall` debug-asserts that identity when
+  it takes ownership, before either guard is acquired. Changing either
+  publication or re-homing invariant requires re-deriving this exception.
   `WakerProxy`'s mutex (`crates/shelterwood-core/src/waker_proxy.rs`) sits at the
   other end of that order: it is a **leaf**. `wake_by_ref` acquires it from
   whatever thread drives the external primitive — the timer driver, a sender,

--- a/crates/shelterwood/src/cells/scope.rs
+++ b/crates/shelterwood/src/cells/scope.rs
@@ -395,6 +395,18 @@ impl ScopeCell {
         })
     }
 
+    /// Diagnostic for the dynamic admission install exemption.
+    ///
+    /// A reservation is adopted onto this scope's gate before publication and
+    /// the live dynamic route prevents the root from being re-homed. The
+    /// driver asserts that invariant when it creates the install ledger, so
+    /// the later handoff check cannot acquire another gate under dynamic
+    /// state.
+    pub(crate) fn shares_observation_gate_with(&self, member: &MemberCell) -> bool {
+        self.current_observation_gate()
+            .shares_gate(&member.current_observation_gate())
+    }
+
     fn current_children(&self) -> MutexGuard<'_, Vec<ResidentChild>> {
         self.observation
             .current_children

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -9,7 +9,6 @@ mod startup;
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    mem::ManuallyDrop,
     ops::{Index, IndexMut},
     sync::{Arc, OnceLock},
     time::Instant,
@@ -105,14 +104,18 @@ fn resident_projection(slot: &SlotCell) -> ResidentProjection {
 /// runs after both control-plane guards have gone: it retires the projection
 /// through detached disposal and completes the caller's response fail-closed.
 ///
-/// `request` is manual so that deleting this destructor cannot silently fall
-/// back through `AdmissionRequest`'s field drop. The ledger, rather than field
-/// order, is the structural owner of the lost-response contract.
+/// The ledger is the *primary* owner of the lost-response contract, not the
+/// only one: `request` stays a plain `Option<AdmissionRequest>` so its own
+/// `Obligation` still discharges the caller's promise on any path this
+/// destructor fails to cover, as SPEC §15.5 requires of every cross-task
+/// promise. Field order below is the Drop body's order, so even the bare
+/// fallback keeps terminality ahead of the removal completion and both ahead
+/// of the response.
 struct AdmissionInstall {
-    request: Option<ManuallyDrop<AdmissionRequest>>,
     projection: Option<ResidentProjection>,
     child: Option<Box<ChildRuntime>>,
     entry: Option<DynamicEntry>,
+    request: Option<AdmissionRequest>,
     key: Option<ChildKey>,
     entry_promoted: bool,
     entry_installed: bool,
@@ -127,7 +130,7 @@ impl AdmissionInstall {
         );
         Self {
             projection: Some(resident_projection(&request.slot)),
-            request: Some(ManuallyDrop::new(request)),
+            request: Some(request),
             child: Some(Box::new(child)),
             entry: None,
             key: None,
@@ -139,22 +142,20 @@ impl AdmissionInstall {
 
     fn request(&self) -> &AdmissionRequest {
         self.request
-            .as_deref()
+            .as_ref()
             .expect("an unfinished admission install owns its request")
     }
 
     fn request_mut(&mut self) -> &mut AdmissionRequest {
         self.request
-            .as_deref_mut()
+            .as_mut()
             .expect("an unfinished admission install owns its request")
     }
 
     fn take_request(&mut self) -> AdmissionRequest {
-        ManuallyDrop::into_inner(
-            self.request
-                .take()
-                .expect("an admission install releases its request once"),
-        )
+        self.request
+            .take()
+            .expect("an admission install releases its request once")
     }
 
     fn slot(&self) -> &Arc<SlotCell> {
@@ -296,8 +297,7 @@ impl Drop for AdmissionInstall {
         if let Some(entry) = self.entry.take() {
             panics.run(move || drop(entry));
         }
-        if let Some(request) = self.request.take() {
-            let mut request = ManuallyDrop::into_inner(request);
+        if let Some(mut request) = self.request.take() {
             panics.run(|| request.complete_lost());
             panics.run(move || drop(request));
         }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -9,6 +9,7 @@ mod startup;
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    mem::ManuallyDrop,
     ops::{Index, IndexMut},
     sync::{Arc, OnceLock},
     time::Instant,
@@ -33,7 +34,7 @@ use crate::{
     ScopeState, ShutdownStraggler, ShutdownTimeout, StartupFailure, StartupFailureCause,
     cells::{
         LifecycleEventKind, MemberCell, MemberStage, MemberTransition, NotAdmittingCause,
-        ReserveError, ResidentProjection, RetainedExit, RetainedRecordedOutcome,
+        ObservationTxn, ReserveError, ResidentProjection, RetainedExit, RetainedRecordedOutcome,
         RetainedStopReason, ScopeCell, ScopeControlEvent, StartupDisposition,
         classify_disposal_panic_retaining, classify_exit_retaining,
         reconcile_recorded_outcomes_retaining,
@@ -66,7 +67,7 @@ use shelterwood_core::supervisor::{
 };
 
 use admission_control::{
-    AdmissionRequest, DynamicControl, DynamicEntry, cancel_dynamic_reservation_parts,
+    AdmissionRequest, DynamicControl, DynamicEntry, DynamicState, cancel_dynamic_reservation_parts,
     reject_admission_after_disposal,
 };
 pub(crate) use admission_control::{
@@ -93,6 +94,194 @@ pub(crate) struct SystemRun {
 
 fn resident_projection(slot: &SlotCell) -> ResidentProjection {
     ResidentProjection::new(Arc::clone(&slot.member), slot.scope.clone())
+}
+
+/// Owns the uncommitted prefix of one dynamic admission install.
+///
+/// The ledger is created before either the observation gate or dynamic-state
+/// mutex is acquired. It then claims the child runtime, exact resident
+/// projection, reserved entry, arena key, and response obligation as each
+/// effect lands. If any fallible step unwinds, its destructor consequently
+/// runs after both control-plane guards have gone: it retires the projection
+/// through detached disposal and completes the caller's response fail-closed.
+///
+/// `request` is manual so that deleting this destructor cannot silently fall
+/// back through `AdmissionRequest`'s field drop. The ledger, rather than field
+/// order, is the structural owner of the lost-response contract.
+struct AdmissionInstall {
+    request: Option<ManuallyDrop<AdmissionRequest>>,
+    projection: Option<ResidentProjection>,
+    child: Option<Box<ChildRuntime>>,
+    entry: Option<DynamicEntry>,
+    key: Option<ChildKey>,
+    entry_promoted: bool,
+    entry_installed: bool,
+    projection_admitted: bool,
+}
+
+impl AdmissionInstall {
+    fn new(root: &ScopeCell, request: AdmissionRequest, child: ChildRuntime) -> Self {
+        debug_assert!(
+            root.shares_observation_gate_with(&request.slot.member),
+            "a reserved admission slot stays on its live root's observation gate"
+        );
+        Self {
+            projection: Some(resident_projection(&request.slot)),
+            request: Some(ManuallyDrop::new(request)),
+            child: Some(Box::new(child)),
+            entry: None,
+            key: None,
+            entry_promoted: false,
+            entry_installed: false,
+            projection_admitted: false,
+        }
+    }
+
+    fn request(&self) -> &AdmissionRequest {
+        self.request
+            .as_deref()
+            .expect("an unfinished admission install owns its request")
+    }
+
+    fn request_mut(&mut self) -> &mut AdmissionRequest {
+        self.request
+            .as_deref_mut()
+            .expect("an unfinished admission install owns its request")
+    }
+
+    fn take_request(&mut self) -> AdmissionRequest {
+        ManuallyDrop::into_inner(
+            self.request
+                .take()
+                .expect("an admission install releases its request once"),
+        )
+    }
+
+    fn slot(&self) -> &Arc<SlotCell> {
+        &self.request().slot
+    }
+
+    fn take_child(&mut self) -> Box<ChildRuntime> {
+        self.child
+            .take()
+            .expect("an admission install inserts its child once")
+    }
+
+    fn claim_entry(&mut self, entry: DynamicEntry) {
+        self.entry = Some(entry);
+    }
+
+    fn record_key(&mut self, key: ChildKey) {
+        assert!(
+            self.key.replace(key).is_none(),
+            "an admission install claims one arena key"
+        );
+    }
+
+    fn promote_entry(&mut self, txn: &mut ObservationTxn<'_>) {
+        let key = self
+            .key
+            .expect("arena insertion precedes dynamic-entry promotion");
+        let fused_cancel = self.request_mut().fused_cancel.take();
+        self.entry_promoted = self
+            .entry
+            .as_mut()
+            .expect("promotion owns the claimed reservation")
+            .promote(key, fused_cancel, txn);
+    }
+
+    fn install_entry(&mut self, state: &mut DynamicState, txn: &mut ObservationTxn<'_>) {
+        let entry = self
+            .entry
+            .take()
+            .expect("the promoted entry remains owned until installation");
+        let id = entry.slot.member.id().clone();
+        match state.insert_vacant(id, entry, txn) {
+            Ok(()) => self.entry_installed = true,
+            Err(entry) => self.entry = Some(entry),
+        }
+    }
+
+    fn projection(&self) -> ResidentProjection {
+        self.projection
+            .as_ref()
+            .expect("the install owns its projection until commit")
+            .clone()
+    }
+
+    fn record_admission(&mut self, admitted: bool) {
+        self.projection_admitted = admitted;
+    }
+
+    fn finish(mut self) -> (AdmissionRequest, ChildKey) {
+        assert!(
+            self.entry_promoted,
+            "only a reservation can become resident"
+        );
+        assert!(
+            self.entry_installed,
+            "a promoted reservation returns to its exact dynamic entry"
+        );
+        assert!(
+            self.projection_admitted,
+            "a promoted reservation is admitted from `Reserved` exactly once"
+        );
+        assert!(
+            self.child.is_none() && self.entry.is_none(),
+            "a committed install leaves no runtime resource in its ledger"
+        );
+        let key = self
+            .key
+            .take()
+            .expect("a committed admission owns its arena key");
+        // Residency and the still-owned request slot both retain this exact
+        // projection, so surrendering the ledger copy is refcount traffic.
+        drop(
+            self.projection
+                .take()
+                .expect("a committed admission releases its projection once"),
+        );
+        (self.take_request(), key)
+    }
+
+    fn into_rejection(mut self) -> (AdmissionRequest, Option<DynamicEntry>) {
+        assert!(
+            self.key.is_none() && self.child.is_none(),
+            "only a pre-insertion admission can reject without an invariant"
+        );
+        // The rejected child and the request slot both retain the member graph, so this
+        // pre-residency projection copy can retire as refcount traffic.
+        drop(
+            self.projection
+                .take()
+                .expect("a rejected admission releases its projection once"),
+        );
+        let entry = self.entry.take();
+        (self.take_request(), entry)
+    }
+}
+
+impl Drop for AdmissionInstall {
+    fn drop(&mut self) {
+        let mut panics = runtime::PanicAccumulator::default();
+        if let Some(projection) = self.projection.take() {
+            panics.run(move || runtime::dispose_detached(projection));
+        }
+        // A child not yet inserted owns its never-started terminality
+        // fallback. Run it before dropping the claimed dynamic entry, whose
+        // removal completion must remain ordered after terminality.
+        if let Some(child) = self.child.take() {
+            panics.run(move || drop(child));
+        }
+        if let Some(entry) = self.entry.take() {
+            panics.run(move || drop(entry));
+        }
+        if let Some(request) = self.request.take() {
+            let mut request = ManuallyDrop::into_inner(request);
+            panics.run(|| request.complete_lost());
+            panics.run(move || drop(request));
+        }
+    }
 }
 
 impl SystemRun {
@@ -844,18 +1033,14 @@ impl ScopeRuntime {
         // the mailbox. Keep that fallible work outside the control-plane lock
         // so driver teardown can still close reservations and removals.
         let child = ChildRuntime::from_plan(plan, &self.root);
-        enum AdmissionInstall {
-            Admitted {
-                key: ChildKey,
-                entry_promoted: bool,
-                projection_admitted: bool,
-            },
-            Rejected {
-                child: Box<ChildRuntime>,
-                removed: Option<DynamicEntry>,
-                error: ReserveError,
-            },
+        struct AdmissionRejection {
+            child: Box<ChildRuntime>,
+            error: ReserveError,
         }
+        // Construct the ledger before either control-plane guard. On every
+        // unwind its destructor therefore runs only after the dynamic-state
+        // mutex and `ObservationTxn` have both released their locks.
+        let mut install = AdmissionInstall::new(&self.root, request, child);
         let root = Arc::clone(&self.root);
         let installed = root.with_observation_gate(|txn| {
             // The dynamic-state mutex rides inside the root gate here. The
@@ -867,103 +1052,77 @@ impl ScopeRuntime {
             // identity: it never acquires a second gate under `state`. This is
             // the install half of the admission exemption in AGENTS.md.
             let mut state = control.state.lock().expect("dynamic-state mutex poisoned");
-            let id = request.slot.member.id();
-            let matches_reservation = state.entry(id).is_some_and(|entry| {
-                entry.slot.member.membership() == request.slot.member.membership()
-                    && entry.is_reserved()
+            let id = install.slot().member.id().clone();
+            let membership = install.slot().member.membership();
+            let matches_reservation = state.entry(&id).is_some_and(|entry| {
+                entry.slot.member.membership() == membership && entry.is_reserved()
             });
-            if !matches_reservation || request.fused_cancel.as_ref().is_some_and(Latch::is_fired) {
-                let removed = matches_reservation.then(|| state.remove(id, txn)).flatten();
+            if !matches_reservation
+                || install
+                    .request()
+                    .fused_cancel
+                    .as_ref()
+                    .is_some_and(Latch::is_fired)
+            {
+                if matches_reservation && let Some(entry) = state.remove(&id, txn) {
+                    install.claim_entry(entry);
+                }
+                let child = install.take_child();
+                let slot = Arc::clone(install.slot());
                 drop(state);
-                request.slot.terminalize_never_started_locked(&root, txn);
-                return AdmissionInstall::Rejected {
-                    child: Box::new(child),
-                    removed,
+                slot.terminalize_never_started_locked(&root, txn);
+                return Err(AdmissionRejection {
+                    child,
                     error: ReserveError::NotAdmitting(NotAdmittingCause::ReservationEnded),
-                };
+                });
             }
+            install.claim_entry(
+                state
+                    .remove(&id, txn)
+                    .expect("the matching reservation remains claimed under dynamic state"),
+            );
             // The control-plane lock makes arena insertion and promotion one
             // state transition: an exact remover sees either the reservation
             // or a resident carrying its live arena key, never an unindexed
             // admitted intermediate.
-            let key = match self.insert_child(child, false) {
+            let child = install.take_child();
+            let key = match self.insert_child(*child, false) {
                 Ok(key) => key,
                 Err(child) => {
-                    let removed = state.remove(id, txn);
+                    let slot = Arc::clone(install.slot());
                     drop(state);
-                    request.slot.terminalize_never_started_locked(&root, txn);
-                    return AdmissionInstall::Rejected {
+                    slot.terminalize_never_started_locked(&root, txn);
+                    return Err(AdmissionRejection {
                         child,
-                        removed,
                         error: ReserveError::IdentityExhausted,
-                    };
+                    });
                 }
             };
-            let entry = state
-                .entry_mut(id)
-                .expect("the matching reservation was just resolved");
-            let entry_promoted = entry.promote(key, request.fused_cancel.take(), txn);
+            install.record_key(key);
+            install.promote_entry(txn);
+            install.install_entry(&mut state, txn);
             // The slot was minted `Reserved` by this reservation and nothing
             // can have started it, so the projection reducer accepts. A
             // refusal here would leave the entry promoted with no residency
             // behind it — see the partial-effect note on issue #392.
-            let admitted = root.admit_child_locked(resident_projection(&request.slot), txn);
-            AdmissionInstall::Admitted {
-                key,
-                entry_promoted,
-                projection_admitted: admitted,
+            if install.entry_installed {
+                let admitted = root.admit_child_locked(install.projection(), txn);
+                install.record_admission(admitted);
             }
+            Ok(())
         });
-        let key = match installed {
-            AdmissionInstall::Admitted {
-                key,
-                entry_promoted,
-                projection_admitted,
-            } => {
-                let invariant = if !entry_promoted {
-                    Some("only a reservation can become resident")
-                } else if !projection_admitted {
-                    Some("a promoted reservation is admitted from `Reserved` exactly once")
-                } else {
-                    None
-                };
-                if let Some(invariant) = invariant {
-                    // The control-plane guards are gone, but `request` still
-                    // owns the caller's response waker. Publish and contain
-                    // that fail-closed completion only after recording the
-                    // framework diagnostic, so neither its wake nor its drop
-                    // runs as ordinary panic-stack destruction and neither
-                    // can replace the primary invariant.
-                    //
-                    // `PanicAccumulator` contains rather than resumes on an
-                    // already-unwinding stack, so record the diagnostic only
-                    // when there is a stack to raise it on. Assuming a resume
-                    // would turn a contained failure into a double panic.
-                    let mut panics = runtime::PanicAccumulator::default();
-                    if !std::thread::panicking() {
-                        panics.run(|| panic!("{invariant}"));
-                    }
-                    panics.run(|| request.complete_lost());
-                    drop(panics);
-                    return;
-                }
-                key
-            }
-            AdmissionInstall::Rejected {
-                mut child,
-                removed,
-                error,
-            } => {
-                // The entry's drop completes its removal response; preserve
-                // the same terminality-before-completion ordering as every
-                // other reservation-cancellation path. Definition disposal
-                // is also complete before either waiter regains ownership.
-                child.complete_terminality();
-                let ChildRuntime { construction, .. } = *child;
-                reject_admission_after_disposal(request, Some(construction), removed, error);
-                return;
-            }
-        };
+        if let Err(AdmissionRejection { mut child, error }) = installed {
+            let (request, removed) = install.into_rejection();
+            // The entry's drop completes its removal response; preserve the
+            // same terminality-before-completion ordering as every other
+            // reservation-cancellation path. Definition disposal is also
+            // complete before either waiter regains ownership.
+            child.complete_terminality();
+            let ChildRuntime { construction, .. } = *child;
+            reject_admission_after_disposal(request, Some(construction), removed, error);
+            return;
+        }
+        let (mut request, key) = install.finish();
         #[cfg(test)]
         self.record_storage();
         request.complete(Ok(()));

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -167,6 +167,10 @@ impl AdmissionInstall {
             .expect("an admission install inserts its child once")
     }
 
+    fn restore_child(&mut self, child: Box<ChildRuntime>) {
+        self.child = Some(child);
+    }
+
     fn claim_entry(&mut self, entry: DynamicEntry) {
         self.entry = Some(entry);
     }
@@ -1067,12 +1071,11 @@ impl ScopeRuntime {
                 if matches_reservation && let Some(entry) = state.remove(&id, txn) {
                     install.claim_entry(entry);
                 }
-                let child = install.take_child();
                 let slot = Arc::clone(install.slot());
                 drop(state);
                 slot.terminalize_never_started_locked(&root, txn);
                 return Err(AdmissionRejection {
-                    child,
+                    child: install.take_child(),
                     error: ReserveError::NotAdmitting(NotAdmittingCause::ReservationEnded),
                 });
             }
@@ -1089,11 +1092,16 @@ impl ScopeRuntime {
             let key = match self.insert_child(*child, false) {
                 Ok(key) => key,
                 Err(child) => {
+                    // Keep the rejected runtime in the outer ledger across
+                    // locked terminalization. If publication panics, dropping
+                    // the runtime here could re-enter this observation gate
+                    // through its terminality obligation.
+                    install.restore_child(child);
                     let slot = Arc::clone(install.slot());
                     drop(state);
                     slot.terminalize_never_started_locked(&root, txn);
                     return Err(AdmissionRejection {
-                        child,
+                        child: install.take_child(),
                         error: ReserveError::IdentityExhausted,
                     });
                 }

--- a/crates/shelterwood/src/driver.rs
+++ b/crates/shelterwood/src/driver.rs
@@ -167,19 +167,35 @@ impl AdmissionInstall {
             .expect("an admission install inserts its child once")
     }
 
+    // The three claims below all land under both control-plane guards, so an
+    // overwrite would destroy the displaced value there: a `ChildRuntime`
+    // re-enters this very observation gate through its terminality fallback,
+    // and a `DynamicEntry` wakes a parked remover through its removal
+    // obligation. Each claim has exactly one caller and follows the matching
+    // take, so these stay diagnostics — and diagnostics under a lock the
+    // codebase `.expect()`s are `debug_assert!`s, never panics.
     fn restore_child(&mut self, child: Box<ChildRuntime>) {
+        debug_assert!(
+            self.child.is_none(),
+            "an admission install restores the runtime it took"
+        );
         self.child = Some(child);
     }
 
     fn claim_entry(&mut self, entry: DynamicEntry) {
+        debug_assert!(
+            self.entry.is_none(),
+            "an admission install claims one reservation"
+        );
         self.entry = Some(entry);
     }
 
     fn record_key(&mut self, key: ChildKey) {
-        assert!(
-            self.key.replace(key).is_none(),
+        debug_assert!(
+            self.key.is_none(),
             "an admission install claims one arena key"
         );
+        self.key = Some(key);
     }
 
     fn promote_entry(&mut self, txn: &mut ObservationTxn<'_>) {

--- a/crates/shelterwood/src/driver/admission_control.rs
+++ b/crates/shelterwood/src/driver/admission_control.rs
@@ -2,7 +2,7 @@
 
 use std::{
     any::Any,
-    collections::HashMap,
+    collections::{HashMap, hash_map::Entry},
     sync::{Arc, Mutex, Weak},
 };
 
@@ -202,6 +202,21 @@ impl DynamicState {
         _txn: &mut ObservationTxn<'_>,
     ) -> Option<DynamicEntry> {
         self.entries.insert(id, entry)
+    }
+
+    pub(super) fn insert_vacant(
+        &mut self,
+        id: ChildId,
+        entry: DynamicEntry,
+        _txn: &mut ObservationTxn<'_>,
+    ) -> Result<(), DynamicEntry> {
+        match self.entries.entry(id) {
+            Entry::Vacant(slot) => {
+                slot.insert(entry);
+                Ok(())
+            }
+            Entry::Occupied(_) => Err(entry),
+        }
     }
 
     pub(super) fn remove(

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -1,6 +1,49 @@
 use super::{super::AdmissionInstall, support::*};
 use crate::plan::ChildPlan;
 
+#[derive(Debug)]
+struct PanicTerminationMailbox;
+
+impl crate::mailbox::MailboxControl for PanicTerminationMailbox {
+    fn configure(
+        &self,
+        _mailbox: shelterwood_core::policy::ResolvedMailbox,
+        _effects: &mut dyn crate::mailbox::MailboxEffectSink,
+    ) -> crate::mailbox::MailboxBindToken {
+        crate::mailbox::MailboxBindToken::new(Arc::new(AtomicBool::new(false)))
+    }
+
+    fn bind(
+        &self,
+        _token: crate::mailbox::MailboxBindToken,
+        _incarnation: Incarnation,
+        _effects: &mut dyn crate::mailbox::MailboxEffectSink,
+    ) {
+    }
+
+    fn freeze(
+        &self,
+        _incarnation: Incarnation,
+        _effects: &mut dyn crate::mailbox::MailboxEffectSink,
+    ) {
+    }
+
+    fn close(
+        &self,
+        _incarnation: Incarnation,
+        _effects: &mut dyn crate::mailbox::MailboxEffectSink,
+    ) -> Option<crate::mailbox::MailboxClose> {
+        None
+    }
+
+    fn prepare_termination(
+        &self,
+        _effects: &mut dyn crate::mailbox::MailboxEffectSink,
+    ) -> Option<Box<dyn crate::mailbox::MailboxTermination>> {
+        panic!("injected locked admission terminalization panic")
+    }
+}
+
 #[crate::runtime::test]
 async fn refused_dynamic_admission_panics_after_control_plane_unlock() {
     let (mut scope, _events, mut dynamic_events, control) = running_dynamic_fixture();
@@ -104,6 +147,55 @@ async fn dropping_admission_install_completes_the_lost_response() {
     assert!(
         !root.observation_gate().is_poisoned(),
         "ledger fallback runs without the observation gate"
+    );
+}
+
+#[crate::runtime::test]
+async fn rejected_admission_retains_its_child_across_locked_terminalization() {
+    let (mut scope, _events, mut dynamic_events, control) = running_dynamic_fixture();
+    let root = Arc::clone(&scope.root);
+    let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
+        .expect("running dynamic scope reserves the child");
+    let member = Arc::clone(&reservation.slot.member);
+    member.attach_mailbox(Arc::new(PanicTerminationMailbox));
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new(|_| future::pending()).erase(),
+    ));
+    let (mut response, request) = begin_admission(&reservation, &mut dynamic_events, None).await;
+
+    // Make the post-conversion, under-lock reservation recheck reject. Its
+    // never-started terminalization then invokes the hostile framework seam
+    // above while the observation gate is held.
+    let removed = control
+        .state
+        .lock()
+        .expect("dynamic-state mutex starts healthy")
+        .entries_mut()
+        .remove(member.id())
+        .expect("the fixture removes its exact reserved entry");
+    drop(removed);
+
+    let (finished, completion) = std::sync::mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let result = catch_unwind(AssertUnwindSafe(|| scope.handle_admission(request)));
+        let _ = finished.send(result.is_err());
+    });
+
+    assert_eq!(
+        completion.recv_timeout(DRIVER_PROGRESS_WAIT),
+        Ok(true),
+        "the rejected child stays in AdmissionInstall until the gate-unlocking unwind; \
+         its terminality fallback must not re-enter the still-held gate"
+    );
+    assert!(matches!(
+        response.try_receive(),
+        Some(Err(ReserveError::NotAdmitting(
+            crate::NotAdmittingCause::Terminal
+        )))
+    ));
+    assert!(
+        !control.state.is_poisoned(),
+        "locked terminalization begins only after dynamic state is released"
     );
 }
 

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -1,4 +1,5 @@
-use super::support::*;
+use super::{super::AdmissionInstall, support::*};
+use crate::plan::ChildPlan;
 
 #[crate::runtime::test]
 async fn refused_dynamic_admission_panics_after_control_plane_unlock() {
@@ -29,8 +30,12 @@ async fn refused_dynamic_admission_panics_after_control_plane_unlock() {
     member.update(|record| record.stage = MemberStage::Running);
     let refusal = catch_unwind(AssertUnwindSafe(|| scope.handle_admission(request)))
         .expect_err("a refused dynamic admission fails closed in every profile");
+    let invariant = refusal
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| refusal.downcast_ref::<&str>().copied());
     assert_eq!(
-        refusal.downcast_ref::<String>().map(String::as_str),
+        invariant,
         Some("a promoted reservation is admitted from `Reserved` exactly once"),
         "the framework invariant stays primary over the hostile response wake"
     );
@@ -69,6 +74,37 @@ async fn refused_dynamic_admission_panics_after_control_plane_unlock() {
     // fail-closed epilogue can discharge this deliberately corrupted fixture.
     member.update(|record| record.stage = MemberStage::Reserved);
     assert!(root.admit_child(resident_projection(&reservation.slot)));
+}
+
+#[crate::runtime::test]
+async fn dropping_admission_install_completes_the_lost_response() {
+    let (scope, _events, mut dynamic_events, _control) = running_dynamic_fixture();
+    let root = Arc::clone(&scope.root);
+    let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
+        .expect("running dynamic scope reserves the child");
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new(|_| future::pending()).erase(),
+    ));
+    let (mut response, request) = begin_admission(&reservation, &mut dynamic_events, None).await;
+    let (definition, resolved) = request
+        .slot
+        .resolve_and_take_defined(&scope.defaults)
+        .expect("the defined reservation resolves once");
+    let plan = ChildPlan::with_options(Arc::clone(&request.slot), definition, resolved);
+    let child = ChildRuntime::from_plan(plan, &root);
+
+    drop(AdmissionInstall::new(&root, request, child));
+
+    assert!(matches!(
+        response.try_receive(),
+        Some(Err(ReserveError::NotAdmitting(
+            crate::NotAdmittingCause::Terminal
+        )))
+    ));
+    assert!(
+        !root.observation_gate().is_poisoned(),
+        "ledger fallback runs without the observation gate"
+    );
 }
 
 #[crate::runtime::test(start_paused = true)]

--- a/crates/shelterwood/src/driver/tests/dynamic.rs
+++ b/crates/shelterwood/src/driver/tests/dynamic.rs
@@ -1,8 +1,16 @@
 use super::{super::AdmissionInstall, support::*};
 use crate::plan::ChildPlan;
 
+/// Panics from the locked never-started terminalization seam.
+///
+/// `fuse`, when present, fires during conversion — after `handle_admission`'s
+/// pre-conversion latch check and before the ledger exists — so the rejection
+/// the panic then interrupts is the fused-cancel disjunct of the under-lock
+/// recheck, the one arm that claims the reservation before terminalizing.
 #[derive(Debug)]
-struct PanicTerminationMailbox;
+struct PanicTerminationMailbox {
+    fuse: Option<Latch>,
+}
 
 impl crate::mailbox::MailboxControl for PanicTerminationMailbox {
     fn configure(
@@ -10,6 +18,9 @@ impl crate::mailbox::MailboxControl for PanicTerminationMailbox {
         _mailbox: shelterwood_core::policy::ResolvedMailbox,
         _effects: &mut dyn crate::mailbox::MailboxEffectSink,
     ) -> crate::mailbox::MailboxBindToken {
+        if let Some(fuse) = &self.fuse {
+            fuse.fire_silently();
+        }
         crate::mailbox::MailboxBindToken::new(Arc::new(AtomicBool::new(false)))
     }
 
@@ -157,7 +168,7 @@ async fn rejected_admission_retains_its_child_across_locked_terminalization() {
     let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
         .expect("running dynamic scope reserves the child");
     let member = Arc::clone(&reservation.slot.member);
-    member.attach_mailbox(Arc::new(PanicTerminationMailbox));
+    member.attach_mailbox(Arc::new(PanicTerminationMailbox { fuse: None }));
     reservation.slot.define(ChildConstruction::Task(
         TaskDef::new(|_| future::pending()).erase(),
     ));
@@ -197,6 +208,102 @@ async fn rejected_admission_retains_its_child_across_locked_terminalization() {
         !control.state.is_poisoned(),
         "locked terminalization begins only after dynamic state is released"
     );
+}
+
+/// Records whether the observation gate was held when a waker fired.
+struct GateVenueWake {
+    root: Arc<ScopeCell>,
+    held: Arc<Mutex<Option<bool>>>,
+}
+
+impl Wake for GateVenueWake {
+    fn wake(self: Arc<Self>) {
+        self.wake_by_ref();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        *self.held.lock().expect("gate venue probe mutex poisoned") =
+            Some(self.root.observation_gate().is_held());
+    }
+}
+
+#[crate::runtime::test]
+async fn rejected_admission_wakes_its_removal_waiter_outside_the_gate() {
+    let (mut scope, _events, mut dynamic_events, control) = running_dynamic_fixture();
+    let root = Arc::clone(&scope.root);
+    let reservation = super::super::reserve_dynamic(&root, ChildId::from("worker"), None)
+        .expect("running dynamic scope reserves the child");
+    let member = Arc::clone(&reservation.slot.member);
+    let fused_cancel = Latch::default();
+    member.attach_mailbox(Arc::new(PanicTerminationMailbox {
+        fuse: Some(fused_cancel.clone()),
+    }));
+    reservation.slot.define(ChildConstruction::Task(
+        TaskDef::new(|_| future::pending()).erase(),
+    ));
+    let (mut response, request) = begin_admission(
+        &reservation,
+        &mut dynamic_events,
+        Some(fused_cancel.clone()),
+    )
+    .await;
+
+    // Park a remover on the still-reserved entry. Its waker fires from the
+    // entry's removal obligation, so it reports the venue that obligation
+    // runs in when the ledger retires the claimed reservation.
+    let removal = control
+        .state
+        .lock()
+        .expect("dynamic-state mutex starts healthy")
+        .entries_mut()
+        .get_mut(member.id())
+        .expect("the reservation is still indexed")
+        .removal
+        .payload_mut()
+        .subscribe();
+    let held = Arc::new(Mutex::new(None));
+    let waker = Waker::from(Arc::new(GateVenueWake {
+        root: Arc::clone(&root),
+        held: Arc::clone(&held),
+    }));
+    let mut removal = Box::pin(removal.receive());
+    assert!(
+        removal
+            .as_mut()
+            .poll(&mut Context::from_waker(&waker))
+            .is_pending(),
+        "the remover parks before the rejection"
+    );
+
+    let (finished, completion) = std::sync::mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let result = catch_unwind(AssertUnwindSafe(|| scope.handle_admission(request)));
+        let _ = finished.send(result.is_err());
+    });
+    assert_eq!(
+        completion.recv_timeout(DRIVER_PROGRESS_WAIT),
+        Ok(true),
+        "the fused-cancel rejection unwinds out of locked terminalization"
+    );
+
+    assert_eq!(
+        *held.lock().expect("gate venue probe mutex remains healthy"),
+        Some(false),
+        "the claimed reservation retires from the ledger, so its removal \
+         obligation cannot wake a remover under the observation gate"
+    );
+    assert!(matches!(
+        removal
+            .as_mut()
+            .poll(&mut Context::from_waker(Waker::noop())),
+        Poll::Ready(Some(RemoveOutcome::Removed))
+    ));
+    assert!(matches!(
+        response.try_receive(),
+        Some(Err(ReserveError::NotAdmitting(
+            crate::NotAdmittingCause::Terminal
+        )))
+    ));
 }
 
 #[crate::runtime::test(start_paused = true)]


### PR DESCRIPTION
Stack: 3 of 3 for #437, based on #474.

Summary:
- replace the function-local admission outcome enum and hand-written invariant arm with an owning AdmissionInstall ledger
- claim the child runtime, reserved entry, arena key, projection, and response obligation across installation
- retain rejected child ownership through locked never-started terminalization so a publication panic cannot run its fallback under the observation gate
- make Drop retire the projection after unlock and complete a lost response with panic containment
- debug-assert the admission gate identity invariant at ledger construction and record it in AGENTS.md
- add direct lost-response Drop coverage, a locked-terminalization unwind regression, and retain the hostile response-waker invariant test

Verification:
- ./tools/dev just ci (961 tests plus doctests, examples, docs, API reachability, manifest and Nix formatting checks)
- mutation check: emptying AdmissionInstall::drop makes dropping_admission_install_completes_the_lost_response fail

Closes #437