### PR TITLE
Gate lifecycle publication on active receivers

### DIFF
--- a/crates/shelterwood/src/cells/observe.rs
+++ b/crates/shelterwood/src/cells/observe.rs
@@ -970,6 +970,18 @@ impl LifecycleHub {
         }
     }
 
+    /// Whether this hub has an active lifecycle subscription.
+    ///
+    /// The signal count is an atomic-load proxy for the broadcast count,
+    /// which would take Tokio's broadcast tail mutex. `LifecycleEvents`
+    /// bundles both receivers and `subscribe` is their only constructor, so
+    /// the counts agree outside the benign user-timed 1 -> 0 drop race. The
+    /// observation gate serializes subscription with publication, preventing
+    /// a missed 0 -> 1 transition.
+    pub(crate) fn has_receivers(&self) -> bool {
+        self.signal.receiver_count() != 0
+    }
+
     pub(crate) fn is_closed(&self) -> bool {
         self.signal.read_with(|signal| signal.closed)
     }
@@ -981,6 +993,10 @@ impl LifecycleHub {
         event: impl Into<RetainedLifecycleEvent>,
     ) {
         let event = event.into();
+        if !self.has_receivers() {
+            txn.defer(move || drop(event));
+            return;
+        }
         let mut published = false;
         let mut undelivered = None;
         self.signal.modify_silently(|signal| {
@@ -1013,6 +1029,12 @@ impl LifecycleHub {
 
     /// Publishes an explicit lag marker under the observation gate.
     pub(crate) fn publish_lagged(&self, txn: &mut ObservationTxn<'_>, dropped: u64) {
+        // A later subscriber baselines `seen_explicit_lag`, so loss accrued
+        // before that subscription cannot be observed and need not mutate the
+        // retained signal state.
+        if !self.has_receivers() {
+            return;
+        }
         let mut published = false;
         self.signal.modify_silently(|signal| {
             if signal.closed {
@@ -1028,6 +1050,8 @@ impl LifecycleHub {
 
     /// Closes while the containing scope's observation gate is held.
     pub(crate) fn close(&self, txn: &mut ObservationTxn<'_>) {
+        // Unlike event publication, closure is retained watch state. Install
+        // it even while receiverless so a later subscriber starts closed.
         let mut modified = false;
         self.signal.modify_silently(|signal| {
             if !signal.closed {
@@ -1551,6 +1575,21 @@ mod tests {
                 Poll::Pending
             ),
             "a failed broadcast send must not pulse the signal watch"
+        );
+    }
+
+    #[test]
+    fn receiverless_lifecycle_lag_is_not_retained() {
+        let hub = LifecycleHub::default();
+        let mut txn = ObservationTxn::detached();
+
+        hub.publish_lagged(&mut txn, 5);
+        drop(txn);
+
+        assert_eq!(
+            hub.signal.read_with(|signal| signal.explicit_lag),
+            0,
+            "lag before any subscription is outside every subscriber's history"
         );
     }
 

--- a/crates/shelterwood/src/cells/observe.rs
+++ b/crates/shelterwood/src/cells/observe.rs
@@ -998,8 +998,10 @@ impl LifecycleHub {
             // critical disposal under both locks. That submission is
             // refcount/framework work only and is the accepted trade because
             // drop glue inside the send has no transaction sink to reach.
-            undelivered = self.events.send(event).err();
-            published = true;
+            match self.events.send(event) {
+                Ok(_) => published = true,
+                Err(event) => undelivered = Some(event),
+            }
         });
         if let Some(undelivered) = undelivered {
             txn.defer(move || drop(undelivered));
@@ -1071,22 +1073,27 @@ pub enum WaitError {
 #[cfg(test)]
 mod tests {
     use std::{
+        fmt,
+        future::Future,
         panic::{AssertUnwindSafe, catch_unwind},
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
+            mpsc,
         },
+        task::{Context, Poll, Waker},
     };
 
     use crate::runtime;
     use shelterwood_core::{
-        ChildId, Intensity, TotalRestarts,
+        Cancellation, ChildId, Exit, ExitError, Intensity, TotalRestarts,
         identity::{PoisonedCounter, ScopeIdentity},
         policy::ScopeFlavor,
     };
 
     use crate::cells::{
-        LifecycleEvent, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, ScopeSnapshot,
+        LifecycleEvent, LifecycleEventKind, LifecycleItem, LifecycleTryRecvError, ObservationGate,
+        ScopeSnapshot, test_support::TEST_WAIT,
     };
     use shelterwood_core::{ScopeState, StopReason};
 
@@ -1108,6 +1115,28 @@ mod tests {
             }),
             Vec::new(),
         )
+    }
+
+    struct DropSignal(mpsc::SyncSender<()>);
+
+    impl fmt::Debug for DropSignal {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("DropSignal")
+        }
+    }
+
+    impl fmt::Display for DropSignal {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("drop signal")
+        }
+    }
+
+    impl std::error::Error for DropSignal {}
+
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            let _ = self.0.send(());
+        }
     }
 
     #[test]
@@ -1469,6 +1498,60 @@ mod tests {
         drop(txn);
 
         assert_eq!(runtime::join_resuming(waiter).await, None);
+    }
+
+    #[test]
+    fn failed_lifecycle_send_does_not_pulse_and_retires_after_commit() {
+        let hub = LifecycleHub::default();
+        // Production bundles the signal and broadcast receivers inside one
+        // `LifecycleEvents`. Holding only this raw signal watcher models the
+        // benign 1 -> 0 broadcast-receiver race after the publication gate.
+        let mut signal = hub.signal.watcher();
+        assert_eq!(hub.events.receiver_count(), 0);
+
+        let mut identity = ScopeIdentity::new();
+        let (membership, mut incarnations) = identity
+            .mint_membership(&ChildId::from("scope"))
+            .expect("membership available")
+            .into_pair();
+        let (dropped, observed) = mpsc::sync_channel(1);
+        let event = LifecycleEvent {
+            scope_path: Vec::new(),
+            scope: membership,
+            seq: LifecycleSeq::new(1),
+            kind: LifecycleEventKind::Exited {
+                id: ChildId::from("worker"),
+                membership,
+                incarnation: incarnations.mint().expect("incarnation available"),
+                exit: Exit::failed(
+                    ExitError::from(DropSignal(dropped)),
+                    Cancellation::NotObserved,
+                ),
+            },
+        };
+        let gate = ObservationGate::new();
+        let mut txn = ObservationTxn::new(&gate, gate.lock());
+
+        hub.publish(&mut txn, event);
+        assert!(
+            observed.try_recv().is_err(),
+            "an undelivered event remains deferred while the transaction holds the gate"
+        );
+        drop(txn);
+
+        observed
+            .recv_timeout(TEST_WAIT)
+            .expect("the undelivered event retires after commit");
+        let mut changed = Box::pin(signal.changed());
+        assert!(
+            matches!(
+                changed
+                    .as_mut()
+                    .poll(&mut Context::from_waker(Waker::noop())),
+                Poll::Pending
+            ),
+            "a failed broadcast send must not pulse the signal watch"
+        );
     }
 
     #[test]

--- a/crates/shelterwood/src/cells/scope/projection.rs
+++ b/crates/shelterwood/src/cells/scope/projection.rs
@@ -313,6 +313,23 @@ impl ScopeCell {
         };
         self.publish_snapshot_chain_through_locked(wakes, &ancestors);
 
+        // Sequence minting and snapshot watermarks stay unconditional: the
+        // catch-up protocol uses them across stretches with no subscribers.
+        // When the whole propagation chain is receiverless, retire the raw
+        // kind before its guards after unlock and avoid event construction,
+        // path extension, cloning, and per-hub publication entirely.
+        if !self.observation.lifecycle.has_receivers()
+            && ancestors
+                .iter()
+                .all(|ancestor| !ancestor.observation.lifecycle.has_receivers())
+        {
+            wakes.defer(move || {
+                drop(kind);
+                drop(guards);
+            });
+            return;
+        }
+
         let scope = self.member.membership();
         let mut event = RetainedLifecycleEvent::from_parts(scope, seq, kind, guards);
         self.observation.lifecycle.publish(wakes, event.clone());

--- a/crates/shelterwood/src/driver/tests/observation.rs
+++ b/crates/shelterwood/src/driver/tests/observation.rs
@@ -1179,7 +1179,7 @@ fn plain_parent_state_preserves_nested_snapshot_propagation() {
 }
 
 #[test]
-fn lifecycle_emit_resolves_the_ancestor_chain_once() {
+fn ancestor_only_lifecycle_subscription_receives_forwarded_leaf_events() {
     let root = isolated_scope("root", ScopeFlavor::Ordered);
     let nested = isolated_scope("nested", ScopeFlavor::Dynamic);
     let nested_slot = SlotCell::new(Arc::clone(&nested.member), Some(Arc::clone(&nested)));

--- a/crates/shelterwood/tests/observation.rs
+++ b/crates/shelterwood/tests/observation.rs
@@ -117,6 +117,33 @@ async fn admit_waiter(scope: &DynamicScopeRef, id: String) {
         .expect("task is admitted");
 }
 
+#[tokio::test]
+async fn lifecycle_sequence_advances_across_an_unobserved_stretch() {
+    let system = DynamicTree::new().spawn().expect("runtime is available");
+    system.wait_started().await.expect("root starts");
+    let scope = system.scope();
+    let before = scope.as_scope().snapshot().lifecycle_seq;
+    assert!(
+        before.get() > 0,
+        "startup mints lifecycle edges without a subscriber"
+    );
+
+    let mut events = scope.as_scope().subscribe_lifecycle();
+    admit_waiter(&scope, "worker".to_owned()).await;
+    let first = next_event(&mut events).await;
+    assert!(matches!(first.kind, LifecycleEventKind::Added { .. }));
+    assert_eq!(
+        first.seq.get(),
+        before.get() + 1,
+        "the first observed edge follows sequence numbers minted while receiverless"
+    );
+
+    system
+        .shutdown(Duration::from_secs(1))
+        .await
+        .expect("root shuts down");
+}
+
 async fn drain_added_started_ready(events: &mut LifecycleEvents) {
     for expected in ["added", "started", "ready"] {
         let event = next_event(events).await;

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -3621,6 +3621,14 @@ Ordering and delivery contract:
   (§16.14's consistent-or-newer guarantee covers every event delivered
   before the snapshot read) — discard it. The same protocol is the
   post-`Lagged` resync. The documentation MUST teach it in this form.
+- Event construction and publication to each scope's lifecycle hub MAY
+  be skipped while that hub has no active subscription. The emitting
+  scope's `LifecycleSeq` mint MUST remain unconditional: a later
+  subscription replays no history, but its first event's sequence still
+  includes the receiverless stretch and every snapshot watermark remains
+  authoritative. Forwarding is gated per hub, so an ancestor subscription
+  still receives descendant events when the descendant itself has no
+  subscriber.
 - `LifecycleSeq` exposes `get()` plus the documented `EXHAUSTED`
   sentinel; `seq`/`lifecycle_seq` mint through §3.1's one primitive:
   `u64`, saturating advance, the saturated value poisoned and never

--- a/tools/benchmarks/README.md
+++ b/tools/benchmarks/README.md
@@ -110,16 +110,15 @@ ring does not saturate: the arms measure the keeping-up-consumer regime, not a
 permanently lagged one. On the current-thread group that consumer is driven by
 the same `block_on` Criterion times, so its cost is attributed; on the
 multi-thread group it runs on another worker and only its wake and contention
-costs are. `none` is not an observer-free baseline for lifecycle work:
-snapshot publication skips a scope with no receivers, but lifecycle emission
-has no such gate — every edge mints retention guards, resolves ancestors,
-mints the sequence, builds the event, clones it per ancestor, takes the hub's
-signal mutex and the broadcast tail lock, and pulses the watch, whether or not
-anyone is subscribed. Only the ring write itself is skipped, and that is the
-channel's own zero-receiver check rather than a Shelterwood gate. The
-`lifecycle` arm's delta over `none` is therefore bounded below by that
-unconditional work and measures only the incremental cost of a subscribed,
-draining consumer — which on a keeping-up consumer is close to zero.
+costs are. `none` is the observation-free publication baseline. Lifecycle
+emission still mints retention guards, resolves ancestors, advances the
+sequence, and keeps on-demand snapshot watermarks authoritative because those
+are unconditional parts of the catch-up contract. When the whole lifecycle
+propagation chain is receiverless, however, it skips event construction, path
+extension, cloning, the signal mutex, the broadcast tail lock, and watch
+pulses. The `lifecycle` arm's delta over `none` therefore measures
+subscriber-dependent event publication plus the cost of its draining
+consumer.
 
 That schedule is **quadratic** in the child count: it settles once per child,
 and every settle rescans the child table — `settle_finish` evaluates


### PR DESCRIPTION
## Summary

- pulse lifecycle waiters only when the broadcast send succeeds
- gate lifecycle publication per hub using the signal watch's atomic receiver count
- skip event construction and ancestor cloning when the complete propagation chain is receiverless
- retain unconditional sequence minting and document the catch-up consequence

## Correctness argument

`LifecycleEvents` is the only production owner of lifecycle signal and broadcast receivers, and `subscribe` creates both while holding the observation transaction. The signal receiver count is therefore an exact, lock-free proxy except during the benign user-timed 1 -> 0 drop window. That window can only create a false positive; a failed broadcast send now keeps `published` false, defers the undelivered retained event, and emits no signal pulse.

The emitting scope still mints `LifecycleSeq` before the chain fast path. Snapshot watermarks therefore continue across unobserved stretches, so the existing subscribe-then-snapshot catch-up protocol remains valid and a later subscriber replays no history. Receiver checks remain per hub, preserving descendant forwarding to an ancestor-only subscriber. Lifecycle closure is deliberately not gated because its retained watch state must be visible to later subscribers.

Retained event and raw-kind retirement stays in `ObservationTxn` effects. The no-receiver paths drop the raw kind before its retention guards after the observation gate unlocks.

## Validation

- `./tools/dev just ci`
- `./tools/dev cargo bench --locked --manifest-path tools/benchmarks/Cargo.toml --bench lifecycle -- dynamic_churn --sample-size 10`
  - current-thread point estimates: `none` 363.05 us, `lifecycle` 403.09 us
  - four-worker point estimates: `none` 613.27 us, `lifecycle` 623.42 us

Fixes #477
